### PR TITLE
Update connected, but not transferrable domain error message

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -31,7 +31,11 @@ export function getAvailabilityErrorMessage( { availabilityData, domainName, sel
 		return null;
 	}
 
-	const availabilityStatus = domainAvailability.MAPPABLE === mappable ? status : mappable;
+	const availabilityStatus = [ domainAvailability.MAPPABLE, domainAvailability.MAPPED ].includes(
+		mappable
+	)
+		? status
+		: mappable;
 	const maintenanceEndTime = maintenance_end_time ?? null;
 	const site = other_site_domain ?? selectedSite.slug;
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -7,6 +7,7 @@ import { domainAvailability } from 'calypso/lib/domains/constants';
 import {
 	CALYPSO_CONTACT,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
+	INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS,
 	MAP_EXISTING_DOMAIN,
 } from 'calypso/lib/url/support';
 import {
@@ -114,12 +115,16 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			);
 			break;
 		case domainAvailability.MAPPED_SAME_SITE_NOT_TRANSFERRABLE:
-			message = translate( '{{strong}}%(domain)s{{/strong}} is already connected to this site.', {
-				args: { domain },
-				components: {
-					strong: <strong />,
-				},
-			} );
+			message = translate(
+				'{{strong}}%(domain)s{{/strong}} is already connected to this site and cannot be transferred to WordPress.com. {{a}}Learn more{{/a}}.',
+				{
+					args: { domain },
+					components: {
+						strong: <strong />,
+						a: <a rel="noopener noreferrer" href={ INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS } />,
+					},
+				}
+			);
 			break;
 		case domainAvailability.MAPPED_OTHER_SITE_SAME_USER:
 			message = translate(

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -39,6 +39,7 @@ export const INCOMING_DOMAIN_TRANSFER = `${ root }/incoming-domain-transfer/`;
 export const INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#unlock`;
 export const INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#auth-code`;
 export const INCOMING_DOMAIN_TRANSFER_AUTH_CODE_INVALID = `${ root }/incoming-domain-transfer/#auth-code-invalid`;
+export const INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS = `${ root }/incoming-domain-transfer/#which-tl-ds-extensions-can-i-transfer-to-word-press-com`;
 export const EDIT_PAYMENT_DETAILS = `${ root }/payment/#edit-payment-details`;
 export const EMAIL_FORWARDING = `${ root }/email-forwarding`;
 export const EMAIL_VALIDATION_AND_VERIFICATION = `${ root }/domains/register-domain/#email-validation-and-verification`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a domain is already connected (mapped) to a site but is not transferrable, we don't show the part of the error message indicating that this domain isn't transferrable (due to the fact that we used to have separate flows for mapping and transfers).

This PR provides more information to help users understand that the domain they are inquiring about is already mapped and isn't transferrable.

#### Testing instructions

Either find a site with a connected domain that isn't transferrable (ex. with a .ca TLD) or hack the `is-available` endpoint to return something like the following:

```
{
    domain_name:"example.com",
    status:"mapped_to_same_site_not_transferrable",
    mappable:"mapped_domain",
    supports_privacy:false,
}
```

Make sure that you see an error message similar to the following:

<img width="1092" alt="Screen Shot 2021-10-06 at 3 09 47 PM" src="https://user-images.githubusercontent.com/1379730/136270562-9ffb07d2-22f8-4c23-9389-f28391f17e6e.png">

