### PR TITLE
Design Picker: Update copy to match mockups

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -190,13 +190,12 @@ class DesignPickerStep extends Component {
 
 	headerText() {
 		const { translate } = this.props;
-
-		return translate( 'Choose a design' );
+		return translate( 'Themes' );
 	}
+
 	subHeaderText() {
 		const { translate } = this.props;
-
-		return translate( 'Pick your favorite homepage layout. You can customize or change it later.' );
+		return translate( 'Choose a starting theme. You can change it later.' );
 	}
 
 	render() {
@@ -204,6 +203,12 @@ class DesignPickerStep extends Component {
 		const { selectedDesign } = this.state;
 		const headerText = this.headerText();
 		const subHeaderText = this.subHeaderText();
+
+		// When we know the user has choosen to "Write" as their first action
+		// then we'll want to pass this label to `skipLabelText` prop.
+		// We're not there yet, but since we know we'll next this copy soon
+		// we'll commit it so that it gets queued up for translation.
+		this.props.translate( 'Skip and draft first post' );
 
 		if ( selectedDesign ) {
 			const isBlankCanvas = isBlankCanvasDesign( selectedDesign );

--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -42,7 +42,7 @@ describe( '<DesignPicker /> integration', () => {
 		render( <DesignPicker locale={ MOCK_LOCALE } onSelect={ jest.fn() } /> );
 
 		const firstDesignButton = screen.getAllByRole( 'button' )[ 0 ];
-		expect( firstDesignButton ).toHaveTextContent( /empty\spage/i );
+		expect( firstDesignButton ).toHaveTextContent( /blank\scanvas/i );
 	} );
 	( [ 'light', 'dark' ] as DesignPickerProps[ 'theme' ][] ).forEach( ( theme ) =>
 		it( `Should have design-picker--theme-${ theme } class when theme prop is set to ${ theme }`, () => {

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -61,7 +61,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const isBlankCanvas = isBlankCanvasDesign( design );
 
 	const defaultTitle = design.title;
-	const blankCanvasTitle = __( 'Start with an empty page', __i18n_text_domain__ );
+	const blankCanvasTitle = __( 'Blank Canvas', __i18n_text_domain__ );
 	const designTitle = isBlankCanvas ? blankCanvasTitle : defaultTitle;
 
 	return (
@@ -81,7 +81,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			>
 				{ isBlankCanvas ? (
 					<div className="design-picker__image-frame-blank-canvas__title">
-						{ __( 'Blank Canvas' ) }
+						{ __( 'Start from scratch', __i18n_text_domain__ ) }
 					</div>
 				) : (
 					<div className="design-picker__image-frame-inside">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the copy in the design picker to match the mockups

EuqfSnWpfYx8fgiBlVmbuA-fi-2119%3A1107

<img width="1264" alt="Screenshot 2021-10-06 at 4 03 19 PM" src="https://user-images.githubusercontent.com/1500769/136134280-8f66d03a-2301-4976-85ed-07d99788d316.png">

The `Skip and draft	first post` label won't appear until we have the intent screen which can tell us whether the user is about to proceed to the post editor. But I've added the label to the PR anyway so that we can get the translation process going.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso live link and go through the signup flow
* When at the design picker step notice that the labels have been updated to match the mockup
* The skip button won't have been updated, because we aren't taking the user to the post editor yet
* Check the site creation flow at `/new` and confirm that the Blank Canvas labels have changed there too

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56567