### PR TITLE
Jetpack Pricing: Change 20GB to 10GB

### DIFF
--- a/packages/calypso-products/src/translations.js
+++ b/packages/calypso-products/src/translations.js
@@ -281,8 +281,8 @@ export const getJetpackStorageAmountDisplays = () => ( {
 		{
 			comment:
 				'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
-			count: 20,
-			args: { numberOfGigabytes: 20 },
+			count: 10,
+			args: { numberOfGigabytes: 10 },
 		}
 	),
 	[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: translate(
@@ -291,8 +291,8 @@ export const getJetpackStorageAmountDisplays = () => ( {
 		{
 			comment:
 				'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
-			count: 20,
-			args: { numberOfGigabytes: 20 },
+			count: 10,
+			args: { numberOfGigabytes: 10 },
 		}
 	),
 	[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: translate(
@@ -321,8 +321,8 @@ export const getJetpackStorageAmountDisplays = () => ( {
 		{
 			comment:
 				'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
-			count: 20,
-			args: { numberOfGigabytes: 20 },
+			count: 10,
+			args: { numberOfGigabytes: 10 },
 		}
 	),
 	[ PLAN_JETPACK_SECURITY_T1_MONTHLY ]: translate(
@@ -331,8 +331,8 @@ export const getJetpackStorageAmountDisplays = () => ( {
 		{
 			comment:
 				'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
-			count: 20,
-			args: { numberOfGigabytes: 20 },
+			count: 10,
+			args: { numberOfGigabytes: 10 },
 		}
 	),
 	[ PLAN_JETPACK_SECURITY_T2_YEARLY ]: translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the 20GB plan to show 10GB.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `http://jetpack.cloud.localhost:3001/pricing/storage/:site?flags=jetpack/only-realtime-products`.
2. Verify that 10GB is displayed instead of 20GB.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
