### PR TITLE
Playwright: remove extraneous `waitForNavigation` call

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-auth__magic-link.ts
+++ b/test/e2e/specs/specs-playwright/wp-auth__magic-link.ts
@@ -44,6 +44,6 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 
 	it( 'Log in using magic link', async function () {
 		const loginPage = new LoginPage( page );
-		await Promise.all( [ page.waitForNavigation(), loginPage.followMagicLink( magicLink ) ] );
+		await loginPage.followMagicLink( magicLink );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR corrects a nit identified by @dpasque that I had forgotten to push up prior to merging.

The `LoginPage.followMagicLink` method already contains a `waitForNavigation` call, so the extra call is unnecessary and potentially problematic.

Related to #56768.
