### PR TITLE
P2 signup: update destination

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -268,7 +268,7 @@ export function generateFlows( {
 		{
 			name: 'p2',
 			steps: [ 'p2-site', 'p2-details', 'user' ],
-			destination: ( dependencies ) => `https://${ dependencies.siteSlug }?p2-site`,
+			destination: ( dependencies ) => `https://${ dependencies.siteSlug }`,
 			description: 'P2 signup flow',
 			lastModified: '2020-09-01',
 			showRecaptcha: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates signup destination for P2: successful signups should redirect to the workspace (i.e. "hub") and not the initial P2.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the P2 signup process (calypso.localhost:3000/start/p2), and verify that it redirects to the hub at the end of the flow.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3810-gh-Automattic/p2