### PR TITLE
Design Picker: Style category filter to match figma

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, { getAvailableDesigns } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
@@ -105,7 +104,6 @@ const Designs: React.FunctionComponent = () => {
 						<span className="designs__premium-badge-text">{ __( 'Premium' ) }</span>
 					</Badge>
 				}
-				showCategoryFilter={ isEnabled( 'signup/design-picker-categories' ) }
 			/>
 		</div>
 	);

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, { isBlankCanvasDesign, getDesignUrl } from '@automattic/design-picker';
+import { englishLocales } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
 import { compose } from '@wordpress/compose';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -211,10 +212,22 @@ class DesignPickerStep extends Component {
 
 		return translate( 'Choose a design' );
 	}
-	subHeaderText() {
-		const { translate } = this.props;
 
-		return translate( 'Pick your favorite homepage layout. You can customize or change it later.' );
+	subHeaderText() {
+		const { locale, translate } = this.props;
+
+		const text = translate(
+			'Pick your favorite homepage layout. You can customize or change it later.'
+		);
+
+		if ( englishLocales.includes( locale ) && isEnabled( 'signup/design-picker-categories' ) ) {
+			// An English only trick so the line wraps between sentences.
+			return text
+				.replace( /\s/g, '\xa0' ) // Replace all spaces with non-breaking spaces
+				.replace( /\.\s/g, '. ' ); // Replace all spaces at the end of sentences with a regular breaking space
+		}
+
+		return text;
 	}
 
 	skipLabelText() {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -210,17 +210,25 @@ class DesignPickerStep extends Component {
 	headerText() {
 		const { translate } = this.props;
 
+		if ( isEnabled( 'signup/design-picker-categories' ) ) {
+			return translate( 'Themes' );
+		}
+
 		return translate( 'Choose a design' );
 	}
 
 	subHeaderText() {
 		const { locale, translate } = this.props;
 
-		const text = translate(
-			'Pick your favorite homepage layout. You can customize or change it later.'
-		);
+		if ( ! isEnabled( 'signup/design-picker-categories' ) ) {
+			return translate(
+				'Pick your favorite homepage layout. You can customize or change it later.'
+			);
+		}
 
-		if ( englishLocales.includes( locale ) && isEnabled( 'signup/design-picker-categories' ) ) {
+		const text = translate( 'Choose a starting theme. You can change it later.' );
+
+		if ( englishLocales.includes( locale ) ) {
 			// An English only trick so the line wraps between sentences.
 			return text
 				.replace( /\s/g, '\xa0' ) // Replace all spaces with non-breaking spaces

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,12 +1,15 @@
+import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, { isBlankCanvasDesign, getDesignUrl } from '@automattic/design-picker';
 import { shuffle } from '@automattic/js-utils';
 import { compose } from '@wordpress/compose';
 import { withViewportMatch } from '@wordpress/viewport';
+import classnames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -157,8 +160,19 @@ class DesignPickerStep extends Component {
 				locale={ this.props.locale } // props.locale obtained via `localize` HoC
 				onSelect={ this.pickDesign }
 				onPreview={ this.previewDesign }
+				className={ classnames( {
+					'design-picker-step__has-categories': isEnabled( 'signup/design-picker-categories' ),
+				} ) }
 				highResThumbnails
 				showCategoryFilter={ this.props.showDesignPickerCategories }
+				categoriesHeading={
+					<FormattedHeader
+						id={ 'step-header' }
+						headerText={ this.headerText() }
+						subHeaderText={ this.subHeaderText() }
+						align="left"
+					/>
+				}
 			/>
 		);
 	}
@@ -217,8 +231,6 @@ class DesignPickerStep extends Component {
 	render() {
 		const { flowName, stepName, userLoggedIn, isReskinned, isMobile, translate } = this.props;
 		const { selectedDesign } = this.state;
-		const headerText = this.headerText();
-		const subHeaderText = this.subHeaderText();
 
 		if ( selectedDesign ) {
 			const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
@@ -252,10 +264,10 @@ class DesignPickerStep extends Component {
 		return (
 			<StepWrapper
 				{ ...this.props }
-				fallbackHeaderText={ headerText }
-				headerText={ headerText }
-				fallbackSubHeaderText={ subHeaderText }
-				subHeaderText={ subHeaderText }
+				className={ classnames( {
+					'design-picker__has-categories': isEnabled( 'signup/design-picker-categories' ),
+				} ) }
+				hideFormattedHeader
 				stepContent={ this.renderDesignPicker() }
 				align={ isReskinned ? 'left' : 'center' }
 				skipButtonAlign={ isReskinned ? 'top' : 'bottom' }

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -35,6 +35,14 @@
 		}
 	}
 
+	.step-wrapper.design-picker__has-categories {
+		.step-wrapper__content {
+			@include break-medium {
+				margin-top: 64px;
+			}
+		}
+	}
+
 	// Ugly, but necessary to cancel out some signup styles
 	// without causing regressions to other parts of `/start`
 	button:not( .is-primary ) {
@@ -52,6 +60,20 @@
 			grid-template-columns: 1fr 1fr;
 			column-gap: 49px;
 			row-gap: 39px;
+		}
+	}
+
+	.design-picker__has-categories {
+		.design-picker__grid {
+			@include break-medium {
+				column-gap: 24px;
+				row-gap: 36px;
+			}
+		}
+
+		.formatted-header__subtitle {
+			// Overrides some very specific selectors in /client/signup/style.scss
+			margin: 12px 0 48px !important;
 		}
 	}
 

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -16,11 +16,6 @@
 			padding-left: 48px;
 			padding-right: 48px;
 		}
-
-		@include break-medium {
-			padding-left: 96px;
-			padding-right: 96px;
-		}
 	}
 
 	.step-wrapper__content {

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -2,25 +2,28 @@ import { NavigableMenu, MenuItem, VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import type { Category } from '../../types';
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import './style.scss';
 
 interface Props {
 	categories: Category[];
 	onSelect: ( selectedSlug: string | null ) => void;
 	selectedCategory: string | null;
+	heading?: ReactNode;
 }
 
 export function DesignPickerCategoryFilter( {
 	categories,
 	onSelect,
 	selectedCategory,
+	heading,
 }: Props ): ReactElement | null {
 	const instanceId = useInstanceId( DesignPickerCategoryFilter );
 	const { __ } = useI18n();
 
 	return (
 		<div className="design-picker-category-filter">
+			{ heading }
 			<VisuallyHidden as="h2" id={ `design-picker__category-heading-${ instanceId }` }>
 				{ __( 'Design categories', __i18n_text_domain__ ) }
 			</VisuallyHidden>
@@ -49,10 +52,11 @@ export function DesignPickerCategoryFilter( {
 					<MenuItem
 						key={ slug }
 						isTertiary
-						aria-selected={ slug === selectedCategory }
+						isPressed={ slug === selectedCategory }
 						data-slug={ slug }
 						onClick={ () => onSelect( slug ) }
 						tabIndex={ slug === selectedCategory ? undefined : -1 }
+						className="design-picker-category-filter__menu-item"
 					>
 						{ name }
 					</MenuItem>

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -3,7 +3,33 @@
 @import '@automattic/typography/styles/fonts';
 
 .design-picker-category-filter {
-	flex: 1;
+	flex: 0 calc( 307px - 1rem );
+	padding-right: 1rem;
+
+	.design-picker-category-filter__menu-item {
+		padding-left: 0;
+		padding-right: 0;
+		color: #3c434a;
+		display: block;
+		width: auto;
+
+		&:hover:not( :disabled ),
+		&:active:not( :disabled ) {
+			box-shadow: none;
+			background: transparent;
+		}
+
+		&.is-pressed {
+			text-decoration: underline;
+			font-weight: 500; /* stylelint-disable-line scales/font-weights */
+			color: #1d2327;
+			background: transparent;
+		}
+
+		.components-menu-item__item {
+			min-width: auto;
+		}
+	}
 }
 
 .design-picker-category-filter__sidebar {

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -2,6 +2,9 @@
 @import '@automattic/onboarding/styles/variables';
 @import '@automattic/typography/styles/fonts';
 
+$design-picker-category-filter-text-color: #3c434a;
+$design-picker-category-filter-text-color-active: #1d2327;
+
 .design-picker-category-filter {
 	flex: 0 calc( 307px - 1rem );
 	padding-right: 1rem;
@@ -9,7 +12,7 @@
 	.design-picker-category-filter__menu-item {
 		padding-left: 0;
 		padding-right: 0;
-		color: #3c434a;
+		color: $design-picker-category-filter-text-color;
 		display: block;
 		width: auto;
 
@@ -17,13 +20,23 @@
 		&:active:not( :disabled ) {
 			box-shadow: none;
 			background: transparent;
+			text-decoration: underline;
+			color: $design-picker-category-filter-text-color;
 		}
 
 		&.is-pressed {
 			text-decoration: underline;
 			font-weight: 500; /* stylelint-disable-line scales/font-weights */
-			color: #1d2327;
+			color: $design-picker-category-filter-text-color-active;
 			background: transparent;
+
+			&:hover:not( :disabled ) {
+				color: $design-picker-category-filter-text-color-active;
+			}
+
+			&:focus:not( :disabled ) {
+				box-shadow: inset 0 0 0 1px #fff, 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
+			}
 		}
 
 		.components-menu-item__item {

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -3,7 +3,7 @@
 @import '@automattic/typography/styles/fonts';
 
 $design-picker-category-filter-text-color: #3c434a;
-$design-picker-category-filter-text-color-active: #1d2327;
+$design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 
 .design-picker-category-filter {
 	flex: 0 calc( 307px - 1rem );
@@ -21,7 +21,7 @@ $design-picker-category-filter-text-color-active: #1d2327;
 			box-shadow: none;
 			background: transparent;
 			text-decoration: underline;
-			color: $design-picker-category-filter-text-color;
+			color: $design-picker-category-filter-text-color-active;
 		}
 
 		&.is-pressed {

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -34,8 +34,13 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 				color: $design-picker-category-filter-text-color-active;
 			}
 
-			&:focus:not( :disabled ) {
+			&:focus:not( :disabled ),
+			&:focus-visible:not( :disabled ) {
 				box-shadow: inset 0 0 0 1px #fff, 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
+			}
+
+			&:focus:not( :disabled ):not( :focus-visible ) {
+				box-shadow: none;
 			}
 		}
 

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -5,7 +5,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, ReactNode } from 'react';
 import {
 	getAvailableDesigns,
 	getDesignUrl,
@@ -204,6 +204,7 @@ export interface DesignPickerProps {
 	className?: string;
 	highResThumbnails?: boolean;
 	showCategoryFilter?: boolean;
+	categoriesHeading?: ReactNode;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -219,6 +220,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	className,
 	highResThumbnails = false,
 	showCategoryFilter = false,
+	categoriesHeading,
 } ) => {
 	const categories = gatherCategories( designs );
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
@@ -246,6 +248,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					categories={ categories }
 					selectedCategory={ selectedCategory }
 					onSelect={ setSelectedCategory }
+					heading={ categoriesHeading }
 				/>
 			) }
 			<div className={ isGridMinimal ? 'design-picker__grid-minimal' : 'design-picker__grid' }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the category picker from `/new/design` onboarding step. Gutenboarding designs use made up category names, and making styles work in both places was getting tricker.
* Update menu items styles so they use the figma
* Moves the step heading and sub-heading to appear beside the design picker
* Addes extra space to the top of the design picker
* Update copy on the step to match mockups (translations have already been completed in #56812)
* Make the subtitle wrap at the fullstop (we can only predict how this will work in English)
* Keyboard focus for the category selector uses `:focus-visible` so that the focus ring only appears when browser heuristics have determined that the user is doing keyboard navigation.

The category selector is still behind a feature flag. This PR only does desktop styles, mobile styles and dropdown control still to come.

<img width="1456" alt="Screenshot 2021-10-07 at 3 13 23 PM" src="https://user-images.githubusercontent.com/1500769/136309599-fc639bd3-4c77-4831-b2e8-17f97b8c674f.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with `signup/design-picker-categories` flag i.e. `https://container-angry-khayyam.calypso.live/start/setup-site/design-setup-site?flags=signup/design-picker-categories&siteSlug=<< test site slug >>`
* Test on desktop (mobile is in #57591)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56567
