### PR TITLE
Add check for legacy JP Security purchases in VideoPress free tier check

### DIFF
--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -5,10 +5,13 @@ import {
 	FEATURE_VIDEO_UPLOADS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import filesize from 'filesize';
 import { localize } from 'i18n-calypso';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -162,6 +165,15 @@ class MediaSettingsPerformance extends Component {
 const checkForJetpackVideoPressProduct = ( purchase ) =>
 	purchase.active && isJetpackVideoPress( purchase );
 
+const checkForLegacySecurityDailyPlan = ( purchase ) =>
+	purchase.active &&
+	( PLAN_JETPACK_SECURITY_DAILY_MONTHLY === purchase.productSlug ||
+		PLAN_JETPACK_SECURITY_DAILY === purchase.productSlug ) &&
+	moment( purchase.subscribedDate ).isBefore( moment.utc( '2021-10-05' ) );
+
+const checkForActiveJetpackVideoPressPurchases = ( purchase ) =>
+	checkForJetpackVideoPressProduct( purchase ) || checkForLegacySecurityDailyPlan( purchase );
+
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
@@ -177,7 +189,9 @@ export default connect( ( state ) => {
 		isVideoPressFreeTier:
 			isJetpackSite( state, selectedSiteId ) &&
 			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
-			! getSitePurchases( state, selectedSiteId ).find( checkForJetpackVideoPressProduct ) &&
+			! getSitePurchases( state, selectedSiteId ).find(
+				checkForActiveJetpackVideoPressPurchases
+			) &&
 			// These features are used in current plans that include VP
 			! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS ) &&
 			! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) &&

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -161,7 +161,7 @@ const checkForJetpackVideoPressProduct = ( purchase ) =>
 	purchase.active && isJetpackVideoPress( purchase );
 
 /**
- * Security Daily plan no longer includes VideoPress as of Oct 5 2021.
+ * Security Daily plan no longer includes VideoPress as of end of day Oct 6 2021 UTC.
  * This check enforces the upsell appears only for customers that purchased Security Daily after that date.
  *
  * @param {*} purchase
@@ -171,7 +171,7 @@ const checkForLegacySecurityDailyPlan = ( purchase ) =>
 	purchase.active &&
 	( PLAN_JETPACK_SECURITY_DAILY_MONTHLY === purchase.productSlug ||
 		PLAN_JETPACK_SECURITY_DAILY === purchase.productSlug ) &&
-	moment( purchase.subscribedDate ).isBefore( moment.utc( '2021-10-05' ) );
+	moment( purchase.subscribedDate ).isBefore( moment.utc( '2021-10-07' ) );
 
 const checkForActiveJetpackVideoPressPurchases = ( purchase ) =>
 	checkForJetpackVideoPressProduct( purchase ) || checkForLegacySecurityDailyPlan( purchase );

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -165,6 +165,13 @@ class MediaSettingsPerformance extends Component {
 const checkForJetpackVideoPressProduct = ( purchase ) =>
 	purchase.active && isJetpackVideoPress( purchase );
 
+/**
+ * Security Daily plan no longer includes VideoPress as of Oct 5 2021.
+ * This check enforces the upsell appears only for customers that purchased Security Daily after that date.
+ *
+ * @param {*} purchase
+ * @returns bool
+ */
 const checkForLegacySecurityDailyPlan = ( purchase ) =>
 	purchase.active &&
 	( PLAN_JETPACK_SECURITY_DAILY_MONTHLY === purchase.productSlug ||

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -82,7 +82,6 @@ class MediaSettingsPerformance extends Component {
 			isVideoPressFreeTier,
 			mediaStorageLimit,
 			mediaStorageUsed,
-			siteId,
 			sitePlanSlug,
 			siteSlug,
 			translate,
@@ -115,12 +114,7 @@ class MediaSettingsPerformance extends Component {
 				/>
 			) );
 
-		return (
-			<div className="site-settings__videopress-storage">
-				<QueryMediaStorage siteId={ siteId } />
-				{ renderedStorageInfo }
-			</div>
-		);
+		return <div className="site-settings__videopress-storage">{ renderedStorageInfo }</div>;
 	}
 
 	renderVideoUpgradeNudge() {
@@ -148,7 +142,7 @@ class MediaSettingsPerformance extends Component {
 	}
 
 	render() {
-		const { isVideoPressAvailable, sitePlanSlug } = this.props;
+		const { isVideoPressAvailable, siteId, sitePlanSlug } = this.props;
 
 		if ( ! sitePlanSlug ) {
 			return null;
@@ -156,6 +150,7 @@ class MediaSettingsPerformance extends Component {
 
 		return (
 			<div className="site-settings__module-settings site-settings__media-settings">
+				<QueryMediaStorage siteId={ siteId } />
 				{ isVideoPressAvailable && <Card>{ this.renderVideoSettings() }</Card> }
 				{ this.renderVideoUpgradeNudge() }
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a date-based override (Oct 7 2021) for holders of Jetpack Security plans to NOT show the VideoPress upsell nudge

#### Testing instructions
1. Launch a new Jetpack site
2. Connect it to Jetpack and purchase one of the Security Daily plans
3. View Settings -> Performance, you SHOULD see the upsell nudge
4. Purchase VideoPress Product
5. Refresh the Settings -> Performance page, you SHOULD NOT see the upsell nudge
4. In Store Admin, remove the VideoPress product AND change the date of purchase of your Security Daily plan back before Oct 5 (or change the date in the code changes in this PR to a later date - ex 2022)
5. Refresh the Settings -> Performance page, you SHOULD NOT see the upsell nudge

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before date cutoff
<img width="746" alt="Screen Shot 2021-10-07 at 11 09 39 AM" src="https://user-images.githubusercontent.com/4081020/136412664-f87e3674-cb0b-40bc-9309-72a9bf2faea4.png">

After date cutoff
<img width="743" alt="Screen Shot 2021-10-07 at 11 10 00 AM" src="https://user-images.githubusercontent.com/4081020/136412667-6116f6fc-e327-41d9-9588-4a347ee063d5.png">
<img width="741" alt="Screen Shot 2021-10-07 at 11 26 44 AM" src="https://user-images.githubusercontent.com/4081020/136415625-45346514-9d5b-4ebf-ab6d-d87ac9f30d13.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
