### PR TITLE
Add Quality Squad as codeowner for `calypso-e2e`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,7 +120,7 @@
 
 # E2E specs
 /test/e2e @WunderBart @scinos @Automattic/quality-squad
-/packages/calypso-e2e @worldomonation
+/packages/calypso-e2e @Automattic/quality-squad
 
 # Node updates
 /.nvmrc @Automattic/ground-control


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the Quality Squad as the codeowners for the `calypso-e2e` package.



#### Testing instructions


Related to #
