### PR TITLE
Plans: Correctly render storage pricing as wide-layout

### DIFF
--- a/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
@@ -34,19 +34,26 @@ export const StoragePricing: React.FC< Props > = ( {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	return (
-		<Main className="storage-pricing__main">
-			{ nav }
-			{ header }
-			<PlansFilterBar showDiscountMessage duration={ duration } onDurationChange={ setDuration } />
-			<StorageTierUpgrade
-				duration={ duration }
-				urlQueryArgs={ urlQueryArgs }
-				siteSlug={ siteSlug }
-			/>
-			<FootnotesList />
-			{ footer }
+		<>
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
-		</Main>
+
+			{ nav }
+			<Main className="storage-pricing__main" wideLayout>
+				{ header }
+				<PlansFilterBar
+					showDiscountMessage
+					duration={ duration }
+					onDurationChange={ setDuration }
+				/>
+				<StorageTierUpgrade
+					duration={ duration }
+					urlQueryArgs={ urlQueryArgs }
+					siteSlug={ siteSlug }
+				/>
+				<FootnotesList />
+				{ footer }
+			</Main>
+		</>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/storage-pricing/style.scss
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/style.scss
@@ -6,4 +6,18 @@
 			padding: 16px 0;
 		}
 	}
+
+	// StoragePricing has a max-width of 1040px,
+	// but we want the upgrade cards to stay narrow
+	// like on the "regular" pricing page
+	.storage-tier-upgrade {
+		max-width: 720px;
+		margin-left: 20px;
+		margin-right: 20px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the `wideLayout` attribute to the `StoragePricing` page.
* Add styling rules to the storage pricing page so that `StorageTierUpgrade` renders at the same width as before (720px), instead of with a wide layout (1040px).
* Add left and right margins to `StorageTierUpgrade` for small screen widths, so that there's a gutter on each side of the page.

#### Testing instructions

1. Go to the following URL in your browser, depending on the experience you'd like to test, substituting your testing environment hostname and the slug of a Jetpack site you control for `:site`:
  a. Calypso Blue: `<calypsoblue>/plans/storage/:site?flags=jetpack/only-realtime-products`
  b. Calypso Green: `<calypso-green>/pricing/storage/:site?flags=jetpack/only-realtime-products`
2. For desktop screens: verify the page header and footer are both rendered roughly in the center of the page and do not wrap or overflow.
3. For mobile screens: verify the page header and footer are full-width and do not overflow. Also verify that product cards do not take up the entire screen width and are bordered by ~20px of empty space on either side.

#### Reference capture

https://user-images.githubusercontent.com/670067/136089099-e102c3d6-9e5d-46f6-bbde-9b86cc87cfef.mp4