### PR TITLE
Remove design_picker_after_onboarding experiment assignment

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -406,14 +406,6 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
-			name: 'with-design-picker',
-			steps: [ 'user', 'domains', 'plans', 'design' ],
-			destination: getSignupDestination,
-			description: 'Default onboarding experience with design picker as the last step',
-			lastModified: '2021-03-29',
-			showRecaptcha: true,
-		},
-		{
 			name: 'setup-site',
 			steps: isEnabled( 'signup/hero-flow' )
 				? [ 'intent', 'design-setup-site' ]

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -71,7 +71,6 @@ const stepNameToModuleName = {
 	'plans-ecommerce-monthly': 'plans',
 	'plans-personal-monthly': 'plans',
 	'plans-premium-monthly': 'plans',
-	design: 'design-picker',
 	'design-setup-site': 'design-picker',
 	'site-info-collection': 'site-info-collection',
 	intent: 'intent',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -707,13 +707,6 @@ export function generateSteps( {
 			},
 		},
 
-		design: {
-			stepName: 'design-picker',
-			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'selectedDesign' ],
-			optionalDependencies: [ 'selectedDesign' ],
-		},
-
 		intent: {
 			stepName: 'intent',
 			dependencies: [ 'siteSlug' ],

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -716,10 +716,6 @@ export function generateSteps( {
 
 		'design-setup-site': {
 			stepName: 'design-setup-site',
-			props: {
-				largeThumbnails: true,
-				showOnlyThemes: true,
-			},
 			apiRequestFunction: setDesignOnSite,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'selectedDesign' ],

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import debugModule from 'debug';
 import { isEmpty } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';
@@ -38,8 +37,6 @@ import {
 	shouldForceLogin,
 	isReskinnedFlow,
 } from './utils';
-
-const debug = debugModule( 'calypso:signup' );
 
 /**
  * Constants
@@ -295,19 +292,6 @@ export default {
 			context.store.dispatch( setSelectedSiteId( null ) );
 		}
 
-		let actualFlowName = flowName;
-		if ( flowName === 'onboarding' || flowName === 'with-design-picker' ) {
-			const experimentAssignment = await loadExperimentAssignment(
-				'design_picker_after_onboarding'
-			);
-			debug(
-				`design_picker_after_onboarding experiment variation: ${ experimentAssignment?.variationName }`
-			);
-			if ( 'treatment' === experimentAssignment?.variationName ) {
-				actualFlowName = 'with-design-picker';
-			}
-		}
-
 		// ExPlat: Temporarily testing out the effects of prefetching experiments. Delete after 2021 week 31.
 		loadExperimentAssignment( 'explat_test_aa_weekly_calypso_2021_week_31' );
 
@@ -316,13 +300,13 @@ export default {
 			path: context.path,
 			initialContext,
 			locale: context.params.lang,
-			flowName: actualFlowName,
+			flowName,
 			queryObject: query,
 			refParameter: query && query.ref,
 			stepName,
 			stepSectionName,
 			stepComponent,
-			pageTitle: getFlowPageTitle( actualFlowName, userLoggedIn ),
+			pageTitle: getFlowPageTitle( flowName, userLoggedIn ),
 		} );
 
 		next();

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,6 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker from '@automattic/design-picker';
-import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -28,22 +27,16 @@ class DesignPickerStep extends Component {
 		stepName: PropTypes.string.isRequired,
 		locale: PropTypes.string.isRequired,
 		translate: PropTypes.func,
-		largeThumbnails: PropTypes.bool,
-		showOnlyThemes: PropTypes.bool,
 		fetchRecommendedThemes: PropTypes.func.isRequired,
 		themes: PropTypes.array.isRequired,
 	};
 
 	static defaultProps = {
 		useHeadstart: true,
-		largeThumbnails: false,
-		showOnlyThemes: false,
 	};
 
 	componentDidMount() {
-		if ( this.props.showOnlyThemes ) {
-			this.fetchThemes();
-		}
+		this.fetchThemes();
 	}
 
 	fetchThemes() {
@@ -69,29 +62,24 @@ class DesignPickerStep extends Component {
 	};
 
 	renderDesignPicker() {
-		// Use <DesignPicker>'s preferred designs by default
-		let designs = undefined;
-
-		if ( this.props.showOnlyThemes ) {
-			// TODO fetching and filtering code should be pulled to a shared place that's usable by both
-			// `/start` and `/new` onboarding flows. Or perhaps fetching should be done within the <DesignPicker>
-			// component itself. The `/new` environment needs helpers for making authenticated requests to
-			// the theme API before we can do this.
-			designs = this.props.themes
-				.filter( ( { id } ) => ! EXCLUDED_THEMES.includes( id ) )
-				.map( ( { id, name, taxonomies } ) => ( {
-					categories: taxonomies?.theme_subject ?? [
-						{ name: this.props.translate( 'No Category' ), slug: 'CLIENT_ONLY-no-category' },
-					],
-					features: [],
-					is_premium: false,
-					slug: id,
-					template: id,
-					theme: id,
-					title: name,
-					...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
-				} ) );
-		}
+		// TODO fetching and filtering code should be pulled to a shared place that's usable by both
+		// `/start` and `/new` onboarding flows. Or perhaps fetching should be done within the <DesignPicker>
+		// component itself. The `/new` environment needs helpers for making authenticated requests to
+		// the theme API before we can do this.
+		const designs = this.props.themes
+			.filter( ( { id } ) => ! EXCLUDED_THEMES.includes( id ) )
+			.map( ( { id, name, taxonomies } ) => ( {
+				categories: taxonomies?.theme_subject ?? [
+					{ name: this.props.translate( 'No Category' ), slug: 'CLIENT_ONLY-no-category' },
+				],
+				features: [],
+				is_premium: false,
+				slug: id,
+				template: id,
+				theme: id,
+				title: name,
+				...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+			} ) );
 
 		return (
 			<DesignPicker
@@ -99,9 +87,6 @@ class DesignPickerStep extends Component {
 				theme={ this.props.isReskinned ? 'light' : 'dark' }
 				locale={ this.props.locale } // props.locale obtained via `localize` HoC
 				onSelect={ this.pickDesign }
-				className={ classnames( {
-					'design-picker-step__is-large-thumbnails': this.props.largeThumbnails,
-				} ) }
 				highResThumbnails
 				showCategoryFilter={ isEnabled( 'signup/design-picker-categories' ) }
 			/>

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -1,7 +1,6 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
-.signup__step.is-design,
 .signup__step.is-design-setup-site {
 	.step-wrapper {
 		padding-left: 24px;

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -46,15 +46,13 @@
 		}
 	}
 
-	.design-picker.design-picker-step__is-large-thumbnails {
-		.design-picker__grid {
-			grid-template-columns: 1fr;
+	.design-picker__grid {
+		grid-template-columns: 1fr;
 
-			@include break-medium {
-				grid-template-columns: 1fr 1fr;
-				column-gap: 49px;
-				row-gap: 39px;
-			}
+		@include break-medium {
+			grid-template-columns: 1fr 1fr;
+			column-gap: 49px;
+			row-gap: 39px;
 		}
 	}
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -767,7 +767,6 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 
-	.signup__step.is-design,
 	.signup__step.is-design-setup-site {
 		.step-wrapper__header {
 			@include breakpoint-deprecated( '<660px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm busy trying to customise style the design picker to show a category selector. A css class kept getting in my way (`.design-picker-step__is-large-thumbnails`) and making everything confusing. So I've just deleted it since we no longer need this level of customisation given that the `with-design-picker` flow is now defunct.

* Removes the `design_picker_after_onboarding` experiment assignment code. This experiment has run its course @razvanpapadopol 
* Removes the `with-design-picker` flow which was only used for this experiment (see also #56264)
* Remove `showOnlyThemes` and `largeThumbnails` props from the design picker component, since they were only there to stop our work impacting the `with-design-picker` flow

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the `/start` flow. After finishing the initial onboarding we should still be directed to the design picker and it should work as before.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
