### PR TITLE
Themes Showcase: Fix current theme card badge and button overflow

### DIFF
--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -72,43 +72,47 @@ class CurrentTheme extends Component {
 							) }
 							<div className="current-theme__description">
 								<div className="current-theme__title-wrapper">
-									{ showBetaBadge && (
-										<Badge type="warning-clear" className="current-theme__badge-beta">
-											{ translate( 'Beta' ) }
-										</Badge>
-									) }
-									<span className="current-theme__label">
-										{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
-									</span>
+									<div className="current-theme__badge-wrapper">
+										{ showBetaBadge && (
+											<Badge type="warning-clear" className="current-theme__badge-beta">
+												{ translate( 'Beta' ) }
+											</Badge>
+										) }
+										<span className="current-theme__label">
+											{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
+										</span>
+									</div>
 									<span className="current-theme__name">{ text }</span>
 								</div>
-								<p>
-									{ translate( 'This is the active theme on your site.' ) }{ ' ' }
-									<InlineSupportLink supportContext="themes-switch">
-										{ translate( 'Learn more.' ) }
-									</InlineSupportLink>
-								</p>
+								<div className="current-theme__content-wrapper">
+									<p>
+										{ translate( 'This is the active theme on your site.' ) }{ ' ' }
+										<InlineSupportLink supportContext="themes-switch">
+											{ translate( 'Learn more.' ) }
+										</InlineSupportLink>
+									</p>
+									<div className={ classNames( 'current-theme__actions' ) }>
+										{ map( options, ( option, name ) => (
+											<Button
+												className={ classNames(
+													'current-theme__button',
+													'components-button',
+													'current-theme__' + this.props.name
+												) }
+												primary={ option.label.toLowerCase() === 'customize' }
+												name={ name }
+												key={ name }
+												label={ option.label }
+												href={ currentThemeId && option.getUrl( currentThemeId ) }
+												onClick={ this.trackClick }
+											>
+												{ option.icon && <Gridicon icon={ option.icon } size={ 18 } /> }
+												{ option.label }
+											</Button>
+										) ) }
+									</div>
+								</div>
 							</div>
-						</div>
-						<div className={ classNames( 'current-theme__actions' ) }>
-							{ map( options, ( option, name ) => (
-								<Button
-									className={ classNames(
-										'current-theme__button',
-										'components-button',
-										'current-theme__' + this.props.name
-									) }
-									primary={ option.label.toLowerCase() === 'customize' }
-									name={ name }
-									key={ name }
-									label={ option.label }
-									href={ currentThemeId && option.getUrl( currentThemeId ) }
-									onClick={ this.trackClick }
-								>
-									{ option.icon && <Gridicon icon={ option.icon } size={ 18 } /> }
-									{ option.label }
-								</Button>
-							) ) }
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -50,13 +50,13 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		width: auto;
 
 		@include break-small {
-			max-height: 150px;
+			max-height: 160px;
 			border-right: $current-theme-border;
 			border-bottom: none;
 		}
 
 		@include break-large {
-			max-height: 120px;
+			max-height: 130px;
 		}
 	}
 
@@ -93,6 +93,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		display: flex;
 		flex-direction: row-reverse;
 		align-items: center;
+		margin-bottom: 6px;
 	}
 
 	.current-theme__label {
@@ -104,11 +105,11 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		padding: 4px 12px;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 120px;
+		margin-right: 8px;
 
 		@include break-small {
 			align-self: center;
 			margin-bottom: 0;
-			margin-right: 8px;
 		}
 	}
 
@@ -120,6 +121,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		font-size: $font-body;
 		max-width: 100%;
 		margin-right: 8px;
+		margin-bottom: 6px;
 
 		@include breakpoint-deprecated( '>960px' ) {
 			font-size: $font-title-small;
@@ -129,6 +131,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	.current-theme__content-wrapper {
 		display: flex;
 		justify-content: center;
+		align-items: center;
 
 		@include break-small {
 			justify-content: space-between;
@@ -144,16 +147,12 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	.current-theme__description {
 		align-self: center;
 		font-size: $font-body-small;
-		margin: 16px;
+		margin: 20px 16px 12px;
 		width: 100%;
 
 		p {
 			color: var( --color-text-subtle );
-			margin: 8px 0 0;
-
-			@include breakpoint-deprecated( '>660px' ) {
-				margin-top: 12px;
-			}
+			margin-bottom: 0;
 		}
 	}
 

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -10,7 +10,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		display: flex;
 		flex-direction: column;
 
-		@include breakpoint-deprecated( '>960px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			min-height: 112px;
 			flex-direction: row;
 		}
@@ -54,12 +54,10 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		flex-direction: column;
 		align-items: center;
 		margin-top: 0;
-		flex-wrap: wrap;
 
-		// TODO: Figure out how to wrap description text
-		// @include breakpoint-deprecated( '>1040px' ) {
-		// 	flex-wrap: nowrap;
-		// }
+		@include breakpoint-deprecated( '<960px' ) {
+			flex-wrap: wrap;
+		}
 
 		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: row-reverse;
@@ -137,7 +135,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		justify-content: flex-end;
 		flex-grow: 1;
 
-		@include breakpoint-deprecated( '>960px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			border-top: none;
 			min-height: 112px;
 			padding-top: 0;

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -33,7 +33,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		@include breakpoint-deprecated( '>660px' ) {
 			border-right: $current-theme-border;
 			border-bottom: none;
-			max-height: 112px;
+			max-height: 150px;
 			width: auto;
 		}
 	}
@@ -53,15 +53,23 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+		margin-top: 0;
+		flex-wrap: wrap;
+
+		// TODO: Figure out how to wrap description text
+		// @include breakpoint-deprecated( '>1040px' ) {
+		// 	flex-wrap: nowrap;
+		// }
 
 		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: row-reverse;
 			justify-content: flex-end;
+			margin-top: -8px;
 		}
 	}
 
 	.current-theme__badge-beta {
-		margin-left: 6px;
+		margin-top: 8px;
 	}
 
 	.current-theme__label {
@@ -74,11 +82,12 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 120px;
 		margin-bottom: 4px;
+		margin-top: 8px;
 
 		@include breakpoint-deprecated( '>660px' ) {
 			align-self: center;
-			margin-left: 8px;
 			margin-bottom: 0;
+			margin-right: 8px;
 		}
 	}
 
@@ -90,6 +99,8 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		text-overflow: ellipsis;
 		font-size: $font-body;
 		max-width: 100%;
+		margin-top: 8px;
+		margin-right: 8px;
 
 		@include breakpoint-deprecated( '>960px' ) {
 			font-size: $font-title-small;
@@ -105,7 +116,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	.current-theme__description {
 		align-self: center;
 		font-size: $font-body-small;
-		margin: 16px;
+		padding: 16px;
 
 		p {
 			color: var( --color-text-subtle );

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -17,6 +17,19 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 			min-height: 112px;
 			flex-direction: row;
 		}
+
+		&::after {
+			content: '';
+			display: block;
+			background: #fff;
+			height: 69px;
+			width: 100%;
+			border-top: $current-theme-border;
+
+			@include break-xlarge {
+				content: none;
+			}
+		}
 	}
 
 	.current-theme__details {
@@ -24,20 +37,26 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		flex-direction: column;
 		font-size: $font-body-small;
 
-		@include breakpoint-deprecated( '>660px' ) {
+		@include break-small {
 			flex-direction: row;
 			font-size: $font-body;
+			width: 100%;
 		}
 	}
 
 	.current-theme__img {
 		border-bottom: $current-theme-border;
+		max-height: none;
+		width: auto;
 
-		@include breakpoint-deprecated( '>660px' ) {
+		@include break-small {
+			max-height: 150px;
 			border-right: $current-theme-border;
 			border-bottom: none;
-			max-height: 150px;
-			width: auto;
+		}
+
+		@include break-large {
+			max-height: 120px;
 		}
 	}
 
@@ -63,15 +82,17 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 			flex-wrap: initial;
 		}
 
-		@include breakpoint-deprecated( '>660px' ) {
+		@include break-small {
 			flex-direction: row-reverse;
 			justify-content: flex-end;
-			margin-top: -8px;
+			flex-wrap: wrap;
 		}
 	}
 
-	.current-theme__badge-beta {
-		margin-top: 8px;
+	.current-theme__badge-wrapper {
+		display: flex;
+		flex-direction: row-reverse;
+		align-items: center;
 	}
 
 	.current-theme__label {
@@ -83,10 +104,8 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		padding: 4px 12px;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 120px;
-		margin-bottom: 4px;
-		margin-top: 8px;
 
-		@include breakpoint-deprecated( '>660px' ) {
+		@include break-small {
 			align-self: center;
 			margin-bottom: 0;
 			margin-right: 8px;
@@ -97,15 +116,22 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		font-weight: 600;
 		box-sizing: border-box;
 		overflow: hidden;
-		white-space: nowrap;
 		text-overflow: ellipsis;
 		font-size: $font-body;
 		max-width: 100%;
-		margin-top: 8px;
 		margin-right: 8px;
 
 		@include breakpoint-deprecated( '>960px' ) {
 			font-size: $font-title-small;
+		}
+	}
+
+	.current-theme__content-wrapper {
+		display: flex;
+		justify-content: center;
+
+		@include break-small {
+			justify-content: space-between;
 		}
 	}
 
@@ -118,7 +144,8 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	.current-theme__description {
 		align-self: center;
 		font-size: $font-body-small;
-		padding: 16px;
+		margin: 16px;
+		width: 100%;
 
 		p {
 			color: var( --color-text-subtle );
@@ -131,25 +158,26 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__actions {
-		border-top: $current-theme-border;
 		box-sizing: border-box;
 		padding-top: 16px;
 		display: flex;
 		align-items: flex-end;
 		justify-content: flex-end;
 		flex-grow: 1;
+		position: absolute;
+		bottom: 16px;
+		right: 15px;
 
 		@include break-xlarge {
-			border-top: none;
-			min-height: 112px;
 			padding-top: 0;
+			position: initial;
 		}
 	}
 
 	.current-theme__button {
 		display: flex;
 		margin-right: 10px;
-		margin-bottom: 16px;
+		margin-top: 12px;
 		font-weight: normal;
 		position: relative;
 		border-width: 1px;

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 $current-theme-border: 1px solid var( --color-border-subtle );
 
 .current-theme {
@@ -10,7 +13,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		display: flex;
 		flex-direction: column;
 
-		@include breakpoint-deprecated( '>1040px' ) {
+		@include break-xlarge {
 			min-height: 112px;
 			flex-direction: row;
 		}
@@ -54,9 +57,10 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		flex-direction: column;
 		align-items: center;
 		margin-top: 0;
+		flex-wrap: wrap;
 
-		@include breakpoint-deprecated( '<960px' ) {
-			flex-wrap: wrap;
+		@include break-large {
+			flex-wrap: initial;
 		}
 
 		@include breakpoint-deprecated( '>660px' ) {
@@ -135,7 +139,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		justify-content: flex-end;
 		flex-grow: 1;
 
-		@include breakpoint-deprecated( '>1040px' ) {
+		@include break-xlarge {
 			border-top: none;
 			min-height: 112px;
 			padding-top: 0;


### PR DESCRIPTION
#### Description

At smaller browser view widths, badges and buttons overflow the "Current theme" card. In this PR, to avoid overflowing content, we place badges on a newline when the card width shrinks below a certain width.

##### Before
<img width="675" alt="Screenshot 2021-10-01 at 15 30 21" src="https://user-images.githubusercontent.com/2070010/135637699-074cd187-5266-4c56-9bfc-685b9fbc428b.png">
<img width="492" alt="Screenshot 2021-10-01 at 15 30 31" src="https://user-images.githubusercontent.com/2070010/135637704-13d8edf0-c9f4-4e16-bcf6-feab306afd60.png">

##### After
![2021-10-19 14 41 16](https://user-images.githubusercontent.com/5414230/137994979-c222a324-ff06-49d9-90c6-a2969e27c664.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create an FSE eligible site
2. Navigate to the themes showcase in Appearance > Themes
3. Decrease width of browser view until badges overflow
4. We may have to manually modify the text of the theme title in the chrome dev console since `Mayland (Blocks)` is no longer selectable

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56853
