### PR TITLE
build: Change `run_full_eslint` param

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -345,6 +345,17 @@ object CheckCodeStyleBranch : BuildType({
 	name = "Code style"
 	description = "Check code style"
 
+	params {
+		checkbox(
+			name = "run_full_eslint",
+			value = "false",
+			label = "Run full eslint",
+			description = "Run ESLint for all files in the repo, not only for changed files",
+			checked = "true",
+			unchecked = "false"
+		)
+	}
+
 	artifactRules = """
 		checkstyle_results => checkstyle_results
 	""".trimIndent()
@@ -370,7 +381,7 @@ object CheckCodeStyleBranch : BuildType({
 				export NODE_ENV="test"
 
 				# Find files to lint
-				if [ "%calypso.run_full_eslint%" = "true" ]; then
+				if [ "%run_full_eslint%" = "true" ]; then
 					FILES_TO_LINT="."
 				else
 					FILES_TO_LINT=${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.md)${'$'}' || exit 0)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -58,7 +58,6 @@ project {
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)
 		text("docker_image", "registry.a8c.com/calypso/base:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)
 		text("docker_image_e2e", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker e2e image", description = "Docker image used to run e2e tests", allowEmpty = true)
-		text("calypso.run_full_eslint", "false", label = "Run full eslint", description = "True will lint all files, empty/false will lint only changed files", allowEmpty = true)
 		text("env.DOCKER_BUILDKIT", "1", label = "Enable Docker BuildKit", description = "Enables BuildKit (faster image generation). Values 0 or 1", allowEmpty = true)
 		password("CONFIG_E2E_ENCRYPTION_KEY", "credentialsJSON:819c139c-90a1-4803-8367-00e5aa5fdb07", display = ParameterDisplay.HIDDEN)
 		password("mc_post_root", "credentialsJSON:2f764583-d399-4d5f-8ee1-06f68ef2e2a6", display = ParameterDisplay.HIDDEN )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move `calypso.run_full_eslint` to the project that actually uses it.
* Rename it to just `run_full_eslint`
* Convert it to a checkbox

#### Testing

This can be tested until merged.
The fact that we have green builds means that at least the DSL is valid and doesn't contain any syntax errors 🤷🏼 
