### PR TITLE
Playwright: use Playwright's built-in page.video.saveAs to save video file.

### DIFF
--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -78,7 +78,7 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 				// Save the failing test case with a specific name.
 				await page.video()?.saveAs( destination );
 			} catch ( err ) {
-				console.error( 'Failed to save video of failing test case.' );
+				console.error( `Failed to save video of failing test case.\nStack trace: ${ err }` );
 			}
 		}
 

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -68,7 +68,6 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 		await page.close();
 
 		if ( __CURRENT_TEST_FAILED__ ) {
-			// const original = await ( page.video() as Video ).path();
 			const destination = path.join(
 				artifactPath,
 				'screenshots',
@@ -78,7 +77,8 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 				// Save the failing test case with a specific name.
 				await page.video()?.saveAs( destination );
 			} catch ( err ) {
-				console.error( `Failed to save video of failing test case.\nStack trace: ${ err }` );
+				console.error( `Failed to save video of failing test case.\nSee stack trace:` );
+				console.trace( err );
 			}
 		}
 

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -1,4 +1,4 @@
-import { mkdir, copyFile } from 'fs/promises';
+import { mkdir } from 'fs/promises';
 import path from 'path';
 import { beforeAll, afterAll } from '@jest/globals';
 import { chromium, Page, Video } from 'playwright';
@@ -68,18 +68,17 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 		await page.close();
 
 		if ( __CURRENT_TEST_FAILED__ ) {
-			const original = await ( page.video() as Video ).path();
+			// const original = await ( page.video() as Video ).path();
 			const destination = path.join(
 				artifactPath,
 				'screenshots',
 				`${ getTestNameWithTime( testName ) }.webm`
 			);
 			try {
-				// Copy the recording from `os.tmpdir` to the artifact directory,
-				// renaming it in the process.
-				await copyFile( original, destination );
+				// Save the failing test case with a specific name.
+				await page.video()?.saveAs( destination );
 			} catch ( err ) {
-				console.error( 'Failed to copy video of failing test case.' );
+				console.error( 'Failed to save video of failing test case.' );
 			}
 		}
 

--- a/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
@@ -31,6 +31,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		it( 'Navigate to Stats', async function () {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.navigate( 'Stats' );
+			throw new Error();
 		} );
 
 		it( 'Click on Insights tab', async function () {

--- a/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
@@ -31,7 +31,6 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		it( 'Navigate to Stats', async function () {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.navigate( 'Stats' );
-			throw new Error();
 		} );
 
 		it( 'Click on Insights tab', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR rectifies an unintentional issue introduced in #56630 due to Docker containers' handling of path permissions.

Key changes:
- use `page.video().saveAs()` to copy the video recording file from `os.tmpdir` to the artifact path.
- remove `if/else` clause separating the `page.video().delete` line, as in all cases the source video file should be deleted.

#### Testing instructions

local

1. pull the branch
2. open any `test/e2e/specs/specs-playwright` file.
3. introduce an intentional failure (eg. `throw new Error()`)
4. run the test with `yarn jest <path>`
5. ensure that:
  a. source video file is no longer present in `os.tmpdir`.
  b. under `test/e2e/results` a directory containing video recording is present.

ci

1. pull the branch
2. open any `test/e2e/specs/specs-playwright` file.
3. introduce an intentional failure (eg. `throw new Error()`)
4. let CI run the test
5. verify that in TeamCity > artifacts tab, video recording is uploaded.

Related to #56630
