### PR TITLE
Fix use my domain validation

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
@@ -7,7 +7,7 @@ export function getDomainNameValidationErrorMessage( domainName ) {
 	}
 
 	if (
-		! /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}(?:[a-zA-Z0-9](?:\.[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]))*(?:\.[a-zA-Z]{2,})+$/.test(
+		! /^(([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)\.)+([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)$/.test(
 			domainName
 		)
 	) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Fix the use a domain I own domain validation regex.

#### Testing instructions

In the "Use a domain I own" flow, attempt to use domains like the following:

Make sure that all of the below are accepted.
abc.com
ab.co
as.as.sd.co
a.co
aa.co
1a.ca
a1.co
fr.asdfasdfasdf.com
es.businessplanioana.com
a.blergh.com
a.com
a.co
a.a.co
a.b.co
aa.co
a-a.co

Make sure that these show the error similar to: "Are you sure you mean a-.com? This is not a valid domain."

a-.com
-a.com

Related to #56838
