### PR TITLE
ci: Speed up dependencies installation

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -1,5 +1,6 @@
 package _self
 
+import Settings
 import jetbrains.buildServer.configs.kotlin.v2019_2.Template
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
@@ -150,7 +151,7 @@ open class PluginBaseBuild : Template({
 						**This PR modifies the release build for $pluginSlug**
 
 						To test your changes on WordPress.com, run \`install-plugin.sh $pluginSlug %teamcity.build.branch%\` on your sandbox.
-						
+
 						To deploy your changes after merging, see the documentation: %docs_link%
 						EOF
 					fi

--- a/.teamcity/_self/lib/playwright/prepareEnvironment.kt
+++ b/.teamcity/_self/lib/playwright/prepareEnvironment.kt
@@ -19,6 +19,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
  */
 fun BuildSteps.prepareEnvironment(): ScriptBuildStep {
 	return script {
+		name = "Prepare environment"
 		scriptContent = """
 			#!/bin/bash
 			# Update node

--- a/.teamcity/_self/lib/playwright/prepareEnvironment.kt
+++ b/.teamcity/_self/lib/playwright/prepareEnvironment.kt
@@ -1,0 +1,43 @@
+package _self.lib.playwright
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
+
+/**
+ * Prepares the environment to run Playwright tests.
+ *
+ * This will generate a Script step that:
+ *
+ * - Updates node
+ * - Set some env variables
+ * - Installs dependencies for @automattic/calypso-e2e and builds it
+ * - Installs dependencies for wp-e2e-tests
+ *
+ * It uses Yarn focus mode (https://yarnpkg.com/cli/workspaces/focus) to minimize the dependencies
+ * installed and save some time. Yarn may throw some warnings about unused overrides, but they are safe to ignore.
+ */
+fun prepareEnvironment(): ScriptBuildStep {
+	return ScriptBuildStep {
+		scriptContent = """
+			#!/bin/bash
+			# Update node
+			. "${'$'}NVM_DIR/nvm.sh" --no-use
+			nvm install
+			set -o errexit
+			set -o nounset
+			set -o pipefail
+
+			export NODE_ENV="test"
+			export PLAYWRIGHT_BROWSERS_PATH=0
+
+			# Install deps
+			yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
+
+			# Build packages
+			yarn workspace @automattic/calypso-e2e build
+		""".trimIndent()
+		dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+		dockerPull = true
+		dockerImage = "%docker_image_e2e%"
+		dockerRunParameters = "-u %env.UID%"
+	}
+}

--- a/.teamcity/_self/lib/playwright/prepareEnvironment.kt
+++ b/.teamcity/_self/lib/playwright/prepareEnvironment.kt
@@ -1,6 +1,8 @@
 package _self.lib.playwright
 
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 /**
  * Prepares the environment to run Playwright tests.
@@ -15,8 +17,8 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
  * It uses Yarn focus mode (https://yarnpkg.com/cli/workspaces/focus) to minimize the dependencies
  * installed and save some time. Yarn may throw some warnings about unused overrides, but they are safe to ignore.
  */
-fun prepareEnvironment(): ScriptBuildStep {
-	return ScriptBuildStep {
+fun BuildSteps.prepareEnvironment(): ScriptBuildStep {
+	return script {
 		scriptContent = """
 			#!/bin/bash
 			# Update node

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -1,12 +1,17 @@
 package _self.projects
 
+import Settings
 import _self.bashNodeScript
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object DesktopApp : Project({

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -1,6 +1,7 @@
 package _self.projects
 
 import _self.bashNodeScript
+import _self.lib.playwright.prepareEnvironment
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
@@ -253,19 +254,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String ): Bui
 		}
 
 		steps {
-			bashNodeScript {
-				name = "Prepare environment"
-				scriptContent = """
-					export NODE_ENV="test"
-					export PLAYWRIGHT_BROWSERS_PATH=0
-
-					# Install modules
-					${_self.yarn_install_cmd}
-
-					# Build packages
-					yarn workspace @automattic/calypso-e2e build
-				"""
-			}
+			prepareEnvironment()
 			bashNodeScript {
 				name = "Run e2e tests ($targetDevice)"
 				scriptContent = """

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -1,16 +1,17 @@
 package _self.projects
 
+import Settings
 import _self.bashNodeScript
 import _self.lib.playwright.prepareEnvironment
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
-import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.buildReportTab
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.buildReportTab
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 
 object WPComTests : Project({

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -599,7 +599,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export PLAYWRIGHT_BROWSERS_PATH=0
 
 					# Install deps
-					yarn workspaces focus wp-e2e-tests wp-e2e-tests
+					yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
 
 					# Build packages
 					yarn workspace @automattic/calypso-e2e build

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -598,8 +598,8 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_ENV="test"
 					export PLAYWRIGHT_BROWSERS_PATH=0
 
-					# Install modules
-					${_self.yarn_install_cmd}
+					# Install deps
+					yarn workspaces focus wp-e2e-tests wp-e2e-tests
 
 					# Build packages
 					yarn workspace @automattic/calypso-e2e build

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -7,7 +7,11 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -22,6 +22,7 @@
 		"@automattic/calypso-typescript-config": "^1.0.0"
 	},
 	"dependencies": {
+		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-e2e": "^0.1.0",
 		"@automattic/mocha-debug-reporter": "^0.1.0",
 		"@automattic/testarmada-magellan-mocha-plugin": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37642,6 +37642,7 @@ typescript@^4.4.3:
   version: 0.0.0-use.local
   resolution: "wp-e2e-tests@workspace:test/e2e"
   dependencies:
+    "@automattic/calypso-build": ^9.0.0
     "@automattic/calypso-e2e": ^0.1.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@automattic/mocha-debug-reporter": ^0.1.0


### PR DESCRIPTION
#### Background

Playwright e2e builds in TeamCity spend 58 seconds on average in the step "Preparing environment". A huge portion of that time (47s) is just running `yarn install`.

#### Changes proposed in this Pull Request

Enables [Yarn focused mode](https://yarnpkg.com/cli/workspaces/focus) to limit the number of dependencies installed. We only install the dependencies for the workspaces `wp-e2e-tests` (aka `./test/e2e`) and `@automattic/calypso-e2e`. 

This brings down the "Preparing environment" time to 29s (17s for `yarn`).

An unfortunate side effect is that yarn will output a ton of warnings like:

```
@emotion/native ➤ peerDependencies ➤ @emotion/core: No matching package in the dependency tree; you may not need this rule anymore.
```

This is caused by the overrides in `.yarnrc.yaml`. They do apply to other workspaces, but as they are not the workspaces installed, Yarn think they don't.


#### Testing instructions

Check e2e tests still work
