### PR TITLE
e2e: Add i18n editor tests

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
@@ -2,7 +2,8 @@ import { Page } from 'playwright';
 
 const selectors = {
 	// Menu items
-	menuItem: ( menu: string ) => `.sidebar a:has(span:has-text("${ menu }"))`,
+	menuItem: ( menu: string ) =>
+		`.sidebar a:has(span:has-text("${ menu }")), .sidebar a[href="${ menu }"]`,
 };
 
 /**
@@ -23,7 +24,7 @@ export class MeSidebarComponent {
 	/**
 	 * Given a string, navigate to the menu on the sidebar.
 	 *
-	 * @param {string} menu Menu item to navigate to.
+	 * @param {string} menu Menu item label or href to navigate to.
 	 */
 	async navigate( menu: string ): Promise< void > {
 		await Promise.all( [

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -3,7 +3,7 @@ import { Page } from 'playwright';
 const selectors = {
 	// Buttons on navbar
 	mySiteButton: '[data-tip-target="my-sites"]',
-	writeButton: '*css=a >> text=Write',
+	writeButton: '.masterbar__item-new',
 	notificationsButton: 'a[href="/notifications"]',
 	meButton: 'a[data-tip-target="me"]',
 };

--- a/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
@@ -1,5 +1,5 @@
 import { Page } from 'playwright';
-import { NavbarComponent } from '../components';
+import { NavbarComponent, SidebarComponent } from '../components';
 import { AccountSettingsPage } from '../pages';
 
 /**
@@ -24,11 +24,15 @@ export class ChangeUILanguageFlow {
 	 * then onto Account Settings.
 	 */
 	async changeUILanguage( localeSlug: string ): Promise< void > {
+		await new SidebarComponent( this.page ).waitForSidebarInitialization();
+
 		const navbarComponent = new NavbarComponent( this.page );
 		await navbarComponent.clickMe();
 
-		// @todo: MeSidebarComponent.navigate() doesn't work on non-English UI.
-		await this.page.click( 'a[href="/me/account"]' );
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.click( 'a[href="/me/account"]' ),
+		] );
 
 		const accountSettingsPage = new AccountSettingsPage( this.page );
 		await accountSettingsPage.changeUILanguage( localeSlug );

--- a/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
@@ -36,5 +36,8 @@ export class ChangeUILanguageFlow {
 
 		const accountSettingsPage = new AccountSettingsPage( this.page );
 		await accountSettingsPage.changeUILanguage( localeSlug );
+
+		// Wait for settings save and page reload.
+		await this.page.waitForLoadState( 'networkidle' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
@@ -1,0 +1,36 @@
+import { Page } from 'playwright';
+import { NavbarComponent } from '../components';
+import { AccountSettingsPage } from '../pages';
+
+/**
+ * Change the UI language.
+ */
+export class ChangeUILanguageFlow {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the flow.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Changes the UI langauge.
+	 *
+	 * This method will navigate from the navbar to the /me page,
+	 * then onto Account Settings.
+	 */
+	async changeUILanguage( localeSlug: string ): Promise< void > {
+		const navbarComponent = new NavbarComponent( this.page );
+		await navbarComponent.clickMe();
+
+		// @todo: MeSidebarComponent.navigate() doesn't work on non-English UI.
+		await this.page.click( 'a[href="/me/account"]' );
+
+		const accountSettingsPage = new AccountSettingsPage( this.page );
+		await accountSettingsPage.changeUILanguage( localeSlug );
+	}
+}

--- a/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
@@ -1,5 +1,5 @@
 import { Page } from 'playwright';
-import { NavbarComponent, SidebarComponent } from '../components';
+import { NavbarComponent, MeSidebarComponent } from '../components';
 import { AccountSettingsPage } from '../pages';
 
 /**
@@ -24,15 +24,11 @@ export class ChangeUILanguageFlow {
 	 * then onto Account Settings.
 	 */
 	async changeUILanguage( localeSlug: string ): Promise< void > {
-		await new SidebarComponent( this.page ).waitForSidebarInitialization();
-
 		const navbarComponent = new NavbarComponent( this.page );
 		await navbarComponent.clickMe();
 
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.click( 'a[href="/me/account"]' ),
-		] );
+		const meSidebar = new MeSidebarComponent( this.page );
+		await meSidebar.navigate( '/me/account' );
 
 		const accountSettingsPage = new AccountSettingsPage( this.page );
 		await accountSettingsPage.changeUILanguage( localeSlug );

--- a/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/change-ui-language-flow.ts
@@ -1,6 +1,7 @@
 import { Page } from 'playwright';
 import { NavbarComponent, MeSidebarComponent } from '../components';
 import { AccountSettingsPage } from '../pages';
+import type { LanguageSlug } from '@automattic/languages';
 
 /**
  * Change the UI language.
@@ -23,7 +24,7 @@ export class ChangeUILanguageFlow {
 	 * This method will navigate from the navbar to the /me page,
 	 * then onto Account Settings.
 	 */
-	async changeUILanguage( localeSlug: string ): Promise< void > {
+	async changeUILanguage( localeSlug: LanguageSlug ): Promise< void > {
 		const navbarComponent = new NavbarComponent( this.page );
 		await navbarComponent.clickMe();
 

--- a/packages/calypso-e2e/src/lib/flows/index.ts
+++ b/packages/calypso-e2e/src/lib/flows/index.ts
@@ -2,3 +2,4 @@ export * from './new-post-flow';
 export * from './gutenboarding-flow';
 export * from './close-account-flow';
 export * from './start-site-flow';
+export * from './change-ui-language-flow';

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -24,7 +24,7 @@ const selectors = {
 
 	// Top bar selectors.
 	postToolbar: '.edit-post-header',
-	settingsToggle: '[aria-label="Settings"]',
+	settingsToggle: '.edit-post-header__settings .interface-pinned-items button:first-child',
 	saveDraftButton: '.editor-post-save-draft',
 	previewButton: ':is(button:text("Preview"), a:text("Preview"))',
 	publishButton: ( parentSelector: string ) =>
@@ -266,16 +266,16 @@ export class GutenbergEditorPage {
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
-	async openSettings( toggleSelector = selectors.settingsToggle ): Promise< void > {
+	async openSettings(): Promise< void > {
 		const frame = await this.getEditorFrame();
 
-		const isSidebarOpen = await frame.$eval( toggleSelector, ( element ) =>
+		const isSidebarOpen = await frame.$eval( selectors.settingsToggle, ( element ) =>
 			element.classList.contains( 'is-pressed' )
 		);
 		if ( ! isSidebarOpen ) {
-			await frame.click( toggleSelector );
+			await frame.click( selectors.settingsToggle );
 		}
-		const settingsToggle = await frame.waitForSelector( toggleSelector );
+		const settingsToggle = await frame.waitForSelector( selectors.settingsToggle );
 		await frame.waitForFunction(
 			( element ) => element.getAttribute( 'aria-pressed' ) === 'true',
 			settingsToggle

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -14,7 +14,7 @@ const selectors = {
 	// Block inserter
 	blockInserterToggle: 'button.edit-post-header-toolbar__inserter-toggle',
 	blockInserterPanel: '.block-editor-inserter__content',
-	blockSearch: '[placeholder="Search"]',
+	blockSearch: '.block-editor-inserter__search input[type="search"]',
 	blockInserterResultItem: '.block-editor-block-types-list__list-item',
 
 	// Within the editor body.
@@ -266,16 +266,16 @@ export class GutenbergEditorPage {
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
-	async openSettings(): Promise< void > {
+	async openSettings( toggleSelector = selectors.settingsToggle ): Promise< void > {
 		const frame = await this.getEditorFrame();
 
-		const isSidebarOpen = await frame.$eval( selectors.settingsToggle, ( element ) =>
+		const isSidebarOpen = await frame.$eval( toggleSelector, ( element ) =>
 			element.classList.contains( 'is-pressed' )
 		);
 		if ( ! isSidebarOpen ) {
-			await frame.click( selectors.settingsToggle );
+			await frame.click( toggleSelector );
 		}
-		const settingsToggle = await frame.waitForSelector( selectors.settingsToggle );
+		const settingsToggle = await frame.waitForSelector( toggleSelector );
 		await frame.waitForFunction(
 			( element ) => element.getAttribute( 'aria-pressed' ) === 'true',
 			settingsToggle

--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -11,6 +11,12 @@ const selectors = {
 	usernameSpan: `span.account-close__confirm-dialog-target-username`,
 	usernameConfirmationInput: `input[id="confirmAccountCloseInput"]`,
 	modalCloseAccountButton: `button:text("Close your account")`,
+
+	// UI Language
+	uiLanguageButton: 'button.language-picker',
+	uiLanguageSearch: '.language-picker-component__search-desktop .search-component__input',
+	uiLanguageItem: '.language-picker-component__language-button',
+	uiLanguageApplyButton: '.language-picker__modal-buttons button.is-secondary',
 };
 
 /**
@@ -51,5 +57,15 @@ export class AccountSettingsPage {
 			.then( ( element ) => element.innerText() );
 		await this.page.fill( selectors.usernameConfirmationInput, username );
 		await this.page.click( selectors.modalCloseAccountButton );
+	}
+
+	/**
+	 * Changes the UI language for the currently logged in user.
+	 */
+	async changeUILanguage( localeSlug: string ): Promise< void > {
+		await this.page.click( selectors.uiLanguageButton );
+		await this.page.fill( selectors.uiLanguageSearch, localeSlug );
+		await this.page.click( `${ selectors.uiLanguageItem }:has([lang="${ localeSlug }"])` );
+		await this.page.click( selectors.uiLanguageApplyButton );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import type { LanguageSlug } from '@automattic/languages';
 
 const selectors = {
 	// Close account
@@ -15,7 +16,8 @@ const selectors = {
 	// UI Language
 	uiLanguageButton: 'button.language-picker',
 	uiLanguageSearch: '.language-picker-component__search-desktop .search-component__input',
-	uiLanguageItem: '.language-picker-component__language-button',
+	uiLanguageItem: ( localeSlug: LanguageSlug ) =>
+		`.language-picker-component__language-button:has([lang="${ localeSlug }"])`,
 	uiLanguageApplyButton: '.language-picker__modal-buttons button.is-secondary',
 };
 
@@ -62,10 +64,10 @@ export class AccountSettingsPage {
 	/**
 	 * Changes the UI language for the currently logged in user.
 	 */
-	async changeUILanguage( localeSlug: string ): Promise< void > {
+	async changeUILanguage( localeSlug: LanguageSlug ): Promise< void > {
 		await this.page.click( selectors.uiLanguageButton );
 		await this.page.fill( selectors.uiLanguageSearch, localeSlug );
-		await this.page.click( `${ selectors.uiLanguageItem }:has([lang="${ localeSlug }"])` );
+		await this.page.click( selectors.uiLanguageItem( localeSlug ) );
 		await this.page.click( selectors.uiLanguageApplyButton );
 	}
 }

--- a/packages/calypso-e2e/tsconfig.json
+++ b/packages/calypso-e2e/tsconfig.json
@@ -4,5 +4,6 @@
 		"outDir": "dist/esm",
 		"declarationDir": "dist/types"
 	},
-	"include": [ "src", "test" ]
+	"include": [ "src", "test" ],
+	"references": [ { "path": "../languages" } ]
 }

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -4,7 +4,7 @@
 
 import {
 	DataHelper,
-	LoginFlow,
+	LoginPage,
 	NewPostFlow,
 	ChangeUILanguageFlow,
 	GutenbergEditorPage,
@@ -220,8 +220,8 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 	} );
 
 	it( 'Log in', async function () {
-		const loginFlow = new LoginFlow( page, 'i18nUser' ); // @todo: Login with i18n testing account.
-		await loginFlow.logIn();
+		const loginPage = new LoginPage( page );
+		await loginPage.login( { account: 'i18nUser' } );
 	} );
 
 	describe.each( locales )( 'Editor translations (%s)', ( locale ) => {

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -25,15 +25,29 @@ const translations = {
 				],
 				blockPanelTitle: 'Image',
 			},
+			{
+				blockName: 'Spacer',
+				blockEditorSelector: '[data-type="core/spacer"]',
+				blockEditorContent: [],
+				blockPanelTitle: 'Spacer',
+			},
+			{
+				blockName: 'Cover',
+				blockEditorSelector: '[data-type="core/cover"]',
+				blockEditorContent: [ '.block-editor-media-placeholder__upload-button:has-text("Upload")' ],
+				blockPanelTitle: 'Cover',
+			},
 
 			// Jetpack
 			{
+				// @todo: Update when Jetpack translations get fixed.
 				blockName: 'Contact Form',
 				blockEditorSelector: '[data-type="jetpack/contact-form"]',
 				blockEditorContent: [ ':text("Name")', ':text("Email")', ':text("Message")' ],
 				blockPanelTitle: 'Form',
 			},
 			{
+				// @todo: Update when Jetpack translations get fixed.
 				blockName: 'Business Hours',
 				blockEditorSelector: '[data-type="jetpack/business-hours"]',
 				blockEditorContent: [
@@ -73,15 +87,31 @@ const translations = {
 				],
 				blockPanelTitle: 'Image',
 			},
+			{
+				blockName: 'Espacement',
+				blockEditorSelector: '[data-type="core/spacer"]',
+				blockEditorContent: [],
+				blockPanelTitle: 'Espacement',
+			},
+			{
+				blockName: 'Bannière',
+				blockEditorSelector: '[data-type="core/cover"]',
+				blockEditorContent: [
+					'.block-editor-media-placeholder__upload-button:has-text("Téléverser")',
+				],
+				blockPanelTitle: 'Bannière',
+			},
 
 			// Jetpack
 			{
+				// @todo: Update when Jetpack translations get fixed.
 				blockName: 'Contact Form',
 				blockEditorSelector: '[data-type="jetpack/contact-form"]',
 				blockEditorContent: [ ':text("Name")', ':text("Email")', ':text("Message")' ],
 				blockPanelTitle: 'Form',
 			},
 			{
+				// @todo: Update when Jetpack translations get fixed.
 				blockName: 'Business Hours',
 				blockEditorSelector: '[data-type="jetpack/business-hours"]',
 				blockEditorContent: [
@@ -121,15 +151,29 @@ const translations = {
 				],
 				blockPanelTitle: 'תמונה',
 			},
+			{
+				blockName: 'מרווח',
+				blockEditorSelector: '[data-type="core/spacer"]',
+				blockEditorContent: [],
+				blockPanelTitle: 'מרווח',
+			},
+			{
+				blockName: 'כיסוי',
+				blockEditorSelector: '[data-type="core/cover"]',
+				blockEditorContent: [ '.block-editor-media-placeholder__upload-button:has-text("העלאה")' ],
+				blockPanelTitle: 'כיסוי',
+			},
 
 			// Jetpack
 			{
+				// @todo: Update when Jetpack translations get fixed.
 				blockName: 'Contact Form',
 				blockEditorSelector: '[data-type="jetpack/contact-form"]',
 				blockEditorContent: [ ':text("Name")', ':text("Email")', ':text("Message")' ],
 				blockPanelTitle: 'Form',
 			},
 			{
+				// @todo: Update when Jetpack translations get fixed.
 				blockName: 'Business Hours',
 				blockEditorSelector: '[data-type="jetpack/business-hours"]',
 				blockEditorContent: [

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -1,0 +1,131 @@
+/**
+ * @group i18n
+ */
+
+import {
+	DataHelper,
+	LoginFlow,
+	// NewPostFlow,
+	ChangeUILanguageFlow,
+	GutenbergEditorPage,
+	setupHooks,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+const translations = {
+	en: {
+		blocks: [
+			{
+				blockName: 'Applause',
+				blockEditorSelector: '[data-type="crowdsignal-forms/applause"]',
+				blockEditorContent: [ ':text("Claps")' ],
+				blockPanelTitle: 'Applause',
+			},
+			{
+				blockName: 'Poll',
+				blockEditorSelector: '[data-type="crowdsignal-forms/poll"]',
+				blockEditorContent: [
+					'[aria-label="Enter your question"]',
+					'[aria-label="Add a note (optional)"]',
+				],
+				blockPanelTitle: 'Poll',
+			},
+		],
+	},
+	// fr: {
+	// 	blocks: [
+	// 		{
+	// 			blockName: 'Applaudissement',
+	// 			blockEditorSelector: '[data-type="crowdsignal-forms/applause"]',
+	// 			blockEditorContent: [ ':text("Claps")' ],
+	// 			blockPanelTitle: 'Applaudissement',
+	// 		},
+	// 		{
+	// 			blockName: 'Sondage',
+	// 			blockEditorSelector: '[data-type="crowdsignal-forms/poll"]',
+	// 			blockEditorContent: [
+	// 				'[aria-label="Entrez votre question"]',
+	// 				'[aria-label="Ajouter une note (facultatif)"]',
+	// 			],
+	// 			blockPanelTitle: 'Sondage',
+	// 		},
+	// 	],
+	// },
+	// he: {
+	// 	blocks: [
+	// 		{
+	// 			blockName: 'מחיאות כפיים',
+	// 			blockEditorSelector: '[data-type="crowdsignal-forms/applause"]',
+	// 			blockEditorContent: [ ':text("Claps")' ],
+	// 			blockPanelTitle: 'מחיאות כפיים',
+	// 		},
+	// 		{
+	// 			blockName: 'סקר',
+	// 			blockEditorSelector: '[data-type="crowdsignal-forms/poll"]',
+	// 			blockEditorContent: [
+	// 				'[aria-label="יש להזין את השאלה שלך"]',
+	// 				'[aria-label="להוסיף פתק (אופציונלי)"]',
+	// 			],
+	// 			blockPanelTitle: 'סקר',
+	// 		},
+	// 	],
+	// },
+};
+const locales = Object.keys( translations );
+
+describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
+	let gutenbergEditorPage: GutenbergEditorPage;
+	let page: Page;
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log in', async function () {
+		const loginFlow = new LoginFlow( page, 'i18nUser' ); // @todo: Login with i18n testing account.
+		// const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' ); // @todo: Login with i18n testing account.
+		await loginFlow.logIn();
+	} );
+
+	describe.each( locales )( 'Editor translations (%s)', ( locale ) => {
+		it( 'Change UI language', async function () {
+			await page.goto( DataHelper.getCalypsoURL( '/' ) );
+
+			const changeUILanguageFlow = new ChangeUILanguageFlow( page );
+			await changeUILanguageFlow.changeUILanguage( locale );
+		} );
+
+		it( 'Start new post', async function () {
+			// @todo: NewPostFlow.newPostFromNavbar() doesn't work on non-English UI.
+			// const newPostFlow = new NewPostFlow( page );
+			// await newPostFlow.newPostFromNavbar();
+			await page.click( '.masterbar__publish a' );
+			await page.click( '.site-selector__sites .site__content' );
+
+			gutenbergEditorPage = new GutenbergEditorPage( page );
+			await gutenbergEditorPage.waitUntilLoaded();
+			await gutenbergEditorPage.dismissWelcomeTourIfPresent();
+		} );
+
+		it.each( translations[ locale ].blocks )(
+			'Translations for block: $blockName',
+			async ( block ) => {
+				const frame = await gutenbergEditorPage.getEditorFrame();
+				await frame.waitForTimeout( 2000 );
+
+				await gutenbergEditorPage.addBlock( block.blockName, block.blockEditorSelector );
+
+				block.blockEditorContent.forEach( async ( content ) => {
+					await frame.waitForSelector( `${ block.blockEditorSelector } ${ content }` );
+				} );
+
+				await gutenbergEditorPage.openSettings();
+				await frame.click( block.blockEditorSelector );
+
+				await frame.waitForSelector(
+					`.block-editor-block-card__title:has-text("${ block.blockPanelTitle }")`
+				);
+			}
+		);
+	} );
+} );

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -61,44 +61,102 @@ const translations = {
 			},
 		],
 	},
-	// fr: {
-	// 	blocks: [
-	// 		{
-	// 			blockName: 'Applaudissement',
-	// 			blockEditorSelector: '[data-type="crowdsignal-forms/applause"]',
-	// 			blockEditorContent: [ ':text("Claps")' ],
-	// 			blockPanelTitle: 'Applaudissement',
-	// 		},
-	// 		{
-	// 			blockName: 'Sondage',
-	// 			blockEditorSelector: '[data-type="crowdsignal-forms/poll"]',
-	// 			blockEditorContent: [
-	// 				'[aria-label="Entrez votre question"]',
-	// 				'[aria-label="Ajouter une note (facultatif)"]',
-	// 			],
-	// 			blockPanelTitle: 'Sondage',
-	// 		},
-	// 	],
-	// },
-	// he: {
-	// 	blocks: [
-	// 		{
-	// 			blockName: 'מחיאות כפיים',
-	// 			blockEditorSelector: '[data-type="crowdsignal-forms/applause"]',
-	// 			blockEditorContent: [ ':text("Claps")' ],
-	// 			blockPanelTitle: 'מחיאות כפיים',
-	// 		},
-	// 		{
-	// 			blockName: 'סקר',
-	// 			blockEditorSelector: '[data-type="crowdsignal-forms/poll"]',
-	// 			blockEditorContent: [
-	// 				'[aria-label="יש להזין את השאלה שלך"]',
-	// 				'[aria-label="להוסיף פתק (אופציונלי)"]',
-	// 			],
-	// 			blockPanelTitle: 'סקר',
-	// 		},
-	// 	],
-	// },
+	fr: {
+		blocks: [
+			// Core
+			{
+				blockName: 'Image',
+				blockEditorSelector: '[data-type="core/image"]',
+				blockEditorContent: [
+					'.components-placeholder__label:has-text("Image")',
+					'.jetpack-external-media-button-menu:text("Select Image")', // Jetpack extension
+				],
+				blockPanelTitle: 'Image',
+			},
+
+			// Jetpack
+			{
+				blockName: 'Contact Form',
+				blockEditorSelector: '[data-type="jetpack/contact-form"]',
+				blockEditorContent: [ ':text("Name")', ':text("Email")', ':text("Message")' ],
+				blockPanelTitle: 'Form',
+			},
+			{
+				blockName: 'Business Hours',
+				blockEditorSelector: '[data-type="jetpack/business-hours"]',
+				blockEditorContent: [
+					'.business-hours__day-name:text("lundi")',
+					'.business-hours__hours:has-text("Add Hours")',
+				],
+				blockPanelTitle: 'Business Hours',
+			},
+
+			// Crowdsignal Forms
+			{
+				blockName: 'Applaudissement',
+				blockEditorSelector: '[data-type="crowdsignal-forms/applause"]',
+				blockEditorContent: [ ':text("Claps")' ],
+				blockPanelTitle: 'Applaudissement',
+			},
+			{
+				blockName: 'Sondage',
+				blockEditorSelector: '[data-type="crowdsignal-forms/poll"]',
+				blockEditorContent: [
+					'[aria-label="Entrez votre question"]',
+					'[aria-label="Ajouter une note (facultatif)"]',
+				],
+				blockPanelTitle: 'Sondage',
+			},
+		],
+	},
+	he: {
+		blocks: [
+			// Core
+			{
+				blockName: 'תמונה',
+				blockEditorSelector: '[data-type="core/image"]',
+				blockEditorContent: [
+					'.components-placeholder__label:has-text("תמונה")',
+					'.jetpack-external-media-button-menu:text("Select Image")', // Jetpack extension
+				],
+				blockPanelTitle: 'תמונה',
+			},
+
+			// Jetpack
+			{
+				blockName: 'Contact Form',
+				blockEditorSelector: '[data-type="jetpack/contact-form"]',
+				blockEditorContent: [ ':text("Name")', ':text("Email")', ':text("Message")' ],
+				blockPanelTitle: 'Form',
+			},
+			{
+				blockName: 'Business Hours',
+				blockEditorSelector: '[data-type="jetpack/business-hours"]',
+				blockEditorContent: [
+					'.business-hours__day-name:text("יום שני")',
+					'.business-hours__hours:has-text("Add Hours")',
+				],
+				blockPanelTitle: 'Business Hours',
+			},
+
+			// Crowdsignal Forms
+			{
+				blockName: 'מחיאות כפיים',
+				blockEditorSelector: '[data-type="crowdsignal-forms/applause"]',
+				blockEditorContent: [ ':text("Claps")' ],
+				blockPanelTitle: 'מחיאות כפיים',
+			},
+			{
+				blockName: 'סקר',
+				blockEditorSelector: '[data-type="crowdsignal-forms/poll"]',
+				blockEditorContent: [
+					'[aria-label="יש להזין את השאלה שלך"]',
+					'[aria-label="להוסיף פתק (אופציונלי)"]',
+				],
+				blockPanelTitle: 'סקר',
+			},
+		],
+	},
 };
 const locales = Object.keys( translations );
 
@@ -108,11 +166,17 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 
 	setupHooks( ( args ) => {
 		page = args.page;
+
+		// Confirm page leave with unsaved changes prompt.
+		page.on( 'dialog', async ( dialog ) => {
+			if ( dialog.type() === 'beforeunload' ) {
+				await dialog.accept();
+			}
+		} );
 	} );
 
 	it( 'Log in', async function () {
 		const loginFlow = new LoginFlow( page, 'i18nUser' ); // @todo: Login with i18n testing account.
-		// const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' ); // @todo: Login with i18n testing account.
 		await loginFlow.logIn();
 	} );
 
@@ -145,9 +209,13 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 					await frame.waitForSelector( `${ block.blockEditorSelector } ${ content }` );
 				} );
 
+				// Open block settings.
 				const settingsToggleLabel = await frame.evaluate( 'wp?.i18n?.__( "Settings" )' );
 				await gutenbergEditorPage.openSettings( `[aria-label="${ settingsToggleLabel }"]` );
 				await frame.click( block.blockEditorSelector );
+				if ( await frame.isVisible( '.block-editor-block-parent-selector__button' ) ) {
+					await frame.click( '.block-editor-block-parent-selector__button' );
+				}
 
 				await frame.waitForSelector(
 					`.block-editor-block-card__title:has-text("${ block.blockPanelTitle }")`

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -15,6 +15,35 @@ import { Page } from 'playwright';
 const translations = {
 	en: {
 		blocks: [
+			// Core
+			{
+				blockName: 'Image',
+				blockEditorSelector: '[data-type="core/image"]',
+				blockEditorContent: [
+					'.components-placeholder__label:has-text("Image")',
+					'.jetpack-external-media-button-menu:text("Select Image")', // Jetpack extension
+				],
+				blockPanelTitle: 'Image',
+			},
+
+			// Jetpack
+			{
+				blockName: 'Contact Form',
+				blockEditorSelector: '[data-type="jetpack/contact-form"]',
+				blockEditorContent: [ ':text("Name")', ':text("Email")', ':text("Message")' ],
+				blockPanelTitle: 'Form',
+			},
+			{
+				blockName: 'Business Hours',
+				blockEditorSelector: '[data-type="jetpack/business-hours"]',
+				blockEditorContent: [
+					'.business-hours__day-name:text("Monday")',
+					'.business-hours__hours:has-text("Add Hours")',
+				],
+				blockPanelTitle: 'Business Hours',
+			},
+
+			// Crowdsignal Forms
 			{
 				blockName: 'Applause',
 				blockEditorSelector: '[data-type="crowdsignal-forms/applause"]',

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -5,7 +5,7 @@
 import {
 	DataHelper,
 	LoginFlow,
-	// NewPostFlow,
+	NewPostFlow,
 	ChangeUILanguageFlow,
 	GutenbergEditorPage,
 	setupHooks,
@@ -93,18 +93,15 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 
 			const changeUILanguageFlow = new ChangeUILanguageFlow( page );
 			await changeUILanguageFlow.changeUILanguage( locale );
+
+			await page.goto( DataHelper.getCalypsoURL( '/' ) );
 		} );
 
 		it( 'Start new post', async function () {
-			// @todo: NewPostFlow.newPostFromNavbar() doesn't work on non-English UI.
-			// const newPostFlow = new NewPostFlow( page );
-			// await newPostFlow.newPostFromNavbar();
-			await page.click( '.masterbar__publish a' );
-			await page.click( '.site-selector__sites .site__content' );
+			const newPostFlow = new NewPostFlow( page );
+			await newPostFlow.newPostFromNavbar();
 
 			gutenbergEditorPage = new GutenbergEditorPage( page );
-			await gutenbergEditorPage.waitUntilLoaded();
-			await gutenbergEditorPage.dismissWelcomeTourIfPresent();
 		} );
 
 		it.each( translations[ locale ].blocks )(
@@ -119,7 +116,8 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 					await frame.waitForSelector( `${ block.blockEditorSelector } ${ content }` );
 				} );
 
-				await gutenbergEditorPage.openSettings();
+				const settingsToggleLabel = await frame.evaluate( 'wp?.i18n?.__( "Settings" )' );
+				await gutenbergEditorPage.openSettings( `[aria-label="${ settingsToggleLabel }"]` );
 				await frame.click( block.blockEditorSelector );
 
 				await frame.waitForSelector(

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -11,8 +11,19 @@ import {
 	setupHooks,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
+import type { LanguageSlug } from '@automattic/languages';
 
-const translations = {
+type Translations = {
+	[ language in LanguageSlug ]?: Partial< {
+		blocks: {
+			blockName: string;
+			blockEditorSelector: string;
+			blockEditorContent: string[];
+			blockPanelTitle: string;
+		}[];
+	} >;
+};
+const translations: Translations = {
 	en: {
 		blocks: [
 			// Core
@@ -202,7 +213,7 @@ const translations = {
 		],
 	},
 };
-const locales = Object.keys( translations );
+const locales = Object.keys( translations ) as LanguageSlug[];
 
 describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 	let gutenbergEditorPage: GutenbergEditorPage;

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -279,9 +279,10 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), () => {
 				it( 'Render block title translations', async () => {
 					await gutenbergEditorPage.openSettings();
 					await frame.click( block.blockEditorSelector );
-					if ( await frame.isVisible( '.block-editor-block-parent-selector__button' ) ) {
-						await frame.click( '.block-editor-block-parent-selector__button' );
-					}
+					await Promise.race( [
+						frame.waitForSelector( `${ block.blockEditorSelector }.is-selected` ),
+						frame.click( '.block-editor-block-parent-selector__button' ),
+					] );
 
 					await frame.waitForSelector(
 						`.block-editor-block-card__title:has-text("${ block.blockPanelTitle }")`

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -265,8 +265,7 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 				} );
 
 				// Open block settings.
-				const settingsToggleLabel = await frame.evaluate( 'wp?.i18n?.__( "Settings" )' );
-				await gutenbergEditorPage.openSettings( `[aria-label="${ settingsToggleLabel }"]` );
+				await gutenbergEditorPage.openSettings();
 				await frame.click( block.blockEditorSelector );
 				if ( await frame.isVisible( '.block-editor-block-parent-selector__button' ) ) {
 					await frame.click( '.block-editor-block-parent-selector__button' );

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -237,12 +237,18 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 
 	describe.each( locales )( 'Editor translations (%s)', ( locale ) => {
 		it( 'Change UI language', async function () {
-			await page.goto( DataHelper.getCalypsoURL( '/' ) );
+			await Promise.all( [
+				page.waitForNavigation( { url: '**/home/**', waitUntil: 'load' } ),
+				page.goto( DataHelper.getCalypsoURL( '/' ) ),
+			] );
 
 			const changeUILanguageFlow = new ChangeUILanguageFlow( page );
 			await changeUILanguageFlow.changeUILanguage( locale );
 
-			await page.goto( DataHelper.getCalypsoURL( '/' ) );
+			await Promise.all( [
+				page.waitForNavigation( { url: '**/home/**', waitUntil: 'load' } ),
+				page.goto( DataHelper.getCalypsoURL( '/' ) ),
+			] );
 		} );
 
 		it( 'Start new post', async function () {
@@ -256,7 +262,6 @@ describe( DataHelper.createSuiteTitle( 'Editor Translations' ), function () {
 			'Translations for block: $blockName',
 			async ( block ) => {
 				const frame = await gutenbergEditorPage.getEditorFrame();
-				await frame.waitForTimeout( 2000 );
 
 				await gutenbergEditorPage.addBlock( block.blockName, block.blockEditorSelector );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update navbar `writeButton` selector to not use text string.
- Update gutenberg editor page `blockSearch` selector to not use text string.
- Add Change UI Language flow.
- Add new i18n editor spec that test if translated strings for various blocks from Core, Jetpack, Crowdsignal Forms are present on the page.


#### Testing instructions

- Run tests `cd test/e2e && LOCALE=fr yarn jest specs/specs-i18n/wp-i18n__editor.ts`. `LOCALE` can be `en`, `fr`, or `he`. Other locales will be skipped as we have only added translations for these three locales.