### PR TITLE
Activity log: show button to expand lumped login activities

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -121,11 +121,13 @@ class FoldableCard extends Component {
 		} );
 		return (
 			<div className={ headerClasses } role="presentation" onClick={ headerClickAction }>
-				<span className="foldable-card__main">{ this.props.header } </span>
+				<span className="foldable-card__main">
+					{ this.props.header }
+					{ this.renderActionButton() }
+				</span>
 				<span className="foldable-card__secondary">
 					{ summary }
 					{ expandedSummary }
-					{ this.renderActionButton() }
 				</span>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently, when there are multiple user login activities, they are lumped together, but the button to see them separately is not displayed:
<img width="600" alt="Screen Shot 2021-10-13 at 11 37 28" src="https://user-images.githubusercontent.com/16329583/137108119-8f12c32f-5c6d-4bfb-984f-59ffb10ab148.png">

This PR makes the expand button visible by adding it to the `foldable-card__main` area:
<img width="600" alt="Screen Shot 2021-10-13 at 11 38 26" src="https://user-images.githubusercontent.com/16329583/137108545-045d9d07-a43f-4004-97f0-da5fd8652c01.png">
<img width="600" alt="Screen Shot 2021-10-13 at 11 38 31" src="https://user-images.githubusercontent.com/16329583/137108350-90e10599-d6c0-4455-8d8e-972790717e26.png">



Testing instructions
  1- Login with two or more users to a site
  2- Check the activity log and confirm that the expand button is displaying and working properly
  Alternatively


GH report for this issue: 
 6857-gh-Automattic/jpop-issues

Asana task:
1170120475965554-as-1200803863833668#### 