### PR TITLE
Remove unneeded permissions to allow tmp dir use

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -292,7 +292,6 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String ): Bui
 					# Run the test
 					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=gutenberg
 				""".trimIndent()
-				dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
 			}
 			bashNodeScript {
 				name = "Collect results"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our media based Playwright tests were failing in the WPCom tests in TeamCity due to some permissions errors when copying to the temp directory.

This PR updates the Docker permissions in that build to match the WebApp build to remove those errors.

#### Testing instructions

- [x] [WPCom Tests pass on this branch](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_Playwright_desktop/6796106)

Related to #
