### PR TITLE
Playwright: limit TeamCity to maximum of 1 concurrent runs of Pre-Release tests.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -707,6 +707,7 @@ object PreReleaseE2ETests : BuildType({
 	uuid = "9c2f634f-6582-4245-bb77-fb97d9f16533"
 	name = "Pre-Release E2E Tests"
 	description = "Runs a pre-release suite of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production."
+	maxRunningBuilds = 1
 
 	artifactRules = """
 		reports => reports


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR places a limit on the Pre-Release tests.

Key change:
- limit the concurrent runs of Pre-Release tests to 1 to avoid clashes.

#### Testing instructions

- can only be tested after merging (as with many other TeamCity configuration changes).

Related to #
