### PR TITLE
Fix: Mobile web sign up flow - domain step

### DIFF
--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -92,6 +92,12 @@
 	}
 }
 
+.step-wrapper.has-navigation .step-wrapper__content {
+	@include breakpoint-deprecated( '<660px' ) {
+		margin-bottom: 60px;
+	}
+}
+
 .step-wrapper__header-image {
 	margin-top: 24px;
 	display: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fix the stepper so that the bottom part of content is not cut off by navigation. 

#### Testing instructions
* Using a mobile device. (or Responsive design mode in developer tools)
* Create an account and on step 2 ( Domain picking step) - notice that the content is not hidden under the Back navigation. 
* but instead you are able to see the bottom-most link (Use a domain I own) 
See screenshots. 

Before:
<img width="200" src="https://user-images.githubusercontent.com/115071/136298777-ecb94094-a78c-4944-ab4a-4ffaef2fd6e3.png" />

After:
<img width="200" src="https://user-images.githubusercontent.com/115071/136298772-851f2d94-fadf-4361-ae11-23cec019f20b.png" />

Fixes https://github.com/Automattic/wp-calypso/issues/56851
