### PR TITLE
Playwright: don't run pull request tests on trunk, only on pull requests

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -681,6 +681,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 				branchFilter = """
 					+:*
 					-:pull*
+					-:trunk
 				""".trimIndent()
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Right now the Playwright tests that run for each pull request _also_ run on trunk post merge. However, there's not really any need to do that - we already run a dedicated set of tests ("Pre-Release") on trunk post merge! So the current configuration is just consuming unneeded resources that could be speeding up builds elsewhere.

#### Testing instructions

After this PR merges, it should no longer trigger the build for pull-requests against trunk with each merge

Related to #
