### PR TITLE
Update domain validation regex to allow for 2 character labels.

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
@@ -7,7 +7,7 @@ export function getDomainNameValidationErrorMessage( domainName ) {
 	}
 
 	if (
-		! /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9])*(?:\.[a-zA-Z]{2,})+$/.test(
+		! /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}(?:[a-zA-Z0-9](?:\.[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]))*(?:\.[a-zA-Z]{2,})+$/.test(
 			domainName
 		)
 	) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There are many TLDs that allow for 2-character SLD labels, so we should take that into account in the regex that checks for a valid domain name in the Use a domain I own flow.

#### Testing instructions

Select "Use a domain I own". Enter a domain name with a valid 2-character SLD label ex.: ab.com). Make sure that it is not reported as invalid.

Note that a s-character name that starts with an illegal character (ex.: -a.com) should still be reported as invalid.

This regex is not meant to be an exhaustive check for all valid domain names, but only a "gate" to reduce unnecessary round-trip traffic to the endpoint.