### PR TITLE
LanguagePicker: Display appropriate languages for Jetpack+Atomic sites

### DIFF
--- a/client/components/language-picker/site-language-picker.jsx
+++ b/client/components/language-picker/site-language-picker.jsx
@@ -76,7 +76,7 @@ const SiteLanguagePicker = ( { languages: origLanguages, ...restProps } ) => {
 	const { data: wporgTranslations, error, isLoading } = useQuery(
 		'wporg-translations-' + wpVersion,
 		async () => fetchWporgTranslationsList( wpVersion ),
-		{ enabled: siteIsJetpack }
+		{ enabled: !! siteIsJetpack }
 	);
 
 	// We only need to modify the language list for jetpack or atomic sites

--- a/client/components/language-picker/site-language-picker.jsx
+++ b/client/components/language-picker/site-language-picker.jsx
@@ -3,67 +3,8 @@ import { useSelector } from 'react-redux';
 import { fetchTranslationsList as fetchWporgTranslationsList } from 'calypso/lib/wporg';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import territoryLookup from './territory-lookup.js';
 import LanguagePicker from './index';
-
-/*
- * Territories are used in Calypso languages, but they're not in
- * WP.org translations. When displaying a WP.org translation, we need
- * to add a territory to it so it displays in the correct section of
- * calypso's language picker.
-	id: 'africa-middle-east',
-	subTerritories: [ '145', '002' ],
-	--
-	name: () => __( 'Americas' ),
-	subTerritories: [ '019' ],
-	--
-	id: 'asia-pacific',
-	subTerritories: [ '143', '009', '030', '034', '035' ],
-	--
-	id: 'eastern-europe',
-	subTerritories: [ '151' ],
-	--
-	id: 'western-europe',
-	subTerritories: [ '154', '155', '039' ],
- */
-const territoryLookup = {
-	ary: '145', // Moroccan Arabic - Africa and Middle East
-	azb: '145', // South Azerbaijani - Africa and Middle East
-	ceb: '143', // Cebuano - Philippines - Asia-Pacific
-	de_CH_informal: '154', // German (Switzerland, Informal) - Western Europe
-	de_AT: '154', // German (Austria) - Western Europe
-	de_DE_formal: '154', // German (Formal) - Western Europe
-	dsb: '154', // Lower Sorbian - Germany - Western Europe
-	dzo: '143', // Dzongkha - Bhutan - Asia-Pacific
-	en_AU: '143', // English Australia - Asia-Pacific
-	en_CA: '019', // English Canada - Americas
-	en_ZA: '145', // English South Africa - Africa and Middle East
-	en_NZ: '143', // English New Zealand - Asia-Pacific
-	es_CR: '019', // Spanish Costa Rica - Americas
-	es_EC: '019', // Spanish Ecuador - Americas
-	es_VE: '019', // Spanish Venezuela - Americas
-	es_UY: '019', // Spanish Uruguay - Americas
-	es_PR: '019', // Spanish Puerto Rico - Americas
-	es_GT: '019', // Spanish Guatemala - Americas
-	es_PE: '019', // Spanish Peru - Americas
-	es_CO: '019', // Spanish Colombia - Americas
-	es_AR: '019', // Spanish Argentina - Americas
-	fa_AF: '145', // Persian (Afghanistan) - Africa and Middle East
-	haz: '145', // Hazaragi - Africa and Middle East
-	hsb: '154', // Upper Sorbian - Germany - Western Europe
-	jv_ID: '143', // Javanese - Asia-Pacific
-	my_MM: '143', // Myanmar - Asia-Pacific
-	nb_NO: '154', // Norwegian (Bokmål) - Western Europe
-	nl_BE: '154', // Dutch (Belgium) - Western Europe
-	nl_NL_formal: '154', // Dutch (Formal) - Western Europe
-	pt_PT_ao90: '154', // Portuguese (Portugal, AO90) - Western Europe
-	pt_AO: '145', // Portuguese (Angola) - Africa and Middle East
-	rhg: '143', // Rohingya - Asia-Pacific
-	sah: '151', // Sakha - Eastern Europe
-	sw: '145', // Swahili - Africa and Middle East
-	szl: '151', // Silesian - Eastern Europe
-	ta_LK: '143', // Tamil (Sri Lanka) - Asia-Pacific
-	tah: '143', // Tahitian - Asia-Pacific
-};
 
 const SiteLanguagePicker = ( { languages: origLanguages, ...restProps } ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || -1;

--- a/client/components/language-picker/site-language-picker.jsx
+++ b/client/components/language-picker/site-language-picker.jsx
@@ -1,4 +1,3 @@
-import { localize } from 'i18n-calypso';
 import { useQuery } from 'react-query';
 import { fetchTranslationsList as fetchWporgTranslationsList } from 'calypso/lib/wporg';
 import LanguagePicker from './index';
@@ -63,47 +62,45 @@ const territoryLookup = {
 	tah: '143', // Tahitian - Asia-Pacific
 };
 
-const SiteLanguagePicker = localize(
-	( { languages: origLanguages, siteIsJetpack, ...restProps } ) => {
-		let languages = origLanguages;
-		const { data: wporgTranslations, error, isLoading } = useQuery(
-			'wporg-translations',
-			async () => fetchWporgTranslationsList(),
-			{ enabled: siteIsJetpack }
+const SiteLanguagePicker = ( { languages: origLanguages, siteIsJetpack, ...restProps } ) => {
+	let languages = origLanguages;
+	const { data: wporgTranslations, error, isLoading } = useQuery(
+		'wporg-translations',
+		async () => fetchWporgTranslationsList(),
+		{ enabled: siteIsJetpack }
+	);
+
+	// Filter the WP.org translations by removing languages also in Calypso
+	let wporgOnlyTranslat = [];
+	if ( ! error && ! isLoading && wporgTranslations?.translations ) {
+		const langSeen = new Set( languages.map( ( l ) => l.wpLocale ) );
+		wporgOnlyTranslat = wporgTranslations.translations.filter(
+			( l ) => ! langSeen.has( l.language )
 		);
-
-		// Filter the WP.org translations by removing languages also in Calypso
-		let wporgOnlyTranslat = [];
-		if ( ! error && ! isLoading && wporgTranslations?.translations ) {
-			const langSeen = new Set( languages.map( ( l ) => l.wpLocale ) );
-			wporgOnlyTranslat = wporgTranslations.translations.filter(
-				( l ) => ! langSeen.has( l.language )
-			);
-		}
-
-		// Map from WP.org API format to Calypso language format
-		const wporgOnlyLanguages = wporgOnlyTranslat.map( ( l ) => ( {
-			value: l.language,
-			langSlug: l.language,
-			name: l.native_name,
-			wpLocale: l.language,
-			parentLangSlug: null,
-			calypsoPercentTranslated: null,
-			isTranslatedCompletely: null,
-			territories: [ territoryLookup[ l.language ] ],
-			revision: null,
-		} ) );
-
-		if ( siteIsJetpack ) {
-			// For jetpack and atomic sites:
-			// (1) Remove Calypso-only languages
-			// (2) Add WP.org only languages
-			languages = languages.filter( ( l ) => l.wpLocale !== '' );
-			languages = languages.concat( wporgOnlyLanguages );
-		}
-		return <LanguagePicker languages={ languages } { ...restProps } />;
 	}
-);
+
+	// Map from WP.org API format to Calypso language format
+	const wporgOnlyLanguages = wporgOnlyTranslat.map( ( l ) => ( {
+		value: l.language,
+		langSlug: l.language,
+		name: l.native_name,
+		wpLocale: l.language,
+		parentLangSlug: null,
+		calypsoPercentTranslated: null,
+		isTranslatedCompletely: null,
+		territories: [ territoryLookup[ l.language ] ],
+		revision: null,
+	} ) );
+
+	if ( siteIsJetpack ) {
+		// For jetpack and atomic sites:
+		// (1) Remove Calypso-only languages
+		// (2) Add WP.org only languages
+		languages = languages.filter( ( l ) => l.wpLocale !== '' );
+		languages = languages.concat( wporgOnlyLanguages );
+	}
+	return <LanguagePicker languages={ languages } { ...restProps } />;
+};
 export default SiteLanguagePicker;
 
 /*

--- a/client/components/language-picker/site-language-picker.jsx
+++ b/client/components/language-picker/site-language-picker.jsx
@@ -1,0 +1,143 @@
+import { localize } from 'i18n-calypso';
+import { useQuery } from 'react-query';
+import { fetchTranslationsList as fetchWporgTranslationsList } from 'calypso/lib/wporg';
+import LanguagePicker from './index';
+
+/*
+ * Territories are used in Calypso languages, but they're not in
+ * WP.org translations. When displaying a WP.org translation, we need
+ * to add a territory to it so it displays in the correct section of
+ * calypso's language picker.
+	id: 'africa-middle-east',
+	subTerritories: [ '145', '002' ],
+	--
+	name: () => __( 'Americas' ),
+	subTerritories: [ '019' ],
+	--
+	id: 'asia-pacific',
+	subTerritories: [ '143', '009', '030', '034', '035' ],
+	--
+	id: 'eastern-europe',
+	subTerritories: [ '151' ],
+	--
+	id: 'western-europe',
+	subTerritories: [ '154', '155', '039' ],
+ */
+const territoryLookup = {
+	ary: '145', // Moroccan Arabic - Africa and Middle East
+	azb: '145', // South Azerbaijani - Africa and Middle East
+	ceb: '143', // Cebuano - Philippines - Asia-Pacific
+	de_CH_informal: '154', // German (Switzerland, Informal) - Western Europe
+	de_AT: '154', // German (Austria) - Western Europe
+	de_DE_formal: '154', // German (Formal) - Western Europe
+	dsb: '154', // Lower Sorbian - Germany - Western Europe
+	dzo: '143', // Dzongkha - Bhutan - Asia-Pacific
+	en_AU: '143', // English Australia - Asia-Pacific
+	en_CA: '019', // English Canada - Americas
+	en_ZA: '145', // English South Africa - Africa and Middle East
+	en_NZ: '143', // English New Zealand - Asia-Pacific
+	es_CR: '019', // Spanish Costa Rica - Americas
+	es_EC: '019', // Spanish Ecuador - Americas
+	es_VE: '019', // Spanish Venezuela - Americas
+	es_UY: '019', // Spanish Uruguay - Americas
+	es_PR: '019', // Spanish Puerto Rico - Americas
+	es_GT: '019', // Spanish Guatemala - Americas
+	es_PE: '019', // Spanish Peru - Americas
+	es_CO: '019', // Spanish Colombia - Americas
+	es_AR: '019', // Spanish Argentina - Americas
+	fa_AF: '145', // Persian (Afghanistan) - Africa and Middle East
+	haz: '145', // Hazaragi - Africa and Middle East
+	hsb: '154', // Upper Sorbian - Germany - Western Europe
+	jv_ID: '143', // Javanese - Asia-Pacific
+	my_MM: '143', // Myanmar - Asia-Pacific
+	nb_NO: '154', // Norwegian (Bokmål) - Western Europe
+	nl_BE: '154', // Dutch (Belgium) - Western Europe
+	nl_NL_formal: '154', // Dutch (Formal) - Western Europe
+	pt_PT_ao90: '154', // Portuguese (Portugal, AO90) - Western Europe
+	pt_AO: '145', // Portuguese (Angola) - Africa and Middle East
+	rhg: '143', // Rohingya - Asia-Pacific
+	sah: '151', // Sakha - Eastern Europe
+	sw: '145', // Swahili - Africa and Middle East
+	szl: '151', // Silesian - Eastern Europe
+	ta_LK: '143', // Tamil (Sri Lanka) - Asia-Pacific
+	tah: '143', // Tahitian - Asia-Pacific
+};
+
+const SiteLanguagePicker = localize(
+	( { languages: origLanguages, siteIsJetpack, ...restProps } ) => {
+		let languages = origLanguages;
+		const { data: wporgTranslations, error, isLoading } = useQuery(
+			'wporg-translations',
+			async () => fetchWporgTranslationsList(),
+			{ enabled: siteIsJetpack }
+		);
+
+		// Filter the WP.org translations by removing languages also in Calypso
+		let wporgOnlyTranslat = [];
+		if ( ! error && ! isLoading && wporgTranslations?.translations ) {
+			const langSeen = new Set( languages.map( ( l ) => l.wpLocale ) );
+			wporgOnlyTranslat = wporgTranslations.translations.filter(
+				( l ) => ! langSeen.has( l.language )
+			);
+		}
+
+		// Map from WP.org API format to Calypso language format
+		const wporgOnlyLanguages = wporgOnlyTranslat.map( ( l ) => ( {
+			value: l.language,
+			langSlug: l.language,
+			name: l.native_name,
+			wpLocale: l.language,
+			parentLangSlug: null,
+			calypsoPercentTranslated: null,
+			isTranslatedCompletely: null,
+			territories: [ territoryLookup[ l.language ] ],
+			revision: null,
+		} ) );
+
+		if ( siteIsJetpack ) {
+			// For jetpack and atomic sites:
+			// (1) Remove Calypso-only languages
+			// (2) Add WP.org only languages
+			languages = languages.filter( ( l ) => l.wpLocale !== '' );
+			languages = languages.concat( wporgOnlyLanguages );
+		}
+		return <LanguagePicker languages={ languages } { ...restProps } />;
+	}
+);
+export default SiteLanguagePicker;
+
+/*
+Example of a translation coming back from the WP.org endpoint:
+data.translations[0]
+{
+  "language": "af",
+  "version": "5.8-beta",
+  "updated": "2021-05-13 15:59:22",
+  "english_name": "Afrikaans",
+  "native_name": "Afrikaans",
+  "package": "https://downloads.wordpress.org/translation/core/5.8-beta/af.zip",
+  "iso": {
+    "1": "af",
+    "2": "afr"
+  },
+  "strings": {
+    "continue": "Gaan voort"
+  }
+}
+
+Example of a "language" object used in calypso:
+language[0]
+{
+  "value": 2,
+  "langSlug": "af",
+  "name": "Afrikaans",
+  "wpLocale": "af",
+  "parentLangSlug": null,
+  "calypsoPercentTranslated": 6,
+  "isTranslatedIncompletely": true,
+  "territories": [
+    "002"
+  ],
+  "revision": 60516
+}
+*/

--- a/client/components/language-picker/site-language-picker.jsx
+++ b/client/components/language-picker/site-language-picker.jsx
@@ -6,6 +6,22 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import territoryLookup from './territory-lookup.js';
 import LanguagePicker from './index';
 
+/*
+ * <SiteLanguagePicker> is a wrapper around <LanguagePicker> with one additional
+ * bit of logic concerning Jetpack and Atomic sites:
+ *
+ *   - If the currently selected site is a jetpack or atomic site, the component:
+ *     - Removes languages from props.languages that WP.Org doesn't support
+ *     - Does an API request to WP.org to find additional languages to add to the languages prop
+ *     - The goal is to update the list of languages to match /wp-admin/options-general.php on
+ *       an atomic or jetpack site.
+ *   - If the currently selected site is not a jetpack or atomic site,
+ *     no changes are made and we passthrough to <LanguagePicker>.
+ *
+ * This component is appropriate for using in a site context on /settings/general,
+ * but not appropriate on for example, /me/account, which affects calypso in general.
+ * Some of the languages we add may not be supported by calypso.
+ */
 const SiteLanguagePicker = ( { languages: origLanguages, ...restProps } ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || -1;
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );

--- a/client/components/language-picker/territory-lookup.js
+++ b/client/components/language-picker/territory-lookup.js
@@ -1,0 +1,54 @@
+/*
+ * Territories are used in Calypso languages, but they're not in
+ * WP.org translations. When displaying a WP.org translation, we need
+ * to add a territory to it so it displays in the correct section of
+ * calypso's language picker.
+ */
+const territoryLookup = {
+	ary: '145', // Moroccan Arabic - Africa and Middle East
+	azb: '145', // South Azerbaijani - Africa and Middle East
+	ceb: '143', // Cebuano - Philippines - Asia-Pacific
+	de_CH_informal: '154', // German (Switzerland, Informal) - Western Europe
+	de_AT: '154', // German (Austria) - Western Europe
+	de_DE_formal: '154', // German (Formal) - Western Europe
+	dsb: '154', // Lower Sorbian - Germany - Western Europe
+	dzo: '143', // Dzongkha - Bhutan - Asia-Pacific
+	en_AU: '143', // English Australia - Asia-Pacific
+	en_CA: '019', // English Canada - Americas
+	en_ZA: '145', // English South Africa - Africa and Middle East
+	en_NZ: '143', // English New Zealand - Asia-Pacific
+	es_CR: '019', // Spanish Costa Rica - Americas
+	es_EC: '019', // Spanish Ecuador - Americas
+	es_VE: '019', // Spanish Venezuela - Americas
+	es_UY: '019', // Spanish Uruguay - Americas
+	es_PR: '019', // Spanish Puerto Rico - Americas
+	es_GT: '019', // Spanish Guatemala - Americas
+	es_PE: '019', // Spanish Peru - Americas
+	es_CO: '019', // Spanish Colombia - Americas
+	es_AR: '019', // Spanish Argentina - Americas
+	fa_AF: '145', // Persian (Afghanistan) - Africa and Middle East
+	haz: '145', // Hazaragi - Africa and Middle East
+	hsb: '154', // Upper Sorbian - Germany - Western Europe
+	jv_ID: '143', // Javanese - Asia-Pacific
+	my_MM: '143', // Myanmar - Asia-Pacific
+	nb_NO: '154', // Norwegian (Bokmål) - Western Europe
+	nl_BE: '154', // Dutch (Belgium) - Western Europe
+	nl_NL_formal: '154', // Dutch (Formal) - Western Europe
+	pt_PT_ao90: '154', // Portuguese (Portugal, AO90) - Western Europe
+	pt_AO: '145', // Portuguese (Angola) - Africa and Middle East
+	rhg: '143', // Rohingya - Asia-Pacific
+	sah: '151', // Sakha - Eastern Europe
+	sw: '145', // Swahili - Africa and Middle East
+	szl: '151', // Silesian - Eastern Europe
+	ta_LK: '143', // Tamil (Sri Lanka) - Asia-Pacific
+	tah: '143', // Tahitian - Asia-Pacific
+};
+export default territoryLookup;
+
+/*
+ The territory sections and subTerritories are taken from 
+ packages/language-picker/src/constants.ts.
+ I manually coorlated each language to a category, then picked
+ the first subTerritory in that category, which was sufficient to make
+ the language display in the correct section of Calypso's language picker.
+*/

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -46,7 +46,7 @@ async function pluginRequest( url, body ) {
 	}
 }
 
-async function themeRequest( url, query ) {
+async function getRequest( url, query ) {
 	const response = await fetch( `${ url }?${ stringifyQs( query ) }`, {
 		method: 'GET',
 		headers: { Accept: 'application/json' },
@@ -138,7 +138,7 @@ export function fetchThemeInformation( themeId ) {
 		'request[slug]': themeId,
 	};
 
-	return themeRequest( WPORG_THEMES_ENDPOINT, query );
+	return getRequest( WPORG_THEMES_ENDPOINT, query );
 }
 
 /**
@@ -162,15 +162,17 @@ export function fetchThemesList( options = {} ) {
 		'request[per_page]:': number,
 	};
 
-	return themeRequest( WPORG_THEMES_ENDPOINT, query );
+	return getRequest( WPORG_THEMES_ENDPOINT, query );
 }
 
-//export function fetchTranslationsList( options = {} ) {
-export function fetchTranslationsList() {
-	// const { search, page, number } = options;
-	const query = {
-		version: '5.8', // FIXME
-	};
-
-	return themeRequest( WPORG_CORE_TRANSLATIONS_ENDPOINT, query );
+/**
+ * Get available WP.org translations.
+ * See: https://codex.wordpress.org/WordPress.org_API
+ *
+ * @param  {string}        wpVersion       The WordPress.org version, like "5.8.1".
+ * @returns {Promise.<object>}             A promise that returns an object containing a `translations` array.
+ */
+export function fetchTranslationsList( wpVersion ) {
+	const query = { version: wpVersion };
+	return getRequest( WPORG_CORE_TRANSLATIONS_ENDPOINT, query );
 }

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -166,7 +166,7 @@ export function fetchThemesList( options = {} ) {
 }
 
 //export function fetchTranslationsList( options = {} ) {
-export function fetchTranslationsList( ) {
+export function fetchTranslationsList() {
 	// const { search, page, number } = options;
 	const query = {
 		version: '5.8', // FIXME

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -16,6 +16,7 @@ const DEFAULT_CATEGORY = 'all';
 const DEFAULT_FIRST_PAGE = 1;
 
 const WPORG_THEMES_ENDPOINT = 'https://api.wordpress.org/themes/info/1.1/';
+const WPORG_CORE_TRANSLATIONS_ENDPOINT = 'https://api.wordpress.org/translations/core/1.0/';
 
 function getWporgLocaleCode() {
 	const currentLocaleCode = i18n.getLocaleSlug();
@@ -162,4 +163,14 @@ export function fetchThemesList( options = {} ) {
 	};
 
 	return themeRequest( WPORG_THEMES_ENDPOINT, query );
+}
+
+//export function fetchTranslationsList( options = {} ) {
+export function fetchTranslationsList( ) {
+	// const { search, page, number } = options;
+	const query = {
+		version: '5.8', // FIXME
+	};
+
+	return themeRequest( WPORG_CORE_TRANSLATIONS_ENDPOINT, query );
 }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -16,7 +16,7 @@ import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import LanguagePicker from 'calypso/components/language-picker';
+import SiteLanguagePicker from 'calypso/components/language-picker/site-language-picker';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import Timezone from 'calypso/components/timezone';
@@ -270,7 +270,7 @@ export class SiteSettingsFormGeneral extends Component {
 			<FormFieldset className={ siteIsJetpack && 'site-settings__has-divider is-top-only' }>
 				<FormLabel htmlFor="lang_id">{ translate( 'Language' ) }</FormLabel>
 				{ errorNotice }
-				<LanguagePicker
+				<SiteLanguagePicker
 					languages={ languages }
 					valueKey={ siteIsJetpack ? 'wpLocale' : 'value' }
 					value={ errorNotice ? 'en_US' : fields.lang_id }
@@ -279,6 +279,7 @@ export class SiteSettingsFormGeneral extends Component {
 					onClick={ eventTracker( 'Clicked Language Field' ) }
 					showEmpathyModeControl={ false }
 					getIncompleteLocaleNoticeMessage={ this.getIncompleteLocaleNoticeMessage }
+					siteIsJetpack={ siteIsJetpack }
 				/>
 				<FormSettingExplanation>
 					{ translate( "The site's primary language." ) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -279,7 +279,6 @@ export class SiteSettingsFormGeneral extends Component {
 					onClick={ eventTracker( 'Clicked Language Field' ) }
 					showEmpathyModeControl={ false }
 					getIncompleteLocaleNoticeMessage={ this.getIncompleteLocaleNoticeMessage }
-					siteIsJetpack={ siteIsJetpack }
 				/>
 				<FormSettingExplanation>
 					{ translate( "The site's primary language." ) }

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -36,6 +36,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { shallow } from 'enzyme';
 import '@testing-library/jest-dom/extend-expect';
 import moment from 'moment';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
@@ -63,12 +64,18 @@ const initialReduxState = {
 };
 
 function renderWithRedux( ui ) {
+	const queryClient = new QueryClient();
 	const store = createStore(
 		( state ) => state,
 		initialReduxState,
 		applyMiddleware( thunkMiddleware )
 	);
-	return render( <Provider store={ store }>{ ui }</Provider> );
+
+	return render(
+		<QueryClientProvider client={ queryClient }>
+			<Provider store={ store }>{ ui }</Provider>
+		</QueryClientProvider>
+	);
 }
 
 const props = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Alter the list of Languages displayed by the language picker on `/settings/general/<site>` for Atomic and Jetpack sites.
  * The list of languages displayed on Simple sites is unchanged.
  * For Atomic and Jetpack sites, we remove languages that Calypso supports that .ORG does not understand.
  * For Atomic and Jetpack sites, we add languages that .ORG understands that Calypso does not support.
    * This is done by making a call to the https://api.wordpress.org/translations/core/1.0/?version=5.8 API.
      * Unfortunately, Calypso requires languages to have "subTerritories" so it knows which region (like Western Europe) to place the language in. WP.Org has no notion of this. I manually had to create a mapping, which doesn't seem great.
  * The goal is to make the languages displayed on `/settings/general/<site>` to match the languages shown in the `/wp-admin/options-general.php` language dropdown.

Languages Removed On Jetpack/Atomic sites:

https://user-images.githubusercontent.com/937354/137035021-b729cc5f-702a-41f8-9113-43e2782ed389.mp4

Trying to set your Jetpack/Atomic site to one of these results in an error:


https://user-images.githubusercontent.com/937354/137035067-224d9279-c483-49d3-a730-5d44c7c1cde7.mp4

Languages Added on Jetpack/Atomic sites:


https://user-images.githubusercontent.com/937354/137035125-888c070c-e8be-463e-9d03-6eff5b432527.mp4

* Note that Deutsch Sie is both added and removed. Setting a jetpack/atomic site to it errors before the PR, and works after.



#### Testing instructions

* Have both a Simple and an Atomic/Jetpack site to test.
* Visit `/wp-admin/options-general.php` on each site and notice that the languages are different (this PR makes no changes to this page).
* Visit `/settings/general/<site>` for each of your testing sites.
  * The simple site languages should remain the same.
  * The Atomic/Jetpack site languages should now match what is in `/wp-admin/options-general.php`.
* There shouldn't be any errors when choosing a language on `/settings/general/<site>` and saving.
* The languages on `/me/account` should remain unchanged.

Related to #35026
