### PR TITLE
Onboarding: Rename track data key of site title to match the property naming

### DIFF
--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -23,7 +23,10 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 	const { stepName, signupDependencies, goToNextStep } = props;
 	const { siteTitle, tagline } = signupDependencies;
 	const submitSiteOptions = ( { siteTitle, tagline }: SiteOptionsFormValues ) => {
-		recordTracksEvent( 'calypso_signup_submit_site_options', { site_title: siteTitle, tagline } );
+		recordTracksEvent( 'calypso_signup_submit_site_options', {
+			has_site_title: !! siteTitle,
+			has_tagline: !! tagline,
+		} );
 		dispatch( submitSignupStep( { stepName }, { siteTitle, tagline } ) );
 		goToNextStep();
 	};

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -23,7 +23,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 	const { stepName, signupDependencies, goToNextStep } = props;
 	const { siteTitle, tagline } = signupDependencies;
 	const submitSiteOptions = ( { siteTitle, tagline }: SiteOptionsFormValues ) => {
-		recordTracksEvent( 'calypso_signup_submit_site_options', { siteTitle, tagline } );
+		recordTracksEvent( 'calypso_signup_submit_site_options', { site_title: siteTitle, tagline } );
 		dispatch( submitSignupStep( { stepName }, { siteTitle, tagline } ) );
 		goToNextStep();
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `recordTracksEvent` doesn't support camel case, so change the property name to `site_title`

![image](https://user-images.githubusercontent.com/13596067/136351441-176e6516-ae7b-49a3-99d9-8a8848aeedeb.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your_site>&flags=signup/hero-flow`
* Select write intent
* Select continue for “Give your blog a name”
* Check console has this error or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55603
