### PR TITLE
Customizer Block Widgets: Change help links from .org to .com

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -5,6 +5,7 @@ import '@wordpress/nux'; //ensure nux store loads
 // Disable nux and welcome guide features from core.
 const unsubscribe = subscribe( () => {
 	dispatch( 'core/nux' ).disableTips();
+	dispatch( 'core/interface' ).setFeatureValue( 'core/customize-widgets', 'welcomeGuide', false );
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request
#### TL;DR - Plan of attack
1. Disable nux and welcome guide features from core.
2. Create dotcom welcome guide (port from Gutenberg/core).
3. Update help links (from .org to .com).
4. Listen for these features being triggered to call dotcom welcome guide instead.

#### Testing instructions
TBD

Related to #56161
