### PR TITLE
clear cookie when restarting '/start' flow in the same tab

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -152,7 +152,9 @@ class Signup extends Component {
 
 	UNSAFE_componentWillMount() {
 		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
-		const queryObject = ( this.props.initialContext && this.props.initialContext.query ) || {};
+		const initialContext = this.props.initialContext || {};
+		const queryObject = initialContext.query || {};
+		const initialPath = initialContext.pathname;
 
 		let providedDependencies;
 
@@ -161,7 +163,7 @@ class Signup extends Component {
 		}
 
 		const searchParams = new URLSearchParams( window.location.search );
-		const isAddNewSiteFlow = searchParams.has( 'ref' );
+		const isAddNewSiteFlow = searchParams.has( 'ref' ) || initialPath === '/start';
 
 		if ( isAddNewSiteFlow ) {
 			clearSignupDestinationCookie();


### PR DESCRIPTION
Some work was previously done to avoid duplicate sites being created when using the browser back button
https://github.com/Automattic/wp-calypso/pull/45040

The work uses session storage to remember which flow a user was on and which site they were purchasing, as well as the `wpcom_signup_complete_destination` which is set on the checkout page in order for post-checkout upsells to redirect to the correct place.

It fixed the browser back button issue, however there is a case where this breaks down (when testing one flow, and then another) that leads to the user getting stuck on the `/start` page. It came up for me quite a few times when testing a new flow, I think we should fix this even if it's likely to mostly only affect a12s at this point. 

#### Testing instructions
start with any flow that's different from the default. I tested by enabling the new blogger onboarding hero flow. 
`/start?flags=signup/hero-flow`
Select a paid or free domain and select any paid plan so that you're taken to the checkout screen. This will set the
`wpcom_signup_complete_destination` cookie.  Notice that values are also set in session storage 
`domain_step_query`, `wpcom_signup_complete_site_slug`, `wpcom_signup_complete_flow_name`.
Confirm the checkout. you should see an upsel depending on which plan you selected

in the browser url bar, navigate to the `/start` flow. Select a new domain.


<br class="Apple-interchange-newline">

#### Expected
I would expect that the flow would start over, either emptying what is in the card or maintaining it

#### Actual
on wordpress.com, I am stuck on a loading page, refreshing the page does not fix it. I'm just returned to this page unless I clear session storage.
<img width="946" alt="Screen Shot 2021-10-07 at 7 22 51 am" src="https://user-images.githubusercontent.com/22446385/136285320-76ef7275-5825-4b2c-8be3-f134fdcb8920.png">
when testing this against my local build I see a WSOD and the following error
<img width="1022" alt="Screen Shot 2021-10-07 at 7 26 03 am" src="https://user-images.githubusercontent.com/22446385/136285585-f31ce1cd-e005-4d17-bb64-bb7ad90e9995.png">


After applying this fix, this issue should be fixed, we should also be careful that this hasn't broken the behaviour around using browser back from the checkout page https://github.com/Automattic/wp-calypso/pull/45040
