### PR TITLE
Experiment: Hide Money-back Guarantee on Jetpack Pricing Page

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -1,15 +1,19 @@
 import { useTranslate } from 'i18n-calypso';
-import * as React from 'react';
-import { useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
+import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
-import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
+
 import './style.scss';
 
 const Header: React.FC< Props > = () => {
 	const translate = useTranslate();
-	const hasJetpackSaleCoupon = useSelector( getJetpackSaleCoupon );
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'calypso_jetpack_pricing_page_without_money_back_banner'
+	);
+
+	const suppressIntroBanner =
+		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'treatment';
 
 	return (
 		<>
@@ -23,7 +27,7 @@ const Header: React.FC< Props > = () => {
 				/>
 			</div>
 
-			{ ! hasJetpackSaleCoupon && <IntroPricingBanner /> }
+			{ ! suppressIntroBanner && <IntroPricingBanner /> }
 		</>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implement an experiment hiding the money-back guarantee banner
![ab test](https://user-images.githubusercontent.com/2810519/136442659-43c3c933-70e2-4888-a77e-d84fbac4c998.png)

#### Testing instructions

1. Boot the branch as Jetpack Cloud
2. Navigate to `/pricing`
3. Verify you still see the intro pricing/money-back guarantee banner, matching the "control" screenshot above
4. Assign yourself to the `treatment` variation by manually updating the value of variationName in the `explat-experiment--calypso_jetpack_pricing_page_without_money_back_banner` local storage item <img width="950" alt="Screen Shot 2021-10-07 at 11 38 17 AM" src="https://user-images.githubusercontent.com/2810519/136443221-9c55d286-19a7-480b-ac56-b9ac030fa8bc.png">
5. Refresh the page
6. Verify you no longer see the intro pricing/money-back guarantee banner, matching the "treatment" screenshot above
