### PR TITLE
Adds a page for in-progress DIFM sites

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -165,6 +165,10 @@ class Site extends Component {
 									: translate( 'Private' ) }
 							</span>
 						) }
+						{ site.options && site.options.is_difm_lite_in_progress && (
+							// TODO: Change name
+							<span className="site__badge site__badge-domain-only">{ translate( 'DIFM' ) }</span>
+						) }
 						{ shouldShowPublicComingSoonSiteBadge && (
 							<span className="site__badge site__badge-coming-soon">
 								{ translate( 'Coming Soon' ) }

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -167,7 +167,7 @@ class Site extends Component {
 						) }
 						{ site.options && site.options.is_difm_lite_in_progress && (
 							<span className="site__badge site__badge-domain-only">
-								{ translate( 'Do It For Me' ) }
+								{ translate( 'Do It For Me (Lite)' ) }
 							</span>
 						) }
 						{ shouldShowPublicComingSoonSiteBadge && (

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -166,8 +166,9 @@ class Site extends Component {
 							</span>
 						) }
 						{ site.options && site.options.is_difm_lite_in_progress && (
-							// TODO: Change name
-							<span className="site__badge site__badge-domain-only">{ translate( 'DIFM' ) }</span>
+							<span className="site__badge site__badge-domain-only">
+								{ translate( 'Do It For Me' ) }
+							</span>
 						) }
 						{ shouldShowPublicComingSoonSiteBadge && (
 							<span className="site__badge site__badge-coming-soon">

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -40,6 +40,7 @@ import {
 	emailManagementPurchaseNewEmailAccount,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
+import DIFMLiteInProgress from 'calypso/my-sites/marketing/do-it-for-me/difm-lite-in-progress';
 import NavigationComponent from 'calypso/my-sites/navigation';
 import SitesComponent from 'calypso/my-sites/sites';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -50,6 +51,7 @@ import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import getP2HubBlogId from 'calypso/state/selectors/get-p2-hub-blog-id';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -153,6 +155,15 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 	clientRender( reactContext );
 }
 
+function renderSelectedSiteIsDIFMLiteInProgress( reactContext, selectedSite ) {
+	reactContext.primary = <DIFMLiteInProgress siteId={ selectedSite.ID } />;
+
+	reactContext.secondary = createNavigation( reactContext );
+
+	makeLayout( reactContext, noop );
+	clientRender( reactContext );
+}
+
 function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParams ) {
 	const allPaths = [
 		domainManagementContactsPrivacy,
@@ -238,6 +249,20 @@ function onSelectedSiteAvailable( context ) {
 		)
 	) {
 		renderSelectedSiteIsDomainOnly( context, selectedSite );
+		return false;
+	}
+
+	// The paths allowed for domain-only sites and DIFM in-progress sites are the same
+	if (
+		isDIFMLiteInProgress( state, selectedSite.ID ) &&
+		! isPathAllowedForDomainOnlySite(
+			context.pathname,
+			selectedSite.slug,
+			primaryDomain,
+			context.params
+		)
+	) {
+		renderSelectedSiteIsDIFMLiteInProgress( context, selectedSite );
 		return false;
 	}
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -58,6 +58,7 @@ import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite, getSiteId, getSiteSlug } from 'calypso/state/sites/selectors';
+import { isSupportSession } from 'calypso/state/support/selectors';
 import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -252,7 +253,10 @@ function onSelectedSiteAvailable( context ) {
 		return false;
 	}
 
-	// The paths allowed for domain-only sites and DIFM in-progress sites are the same
+	/**
+	 * The paths allowed for domain-only sites and DIFM in-progress sites are the same.
+	 * Ignore this check if we are inside a support session.
+	 */
 	if (
 		isDIFMLiteInProgress( state, selectedSite.ID ) &&
 		! isPathAllowedForDomainOnlySite(
@@ -260,7 +264,8 @@ function onSelectedSiteAvailable( context ) {
 			selectedSite.slug,
 			primaryDomain,
 			context.params
-		)
+		) &&
+		! isSupportSession( state )
 	) {
 		renderSelectedSiteIsDIFMLiteInProgress( context, selectedSite );
 		return false;

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.scss
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.scss
@@ -1,0 +1,9 @@
+.difm-lite-in-progress__site-placeholder {
+	h2 {
+		@include placeholder();
+	}
+}
+
+.difm-lite-in-progress__action-panel {
+	text-align: left;
+}

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -61,7 +61,9 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactE
 			<EmptyContent
 				title={ translate( 'Hang on! Our experts are building your site.' ) }
 				line={ translate(
-					'Our Built By WordPress.com team will be in touch with you when your site is ready to be transferred to your account and launched.'
+					'Thank you for your purchase. ' +
+						'Our Built By WordPress.com team will begin building your site soon. ' +
+						'We’ll be in touch when your site is ready to be launched.'
 				) }
 				secondaryAction={ translate( 'Manage domain' ) }
 				secondaryActionURL={ domainManagementEdit( slug, domainName ) }

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -1,0 +1,90 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import Illustration from 'calypso/assets/images/illustrations/builder-referral.svg';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import EmptyContent from 'calypso/components/empty-content';
+import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
+import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { emailManagement } from 'calypso/my-sites/email/paths';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { AppState } from 'calypso/types';
+
+import './difm-lite-in-progress.scss';
+
+type DIFMLiteInProgressProps = {
+	siteId: number;
+};
+
+type DomainName = {
+	name?: string;
+};
+
+function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactElement {
+	const slug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
+	const primaryDomain: DomainName = useSelector( ( state: AppState ) =>
+		getPrimaryDomainBySiteId( state, siteId )
+	);
+	const translate = useTranslate();
+
+	if ( ! primaryDomain ) {
+		return (
+			<div>
+				<QuerySiteDomains siteId={ siteId } />
+				<EmptyContent
+					className="difm-lite-in-progress__site-placeholder"
+					illustration={ Illustration }
+					illustrationWidth={ 225 }
+				/>
+			</div>
+		);
+	}
+
+	const hasEmailWithUs = hasGSuiteWithUs( primaryDomain ) || hasTitanMailWithUs( primaryDomain );
+	const domainName = primaryDomain.name;
+
+	const recordEmailClick = () => {
+		const tracksName = hasEmailWithUs
+			? 'calypso_difm_lite_in_progress_email_manage'
+			: 'calypso_difm_lite_in_progress_email_cta';
+		recordTracksEvent( tracksName, {
+			domain: domainName,
+		} );
+	};
+
+	return (
+		<div>
+			<EmptyContent
+				title={ translate( 'Hang on! Our experts are building your site.' ) }
+				line={ translate(
+					'Our Built By WordPress.com team will be in touch with you when your site is ready to be transferred to your account and launched.'
+				) }
+				secondaryAction={ translate( 'Manage domain' ) }
+				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
+				illustration={ Illustration }
+				illustrationWidth={ 225 }
+			>
+				{
+					<Button
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						className="empty-content__action button"
+						href={ emailManagement( slug, domainName ) }
+						onClick={ recordEmailClick }
+					>
+						{ hasEmailWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }
+					</Button>
+				}
+			</EmptyContent>
+		</div>
+	);
+}
+
+DIFMLiteInProgress.propTypes = {
+	siteId: PropTypes.number.isRequired,
+};
+
+export default DIFMLiteInProgress;

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -71,6 +71,7 @@ import {
 } from 'calypso/state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
+import { isSupportSession } from 'calypso/state/support/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
@@ -986,7 +987,10 @@ export class MySitesSidebar extends Component {
 	};
 
 	renderSidebarMenus() {
-		if ( this.props.isDomainOnly || this.props.isDIFMLiteInProgress ) {
+		if (
+			! this.props.isSupportSession &&
+			( this.props.isDomainOnly || this.props.isDIFMLiteInProgress )
+		) {
 			return (
 				<SidebarMenu>
 					<SidebarItem
@@ -1140,6 +1144,7 @@ function mapStateToProps( state ) {
 		forceAllSitesView: isAllDomainsView,
 		hasJetpackSites: hasJetpackSites( state ),
 		isDIFMLiteInProgress: isDIFMLiteInProgress( state, selectedSiteId ),
+		isSupportSession: isSupportSession( state ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
 		shouldRenderJetpackSection: isJetpackSectionEnabledForSite( state, selectedSiteId ),

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -47,6 +47,7 @@ import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getScanState from 'calypso/state/selectors/get-site-scan-state';
 import getSiteTaskList from 'calypso/state/selectors/get-site-task-list';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
+import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isEligibleForDotcomChecklist from 'calypso/state/selectors/is-eligible-for-dotcom-checklist';
 import isJetpackCloudEligible from 'calypso/state/selectors/is-jetpack-cloud-eligible';
@@ -92,6 +93,7 @@ export class MySitesSidebar extends Component {
 		setLayoutFocus: PropTypes.func.isRequired,
 		path: PropTypes.string,
 		currentUser: PropTypes.object,
+		isDIFMLiteInProgress: PropTypes.bool,
 		isDomainOnly: PropTypes.bool,
 		isJetpack: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
@@ -984,7 +986,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	renderSidebarMenus() {
-		if ( this.props.isDomainOnly ) {
+		if ( this.props.isDomainOnly || this.props.isDIFMLiteInProgress ) {
 			return (
 				<SidebarMenu>
 					<SidebarItem
@@ -1137,6 +1139,7 @@ function mapStateToProps( state ) {
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		forceAllSitesView: isAllDomainsView,
 		hasJetpackSites: hasJetpackSites( state ),
+		isDIFMLiteInProgress: isDIFMLiteInProgress( state, selectedSiteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
 		shouldRenderJetpackSection: isJetpackSectionEnabledForSite( state, selectedSiteId ),

--- a/client/state/selectors/is-difm-lite-in-progress.js
+++ b/client/state/selectors/is-difm-lite-in-progress.js
@@ -1,0 +1,19 @@
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+
+/**
+ * Returns true if site is marked as a DIFM In Progress site, false if the site is a regular site,
+ * or null if the site is unknown.
+ *
+ * @param  {object}   state  Global state tree
+ * @param  {number}   siteId Site ID
+ * @returns {?boolean}        Whether site is marked as a DIFM In Progress site
+ */
+export default function isDIFMLiteInProgress( state, siteId ) {
+	const site = getRawSite( state, siteId );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.options?.is_difm_lite_in_progress ?? false;
+}

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -69,4 +69,5 @@ export const SITE_REQUEST_OPTIONS = [
 	'woocommerce_is_active',
 	'wordads',
 	'site_creation_flow',
+	'is_difm_lite_in_progress',
 ].join();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a new page to show the in-progress status of a DIFM Lite site. The page is shown if the site is currently being built by the DIFM Lite Team. Please see D68203-code for more details.

Also blocks access to site editing features in the admin menu. The page and blocking is similar to the ones shown for domain-only sites.

If there is an active support session, the page is not shown and menus are not hidden.

Please see pdh1Xd-4l-p2 for additional context. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D68203-code
* Enable the `difm-lite-in-progress` sticker using Blog RC.
* Switch to the site with the sticker enabled and check the UI:
![image](https://user-images.githubusercontent.com/5436027/136785360-51618e47-197c-443d-bb53-1b32a46b84ac.png)

-----

* Start a support session.
* In the incognito window started by the support session, open calypso.localhost or the calypso.live link in a new tab. 
* Confirm that the above page is **not** shown.

#### Pending
EDIT: These tasks will be done in a future iteration.
- [ ] ~Change the name.~
- [ ] ~Update the design of the page with feedback received from <P2>.~