### PR TITLE
Design Picker: Use translucent border for designs so colours bleed through from the thumbnail beneath

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -213,12 +213,36 @@
 	}
 	.design-picker__design-option {
 		.design-picker__image-frame {
-			border-color: var( --studio-gray-5 );
+			border-color: transparent;
+
+			&::after {
+				content: '';
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				box-shadow: inset 0 0 0 1px var( --studio-black );
+				border-radius: 4px; /* stylelint-disable-line scales/radii */
+				opacity: 0.12;
+			}
 		}
-		&:hover,
+		&:hover {
+			.design-picker__image-frame {
+				border-color: transparent;
+
+				&::after {
+					opacity: 0.24;
+				}
+			}
+		}
 		&:focus {
 			.design-picker__image-frame {
 				border-color: var( --studio-blue-20 );
+
+				&::after {
+					opacity: 0;
+				}
 			}
 		}
 	}

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -214,6 +214,7 @@
 	.design-picker__design-option {
 		.design-picker__image-frame {
 			border-color: transparent;
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.03 );
 
 			&::after {
 				content: '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If you look very closely at the mockup you'll see that the borders aren't grey. They're actually translucent, allowing the colours from the thumbnail to show through.
EuqfSnWpfYx8fgiBlVmbuA-fi-2119%3A1107


<img width="454" alt="Screenshot 2021-10-07 at 8 04 53 PM" src="https://user-images.githubusercontent.com/1500769/136335552-6a06c445-eb4e-4c53-b2fe-2b11b1cfe230.png">

This looks pretty cool for themes Pollard and Bantry.

Also added a very subtle shadow to each design, as seen in the figma.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Is testable using calypso.live
* Test design picker in `/start` and `/new`, it should appear in both places
* Test hover and focus states thumbnails

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56567