### PR TITLE
Themes Showcase: Only display beta badges for FSE beta eligible sites

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -15,7 +15,6 @@ import { decodeEntities } from 'calypso/lib/formatting';
 import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThemeMoreButton from './more-button';
 
 import './style.scss';
@@ -282,9 +281,6 @@ export class Theme extends Component {
 
 const ThemeWithEditorSettings = withBlockEditorSettings( Theme );
 
-export default connect(
-	( state ) => {
-		return { siteId: getSelectedSiteId( state ) };
-	},
-	{ recordTracksEvent, setThemesBookmark }
-)( localize( ThemeWithEditorSettings ) );
+export default connect( null, { recordTracksEvent, setThemesBookmark } )(
+	localize( ThemeWithEditorSettings )
+);

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -71,11 +71,9 @@ export class Theme extends Component {
 			PropTypes.func,
 			PropTypes.shape( { current: PropTypes.any } ),
 		] ),
-		blockEditorSettings: PropTypes.objectOf(
-			PropTypes.shape( {
-				is_fse_eligible: PropTypes.bool,
-			} )
-		),
+		blockEditorSettings: PropTypes.shape( {
+			is_fse_eligible: PropTypes.bool,
+		} ),
 	};
 
 	static defaultProps = {

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -9,11 +9,11 @@ import { connect } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import InfoPopover from 'calypso/components/info-popover';
 import PulsingDot from 'calypso/components/pulsing-dot';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import isSiteUsingCoreSiteEditorSelector from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThemeMoreButton from './more-button';
@@ -72,7 +72,11 @@ export class Theme extends Component {
 			PropTypes.func,
 			PropTypes.shape( { current: PropTypes.any } ),
 		] ),
-		isSiteUsingCoreSiteEditor: PropTypes.bool,
+		blockEditorSettings: PropTypes.objectOf(
+			PropTypes.shape( {
+				is_fse_eligible: PropTypes.bool,
+			} )
+		),
 	};
 
 	static defaultProps = {
@@ -144,7 +148,7 @@ export class Theme extends Component {
 	};
 
 	render() {
-		const { active, isSiteUsingCoreSiteEditor, price, theme, translate, upsellUrl } = this.props;
+		const { active, blockEditorSettings, price, theme, translate, upsellUrl } = this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
@@ -205,7 +209,8 @@ export class Theme extends Component {
 		const e2eThemeName = name.toLowerCase().replace( /\s+/g, '-' );
 
 		const bookmarkRef = this.props.bookmarkRef ? { ref: this.props.bookmarkRef } : {};
-		const showBetaBadge = isFullSiteEditingTheme( this.props.theme ) && isSiteUsingCoreSiteEditor;
+		const isFSEEligible = blockEditorSettings?.is_fse_eligible ?? false;
+		const showBetaBadge = isFullSiteEditingTheme( this.props.theme ) && isFSEEligible;
 
 		return (
 			<Card className={ themeClass } data-e2e-theme={ e2eThemeName } onClick={ this.setBookmark }>
@@ -275,12 +280,11 @@ export class Theme extends Component {
 	}
 }
 
+const ThemeWithEditorSettings = withBlockEditorSettings( Theme );
+
 export default connect(
 	( state ) => {
-		const siteId = getSelectedSiteId( state );
-		return {
-			isSiteUsingCoreSiteEditor: isSiteUsingCoreSiteEditorSelector( state, siteId ),
-		};
+		return { siteId: getSelectedSiteId( state ) };
 	},
 	{ recordTracksEvent, setThemesBookmark }
-)( localize( Theme ) );
+)( localize( ThemeWithEditorSettings ) );

--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -4,7 +4,7 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
 <div
   className="themes-list"
 >
-  <Connect(Localized(Theme))
+  <Connect(Localized(WithBlockEditorSettings(Theme)))
     actionLabel=""
     active={false}
     bookmarkRef={null}
@@ -21,7 +21,7 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
       }
     }
   />
-  <Connect(Localized(Theme))
+  <Connect(Localized(WithBlockEditorSettings(Theme)))
     actionLabel=""
     active={false}
     bookmarkRef={null}

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { getLocaleSlug } from 'i18n-calypso';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { RouteProvider } from 'calypso/components/route';
@@ -18,6 +19,7 @@ export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
 
 const ProviderWrappedLoggedOutLayout = ( {
 	store,
+	queryClient = new QueryClient(),
 	currentSection,
 	currentRoute,
 	currentQuery,
@@ -31,9 +33,15 @@ const ProviderWrappedLoggedOutLayout = ( {
 			currentRoute={ currentRoute }
 			currentQuery={ currentQuery }
 		>
-			<ReduxProvider store={ store }>
-				<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
-			</ReduxProvider>
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<LayoutLoggedOut
+						primary={ primary }
+						secondary={ secondary }
+						redirectUri={ redirectUri }
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
 		</RouteProvider>
 	</CalypsoI18nProvider>
 );

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -17,6 +17,23 @@ import { ssrSetupLocaleMiddleware } from './ssr-setup-locale.js';
  */
 export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
 
+/**
+ * Server side rendering (SSR) is used exclusively for logged out users. Normally, for
+ * logged out users, we wouldn't need the react-query QueryClientProvider. This is
+ * because only logged-in users have access to REST endpoints, hence no fetches made by
+ * react-query, and no need for the QueryClientProvider.
+ *
+ * We, however add it here in order to prevent errors when server side rendering (SSR).
+ * For context, there are components shared between logged-in and logged-out views.
+ * If ProviderWrappedLoggedOutLayout initializes content that contains a useQuery call
+ * in one of these shared components (even if it's not enabled), SSR will throw an error
+ * regarding an inaccessible QueryClient.
+ *
+ * Ideally, useQuery would only be called for logged-in routes on a site, but ensuring
+ * that will require more planning and deliberate refactoring.
+ *
+ * https://github.com/Automattic/wp-calypso/pull/56916#issuecomment-942730743
+ */
 const ProviderWrappedLoggedOutLayout = ( {
 	store,
 	queryClient = new QueryClient(),

--- a/client/data/block-editor/use-block-editor-settings-query.ts
+++ b/client/data/block-editor/use-block-editor-settings-query.ts
@@ -6,7 +6,8 @@ export type BlockEditorSettings = {
 };
 
 export const useBlockEditorSettingsQuery = (
-	siteId: string
+	siteId: string,
+	userLoggedIn = false
 ): UseQueryResult< BlockEditorSettings > => {
 	const queryKey = [ 'blockEditorSettings', siteId ];
 
@@ -18,6 +19,6 @@ export const useBlockEditorSettingsQuery = (
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		{ enabled: !! siteId }
+		{ enabled: userLoggedIn && !! siteId }
 	);
 };

--- a/client/data/block-editor/use-block-editor-settings-query.ts
+++ b/client/data/block-editor/use-block-editor-settings-query.ts
@@ -10,10 +10,14 @@ export const useBlockEditorSettingsQuery = (
 ): UseQueryResult< BlockEditorSettings > => {
 	const queryKey = [ 'blockEditorSettings', siteId ];
 
-	return useQuery< BlockEditorSettings >( queryKey, () => {
-		return wpcom.req.get( {
-			path: `/sites/${ siteId }/block-editor`,
-			apiNamespace: 'wpcom/v2',
-		} );
-	} );
+	return useQuery< BlockEditorSettings >(
+		queryKey,
+		() => {
+			return wpcom.req.get( {
+				path: `/sites/${ siteId }/block-editor`,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+		{ enabled: !! siteId }
+	);
 };

--- a/client/data/block-editor/with-block-editor-settings.js
+++ b/client/data/block-editor/with-block-editor-settings.js
@@ -1,0 +1,16 @@
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useBlockEditorSettingsQuery } from './use-block-editor-settings-query';
+
+const withBlockEditorSettings = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const siteId = useSelector( getSelectedSiteId );
+		const { data } = useBlockEditorSettingsQuery( siteId );
+
+		return <Wrapped { ...props } blockEditorSettings={ data } />;
+	},
+	'withBlockEditorSettings'
+);
+
+export default withBlockEditorSettings;

--- a/client/data/block-editor/with-block-editor-settings.js
+++ b/client/data/block-editor/with-block-editor-settings.js
@@ -1,13 +1,14 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelector } from 'react-redux';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useBlockEditorSettingsQuery } from './use-block-editor-settings-query';
 
 const withBlockEditorSettings = createHigherOrderComponent(
 	( Wrapped ) => ( props ) => {
 		const siteId = useSelector( getSelectedSiteId );
-		const { data } = useBlockEditorSettingsQuery( siteId );
-
+		const userLoggedIn = useSelector( isUserLoggedIn );
+		const { data } = useBlockEditorSettingsQuery( siteId, userLoggedIn );
 		return <Wrapped { ...props } blockEditorSettings={ data } />;
 	},
 	'withBlockEditorSettings'

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -26,6 +26,7 @@ import SectionHeader from 'calypso/components/section-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
@@ -102,6 +103,11 @@ class ThemeSheet extends Component {
 			action: PropTypes.func,
 			getUrl: PropTypes.func,
 		} ),
+		blockEditorSettings: PropTypes.objectOf(
+			PropTypes.shape( {
+				is_fse_eligible: PropTypes.bool,
+			} )
+		),
 	};
 
 	static defaultProps = {
@@ -178,17 +184,19 @@ class ThemeSheet extends Component {
 	};
 
 	renderBar = () => {
-		const { author, name, taxonomies, translate } = this.props;
+		const { author, blockEditorSettings, name, taxonomies, translate } = this.props;
 
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
 		const tag = author ? translate( 'by %(author)s', { args: { author: author } } ) : placeholder;
+		const isFSEEligible = blockEditorSettings?.is_fse_eligible ?? false;
+		const showBetaBadge = isFullSiteEditingTheme( { taxonomies } ) && isFSEEligible;
 
 		return (
 			<div className="theme__sheet-bar">
 				<span className="theme__sheet-bar-title">
 					{ title }
-					{ isFullSiteEditingTheme( { taxonomies } ) && (
+					{ showBetaBadge && (
 						<Badge type="warning-clear" className="theme__sheet-badge-beta">
 							{ translate( 'Beta' ) }
 						</Badge>
@@ -794,6 +802,7 @@ class ThemeSheet extends Component {
 }
 
 const ConnectedThemeSheet = connectOptions( ThemeSheet );
+const ThemeSheetWithEditorSettings = withBlockEditorSettings( ConnectedThemeSheet );
 
 const ThemeSheetWithOptions = ( props ) => {
 	const { siteId, isActive, isLoggedIn, isPremium, isPurchased, isJetpack, demoUrl } = props;
@@ -820,7 +829,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	}
 
 	return (
-		<ConnectedThemeSheet
+		<ThemeSheetWithEditorSettings
 			{ ...props }
 			demo_uri={ demoUrl }
 			siteId={ siteId }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -103,11 +103,9 @@ class ThemeSheet extends Component {
 			action: PropTypes.func,
 			getUrl: PropTypes.func,
 		} ),
-		blockEditorSettings: PropTypes.objectOf(
-			PropTypes.shape( {
-				is_fse_eligible: PropTypes.bool,
-			} )
-		),
+		blockEditorSettings: PropTypes.shape( {
+			is_fse_eligible: PropTypes.bool,
+		} ),
 	};
 
 	static defaultProps = {

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -1,4 +1,5 @@
 import { renderToString } from 'react-dom/server';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import { setStore } from 'calypso/state/redux-store';
@@ -19,75 +20,60 @@ jest.mock( 'calypso/state/selectors/is-nav-unification-enabled', () => ( {
 	default: () => true,
 } ) );
 
+const themeData = {
+	name: 'Twenty Sixteen',
+	author: 'the WordPress team',
+	screenshot:
+		'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
+	description: 'Twenty Sixteen is a modernized take on an ever-popular WordPress layout — ...',
+	descriptionLong: '<p>Mumble Mumble</p>',
+	download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentysixteen.zip',
+	taxonomies: {},
+	stylesheet: 'pub/twentysixteen',
+	demo_uri: 'https://twentysixteendemo.wordpress.com/',
+};
+
+const TestComponent = ( { themeId, store } ) => {
+	const queryClient = new QueryClient();
+	return (
+		<ReduxProvider store={ store }>
+			<QueryClientProvider client={ queryClient }>
+				<ThemeSheetComponent id={ themeId } />
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+};
+
 describe( 'main', () => {
-	describe( 'Calling renderToString() on Theme Info sheet', () => {
-		const themeData = {
-			name: 'Twenty Sixteen',
-			author: 'the WordPress team',
-			screenshot:
-				'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
-			description: 'Twenty Sixteen is a modernized take on an ever-popular WordPress layout — ...',
-			descriptionLong: '<p>Mumble Mumble</p>',
-			download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentysixteen.zip',
-			taxonomies: {},
-			stylesheet: 'pub/twentysixteen',
-			demo_uri: 'https://twentysixteendemo.wordpress.com/',
-		};
+	test( "doesn't throw an exception without theme data", () => {
+		const store = createReduxStore();
+		setStore( store );
+		let markup;
+		expect( () => {
+			markup = renderToString( <TestComponent store={ store } themeId="twentysixteen" /> );
+		} ).not.toThrow();
+		expect( markup.includes( 'theme__sheet' ) ).toBeTruthy();
+	} );
 
-		let store;
-		let initialState;
+	test( "doesn't throw an exception with theme data", () => {
+		const store = createReduxStore();
+		setStore( store );
+		store.dispatch( receiveTheme( themeData ) );
+		let markup;
+		expect( () => {
+			markup = renderToString( <TestComponent store={ store } themeId="twentysixteen" /> );
+		} ).not.toThrow();
+		expect( markup.includes( 'theme__sheet' ) ).toBeTruthy();
+	} );
 
-		beforeAll( () => {
-			store = createReduxStore();
-			setStore( store );
-			// Preserve initial theme state by deep cloning it.
-			initialState = JSON.parse( JSON.stringify( store.getState().themes ) );
-		} );
-
-		beforeEach( () => {
-			// Ensure initial theme state at the beginning of every test.
-			store.getState().themes = initialState;
-		} );
-
-		test( "doesn't throw an exception without theme data", () => {
-			const layout = (
-				<ReduxProvider store={ store }>
-					<ThemeSheetComponent id={ 'twentysixteen' } />
-				</ReduxProvider>
-			);
-			let markup;
-			expect( () => {
-				markup = renderToString( layout );
-			} ).not.toThrow();
-			expect( markup.includes( 'theme__sheet' ) ).toBeTruthy();
-		} );
-
-		test( "doesn't throw an exception with theme data", () => {
-			store.dispatch( receiveTheme( themeData ) );
-			const layout = (
-				<ReduxProvider store={ store }>
-					<ThemeSheetComponent id={ 'twentysixteen' } />
-				</ReduxProvider>
-			);
-			let markup;
-			expect( () => {
-				markup = renderToString( layout );
-			} ).not.toThrow();
-			expect( markup.includes( 'theme__sheet' ) ).toBeTruthy();
-		} );
-
-		test( "doesn't throw an exception with invalid theme data", () => {
-			store.dispatch( themeRequestFailure( 'wpcom', 'invalidthemeid', 'not found' ) );
-			const layout = (
-				<ReduxProvider store={ store }>
-					<ThemeSheetComponent id={ 'invalidthemeid' } />
-				</ReduxProvider>
-			);
-			let markup;
-			expect( () => {
-				markup = renderToString( layout );
-			} ).not.toThrow();
-			expect( markup.includes( 'empty-content' ) ).toBeTruthy();
-		} );
+	test( "doesn't throw an exception with invalid theme data", () => {
+		const store = createReduxStore();
+		setStore( store );
+		store.dispatch( themeRequestFailure( 'wpcom', 'invalidthemeid', 'not found' ) );
+		let markup;
+		expect( () => {
+			markup = renderToString( <TestComponent store={ store } themeId="invalidthemeid" /> );
+		} ).not.toThrow();
+		expect( markup.includes( 'empty-content' ) ).toBeTruthy();
 	} );
 } );

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -30,11 +30,7 @@ class CurrentTheme extends Component {
 				getUrl: PropTypes.func,
 			} )
 		),
-		blockEditorSettings: PropTypes.objectOf(
-			PropTypes.shape( {
-				is_fse_eligible: PropTypes.bool,
-			} )
-		),
+		blockEditorSettings: PropTypes.shape( { is_fse_eligible: PropTypes.bool } ),
 		siteId: PropTypes.number.isRequired,
 		// connected props
 		currentTheme: PropTypes.object,

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -9,8 +9,8 @@ import Badge from 'calypso/components/badge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
-import isSiteUsingCoreSiteEditorSelector from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { trackClick } from '../helpers';
 import { connectOptions } from '../theme-options';
@@ -30,6 +30,11 @@ class CurrentTheme extends Component {
 				getUrl: PropTypes.func,
 			} )
 		),
+		blockEditorSettings: PropTypes.objectOf(
+			PropTypes.shape( {
+				is_fse_eligible: PropTypes.bool,
+			} )
+		),
 		siteId: PropTypes.number.isRequired,
 		// connected props
 		currentTheme: PropTypes.object,
@@ -38,13 +43,7 @@ class CurrentTheme extends Component {
 	trackClick = ( event ) => trackClick( 'current theme', event );
 
 	render() {
-		const {
-			currentTheme,
-			currentThemeId,
-			isSiteUsingCoreSiteEditor,
-			siteId,
-			translate,
-		} = this.props;
+		const { currentTheme, currentThemeId, blockEditorSettings, siteId, translate } = this.props;
 		const placeholderText = <span className="current-theme__placeholder">loading...</span>;
 		const text = currentTheme && currentTheme.name ? currentTheme.name : placeholderText;
 
@@ -57,7 +56,8 @@ class CurrentTheme extends Component {
 		const showScreenshot = currentTheme && currentTheme.screenshot;
 		// Some themes have no screenshot, so only show placeholder until details loaded
 		const showScreenshotPlaceholder = ! currentTheme;
-		const showBetaBadge = isFullSiteEditingTheme( currentTheme ) && isSiteUsingCoreSiteEditor;
+		const isFSEEligible = blockEditorSettings?.is_fse_eligible ?? false;
+		const showBetaBadge = isFullSiteEditingTheme( currentTheme ) && isFSEEligible;
 
 		return (
 			<Card className="current-theme">
@@ -122,17 +122,12 @@ class CurrentTheme extends Component {
 }
 
 const ConnectedCurrentTheme = connectOptions( localize( CurrentTheme ) );
+const CurrentThemeWithEditorSettings = withBlockEditorSettings( ConnectedCurrentTheme );
 
-const CurrentThemeWithOptions = ( {
-	siteId,
-	currentTheme,
-	currentThemeId,
-	isSiteUsingCoreSiteEditor,
-} ) => (
-	<ConnectedCurrentTheme
+const CurrentThemeWithOptions = ( { siteId, currentTheme, currentThemeId } ) => (
+	<CurrentThemeWithEditorSettings
 		currentTheme={ currentTheme }
 		currentThemeId={ currentThemeId }
-		isSiteUsingCoreSiteEditor={ isSiteUsingCoreSiteEditor }
 		siteId={ siteId }
 		source="current theme"
 	/>
@@ -143,6 +138,5 @@ export default connect( ( state, { siteId } ) => {
 	return {
 		currentThemeId,
 		currentTheme: getCanonicalTheme( state, siteId, currentThemeId ),
-		isSiteUsingCoreSiteEditor: isSiteUsingCoreSiteEditorSelector( state, siteId ),
 	};
 } )( CurrentThemeWithOptions );

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useBlockEditorSettingsQuery } from 'calypso/data/block-editor/use-block-editor-settings-query';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRecommendedThemes } from 'calypso/state/themes/actions';
 import {
 	getRecommendedThemes as getRecommendedThemesSelector,
@@ -10,8 +11,12 @@ import { ConnectedThemesSelection } from './themes-selection';
 
 const RecommendedThemes = ( props ) => {
 	const dispatch = useDispatch();
+	const userLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
 	const { siteId } = props;
-	const { isLoading: isLoadingBlockEditorSettings, data } = useBlockEditorSettingsQuery( siteId );
+	const { isLoading: isLoadingBlockEditorSettings, data } = useBlockEditorSettingsQuery(
+		siteId,
+		userLoggedIn
+	);
 
 	const isFSEEligible = data?.is_fse_eligible ?? false;
 	const recommendedThemesFilter = isFSEEligible ? 'block-templates' : 'auto-loading-homepage';

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -1,4 +1,5 @@
 import { renderToString } from 'react-dom/server';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import { setStore } from 'calypso/state/redux-store';
@@ -87,9 +88,13 @@ describe( 'logged-out', () => {
 		beforeEach( () => {
 			// Ensure initial theme state at the beginning of every test.
 			store.getState().themes = initialState;
+
+			const queryClient = new QueryClient();
 			layout = (
 				<ReduxProvider store={ store }>
-					<LoggedOutShowcase />
+					<QueryClientProvider client={ queryClient }>
+						<LoggedOutShowcase />
+					</QueryClientProvider>
 				</ReduxProvider>
 			);
 		} );

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -1,4 +1,9 @@
-import { renderToString } from 'react-dom/server';
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
@@ -15,126 +20,116 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () =>
 jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
 	require( 'calypso/components/empty-component' )
 );
+jest.mock( 'calypso/my-sites/themes/themes-magic-search-card', () =>
+	require( 'calypso/components/empty-component' )
+);
+
+const themes = [
+	{
+		author: 'AudioTheme',
+		id: 'wayfarer',
+		stylesheet: 'premium/wayfarer',
+		name: 'Wayfarer',
+		author_uri: 'https://audiotheme.com/',
+		demo_uri: 'https://wayfarerdemo.wordpress.com/',
+		screenshot:
+			'https://i1.wp.com/theme.wordpress.com/wp-content/themes/premium/wayfarer/screenshot.png',
+		price: '$69',
+	},
+	{
+		author: 'Organic Themes',
+		id: 'natural',
+		stylesheet: 'premium/natural',
+		name: 'Natural',
+		author_uri: 'http://www.organicthemes.com',
+		demo_uri: 'https://naturaldemo.wordpress.com/',
+		screenshot:
+			'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/natural/screenshot.png',
+		price: '$69',
+	},
+	{
+		author: 'Press75',
+		id: 'attache',
+		stylesheet: 'premium/attache',
+		name: 'Attache',
+		author_uri: 'http://www.press75.com/',
+		demo_uri: 'https://attachedemo.wordpress.com/',
+		screenshot:
+			'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/attache/screenshot.png',
+		price: '$69',
+	},
+	{
+		author: 'Anariel Design',
+		id: 'pena',
+		stylesheet: 'premium/pena',
+		name: 'Pena',
+		author_uri: 'http://theme.wordpress.com/themes/by/anariel-design/',
+		demo_uri: 'https://penademo.wordpress.com/',
+		screenshot:
+			'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/pena/screenshot.png',
+		price: '$89',
+	},
+	{
+		author: 'Automattic',
+		id: 'karuna',
+		stylesheet: 'pub/karuna',
+		name: 'Karuna',
+		author_uri: 'http://wordpress.com/themes/',
+		demo_uri: 'https://karunademo.wordpress.com/',
+		screenshot: 'https://i1.wp.com/theme.wordpress.com/wp-content/themes/pub/karuna/screenshot.png',
+	},
+];
+
+const TestComponent = ( { store } ) => {
+	const queryClient = new QueryClient();
+	return (
+		<ReduxProvider store={ store }>
+			<QueryClientProvider client={ queryClient }>
+				<LoggedOutShowcase />
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+};
 
 describe( 'logged-out', () => {
-	describe( 'when calling renderToString()', () => {
-		const themes = [
-			{
-				author: 'AudioTheme',
-				id: 'wayfarer',
-				stylesheet: 'premium/wayfarer',
-				name: 'Wayfarer',
-				author_uri: 'https://audiotheme.com/',
-				demo_uri: 'https://wayfarerdemo.wordpress.com/',
-				screenshot:
-					'https://i1.wp.com/theme.wordpress.com/wp-content/themes/premium/wayfarer/screenshot.png',
-				price: '$69',
-			},
-			{
-				author: 'Organic Themes',
-				id: 'natural',
-				stylesheet: 'premium/natural',
-				name: 'Natural',
-				author_uri: 'http://www.organicthemes.com',
-				demo_uri: 'https://naturaldemo.wordpress.com/',
-				screenshot:
-					'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/natural/screenshot.png',
-				price: '$69',
-			},
-			{
-				author: 'Press75',
-				id: 'attache',
-				stylesheet: 'premium/attache',
-				name: 'Attache',
-				author_uri: 'http://www.press75.com/',
-				demo_uri: 'https://attachedemo.wordpress.com/',
-				screenshot:
-					'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/attache/screenshot.png',
-				price: '$69',
-			},
-			{
-				author: 'Anariel Design',
-				id: 'pena',
-				stylesheet: 'premium/pena',
-				name: 'Pena',
-				author_uri: 'http://theme.wordpress.com/themes/by/anariel-design/',
-				demo_uri: 'https://penademo.wordpress.com/',
-				screenshot:
-					'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/pena/screenshot.png',
-				price: '$89',
-			},
-			{
-				author: 'Automattic',
-				id: 'karuna',
-				stylesheet: 'pub/karuna',
-				name: 'Karuna',
-				author_uri: 'http://wordpress.com/themes/',
-				demo_uri: 'https://karunademo.wordpress.com/',
-				screenshot:
-					'https://i1.wp.com/theme.wordpress.com/wp-content/themes/pub/karuna/screenshot.png',
-			},
-		];
-		let layout;
-		let store;
-		let initialState;
+	test( 'renders without error when no themes are present', async () => {
+		const store = createReduxStore();
+		setStore( store );
+		render( <TestComponent store={ store } /> );
 
-		beforeAll( () => {
-			store = createReduxStore();
-			setStore( store );
-			// Preserve initial theme state by deep cloning it.
-			initialState = JSON.parse( JSON.stringify( store.getState().themes ) );
+		await waitFor( () => {
+			expect( screen.getByText( 'Sorry, no themes found.' ) ).toBeInTheDocument();
 		} );
+	} );
 
-		beforeEach( () => {
-			// Ensure initial theme state at the beginning of every test.
-			store.getState().themes = initialState;
+	test( 'renders without error when themes are present', async () => {
+		const store = createReduxStore();
+		setStore( store );
+		store.dispatch( receiveThemes( themes, 'wpcom', DEFAULT_THEME_QUERY, themes.length ) );
+		render( <TestComponent store={ store } /> );
 
-			const queryClient = new QueryClient();
-			layout = (
-				<ReduxProvider store={ store }>
-					<QueryClientProvider client={ queryClient }>
-						<LoggedOutShowcase />
-					</QueryClientProvider>
-				</ReduxProvider>
-			);
-		} );
-
-		test( 'renders without error when no themes are present', () => {
-			let markup;
-			expect( () => {
-				markup = renderToString( layout );
-			} ).not.toThrow();
-			// Should show a "No themes found" message
-			expect( markup.includes( 'empty-content' ) ).toBeTruthy();
-		} );
-
-		test( 'renders without error when themes are present', () => {
-			store.dispatch( receiveThemes( themes, 'wpcom', DEFAULT_THEME_QUERY, themes.length ) );
-
-			let markup;
-			expect( () => {
-				markup = renderToString( layout );
-			} ).not.toThrow();
-			// All 5 themes should appear...
-			expect( markup.match( /theme__content/g ).length ).toBe( 5 );
-			// .. and no empty content placeholders should appear
-			expect( markup.includes( 'empty-content' ) ).toBeFalsy();
-		} );
-
-		test( 'renders without error when theme fetch fails', () => {
-			store.dispatch( {
-				type: THEMES_REQUEST_FAILURE,
-				siteId: 'wpcom',
-				query: {},
-				error: 'Error',
+		await waitFor( () => {
+			themes.forEach( ( theme ) => {
+				expect( screen.getByText( theme.name ) ).toBeInTheDocument();
 			} );
+			expect( screen.queryByText( 'Sorry, no themes found.' ) ).not.toBeInTheDocument();
+		} );
+	} );
 
-			let markup;
-			expect( () => {
-				markup = renderToString( layout );
-			} ).not.toThrow();
-			// Should show a "No themes found" message
-			expect( markup.includes( 'empty-content' ) ).toBeTruthy();
+	test( 'renders without error when theme fetch fails', async () => {
+		const store = createReduxStore();
+		setStore( store );
+
+		store.dispatch( {
+			type: THEMES_REQUEST_FAILURE,
+			siteId: 'wpcom',
+			query: {},
+			error: 'Error',
+		} );
+		render( <TestComponent store={ store } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByText( 'Sorry, no themes found.' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -118,11 +118,9 @@ class ThemeShowcase extends Component {
 		loggedOutComponent: PropTypes.bool,
 		isJetpackSite: PropTypes.bool,
 		isSiteEditorActive: PropTypes.bool,
-		blockEditorSettings: PropTypes.objectOf(
-			PropTypes.shape( {
-				is_fse_eligible: PropTypes.bool,
-			} )
-		),
+		blockEditorSettings: PropTypes.shape( {
+			is_fse_eligible: PropTypes.bool,
+		} ),
 	};
 
 	static defaultProps = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -14,6 +14,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import SubMasterbarNav from 'calypso/components/sub-masterbar-nav';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
@@ -117,6 +118,11 @@ class ThemeShowcase extends Component {
 		loggedOutComponent: PropTypes.bool,
 		isJetpackSite: PropTypes.bool,
 		isSiteEditorActive: PropTypes.bool,
+		blockEditorSettings: PropTypes.objectOf(
+			PropTypes.shape( {
+				is_fse_eligible: PropTypes.bool,
+			} )
+		),
 	};
 
 	static defaultProps = {
@@ -269,7 +275,7 @@ class ThemeShowcase extends Component {
 				return this.props.isJetpackSite;
 			case this.tabFilters.FSE.key:
 				// Display FSE tab if the Site Editor is active for the site.
-				return this.props.isSiteEditorActive;
+				return this.props.blockEditorSettings?.is_fse_eligible;
 		}
 	};
 
@@ -438,4 +444,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 	};
 };
 
-export default connect( mapStateToProps, null )( localize( ThemeShowcase ) );
+export default connect(
+	mapStateToProps,
+	null
+)( localize( withBlockEditorSettings( ThemeShowcase ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We only want to display beta badges when sites are full site editing (FSE) eligible, which is when sites have the `fse-eligible` blog sticker. Otherwise, we'd like to hide the beta badges.

| With Sticker      | Without Sticker |
| --- | --- |
| <img width="1344" alt="Screen Shot 2021-10-08 at 4 54 40 PM" src="https://user-images.githubusercontent.com/5414230/136636474-f53ee026-2e24-4679-b576-c5d5915e599c.png"> | <img width="1344" alt="Screen Shot 2021-10-08 at 5 13 17 PM" src="https://user-images.githubusercontent.com/5414230/136636797-144e4f6f-b3be-4bb5-a3df-142920f200dc.png"> |
| <img width="1344" alt="Screen Shot 2021-10-08 at 4 54 20 PM" src="https://user-images.githubusercontent.com/5414230/136636848-cd794636-8ceb-4bd1-9097-9a04f3eb9671.png"> | <img width="1344" alt="Screen Shot 2021-10-08 at 4 53 59 PM" src="https://user-images.githubusercontent.com/5414230/136636857-20755774-7171-40f3-a239-460ce9122def.png"> | 

#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. [Create a full site editing enabled site](https://horizon.wordpress.com/new?flags=gutenboarding/site-editor)
2. Ensure that it has the `fse-eligible` blog sticker. If not, run `wp blog-stickers add --who=USER --url=SITE_URL --sticker=fse-eligible`. Also, remove the `core-site-editor-enabled` sticker if it exists. I'm unsure if this matters, but we're in the process of removing it entirely from FSE onboarding.
3. Verify that beta badges appear in the theme cards, the current theme card, and the theme info sheet.
4. Run `wp blog-stickers remove --who=USER --url=SITE_URL --sticker=fse-eligible` to make a site FSE beta ineligible
5. Return to the themes showcase
6. Verify that beta badges for theme cards, the current theme card, and the theme info sheet have disappeared.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56854
