### PR TITLE
Revert "Editor: Use native preview on Block Editor. (#56899)"

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/editor.scss
+++ b/apps/wpcom-block-editor/src/calypso/editor.scss
@@ -1,1 +1,5 @@
 @import './features/iframe-bridge-server';
+
+// Temporary load this here too to get it work on Atomic sites at least via Calypso
+// Will be moved to wpcom folder unless fixed otherwise
+@import './features/legacy-preview-button';

--- a/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
@@ -1,0 +1,26 @@
+/**
+ * Enforces simple preview button to be always visible and hide more complex preview that was introduced in Gutenberg 7.7
+ *
+ * Doesn't affect editors older than 7.7
+ *
+ * This can be removed once we support scaling down CSS to the new preview
+ * @link https://github.com/Automattic/wp-calypso/issues/40401
+ */
+.edit-post-header__settings,
+.edit-site-header__actions {
+	@media ( min-width: 600px ) {
+		// Normally visible on mobile only, make it always visible
+		.editor-post-preview {
+			display: inline-flex;
+		}
+	}
+}
+
+@media ( min-width: 600px ) {
+	// Normally visible on desktops, make it always hidden
+	// .block-editor-post-preview__dropdown is the class name in versions >= 8.0
+	.editor-post-preview__dropdown,
+	.block-editor-post-preview__dropdown {
+		display: none;
+	}
+}

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /* eslint-disable no-restricted-imports */
+import url from 'url';
 import config from '@automattic/calypso-config';
 import { getQueryArg } from '@wordpress/url';
 import { localize, LocalizeProps } from 'i18n-calypso';
@@ -10,6 +11,7 @@ import { Component, Fragment } from 'react';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import WebPreview from 'calypso/components/web-preview';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { navigate } from 'calypso/lib/navigate';
 import {
@@ -81,13 +83,16 @@ interface CheckoutModalOptions extends RequestCart {
 interface State {
 	allowedTypes?: any;
 	classicBlockEditorId?: any;
+	editedPost?: any;
 	gallery?: any;
 	isIframeLoaded: boolean;
 	currentIFrameUrl: string;
 	isMediaModalVisible: boolean;
 	isCheckoutModalVisible: boolean;
+	isPreviewVisible: boolean;
 	multiple?: any;
 	postUrl?: T.URL;
+	previewUrl: T.URL;
 	checkoutModalOptions?: CheckoutModalOptions;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -105,6 +110,7 @@ enum EditorActions {
 	GetCheckoutModalStatus = 'getCheckoutModalStatus',
 	OpenRevisions = 'openRevisions',
 	PostStatusChange = 'postStatusChange',
+	PreviewPost = 'previewPost',
 	ViewPost = 'viewPost',
 	SetDraftId = 'draftIdSet',
 	TrashPost = 'trashPost',
@@ -131,6 +137,8 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		isMediaModalVisible: false,
 		isCheckoutModalVisible: false,
 		isIframeLoaded: false,
+		isPreviewVisible: false,
+		previewUrl: 'about:blank',
 		currentIFrameUrl: '',
 		checkoutModalOptions: undefined,
 	};
@@ -385,6 +393,11 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			this.props.openPostRevisionsDialog();
 		}
 
+		if ( EditorActions.PreviewPost === action ) {
+			const { postUrl } = payload;
+			this.openPreviewModal( postUrl, ports[ 0 ] );
+		}
+
 		if ( EditorActions.ViewPost === action ) {
 			const { postUrl } = payload;
 			window.open( postUrl, '_top' );
@@ -597,6 +610,42 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		} );
 	};
 
+	openPreviewModal = ( postUrl: string, previewPort: MessagePort ) => {
+		this.setState( {
+			isPreviewVisible: true,
+			previewUrl: 'about:blank',
+			postUrl,
+		} );
+
+		previewPort.onmessage = ( message: MessageEvent ) => {
+			previewPort.close();
+
+			const { frameNonce, unmappedSiteUrl } = this.props;
+			const { previewUrl, editedPost } = message.data;
+			const parsedPreviewUrl = url.parse( previewUrl, true );
+
+			if ( frameNonce ) {
+				parsedPreviewUrl.query[ 'frame-nonce' ] = frameNonce;
+			}
+
+			parsedPreviewUrl.query.iframe = 'true';
+			delete parsedPreviewUrl.search;
+
+			const { host: unmappedSiteUrlHost } = url.parse( unmappedSiteUrl );
+			if ( unmappedSiteUrlHost ) {
+				parsedPreviewUrl.host = unmappedSiteUrlHost;
+				parsedPreviewUrl.hostname = unmappedSiteUrlHost;
+			}
+
+			this.setState( {
+				previewUrl: url.format( parsedPreviewUrl ),
+				editedPost,
+			} );
+		};
+	};
+
+	closePreviewModal = () => this.setState( { isPreviewVisible: false } );
+
 	/* eslint-disable @typescript-eslint/ban-types */
 	openCustomizer = ( autofocus: object, unsavedChanges: boolean ) => {
 		let { customizerUrl } = this.props;
@@ -685,6 +734,10 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			allowedTypes,
 			multiple,
 			isIframeLoaded,
+			isPreviewVisible,
+			previewUrl,
+			postUrl,
+			editedPost,
 			currentIFrameUrl,
 			checkoutModalOptions,
 		} = this.state;
@@ -755,6 +808,14 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 					require="calypso/post-editor/editor-revisions/dialog"
 					placeholder={ null }
 					loadRevision={ this.loadRevision }
+				/>
+				<WebPreview
+					externalUrl={ postUrl }
+					onClose={ this.closePreviewModal }
+					overridePost={ editedPost }
+					previewUrl={ previewUrl }
+					showEditHeaderLink={ true }
+					showPreview={ isPreviewVisible }
 				/>
 			</Fragment>
 		);

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -24,6 +24,7 @@ const selectors = {
 	settingsToggle: '[aria-label="Settings"]',
 	saveDraftButton: '.editor-post-save-draft',
 	// there's a hidden button also with the "Preview" text, so using unique class name instead of text selector
+	previewButton: '.edit-post-header .editor-post-preview',
 	publishButton: ( parentSelector: string ) =>
 		`${ parentSelector } button:text("Publish")[aria-disabled=false]`,
 
@@ -315,6 +316,16 @@ export class GutenbergEditorPage {
 		// are disabled while the post is saved. Wait for the state of
 		// Publish button to return to 'enabled' before proceeding.
 		await frame.waitForSelector( selectors.publishButton( selectors.postToolbar ) );
+	}
+
+	/**
+	 * Launches editor preview by clicking toolbar preview button.
+	 *
+	 * @returns {Promise<void} No return value.
+	 */
+	async preview(): Promise< void > {
+		const frame = await this.getEditorFrame();
+		await frame.click( selectors.previewButton );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -12,6 +12,7 @@ import {
 	LoginFlow,
 	NewPostFlow,
 	setupHooks,
+	PreviewComponent,
 	PublishedPostPage,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
@@ -26,6 +27,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let page: Page;
 	let gutenbergEditorPage: GutenbergEditorPage;
 	let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
+	let previewComponent: PreviewComponent;
 	let publishedPostPage: PublishedPostPage;
 	const user = BrowserHelper.targetGutenbergEdge()
 		? 'gutenbergSimpleSiteEdgeUser'
@@ -73,12 +75,34 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 	} );
 
-	describe( 'Publish post', function () {
+	describe( 'Preview post', function () {
 		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional
 		it( 'Close settings sidebar', async function () {
 			await editorSettingsSidebarComponent.closeSidebar();
 		} );
 
+		it( 'Launch preview', async function () {
+			await gutenbergEditorPage.preview();
+			previewComponent = new PreviewComponent( page );
+			await previewComponent.previewReady();
+		} );
+
+		it( 'Post content is found in preview', async function () {
+			await previewComponent.validateTextInPreviewContent( title );
+			await previewComponent.validateTextInPreviewContent( quote );
+		} );
+
+		// We won't preview the metadata in the preview because of a race condition with tags.
+		// If you are really fast, like Playwright is, you can add a tag and launch a preview before
+		// the tag has been saved to the database, meaning it is not in the preview!
+		// It's sufficient to verify content in preview, and metadata in published post.
+
+		it( 'Close preview', async function () {
+			await previewComponent.closePreview();
+		} );
+	} );
+
+	describe( 'Publish post', function () {
 		it( 'Publish and visit post', async function () {
 			const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
 			expect( publishedURL ).toBe( await page.url() );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import config from 'config';
+import PagePreviewComponent from '../../lib/components/page-preview-component';
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverHelper from '../../lib/driver-helper';
 import * as driverManager from '../../lib/driver-manager.js';
@@ -61,6 +62,51 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			await gEditorSidebarComponent.setSharingButtons( false );
 			await gEditorSidebarComponent.closeSharingSection();
 		} );*/
+
+		it( 'Can launch page preview', async function () {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+			await gEditorComponent.ensureSaved();
+			await gEditorComponent.launchPreview();
+		} );
+
+		it( 'Can see correct page title in preview', async function () {
+			const pagePreviewComponent = await PagePreviewComponent.Expect( this.driver );
+			const actualPageTitle = await pagePreviewComponent.pageTitle();
+			assert.strictEqual(
+				actualPageTitle.toUpperCase(),
+				pageTitle.toUpperCase(),
+				'The page preview title is not correct'
+			);
+		} );
+
+		it( 'Can see correct page content in preview', async function () {
+			const pagePreviewComponent = await PagePreviewComponent.Expect( this.driver );
+			const content = await pagePreviewComponent.pageContent();
+			assert.strictEqual(
+				content.indexOf( pageQuote ) > -1,
+				true,
+				'The page preview content (' +
+					content +
+					') does not include the expected content (' +
+					pageQuote +
+					')'
+			);
+		} );
+
+		it( 'Can see the image uploaded in the preview', async function () {
+			const pagePreviewComponent = await PagePreviewComponent.Expect( this.driver );
+			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
+			return assert.strictEqual(
+				imageDisplayed,
+				true,
+				'Could not see the image in the web preview'
+			);
+		} );
+
+		it( 'Can close page preview', async function () {
+			const pagePreviewComponent = await PagePreviewComponent.Expect( this.driver );
+			await pagePreviewComponent.close();
+		} );
 
 		it( 'Can publish and preview published content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
@@ -3,6 +3,7 @@ import config from 'config';
 import { By } from 'selenium-webdriver';
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import NoticesComponent from '../../lib/components/notices-component.js';
+import PostPreviewComponent from '../../lib/components/post-preview-component';
 import RevisionsModalComponent from '../../lib/components/revisions-modal-component';
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import * as dataHelper from '../../lib/data-helper';
@@ -94,6 +95,64 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEditorSidebarComponent.collapseCategories();
 			await gEditorSidebarComponent.collapseTags();
 			await gEditorComponent.closeSidebar();
+		} );
+
+		it( 'Can launch post preview', async function () {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+			await gEditorComponent.ensureSaved();
+			await gEditorComponent.launchPreview();
+		} );
+
+		it( 'Can see correct post title in preview', async function () {
+			this.postPreviewComponent = await PostPreviewComponent.Expect( this.driver );
+
+			const postTitle = await this.postPreviewComponent.postTitle();
+			assert.strictEqual(
+				postTitle.toLowerCase(),
+				blogPostTitle.toLowerCase(),
+				'The blog post preview title is not correct'
+			);
+		} );
+
+		it( 'Can see correct post content in preview', async function () {
+			const content = await this.postPreviewComponent.postContent();
+			assert.strictEqual(
+				content.indexOf( blogPostQuote ) > -1,
+				true,
+				'The post preview content (' +
+					content +
+					') does not include the expected content (' +
+					blogPostQuote +
+					')'
+			);
+		} );
+
+		it( 'Can see the post category in preview', async function () {
+			const categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
+			assert.strictEqual(
+				categoryDisplayed.toUpperCase(),
+				newCategoryName.toUpperCase(),
+				'The tag: ' + newCategoryName + ' is not being displayed on the post'
+			);
+		} );
+
+		// Disable this step until https://github.com/Automattic/wp-calypso/issues/28974 is solved
+		// it( 'Can see the post tag in preview', async function() {
+		// 	let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
+		// 	assert.strictEqual(
+		// 		tagDisplayed.toUpperCase(),
+		// 		newTagName.toUpperCase(),
+		// 		'The tag: ' + newTagName + ' is not being displayed on the post'
+		// 	);
+		// } );
+
+		it( 'Can see the image in preview', async function () {
+			const imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );
+			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
+		} );
+
+		it( 'Can close post preview', async function () {
+			await this.postPreviewComponent.close();
 		} );
 
 		it( 'Can publish and view content', async function () {


### PR DESCRIPTION
This reverts commit daba7fd4a1ac15f1c372e76b753c1b2fff249adf.

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
