### PR TITLE
Playwright: delete magic link email after spec concludes.

### DIFF
--- a/packages/calypso-e2e/src/email-client.ts
+++ b/packages/calypso-e2e/src/email-client.ts
@@ -38,7 +38,10 @@ export class EmailClient {
 			subject: subject !== undefined ? subject : '',
 		};
 
-		const message = await this.client.messages.get( inboxId, searchCriteria );
+		// Get messages sent within the last 100 seconds.
+		const message = await this.client.messages.get( inboxId, searchCriteria, {
+			receivedAfter: new Date( Date.now() - 100 ),
+		} );
 		return message;
 	}
 
@@ -66,5 +69,17 @@ export class EmailClient {
 			}
 		}
 		return Array.from( results );
+	}
+
+	/**
+	 * Given a Message object, permanently deletes the message from the server.
+	 *
+	 * @param {Message} message E-mail message to delete.
+	 */
+	async deleteMessage( message: Message ): Promise< void > {
+		if ( ! message.id ) {
+			throw new Error( 'Message ID not found.' );
+		}
+		return await this.client.messages.del( message.id );
 	}
 }

--- a/packages/calypso-e2e/src/email-client.ts
+++ b/packages/calypso-e2e/src/email-client.ts
@@ -40,7 +40,7 @@ export class EmailClient {
 
 		// Get messages sent within the last 100 seconds.
 		const message = await this.client.messages.get( inboxId, searchCriteria, {
-			receivedAfter: new Date( Date.now() - 100 ),
+			receivedAfter: new Date( Date.now() - 30 * 1000 ),
 		} );
 		return message;
 	}

--- a/packages/calypso-e2e/src/email-client.ts
+++ b/packages/calypso-e2e/src/email-client.ts
@@ -38,7 +38,7 @@ export class EmailClient {
 			subject: subject !== undefined ? subject : '',
 		};
 
-		// Get messages sent within the last 100 seconds.
+		// Get messages sent within the last 30 seconds.
 		const message = await this.client.messages.get( inboxId, searchCriteria, {
 			receivedAfter: new Date( Date.now() - 30 * 1000 ),
 		} );

--- a/test/e2e/specs/specs-playwright/wp-auth__magic-link.ts
+++ b/test/e2e/specs/specs-playwright/wp-auth__magic-link.ts
@@ -4,6 +4,7 @@
 
 import { setupHooks, DataHelper, EmailClient, LoginPage } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
+import type { Message } from 'mailosaur/lib/models';
 
 describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function () {
 	const inboxId = DataHelper.config.get( 'defaultUserInboxId' ) as string;
@@ -16,8 +17,10 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 	let magicLink: string;
 	let loginPage: LoginPage;
 	let page: Page;
+	let message: Message;
+	let emailClient: EmailClient;
 
-	setupHooks( ( args ) => {
+	setupHooks( ( args: { page: Page } ) => {
 		page = args.page;
 	} );
 
@@ -31,8 +34,8 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 	} );
 
 	it( 'Magic link is received', async function () {
-		const emailClient = new EmailClient();
-		const message = await emailClient.getLastEmail( {
+		emailClient = new EmailClient();
+		message = await emailClient.getLastEmail( {
 			inboxId: inboxId,
 			emailAddress: email,
 			subject: 'Log in to WordPress.com',
@@ -45,5 +48,11 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 	it( 'Log in using magic link', async function () {
 		const loginPage = new LoginPage( page );
 		await loginPage.followMagicLink( magicLink );
+	} );
+
+	afterAll( async function () {
+		if ( message ) {
+			await emailClient.deleteMessage( message );
+		}
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes some changes to the `Magic Link` spec.

Key changes:
- new method `EmailClient.deleteMessage` which is a thin wrapper around the Mailosaur client's `del` method.
- new `afterAll` hook that attempts to call the `EmailClient.deleteMessage` method if a message is defined.

#### Testing instructions

- [x] normal
  - [x] pre-release
- [x] stress
  - [x] pre-release
