### PR TITLE
Design Picker: fix keyboard navigation of category filter

### DIFF
--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -3,7 +3,7 @@
 import { Tooltip } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
 	getAvailableDesigns,
 	getDesignUrl,
@@ -130,6 +130,17 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
 		categories[ 0 ]?.slug ?? null
 	);
+
+	useEffect( () => {
+		// When the category list changes check that the current selection
+		// still matches one of the given slugs, and if it doesn't reset
+		// the current selection.
+		const findResult = categories.find( ( { slug } ) => slug === selectedCategory );
+		if ( ! findResult ) {
+			setSelectedCategory( categories[ 0 ]?.slug ?? null );
+		}
+	}, [ categories, selectedCategory ] );
+
 	const filteredDesigns = ! showCategoryFilter
 		? designs
 		: filterDesignsByCategory( designs, selectedCategory );

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -147,7 +147,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 
 	return (
 		<div className={ classnames( 'design-picker', `design-picker--theme-${ theme }`, className ) }>
-			{ showCategoryFilter && categories.length && (
+			{ showCategoryFilter && !! categories.length && (
 				<DesignPickerCategoryFilter
 					categories={ categories }
 					selectedCategory={ selectedCategory }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates selected category whenever the design list changes.

The <DesignPicker>'s filter uses the first category as the initially
selected category. When the picker is rendered before the themes are
loaded this means the selected category is set to `null`.

The keyboard navigation depends on one category being selected,
otherwise tabindex will be `-1` for all of the buttons (this is how list
causes the up/down buttons to be used for keyboard navigation instead of
the tab key).

The loading case is the same as the general case: when `designs` prop
changes the category list can change, and when it changes we potentially
need to update the current selection.

Keyboard nav in action:

https://user-images.githubusercontent.com/1500769/136325912-1b78dbc6-a55a-48b5-b13d-ffe9c8f69395.mov

I also made a wee change to prevent a digit "0" from flashing on the screen during loading. `categories.length` is being used to short circuit rendering of the category filter, but short circuiting means it will return `0` during loading, which React renders.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using `calypso.localhost:3000` or `signup/design-picker-categories` flag
* `/start/setup-site/design-setup-site?siteSlug=<< test site >>`
* Tab to the category filter
* Press up and down to select different categories

Previously it wasn't possible to tab to the category filter.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56567
