### PR TITLE
Jetpack Cloud: Turn off Jetpack Cloud realtime only products flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -89,7 +89,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/siteless-checkout": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -40,7 +40,7 @@
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/backups-date-picker": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -36,7 +36,7 @@
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/pricing-page": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -36,7 +36,7 @@
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/backups-date-picker": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -59,7 +59,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/siteless-checkout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -58,7 +58,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/siteless-checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -66,7 +66,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/user-licensing-m1": false,
 		"jetpack/userless-checkout": true,


### PR DESCRIPTION
Revert of the unintended flag changes for realtime only products in https://github.com/Automattic/wp-calypso/pull/56103/commits/89839f379a490c6c067f0450cc0ab45c8056badb

#### Changes proposed in this Pull Request

* Turn off the realtime only products flag

#### Testing instructions
Confirm the products listed on /pricing are not realtime only.

