### PR TITLE
Pass the siteId along to the intent screen on the new hero flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -61,21 +61,21 @@ function getSignupDestination( { domainItem, siteId, siteSlug } ) {
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
+	let queryParam = { siteSlug };
+	if ( domainItem ) {
+		// If the user is purchasing a domain then the site's primary url might change from
+		// `siteSlug` to something else during the checkout process, which means the
+		// `/start/setup-site?siteSlug=${ siteSlug }` url would become invalid. So in this
+		// case we use the ID because we know it won't change depending on whether the user
+		// successfully completes the checkout process or not.
+		queryParam = { siteId };
+	}
 
 	if ( isEnabled( 'signup/hero-flow' ) ) {
-		return addQueryArgs( { siteSlug }, '/start/setup-site' ) + '&flags=signup/hero-flow'; // we don't want the flag name to be escaped
+		return addQueryArgs( queryParam, '/start/setup-site' ) + '&flags=signup/hero-flow'; // we don't want the flag name to be escaped
 	}
 
 	if ( isEnabled( 'signup/setup-site-after-checkout' ) ) {
-		let queryParam = { siteSlug };
-		if ( domainItem ) {
-			// If the user is purchasing a domain then the site's primary url might change from
-			// `siteSlug` to something else during the checkout process, which means the
-			// `/start/setup-site?siteSlug=${ siteSlug }` url would become invalid. So in this
-			// case we use the ID because we know it won't change depending on whether the user
-			// successfully completes the checkout process or not.
-			queryParam = { siteId };
-		}
 		return addQueryArgs( queryParam, '/start/setup-site' );
 	}
 


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/56677 we handled the case where a user has purchased a domain and the siteSlug no longer can be used to load the site-setup flow. see https://github.com/Automattic/wp-calypso/pull/56677 for a clearer description.

This applies the same fix to the intent gathering flow.

### Test instructions  

begin the intent gathering (hero) flow from `/start?flags=signup/hero-flow`
select a *.blog domain name
complete the purchase and you will be taken to the intent step with `siteId` set in the query string
This will allow the page to load ( previously we would get a WSOD on the intent page )