### PR TITLE
Media Library: show secondary link to Pexels with empty content

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -67,6 +67,7 @@ export class MediaLibraryContent extends Component {
 		filterRequiresUpgrade: PropTypes.bool,
 		search: PropTypes.string,
 		source: PropTypes.string,
+		onSourceChange: PropTypes.func,
 		containerWidth: PropTypes.number,
 		single: PropTypes.bool,
 		scrollable: PropTypes.bool,
@@ -423,6 +424,7 @@ export class MediaLibraryContent extends Component {
 					thumbnailType={ this.getThumbnailType() }
 					single={ this.props.single }
 					scrollable={ this.props.scrollable }
+					onSourceChange={ this.props.onSourceChange }
 					mediaScale={ this.props.mediaScale }
 				/>
 			</MediaListData>

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -74,6 +74,10 @@ class MediaLibraryListNoContent extends Component {
 	render() {
 		let line = '';
 		let action = '';
+		const showPexelsButton =
+			config.isEnabled( 'external-media/free-photo-library' ) &&
+			userCan( 'upload_files', this.props.site ) &&
+			! this.props.source;
 
 		if ( userCan( 'upload_files', this.props.site ) && ! this.props.source ) {
 			line = this.props.translate( 'Would you like to upload something?' );
@@ -94,10 +98,7 @@ class MediaLibraryListNoContent extends Component {
 				title={ this.getLabel() }
 				line={ line }
 				action={ action }
-				secondaryAction={
-					config.isEnabled( 'external-media/free-photo-library' ) &&
-					this.props.translate( 'Browse free images' )
-				}
+				secondaryAction={ showPexelsButton && this.props.translate( 'Browse free images' ) }
 				secondaryActionCallback={ this.changeSource }
 				illustration={ mediaImage }
 				illustrationWidth={ 150 }

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -11,7 +12,10 @@ class MediaLibraryListNoContent extends Component {
 		site: PropTypes.object,
 		filter: PropTypes.string,
 		source: PropTypes.string,
+		onSourceChange: PropTypes.func,
 	};
+
+	changeSource = () => this.props.onSourceChange( 'pexels' );
 
 	getLabel() {
 		const { filter, source, translate } = this.props;
@@ -90,6 +94,11 @@ class MediaLibraryListNoContent extends Component {
 				title={ this.getLabel() }
 				line={ line }
 				action={ action }
+				secondaryAction={
+					config.isEnabled( 'external-media/free-photo-library' ) &&
+					this.props.translate( 'Browse free images' )
+				}
+				secondaryActionCallback={ this.changeSource }
 				illustration={ mediaImage }
 				illustrationWidth={ 150 }
 			/>

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -36,6 +36,8 @@ export class MediaLibraryList extends Component {
 		mediaOnFetchNextPage: PropTypes.func,
 		single: PropTypes.bool,
 		scrollable: PropTypes.bool,
+		source: PropTypes.string,
+		onSourceChange: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -214,6 +216,7 @@ export class MediaLibraryList extends Component {
 				filter: this.props.filter,
 				search: this.props.search,
 				source: this.props.source,
+				onSourceChange: this.props.onSourceChange,
 			} );
 		}
 


### PR DESCRIPTION
This adds a secondary CTA to the Pexels library view when a user's media library is empty.

Discussion: p1633979345104200/1633964741.097200-slack-C029SB8JT8S

<img width="1354" alt="Screen Shot 2021-10-11 at 4 09 32 PM" src="https://user-images.githubusercontent.com/942359/136850148-19209c8c-b9b9-49e6-bb39-d78490218a4a.png">

**To test:**
- on a site without media, visit the media library
- verify that you see two options in the EmptyContent placeholder
- verify that clicking "Browse free images" takes you to the Pexels library view

