### PR TITLE
Payment methods: add tracks props for state of the "use for my other subs" checkbox

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -51,9 +51,18 @@ export async function assignNewCardProcessor(
 		cardNumberElement: StripeCardNumberElement | undefined;
 		reduxDispatch: ReturnType< typeof useDispatch >;
 	},
-	submitData: unknown
+	submitData: {
+		name?: string;
+		countryCode?: string;
+		postalCode?: string;
+		useForAllSubscriptions?: boolean;
+	}
 ): Promise< PaymentProcessorResponse > {
-	recordFormSubmitEvent( { reduxDispatch, purchase } );
+	recordFormSubmitEvent( {
+		reduxDispatch,
+		purchase,
+		useForAllSubscriptions: submitData.useForAllSubscriptions,
+	} );
 
 	try {
 		if ( ! isNewCardDataValid( submitData ) ) {
@@ -201,15 +210,20 @@ export async function assignPayPalProcessor(
 function recordFormSubmitEvent( {
 	reduxDispatch,
 	purchase,
+	useForAllSubscriptions,
 }: {
 	reduxDispatch: ReturnType< typeof useDispatch >;
 	purchase?: Purchase | undefined;
+	useForAllSubscriptions?: boolean;
 } ) {
 	reduxDispatch(
 		purchase?.productSlug
 			? recordTracksEvent( 'calypso_purchases_credit_card_form_submit', {
 					product_slug: purchase.productSlug,
+					use_for_all_subs: String( useForAllSubscriptions ),
 			  } )
-			: recordTracksEvent( 'calypso_add_credit_card_form_submit' )
+			: recordTracksEvent( 'calypso_add_credit_card_form_submit', {
+					use_for_all_subs: String( useForAllSubscriptions ),
+			  } )
 	);
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -51,19 +51,8 @@ export async function assignNewCardProcessor(
 		cardNumberElement: StripeCardNumberElement | undefined;
 		reduxDispatch: ReturnType< typeof useDispatch >;
 	},
-	submitData: {
-		name?: string;
-		countryCode?: string;
-		postalCode?: string;
-		useForAllSubscriptions?: boolean;
-	}
+	submitData: unknown
 ): Promise< PaymentProcessorResponse > {
-	recordFormSubmitEvent( {
-		reduxDispatch,
-		purchase,
-		useForAllSubscriptions: submitData.useForAllSubscriptions,
-	} );
-
 	try {
 		if ( ! isNewCardDataValid( submitData ) ) {
 			throw new Error( 'Credit Card data is missing name, country, or postal code' );
@@ -76,6 +65,12 @@ export async function assignNewCardProcessor(
 		}
 
 		const { name, countryCode, postalCode, useForAllSubscriptions } = submitData;
+
+		recordFormSubmitEvent( {
+			reduxDispatch,
+			purchase,
+			useForAllSubscriptions,
+		} );
 
 		const formFieldValues = {
 			country: countryCode,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -43,7 +43,7 @@ export default function CreditCardPayButton( {
 				if ( isCreditCardFormValid( store, paymentPartner, __ ) ) {
 					if ( paymentPartner === 'stripe' ) {
 						debug( 'submitting stripe payment' );
-						onEvent( { type: 'STRIPE_TRANSACTION_BEGIN' } );
+						onEvent( { type: 'STRIPE_TRANSACTION_BEGIN', payload: { useForAllSubscriptions } } );
 						onClick( 'card', {
 							stripe,
 							name: cardholderName?.value,

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -182,12 +182,14 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_form_submit', {
 							credits: null,
 							payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+							use_for_all_subs: action.payload?.useForAllSubscriptions,
 						} )
 					);
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 							credits: null,
 							payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+							use_for_all_subs: action.payload?.useForAllSubscriptions,
 						} )
 					);
 					return reduxDispatch(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds props to tracks events indicating the status of the "Use this card on my other subs" checkbox added in #56736 for both the add/update payment method and checkout screens.

#### Testing instructions

1. Make a purchase with credits (this is so we can "add" a payment method as well as "update")
2. On the subscription level add card page (Upgrades nav > Purchases item > Active Upgrades tab > choose subscription > Add Payment Method) choose "Credit or debit card", fill out the form, and note the state of the checkbox before submitting.

<img width="733" alt="Screen Shot 2021-10-06 at 1 47 23 PM" src="https://user-images.githubusercontent.com/9310939/136264625-3802333a-9553-4712-b6fc-8e5dde3aaab2.png">

3. Check the tracks page for your test user and wait for the `calypso_purchases_credit_card_form_submit` event. Make sure it has a prop called `use_for_all_subs` with the correct value.

<img width="436" alt="Screen Shot 2021-10-06 at 1 22 56 PM" src="https://user-images.githubusercontent.com/9310939/136263528-8203bd77-0237-465c-bd31-83bd47d6514d.png">

4. Next, navigate to the site level add card page (Upgrades > Purchases > Payment Methods tab > Add Payment Method button). Again fill out the form and note the state of the checkbox before submitting.
5. Check the tracks page for your test user and wait for the `calypso_add_credit_card_form_submit` event. Make sure it has a prop called `use_for_all_subs` with the correct value.

<img width="408" alt="Screen Shot 2021-10-06 at 1 43 50 PM" src="https://user-images.githubusercontent.com/9310939/136264007-ca16b7a3-e61e-4e45-9876-b8489833ea76.png">

6. Go back to the subscription level management screen, which now gives the option to change the primary payment method. (Upgrades nav > Purchases item > Active Upgrades tab > choose subscription > Change Payment Method.) Choose "Credit or debit card", fill out the form, and note the state of the checkbox before submitting.
7. Again check the tracks page for your test user and wait for the `calypso_purchases_credit_card_form_submit` event; make sure it has a prop called `use_for_all_subs` with the correct value.

<img width="424" alt="Screen Shot 2021-10-06 at 1 54 55 PM" src="https://user-images.githubusercontent.com/9310939/136265580-26959e19-5c5f-4419-807d-c8560ffa6f94.png">

8. Almost done! Now go to the account level management screen (/me > Purchases > Payment Methods > Add Payment Method) and do the thing again.
9. Check the tracks page, wait for the `calypso_add_credit_card_form_submit` event, make sure it has the `use_for_all_subs` prop as expected.

<img width="388" alt="Screen Shot 2021-10-06 at 2 02 52 PM" src="https://user-images.githubusercontent.com/9310939/136266655-3360ab7f-98ba-4b30-a007-88690f7f9974.png">

10. Finally- test checkout. Remove any residual credits on your test user account to make sure the credit card payment method is available. Renew the subscription, choose to pay with a new card, and note the state of the checkbox before submitting.
11. Check the tracks page and wait for the `calypso_checkout_composite_form_submit` and `calypso_checkout_form_submit` events; make sure they have the `use_for_all_subs` prop as expected.

<img width="513" alt="Screen Shot 2021-10-06 at 2 31 23 PM" src="https://user-images.githubusercontent.com/9310939/136271255-8ad8057b-50b8-4bc6-ab79-d61556cf3746.png">

(We have two events here for legacy reasons.)

<img width="504" alt="Screen Shot 2021-10-06 at 2 32 37 PM" src="https://user-images.githubusercontent.com/9310939/136271278-3620af22-672d-4cb4-848a-6ff273744b5e.png">

Depends on #56736
