### PR TITLE
Add tracks event for assign payment method checkbox

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/assign-to-all-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/assign-to-all-payment-methods.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 import { CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const CheckboxWrapper = styled.div`
 	margin-top: 16px;
@@ -15,11 +17,23 @@ export default function AssignToAllPaymentMethods( {
 	onChange: ( isChecked: boolean ) => void;
 } ): JSX.Element {
 	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+
+	const handleChangeEvent = ( newIsChecked: boolean ): void => {
+		reduxDispatch(
+			recordTracksEvent( 'calypso_add_credit_card_form_assign_to_all_methods_toggle', {
+				old_value: isChecked,
+				new_value: newIsChecked,
+			} )
+		);
+		onChange( newIsChecked );
+	};
+
 	return (
 		<CheckboxWrapper>
 			<CheckboxControl
 				checked={ isChecked }
-				onChange={ onChange }
+				onChange={ handleChangeEvent }
 				label={ translate(
 					'Use this payment method for all subscriptions on my account. {{link}}Learn more.{{/link}}',
 					{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new tracks event (`calypso_add_credit_card_form_assign_to_all_methods_toggle`; verbose and yet precise) that fires when the "Assign new card to all my subscriptions" checkbox is toggled. Includes the old and new values of the checkbox as props.

#### Testing instructions

1. Navigate to any of the add or change payment method screens which have the "Use this payment method for all subscriptions on my account" checkbox.
2. Click on the checkbox; don't worry about submitting the form.
3. Watch your test user's tracks events for `calypso_add_credit_card_form_assign_to_all_methods_toggle` and verify that it has the expected props. Screenshot is from an earlier iteration that used a different slug for the event; the final version uses the same prefix as the other add-card-specific events.

<img width="454" alt="Screen Shot 2021-10-08 at 4 33 23 PM" src="https://user-images.githubusercontent.com/9310939/136627826-bfdfe112-899b-4d22-b690-1cd060f18b74.png">

Related to #56736
