### PR TITLE
P2: fix login layout

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -340,6 +340,7 @@
 
 	.form-text-input {
 		@extend %p2-form-input-text;
+		margin-bottom: 0;
 	}
 
 	.form-input-validation {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes undesired bottom margin from text input fields, for P2 login. This will also vertically center the password icon.

**BEFORE**
<img width="700" alt="Screen Shot 2021-10-12 at 2 24 13 PM" src="https://user-images.githubusercontent.com/730823/136905470-c858d6fe-2e41-4702-9414-cd631086e12f.png">

**AFTER**
<img width="700" alt="Screen Shot 2021-10-12 at 2 26 16 PM" src="https://user-images.githubusercontent.com/730823/136905754-ad656c48-cf06-47a5-bcd8-a043a1bff5ec.png">

#### Testing instructions
1. Open the calypso.live link in incognito and replace the path with `/log-in?from=p2`.  
2. Enter some username and click Continue.
3. Verify that the bottom margins in the Before pic are gone, and the log in layout is as expected.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56398
