### PR TITLE
Add IndexedDB persistence for React Query

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -2,10 +2,12 @@ import accessibleFocus from '@automattic/accessible-focus';
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import debugFactory from 'debug';
+import { throttle } from 'lodash';
 import page from 'page';
-import { createElement } from 'react';
 import ReactDom from 'react-dom';
 import Modal from 'react-modal';
+import { QueryClient } from 'react-query';
+import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
 import { ProviderWrappedLayout } from 'calypso/controller';
@@ -39,7 +41,18 @@ import { initConnection as initHappychatConnection } from 'calypso/state/happych
 import wasHappychatRecentlyActive from 'calypso/state/happychat/selectors/was-happychat-recently-active';
 import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { getHappychatAuth } from 'calypso/state/happychat/utils';
-import { getInitialState, persistOnChange, loadAllState } from 'calypso/state/initial-state';
+import {
+	getInitialState,
+	persistOnChange,
+	shouldPersist,
+	MAX_AGE,
+	SERIALIZE_THROTTLE,
+} from 'calypso/state/initial-state';
+import {
+	loadPersistedState,
+	getPersistedStateItem,
+	storePersistedStateItem,
+} from 'calypso/state/persisted-state';
 import { init as pushNotificationsInit } from 'calypso/state/push-notifications/actions';
 import { requestUnseenStatus } from 'calypso/state/reader-ui/seen-posts/actions';
 import initialReducer from 'calypso/state/reducer';
@@ -51,7 +64,7 @@ import { setupLocale } from './locale';
 
 const debug = debugFactory( 'calypso' );
 
-const setupContextMiddleware = ( reduxStore ) => {
+const setupContextMiddleware = ( reduxStore, reactQueryClient ) => {
 	page( '*', ( context, next ) => {
 		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
 		const parsed = getUrlParts( context.canonicalPath );
@@ -75,6 +88,7 @@ const setupContextMiddleware = ( reduxStore ) => {
 		}
 
 		context.store = reduxStore;
+		context.queryClient = reactQueryClient;
 
 		// client version of the isomorphic method for redirecting to another page
 		context.redirect = ( httpCode, newUrl = null ) => {
@@ -102,9 +116,9 @@ const setupContextMiddleware = ( reduxStore ) => {
 	} );
 
 	page.exit( '*', ( context, next ) => {
-		if ( ! context.store ) {
-			context.store = reduxStore;
-		}
+		context.store = reduxStore;
+		context.queryClient = reactQueryClient;
+
 		next();
 	} );
 };
@@ -271,10 +285,10 @@ function setupErrorLogger( reduxStore ) {
 	} );
 }
 
-const setupMiddlewares = ( currentUser, reduxStore ) => {
+const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 	debug( 'Executing Calypso setup middlewares.' );
 
-	setupContextMiddleware( reduxStore );
+	setupContextMiddleware( reduxStore, reactQueryClient );
 	oauthTokenMiddleware();
 	setupRoutes();
 	setRouteMiddleware();
@@ -408,44 +422,63 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	}
 };
 
-function renderLayout( reduxStore ) {
-	const layoutElement = createElement( ProviderWrappedLayout, {
-		store: reduxStore,
-	} );
-
-	ReactDom.render( layoutElement, document.getElementById( 'wpcom' ) );
-
-	debug( 'Main layout rendered.' );
+function renderLayout( reduxStore, reactQueryClient ) {
+	ReactDom.render(
+		<ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } />,
+		document.getElementById( 'wpcom' )
+	);
 }
 
-const boot = ( currentUser, registerRoutes ) => {
+async function createQueryClient( userId ) {
+	const queryClient = new QueryClient();
+	if ( shouldPersist() ) {
+		const storeKey = `query-state-${ userId ?? 'logged-out' }`;
+		const persistor = {
+			persistClient: throttle(
+				( state ) => storePersistedStateItem( storeKey, state ),
+				SERIALIZE_THROTTLE,
+				{ leading: false, trailing: true }
+			),
+			restoreClient: () => getPersistedStateItem( storeKey ),
+			removeClient: () => {}, // not implemented
+		};
+		await persistQueryClient( {
+			queryClient,
+			persistor,
+			maxAge: MAX_AGE,
+		} );
+	}
+	return queryClient;
+}
+
+const boot = async ( currentUser, registerRoutes ) => {
 	saveOauthFlags();
 	utils();
-	loadAllState().then( () => {
-		const initialState = getInitialState( initialReducer, currentUser?.ID );
-		const reduxStore = createReduxStore( initialState, initialReducer );
-		setStore( reduxStore, currentUser?.ID );
-		onDisablePersistence( persistOnChange( reduxStore, currentUser?.ID ) );
-		setupLocale( currentUser, reduxStore );
-		configureReduxStore( currentUser, reduxStore );
-		setupMiddlewares( currentUser, reduxStore );
-		detectHistoryNavigation.start();
-		if ( registerRoutes ) {
-			registerRoutes();
-		}
+	await loadPersistedState();
+	const queryClient = await createQueryClient( currentUser?.ID );
+	const initialState = getInitialState( initialReducer, currentUser?.ID );
+	const reduxStore = createReduxStore( initialState, initialReducer );
+	setStore( reduxStore, currentUser?.ID );
+	onDisablePersistence( persistOnChange( reduxStore, currentUser?.ID ) );
+	setupLocale( currentUser, reduxStore );
+	configureReduxStore( currentUser, reduxStore );
+	setupMiddlewares( currentUser, reduxStore, queryClient );
+	detectHistoryNavigation.start();
+	if ( registerRoutes ) {
+		registerRoutes();
+	}
 
-		// Render initial `<Layout>` for non-isomorphic sections.
-		// Isomorphic sections will take care of rendering their `<Layout>` themselves.
-		if ( ! document.getElementById( 'primary' ) ) {
-			renderLayout( reduxStore );
-		}
+	// Render initial `<Layout>` for non-isomorphic sections.
+	// Isomorphic sections will take care of rendering their `<Layout>` themselves.
+	if ( ! document.getElementById( 'primary' ) ) {
+		renderLayout( reduxStore, queryClient );
+	}
 
-		page.start( { decodeURLComponents: false } );
-	} );
+	page.start( { decodeURLComponents: false } );
 };
 
 export const bootApp = async ( appName, registerRoutes ) => {
 	const user = await initializeCurrentUser();
 	debug( `Starting ${ appName }. Let's do this.` );
-	boot( user, registerRoutes );
+	await boot( user, registerRoutes );
 };

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import EmptyContent from 'calypso/components/empty-content';
@@ -26,10 +26,9 @@ import { render, hydrate } from './web-util.js';
 export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
 export { render, hydrate } from './web-util.js';
 
-const queryClient = new QueryClient();
-
 export const ProviderWrappedLayout = ( {
 	store,
+	queryClient,
 	currentSection,
 	currentRoute,
 	currentQuery,

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -8,13 +8,14 @@ const noop = () => {};
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
-		const { store, section, pathname, query, primary, secondary } = context;
+		const { store, queryClient, section, pathname, query, primary, secondary } = context;
 
 		// On server, only render LoggedOutLayout when logged-out.
 		if ( ! ( context.isServerSide && isUserLoggedIn( context.store.getState() ) ) ) {
 			context.layout = (
 				<LayoutComponent
 					store={ store }
+					queryClient={ queryClient }
 					currentSection={ section }
 					currentRoute={ pathname }
 					currentQuery={ query }

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -4,6 +4,7 @@
 import 'calypso/boot/polyfills';
 
 import page from 'page';
+import { QueryClient } from 'react-query';
 import { setupLocale } from 'calypso/boot/locale';
 import { render } from 'calypso/controller/web-util';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
@@ -22,14 +23,17 @@ const boot = ( currentUser ) => {
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
 	setupLocale( currentUser, store );
+	const queryClient = new QueryClient();
 
 	page( '*', ( context, next ) => {
 		context.store = store;
+		context.queryClient = queryClient;
 		next();
 	} );
 
 	page.exit( '*', ( context, next ) => {
 		context.store = store;
+		context.queryClient = queryClient;
 		next();
 	} );
 

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -4,7 +4,6 @@
 import 'calypso/boot/polyfills';
 
 import page from 'page';
-import { QueryClient } from 'react-query';
 import { setupLocale } from 'calypso/boot/locale';
 import { render } from 'calypso/controller/web-util';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
@@ -23,17 +22,14 @@ const boot = ( currentUser ) => {
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
 	setupLocale( currentUser, store );
-	const queryClient = new QueryClient();
 
 	page( '*', ( context, next ) => {
 		context.store = store;
-		context.queryClient = queryClient;
 		next();
 	} );
 
 	page.exit( '*', ( context, next ) => {
 		context.store = store;
-		context.queryClient = queryClient;
 		next();
 	} );
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -140,7 +140,7 @@ export function persistOnChange( reduxStore, currentUserId ) {
 // Retrieve the initial state for the application, combining it from server and
 // local persistence (server data gets priority).
 // This function only handles legacy Redux state for the monolithic root reducer
-// `loadAllState` must have completed first.
+// `loadPersistedState` must have completed first.
 export function getInitialState( initialReducer, currentUserId ) {
 	const storedState = getInitialPersistedState( initialReducer, currentUserId );
 	const serverState = getInitialServerState( initialReducer );
@@ -160,7 +160,7 @@ function getInitialServerState( initialReducer ) {
 
 // Retrieve the initial persisted state from the cached local client data.
 // This function only handles legacy Redux state for the monolithic root reducer
-// `loadAllState` must have completed first.
+// `loadPersistedState` must have completed first.
 function getInitialPersistedState( initialReducer, currentUserId ) {
 	if ( ! shouldPersist() ) {
 		return null;
@@ -205,7 +205,7 @@ function getInitialPersistedState( initialReducer, currentUserId ) {
 
 // Retrieve the initial state for a portion of state, from persisted data alone.
 // This function handles both legacy and modularized Redux state.
-// `loadAllState` must have completed first.
+// `loadPersistedState` must have completed first.
 function getStateFromPersistence( reducer, subkey, currentUserId ) {
 	const reduxStateKey = getPersistenceKey( currentUserId, subkey );
 	const state = getPersistedStateItem( reduxStateKey );
@@ -215,7 +215,7 @@ function getStateFromPersistence( reducer, subkey, currentUserId ) {
 // Retrieve the initial state for a portion of state, choosing the freshest
 // between server and local persisted data.
 // This function handles both legacy and modularized Redux state.
-// `loadAllState` must have completed first.
+// `loadPersistedState` must have completed first.
 export function getStateFromCache( reducer, subkey, currentUserId ) {
 	let serverState = null;
 

--- a/client/state/persisted-state.js
+++ b/client/state/persisted-state.js
@@ -1,0 +1,37 @@
+import debugModule from 'debug';
+import { getAllStoredItems, setStoredItem, clearStorage } from 'calypso/lib/browser-storage';
+
+const debug = debugModule( 'calypso:state' );
+
+/**
+ * In-memory copy of persisted state.
+ *
+ * We load from browser storage into this cache on boot, and initialize state
+ * from it, rather than asynchronously reading from browser storage for every
+ * persisted reducer.
+ */
+let stateCache = {};
+
+export async function loadPersistedState() {
+	try {
+		const storedState = await getAllStoredItems( /^(redux-state|query-state)-/ );
+		debug( 'fetched persisted state from storage', storedState );
+		stateCache = storedState ?? {};
+	} catch ( error ) {
+		debug( 'error while loading persisted state:', error );
+	}
+}
+
+export async function clearPersistedState() {
+	stateCache = {};
+	await clearStorage();
+}
+
+export function getPersistedStateItem( key ) {
+	return stateCache[ key ] ?? null;
+}
+
+export async function storePersistedStateItem( key, state ) {
+	await setStoredItem( key, state );
+	stateCache[ key ] = state;
+}

--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -5,7 +5,10 @@ import { shouldPersist, MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/initia
 import { getPersistedStateItem, storePersistedStateItem } from 'calypso/state/persisted-state';
 
 export async function createQueryClient( userId: number | undefined ): Promise< QueryClient > {
-	const queryClient = new QueryClient();
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { cacheTime: MAX_AGE } },
+	} );
+
 	if ( shouldPersist() ) {
 		const storeKey = `query-state-${ userId ?? 'logged-out' }`;
 		const persistor = {

--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -1,0 +1,29 @@
+import { throttle } from 'lodash';
+import { QueryClient } from 'react-query';
+import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
+import { shouldPersist, MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/initial-state';
+import { getPersistedStateItem, storePersistedStateItem } from 'calypso/state/persisted-state';
+
+export async function createQueryClient( userId: number | undefined ): Promise< QueryClient > {
+	const queryClient = new QueryClient();
+	if ( shouldPersist() ) {
+		const storeKey = `query-state-${ userId ?? 'logged-out' }`;
+		const persistor = {
+			persistClient: throttle(
+				( state ) => storePersistedStateItem( storeKey, state ),
+				SERIALIZE_THROTTLE,
+				{ leading: false, trailing: true }
+			),
+			restoreClient: () => getPersistedStateItem( storeKey ),
+			removeClient: () => {
+				// not implemented
+			},
+		};
+		await persistQueryClient( {
+			queryClient,
+			persistor,
+			maxAge: MAX_AGE,
+		} );
+	}
+	return queryClient;
+}

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -14,10 +14,10 @@ import {
 	getInitialState,
 	getStateFromCache,
 	persistOnChange,
-	loadAllState,
 	MAX_AGE,
 	SERIALIZE_THROTTLE,
 } from 'calypso/state/initial-state';
+import { loadPersistedState } from 'calypso/state/persisted-state';
 import postTypes from 'calypso/state/post-types/reducer';
 import reader from 'calypso/state/reader/reducer';
 import signupReducer from 'calypso/state/signup/reducer';
@@ -64,7 +64,7 @@ describe( 'initial-state', () => {
 						getStoredItemSpy = jest
 							.spyOn( browserStorage, 'getAllStoredItems' )
 							.mockResolvedValue( savedState );
-						await loadAllState();
+						await loadPersistedState();
 						state = getInitialState( initialReducer, 123456789 );
 					} );
 
@@ -129,7 +129,7 @@ describe( 'initial-state', () => {
 					getStoredItemSpy = jest
 						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					await loadAllState();
+					await loadPersistedState();
 					state = getInitialState( initialReducer, 123456789 );
 				} );
 
@@ -192,7 +192,7 @@ describe( 'initial-state', () => {
 					getStoredItemSpy = jest
 						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					await loadAllState();
+					await loadPersistedState();
 					state = getInitialState( initialReducer, 123456789 );
 				} );
 
@@ -247,7 +247,7 @@ describe( 'initial-state', () => {
 					getStoredItemSpy = jest
 						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					await loadAllState();
+					await loadPersistedState();
 					state = getInitialState( initialReducer, 123456789 );
 				} );
 
@@ -305,7 +305,7 @@ describe( 'initial-state', () => {
 					getStoredItemSpy = jest
 						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					await loadAllState();
+					await loadPersistedState();
 					state = getInitialState( initialReducer, 123456789 );
 				} );
 
@@ -351,7 +351,7 @@ describe( 'initial-state', () => {
 				getStoredItemSpy = jest
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
-				await loadAllState();
+				await loadPersistedState();
 				state = getStateFromCache( reader, 'reader', 123456789 );
 			} );
 
@@ -393,7 +393,7 @@ describe( 'initial-state', () => {
 				getStoredItemSpy = jest
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
-				await loadAllState();
+				await loadPersistedState();
 				state = getStateFromCache( reader, 'reader' );
 			} );
 
@@ -443,7 +443,7 @@ describe( 'initial-state', () => {
 				getStoredItemSpy = jest
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
-				await loadAllState();
+				await loadPersistedState();
 				state = getStateFromCache( reader, 'reader', 123456789 );
 			} );
 
@@ -493,7 +493,7 @@ describe( 'initial-state', () => {
 				getStoredItemSpy = jest
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
-				await loadAllState();
+				await loadPersistedState();
 				state = getStateFromCache( reader, 'reader', 123456789 );
 			} );
 
@@ -546,7 +546,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( storedState );
 
-				await loadAllState();
+				await loadPersistedState();
 				state = getStateFromCache( signupReducer, 'signup' );
 			} );
 
@@ -615,7 +615,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( storedState );
 
-				await loadAllState();
+				await loadPersistedState();
 				state = getStateFromCache( signupReducer, 'signup', 123456789 );
 			} );
 
@@ -858,7 +858,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		await loadAllState();
+		await loadPersistedState();
 		const state = getInitialState( reducer, 123456789 );
 		const store = createReduxStore( state, reducer );
 
@@ -885,7 +885,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		await loadAllState();
+		await loadPersistedState();
 		const userId = 123456789;
 		const state = getInitialState( reducer, userId );
 		const store = createReduxStore( state, reducer );
@@ -920,7 +920,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		await loadAllState();
+		await loadPersistedState();
 		const userId = 123456789;
 		const state = getInitialState( reducer, userId );
 		const store = createReduxStore( state, reducer );
@@ -957,7 +957,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		await loadAllState();
+		await loadPersistedState();
 		const userId = 123456789;
 		const state = getInitialState( reducer, userId );
 		const store = createReduxStore( state, reducer );
@@ -993,7 +993,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		await loadAllState();
+		await loadPersistedState();
 		const userId = 123456789;
 		const state = getInitialState( reducer, userId );
 		const store = createReduxStore( state, reducer );


### PR DESCRIPTION
Adds IndexedDB persistence to React Query, using their [experimental `persistQueryClient` plugin](https://github.com/tannerlinsley/react-query/blob/master/docs/src/pages/plugins/persistQueryClient.md).

What I had to do is:
- move creation of the `QueryClient` object to the boot code, the same place where the Redux store is created. The reason is that after creating the client, we need to `await` the persistence initialization, and the boot code is the best place for that.
- put the `queryClient` into the page.js `context.queryClient` attribute and the inject it into React layouts from there
- extract the code that loads state from IndexedDB and stores it in a memory object to a separate module, `client/state/persisted-state`, because it's now used outside Redux, too.

Generally, the lifecycle of the Redux store and the React Query client should now be exactly the same. Where they are created, initialized by persisted state, passed in page.js and React context... They always travel together.

**How to test:**
Go to a route that uses React Query, e.g., `/people/team`, and verify that a `query-state-XXX` key has been stored to IndexedDB, containing React Query Cache data. It's there alongside with all the existing `redux-state-XXX:YYY` keys for modular Redux reducers.