### PR TITLE
Design Picker: Pass `trim_content` flag to `/theme-setup` endpoint during onboarding

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -337,6 +337,7 @@ export function setDesignOnSite( callback, { siteSlug, selectedDesign } ) {
 			wpcom.req.post( {
 				path: `/sites/${ siteSlug }/theme-setup`,
 				apiNamespace: 'wpcom/v2',
+				body: { trim_content: true },
 			} )
 		)
 		.then( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables the `trim_content` mode of the theme setup endpoint. Trimming logic in D68118-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D68118-code
* `/start/setup-site?siteSlug=<< test site >>`
* See in network tab that `trim_content: true` param is sent with POST request to setup the theme

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
