### PR TITLE
Emails: Fix confusing message when user is still on trial period for Professional Email

### DIFF
--- a/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
@@ -26,16 +26,7 @@ const doesAdditionalPriceMatchStandardPrice = ( domain, titanMonthlyProduct ) =>
 function getPriceMessage( purchaseCost, expiryDate, translate ) {
 	return purchaseCost.amount === 0
 		? translate(
-				'You are still in your Professional Email trial period, so this mailbox is free for the remainder of your trial.',
-				{
-					args: {
-						expiryDate: expiryDate,
-					},
-					components: {
-						strong: <strong />,
-					},
-					comment: '%(expiryDate)s is a localized date (e.g. February 17, 2021)',
-				}
+				'You are still in your Professional Email trial period, so this mailbox is free for the remainder of your trial.'
 		  )
 		: translate(
 				'You can purchase new mailboxes at the prorated price of {{strong}}%(proratedPrice)s{{/strong}} per mailbox.',

--- a/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
@@ -27,9 +27,7 @@ function getPriceMessage( props ) {
 	const { purchaseCost, translate } = props;
 
 	return purchaseCost.amount === 0
-		? translate(
-				'You are still in your Professional Email trial period, so this mailbox is free for the remainder of your trial.'
-		  )
+		? translate( 'You can add new mailboxes for free until the end of your trial period.' )
 		: translate(
 				'You can purchase new mailboxes at the prorated price of {{strong}}%(proratedPrice)s{{/strong}} per mailbox.',
 				{

--- a/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
@@ -46,7 +46,7 @@ function getPriceMessage( props ) {
 function getPriceMessageExplanation( props ) {
 	const { purchaseCost, renewalCost, translate } = props;
 
-	//We don't need any explanation of the price at this point, because we have already handled it previusly.
+	// We don't need any explanation of the price at this point, because we have already handled it previously.
 	if ( purchaseCost.amount === 0 ) {
 		return '';
 	}

--- a/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
@@ -23,6 +23,66 @@ const doesAdditionalPriceMatchStandardPrice = ( domain, titanMonthlyProduct ) =>
 	);
 };
 
+function getPriceMessage( purchaseCost, expiryDate, translate ) {
+	return purchaseCost.amount === 0
+		? translate(
+				'You are still in your Professional Email trial period, so this mailbox is free for the remainder of your trial.',
+				{
+					args: {
+						expiryDate: expiryDate,
+					},
+					components: {
+						strong: <strong />,
+					},
+					comment: '%(expiryDate)s is a localized date (e.g. February 17, 2021)',
+				}
+		  )
+		: translate(
+				'You can purchase new mailboxes at the prorated price of {{strong}}%(proratedPrice)s{{/strong}} per mailbox.',
+				{
+					args: {
+						proratedPrice: purchaseCost.text,
+					},
+					components: {
+						strong: <strong />,
+					},
+					comment:
+						'%(proratedPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50)',
+				}
+		  );
+}
+
+function getPriceMessageExplanation( purchaseCost, renewalCost, translate ) {
+	if ( purchaseCost.amount === 0 ) {
+		return '';
+	}
+	return purchaseCost.amount < renewalCost.amount
+		? translate(
+				'This is less than the regular price because you are only charged for the remainder of the current month.'
+		  )
+		: translate(
+				'This is more than the regular price because you are charged for the remainder of the current month plus any additional month until renewal.'
+		  );
+}
+
+function getPriceMessageRenewal( renewalCost, expiryDate, translate ) {
+	return translate(
+		'All of your mailboxes are due to renew at the regular price of {{strong}}%(fullPrice)s{{/strong}} per mailbox when your subscription renews on {{strong}}%(expiryDate)s{{/strong}}.',
+		{
+			args: {
+				fullPrice: renewalCost.text,
+				expiryDate: expiryDate,
+			},
+			components: {
+				strong: <strong />,
+			},
+			comment:
+				'%(fullPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50), ' +
+				'%(expiryDate)s is a localized date (e.g. February 17, 2021)',
+		}
+	);
+}
+
 const TitanMailboxPricingNotice = ( { domain, titanMonthlyProduct } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
@@ -54,45 +114,19 @@ const TitanMailboxPricingNotice = ( { domain, titanMonthlyProduct } ) => {
 	}
 	const renewalCost = getTitanMailboxRenewalCost( domain );
 	const expiryDate = getTitanExpiryDate( domain );
+	const expiryDateString = moment( expiryDate ).format( 'LL' );
+	const priceMessage = getPriceMessage( purchaseCost, expiryDateString, translate );
+	const priceMessageExplanation = getPriceMessageExplanation(
+		purchaseCost,
+		renewalCost,
+		translate
+	);
+	const priceMessageRenewal = getPriceMessageRenewal( renewalCost, expiryDateString, translate );
 
 	return (
 		<Notice icon="info-outline" showDismiss={ false } status="is-success">
 			<>
-				{ translate(
-					'You can purchase new mailboxes at the prorated price of {{strong}}%(proratedPrice)s{{/strong}} per mailbox.',
-					{
-						args: {
-							proratedPrice: purchaseCost.text,
-						},
-						components: {
-							strong: <strong />,
-						},
-						comment:
-							'%(proratedPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50)',
-					}
-				) }{ ' ' }
-				{ purchaseCost.amount < renewalCost.amount
-					? translate(
-							'This is less than the regular price because you are only charged for the remainder of the current month.'
-					  )
-					: translate(
-							'This is more than the regular price because you are charged for the remainder of the current month plus any additional month until renewal.'
-					  ) }{ ' ' }
-				{ translate(
-					'All of your mailboxes are due to renew at the regular price of {{strong}}%(fullPrice)s{{/strong}} per mailbox when your subscription renews on {{strong}}%(expiryDate)s{{/strong}}.',
-					{
-						args: {
-							fullPrice: renewalCost.text,
-							expiryDate: moment( expiryDate ).format( 'LL' ),
-						},
-						components: {
-							strong: <strong />,
-						},
-						comment:
-							'%(fullPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50), ' +
-							'%(expiryDate)s is a localized date (e.g. February 17, 2021)',
-					}
-				) }
+				{ priceMessage } { priceMessageExplanation } { priceMessageRenewal }
 			</>
 		</Notice>
 	);

--- a/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
@@ -110,7 +110,6 @@ const TitanMailboxPricingNotice = ( { domain, titanMonthlyProduct } ) => {
 	}
 	const renewalCost = getTitanMailboxRenewalCost( domain );
 	const expiryDate = getTitanExpiryDate( domain );
-	const expiryDateString = moment( expiryDate ).format( 'LL' );
 	const priceMessage = getPriceMessage( { purchaseCost, translate } );
 	const priceMessageExplanation = getPriceMessageExplanation( {
 		purchaseCost,
@@ -119,7 +118,7 @@ const TitanMailboxPricingNotice = ( { domain, titanMonthlyProduct } ) => {
 	} );
 	const priceMessageRenewal = getPriceMessageRenewal( {
 		renewalCost,
-		expiryDateString,
+		expiryDate: moment( expiryDate ).format( 'LL' ),
 		translate,
 	} );
 

--- a/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.jsx
@@ -23,7 +23,9 @@ const doesAdditionalPriceMatchStandardPrice = ( domain, titanMonthlyProduct ) =>
 	);
 };
 
-function getPriceMessage( purchaseCost, expiryDate, translate ) {
+function getPriceMessage( props ) {
+	const { purchaseCost, translate } = props;
+
 	return purchaseCost.amount === 0
 		? translate(
 				'You are still in your Professional Email trial period, so this mailbox is free for the remainder of your trial.'
@@ -43,7 +45,10 @@ function getPriceMessage( purchaseCost, expiryDate, translate ) {
 		  );
 }
 
-function getPriceMessageExplanation( purchaseCost, renewalCost, translate ) {
+function getPriceMessageExplanation( props ) {
+	const { purchaseCost, renewalCost, translate } = props;
+
+	//We don't need any explanation of the price at this point, because we have already handled it previusly.
 	if ( purchaseCost.amount === 0 ) {
 		return '';
 	}
@@ -56,7 +61,9 @@ function getPriceMessageExplanation( purchaseCost, renewalCost, translate ) {
 		  );
 }
 
-function getPriceMessageRenewal( renewalCost, expiryDate, translate ) {
+function getPriceMessageRenewal( props ) {
+	const { renewalCost, expiryDate, translate } = props;
+
 	return translate(
 		'All of your mailboxes are due to renew at the regular price of {{strong}}%(fullPrice)s{{/strong}} per mailbox when your subscription renews on {{strong}}%(expiryDate)s{{/strong}}.',
 		{
@@ -106,13 +113,17 @@ const TitanMailboxPricingNotice = ( { domain, titanMonthlyProduct } ) => {
 	const renewalCost = getTitanMailboxRenewalCost( domain );
 	const expiryDate = getTitanExpiryDate( domain );
 	const expiryDateString = moment( expiryDate ).format( 'LL' );
-	const priceMessage = getPriceMessage( purchaseCost, expiryDateString, translate );
-	const priceMessageExplanation = getPriceMessageExplanation(
+	const priceMessage = getPriceMessage( { purchaseCost, translate } );
+	const priceMessageExplanation = getPriceMessageExplanation( {
 		purchaseCost,
 		renewalCost,
-		translate
-	);
-	const priceMessageRenewal = getPriceMessageRenewal( renewalCost, expiryDateString, translate );
+		translate,
+	} );
+	const priceMessageRenewal = getPriceMessageRenewal( {
+		renewalCost,
+		expiryDateString,
+		translate,
+	} );
 
 	return (
 		<Notice icon="info-outline" showDismiss={ false } status="is-success">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we are in a trial period and we want to add mailboxes, we have a strange or confusing message which claims that we are going to have a mailboxes at a prorated price of 0.00$. This pull request adds necessary code to fix this issue. It also refactors a bit for better readability.

#### Testing instructions

1. Go to Upgrades
2. Go to Emails
3. Add a domain _(or use existing one)_ and add a mailbox for Professional Email

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/137152803-7b9a9fbf-a1fa-4dd3-a263-2d6bdeb89923.png) | ![image](https://user-images.githubusercontent.com/5689927/137361572-0b7f3903-cc11-46c8-b943-082fae675919.png)


Related to {1200182182542585-as-1200481830741559}
