### PR TITLE
Titan: Show post-checkout upsell for eligible domains

### DIFF
--- a/client/lib/titan/get-eligible-titan-domain.js
+++ b/client/lib/titan/get-eligible-titan-domain.js
@@ -1,0 +1,48 @@
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
+import { hasPaidEmailWithUs } from 'calypso/lib/emails';
+
+/**
+ * Retrieves the first domain that is eligible to Titan in this order:
+ *
+ *   - The domain from the site currently selected, if eligible
+ *   - The primary domain of the site, if eligible
+ *   - The first non-primary domain eligible found
+ *
+ * Note this method doesn't check if a domain is eligible to the 3-month free trial.
+ *
+ * @param {string} selectedDomainName - domain name for the site currently selected by the user
+ * @param {Array} domains - list of domain objects
+ * @returns {?object} - the first eligible domain found, null otherwise
+ */
+export function getEligibleTitanDomain( selectedDomainName, domains ) {
+	if ( ! domains ) {
+		return null;
+	}
+
+	const eligibleDomains = domains.filter( ( domain ) => {
+		if ( domain.expired || domain.isWpcomStagingDomain ) {
+			return false;
+		}
+
+		if ( hasPaidEmailWithUs( domain ) ) {
+			return false;
+		}
+
+		return canCurrentUserAddEmail( domain );
+	} );
+
+	if ( eligibleDomains.length === 0 ) {
+		return null;
+	}
+
+	const selectedDomain = eligibleDomains.find( ( domain ) => domain.name === selectedDomainName );
+
+	if ( selectedDomain ) {
+		return selectedDomain;
+	}
+
+	// Orders domains with the primary domain in first position, if any, and returns the first domain
+	return eligibleDomains.sort(
+		( a, b ) => Number( b.isPrimary ?? false ) - Number( a.isPrimary ?? false )
+	)[ 0 ];
+}

--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -1,4 +1,5 @@
 export { getConfiguredTitanMailboxCount } from './get-configured-titan-mailbox-count';
+export { getEligibleTitanDomain } from './get-eligible-titan-domain';
 export { getMaxTitanMailboxCount } from './get-max-titan-mailbox-count';
 export { getTitanExpiryDate } from './get-titan-expiry-date';
 export { getTitanMailboxPurchaseCost } from './get-titan-mailbox-purchase-cost';

--- a/client/lib/titan/test/index.ts
+++ b/client/lib/titan/test/index.ts
@@ -1,0 +1,144 @@
+import { getEligibleTitanDomain } from '..';
+
+describe( 'getEligibleTitanDomain()', () => {
+	test( 'return null when domains are undefined', () => {
+		expect( getEligibleTitanDomain( 'foo.bar' ) ).toBeNull();
+	} );
+
+	test( 'return null when domains are false', () => {
+		expect( getEligibleTitanDomain( 'foo.bar', false ) ).toBeNull();
+	} );
+
+	test( 'return null when domains are empty', () => {
+		expect( getEligibleTitanDomain( 'foo.bar', [] ) ).toBeNull();
+	} );
+
+	test( 'return null with domain with G Suite', () => {
+		expect(
+			getEligibleTitanDomain( 'foo.bar', [
+				{
+					name: 'domain-with-gsuite.com',
+					currentUserCanAddEmail: true,
+					googleAppsSubscription: { status: 'active' },
+				},
+			] )
+		).toBeNull();
+	} );
+
+	test( 'return null with domain with Titan', () => {
+		expect(
+			getEligibleTitanDomain( 'foo.bar', [
+				{
+					name: 'domain-with-titan.com',
+					currentUserCanAddEmail: true,
+					titanMailSubscription: { status: 'active' },
+				},
+			] )
+		).toBeNull();
+	} );
+
+	test( 'return null with expired domain', () => {
+		expect(
+			getEligibleTitanDomain( 'foo.bar', [
+				{
+					name: 'domain-expired.com',
+					currentUserCanAddEmail: true,
+					expired: true,
+				},
+			] )
+		).toBeNull();
+	} );
+
+	test( 'return null with staging domain', () => {
+		expect(
+			getEligibleTitanDomain( 'foo.bar', [
+				{
+					name: 'invalid.wpcomstaging.com',
+					currentUserCanAddEmail: true,
+					isWpcomStagingDomain: true,
+				},
+			] )
+		).toBeNull();
+	} );
+
+	test( 'return null when user cannot add email', () => {
+		expect(
+			getEligibleTitanDomain( 'foo.bar', [
+				{
+					name: 'domain.com',
+					currentUserCanAddEmail: false,
+				},
+			] )
+		).toBeNull();
+	} );
+
+	test( 'return domain when eligible', () => {
+		const domain = {
+			name: 'domain-eligible.com',
+			currentUserCanAddEmail: true,
+		};
+
+		expect( getEligibleTitanDomain( 'foo.bar', [ domain ] ) ).toBe( domain );
+	} );
+
+	test( 'return primary domain instead of other eligible domains', () => {
+		const domain = {
+			name: 'domain-eligible-primary.com',
+			currentUserCanAddEmail: true,
+			isPrimary: true,
+		};
+
+		const domains = [
+			{
+				name: 'domain-eligible.com',
+				currentUserCanAddEmail: true,
+			},
+			domain,
+		];
+
+		expect( getEligibleTitanDomain( 'foo.bar', domains ) ).toBe( domain );
+	} );
+
+	test( 'return selected domain instead of other eligible domains', () => {
+		const domain = {
+			name: 'foo.bar',
+			currentUserCanAddEmail: true,
+		};
+
+		const domains = [
+			{
+				name: 'domain-eligible.com',
+				currentUserCanAddEmail: true,
+			},
+			{
+				name: 'domain-eligible-primary.com',
+				currentUserCanAddEmail: true,
+				isPrimary: true,
+			},
+			domain,
+		];
+
+		expect( getEligibleTitanDomain( 'foo.bar', domains ) ).toBe( domain );
+	} );
+
+	test( 'return first domain instead of other eligible domains when selected domain differs', () => {
+		const domain = {
+			name: 'domain-eligible.com',
+			currentUserCanAddEmail: true,
+		};
+
+		const domains = [
+			domain,
+			{
+				name: 'another-domain-eligible.com',
+				currentUserCanAddEmail: true,
+			},
+			{
+				name: 'foo.bar',
+				currentUserCanAddEmail: true,
+			},
+		];
+
+		expect( getEligibleTitanDomain( 'bar.bar', domains ) ).toBe( domain );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -26,6 +26,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import wp from 'calypso/lib/wp';
+import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
@@ -231,6 +232,8 @@ export default function CompositeCheckout( {
 		[ responseCart ]
 	);
 
+	const domains = useSiteDomains( siteId );
+
 	const getThankYouUrlBase = useGetThankYouUrl( {
 		siteSlug: updatedSiteSlug,
 		redirectTo,
@@ -242,7 +245,9 @@ export default function CompositeCheckout( {
 		hideNudge: !! isComingFromUpsell,
 		isInEditor,
 		isJetpackCheckout,
+		domains,
 	} );
+
 	const getThankYouUrl = useCallback( () => {
 		const url = getThankYouUrlBase();
 		recordEvent( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -16,6 +16,7 @@ import {
 import { getDomainNameFromReceiptOrCart } from 'calypso/lib/domains/cart-utils';
 import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
 import { AUTO_RENEWAL } from 'calypso/lib/url/support';
+import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import {
 	retrieveSignupDestination,
@@ -96,6 +97,8 @@ export default function useCreatePaymentCompleteCallback( {
 		getJetpackCheckoutRedirectUrl( state, siteId )
 	);
 
+	const domains = useSiteDomains( siteId );
+
 	return useCallback(
 		( { paymentMethodId, transactionLastResponse }: PaymentEventCallbackArguments ): void => {
 			debug( 'payment completed successfully' );
@@ -126,7 +129,9 @@ export default function useCreatePaymentCompleteCallback( {
 				isJetpackCheckout,
 				jetpackTemporarySiteId,
 				adminPageRedirect,
+				domains,
 			};
+
 			debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
 			const url = getThankYouPageUrl( getThankYouPageUrlArguments );
 			debug( 'getThankYouUrl returned', url );
@@ -257,6 +262,7 @@ export default function useCreatePaymentCompleteCallback( {
 			isJetpackCheckout,
 			checkoutFlow,
 			adminPageRedirect,
+			domains,
 		]
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getThankYouPageUrl from './get-thank-you-page-url';
+import type { Domain } from '@automattic/data-stores';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { WPCOMTransactionEndpointResponse } from '@automattic/wpcom-checkout';
 
@@ -23,6 +24,7 @@ export default function useGetThankYouUrl( {
 	hideNudge,
 	isInEditor,
 	isJetpackCheckout = false,
+	domains,
 }: GetThankYouUrlProps ): GetThankYouUrl {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 
@@ -49,10 +51,13 @@ export default function useGetThankYouUrl( {
 			hideNudge,
 			isInEditor,
 			isJetpackCheckout,
+			domains,
 		};
+
 		debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
 		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
 		debug( 'getThankYouUrl returned', url );
+
 		return url;
 	}, [
 		isInEditor,
@@ -68,6 +73,7 @@ export default function useGetThankYouUrl( {
 		cart,
 		hideNudge,
 		isJetpackCheckout,
+		domains,
 	] );
 	return getThankYouUrl;
 }
@@ -84,4 +90,5 @@ export interface GetThankYouUrlProps {
 	hideNudge?: boolean;
 	isInEditor?: boolean;
 	isJetpackCheckout?: boolean;
+	domains: Domain[] | undefined;
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-site-domains.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-site-domains.ts
@@ -1,0 +1,34 @@
+import debugFactory from 'debug';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
+import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import type { Domain } from '@automattic/data-stores';
+
+const debug = debugFactory( 'calypso:composite-checkout:use-site-domains' );
+
+export default function useSiteDomains( siteId: number | undefined ): Domain[] {
+	const dispatch = useDispatch();
+
+	const [ siteDomains, setSiteDomains ] = useState( [] );
+
+	const areDomainsLoaded = useSelector( ( state ) => hasLoadedSiteDomains( state, siteId ) );
+
+	const domains = useSelector(
+		( state ) => areDomainsLoaded && getDomainsBySiteId( state, siteId )
+	);
+
+	useEffect( () => {
+		if ( areDomainsLoaded ) {
+			debug( 'Setting list of domains', domains );
+
+			setSiteDomains( domains );
+		} else {
+			debug( 'Fetching list of domains' );
+
+			dispatch( fetchSiteDomains( siteId ) );
+		}
+	}, [ areDomainsLoaded, dispatch, domains, siteId ] );
+
+	return siteDomains;
+}

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
@@ -13,6 +13,7 @@ import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
+import { isDomainEligibleForTitanFreeTrial } from 'calypso/lib/titan';
 import {
 	areAllMailboxesValid,
 	buildNewTitanMailbox,
@@ -38,7 +39,7 @@ const ProfessionalEmailFeature = ( { children } ) => {
 
 const ProfessionalEmailUpsell = ( {
 	currencyCode,
-	domainName = 'example.com',
+	domain,
 	handleClickAccept,
 	handleClickDecline,
 	productCost,
@@ -46,6 +47,8 @@ const ProfessionalEmailUpsell = ( {
 } ) => {
 	const translate = useTranslate();
 	const productsList = useSelector( getProductsList );
+
+	const domainName = domain.name;
 
 	const [ mailboxData, setMailboxData ] = useState( buildNewTitanMailbox( domainName, false ) );
 	const [ showAllErrors, setShowAllErrors ] = useState( false );
@@ -71,7 +74,8 @@ const ProfessionalEmailUpsell = ( {
 		comment: '{{price/}} is the formatted price, e.g. $20',
 	} );
 
-	const isEligibleForFreeTrial = true;
+	const isEligibleForFreeTrial = isDomainEligibleForTitanFreeTrial( domain );
+
 	const discountBadge = isEligibleForFreeTrial ? (
 		<span>
 			<Badge type="success">{ translate( '3 months free' ) }</Badge>

--- a/config/development.json
+++ b/config/development.json
@@ -170,6 +170,7 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
+		"upsell/professional-email": true,
 		"upsell/nudge-component": true,
 		"upsell/troubleshooting": true,
 		"woocommerce/extension-referrers": true,


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/56671 and https://github.com/Automattic/wp-calypso/pull/56690. It updates the purchase flow to show an upsell for Professional Email after the checkout under certain conditions:

<img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/136393399-e560cc63-6b39-4535-be8f-f40be57f7de5.png">

This pull request:

* Adds an `upsell/professional-email` feature gate
* Adds a function that retrieves the first domain eligible to Professional Email from a list of domains
* Adds a function that retrieves the url of the Professional Email upsell page
* Adds a hook that can be used to retrieve a list of domains for a site
* Renames several methods dealing with upsells to follow the same naming convention
* Updates the logic that determines which upsell should be shown to a user
* Adds unit tests for those changes

Note the logic for showing and handling an upsell page follows these high-level steps:

1. Determines what page should be displayed when purchase is successful
2. Redirects the user to that page
3. Shows the upsell
4. Determines what page should be displayed when an upsell is declined

That means we need to retrieve a domain eligible to Professional Email in step #1 but also in step #3 (we don't pass the domain name in the url of the Professional Email upsell page). A domain is eligible if it:

* Has not expired
* Is not a staging domain (Atomic)
* Has neither Titan nor Google Workspace already
* Can be added/managed by the user

In addition to that, the Professional Email upsell page should only be displayed when purchasing the Blogger, Personal, or Business plans. Right now this page is also managed by the `upsell/professional-email` feature gate. We will move to an A/B test in another pull request.

#### Testing instructions

You can run unit tests with:

```javascript
npm run test-client client/lib/titan
npm run test-client client/my-sites/checkout/composite-checkout
```

Otherwise you can:

1. Run `git checkout update/professional-email-upsell` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/56794#issuecomment-934563437)
2. Paste the following in your browser's console to debug the hook:
```javascript
localStorage.setItem( 'debug', 'calypso:composite-checkout:use-site-domains' )
```
3. Log into a WordPress.com account that has a site with an eligible domain
4. Open the [`Plans` page](http://calypso.localhost:3000/plans)
5. Purchase any plan except Premium
6. Assert that you are presented with the Professional Email upsell
7. Assert that that page still works if you refresh it
8. Upgrade your plan to Premium
9. Assert that you are still presented with the Business Plan upsell
10. Upgrade your plan to Business
11. Assert that you are presented with the Professional Email upsell
12. Navigate to the [`Emails` page](http://calypso.localhost:3000/email/stephanethomas494.wordpress.com)
13. Click the `Add Email` button located in front of your eligible domain
14. Add either Titan or Google Workspace account to your shopping cart (but don't purchase it)
15. Head back to the `Plans` page
16. Click the `Upgrade` button below the eCommerce plan
17. Assert that the `Checkout` page shows both that plan and the email solution you chose before
18. Pay, and assert that you are not presented with any upsell (you are taken to the site setup flow)

You may want to follow these [instructions](https://github.com/Automattic/wp-calypso/pull/43199) to cover existing use cases.