### PR TITLE
Jetpack Cloud: Display Search Upsell for Jetpack Backup Plugin

### DIFF
--- a/client/my-sites/jetpack-search/main-jetpack.tsx
+++ b/client/my-sites/jetpack-search/main-jetpack.tsx
@@ -48,12 +48,12 @@ export default function JetpackSearchMainJetpack( { siteId }: Props ): ReactElem
 		return <JetpackSearchPlaceholder siteId={ siteId } isJetpack={ true } />;
 	}
 
-	if ( ! isLoading && modules === null ) {
-		return <JetpackSearchDisconnected />;
-	}
-
 	if ( ! hasSearchProduct ) {
 		return <JetpackSearchUpsell />;
+	}
+
+	if ( ! isLoading && modules === null ) {
+		return <JetpackSearchDisconnected />;
 	}
 
 	return <JetpackSearchDetails isSearchEnabled={ isJetpackSearchModuleActive } />;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the order of the Search Upsell so it will be displayed for sites with Jetpack Backup plugin only.
* Since the Jetpack Backup plugin lacks search end points it's detected as 'disconnected' which had display priority over the upsell.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test Jetpack Backup
* Setup a site with Jetpack Backup and a Backup plan (one that doesn't include scan)
* Visit a calypso instance running this branch and ensure the Search Upsell page shows, not the disconnected screen.

Test Jetpack
* Setup a site with the Jetpack plugin, Jetpack Debugger plugin and a plan with Search (like Complete)
* Visit a calypso instance running this branch and ensure the Search page shows properly
* Clear the site tokens with the Jetpack Debugger Broken token Utilities
* Visit a calypso instance running this branch and ensure the Search page shows the disconnected screen.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->