### PR TITLE
Theme Showcase: use FSE active status to determine FSE tab

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
@@ -20,6 +19,7 @@ import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	getActiveTheme,
@@ -116,6 +116,7 @@ class ThemeShowcase extends Component {
 		trackMoreThemesClick: PropTypes.func,
 		loggedOutComponent: PropTypes.bool,
 		isJetpackSite: PropTypes.bool,
+		isSiteEditorActive: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -267,13 +268,8 @@ class ThemeShowcase extends Component {
 			case this.tabFilters.MYTHEMES.key:
 				return this.props.isJetpackSite;
 			case this.tabFilters.FSE.key:
-				// Display FSE tab if feature flag is enabled or if current theme is already FSE-enabled.
-				return (
-					config.isEnabled( 'gutenboarding/site-editor' ) ||
-					this.props.currentTheme?.taxonomies?.theme_feature?.some(
-						( f ) => f.slug === 'block-templates'
-					)
-				);
+				// Display FSE tab if the Site Editor is active for the site.
+				return this.props.isSiteEditorActive;
 		}
 	};
 
@@ -438,6 +434,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 		filterString: prependThemeFilterKeys( state, filter ),
 		filterToTermTable: getThemeFilterToTermTable( state ),
 		themesBookmark: getThemesBookmark( state ),
+		isSiteEditorActive: isSiteUsingCoreSiteEditor( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
We're about to ship Universal Themes (the ability to run FSE themes without the Site Editor) and I realized that the Theme Showcase FSE tab was keyed to whether or not the theme is FSE, rather than whether or not FSE is active for the site. This would lead to anyone activating a Universal Theme seeing the FSE tab in the Theme Showcase, which is premature.

This will ensure that only sites with FSE active will see this. In the future we can switch this tab's visibility to FSE eligible.

#### Testing instructions

1. On a site with FSE active, you should see the FSE beta tab in the theme showcase
2. On a site without FSE active, you should _not_ see the FSE beta tab, even if you're running a Universal Theme

FSE Active:
<img width="1279" alt="Screen Shot 2021-10-05 at 12 55 32" src="https://user-images.githubusercontent.com/195089/136076986-997a64fc-7ad2-492d-97c5-5bbffa115399.png">


