### PR TITLE
Playwright: update suite naming convention

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -1,6 +1,5 @@
 import phrase from 'asana-phrase';
 import config from 'config';
-import { getTargetDeviceName } from './browser-helper';
 
 export type DateFormat = 'ISO';
 export { config };
@@ -262,12 +261,7 @@ export function getRandomPhrase(): string {
  * @returns {string} Test suite name.
  */
 export function createSuiteTitle( title: string ): string {
-	const parts = [
-		`[${ getJetpackHost() }]`,
-		`${ toTitleCase( title ) }:`,
-		`(${ getTargetDeviceName() })`,
-		'@parallel',
-	];
+	const parts = [ `${ toTitleCase( title ) }` ];
 
 	return parts.join( ' ' );
 }

--- a/packages/calypso-e2e/test/data-helper.test.ts
+++ b/packages/calypso-e2e/test/data-helper.test.ts
@@ -102,8 +102,8 @@ describe( 'DataHelper Tests', function () {
 	describe( `Test: createSuiteTitle`, function () {
 		test.each`
 			suite                       | viewport       | expected
-			${ 'Feature (Click: Tap)' } | ${ 'desktop' } | ${ '[WPCOM] Feature (Click: Tap): (desktop) @parallel' }
-			${ 'Manage' }               | ${ 'mobile' }  | ${ '[WPCOM] Manage: (mobile) @parallel' }
+			${ 'Feature (Click: Tap)' } | ${ 'desktop' } | ${ 'Feature (Click: Tap)' }
+			${ 'Manage' }               | ${ 'mobile' }  | ${ 'Manage' }
 		`(
 			'Returns $expected if toTitleCase is called with $words',
 			function ( { suite, viewport, expected } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR simplifies the naming convention for the e2e test suites.

Key changes:
- drop the `[WPCOM]` prefix.
- drop the device identifier `(mobile/desktop)`
