### PR TITLE
Domains: Use new domain transfer flow when starting a pending transfer

### DIFF
--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -67,3 +67,9 @@ export const useMyDomainInputMode = {
 	ownershipVerification: 'ownership-verification',
 	transferDomain: 'transfer-domain',
 } as const;
+
+export const transferDomainError = {
+	AUTH_CODE: __( 'Invalid auth code. Please check the specified code and try again.' ),
+	NO_SELECTED_SITE: __( 'Please specify a site.' ),
+	GENERIC_ERROR: __( 'We were unable to start the transfer.' ),
+};

--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -60,3 +60,10 @@ export const stepsHeadingTransfer = __( 'Initial setup' );
 export const authCodeStepDefaultDescription = __(
 	'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
 );
+
+export const useMyDomainInputMode = {
+	domainInput: 'domain-input',
+	transferOrConnect: 'transfer-or-connect',
+	ownershipVerification: 'ownership-verification',
+	transferDomain: 'transfer-domain',
+} as const;

--- a/client/components/domains/connect-domain-step/domain-step-auth-code.tsx
+++ b/client/components/domains/connect-domain-step/domain-step-auth-code.tsx
@@ -21,6 +21,7 @@ const DomainStepAuthCode = ( {
 	selectedSite,
 	buttonMessage,
 	customHeading,
+	...props
 }: DomainStepAuthCodeProps ) => {
 	const { __ } = useI18n();
 	const [ authCode, setAuthCode ] = useState( '' );
@@ -43,6 +44,7 @@ const DomainStepAuthCode = ( {
 
 		validateHandler(
 			{
+				...props,
 				domain,
 				selectedSite,
 				verificationData: getVerificationData(),

--- a/client/components/domains/connect-domain-step/domain-step-auth-code.tsx
+++ b/client/components/domains/connect-domain-step/domain-step-auth-code.tsx
@@ -51,7 +51,7 @@ const DomainStepAuthCode = ( {
 			},
 			( error ) => {
 				if ( ! error ) return;
-				if ( 'ownership_verification_failed' === error.error ) {
+				if ( error.message ) {
 					setAuthCodeError( error.message );
 				}
 				setConnectInProgress( false );

--- a/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
@@ -15,6 +15,7 @@ const TransferDomainStepAuthCode = ( {
 	pageSlug,
 	transferDomainActionHandler,
 	progressStepList,
+	...props
 } ) => {
 	const { __ } = useI18n();
 	const recordTransferButtonClickInUseYourDomain = useCallback(
@@ -26,6 +27,7 @@ const TransferDomainStepAuthCode = ( {
 	);
 	return (
 		<DomainStepAuthCode
+			{ ...props }
 			buttonMessage={ __( 'Check readiness for transfer' ) }
 			customHeading={ stepsHeadingTransfer }
 			authCodeDescription={ authCodeDescription }

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -19,6 +19,7 @@ export default function TransferDomainStepStart( {
 	progressStepList,
 	domainInboundTransferStatusInfo,
 	domain,
+	isFetchingAvailability,
 }: StartStepProps ): JSX.Element {
 	const { __ } = useI18n();
 	const switchToDomainConnect = () => null;
@@ -27,7 +28,7 @@ export default function TransferDomainStepStart( {
 
 	const stepContent = (
 		<>
-			{ ! isDomainTransferrable && (
+			{ ! isFetchingAvailability && ! isDomainTransferrable && (
 				<Notice
 					status="is-error"
 					showDismiss={ false }
@@ -68,7 +69,12 @@ export default function TransferDomainStepStart( {
 						}
 					) }
 				</p>
-				<Button primary onClick={ onNextStep } disabled={ ! isDomainTransferrable }>
+				<Button
+					primary
+					onClick={ onNextStep }
+					disabled={ ! isDomainTransferrable }
+					busy={ isFetchingAvailability }
+				>
 					{ __( 'Start setup' ) }
 				</Button>
 			</div>

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -1,57 +1,78 @@
 import { Button } from '@automattic/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import CardHeading from 'calypso/components/card-heading';
 import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
+import { getDomainTransferrability } from 'calypso/components/domains/use-my-domain/utilities';
 import MaterialIcon from 'calypso/components/material-icon';
+import Notice from 'calypso/components/notice';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import './style.scss';
 import { StartStepProps } from './types';
+
+import './style.scss';
 
 export default function TransferDomainStepStart( {
 	className,
 	pageSlug,
 	onNextStep,
 	progressStepList,
+	domainInboundTransferStatusInfo,
+	domain,
 }: StartStepProps ): JSX.Element {
 	const { __ } = useI18n();
 	const switchToDomainConnect = () => null;
+	const isDomainTransferrable = getDomainTransferrability( domainInboundTransferStatusInfo )
+		.transferrable;
 
 	const stepContent = (
-		<div className={ className + '__transfer-start' }>
-			<p className={ className + '__text' }>
-				{ __(
-					'For this setup you will need to log in to your current domain provider and go through a few steps.'
-				) }
-			</p>
-			<CardHeading tagName="h2" className={ className + '__sub-heading' }>
-				<MaterialIcon className={ className + '__sub-heading-icon' } size={ 24 } icon="timer" />
-				{ __( 'How long will it take?' ) }
-			</CardHeading>
-			<p className={ className + '__text' }>
-				{ __( 'It takes 10-20 minutes to set up.' ) }
-				<br />
-				{ __(
-					'It can take up to 5 days for the domain to be transferred, depending on your provider.'
-				) }
-			</p>
-			<p className={ className + '__text' }>
-				{ createInterpolateElement(
-					__(
-						'If you would like to have your domain point to your WordPress.com site faster, consider <a>connecting your domain</a> first.'
-					),
-					{
-						a: createElement( 'a', {
-							className: 'connect-domain-step__change_mode_link',
-							onClick: switchToDomainConnect,
-						} ),
-					}
-				) }
-			</p>
-			<Button primary onClick={ onNextStep }>
-				{ __( 'Start setup' ) }
-			</Button>
-		</div>
+		<>
+			{ ! isDomainTransferrable && (
+				<Notice
+					status="is-error"
+					showDismiss={ false }
+					text={ sprintf(
+						/* translators: %s: the domain name that is being transferred (ex.: example.com) */
+						__( 'The domain %s is not transferable.' ),
+						domain
+					) }
+				></Notice>
+			) }
+			<div className={ className + '__transfer-start' }>
+				<p className={ className + '__text' }>
+					{ __(
+						'For this setup you will need to log in to your current domain provider and go through a few steps.'
+					) }
+				</p>
+				<CardHeading tagName="h2" className={ className + '__sub-heading' }>
+					<MaterialIcon className={ className + '__sub-heading-icon' } size={ 24 } icon="timer" />
+					{ __( 'How long will it take?' ) }
+				</CardHeading>
+				<p className={ className + '__text' }>
+					{ __( 'It takes 10-20 minutes to set up.' ) }
+					<br />
+					{ __(
+						'It can take up to 5 days for the domain to be transferred, depending on your provider.'
+					) }
+				</p>
+				<p className={ className + '__text' }>
+					{ createInterpolateElement(
+						__(
+							'If you would like to have your domain point to your WordPress.com site faster, consider <a>connecting your domain</a> first.'
+						),
+						{
+							a: createElement( 'a', {
+								className: 'connect-domain-step__change_mode_link',
+								onClick: switchToDomainConnect,
+							} ),
+						}
+					) }
+				</p>
+				<Button primary onClick={ onNextStep } disabled={ ! isDomainTransferrable }>
+					{ __( 'Start setup' ) }
+				</Button>
+			</div>
+		</>
 	);
 
 	return (

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -2,15 +2,16 @@ import { Button } from '@automattic/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import page from 'page';
 import CardHeading from 'calypso/components/card-heading';
 import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
 import { getDomainTransferrability } from 'calypso/components/domains/use-my-domain/utilities';
 import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
+import { MAP_EXISTING_DOMAIN } from 'calypso/lib/url/support';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { StartStepProps } from './types';
-
 import './style.scss';
+import { StartStepProps } from './types';
 
 export default function TransferDomainStepStart( {
 	className,
@@ -22,7 +23,7 @@ export default function TransferDomainStepStart( {
 	isFetchingAvailability,
 }: StartStepProps ): JSX.Element {
 	const { __ } = useI18n();
-	const switchToDomainConnect = () => null;
+	const switchToDomainConnect = () => page( MAP_EXISTING_DOMAIN );
 	const isDomainTransferrable = getDomainTransferrability( domainInboundTransferStatusInfo )
 		.transferrable;
 

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -24,8 +24,8 @@ export default function TransferDomainStepStart( {
 }: StartStepProps ): JSX.Element {
 	const { __ } = useI18n();
 	const switchToDomainConnect = () => page( MAP_EXISTING_DOMAIN );
-	const isDomainTransferrable = getDomainTransferrability( domainInboundTransferStatusInfo )
-		.transferrable;
+	const isDomainTransferrable =
+		true || getDomainTransferrability( domainInboundTransferStatusInfo ).transferrable;
 
 	const stepContent = (
 		<>

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -24,8 +24,8 @@ export default function TransferDomainStepStart( {
 }: StartStepProps ): JSX.Element {
 	const { __ } = useI18n();
 	const switchToDomainConnect = () => page( MAP_EXISTING_DOMAIN );
-	const isDomainTransferrable =
-		true || getDomainTransferrability( domainInboundTransferStatusInfo ).transferrable;
+	const isDomainTransferrable = getDomainTransferrability( domainInboundTransferStatusInfo )
+		.transferrable;
 
 	const stepContent = (
 		<>

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -7,10 +7,12 @@ type Maybe< T > = T | null;
 type PossibleSlugs = ValueOf< typeof stepSlug >;
 type PossibleInitialModes = ValueOf< typeof useMyDomainInputMode >;
 
-export type AuthCodeValidationError = {
+export type DomainsApiError = {
 	error?: string;
 	message?: string;
 };
+
+export type AuthCodeValidationError = DomainsApiError;
 
 export type AuthCodeValidationData = {
 	domain: string;
@@ -27,6 +29,10 @@ export type AuthCodeValidationHandler = (
 	authData: AuthCodeValidationData,
 	onDone?: ( error?: Maybe< AuthCodeValidationError >, callbackData?: unknown ) => void
 ) => unknown;
+
+export type InboundTransferResult = {
+	success: boolean;
+};
 
 export type InboundTransferStatusInfo = {
 	creationDate: string;

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -52,6 +52,7 @@ export type StartStepProps = {
 	pageSlug: PossibleSlugs;
 	onNextStep: () => void;
 	stepContent: JSX.Element;
+	isFetchingAvailability: boolean;
 	progressStepList: Record< PossibleSlugs, string >;
 	domainInboundTransferStatusInfo: Partial< InboundTransferStatusInfo >;
 	initialMode: PossibleInitialModes;

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -1,10 +1,11 @@
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
-import { stepSlug } from '../constants';
+import { stepSlug, useMyDomainInputMode } from '../constants';
 
 type ValueOf< T > = T[ keyof T ];
 type Maybe< T > = T | null;
 
 type PossibleSlugs = ValueOf< typeof stepSlug >;
+type PossibleInitialModes = ValueOf< typeof useMyDomainInputMode >;
 
 export type AuthCodeValidationError = {
 	error?: string;
@@ -27,6 +28,18 @@ export type AuthCodeValidationHandler = (
 	onDone?: ( error?: Maybe< AuthCodeValidationError >, callbackData?: unknown ) => void
 ) => unknown;
 
+export type InboundTransferStatusInfo = {
+	creationDate: string;
+	email: string;
+	inRedemption: boolean;
+	losingRegistrar: boolean;
+	privacy: boolean;
+	termMaximumInYears: number;
+	transferEligibleDate: string;
+	transferRestrictionStatus: string;
+	unlocked: boolean;
+};
+
 export type StartStepProps = {
 	domain: string;
 	className: string;
@@ -34,6 +47,8 @@ export type StartStepProps = {
 	onNextStep: () => void;
 	stepContent: JSX.Element;
 	progressStepList: Record< PossibleSlugs, string >;
+	domainInboundTransferStatusInfo: Partial< InboundTransferStatusInfo >;
+	initialMode: PossibleInitialModes;
 	setPage: ( page: PossibleSlugs ) => void;
 };
 

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -46,11 +46,10 @@ function UseMyDomain( {
 		transferLockedDomainStepsDefinition
 	);
 	const [ isFetchingAvailability, setIsFetchingAvailability ] = useState( false );
-	const [ mode, setMode ] = useState(
+	const wasInitialModeSet = Boolean(
 		Object.values( inputMode ).includes( initialMode ) && initialQuery
-			? initialMode
-			: inputMode.domainInput
 	);
+	const [ mode, setMode ] = useState( wasInitialModeSet ? initialMode : inputMode.domainInput );
 	const [ ownershipVerificationFlowPageSlug, setOwnershipVerificationFlowPageSlug ] = useState(
 		stepSlug.OWNERSHIP_VERIFICATION_LOGIN
 	);
@@ -79,6 +78,7 @@ function UseMyDomain( {
 				if ( prevTransferDomainStepsDefinition ) {
 					setTransferDomainFlowPageSlug( prevTransferDomainStepsDefinition );
 				} else {
+					if ( wasInitialModeSet ) return goBack();
 					setMode( inputMode.transferOrConnect );
 				}
 				return;

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -8,6 +8,7 @@ import ConnectDomainSteps from 'calypso/components/domains/connect-domain-step/c
 import {
 	stepSlug,
 	domainLockStatusType,
+	useMyDomainInputMode as inputMode,
 } from 'calypso/components/domains/connect-domain-step/constants';
 import {
 	connectADomainOwnershipVerificationStepsDefinition,
@@ -34,18 +35,8 @@ function UseMyDomain( {
 	onTransfer,
 	selectedSite,
 	transferDomainUrl,
-	initialStep,
+	initialMode,
 } ) {
-	const inputMode = useMemo(
-		() => ( {
-			domainInput: 'domain-input',
-			transferOrConnect: 'transfer-or-connect',
-			ownershipVerification: 'ownership-verification',
-			transferDomain: 'transfer-domain',
-		} ),
-		[]
-	);
-
 	const [ domainAvailabilityData, setDomainAvailabilityData ] = useState( {} );
 	const [ domainInboundTransferStatusInfo, setDomainInboundTransferStatusInfo ] = useState( {} );
 	const [ domainName, setDomainName ] = useState( initialQuery ?? '' );
@@ -55,7 +46,9 @@ function UseMyDomain( {
 		transferLockedDomainStepsDefinition
 	);
 	const [ isFetchingAvailability, setIsFetchingAvailability ] = useState( false );
-	const [ mode, setMode ] = useState( inputMode.domainInput );
+	const [ mode, setMode ] = useState(
+		Object.values( inputMode ).includes( initialMode ) ? initialMode : inputMode.domainInput
+	);
 	const [ ownershipVerificationFlowPageSlug, setOwnershipVerificationFlowPageSlug ] = useState(
 		stepSlug.OWNERSHIP_VERIFICATION_LOGIN
 	);

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -120,6 +120,7 @@ function UseMyDomain( {
 
 	const setDomainTransferData = useCallback( async () => {
 		// TODO: remove this try-catch when the next statuses get added on the API
+		setIsFetchingAvailability( true );
 		let inboundTransferStatusResult = {};
 		try {
 			inboundTransferStatusResult = await wpcom
@@ -142,6 +143,8 @@ function UseMyDomain( {
 
 		setDomainInboundTransferStatusInfo( inboundTransferStatusInfo );
 		setTransferStepsAndLockStatus( inboundTransferStatusInfo.unlocked );
+
+		setIsFetchingAvailability( false );
 	}, [ domainName, setTransferStepsAndLockStatus ] );
 
 	const onNext = useCallback( async () => {
@@ -265,6 +268,7 @@ function UseMyDomain( {
 			<ConnectDomainSteps
 				baseClassName={ 'connect-domain-step' }
 				domainInboundTransferStatusInfo={ domainInboundTransferStatusInfo }
+				isFetchingAvailability={ isFetchingAvailability }
 				initialMode={ initialMode }
 				domain={ domainName }
 				initialPageSlug={ transferDomainFlowPageSlug }

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -174,13 +174,7 @@ function UseMyDomain( {
 		} finally {
 			setIsFetchingAvailability( false );
 		}
-	}, [
-		domainName,
-		inputMode.transferOrConnect,
-		selectedSite,
-		setDomainTransferData,
-		validateDomainName,
-	] );
+	}, [ domainName, selectedSite, setDomainTransferData, validateDomainName ] );
 
 	const onDomainNameChange = ( event ) => {
 		setDomainName( event.target.value );
@@ -198,20 +192,16 @@ function UseMyDomain( {
 		}
 
 		initialValidation.current = true;
-		initialQuery && ! getDomainNameValidationErrorMessage( initialQuery ) && onNext();
+		initialQuery &&
+			! initialMode &&
+			! getDomainNameValidationErrorMessage( initialQuery ) &&
+			onNext();
 	}, [ initialQuery, onNext ] );
 
 	useEffect( () => {
-		if ( inputMode.transferDomain === mode && inputMode.transferDomain === initialStep )
+		if ( inputMode.transferDomain === mode && inputMode.transferDomain === initialMode )
 			setDomainTransferData();
-	}, [
-		mode,
-		domainName,
-		inputMode,
-		setDomainTransferData,
-		setDomainInboundTransferStatusInfo,
-		initialStep,
-	] );
+	}, [ mode, inputMode, setDomainTransferData, initialMode ] );
 
 	const showOwnershipVerificationFlow = () => {
 		setMode( inputMode.ownershipVerification );
@@ -272,6 +262,7 @@ function UseMyDomain( {
 		return (
 			<ConnectDomainSteps
 				baseClassName={ 'connect-domain-step' }
+				domainInboundTransferStatusInfo={ domainInboundTransferStatusInfo }
 				domain={ domainName }
 				initialPageSlug={ transferDomainFlowPageSlug }
 				onTransfer={ onTransfer }

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -201,12 +201,12 @@ function UseMyDomain( {
 			! initialMode &&
 			! getDomainNameValidationErrorMessage( initialQuery ) &&
 			onNext();
-	}, [ initialQuery, onNext ] );
+	}, [ initialMode, initialQuery, onNext ] );
 
 	useEffect( () => {
 		if ( inputMode.transferDomain === mode && inputMode.transferDomain === initialMode )
 			setDomainTransferData();
-	}, [ mode, inputMode, setDomainTransferData, initialMode ] );
+	}, [ mode, setDomainTransferData, initialMode ] );
 
 	const showOwnershipVerificationFlow = () => {
 		setMode( inputMode.ownershipVerification );

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -47,7 +47,9 @@ function UseMyDomain( {
 	);
 	const [ isFetchingAvailability, setIsFetchingAvailability ] = useState( false );
 	const [ mode, setMode ] = useState(
-		Object.values( inputMode ).includes( initialMode ) ? initialMode : inputMode.domainInput
+		Object.values( inputMode ).includes( initialMode ) && initialQuery
+			? initialMode
+			: inputMode.domainInput
 	);
 	const [ ownershipVerificationFlowPageSlug, setOwnershipVerificationFlowPageSlug ] = useState(
 		stepSlug.OWNERSHIP_VERIFICATION_LOGIN

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -263,6 +263,7 @@ function UseMyDomain( {
 			<ConnectDomainSteps
 				baseClassName={ 'connect-domain-step' }
 				domainInboundTransferStatusInfo={ domainInboundTransferStatusInfo }
+				initialMode={ initialMode }
 				domain={ domainName }
 				initialPageSlug={ transferDomainFlowPageSlug }
 				onTransfer={ onTransfer }

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -168,10 +168,7 @@ function UseMyDomain( {
 				setMode( inputMode.transferOrConnect );
 				setDomainAvailabilityData( availabilityData );
 				setDomainInboundTransferStatusInfo( inboundTransferStatusInfo );
-				setDomainTransferData(
-					inboundTransferStatusInfo.isDomainUnlocked,
-					inboundTransferStatusInfo.transferEligibleDate
-				);
+				setDomainTransferData( inboundTransferStatusInfo.isDomainUnlocked );
 			}
 		} catch ( error ) {
 			setDomainNameValidationError( error.message );

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -13,7 +13,7 @@ import {
 	optionInfo,
 } from './index';
 
-const getDomainTransferrability = ( domainInboundTransferStatusInfo ) => {
+export const getDomainTransferrability = ( domainInboundTransferStatusInfo ) => {
 	const { inRedemption, transferEligibleDate } = domainInboundTransferStatusInfo;
 
 	const result = {

--- a/client/components/domains/use-my-domain/utilities/index.js
+++ b/client/components/domains/use-my-domain/utilities/index.js
@@ -3,7 +3,7 @@ export { getAvailabilityErrorMessage } from './get-availability-error-message';
 export { getDomainNameValidationErrorMessage } from './get-domain-name-validation-error-message';
 export { getMappingFreeText } from './get-mapping-free-text';
 export { getMappingPriceText } from './get-mapping-price-text';
-export { getOptionInfo } from './get-option-info';
+export { getOptionInfo, getDomainTransferrability } from './get-option-info';
 export { getTransferFreeText } from './get-transfer-free-text';
 export { getTransferPriceText } from './get-transfer-price-text';
 export { getTransferRestrictionMessage } from './get-transfer-restriction-message';

--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -70,7 +70,7 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 
 		const startInboundTransferAndReload = async () => {
 			try {
-				const result = await wpcomDomain
+				const result = await wpcom
 					.undocumented()
 					.startInboundTransfer( selectedSite.ID, domain, authCode );
 				if ( result.success ) {

--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -1,7 +1,10 @@
 import page from 'page';
 import { DefaultRootState } from 'react-redux';
 import { Dispatch } from 'redux';
-import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
+import {
+	transferDomainError,
+	useMyDomainInputMode as inputMode,
+} from 'calypso/components/domains/connect-domain-step/constants';
 import {
 	AuthCodeValidationError,
 	AuthCodeValidationHandler,
@@ -25,9 +28,8 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 		domainAvailability.TRANSFERRABLE,
 		domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE,
 	];
-	const transferGenericErrorMessage = 'We were unable to start the transfer.';
 
-	if ( ! selectedSite ) return onDone( { message: 'Please specify a site.' } );
+	if ( ! selectedSite ) return onDone( { message: transferDomainError.NO_SELECTED_SITE } );
 
 	try {
 		const wpcomDomain = wpcom.domain( domain );
@@ -38,7 +40,7 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 		if ( ! authCodeCheckResult.success )
 			return onDone( {
 				error: 'ownership_verification_failed',
-				message: 'Invalid auth code. Please check the specified code and try again.',
+				message: transferDomainError.AUTH_CODE,
 			} );
 
 		const checkAvailabilityResult = await wpcomDomain.isDomainAvailable( selectedSite.ID, false );
@@ -77,12 +79,12 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 					page( domainManagementTransferIn( selectedSite.slug, domain ) );
 				} else {
 					return onDone( {
-						message: transferGenericErrorMessage,
+						message: transferDomainError.GENERIC_ERROR,
 					} );
 				}
 			} catch ( error ) {
 				return onDone( {
-					message: transferGenericErrorMessage,
+					message: transferDomainError.GENERIC_ERROR,
 				} );
 			}
 		};

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -198,6 +198,7 @@ const useMyDomain = ( context, next ) => {
 				<UseMyDomain
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
+					initialMode={ context.query.initialMode }
 					goBack={ handleGoBack }
 				/>
 			</CalypsoShoppingCartProvider>

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -183,6 +183,10 @@ const useMyDomain = ( context, next ) => {
 		let path = `/domains/add/${ context.params.site }`;
 		if ( context.query.initialQuery ) {
 			path += `?suggestion=${ context.query.initialQuery }`;
+
+			if ( context.query.initialMode ) {
+				path = `/domains/manage/${ context.params.site }`;
+			}
 		}
 
 		page( path );

--- a/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
@@ -21,10 +21,10 @@ import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 
 class TransferInDomainType extends Component {
 	startTransfer = () => {
-		this.setState( { isTransferring: true }, this.inboundTransfer );
+		this.setState( { isTransferring: true }, this.goToInboundTransferPage );
 	};
 
-	inboundTransfer() {
+	goToInboundTransferPage() {
 		const { domain, selectedSite } = this.props;
 		page(
 			domainUseMyDomain( selectedSite.slug, domain.name, useMyDomainInputMode.transferDomain )

--- a/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
@@ -4,11 +4,12 @@ import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { resolveDomainStatus, startInboundTransfer } from 'calypso/lib/domains';
+import { resolveDomainStatus } from 'calypso/lib/domains';
 import { transferStatus } from 'calypso/lib/domains/constants';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES } from 'calypso/lib/url/support';
-import { domainManagementTransferIn } from 'calypso/my-sites/domains/paths';
+import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
 import {
 	getByPurchaseId,
@@ -24,18 +25,10 @@ class TransferInDomainType extends Component {
 	};
 
 	inboundTransfer() {
-		const { domain, selectedSite, translate } = this.props;
-		const domainName = domain.name;
-
-		startInboundTransfer( selectedSite.ID, domainName, null, ( error, result ) => {
-			this.setState( { isTransferring: false } );
-			if ( result ) {
-				this.props.fetchSiteDomains( selectedSite.ID );
-				page( domainManagementTransferIn( selectedSite.slug, domainName ) );
-			} else {
-				this.props.errorNotice( translate( 'We were unable to start the transfer.' ) );
-			}
-		} );
+		const { domain, selectedSite } = this.props;
+		page(
+			domainUseMyDomain( selectedSite.slug, domain.name, useMyDomainInputMode.transferDomain )
+		);
 	}
 
 	renderPendingStart() {
@@ -56,7 +49,7 @@ class TransferInDomainType extends Component {
 					) }
 				</p>
 
-				<Button primary onClick={ this.startTransfer } busy={ this.state?.isTransferring }>
+				<Button primary onClick={ this.startTransfer }>
 					{ translate( 'Start transfer' ) }
 				</Button>
 			</>

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -237,13 +237,18 @@ export function domainUseYourDomain( siteName, domain ) {
 	return path;
 }
 
-export function domainUseMyDomain( siteName, domain ) {
-	let path = `/domains/add/use-my-domain/${ siteName }`;
+export function domainUseMyDomain( siteName, domain, initialMode ) {
+	const path = `/domains/add/use-my-domain/${ siteName }`;
+	const queryArgs = [];
 	if ( domain ) {
-		path += `?initialQuery=${ domain }`;
+		queryArgs.push( `initialQuery=${ domain }` );
+
+		if ( initialMode ) {
+			queryArgs.push( `initialMode=${ initialMode }` );
+		}
 	}
 
-	return path;
+	return path + ( queryArgs.length ? `?${ queryArgs.join( '&' ) }` : '' );
 }
 
 export function getSectionName( pathname ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Replaces the previous precheck call with the new transfer flow.
Some changes were made to the container components in order to accept the `transfer` state as the initial one.

#### Preview
##### Normal state
![image](https://user-images.githubusercontent.com/18705930/136492415-41b704dd-4441-44a9-871c-237ec8a66960.png)

##### Domain not transferable (a sanity check, in case URL is manually changed by user)
![image](https://user-images.githubusercontent.com/18705930/136492630-a8649702-bcf9-4780-b791-405a31ec66cc.png)

These are the only changes specific to this flow: all the other parts are the same.

#### Testing instructions
- With a domain in "pending transfer" state, check that clicking on the "Start transfer" button no longer shows the precheck - and that the transfer within the new flow is successfully started. 
- Check that this flow is not able to proceed if a domain that can't be transferred is provided: 
  - Change the query param to a domain that is not transferrable;
  - Confirm that the message displayed is the same that the one in the "Preview" section of this PR's description.
- Check that forcing a transfer to a domain different than the one previously bought is not possible:
  - Change the query param to a different (and transferrable) domain than the one previously bought;
  - Confirm that the final step of the flow returns an error - even if you provide the correct auth code.