### PR TITLE
Billing: Update receipts to use monospaced font in Receipt and Transaction IDs

### DIFF
--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -128,7 +128,7 @@ export function ReceiptBody( { transaction, handlePrintLinkClick } ) {
 				<ul className="billing-history__receipt-details group">
 					<li>
 						<strong>{ translate( 'Receipt ID' ) }</strong>
-						<span>{ transaction.id }</span>
+						<span className="receipt__monospace">{ transaction.id }</span>
 					</li>
 					<ReceiptTransactionId transaction={ transaction } />
 					<ReceiptPaymentMethod transaction={ transaction } />
@@ -160,7 +160,7 @@ function ReceiptTransactionId( { transaction } ) {
 	return (
 		<li>
 			<strong>{ translate( 'Transaction ID' ) }</strong>
-			<span>{ transaction.pay_ref }</span>
+			<span className="receipt__monospace">{ transaction.pay_ref }</span>
 		</li>
 	);
 }

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -252,6 +252,11 @@ textarea.billing-history__billing-details-editable {
 			text-transform: uppercase;
 		}
 
+		.receipt__monospace {
+			font-family: 'Courier', 'Courier New', monospace;
+			text-transform: uppercase;
+		}
+
 		.receipt__vat-vendor-details-number {
 			display: block;
 			margin-top: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will address concerns in 528-gh-Automattic/payments-shilling, where users or others may easily misread proportional font transaction IDs (swapping `I` for `l` for example). Changing the IDs to a monospace font should help with legibility.

#### Testing instructions

1. Switch to this branch.
2. Navigate to a receipt that contains a transaction ID.
3. You should see the transaction ID displayed in a `monospaced font`. 

**Before**:
<img width="768" alt="Screen Shot 2021-10-07 at 1 43 57 PM" src="https://user-images.githubusercontent.com/8002138/136459531-c04ab0b9-5c76-4b21-9882-11339566fc2d.png">

**After**:
<img width="766" alt="Screen Shot 2021-10-07 at 1 44 08 PM" src="https://user-images.githubusercontent.com/8002138/136459581-3fb6819a-1805-476a-a313-f02414cce613.png">

Resolves 528-gh-Automattic/payments-shilling