### PR TITLE
Domains: Fix Domain Only flow post-checkout redirect

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -207,8 +207,9 @@ export default function getThankYouPageUrl( {
 
 	// Domain only flow
 	if ( cart?.create_new_blog ) {
-		const newBlogUrl = urlFromCookie;
-		const newBlogReceiptUrl = newBlogUrl ? `${ newBlogUrl }/${ pendingOrReceiptId }` : fallbackUrl;
+		const newBlogReceiptUrl = urlFromCookie
+			? `${ urlFromCookie }/${ pendingOrReceiptId }`
+			: fallbackUrl;
 		debug( 'new blog created, so returning', newBlogReceiptUrl );
 		return newBlogReceiptUrl;
 	}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -207,8 +207,8 @@ export default function getThankYouPageUrl( {
 
 	// Domain only flow
 	if ( cart?.create_new_blog ) {
-		const newBlogUrl = urlFromCookie || fallbackUrl;
-		const newBlogReceiptUrl = `${ newBlogUrl }/${ pendingOrReceiptId }`;
+		const newBlogUrl = urlFromCookie;
+		const newBlogReceiptUrl = newBlogUrl ? `${ newBlogUrl }/${ pendingOrReceiptId }` : fallbackUrl;
 		debug( 'new blog created, so returning', newBlogReceiptUrl );
 		return newBlogReceiptUrl;
 	}

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -635,18 +635,16 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/cookie/:receiptId' );
 	} );
 
-	// Note: This just verifies the existing behavior; I suspect this is a bug
-	it( 'redirects to thank-you page followed by placeholder receiptId twice if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
+	it( 'redirects to thank-you page followed by placeholder receiptId if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
 		const cart = {
 			create_new_blog: true,
 			products: [ { id: '123' } ],
 		};
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );
-		expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId/:receiptId' );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
 	} );
 
-	// Note: This just verifies the existing behavior; I suspect this is a bug
-	it( 'redirects to thank-you page followed by purchase id twice if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
+	it( 'redirects to thank-you page followed by purchase id if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
 		const cart = {
 			create_new_blog: true,
 			products: [ { id: '123' } ],
@@ -657,7 +655,7 @@ describe( 'getThankYouPageUrl', () => {
 			purchaseId: '1234abcd',
 			cart,
 		} );
-		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd/1234abcd' );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
 
 	it( 'redirects to thank-you page for a new site with a domain and some failed purchases', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes #56548.

Apparently (reported by `git bisect`) #55809 caused a bug for the domain-only flow, reported in #56548.
In short: the redirected post-checkout page is invalid. This PR fixes it.

#### Testing instructions
Same as #56548, but the post-checkout page should be correct:
- Start at `/start/domain`;
- Search for a domain name and add it to the cart;
- Opt to purchase just the domain name ("Just buy a domain" option);
- Add the billing details/checkout information and confirm the checkout;
- Check that after completing the checkout, there is a redirect to the domain-only page.

Also, make sure that the changes won't affect any flows other than the domain-only one.