### PR TITLE
Jetpack: Reduce title length in siteless post-checkout UI

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -51,17 +51,9 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 
 	const title = useMemo( () => {
 		return automaticTransferSucceeded
-			? translate( 'Your %(productName)s subscription has been activated and is ready to go!', {
-					args: {
-						productName,
-					},
-			  } )
-			: translate( 'Your %(productName)s subscription will be activated soon', {
-					args: {
-						productName,
-					},
-			  } );
-	}, [ automaticTransferSucceeded, productName, translate ] );
+			? translate( 'Your subscription has been activated and is ready to go!' )
+			: translate( 'Your subscription will be activated soon' );
+	}, [ automaticTransferSucceeded, translate ] );
 
 	return (
 		<Main wideLayout className="jetpack-checkout-siteless-thank-you-completed">
@@ -87,9 +79,17 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 					</h1>
 					{ ! automaticTransferSucceeded && (
 						<p>
-							{ translate(
-								'As soon as your subscription is activated you will receive a confirmation email from our Happiness Engineers.'
-							) }
+							{ productName &&
+								translate(
+									'As soon as your %(productName)s subscription is activated you will receive a confirmation email from our Happiness Engineers.',
+									{
+										args: { productName },
+									}
+								) }
+							{ ! productName &&
+								translate(
+									'As soon as your subscription is activated you will receive a confirmation email from our Happiness Engineers.'
+								) }
 						</p>
 					) }
 					{ automaticTransferSucceeded && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reduce title length in siteless post-checkout UI.
* Move product name to the description below.

#### Testing instructions

- Fire up this branch.
- Go to Jetpack.com and select a product.
- Once in the checkout, replace `http://wordpress.com` for `http://calypso.localhost:3000` in the URL.
- Complete the purchase.
- In the post-purchase UI, confirm you see the changes.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/136788094-a90e3d84-5ae4-423e-b5cf-519169ca8214.png) | ![image](https://user-images.githubusercontent.com/390760/136788079-931d9b5e-edeb-4fff-b1ad-2cdb223abe15.png)
