### PR TITLE
Emails: Unify minimal possible code to fix 15px gap in the top of thank you pages

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -16,8 +16,6 @@ import './style.scss';
 const ThankYouContainer = styled.div`
 	background-color: #fff;
 	-ms-overflow-style: none;
-	/* Negative value to counteract default content padding */
-	margin-top: calc( -79px + var( --masterbar-height ) );
 `;
 
 const ThankYouSectionTitle = styled.h1`

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -16,6 +16,8 @@ import './style.scss';
 const ThankYouContainer = styled.div`
 	background-color: #fff;
 	-ms-overflow-style: none;
+	/* Negative value to counteract default content padding */
+	margin-top: calc( -79px + var( --masterbar-height ) );
 `;
 
 const ThankYouSectionTitle = styled.h1`

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -3,7 +3,8 @@
 
 .thank-you__container {
 
-	margin: calc( -60px + var( --masterbar-height ) ) 0 33px 0;
+	margin-left: -33px;
+	margin-right: -32px;
 
 	@include break-medium {
 		margin: calc( -74px + var( --masterbar-height ) ) 0 33px 0;

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -1,21 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.thank-you__container {
-
-	margin-left: -33px;
-	margin-right: -32px;
-
-	@include break-medium {
-		margin: calc( -74px + var( --masterbar-height ) ) 0 33px 0;
-	}
-
-	@include breakpoint-deprecated( '>660px' ) {
-		margin: calc( -79px + var( --masterbar-height ) ) 0 33px 0;
-	}
-}
-
-
 .thank-you__container-header img {
 	max-width: 200px;
 
@@ -28,6 +13,7 @@
 	flex-direction: column;
 	text-align: center;
 	align-items: center;
+	padding-top: calc( -33px + var( --masterbar-height ) );
 }
 
 .thank-you__step-cta {

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -1,6 +1,20 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.thank-you__container {
+
+	margin: calc( -60px + var( --masterbar-height ) ) 0 33px 0;
+
+	@include break-medium {
+		margin: calc( -74px + var( --masterbar-height ) ) 0 33px 0;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: calc( -79px + var( --masterbar-height ) ) 0 33px 0;
+	}
+}
+
+
 .thank-you__container-header img {
 	max-width: 200px;
 

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -87,7 +87,9 @@
 		&__container-header {
 			width: auto;
 			background-color: var( --studio-blue-50 );
-			padding: 0 20px 35px;
+			padding-right: 20px;
+			padding-left: 20px;
+			padding-bottom: 35px;
 			box-sizing: border-box;
 			text-align: center;
 			height: auto;

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -4,7 +4,7 @@
 
 .is-section-checkout-thank-you {
 	background: var( --studio-white );
-	
+
 	.layout__content {
 		padding-right: 0;
 		padding-left: 0;
@@ -12,19 +12,6 @@
 }
 
 .checkout-thank-you__domains {
-	&.thank-you__container {
-		
-		margin-top: calc( -79px + var( --masterbar-height ) );
-	
-		@include breakpoint-deprecated( '<960px' ) {
-			margin-top: calc( -71px + var( --masterbar-height ) );
-		}
-	
-		@include breakpoint-deprecated( '<660px' ) {
-			margin-top: -1px;
-		}
-	}
-
 	.thank-you {
 
 		&__header {
@@ -81,7 +68,7 @@
 						width: 100%;
 					}
 				}
-				
+
 				@include break-mobile {
 					width: 144px;
 

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -115,6 +115,7 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 
 	return (
 		<ThankYou
+			containerClassName="titan-set-up-thank-you__container"
 			headerClassName={ 'titan-set-up-thank-you__header' }
 			sections={ [ titanThankYouSection ] }
 			showSupportSection={ true }

--- a/client/my-sites/email/titan-set-up-thank-you/style.scss
+++ b/client/my-sites/email/titan-set-up-thank-you/style.scss
@@ -16,10 +16,6 @@
 	}
 }
 
-.thank-you__container-header.titan-set-up-thank-you__header {
-	padding-top: calc( -33px + var( --masterbar-height ) );
-}
-
 .thank-you__step-cta {
 	width: 100%;
 	@include break-mobile {

--- a/client/my-sites/email/titan-set-up-thank-you/style.scss
+++ b/client/my-sites/email/titan-set-up-thank-you/style.scss
@@ -5,6 +5,21 @@
 	margin-left: 4px;
 }
 
+.thank-you__container.titan-set-up-thank-you__container {
+	margin-left: -33px;
+	margin-right: -32px;
+	padding-left: 33px;
+	padding-right: 32px;
+	@include breakpoint-deprecated( '>660px' ) {
+		padding-left: 0;
+		padding-right: 0;
+	}
+}
+
+.thank-you__container-header.titan-set-up-thank-you__header {
+	padding-top: calc( -33px + var( --masterbar-height ) );
+}
+
 .thank-you__step-cta {
 	width: 100%;
 	@include break-mobile {

--- a/client/my-sites/email/titan-set-up-thank-you/style.scss
+++ b/client/my-sites/email/titan-set-up-thank-you/style.scss
@@ -5,9 +5,10 @@
 	margin-left: 4px;
 }
 
-.thank-you__container {
-	margin: -32px -32px -33px -34px;
-	@media ( max-width: 660px ) {
-		padding: 0 32px 34px 34px;
+.thank-you__step-cta {
+	width: 100%;
+	@include break-mobile {
+		min-width: 144px;
+		width: auto;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After closing previous PR regarding of too many things being fixed in one change request, this PR just fixes the 15px gap in the top of thank you page, unifying the minimum possible code for domains and emails.

Thank you page hero card has a small 15px gap between MasterBar and the Thank you page itself. The fix just adds into the equation the MasterBar height

In addition this Pull Request is unifying the two only styles that ThankYou component uses for the 15px gap.

It also fix some regression added previously, where the buttons were not full width on mobile designs. Everything is documented in the screenshots.

#### Testing instructions

1. Go to Upgrades -> Emails
2. Buy or add a mailbox (Professional Email)
3. Check the thank you page is not showing an empty gap in the top side as per the below table.

#### Emails

BEFORE | AFTER
------------ | -------------
![before-emails](https://user-images.githubusercontent.com/5689927/136783563-bda11900-1bb7-476b-a2d2-229fb5ee4329.gif) | ![new fix gap](https://user-images.githubusercontent.com/5689927/137287753-c255269a-851a-4b95-82b5-05b1d604ea6f.gif)

BEFORE | AFTER
------------ | -------------
![new fix gap setup old](https://user-images.githubusercontent.com/5689927/137299168-c4c42de4-8351-4b30-8548-60246c1ac2ae.gif) | ![new fix gap setup](https://user-images.githubusercontent.com/5689927/137299218-8fcef34a-68e2-4c37-aa3c-d68ebc11b439.gif)


#### Domains

To test the domain Thank you Page please, refer to this [Pull Request](https://github.com/Automattic/wp-calypso/pull/55675). This view should remain unchanged. We want to avoid regression issue, the screenshots below proves that everything should be equivalent after this PR.

BEFORE | AFTER
------------ | -------------
![before-domains](https://user-images.githubusercontent.com/5689927/136783703-9ba842ed-88d9-4013-9590-725840e91f82.gif) | ![domains-regression](https://user-images.githubusercontent.com/5689927/136783779-4c6f0e47-4484-443a-808e-d733e4dc10af.gif)

#### Remarks

This issue is not replicable with old purchases, or reloading the site. In this case the order of stylesheet loading is different and makes not possible to replicate the issue.

Related to {1200182182542585-as-1201165030390295}
