### PR TITLE
Wip/logger

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -1,5 +1,6 @@
 import accessibleFocus from '@automattic/accessible-focus';
 import config from '@automattic/calypso-config';
+import { setup as setupLogger, debugFactory2 } from '@automattic/calypso-logger';
 import { getUrlParts } from '@automattic/calypso-url';
 import debugFactory from 'debug';
 import page from 'page';
@@ -50,6 +51,7 @@ import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 import { setupLocale } from './locale';
 
 const debug = debugFactory( 'calypso' );
+const debug2 = debugFactory2( 'calypso' );
 
 const setupContextMiddleware = ( reduxStore ) => {
 	page( '*', ( context, next ) => {
@@ -445,7 +447,13 @@ const boot = ( currentUser, registerRoutes ) => {
 };
 
 export const bootApp = async ( appName, registerRoutes ) => {
+	setupLogger( config( 'env_id' ) === 'production' ? 'warn' : 'trace' );
+
 	const user = await initializeCurrentUser();
-	debug( `Starting ${ appName }. Let's do this.` );
+
+	console.debug( `Starting ${ appName }. Let's do this. 1` );
+	debug( `Starting ${ appName }. Let's do this. 2 ` );
+	debug2( `Starting ${ appName }. Let's do this. 3` );
+
 	boot( user, registerRoutes );
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -1,6 +1,6 @@
 import accessibleFocus from '@automattic/accessible-focus';
 import config from '@automattic/calypso-config';
-import { setup as setupLogger, debugFactory2 } from '@automattic/calypso-logger';
+import { setup as setupLogger, debugLoggerFactory } from '@automattic/calypso-logger';
 import { getUrlParts } from '@automattic/calypso-url';
 import debugFactory from 'debug';
 import page from 'page';
@@ -51,7 +51,7 @@ import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 import { setupLocale } from './locale';
 
 const debug = debugFactory( 'calypso' );
-const debug2 = debugFactory2( 'calypso' );
+const debugLogger = debugLoggerFactory( 'calypso' );
 
 const setupContextMiddleware = ( reduxStore ) => {
 	page( '*', ( context, next ) => {
@@ -451,9 +451,18 @@ export const bootApp = async ( appName, registerRoutes ) => {
 
 	const user = await initializeCurrentUser();
 
-	console.debug( `Starting ${ appName }. Let's do this. 1` );
-	debug( `Starting ${ appName }. Let's do this. 2 ` );
-	debug2( `Starting ${ appName }. Let's do this. 3` );
+	console.trace( 'This is trace' );
+	console.debug( 'This is debug' );
+	console.log( 'This is log' );
+	console.log( 'This is log', 'with multiple', 'strings' );
+	console.log( 'This is log with formatting %i', 42 );
+	console.log( 'This is log with objects', { a: true } );
+	console.info( 'This is info' );
+	console.warn( 'This is warn. This should come from common.js' );
+	console.error( 'This is error. This should come from common.js' );
+
+	debug( `Starting ${ appName }. Let's do this. This is the old debug` );
+	debugLogger( `Starting ${ appName }. Let's do this. This is the new debug` );
 
 	boot( user, registerRoutes );
 };

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
 		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-config": "^1.0.0",
+		"@automattic/calypso-logger": "^1.0.0",
 		"@automattic/calypso-polyfills": "^2.0.0",
 		"@automattic/calypso-products": "^1.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",

--- a/packages/calypso-logger/package.json
+++ b/packages/calypso-logger/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@automattic/calypso-logger",
+	"version": "1.0.0",
+	"description": "Logger utility for the browser",
+	"main": "dist/cjs/index.js",
+	"module": "dist/cjs/index.js",
+	"calypso:src": "src/index.ts",
+	"types": "dist/types/index.d.ts",
+	"author": "Automattic Inc.",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/calypso-logger"
+	},
+	"license": "GPL-2.0-or-later",
+	"dependencies": {
+		"loglevel": "^1.7.1"
+	},
+	"devDependencies": {
+		"typescript": "^4.4.3"
+	},
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"watch": "tsc --build ./tsconfig.json --watch",
+		"prepack": "yarn run clean && yarn run build"
+	}
+}

--- a/packages/calypso-logger/src/index.ts
+++ b/packages/calypso-logger/src/index.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+
+import log from 'loglevel';
+import type { Logger, LogLevelDesc } from 'loglevel';
+
+type ConsoleImpl = {
+	trace: ( ...args: unknown[] ) => void;
+	debug: ( ...args: unknown[] ) => void;
+	log: ( ...args: unknown[] ) => void;
+	info: ( ...args: unknown[] ) => void;
+	warn: ( ...args: unknown[] ) => void;
+	error: ( ...args: unknown[] ) => void;
+};
+
+const nativeConsoleMethods: ConsoleImpl = {
+	trace: window.console.trace,
+	debug: window.console.debug,
+	log: window.console.log,
+	info: window.console.info,
+	warn: window.console.warn,
+	error: window.console.error,
+};
+
+export const setup = ( logLevel: LogLevelDesc ): void => {
+	log.methodFactory = function ( methodName ) {
+		return nativeConsoleMethods[ methodName as keyof ConsoleImpl ] ?? nativeConsoleMethods.log;
+	};
+	log.setLevel( logLevel, false );
+
+	window.console.trace = log.trace.bind( log );
+	window.console.debug = log.debug.bind( log );
+	window.console.log = log.log.bind( log );
+	window.console.info = log.info.bind( log );
+	window.console.warn = log.warn.bind( log );
+	window.console.error = log.error.bind( log );
+};
+
+export const debugFactory2 = ( name: string ): ( ( ...msg: unknown[] ) => void ) => {
+	const namedLogger = log.getLogger( name );
+	namedLogger.methodFactory = function ( methodName, logLevel, loggerName ) {
+		const rawMethod = log.methodFactory( methodName, logLevel, loggerName );
+		return function ( msg ) {
+			rawMethod( name + msg );
+		};
+	};
+	namedLogger.setLevel( 'debug', false );
+	return namedLogger.debug.bind( namedLogger );
+};

--- a/packages/calypso-logger/src/index.ts
+++ b/packages/calypso-logger/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import log from 'loglevel';
-import type { LogLevelDesc } from 'loglevel';
+import type { LogLevelDesc, Logger } from 'loglevel';
 
 type ConsoleImpl = {
 	trace: ( ...args: unknown[] ) => void;
@@ -21,25 +21,46 @@ const nativeConsoleMethods: ConsoleImpl = {
 	error: window.console.error,
 };
 
-export const setup = ( logLevel: LogLevelDesc ): void => {
-	log.setDefaultLevel( logLevel );
-
-	log.methodFactory = function ( methodName ) {
-		return nativeConsoleMethods[ methodName as keyof ConsoleImpl ] ?? nativeConsoleMethods.log;
-	};
-	// This call is used to apply methodFactory changes
-	log.setLevel( log.getLevel() );
-
+const interceptNativeConsole = ( log: Logger ): void => {
 	window.console.trace = log.trace.bind( log );
 	window.console.debug = log.debug.bind( log );
 	window.console.log = log.log.bind( log );
 	window.console.info = log.info.bind( log );
 	window.console.warn = log.warn.bind( log );
 	window.console.error = log.error.bind( log );
-
-	window.__setLoggerLevel = log.setLevel.bind( log );
 };
 
+export const setup = ( logLevel: LogLevelDesc ): void => {
+	// Set the default level. This is not persisted on page reload
+	log.setDefaultLevel( logLevel );
+
+	// Delegate log methods to `nativeConsoleMethods`. We need to use native methods
+	// so they maintain the stack trace.
+	log.methodFactory = ( methodName ) =>
+		nativeConsoleMethods[ methodName as keyof ConsoleImpl ] ?? nativeConsoleMethods.log;
+
+	// This call is used to apply methodFactory changes
+	log.setLevel( log.getLevel() );
+
+	// Overwrite console.* methods so they defer to log.*
+	interceptNativeConsole( log );
+
+	window.__setLoggerLevel = ( level: LogLevelDesc, persist = false ) => {
+		// By default, don't persist the level.
+		log.setLevel( level, persist );
+		// loglevel works by setting some log methods to noop when we set a level, so we need to
+		// re-attach them to window.console
+		interceptNativeConsole( log );
+	};
+};
+
+/**
+ * Experimental debug-like API.
+ *
+ * Usage:
+ *   const log = debugLoggerFactory("foo");
+ *   log("bar") // will output 'foo bar' to the console
+ */
 export const debugLoggerFactory = ( name: string ): ( ( ...msg: unknown[] ) => void ) => {
 	const namedLogger = log.getLogger( name );
 	namedLogger.methodFactory = function ( methodName, logLevel, loggerName ) {

--- a/packages/calypso-logger/tsconfig-cjs.json
+++ b/packages/calypso-logger/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/calypso-logger/tsconfig.json
+++ b/packages/calypso-logger/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@automattic/calypso-build/typescript/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+		"types": [ "node" ]
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,6 +171,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/calypso-logger@^1.0.0, @automattic/calypso-logger@workspace:packages/calypso-logger":
+  version: 0.0.0-use.local
+  resolution: "@automattic/calypso-logger@workspace:packages/calypso-logger"
+  dependencies:
+    loglevel: ^1.7.1
+    typescript: ^4.4.3
+  languageName: unknown
+  linkType: soft
+
 "@automattic/calypso-polyfills@^2.0.0, @automattic/calypso-polyfills@workspace:packages/calypso-polyfills":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-polyfills@workspace:packages/calypso-polyfills"
@@ -11895,6 +11904,7 @@ __metadata:
     "@automattic/calypso-build": ^9.0.0
     "@automattic/calypso-color-schemes": ^2.1.1
     "@automattic/calypso-config": ^1.0.0
+    "@automattic/calypso-logger": ^1.0.0
     "@automattic/calypso-polyfills": ^2.0.0
     "@automattic/calypso-products": ^1.0.0
     "@automattic/calypso-stripe": ^1.0.0
@@ -24638,7 +24648,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"loglevel@npm:^1.6.8":
+"loglevel@npm:^1.6.8, loglevel@npm:^1.7.1":
   version: 1.7.1
   resolution: "loglevel@npm:1.7.1"
   checksum: 14b481b7f5a3e2405f2c54c7a5914ba0e65c6cbc961dc90dc8ec67e1cf0ce549330ff5ab9024e52f232f8f2ca78ef27286f72c38f495ba8ab281aff18763b53c


### PR DESCRIPTION
**EXPERIMENTAL** - **EXPERIMENTAL** - **EXPERIMENTAL** - **EXPERIMENTAL**

---

## Background

Right now we have two different ways to log information from our app:

- Use `debug`, as documented [here](https://github.com/Automattic/wp-calypso/blob/trunk/docs/development-workflow.md#debugging). It has some issues, in my opinion:
   - It is hidden by default. If you see something failing, you can't just look at the debug log: you have to enable the log and then try to reproduce the bug.
   - Doesn't capture 3rd party logs. We'll miss any component using `console.log`.

- Use `console.log`, but we have an eslint rule to prevent it. If the developer wants to use it, they still can but they have to override the eslint rule. Problems:
   - Makes harder to switch to write server code, where `console.log` is allowed
   - Requires custom eslint config everywhere to disable `no-console` for some subset of files.
   - Can pollute the user's console if a `console.log` is committed accidentally

See this thread (p1633006507346300-slack-C7YPUHBB2) for more info
  
This PR creates an experimental Logger library to replace both systems. It uses [`loglevel`](https://github.com/pimterry/loglevel), a battle-tested library (>10m weekly downloads) with a small footprint (1.2kb min+gzip).

## Features

* Replaces native `console.trace`, `console.debug`, `console.log`, `console.info`, `console.warn` and `console.error`. This allows devs to just use `console.log` and not worry about anything else. It also captures logs from 3rd party packages.

* Supports logging several strings (`console.log("a","b")')

* Supports formatting (`console.log("id %i", 42)`)

* Supports logging objects (`console.log({foo:true})`)

* Different log levels for dev and prod (right not configured to `trace` and `warning` respectively). This address the problem of not polluting the user's console

* Can set the log level dynamically with `window.__setLoggerLevel("warn")`. Can be made persistent (i.e. will apply even after a page refresh) passing `true` as the second arg.

* Provides a `debug` like interface. Usage:

```
import { debugLoggerFactory } from '@automattic/calypso-logger';
const debug = debugLoggerFactory("calypso")
debug("Starting") // Will output "calypso starting"
```

## How it works:

It doesn't really _replace_ console methods. Instead, it replaces the log commands _above_ the current level with a noop. For example, if the level is `warn`, `console.warn` and `console.error` are untouched, where `console.log` and `console.info` are replaced with a noop. So any syntax supported by the native methods will continue to work exactly the same. This is also how it can keep the stack trace intact.

The downside is that every time we set the log level we have to re-run the logic to block some log levels.

## Caveats:

The console replacement works just fine, I couldn't find any caveat. However, the `debug`-like interface has some problems or limitations compared with the original `debug`:

* The stack trace is lost, all logs will appear as they come from `packages/calypso-logger/src/index.ts`
* Doesn't support colors
* Doesn't support relative timestamps

I have a couple of ideas of how to overcome those problems, in case we really want to keep that interface. But my guess is we won't really miss the colors or the timestamps.

## Future Improvements

`loglevel` have some nice plugins we could apply:

* [`loglevel-plugin-prefix`](https://github.com/kutuluk/loglevel-plugin-prefix) if we want nice prefix and timestamp for messages.
* [`loglevel-debug`](https://github.com/vectrlabs/loglevel-debug) if we want to use the `DEBUG=foo` semantics.

## Testing instructions

Play with it in the [`calypso.live`](https://calypso.live/?image=registry.a8c.com/calypso/app:build-16513) link. You should be able to see a few log lines in the console.

![image](https://user-images.githubusercontent.com/975703/136542653-2d1d466f-ae12-4ee6-80e1-f28b04223f9d.png)


* Run `__setLoggerLevel("silent")` and try `console.log("a")`. The output should be suppressed. Refreshing the page restores the level

* Run `__setLoggerLevel("silent", true)` and refresh the page. All console.log output (including the initial one) should be suppressed