### PR TITLE
Onboarding: Enable hero flow for English users only now

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -21,6 +21,7 @@ import flows from 'calypso/signup/config/flows';
 import untypedSteps from 'calypso/signup/config/steps';
 import { getStepUrl } from 'calypso/signup/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import {
 	resetSignup,
 	updateDependencies,
@@ -411,7 +412,8 @@ export default class SignupFlowController {
 
 	_destination( dependencies: Dependencies ): string {
 		if ( typeof this._flow.destination === 'function' ) {
-			return this._flow.destination( dependencies );
+			const localeSlug = getCurrentLocaleSlug( this._reduxStore.getState() );
+			return this._flow.destination( dependencies, localeSlug );
 		}
 
 		return this._flow.destination;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { englishLocales } from '@automattic/i18n-utils';
 import { get, includes, reject } from 'lodash';
 import { addQueryArgs } from 'calypso/lib/url';
 import { generateFlows } from 'calypso/signup/config/flows-pure';
@@ -57,7 +58,7 @@ function getRedirectDestination( dependencies ) {
 	return '/';
 }
 
-function getSignupDestination( { domainItem, siteId, siteSlug } ) {
+function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
@@ -71,7 +72,8 @@ function getSignupDestination( { domainItem, siteId, siteSlug } ) {
 		queryParam = { siteId };
 	}
 
-	if ( isEnabled( 'signup/hero-flow' ) ) {
+	// Initially ship to English users only, then ship to all users when translations complete
+	if ( isEnabled( 'signup/hero-flow' ) && englishLocales.includes( localeSlug ) ) {
 		return addQueryArgs( queryParam, '/start/setup-site' ) + '&flags=signup/hero-flow'; // we don't want the flag name to be escaped
 	}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -77,7 +77,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 		return addQueryArgs( queryParam, '/start/setup-site' ) + '&flags=signup/hero-flow'; // we don't want the flag name to be escaped
 	}
 
-	if ( isEnabled( 'signup/setup-site-after-checkout' ) ) {
+	if ( isEnabled( 'signup/setup-site-after-checkout' ) && englishLocales.includes( localeSlug ) ) {
 		return addQueryArgs( queryParam, '/start/setup-site' );
 	}
 

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -5,7 +5,7 @@ export interface Dependencies {
 export interface Flow {
 	name: string;
 	steps: string[];
-	destination: string | ( ( dependencies: Dependencies ) => string );
+	destination: string | ( ( dependencies: Dependencies, localeSlug: string ) => string );
 	description: string;
 	lastModified: string;
 	pageTitle?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As discussed in pdgK6S-bD-p2#comment-379, we initially ship to English users only, then ship to all users when translations are complete.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start?flags=signup/hero-flow` with English locale
* Complete the signup flow (including domains, plans and checkout)
* Check the page redirect to intent screen or not
* Repeat the first step with non-English locale
* Check the page doesn't redirect to intent screen after completing the signup flow

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55603