### PR TITLE
chore: Add missing test/e2e dependencies

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -40,6 +40,7 @@
 		"concurrently": "^3.6.1",
 		"config": "^1.28.0",
 		"cryptiles": ">=4.1.2",
+		"enzyme": "^3.11.0",
 		"esformatter-braces": "^1.2.1",
 		"esformatter-collapse-objects-a8c": "^0.1.0",
 		"esformatter-dot-notation": "^1.3.1",
@@ -71,8 +72,11 @@
 		"mocha-teamcity-reporter": "^3.0.0",
 		"node-slack-upload": "^1.2.1",
 		"png-itxt": "^1.3.0",
+		"postcss": "^8.2.15",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"push-receiver": "^2.0.0",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
 		"request": "^2.88.2",
 		"request-promise": "^4.2.2",
 		"sanitize-filename": "^1.6.0",
@@ -83,6 +87,7 @@
 		"spec-junit-reporter": "^0.0.1",
 		"testarmada-magellan": "patch:testarmada-magellan@11.0.10#../../.patches/testarmada-magellan@11.0.10.diff",
 		"testarmada-magellan-local-executor": "^2.0.3",
+		"webpack": "^5.54.0",
 		"xml2json-command": "^0.0.3",
 		"xmpp.js": "^0.3.0"
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -37694,6 +37694,7 @@ typescript@^4.4.3:
     concurrently: ^3.6.1
     config: ^1.28.0
     cryptiles: ">=4.1.2"
+    enzyme: ^3.11.0
     esformatter-braces: ^1.2.1
     esformatter-collapse-objects-a8c: ^0.1.0
     esformatter-dot-notation: ^1.3.1
@@ -37725,8 +37726,11 @@ typescript@^4.4.3:
     mocha-teamcity-reporter: ^3.0.0
     node-slack-upload: ^1.2.1
     png-itxt: ^1.3.0
+    postcss: ^8.2.15
     prettier: "npm:wp-prettier@2.2.1-beta-1"
     push-receiver: ^2.0.0
+    react: ^17.0.2
+    react-dom: ^17.0.2
     request: ^2.88.2
     request-promise: ^4.2.2
     sanitize-filename: ^1.6.0
@@ -37737,6 +37741,7 @@ typescript@^4.4.3:
     spec-junit-reporter: ^0.0.1
     testarmada-magellan: "patch:testarmada-magellan@11.0.10#../../.patches/testarmada-magellan@11.0.10.diff"
     testarmada-magellan-local-executor: ^2.0.3
+    webpack: ^5.54.0
     xml2json-command: ^0.0.3
     xmpp.js: ^0.3.0
   languageName: unknown


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add missing dependencies required by `@automattic/calypso-build`

It solves these warnings:
```
➤ YN0002: │ wp-e2e-tests@workspace:test/e2e doesn't provide enzyme (p6c870), requested by @automattic/calypso-build
➤ YN0002: │ wp-e2e-tests@workspace:test/e2e doesn't provide postcss (p3b56f), requested by @automattic/calypso-build
➤ YN0002: │ wp-e2e-tests@workspace:test/e2e doesn't provide react (pcf0c4), requested by @automattic/calypso-build
➤ YN0002: │ wp-e2e-tests@workspace:test/e2e doesn't provide react-dom (pd5f53), requested by @automattic/calypso-build
➤ YN0002: │ wp-e2e-tests@workspace:test/e2e doesn't provide webpack (p851bf), requested by @automattic/calypso-build
```
