### PR TITLE
Update video sharing text to remove download mention

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -229,7 +229,7 @@ class EditorMediaModalDetailFields extends Component {
 					/>
 					<span>
 						{ this.props.translate(
-							'Display share menu and allow viewers to embed or download this video'
+							'Display share menu and allow viewers to copy a link or embed this video'
 						) }
 					</span>
 				</FormLabel>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change "share" option text for video in the media library to remove "download" in it.

#### Testing instructions

* On a WordPress.com test site with a plan allowing video upload
* Go to Media in the admin section
* Upload a video
* Once uploaded, select the video and click "Edit"
* Under "share", you should see the updated text "Display share menu and allow viewers to copy a link or embed this video"

![Capture d’écran 2021-10-12 à 15 40 32](https://user-images.githubusercontent.com/1420594/136970876-35fd5338-58db-427a-a511-83dd116a9711.png)


Related to 988-gh-Automattic/greenhouse
