### PR TITLE
Plans: Fix missing intro discount % when a site is in context

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -188,7 +188,8 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 					createButtonURL={ createProductURL }
 				/>
 
-				{ siteId ? <QuerySiteProducts siteId={ siteId } /> : <QueryProductsList type="jetpack" /> }
+				<QueryProductsList type="jetpack" />
+				{ siteId && <QuerySiteProducts siteId={ siteId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				{ siteId && <QuerySites siteId={ siteId } /> }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Always render `QueryProductsList` on the Calypso Green pricing page, so that the `getHighestAnnualDiscount` works properly and is able to supply data to the `DiscountMessage` component.

#### Testing instructions

##### Reproduce the original issue

0. Ensure you're authenticated on cloud.jetpack.com.
1. Open `cloud.jetpack.com/pricing/:yourSite`, where `:yourSite` is a site you can access.
2. Erase the entire Redux state tree from your browser's Indexed DB storage. Here's what that looks like in Firefox:

<img width="780" alt="Screen Shot 2021-10-05 at 13 42 33" src="https://user-images.githubusercontent.com/670067/136083692-11b6d6db-b087-46f3-8c6a-07f0f05b7b66.png">

3. Hard-refresh your browser.
4. Note that the discount percentage that normally shows up to the right of the billing toggle is not visible (see below screenshots).

<img height="100" alt="image" src="https://user-images.githubusercontent.com/670067/136083258-1622c1c2-303a-4743-bb8c-2c0b1154b08c.png"> <img height="100" alt="image" src="https://user-images.githubusercontent.com/670067/136083194-85041b00-b429-4c22-8a68-25f5e6c211a0.png">

##### Test the fix

4. Repeat the same steps as in the "Reproduce the original issue" section, replacing `cloud.jetpack.com` with your testing environment.
5. Verify the discount percentage appears next to the billing term toggle on the Pricing page, where it failed to appear before.