### PR TITLE
Support url encoded feature flag settings in the url 

### DIFF
--- a/packages/calypso-config/src/index.ts
+++ b/packages/calypso-config/src/index.ts
@@ -80,11 +80,10 @@ if (
 	const match =
 		document.location.search && document.location.search.match( /[?&]flags=([^&]+)(&|$)/ );
 	if ( match ) {
-		applyFlags( match[ 1 ], 'URL' );
+		applyFlags( decodeURIComponent( match[ 1 ] ), 'URL' );
 	}
 }
 const configApi = createConfig( configData );
-
 export default configApi;
 export const isEnabled = configApi.isEnabled;
 export const enabledFeatures = configApi.enabledFeatures;


### PR DESCRIPTION
Currently we can override feature flags in calypso by appending `?flags=namespace/flag`  to the URL
But there are places in calypso where the url may be saved and restored such as in the onboarding flow when an upsell is shown. In this case the feature flag may become url encoded i.e. `flags=namespace%2Fflag` 

In this case the string will not be encoded correctly and the flag setting will be lost.

This is evident when testing the intent gathering onboarding flow with `/start?flags=signup/hero-flow`. 

#### Testing instructions 
When an existing user purchases a new site with a domain and the premium plan, they should see the business plan upsell. 
When they are redirected to the intent page, the flag will be url encoded, before this fix, the user will be taken to the design selector page, after applying this change, the user will be correctly taken to the intent gathering step.