### PR TITLE
Stick the international discounts banner to the top on mobile env

### DIFF
--- a/client/components/marketing-message/index.tsx
+++ b/client/components/marketing-message/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import cx from 'classnames';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useMarketingMessage } from './use-marketing-message';
 import './style.scss';
 
@@ -9,48 +9,53 @@ type NudgeProps = {
 	useMockData: boolean;
 	siteId: number | null;
 	className?: string;
-	path?: string;
+	path: string;
 };
 
 const Container = styled.div< Pick< NudgeProps, 'path' > >`
 	display: flex;
-	position: ${ ( props ) => ( props.path === 'signup/plans' ? 'absolute' : 'static' ) };
-	top: 0;
-	width: 100%;
-	z-index: ${ ( props ) => ( props.path === 'signup/plans' ? 31 : 'auto' ) };
+
+	&.is-signup-plans {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		z-index: 31;
+
+		@media ( max-width: 782px ) {
+			position: fixed;
+		}
+	}
 `;
 
-const Message = styled.div< Pick< NudgeProps, 'path' > >`
+const Message = styled.div< { isPlansStep: boolean } >`
 	position: relative;
 	display: flex;
-	justify-content: ${ ( props ) => ( props.path === 'signup/plans' ? 'center' : 'space-between' ) };
+	justify-content: ${ ( props ) => ( props.isPlansStep ? 'center' : 'space-between' ) };
 	align-items: center;
 	background-color: var(
-		${ ( props ) => ( props.path === 'signup/plans' ? '--color-accent-5' : '--color-neutral-80' ) }
+		${ ( props ) => ( props.isPlansStep ? '--color-accent-5' : '--color-neutral-80' ) }
 	);
-	color: var(
-		${ ( props ) => ( props.path === 'signup/plans' ? '--color-text' : '--color-text-inverted' ) }
-	);
+	color: var( ${ ( props ) => ( props.isPlansStep ? '--color-text' : '--color-text-inverted' ) } );
 	padding: 1em 2.5em;
 	margin-bottom: 9px;
 	flex-grow: 1;
 
 	.button {
-		position: ${ ( props ) => ( props.path === 'signup/plans' ? 'absolute' : 'relative' ) };
+		position: ${ ( props ) => ( props.isPlansStep ? 'absolute' : 'relative' ) };
 		display: flex;
 		align-self: flex-start;
 		min-width: 26px;
 		min-height: 26px;
-		left: ${ ( props ) => ( props.path === 'signup/plans' ? 'auto' : '1.5em' ) };
-		right: ${ ( props ) => ( props.path === 'signup/plans' ? '10px' : 'auto' ) };
+		left: ${ ( props ) => ( props.isPlansStep ? 'auto' : '1.5em' ) };
+		right: ${ ( props ) => ( props.isPlansStep ? '10px' : 'auto' ) };
 		color: var(
-			${ ( props ) => ( props.path === 'signup/plans' ? '--color-text' : '--color-text-inverted' ) }
+			${ ( props ) => ( props.isPlansStep ? '--color-text' : '--color-text-inverted' ) }
 		);
 
 		&:hover {
 			color: var(
-				${ ( props ) =>
-					props.path === 'signup/plans' ? '--color-text' : '--color-text-inverted' }
+				${ ( props ) => ( props.isPlansStep ? '--color-text' : '--color-text-inverted' ) }
 			);
 		}
 	}
@@ -61,6 +66,14 @@ const Text = styled.p< Pick< NudgeProps, 'path' > >`
 	text-indent: -1.5em;
 	margin: 0;
 `;
+
+function slugify( text: string ) {
+	return text
+		.trim()
+		.toLowerCase()
+		.replace( /[^a-z0-9]+/g, '-' )
+		.replace( /^-+|-+$/g, '' );
+}
 
 export default function MarketingMessage( { siteId, useMockData, ...props }: NudgeProps ) {
 	const [ isFetching, messages, removeMessage ] = useMarketingMessage( siteId, useMockData );
@@ -74,10 +87,12 @@ export default function MarketingMessage( { siteId, useMockData, ...props }: Nud
 		return null;
 	}
 
+	const classNames = cx( 'nudge-container', props.className, `is-${ slugify( props.path ) }` );
+
 	return (
-		<Container path={ props.path } className={ cx( 'nudge-container', props.className ) }>
+		<Container path={ props.path } className={ classNames }>
 			{ messages.map( ( msg ) => (
-				<Message key={ msg.id } path={ props.path }>
+				<Message key={ msg.id } isPlansStep={ props.path === 'signup/plans' }>
 					<Text path={ props.path }>{ msg.text }</Text>
 					<Button compact borderless onClick={ () => removeMessage( msg.id ) }>
 						<Gridicon icon="cross" size={ 24 } />
@@ -91,4 +106,5 @@ export default function MarketingMessage( { siteId, useMockData, ...props }: Nud
 MarketingMessage.defaultProps = {
 	useMockData: false,
 	siteId: null,
+	path: '',
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR sticks the international discounts banner to the top of the plans step on mobile devices.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can find the detailed testing instruction here pdgrnI-bk-p2
* Make sure the banner is sticked to the top on mobile devices.
  ![sticky-banner](https://user-images.githubusercontent.com/212034/136324765-671dcf6e-942d-4c12-afbe-daa78cd09b6b.gif)  


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #