### PR TITLE
Inline Support Links: update legacy links to context format

### DIFF
--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -33,12 +33,12 @@ function Link() {
 The `supportContext` is a combination of the `supportPostId` and `supportLink` found in _context-links.js_.
 
 ```js
-const getContextLinks = () => ( {
-	purchases: {
-		link: 'https://wordpress.com/support/manage-purchases/',
-		post_id: 111349,
-	},
-} );
+// ...
+purchases: {
+	link: 'https://wordpress.com/support/manage-purchases/',
+	post_id: 111349,
+},
+// ...
 ```
 
 ## Props

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -33,12 +33,14 @@ function Link() {
 The `supportContext` is a combination of the `supportPostId` and `supportLink` found in _context-links.js_.
 
 ```js
-// ...
-purchases: {
-	link: 'https://wordpress.com/support/manage-purchases/',
-	post_id: 111349,
-},
-// ...
+const contextLinks = {
+	// ...
+	purchases: {
+		link: 'https://wordpress.com/support/manage-purchases/',
+		post_id: 111349,
+	},
+	// ...
+};
 ```
 
 ## Props

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -24,6 +24,31 @@ export const getContextLinks = () => ( {
 			'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com',
 		post_id: 158974,
 	},
+	'importers-blogger': {
+		link: 'https://wordpress.com/support/import/coming-from-blogger/',
+		post_id: 66764,
+	},
+	'importers-medium': {
+		link: 'https://wordpress.com/support/import/import-from-medium/',
+		post_id: 93180,
+	},
+	'importers-squarespace': {
+		link: 'https://wordpress.com/support/import/import-from-squarespace/',
+		post_id: 87696,
+	},
+	// @TODO: This isn't a real page and the post_id is Squarespace
+	'importers-substack': {
+		link: 'https://wordpress.com/support/import/import-from-substack/',
+		post_id: 87696,
+	},
+	'importers-wix': {
+		link: 'https://wordpress.com/support/import/import-from-wix/',
+		post_id: 147777,
+	},
+	'importers-wordpress': {
+		link: 'https://wordpress.com/support/moving-from-self-hosted-wordpress-to-wordpress-com/',
+		post_id: 102755,
+	},
 	media: {
 		link: 'https://wordpress.com/support/media/',
 		post_id: 853,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -19,6 +19,11 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/add-email/',
 		post_id: 34087,
 	},
+	'getting-started-video': {
+		link:
+			'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com',
+		post_id: 158974,
+	},
 	media: {
 		link: 'https://wordpress.com/support/media/',
 		post_id: 853,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -23,6 +23,10 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/media/',
 		post_id: 853,
 	},
+	'paid-newsletters': {
+		link: 'https://wordpress.com/support/paid-newsletters/',
+		post_id: 168381,
+	},
 	portfolios: {
 		link: 'https://wordpress.com/support/portfolios/',
 		post_id: 84808,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -23,6 +23,10 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/media/',
 		post_id: 853,
 	},
+	menus: {
+		link: 'https://wordpress.com/support/menus/',
+		post_id: 59580,
+	},
 	'paid-newsletters': {
 		link: 'https://wordpress.com/support/paid-newsletters/',
 		post_id: 168381,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -35,6 +35,10 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/comments/',
 		post_id: 113,
 	},
+	'site-verification': {
+		link: 'https://wordpress.com/support/site-verification-services/',
+		post_id: 5022,
+	},
 	themes: {
 		link: 'https://wordpress.com/support/themes/',
 		post_id: 2278,
@@ -94,5 +98,9 @@ export const getContextLinks = () => ( {
 	payment_methods: {
 		link: 'https://wordpress.com/support/payment/',
 		post_id: 76237,
+	},
+	'webmaster-tools': {
+		link: 'https://wordpress.com/support/webmaster-tools/',
+		post_id: 5022,
 	},
 } );

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -39,6 +39,10 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/themes/',
 		post_id: 2278,
 	},
+	'themes-upload': {
+		link: 'https://wordpress.com/support/themes/uploading-setting-up-custom-themes/',
+		post_id: 134784,
+	},
 	publicize: {
 		link: 'https://wordpress.com/support/publicize/',
 		post_id: 4789,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -55,6 +55,10 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/plugins/third-party-plugins-and-themes-support/',
 		post_id: 174865,
 	},
+	podcasting: {
+		link: 'https://wordpress.com/support/audio/podcasting/',
+		post_id: 38147,
+	},
 	publicize: {
 		link: 'https://wordpress.com/support/publicize/',
 		post_id: 4789,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -1,28 +1,44 @@
 export const getContextLinks = () => ( {
-	pages: {
-		link: 'https://wordpress.com/support/pages/',
-		post_id: 86,
+	billing: {
+		link: 'https://wordpress.com/support/billing-history/',
+		post_id: 40792,
 	},
-	posts: {
-		link: 'https://wordpress.com/support/posts/',
-		post_id: 84,
+	comments: {
+		link: 'https://wordpress.com/support/comments/',
+		post_id: 113,
 	},
-	stats: {
-		link: 'https://wordpress.com/support/stats/',
-		post_id: 4454,
+	discussion: {
+		link: 'https://wordpress.com/support/settings/discussion-settings/',
+		post_id: 1504,
 	},
 	domains: {
 		link: 'https://wordpress.com/support/domains/',
 		post_id: 1988,
 	},
+	earn: {
+		link: 'https://wordpress.com/support/monetize-your-site/',
+		post_id: 120172,
+	},
 	emails: {
 		link: 'https://wordpress.com/support/add-email/',
 		post_id: 34087,
+	},
+	export: {
+		link: 'https://wordpress.com/support/export/',
+		post_id: 2087,
 	},
 	'getting-started-video': {
 		link:
 			'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com',
 		post_id: 158974,
+	},
+	'google-analytics-measurement-id': {
+		link: 'https://wordpress.com/support/google-analytics/#get-your-measurement-id',
+		post_id: 98905,
+	},
+	import: {
+		link: 'https://wordpress.com/support/import/',
+		post_id: 41,
 	},
 	'importers-blogger': {
 		link: 'https://wordpress.com/support/import/coming-from-blogger/',
@@ -57,29 +73,61 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/menus/',
 		post_id: 59580,
 	},
+	pages: {
+		link: 'https://wordpress.com/support/pages/',
+		post_id: 86,
+	},
 	'paid-newsletters': {
 		link: 'https://wordpress.com/support/paid-newsletters/',
 		post_id: 168381,
+	},
+	payment_methods: {
+		link: 'https://wordpress.com/support/payment/',
+		post_id: 76237,
+	},
+	plugins: {
+		link: 'https://wordpress.com/support/plugins/',
+		post_id: 2108,
+	},
+	podcasting: {
+		link: 'https://wordpress.com/support/audio/podcasting/',
+		post_id: 38147,
 	},
 	portfolios: {
 		link: 'https://wordpress.com/support/portfolios/',
 		post_id: 84808,
 	},
-	testimonials: {
-		link: 'https://wordpress.com/support/testimonials/',
-		post_id: 97757,
+	posts: {
+		link: 'https://wordpress.com/support/posts/',
+		post_id: 84,
 	},
-	comments: {
-		link: 'https://wordpress.com/support/comments/',
-		post_id: 113,
+	privacy: {
+		link: 'https://wordpress.com/support/settings/privacy-settings/',
+		post_id: 1507,
+	},
+	publicize: {
+		link: 'https://wordpress.com/support/publicize/',
+		post_id: 4789,
+	},
+	purchases: {
+		link: 'https://wordpress.com/support/manage-purchases/',
+		post_id: 111349,
 	},
 	'site-verification': {
 		link: 'https://wordpress.com/support/site-verification-services/',
 		post_id: 5022,
 	},
-	'google-analytics-measurement-id': {
-		link: 'https://wordpress.com/support/google-analytics/#get-your-measurement-id',
-		post_id: 98905,
+	stats: {
+		link: 'https://wordpress.com/support/stats/',
+		post_id: 4454,
+	},
+	team: {
+		link: 'https://wordpress.com/support/user-roles/',
+		post_id: 1221,
+	},
+	testimonials: {
+		link: 'https://wordpress.com/support/testimonials/',
+		post_id: 97757,
 	},
 	themes: {
 		link: 'https://wordpress.com/support/themes/',
@@ -96,54 +144,6 @@ export const getContextLinks = () => ( {
 	'themes-unsupported': {
 		link: 'https://wordpress.com/support/plugins/third-party-plugins-and-themes-support/',
 		post_id: 174865,
-	},
-	podcasting: {
-		link: 'https://wordpress.com/support/audio/podcasting/',
-		post_id: 38147,
-	},
-	publicize: {
-		link: 'https://wordpress.com/support/publicize/',
-		post_id: 4789,
-	},
-	earn: {
-		link: 'https://wordpress.com/support/monetize-your-site/',
-		post_id: 120172,
-	},
-	import: {
-		link: 'https://wordpress.com/support/import/',
-		post_id: 41,
-	},
-	export: {
-		link: 'https://wordpress.com/support/export/',
-		post_id: 2087,
-	},
-	team: {
-		link: 'https://wordpress.com/support/user-roles/',
-		post_id: 1221,
-	},
-	privacy: {
-		link: 'https://wordpress.com/support/settings/privacy-settings/',
-		post_id: 1507,
-	},
-	discussion: {
-		link: 'https://wordpress.com/support/settings/discussion-settings/',
-		post_id: 1504,
-	},
-	plugins: {
-		link: 'https://wordpress.com/support/plugins/',
-		post_id: 2108,
-	},
-	purchases: {
-		link: 'https://wordpress.com/support/manage-purchases/',
-		post_id: 111349,
-	},
-	billing: {
-		link: 'https://wordpress.com/support/billing-history/',
-		post_id: 40792,
-	},
-	payment_methods: {
-		link: 'https://wordpress.com/support/payment/',
-		post_id: 76237,
 	},
 	'webmaster-tools': {
 		link: 'https://wordpress.com/support/webmaster-tools/',

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -39,6 +39,10 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/site-verification-services/',
 		post_id: 5022,
 	},
+	'google-analytics-measurement-id': {
+		link: 'https://wordpress.com/support/google-analytics/#get-your-measurement-id',
+		post_id: 98905,
+	},
 	themes: {
 		link: 'https://wordpress.com/support/themes/',
 		post_id: 2278,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -47,6 +47,10 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/themes/uploading-setting-up-custom-themes/',
 		post_id: 134784,
 	},
+	'themes-unsupported': {
+		link: 'https://wordpress.com/support/plugins/third-party-plugins-and-themes-support/',
+		post_id: 174865,
+	},
 	publicize: {
 		link: 'https://wordpress.com/support/publicize/',
 		post_id: 4789,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -39,6 +39,10 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/themes/',
 		post_id: 2278,
 	},
+	'themes-switch': {
+		link: 'https://wordpress.com/support/changing-themes/',
+		post_id: 184023,
+	},
 	'themes-upload': {
 		link: 'https://wordpress.com/support/themes/uploading-setting-up-custom-themes/',
 		post_id: 134784,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -1,4 +1,4 @@
-export const getContextLinks = () => ( {
+const contextLinks = {
 	billing: {
 		link: 'https://wordpress.com/support/billing-history/',
 		post_id: 40792,
@@ -149,4 +149,6 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/webmaster-tools/',
 		post_id: 5022,
 	},
-} );
+};
+
+export default contextLinks;

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -54,7 +54,8 @@ class InlineSupportLink extends Component {
 	componentDidMount() {
 		if ( this.props.supportContext && ! this.props.supportPostId && ! this.props.supportLink ) {
 			// Lazy load the supportPostId and supportLink by key if not provided.
-			import( './context-links' ).then( ( contextLinks ) => {
+			import( './context-links' ).then( ( module ) => {
+				const contextLinks = module.default;
 				const supportDataFromContext = contextLinks[ this.props.supportContext ];
 				if ( ! supportDataFromContext ) {
 					return;

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -15,13 +15,13 @@ import {
 } from 'calypso/state/analytics/actions';
 import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import contextLinks from './context-links';
 
 import './style.scss';
 
 class InlineSupportLink extends Component {
 	state = {
 		shouldLazyLoadAlternates: false,
+		supportDataFromContext: undefined,
 	};
 
 	static propTypes = {
@@ -51,12 +51,23 @@ class InlineSupportLink extends Component {
 		this.setState( { shouldLazyLoadAlternates: true } );
 	};
 
+	componentDidMount() {
+		if ( this.props.supportContext && ! this.props.supportPostId && ! this.props.supportLink ) {
+			// Lazy load the supportPostId and supportLink by key if not provided.
+			import( './context-links' ).then( ( contextLinks ) => {
+				const supportDataFromContext = contextLinks[ this.props.supportContext ];
+				if ( ! supportDataFromContext ) {
+					return;
+				}
+				this.setState( { supportDataFromContext } );
+			} );
+		}
+	}
+
 	render() {
 		const {
 			className,
 			showText,
-			supportPostId,
-			supportLink,
 			showIcon,
 			iconSize,
 			translate,
@@ -65,6 +76,12 @@ class InlineSupportLink extends Component {
 			localeSlug,
 		} = this.props;
 		const { shouldLazyLoadAlternates } = this.state;
+
+		let { supportPostId, supportLink } = this.props;
+		if ( this.state.supportDataFromContext ) {
+			supportPostId = this.state.supportDataFromContext.post_id;
+			supportLink = this.state.supportDataFromContext.link;
+		}
 
 		if ( ! supportPostId && ! supportLink ) {
 			return null;
@@ -115,24 +132,9 @@ class InlineSupportLink extends Component {
 	}
 }
 
-const getLinkData = ( ownProps ) => {
-	const { supportContext } = ownProps;
-	const linkData = contextLinks[ supportContext ];
-	if ( ! linkData ) {
-		return {};
-	}
-	return {
-		supportPostId: linkData.post_id,
-		supportLink: linkData.link,
-	};
-};
-
-const mapStateToProps = ( state, ownProps ) => {
-	return {
-		localeSlug: getCurrentLocaleSlug( state ),
-		...getLinkData( ownProps ),
-	};
-};
+const mapStateToProps = ( state ) => ( {
+	localeSlug: getCurrentLocaleSlug( state ),
+} );
 
 const mapDispatchToProps = ( dispatch, ownProps ) => {
 	const { tracksEvent, tracksOptions, statsGroup, statsName, supportContext } = ownProps;

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -15,7 +15,7 @@ import {
 } from 'calypso/state/analytics/actions';
 import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import { getContextLinks } from './context-links';
+import contextLinks from './context-links';
 
 import './style.scss';
 
@@ -117,7 +117,6 @@ class InlineSupportLink extends Component {
 
 const getLinkData = ( ownProps ) => {
 	const { supportContext } = ownProps;
-	const contextLinks = getContextLinks();
 	const linkData = contextLinks[ supportContext ];
 	if ( ! linkData ) {
 		return {};

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -31,11 +31,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 			{
 				components: {
 					supportLink: (
-						<InlineSupportLink
-							supportPostId={ 102755 }
-							supportLink="https://wordpress.com/support/moving-from-self-hosted-wordpress-to-wordpress-com/"
-							showIcon={ false }
-						>
+						<InlineSupportLink supportContext="importers-wordpress" showIcon={ false }>
 							{ translate( 'Need help exporting your content?' ) }
 						</InlineSupportLink>
 					),
@@ -74,11 +70,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 				components: {
 					supportLink: (
-						<InlineSupportLink
-							supportPostId={ 66764 }
-							supportLink="https://wordpress.com/support/import/coming-from-blogger/"
-							showIcon={ false }
-						>
+						<InlineSupportLink supportContext="importers-blogger" showIcon={ false }>
 							{ translate( 'Need help exporting your content?' ) }
 						</InlineSupportLink>
 					),
@@ -116,11 +108,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 				components: {
 					supportLink: (
-						<InlineSupportLink
-							supportPostId={ 93180 }
-							supportLink="https://wordpress.com/support/import/import-from-medium/"
-							showIcon={ false }
-						>
+						<InlineSupportLink supportContext="importers-medium" showIcon={ false }>
 							{ translate( 'Need help exporting your content?' ) }
 						</InlineSupportLink>
 					),
@@ -158,11 +146,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 				components: {
 					supportLink: (
-						<InlineSupportLink
-							supportPostId={ 87696 } // TODO: update
-							supportLink="https://wordpress.com/support/import/import-from-substack/"
-							showIcon={ false }
-						>
+						<InlineSupportLink supportContext="importers-substack" showIcon={ false }>
 							{ translate( 'Need help exporting your content?' ) }
 						</InlineSupportLink>
 					),
@@ -209,11 +193,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 				components: {
 					supportLink: (
-						<InlineSupportLink
-							supportPostId={ 87696 }
-							supportLink="https://wordpress.com/support/import/import-from-squarespace/"
-							showIcon={ false }
-						>
+						<InlineSupportLink supportContext="importers-squarespace" showIcon={ false }>
 							{ translate( 'Need help exporting your content?' ) }
 						</InlineSupportLink>
 					),
@@ -243,11 +223,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 		uploadDescription: translate( 'Enter the URL of your existing site. ' + '{{supportLink/}}', {
 			components: {
 				supportLink: (
-					<InlineSupportLink
-						supportPostId={ 147777 }
-						supportLink="https://wordpress.com/support/import/import-from-wix/"
-						showIcon={ false }
-					>
+					<InlineSupportLink supportContext="importers-wix" showIcon={ false }>
 						{ translate( 'Need help?' ) }
 					</InlineSupportLink>
 				),

--- a/client/my-sites/customer-home/cards/education/quick-start-video/index.jsx
+++ b/client/my-sites/customer-home/cards/education/quick-start-video/index.jsx
@@ -32,10 +32,7 @@ export const QuickStartVideo = ( { trackQuickStartImpression } ) => {
 							<div className="quick-start-video__content-link educational-content__link">
 								<MaterialIcon icon="play_circle_outline" />
 								<InlineSupportLink
-									supportPostId={ 158974 }
-									supportLink={ localizeUrl(
-										'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com'
-									) }
+									supportContext="getting-started-video"
 									showIcon={ false }
 									showText={ true }
 									tracksEvent="calypso_customer_home_education"
@@ -56,10 +53,7 @@ export const QuickStartVideo = ( { trackQuickStartImpression } ) => {
 					{ isDesktop() && (
 						<div className="quick-start-video__content-illustration educational-content__illustration">
 							<InlineSupportLink
-								supportPostId={ 158974 }
-								supportLink={ localizeUrl(
-									'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com'
-								) }
+								supportContext="getting-started-video"
 								showIcon={ false }
 								showText={ true }
 								tracksEvent="calypso_customer_home_education"

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -10,7 +10,6 @@ import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Spinner from 'calypso/components/spinner';
 import { preventWidows } from 'calypso/lib/formatting';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { buildChartData } from 'calypso/my-sites/stats/stats-chart-tabs/utility';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSiteOption } from 'calypso/state/sites/selectors';
@@ -87,8 +86,7 @@ export const StatsV2 = ( {
 						<div>
 							{ translate( 'Launch your site to see a snapshot of traffic and insights.' ) }
 							<InlineSupportLink
-								supportPostId={ 4454 }
-								supportLink={ localizeUrl( 'https://wordpress.com/support/stats/' ) }
+								supportContext="stats"
 								showIcon={ false }
 								tracksEvent="calypso_customer_home_stats_support_page_view"
 								statsGroup="calypso_customer_home"
@@ -114,8 +112,7 @@ export const StatsV2 = ( {
 								'Stats can help you optimize for the right keywords, and feature content your readers are interested in.'
 							) }
 							<InlineSupportLink
-								supportPostId={ 4454 }
-								supportLink={ localizeUrl( 'https://wordpress.com/support/stats/' ) }
+								supportContext="stats"
 								showIcon={ false }
 								tracksEvent="calypso_customer_home_stats_support_page_view"
 								statsGroup="calypso_customer_home"

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,6 +1,5 @@
 import { translate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import { requestSiteChecklistTaskUpdate } from 'calypso/state/checklist/actions';
@@ -181,8 +180,7 @@ export const getTask = (
 						// The following classes are globally shared
 						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 						className="button is-primary task__action"
-						supportPostId={ 59580 }
-						supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
+						supportContext="menus"
 						showIcon={ false }
 						tracksEvent="calypso_customer_home_menus_support_page_view"
 						statsGroup="calypso_customer_home"

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -31,7 +31,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
  * Stripe Currencies also supported by WordPress.com with minimum transaction amounts.
  *
  * https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
- *
  * @type { [currency: string]: number }
  */
 const MINIMUM_CURRENCY_AMOUNT = {
@@ -303,11 +302,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						{ translate(
 							'Allow members of this payment plan to opt into receiving new posts via email.'
 						) }{ ' ' }
-						<InlineSupportLink
-							supportPostId={ 168381 }
-							supportLink="https://wordpress.com/support/paid-newsletters/"
-							showIcon={ false }
-						>
+						<InlineSupportLink supportContext="paid-newsletters" showIcon={ false }>
 							{ translate( 'Learn more.' ) }
 						</InlineSupportLink>
 					</p>

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -136,10 +136,7 @@ const GoogleAnalyticsJetpackForm = ( {
 										text={ translate( 'Invalid Google Analytics Measurement ID.' ) }
 									/>
 								) }
-								<InlineSupportLink
-									supportPostId={ 98905 }
-									supportLink="https://wordpress.com/support/google-analytics/#get-your-measurement-id"
-								>
+								<InlineSupportLink supportContext="google-analytics-measurement-id">
 									{ translate( 'Where can I find my Measurement ID?' ) }
 								</InlineSupportLink>
 							</FormFieldset>

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -138,10 +138,7 @@ const GoogleAnalyticsSimpleForm = ( {
 										text={ translate( 'Invalid Google Analytics Measurement ID.' ) }
 									/>
 								) }
-								<InlineSupportLink
-									supportPostId={ 98905 }
-									supportLink="https://wordpress.com/support/google-analytics/#get-your-measurement-id"
-								>
+								<InlineSupportLink supportContext="google-analytics-measurement-id">
 									{ translate( 'Where can I find my Measurement ID?' ) }
 								</InlineSupportLink>
 							</FormFieldset>

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -10,7 +10,6 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import SupportInfo from 'calypso/components/support-info';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
@@ -141,12 +140,7 @@ class CustomContentTypes extends Component {
 				'you can display them using the shortcode [testimonials].',
 			{
 				components: {
-					link: (
-						<InlineSupportLink
-							supportLink={ localizeUrl( 'https://wordpress.com/support/testimonials/' ) }
-							supportPostId={ 97757 }
-						/>
-					),
+					link: <InlineSupportLink supportContext="testimonials" />,
 				},
 			}
 		);
@@ -162,12 +156,7 @@ class CustomContentTypes extends Component {
 				'you can display them using the shortcode [portfolio].',
 			{
 				components: {
-					link: (
-						<InlineSupportLink
-							supportLink={ localizeUrl( 'https://wordpress.com/support/portfolios/' ) }
-							supportPostId={ 84808 }
-						/>
-					),
+					link: <InlineSupportLink supportContext="portfolios" />,
 				},
 			}
 		);

--- a/client/my-sites/site-settings/podcasting-details/support-link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/support-link.jsx
@@ -1,15 +1,10 @@
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 function PodcastingSupportLink( { showText, iconSize } ) {
-	const supportLink = localizeUrl( 'https://wordpress.com/support/audio/podcasting/' );
-	const supportPostId = 38147;
-
 	return (
 		<InlineSupportLink
 			className="podcasting-details__support-link"
-			supportPostId={ supportPostId }
-			supportLink={ supportLink }
+			supportContext="podcasting"
 			showText={ showText }
 			iconSize={ iconSize }
 		/>

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -315,10 +315,7 @@ class SiteVerification extends Component {
 								components: {
 									b: <strong />,
 									supportLink: (
-										<InlineSupportLink
-											supportPostId={ 5022 }
-											supportLink="https://wordpress.com/support/site-verification-services/"
-										>
+										<InlineSupportLink supportContext="site-verification">
 											{ translate( 'full instructions', {
 												comment: 'Full phrase: Read the full instructions',
 											} ) }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -510,13 +510,7 @@ class ThemeSheet extends Component {
 								{
 									components: {
 										InlineSupportLink: (
-											<InlineSupportLink
-												showIcon={ false }
-												supportPostId={ 174865 }
-												supportLink={ localizeUrl(
-													'https://wordpress.com/support/plugins/third-party-plugins-and-themes-support/'
-												) }
-											/>
+											<InlineSupportLink supportContext="themes-unsupported" showIcon={ false } />
 										),
 									},
 								}

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -9,7 +9,6 @@ import Badge from 'calypso/components/badge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
 import isSiteUsingCoreSiteEditorSelector from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
@@ -89,10 +88,7 @@ class CurrentTheme extends Component {
 								</div>
 								<p>
 									{ translate( 'This is the active theme on your site.' ) }{ ' ' }
-									<InlineSupportLink
-										supportPostId={ 184023 }
-										supportLink={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
-									>
+									<InlineSupportLink supportContext="themes-switch">
 										{ translate( 'Learn more.' ) }
 									</InlineSupportLink>
 								</p>

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -332,11 +332,7 @@ class Upload extends Component {
 						{
 							components: {
 								learnMoreLink: (
-									<InlineSupportLink
-										supportLink="https://wordpress.com/support/themes/uploading-setting-up-custom-themes/"
-										supportPostId={ 134784 }
-										showIcon={ false }
-									/>
+									<InlineSupportLink supportContext="themes-upload" showIcon={ false } />
 								),
 							},
 						}


### PR DESCRIPTION
In #54991 we switched the `InlineSupportLink` component to use an object of support links and a `supportContext` prop, and in #56661 we added a Tracks event that records that context. Since the legacy events all pass a `null` context, the event can be hard to segment, so this PR switches most of the legacy support links to use the new `supportContext` prop.

**To test:**
- run `localStorage.setItem('debug', 'calypso:analytics*');` on your browser console and filter for "recording event"
- visit the updated links (e.g. Importers, Podcasting, or Customer Home cards)
- click on an inline support link
- verify that the correct support document is shown in a modal
- verify that the `calypso_inlinesupportlink_click` event is fired and the `support_context` prop has a non-null value