### PR TITLE
Jetpack Cloud: Update VideoPress link in pricing page menu

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -82,7 +82,7 @@ const JetpackComMasterbar: React.FC = () => {
 							{
 								label: translate( 'VideoPress' ),
 								description: translate( 'High-quality, ad-free video' ),
-								href: '/upgrade/video/',
+								href: '/videopress/',
 								icon: videoIcon,
 							},
 						],


### PR DESCRIPTION
There's a new marketing page at http://jetpack.com/videopress that we forgot to point to from the menu on the pricing page.

<img width="910" alt="Screen Shot 2021-10-05 at 4 22 59 PM" src="https://user-images.githubusercontent.com/789137/136111308-e4d7a5d2-a426-4f68-b08a-28cf11304a1d.png">


**To Test**
* CALYPSO_ENV=jetpack-cloud-development yarn start
* Visit http://jetpack.cloud.localhost:3000/pricing
* Click on the `VideoPress` link in the drop-down menu.
* You should be at https://jetpack.com/videopress 😄 