### PR TITLE
Happy Chat: Clean up timeline component

### DIFF
--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -16,13 +16,6 @@ import './timeline.scss';
 
 const debug = debugFactory( 'calypso:happychat:timeline' );
 
-const MessageParagraph = ( { message, isEdited, isOptimistic } ) => (
-	<p className={ classnames( { 'is-optimistic': isOptimistic } ) }>
-		{ message }
-		{ isEdited && <small className="happychat__message-edited-flag">(edited)</small> }
-	</p>
-);
-
 class MessageLink extends Component {
 	handleClick = () => {
 		const { href, messageId, sendEventMessage, userId } = this.props;
@@ -70,18 +63,11 @@ class MessageLink extends Component {
 const MessageLinkConnected = connect( ( state ) => ( { userId: getCurrentUserId( state ) } ), {
 	sendEventMessage: sendEvent,
 } )( MessageLink );
+
 /*
- * Given a message and array of links contained within that message, returns the message
- * with clickable links inside of it.
+ * Render a formatted message.
  */
-const MessageWithLinks = ( {
-	message,
-	messageId,
-	isEdited,
-	isOptimistic,
-	links,
-	isExternalUrl,
-} ) => {
+const Message = ( { message, messageId, isEdited, isOptimistic, links = [], isExternalUrl } ) => {
 	const children = links.reduce(
 		( { parts, last }, [ url, startIndex, length ] ) => {
 			const text = url;
@@ -137,17 +123,6 @@ const MessageWithLinks = ( {
 };
 
 /*
- * If a message event has a message with links in it, return a component with clickable links.
- * Otherwise just return a single paragraph with the text.
- */
-const MessageText = ( props ) =>
-	props.links && props.links.length > 0 ? (
-		<MessageWithLinks { ...props } />
-	) : (
-		<MessageParagraph { ...props } />
-	);
-
-/*
  * Group messages based on user so when any user sends multiple messages they will be grouped
  * within the same message bubble until it reaches a message from a different user.
  */
@@ -161,7 +136,7 @@ const renderGroupedMessages = ( { item, isCurrentUser, isExternalUrl }, index ) 
 			key={ event.id || index }
 		>
 			<div className="happychat__message-text">
-				<MessageText
+				<Message
 					name={ event.name }
 					message={ event.message }
 					messageId={ event.id }
@@ -171,7 +146,7 @@ const renderGroupedMessages = ( { item, isCurrentUser, isExternalUrl }, index ) 
 					isExternalUrl={ isExternalUrl }
 				/>
 				{ rest.map( ( { message, id, isEdited, isOptimistic, links } ) => (
-					<MessageText
+					<Message
 						key={ id }
 						message={ message }
 						messageId={ event.id }

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -254,18 +254,13 @@ function Timeline( props ) {
 				onMouseEnter={ scrollbleed.lock }
 				onMouseLeave={ scrollbleed.unlock }
 			>
-				{ groupMessages( timeline ).map( ( item ) => {
-					const firstItem = item[ 0 ];
-					if ( firstItem.type !== 'message' ) {
-						debug( 'no handler for message type', firstItem.type, firstItem );
-						return null;
-					}
-					return renderGroupedMessages( {
+				{ groupMessages( timeline ).map( ( item ) =>
+					renderGroupedMessages( {
 						item,
-						isCurrentUser: isCurrentUser( firstItem ),
+						isCurrentUser: isCurrentUser( item[ 0 ] ),
 						isExternalUrl,
-					} );
-				} ) }
+					} )
+				) }
 			</div>
 			{ unreadMessagesCount > 0 && (
 				<div className="happychat__unread-messages-container">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR mirrors changes that have been made in the `happychat-client` repo here: https://github.com/Automattic/happychat-client/pull/336 I tried to match each commit here with a commit from that PR to make it easier to follow why each change was being made. Some of the `happychat-client` commits had already been addressed here, which is why there are fewer commits on this PR.

The ultimate goal of this PR is to remove some of the code duplication and cruft from the Chat timeline code, so that changes in the future are simpler and less error-prone. Specifically this supports the Image Upload project (p7OimR-ID-p2) which will build on this work to show images inline in the timeline.

#### Testing instructions

The biggest risk factors are around how Chat messages are grouped, rendered, and auto-linked. Open a chat and check that the following features look the same as before:

- Grouping messages (customer and operator messages should group together correctly)
- Link rendering (single links, multiple links in a message)
- External links should open in new tab to correct URL
- Internal links should navigate you there in Calypso
- Messages edited from HUD should have the (edited) flag
- Scrolling should work as expected
- If you scroll up and send a message from HUD you should see a "New messages" button