### PR TITLE
Inbox upsell: Page view tracker and other tracking improvements

### DIFF
--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -183,6 +183,14 @@ export function recordEmailAppLaunchEvent( { app, context, provider } ) {
 }
 
 /**
+ * Tracks an event for the key 'calypso_inbox_new_mailbox_upsell_click'.
+ *
+ */
+export function recordInboxNewMailboxUpsellClickEvent() {
+	recordTracksEvent( 'calypso_inbox_new_mailbox_upsell_click', {} );
+}
+
+/**
  * Tracks an event for the key 'calypso_inbox_upsell'.
  *
  * @param context context, where this event was logged.

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -59,7 +59,6 @@ import {
 	getGoogleFeatures,
 	getTitanFeatures,
 } from 'calypso/my-sites/email/email-provider-features/list';
-import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagementForwarding, emailManagement } from 'calypso/my-sites/email/paths';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -157,7 +156,7 @@ class EmailProvidersComparison extends Component {
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
 			provider: 'email-forwarding',
-			source: source === INBOX_SOURCE ? source : null,
+			source,
 		} );
 
 		page( emailManagementForwarding( selectedSite.slug, selectedDomainName, currentRoute ) );
@@ -196,7 +195,7 @@ class EmailProvidersComparison extends Component {
 			mailbox_count: validatedTitanMailboxes.length,
 			mailboxes_valid: mailboxesAreValid ? 1 : 0,
 			provider: TITAN_PROVIDER_NAME,
-			source: source === INBOX_SOURCE ? source : null,
+			source,
 			user_can_add_email: userCanAddEmail,
 			user_cannot_add_email_code: userCannotAddEmailReason ? userCannotAddEmailReason.code : '',
 		} );
@@ -264,7 +263,7 @@ class EmailProvidersComparison extends Component {
 			mailbox_count: googleUsers.length,
 			mailboxes_valid: usersAreValid ? 1 : 0,
 			provider: GOOGLE_PROVIDER_NAME,
-			source: source === INBOX_SOURCE ? source : null,
+			source,
 			user_can_add_email: userCanAddEmail ? 1 : 0,
 		} );
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -155,14 +155,10 @@ class EmailProvidersComparison extends Component {
 	goToEmailForwarding = () => {
 		const { currentRoute, selectedDomainName, selectedSite, source } = this.props;
 
-		const eventProperties = {
+		recordTracksEvent( 'calypso_email_providers_add_click', {
 			provider: 'email-forwarding',
-		};
-
-		if ( source === INBOX_SOURCE ) {
-			eventProperties.source = source;
-		}
-		recordTracksEvent( 'calypso_email_providers_add_click', eventProperties );
+			source: source === INBOX_SOURCE ? source : null,
+		} );
 
 		page( emailManagementForwarding( selectedSite.slug, selectedDomainName, currentRoute ) );
 	};
@@ -195,20 +191,15 @@ class EmailProvidersComparison extends Component {
 			? null
 			: getCurrentUserCannotAddEmailReason( domain );
 
-		const eventProperties = {
+		recordTracksEvent( 'calypso_email_providers_add_click', {
 			context: comparisonContext,
 			mailbox_count: validatedTitanMailboxes.length,
 			mailboxes_valid: mailboxesAreValid ? 1 : 0,
 			provider: TITAN_PROVIDER_NAME,
+			source: source === INBOX_SOURCE ? source : null,
 			user_can_add_email: userCanAddEmail,
 			user_cannot_add_email_code: userCannotAddEmailReason ? userCannotAddEmailReason.code : '',
-		};
-
-		if ( source === INBOX_SOURCE ) {
-			eventProperties.source = INBOX_SOURCE;
-		}
-
-		recordTracksEvent( 'calypso_email_providers_add_click', eventProperties );
+		} );
 
 		const validatedTitanMailboxUuids = validatedTitanMailboxes.map( ( mailbox ) => mailbox.uuid );
 
@@ -268,19 +259,14 @@ class EmailProvidersComparison extends Component {
 		const usersAreValid = areAllUsersValid( googleUsers );
 		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
 
-		const eventProperties = {
+		recordTracksEvent( 'calypso_email_providers_add_click', {
 			context: comparisonContext,
 			mailbox_count: googleUsers.length,
 			mailboxes_valid: usersAreValid ? 1 : 0,
 			provider: GOOGLE_PROVIDER_NAME,
+			source: source === INBOX_SOURCE ? source : null,
 			user_can_add_email: userCanAddEmail ? 1 : 0,
-		};
-
-		if ( source === INBOX_SOURCE ) {
-			eventProperties.source = INBOX_SOURCE;
-		}
-
-		recordTracksEvent( 'calypso_email_providers_add_click', eventProperties );
+		} );
 
 		if ( ! usersAreValid || ! userCanAddEmail ) {
 			return;

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -59,7 +59,7 @@ import {
 	getGoogleFeatures,
 	getTitanFeatures,
 } from 'calypso/my-sites/email/email-provider-features/list';
-import { INBOX } from 'calypso/my-sites/email/inbox';
+import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagementForwarding, emailManagement } from 'calypso/my-sites/email/paths';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -159,7 +159,7 @@ class EmailProvidersComparison extends Component {
 			provider: 'email-forwarding',
 		};
 
-		if ( source === INBOX ) {
+		if ( source === INBOX_SOURCE ) {
 			eventProperties.source = source;
 		}
 		recordTracksEvent( 'calypso_email_providers_add_click', eventProperties );
@@ -204,8 +204,8 @@ class EmailProvidersComparison extends Component {
 			user_cannot_add_email_code: userCannotAddEmailReason ? userCannotAddEmailReason.code : '',
 		};
 
-		if ( source === INBOX ) {
-			eventProperties.source = INBOX;
+		if ( source === INBOX_SOURCE ) {
+			eventProperties.source = INBOX_SOURCE;
 		}
 
 		recordTracksEvent( 'calypso_email_providers_add_click', eventProperties );
@@ -276,8 +276,8 @@ class EmailProvidersComparison extends Component {
 			user_can_add_email: userCanAddEmail ? 1 : 0,
 		};
 
-		if ( source === INBOX ) {
-			eventProperties.source = INBOX;
+		if ( source === INBOX_SOURCE ) {
+			eventProperties.source = INBOX_SOURCE;
 		}
 
 		recordTracksEvent( 'calypso_email_providers_add_click', eventProperties );

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -35,7 +35,7 @@ import {
 } from 'calypso/lib/gsuite/new-users';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
-import { INBOX } from 'calypso/my-sites/email/inbox';
+import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors/get-products-list';
@@ -122,10 +122,10 @@ class GSuiteAddUsers extends Component {
 			user_count: users.length,
 		};
 
-		if ( source === INBOX ) {
+		if ( source === INBOX_SOURCE ) {
 			eventObject.provider = GOOGLE_PROVIDER_NAME;
 			eventObject.product = 'inbox';
-			eventObject.source = INBOX;
+			eventObject.source = INBOX_SOURCE;
 		}
 
 		recordTracksEvent( eventName, eventObject );

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -35,7 +35,6 @@ import {
 } from 'calypso/lib/gsuite/new-users';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
-import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors/get-products-list';
@@ -120,11 +119,9 @@ class GSuiteAddUsers extends Component {
 
 		recordTracksEvent( eventName, {
 			domain_name: selectedDomainName,
+			provider: GOOGLE_PROVIDER_NAME,
+			source,
 			user_count: users.length,
-			...( source === INBOX_SOURCE && {
-				provider: GOOGLE_PROVIDER_NAME,
-				source,
-			} ),
 		} );
 	};
 

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -117,18 +117,15 @@ class GSuiteAddUsers extends Component {
 	recordClickEvent = ( eventName ) => {
 		const { recordTracksEvent, selectedDomainName, source } = this.props;
 		const { users } = this.state;
-		const eventObject = {
+
+		recordTracksEvent( eventName, {
 			domain_name: selectedDomainName,
 			user_count: users.length,
-		};
-
-		if ( source === INBOX_SOURCE ) {
-			eventObject.provider = GOOGLE_PROVIDER_NAME;
-			eventObject.product = 'inbox';
-			eventObject.source = INBOX_SOURCE;
-		}
-
-		recordTracksEvent( eventName, eventObject );
+			...( source === INBOX_SOURCE && {
+				provider: GOOGLE_PROVIDER_NAME,
+				source,
+			} ),
+		} );
 	};
 
 	recordUsersChangedEvent = ( previousUsers, nextUsers ) => {

--- a/client/my-sites/email/inbox/constants.js
+++ b/client/my-sites/email/inbox/constants.js
@@ -1,0 +1,6 @@
+/**
+ * The value `inbox` often used as a `source` url parameter
+ *
+ * @type {string}
+ */
+export const INBOX_SOURCE = 'inbox';

--- a/client/my-sites/email/inbox/index.jsx
+++ b/client/my-sites/email/inbox/index.jsx
@@ -10,6 +10,7 @@ import { getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import { getConfiguredTitanMailboxCount } from 'calypso/lib/titan';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
+import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import MailboxSelectionList from 'calypso/my-sites/email/inbox/mailbox-selection-list';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -17,8 +18,6 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
-
-export const INBOX = 'inbox';
 
 const NoAccessCard = () => {
 	const translate = useTranslate();
@@ -107,7 +106,7 @@ const InboxManagement = () => {
 				emailListInactiveHeader={ <MainHeader /> }
 				sectionHeaderLabel={ translate( 'Domains' ) }
 				showActiveDomainList={ showActiveDomainList( nonWPCOMDomains ) }
-				source={ INBOX }
+				source={ INBOX_SOURCE }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -2,9 +2,9 @@ import { Button, Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useQueryClient } from 'react-query';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { getMailboxesCacheKey, useGetMailboxes } from 'calypso/data/emails/use-get-mailboxes';
@@ -20,9 +20,13 @@ import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
 import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
+import {
+	recordEmailAppLaunchEvent,
+	recordInboxNewMailboxUpsellClickEvent,
+} from 'calypso/my-sites/email/email-management/home/utils';
 import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
-import { emailManagement } from 'calypso/my-sites/email/paths';
+import { emailManagement, emailManagementInbox } from 'calypso/my-sites/email/paths';
+import { recordPageView } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ProgressLine from './progress-line';
 
@@ -123,6 +127,7 @@ const NewMailboxUpsell = () => {
 	const selectedSiteSlug = selectedSite?.slug;
 
 	const handleCreateNewMailboxClick = useCallback( () => {
+		recordInboxNewMailboxUpsellClickEvent();
 		page( emailManagement( selectedSiteSlug, null, null, { source: INBOX_SOURCE } ) );
 	}, [ selectedSiteSlug ] );
 
@@ -223,9 +228,11 @@ MailboxLoaderError.propType = {
 };
 
 const MailboxSelectionList = () => {
-	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteId = selectedSite?.ID ?? null;
+	const selectedSiteIdRef = useRef( null );
+	const translate = useTranslate();
 
 	const { data, isError, isLoading, refetch } = useGetMailboxes( selectedSiteId, {
 		retry: 2,
@@ -242,6 +249,12 @@ const MailboxSelectionList = () => {
 	const mailboxes = ( data?.mailboxes ?? [] ).filter(
 		( mailbox ) => ! isEmailForwardAccount( mailbox )
 	);
+
+	if ( selectedSiteId !== selectedSiteIdRef.current ) {
+		dispatch( recordPageView( emailManagementInbox( selectedSiteId ), 'Inbox' ) );
+	}
+
+	selectedSiteIdRef.current = selectedSiteId;
 
 	return (
 		<div className="mailbox-selection-list__container">

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -2,7 +2,7 @@ import { Button, Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
@@ -231,12 +231,15 @@ const MailboxSelectionList = () => {
 	const dispatch = useDispatch();
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteId = selectedSite?.ID ?? null;
-	const selectedSiteIdRef = useRef( null );
 	const translate = useTranslate();
 
 	const { data, isError, isLoading, refetch } = useGetMailboxes( selectedSiteId, {
 		retry: 2,
 	} );
+
+	useEffect( () => {
+		dispatch( recordPageView( emailManagementInbox( ':site' ), 'Inbox' ) );
+	}, [ dispatch ] );
 
 	if ( isLoading || selectedSiteId === null ) {
 		return <ProgressLine statusText={ translate( 'Loading your mailboxes' ) } />;
@@ -249,12 +252,6 @@ const MailboxSelectionList = () => {
 	const mailboxes = ( data?.mailboxes ?? [] ).filter(
 		( mailbox ) => ! isEmailForwardAccount( mailbox )
 	);
-
-	if ( selectedSiteId !== selectedSiteIdRef.current ) {
-		dispatch( recordPageView( emailManagementInbox( selectedSiteId ), 'Inbox' ) );
-	}
-
-	selectedSiteIdRef.current = selectedSiteId;
 
 	return (
 		<div className="mailbox-selection-list__container">

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -21,7 +21,7 @@ import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
-import { INBOX } from 'calypso/my-sites/email/inbox';
+import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ProgressLine from './progress-line';
@@ -123,7 +123,7 @@ const NewMailboxUpsell = () => {
 	const selectedSiteSlug = selectedSite?.slug;
 
 	const handleCreateNewMailboxClick = useCallback( () => {
-		page( emailManagement( selectedSiteSlug, null, null, { source: INBOX } ) );
+		page( emailManagement( selectedSiteSlug, null, null, { source: INBOX_SOURCE } ) );
 	}, [ selectedSiteSlug ] );
 
 	return (

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -5,7 +5,7 @@ export const emailManagementPrefix = '/email';
 export const emailManagementAllSitesPrefix = '/email/all';
 
 /**
- * Retrieves the query string from an object
+ * Builds a URL query string from an object. Handles null values.
  *
  * @param {Object} parameters - optional path prefix
  * @returns {string} the corresponding query string

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -68,10 +68,12 @@ class TitanAddMailboxes extends Component {
 	}
 
 	recordClickEvent = ( eventName, eventProps ) => {
-		const { recordTracksEvent, selectedDomainName } = this.props;
+		const { recordTracksEvent, selectedDomainName, source } = this.props;
 		recordTracksEvent( eventName, {
 			...eventProps,
 			domain_name: selectedDomainName,
+			source,
+			provider: TITAN_PROVIDER_NAME,
 		} );
 	};
 
@@ -117,7 +119,7 @@ class TitanAddMailboxes extends Component {
 	};
 
 	handleContinue = async () => {
-		const { selectedSite, source } = this.props;
+		const { selectedSite } = this.props;
 		const { mailboxes } = this.state;
 
 		const validatedMailboxes = validateMailboxes( mailboxes );
@@ -148,8 +150,6 @@ class TitanAddMailboxes extends Component {
 		this.recordClickEvent( 'calypso_email_management_titan_add_mailboxes_continue_button_click', {
 			can_continue: canContinue,
 			mailbox_count: mailboxes.length,
-			provider: TITAN_PROVIDER_NAME,
-			source,
 		} );
 
 		if ( canContinue ) {

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -72,8 +72,8 @@ class TitanAddMailboxes extends Component {
 		recordTracksEvent( eventName, {
 			...eventProps,
 			domain_name: selectedDomainName,
-			source,
 			provider: TITAN_PROVIDER_NAME,
+			source,
 		} );
 	};
 

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -31,7 +31,6 @@ import {
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
-import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import {
 	emailManagement,
 	emailManagementNewTitanAccount,
@@ -149,10 +148,8 @@ class TitanAddMailboxes extends Component {
 		this.recordClickEvent( 'calypso_email_management_titan_add_mailboxes_continue_button_click', {
 			can_continue: canContinue,
 			mailbox_count: mailboxes.length,
-			...( source === INBOX_SOURCE && {
-				provider: TITAN_PROVIDER_NAME,
-				source,
-			} ),
+			provider: TITAN_PROVIDER_NAME,
+			source,
 		} );
 
 		if ( canContinue ) {

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -146,21 +146,14 @@ class TitanAddMailboxes extends Component {
 			validatedMailboxUuids,
 		} );
 
-		const eventProps = {
+		this.recordClickEvent( 'calypso_email_management_titan_add_mailboxes_continue_button_click', {
 			can_continue: canContinue,
 			mailbox_count: mailboxes.length,
-		};
-
-		if ( source === INBOX_SOURCE ) {
-			eventProps.product = 'inbox';
-			eventProps.provider = TITAN_PROVIDER_NAME;
-			eventProps.source = INBOX_SOURCE;
-		}
-
-		this.recordClickEvent(
-			'calypso_email_management_titan_add_mailboxes_continue_button_click',
-			eventProps
-		);
+			...( source === INBOX_SOURCE && {
+				provider: TITAN_PROVIDER_NAME,
+				source,
+			} ),
+		} );
 
 		if ( canContinue ) {
 			this.setState( { isAddingToCart: true } );

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -31,7 +31,7 @@ import {
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
-import { INBOX } from 'calypso/my-sites/email/inbox';
+import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import {
 	emailManagement,
 	emailManagementNewTitanAccount,
@@ -151,10 +151,10 @@ class TitanAddMailboxes extends Component {
 			mailbox_count: mailboxes.length,
 		};
 
-		if ( source === INBOX ) {
+		if ( source === INBOX_SOURCE ) {
 			eventProps.product = 'inbox';
 			eventProps.provider = TITAN_PROVIDER_NAME;
-			eventProps.source = INBOX;
+			eventProps.source = INBOX_SOURCE;
 		}
 
 		this.recordClickEvent(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up of #56786. The effort essentially rectifies some comments and refines logic to make it easier to find stuff.

- Installs a page view tracker
- Click event tracker for new mailbox upsells
- Refines some JavaDoc
- Removes long IFs
- Extracts constants

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

NOTE: You can confirm that track events are fired by using the browser's developer console, the network panel, and looking for requests for `*/t.gif` and checking out the URL query parameters.

* Navigate to the `/inbox` using a site with mailboxes
* Confirm the existence of a `calypso_page_view` event on page load
* Click on the upsell button at the bottom of the street
* Confirm that a `calypso_inbox_new_mailbox_upsell_click` event was fired

Also test out these flows:
 * Load the Inbox
 * Click on the "Create a new mailbox" button
 * From this point, test both of the following flows:
   - **Google**
     = Open an existing Google subscription
     = Verify the URL still includes the `source` URL parameter
     = Click on "Add new mailboxes"
     = Verify the URL still includes the `source` URL parameter
     = Click on the Cancel button
     = Verify that the `source` field is included in the Tracks event for the click
     = Click on "Add new mailboxes" again
     = Fill in enough data for the "Continue" button to be enabled
     = Click on the Continue button
     = Verify that the click event includes the `source` field
   - **Professional Email**
    = Open an existing Professional Email subscription
    = Verify the URL still includes the `source` URL parameter
     = Click on "Add new mailboxes"
     = Verify the URL still includes the `source` URL parameter
     = Click on the Cancel button
     = Verify that the `source` field is included in the Tracks event for the click - _Note: this is NOT currently true_
     = Click on "Add new mailboxes" again
     = Click on the Continue button
     = Verify that the click event includes the `source` field
 * Navigate to Upgrades -> Emails
 * Repeat the steps above, except we need to verify that `source` is not present in the URL and in the Tracks events


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56786
