### PR TITLE
Playwright: More accurate waiting after canceling plan

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -8,6 +8,7 @@ const selectors = {
 	radioButton: ( value: string ) => `input[type="radio"][value=${ value }]`,
 	modalSubmit: 'button[data-e2e-button="submit"]',
 	button: ( text: string ) => `button:has-text("${ text }")`,
+	purchasePlaceholder: '.subscriptions__list .purchase-item__placeholder',
 
 	// Purchased item actions: plans
 	renewNowCardButton: 'button.card:has-text("Renew Now")',
@@ -130,6 +131,13 @@ export class IndividualPurchasePage {
 		await this.completeSurvey();
 		await this.page.click( selectors.button( 'Cancel plan' ) );
 
+		// It takes a second for the plan cancellation to propagate on the backend after cancelling.
+		// If you go too fast, you won't be able to close an account, because it thinks there is still an active plan.
+		// Waiting for the notification banner is not accurate - it shows immediately regardless.
+		// Waiting for the disappearance of the placeholder for currently active upgrades, ultimately then showing the new true status of upgrades, is much more accurate.
+		await this.page.waitForSelector( selectors.purchasePlaceholder, { state: 'detached' } );
+
+		// Still dismiss the banner though, it hangs for a while and can eat clicks if not careful.
 		await this.page.click( selectors.dismissBanner );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the Paid Signup spec, we were getting some failures where after canceling the plan, we would make it too quickly to account closure and be blocked because the full cancellation hadn't propagated on the back end.

It turns out the notification is not a good indicator of the cancellation _actually_ being complete - it shows immediately. However, waiting for the up to date active plan details to resolve and show is an accurate indicator of the cancellation propagation being complete. So now we wait for that!

#### Testing instructions

- [ ] Pre-release tests pass on the branch
- [x] Test passes locally

Related to #
