### PR TITLE
Onboarding: Don't show skip icon

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -170,7 +170,9 @@ class StepWrapper extends Component {
 
 		const backButton = ! hideBack && this.renderBack();
 		const skipButton =
-			! hideSkip && skipButtonAlign === 'top' && this.renderSkip( { borderless: true } );
+			! hideSkip &&
+			skipButtonAlign === 'top' &&
+			this.renderSkip( { borderless: true, forwardIcon: null } );
 		const nextButton = ! hideNext && this.renderNext();
 		const hasNavigation = backButton || skipButton || nextButton;
 		const classes = classNames( 'step-wrapper', this.props.className, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I'm sorry that I don't notice this one when I test https://github.com/Automattic/wp-calypso/pull/56527 before shipping 😅 

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/136885211-2ceed76a-1854-4ebb-a646-d7a085d5203c.png) | ![image](https://user-images.githubusercontent.com/13596067/136885078-81ad91f9-607d-4ebd-9c11-961a276070af.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/start/setup-site?siteSlug=<your_site>
* Check the icon after `Skip for now` doesn't show

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/56527
