### PR TITLE
Add pagination to plugin search

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/README.md
+++ b/client/my-sites/plugins/plugins-browser-list/README.md
@@ -31,3 +31,4 @@ export default localize( MyPluginsList );
 - `size`: a number, the amount of plugins to be shown
 - `site`: a string containing the slug of the selected site
 - `addPlaceholders`: if present, indicates that there should placeholders inserted after the real components list
+- `paginated`: the component can be used with pagination or infinite scroll, if set to true, it will replace all the rendered items with placeholders while loading

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -33,7 +33,11 @@ class PluginsBrowserList extends Component {
 		} );
 
 		if ( this.props.showPlaceholders ) {
-			pluginsViewsList = pluginsViewsList.concat( this.renderPlaceholdersViews() );
+			if ( this.props.paginated ) {
+				pluginsViewsList = this.renderPlaceholdersViews();
+			} else {
+				pluginsViewsList = pluginsViewsList.concat( this.renderPlaceholdersViews() );
+			}
 		}
 
 		// We need to complete the list with empty elements to keep the grid drawn.

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -20,7 +20,7 @@ class PluginsBrowserList extends Component {
 	renderPluginsViewList() {
 		let emptyCounter = 0;
 
-		let pluginsViewsList = this.props.plugins.map( ( plugin, n ) => {
+		const pluginsViewsList = this.props.plugins.map( ( plugin, n ) => {
 			return (
 				<PluginBrowserItem
 					site={ this.props.site }
@@ -32,13 +32,7 @@ class PluginsBrowserList extends Component {
 			);
 		} );
 
-		if ( this.props.showPlaceholders ) {
-			if ( this.props.paginated ) {
-				pluginsViewsList = this.renderPlaceholdersViews();
-			} else {
-				pluginsViewsList = pluginsViewsList.concat( this.renderPlaceholdersViews() );
-			}
-		}
+		this.renderPlaceholdersViews( pluginsViewsList );
 
 		// We need to complete the list with empty elements to keep the grid drawn.
 		while ( pluginsViewsList.length % 3 !== 0 || pluginsViewsList.length % 2 !== 0 ) {
@@ -56,10 +50,21 @@ class PluginsBrowserList extends Component {
 		return pluginsViewsList;
 	}
 
-	renderPlaceholdersViews() {
-		return times( this.props.size || DEFAULT_PLACEHOLDER_NUMBER, ( i ) => (
+	renderPlaceholdersViews( pluginViewsList ) {
+		if ( ! this.props.showPlaceholders ) {
+			return null;
+		}
+
+		const placeholders = times( this.props.size || DEFAULT_PLACEHOLDER_NUMBER, ( i ) => (
 			<PluginBrowserItem isPlaceholder key={ 'placeholder-plugin-' + i } />
 		) );
+
+		if ( this.props.paginated || undefined === pluginViewsList ) {
+			return placeholders;
+		}
+
+		// this is for handling infinite scroll
+		return pluginViewsList.concat( placeholders );
 	}
 
 	renderViews() {

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -147,3 +147,25 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 		}
 	);
 } );
+
+describe( 'Search view', () => {
+	const myProps = {
+		...props,
+		search: 'test searchterm',
+	};
+
+	test( 'should show NoResults when there are no results', () => {
+		const comp = shallow( <PluginsBrowser { ...myProps } /> );
+		expect( comp.find( 'NoResults' ).length ).toBe( 1 );
+	} );
+
+	test( 'should show plugin list when there are results', () => {
+		const myProps2 = {
+			...myProps,
+			pluginsBySearchTerm: [ { name: 'plugin1', slug: 'test-plugin' } ],
+		};
+
+		const comp = shallow( <PluginsBrowser { ...myProps2 } /> );
+		expect( comp.find( 'Localized(PluginsBrowserList)' ).length ).toBe( 1 );
+	} );
+} );

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -77,16 +77,21 @@ function receivePluginsList( category, page, searchTerm, data, error, pagination
  * Retrieve a list of pliugins, identified by category and page number, or a search term.
  *
  * WP.org plugins can be filtered either by category or search term.
- * Pagination is supported only for category queries.
  * Category can be one of "featured", "popular", "new", "beta" or "recommended".
  * Search term is an open text field.
  *
- * @param {string} category   Plugin category
- * @param {number} page       Page (1-based)
- * @param {string} searchTerm Search term
- * @returns {Function} Action thunk
+ * @param {string} category   	Plugin category
+ * @param {number} page       	Page (1-based)
+ * @param {string} searchTerm 	Search term
+ * @param {number} pageSize		Page size
+ * @returns {Function} 			Action thunk
  */
-export function fetchPluginsList( category, page, searchTerm ) {
+export function fetchPluginsList(
+	category,
+	page,
+	searchTerm,
+	pageSize = PLUGINS_LIST_DEFAULT_SIZE
+) {
 	return ( dispatch, getState ) => {
 		// Bail if we are currently fetching this plugins list
 		if ( isFetchingPluginsList( getState(), category, searchTerm ) ) {
@@ -116,7 +121,7 @@ export function fetchPluginsList( category, page, searchTerm ) {
 
 		fetchWporgPluginsList(
 			{
-				pageSize: PLUGINS_LIST_DEFAULT_SIZE,
+				pageSize,
 				page,
 				category,
 				search: searchTerm,

--- a/client/state/plugins/wporg/reducer.js
+++ b/client/state/plugins/wporg/reducer.js
@@ -102,17 +102,27 @@ export function lists( state = {}, action ) {
 }
 
 export function listsPagination( state = {}, action ) {
+	const { category, pagination, searchTerm } = action;
 	switch ( action.type ) {
 		case PLUGINS_WPORG_LIST_RECEIVE:
-			// The API supports pagination only for categories right now
-			if ( action.pagination && action.category ) {
-				return {
-					...state,
-					category: {
-						...state.category,
-						[ action.category ]: action.pagination,
-					},
-				};
+			if ( pagination ) {
+				if ( category ) {
+					return {
+						...state,
+						category: {
+							...state.category,
+							[ category ]: pagination,
+						},
+					};
+				} else if ( searchTerm ) {
+					return {
+						...state,
+						search: {
+							...state.search,
+							[ searchTerm ]: pagination,
+						},
+					};
+				}
 			}
 	}
 	return state;

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -64,7 +64,7 @@ export function getNextPluginsListPage( state, category ) {
 }
 
 /**
- * Retrieve the next page for the particular plugins list.
+ * Retrieve the current state of pagination.
  *
  * @param {object} state		State object
  * @param {string} searchTerm	Plugin search term

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -1,4 +1,5 @@
 import 'calypso/state/plugins/init';
+import { Pagination } from './types';
 
 export function getAllPlugins( state ) {
 	return state?.plugins.wporg.items;
@@ -47,7 +48,6 @@ export function isFetchingPluginsList( state, category, searchTerm ) {
 
 /**
  * Retrieve the next page for the particular plugins list.
- * Pagination is currently supported only for category queries in the API.
  *
  * @param {object} state    State object
  * @param {string} category Plugin category
@@ -61,4 +61,15 @@ export function getNextPluginsListPage( state, category ) {
 	}
 
 	return null;
+}
+
+/**
+ * Retrieve the next page for the particular plugins list.
+ *
+ * @param {object} state		State object
+ * @param {string} searchTerm	Plugin search term
+ * @returns {Pagination}		Pagination object, including current page, total pages, and total results
+ */
+export function getPluginsListPagination( state, searchTerm ) {
+	return state.plugins.wporg.listsPagination?.search?.[ searchTerm ];
 }

--- a/client/state/plugins/wporg/test/actions.js
+++ b/client/state/plugins/wporg/test/actions.js
@@ -2,11 +2,12 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import * as wporg from 'calypso/lib/wporg';
 import { combineReducers } from 'calypso/state/utils';
-import { fetchPluginData } from '../actions';
+import { fetchPluginData, fetchPluginsList } from '../actions';
 import wporgReducer from '../reducer';
 
 jest.mock( 'calypso/lib/wporg', () => ( {
 	fetchPluginInformation: jest.fn( ( slug ) => Promise.resolve( { slug } ) ),
+	fetchPluginsList: jest.fn( () => Promise.resolve( [ { slug: 'test-plugin' } ] ) ),
 } ) );
 
 const reducer = combineReducers( {
@@ -62,6 +63,54 @@ describe( 'WPorg Data Actions', () => {
 		const request2 = store.dispatch( fetchPluginData( 'test' ) );
 		// just one fetch should have been issued
 		expect( wporg.fetchPluginInformation ).toHaveBeenCalledTimes( 1 );
+		// wait for all requests to finish before finishing the test
+		return Promise.all( [ request1, request2 ] );
+	} );
+
+	test( 'Actions should have method fetchPluginList', () => {
+		expect( fetchPluginsList ).toBeInstanceOf( Function );
+	} );
+
+	test( 'FetchPluginList action should make a request', async () => {
+		await store.dispatch( fetchPluginsList( 'new', 1, undefined ) );
+		expect( store.dispatch ).toHaveBeenCalledTimes( 2 );
+		expect( wporg.fetchPluginsList ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( "FetchPluginList action shouldn't return an error", async () => {
+		await store.dispatch( fetchPluginsList( 'new', 1, undefined ) );
+		expect( store.dispatch ).toHaveBeenCalledTimes( 2 );
+		expect( store.dispatch ).toHaveBeenLastCalledWith(
+			expect.not.objectContaining( { error: expect.anything() } )
+		);
+	} );
+
+	test( 'FetchPluginList action should return a plugin list', async () => {
+		await store.dispatch( fetchPluginsList( 'new', 1, undefined ) );
+		expect( store.dispatch ).toHaveBeenCalledTimes( 2 );
+		expect( store.dispatch ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				category: 'new',
+			} )
+		);
+	} );
+
+	test( 'FetchPluginList action should return plugins for search term', async () => {
+		await store.dispatch( fetchPluginsList( undefined, 1, 'woocommerce' ) );
+		expect( store.dispatch ).toHaveBeenCalledTimes( 2 );
+		expect( store.dispatch ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				searchTerm: 'woocommerce',
+			} )
+		);
+	} );
+
+	test( "FetchPluginList action should not make another request if there's already one in progress", () => {
+		// issue a second request immediately after the first one (while it's still in progress)
+		const request1 = store.dispatch( fetchPluginsList( 'new', 1, undefined ) );
+		const request2 = store.dispatch( fetchPluginsList( 'new', 1, undefined ) );
+		// just one fetch should have been issued
+		expect( wporg.fetchPluginsList ).toHaveBeenCalledTimes( 1 );
 		// wait for all requests to finish before finishing the test
 		return Promise.all( [ request1, request2 ] );
 	} );

--- a/client/state/plugins/wporg/test/actions.js
+++ b/client/state/plugins/wporg/test/actions.js
@@ -71,7 +71,7 @@ describe( 'WPorg Data Actions', () => {
 		expect( fetchPluginsList ).toBeInstanceOf( Function );
 	} );
 
-	test( 'FetchPluginList action should make a request', async () => {
+	test( 'FetchPluginList action should dispatch two actions and make a request', async () => {
 		await store.dispatch( fetchPluginsList( 'new', 1, undefined ) );
 		expect( store.dispatch ).toHaveBeenCalledTimes( 2 );
 		expect( wporg.fetchPluginsList ).toHaveBeenCalledTimes( 1 );
@@ -79,7 +79,6 @@ describe( 'WPorg Data Actions', () => {
 
 	test( "FetchPluginList action shouldn't return an error", async () => {
 		await store.dispatch( fetchPluginsList( 'new', 1, undefined ) );
-		expect( store.dispatch ).toHaveBeenCalledTimes( 2 );
 		expect( store.dispatch ).toHaveBeenLastCalledWith(
 			expect.not.objectContaining( { error: expect.anything() } )
 		);
@@ -87,7 +86,6 @@ describe( 'WPorg Data Actions', () => {
 
 	test( 'FetchPluginList action should return a plugin list', async () => {
 		await store.dispatch( fetchPluginsList( 'new', 1, undefined ) );
-		expect( store.dispatch ).toHaveBeenCalledTimes( 2 );
 		expect( store.dispatch ).toHaveBeenLastCalledWith(
 			expect.objectContaining( {
 				category: 'new',
@@ -97,7 +95,6 @@ describe( 'WPorg Data Actions', () => {
 
 	test( 'FetchPluginList action should return plugins for search term', async () => {
 		await store.dispatch( fetchPluginsList( undefined, 1, 'woocommerce' ) );
-		expect( store.dispatch ).toHaveBeenCalledTimes( 2 );
 		expect( store.dispatch ).toHaveBeenLastCalledWith(
 			expect.objectContaining( {
 				searchTerm: 'woocommerce',

--- a/client/state/plugins/wporg/test/reducer.js
+++ b/client/state/plugins/wporg/test/reducer.js
@@ -258,6 +258,7 @@ describe( 'wporg reducer', () => {
 				category: { popular: pagination },
 			} );
 		} );
+
 		test( 'should store plugin list pagination by multiple categories', () => {
 			const state = listsPagination(
 				{
@@ -276,6 +277,7 @@ describe( 'wporg reducer', () => {
 				},
 			} );
 		} );
+
 		test( 'should overwrite existing plugin list paginations', () => {
 			const state = listsPagination(
 				{
@@ -294,6 +296,58 @@ describe( 'wporg reducer', () => {
 				category: {
 					popular: pagination2,
 					new: pagination,
+				},
+			} );
+		} );
+
+		test( 'should store plugin list pagination by search term', () => {
+			const state = listsPagination( undefined, {
+				type: PLUGINS_WPORG_LIST_RECEIVE,
+				searchTerm: 'woocommerce',
+				pagination,
+			} );
+			expect( state ).to.deep.equal( {
+				search: { woocommerce: pagination },
+			} );
+		} );
+
+		test( 'should store plugin list pagination by multiple search terms', () => {
+			const state = listsPagination(
+				{
+					search: { woocommerce: pagination },
+				},
+				{
+					type: PLUGINS_WPORG_LIST_RECEIVE,
+					searchTerm: 'jetpack',
+					pagination: pagination2,
+				}
+			);
+			expect( state ).to.deep.equal( {
+				search: {
+					woocommerce: pagination,
+					jetpack: pagination2,
+				},
+			} );
+		} );
+
+		test( 'should overwrite existing search term paginations', () => {
+			const state = listsPagination(
+				{
+					search: {
+						woocommerce: pagination,
+						jetpack: pagination,
+					},
+				},
+				{
+					type: PLUGINS_WPORG_LIST_RECEIVE,
+					searchTerm: 'woocommerce',
+					pagination: pagination2,
+				}
+			);
+			expect( state ).to.deep.equal( {
+				search: {
+					woocommerce: pagination2,
+					jetpack: pagination,
 				},
 			} );
 		} );

--- a/client/state/plugins/wporg/test/selectors.js
+++ b/client/state/plugins/wporg/test/selectors.js
@@ -5,6 +5,7 @@ import {
 	isFetched,
 	isFetching,
 	isFetchingPluginsList,
+	getPluginsListPagination,
 } from '../selectors';
 
 const items = deepFreeze( {
@@ -35,6 +36,13 @@ const listsPagination = deepFreeze( {
 			page: 1,
 			pages: 100,
 			results: 2359,
+		},
+	},
+	search: {
+		woocommerce: {
+			page: 1,
+			pages: 50,
+			results: 1000,
 		},
 	},
 } );
@@ -141,6 +149,26 @@ describe( 'WPorg Selectors', () => {
 		} );
 		test( 'Should return next page number when there is one', () => {
 			expect( getNextPluginsListPage( state, 'popular' ) ).toBe( 2 );
+		} );
+	} );
+
+	describe( 'getPluginsListPagination', () => {
+		test( 'Should return undefined by default', () => {
+			const emptyState = { plugins: { wporg: { listsPagination: {} } } };
+			expect( getPluginsListPagination( emptyState, 'woocommerce' ) ).toBe( undefined );
+		} );
+
+		test( 'Should return the pagination data by search term', () => {
+			const currentState = {
+				plugins: {
+					wporg: {
+						listsPagination,
+					},
+				},
+			};
+			expect( getPluginsListPagination( currentState, 'woocommerce' ) ).toBe(
+				listsPagination.search.woocommerce
+			);
 		} );
 	} );
 } );

--- a/client/state/plugins/wporg/types.ts
+++ b/client/state/plugins/wporg/types.ts
@@ -1,0 +1,5 @@
+export type Pagination = null | {
+	page: number;
+	pages: number;
+	results: number;
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Adds pagination feature to the search view in the `PluginsBrowser` component
- Updated page size to 12 on the search view according to Figma: oU6nEIeiKSg8CayhEtgR6b-fi-6450%3A38801
- Adds `paginated` prop to the `PluginsBrowserList` component

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Calypso live
* Click on the "See All" button on the top right of the "Popular" or "New" sections and do a sanity check, they should be using an infinite scroll and work like before
* Search for a plugin
* The search results list should use pagination and a page size of 12

|Before | After|
|-------|------|
| ![wpcalypso wordpress com_plugins_gcsecseyfree wordpress com_s=Engagement](https://user-images.githubusercontent.com/11555574/136951172-becbea3d-dbc6-40e6-8e5d-7dcb25b911c8.png) | ![calypso localhost_3000_plugins_gcsecseyfree wordpress com_s=Security](https://user-images.githubusercontent.com/11555574/136950999-0602dca1-6d3d-4819-9931-abfed2a2e03a.png) |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #56793