### PR TITLE
Onboarding: update FSE logic for themes

### DIFF
--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -53,11 +53,7 @@ export default function useSteps(): Array< StepType > {
 	// - Site Editor flow (feature flag)
 	// - the user has selected a design without fonts
 	// - the user is enrolled in Beta FSE
-	if (
-		isEnabled( 'gutenboarding/site-editor' ) ||
-		hasSelectedDesignWithoutFonts ||
-		isEnrollingInFse
-	) {
+	if ( hasSelectedDesignWithoutFonts || isEnrollingInFse ) {
 		steps = steps.filter( ( step ) => step !== Step.Style );
 	}
 

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -59,7 +59,7 @@ export function* createSite( {
 
 	const siteUrl = domain?.domain_name || siteTitle || username;
 	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
-	const defaultTheme = shouldEnrollInFseBeta ? 'seedlet-blocks' : 'twentytwenty';
+	const defaultTheme = 'quadrat';
 	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 
 	const params: CreateSiteParams = {

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -54,12 +54,12 @@ export function* createSite( {
 		siteTitle,
 		siteVertical,
 		selectedFeatures,
+		shouldEnrollInFseBeta,
 	}: State = yield select( ONBOARD_STORE, 'getState' );
 
-	const shouldEnableFse = !! selectedDesign?.is_fse;
 	const siteUrl = domain?.domain_name || siteTitle || username;
 	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
-	const defaultTheme = shouldEnableFse ? 'seedlet-blocks' : 'twentytwenty';
+	const defaultTheme = shouldEnrollInFseBeta ? 'seedlet-blocks' : 'twentytwenty';
 	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 
 	const params: CreateSiteParams = {
@@ -79,7 +79,7 @@ export function* createSite( {
 			},
 			lang_id: lang_id,
 			site_creation_flow: 'gutenboarding',
-			enable_fse: shouldEnableFse,
+			enable_fse: shouldEnrollInFseBeta,
 			theme: `pub/${ selectedDesign?.theme || defaultTheme }`,
 			timezone_string: guessTimezone(),
 			...( selectedDesign?.template && { template: selectedDesign.template } ),

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -3,7 +3,7 @@
 		{
 			"title": "Quadrat",
 			"slug": "quadrat",
-			"template": "blockbase",
+			"template": "quadrat",
 			"theme": "quadrat",
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
@@ -11,17 +11,31 @@
 			"features": []
 		},
 		{
-			"title": "Seedlet",
-			"slug": "seedlet-blocks",
-			"template": "seedlet-blocks",
-			"theme": "seedlet-blocks",
-			"fonts": {
-				"headings": "Playfair Display",
-				"base": "Fira Sans"
-			},
+			"title": "Quadrat",
+			"slug": "quadrat",
+			"template": "quadrat",
+			"theme": "quadrat",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
+			"title": "Geologist",
+			"slug": "geologist",
+			"template": "geologist",
+			"theme": "geologist",
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Geologist",
+			"slug": "geologist",
+			"template": "geologist",
+			"theme": "geologist",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
 			"features": []
 		},
 		{
@@ -449,20 +463,6 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"features": [ "anchorfm" ]
-		},
-		{
-			"title": "Mayland",
-			"slug": "mayland-blocks",
-			"template": "mayland-blocks",
-			"theme": "mayland-blocks",
-			"fonts": {
-				"headings": "Raleway",
-				"base": "Cabin"
-			},
-			"categories": [ { "slug": "featured", "name": "Featured" } ],
-			"is_premium": false,
-			"is_fse": true,
-			"features": []
 		},
 		{
 			"title": "Start with an empty page",

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -1,6 +1,16 @@
 {
 	"featured": [
 		{
+			"title": "Quadrat",
+			"slug": "quadrat",
+			"template": "blockbase",
+			"theme": "quadrat",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
 			"title": "Seedlet",
 			"slug": "seedlet-blocks",
 			"template": "seedlet-blocks",

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -58,6 +58,25 @@
 			"features": []
 		},
 		{
+			"title": "Blockbase",
+			"slug": "blockbase",
+			"template": "blockbase",
+			"theme": "blockbase",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Blockbase",
+			"slug": "blockbase",
+			"template": "blockbase",
+			"theme": "blockbase",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
 			"title": "Cassel",
 			"slug": "cassel",
 			"template": "cassel",
@@ -491,16 +510,6 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": false,
-			"features": []
-		},
-		{
-			"title": "Blockbase",
-			"slug": "blockbase",
-			"template": "blockbase",
-			"theme": "blockbase",
-			"categories": [ { "slug": "featured", "name": "Featured" } ],
-			"is_premium": false,
-			"is_fse": true,
 			"features": []
 		}
 	]

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -494,7 +494,7 @@
 			"features": []
 		},
 		{
-			"title": "Start with an empty page",
+			"title": "Blockbase",
 			"slug": "blockbase",
 			"template": "blockbase",
 			"theme": "blockbase",

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -39,6 +39,25 @@
 			"features": []
 		},
 		{
+			"title": "Zoologist",
+			"slug": "zoologist",
+			"template": "zoologist",
+			"theme": "zoologist",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Zoologist",
+			"slug": "zoologist",
+			"template": "zoologist",
+			"theme": "zoologist",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
 			"title": "Cassel",
 			"slug": "cassel",
 			"template": "cassel",

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -45,6 +45,12 @@ interface AvailableDesignsOptions {
 	useFseDesigns?: boolean;
 	randomize?: boolean;
 }
+
+/**
+ * To prevent the accumulation of tech debt, make duplicate entries for all Universal
+ * themes, one with `is_fse: true`, the other not. This tech debt can be eliminated
+ * by using the REST API for themes rather than a hardcoded list.
+ */
 export function getAvailableDesigns( {
 	includeAlphaDesigns = isEnabled( 'gutenboarding/alpha-templates' ),
 	useFseDesigns = false,
@@ -62,8 +68,7 @@ export function getAvailableDesigns( {
 		};
 	}
 
-	// If we are in the FSE flow, only show FSE designs. In normal flows, remove
-	// the FSE designs.
+	// If we are opting into FSE, show only FSE designs.
 	designs = {
 		...designs,
 		featured: designs.featured.filter( ( design ) =>

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -47,7 +47,7 @@ interface AvailableDesignsOptions {
 }
 export function getAvailableDesigns( {
 	includeAlphaDesigns = isEnabled( 'gutenboarding/alpha-templates' ),
-	useFseDesigns = isEnabled( 'gutenboarding/site-editor' ),
+	useFseDesigns = false,
 	randomize = false,
 }: AvailableDesignsOptions = {} ): AvailableDesigns {
 	let designs = { ...availableDesignsConfig };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* remove all references to `gutenboarding/full-site-editing` feature flag
* use `shouldEnrollInFseBeta` selector to determine a site's FSE status
* add Universal Themes twice: once each for `is_fse` and not

#### Testing instructions

1. Visit `calpso.localhost:3000/new`
2. When enrolling in FSE, on `/new/design`, you should see Blockbase, Geologist, Zoologist, and Quadrat.
3. When _not_ enrolling in FSE, on `/new/design`, you should also see those themes alongside non-FSE themes.

Ensure that sites are properly enrolled (or not) in FSE based on what was chosen in the beta step, especially if opting out of FSE but choosing a Universal theme (Quadrat or Geologist).

Fixes #56876
