### PR TITLE
Accounts: Remove redirect in AccountSettingsClosedComponent render

### DIFF
--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
@@ -15,11 +14,7 @@ class AccountSettingsClosedComponent extends Component {
 	};
 
 	render() {
-		const { isUserAccountClosed, previousRoute, translate } = this.props;
-
-		if ( previousRoute !== '/me/account/close' ) {
-			page( '/me/account/close' );
-		}
+		const { isUserAccountClosed, translate } = this.props;
 
 		if ( ! isUserAccountClosed ) {
 			return (


### PR DESCRIPTION
#### Background

When closing a WordPress.com account, there's several stages of confirmation required. Once the final confirmation is complete, the confirmation dialog component (at `/me/account/close`) redirects the user to a "Your account is being deleted" page (at `/me/account/closed`) which eventually will display a notice that "Your account has been closed" and provide a call-to-action button to return to the home page.

The "Your account is being deleted" page has [a special condition](https://github.com/Automattic/wp-calypso/blob/f243ee759ce1add7d8b07bf5d0f35e83b0d3b559/client/me/account-close/closed.jsx#L20-L22) which is rarely triggered: if the previous page's route is not the "Close account" page, it will redirect the user to that page instead. I assume that the reason behind this logic is that there's no use in seeing the "Your account is being deleted" page if your account is not actually being deleted, and that it would be pretty easy to accidentally mis-type `closed` instead of `close` if you were visiting the close page manually.

There's a problem with this feature, though, which can cause an expected bug. First of all, the condition and its redirect occurs during the `render` method of the component, which is not a good idea because the redirect is a side effect. The result can be undefined behavior depending on things like the current way that React is rendering components and the way that the router interacts with them. At the very least, it's a race condition that's likely to show a console error. Secondly, there are cases where calypso's ability to determine the previous route will not operate. I'm not exactly sure how that works but it's easy to reproduce: after passing through signup to create an account without reloading the page, the previous route appears to always be wrong.

As a result, if the previous route is incorrect and the redirect occurs, either rendering will break, or the user will remain on the "Close account" page (they'll be routed to the "Your account is being deleted" page but it will send them right back and calypso will be smart enough to make that appear seamless so there's no apparent change to the page except for the dialog vanishing). Then, once account deletion is finished, the parent page [will redirect the user to log out](https://github.com/Automattic/wp-calypso/blob/f5ea5f3382ad3a98487bc5fd10104560ace041c0/client/me/account-close/main.jsx#L41), sending them directly to the WordPress.com homepage with no success message or explanation.

#### Changes proposed in this Pull Request

This PR removes the previous route guard in the "Your account is being deleted" page. This fixes the unexpected behavior described above and makes sure that you can always get a success page after deleting an account.

Now it will be possible to view that page even if the account is not being deleted, but the user in that case will just see a never-ending spinner. That's not ideal UX but it's better than breaking the page entirely. A future PR might be able to re-enable that redirect, but perhaps in such a way that doesn't rely on the Redux previous path data, or perhaps the previous path data can be made more robust.

Fixes https://github.com/Automattic/wp-calypso/issues/56841

Bug introduced originally in https://github.com/Automattic/wp-calypso/pull/37688 but it was probably hidden for years because there were page reloads happening somewhere (or perhaps the previous route used to work more reliably in all situations and something changed so that this is no longer the case).

<img width="1359" alt="close-account-page" src="https://user-images.githubusercontent.com/2036909/136298066-b49d0612-447e-4414-b135-6345592dd202.png">

<img width="1035" alt="close-account-modal" src="https://user-images.githubusercontent.com/2036909/136298082-c5b1c02e-920c-409b-ae06-5d380f94d620.png">

<img width="1380" alt="close-account-spinner" src="https://user-images.githubusercontent.com/2036909/136298092-2d9a7507-6d7a-43a1-8060-92b0e12bd0b9.png">

#### Testing instructions


It's essential that during each of these steps, the page is never reloaded, including use of the back button, or any "real" (non-SPA) links.

1. Start at `/start/domain` when logged-out.
2. Search for and select a paid domain.
3. Select `Just buy a domain` on the following screen.
4. Fill in the new account info form. You must not use an a8c email address because those block the signup flow until confirmation which will cause a reload.
5. Complete checkout (using a test card while sandboxed is fine). You must not use a redirect payment method because this will cause a reload.
6. After checkout, click "My sites" in the masterbar to reach the account section without causing a reload.
7. Click the Manage button and click through to cancel and refund the domain.
8. Click "Account Settings" in the account sidebar.
9. Click "Close your account permanently" at the bottom of the page.
10. Click through the confirmation steps to cancel your account.
11. Verify that after the final confirmation step you see a spinner that reads "Your account is being deleted" followed by "Your account has been closed".
