### PR TITLE
Optimize the Masterbar Shopping Cart widget

### DIFF
--- a/apps/masterbar-cart/package.json
+++ b/apps/masterbar-cart/package.json
@@ -35,6 +35,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/webpack-extensive-lodash-replacement-plugin": "^0.0.2",
 		"autoprefixer": "^10.2.5",
 		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",

--- a/apps/masterbar-cart/src/app.tsx
+++ b/apps/masterbar-cart/src/app.tsx
@@ -28,11 +28,15 @@ function App( { siteId, wpcom }: { siteId: string; wpcom: any } ) {
 		[ wpcomGetCart, wpcomSetCart ]
 	);
 
+	const goToCheckout = ( siteSlug: string ) => {
+		window.location.href = `/checkout/${ siteSlug }`;
+	};
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<ShoppingCartProvider managerClient={ cartManagerClient }>
 			<header id="masterbar" className="masterbar masterbar-cart-standalone">
-				<MasterbarCart selectedSiteSlug={ siteId } />
+				<MasterbarCart selectedSiteSlug={ siteId } goToCheckout={ goToCheckout } />
 			</header>
 		</ShoppingCartProvider>
 	);

--- a/apps/masterbar-cart/webpack.config.js
+++ b/apps/masterbar-cart/webpack.config.js
@@ -5,6 +5,7 @@ const Minify = require( '@automattic/calypso-build/webpack/minify' );
 const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
 const { shouldTranspileDependency } = require( '@automattic/calypso-build/webpack/util' );
+const ExtensiveLodashReplacementPlugin = require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
 const autoprefixerPlugin = require( 'autoprefixer' );
 const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
 const webpack = require( 'webpack' );
@@ -96,6 +97,7 @@ module.exports = {
 			isRTL: false,
 		} ),
 		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),
+		new ExtensiveLodashReplacementPlugin(),
 		shouldEmitStats &&
 			new BundleAnalyzerPlugin( {
 				analyzerMode: 'server',

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
 import { Component } from 'react';
@@ -158,6 +159,10 @@ class MasterbarLoggedIn extends Component {
 		preload( 'me' );
 	};
 
+	goToCheckout = ( siteId ) => {
+		page( `/checkout/${ siteId }` );
+	};
+
 	isActive = ( section ) => {
 		return section === this.props.section && ! this.props.isNotificationsShowing;
 	};
@@ -289,6 +294,7 @@ class MasterbarLoggedIn extends Component {
 							placeholder={ null }
 							className="masterbar__item-cart"
 							tooltip={ translate( 'View my Shopping Cart' ) }
+							goToCheckout={ this.goToCheckout }
 						/>
 					) }
 					<Item

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -290,7 +290,7 @@ class MasterbarLoggedIn extends Component {
 					) }
 					{ shouldShowCartIcon && (
 						<AsyncLoad
-							require="./masterbar-cart"
+							require="./masterbar-cart-wrapper"
 							placeholder={ null }
 							className="masterbar__item-cart"
 							tooltip={ translate( 'View my Shopping Cart' ) }

--- a/client/layout/masterbar/masterbar-cart-wrapper.tsx
+++ b/client/layout/masterbar/masterbar-cart-wrapper.tsx
@@ -1,0 +1,10 @@
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import { MasterbarCart, MasterbarCartProps } from './masterbar-cart';
+
+export default function MasterbarCartWrapper( props: MasterbarCartProps ): JSX.Element {
+	return (
+		<CalypsoShoppingCartProvider>
+			<MasterbarCart { ...props } />
+		</CalypsoShoppingCartProvider>
+	);
+}

--- a/client/layout/masterbar/masterbar-cart.tsx
+++ b/client/layout/masterbar/masterbar-cart.tsx
@@ -3,14 +3,13 @@ import { CheckoutProvider, CheckoutErrorBoundary, Button } from '@automattic/com
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import MasterbarItem from './item';
 import { MasterbarCartLineItems } from './masterbar-cart-line-items';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
 import './masterbar-cart-style.scss';
 
-type MasterbarCartProps = {
+export type MasterbarCartProps = {
 	selectedSiteSlug: string | undefined;
 	goToCheckout: ( siteSlug: string ) => void;
 };
@@ -128,13 +127,5 @@ function MasterbarCartContents( {
 				</div>
 			</div>
 		</CheckoutProvider>
-	);
-}
-
-export default function MasterbarCartWrapper( props: MasterbarCartProps ): JSX.Element {
-	return (
-		<CalypsoShoppingCartProvider>
-			<MasterbarCart { ...props } />
-		</CalypsoShoppingCartProvider>
 	);
 }

--- a/client/layout/masterbar/masterbar-cart.tsx
+++ b/client/layout/masterbar/masterbar-cart.tsx
@@ -2,7 +2,6 @@ import { Popover } from '@automattic/components';
 import { CheckoutProvider, CheckoutErrorBoundary, Button } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useRef, useState } from 'react';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import MasterbarItem from './item';
@@ -11,9 +10,15 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 
 import './masterbar-cart-style.scss';
 
-type MasterbarCartProps = { selectedSiteSlug: string | undefined };
+type MasterbarCartProps = {
+	selectedSiteSlug: string | undefined;
+	goToCheckout: ( siteSlug: string ) => void;
+};
 
-export function MasterbarCart( { selectedSiteSlug }: MasterbarCartProps ): JSX.Element | null {
+export function MasterbarCart( {
+	selectedSiteSlug,
+	goToCheckout,
+}: MasterbarCartProps ): JSX.Element | null {
 	const { responseCart, reloadFromServer } = useShoppingCart( selectedSiteSlug );
 	const masterbarButtonRef = useRef( null );
 	const [ isActive, setIsActive ] = useState( false );
@@ -45,7 +50,10 @@ export function MasterbarCart( { selectedSiteSlug }: MasterbarCartProps ): JSX.E
 					context={ masterbarButtonRef.current }
 					position="bottom left"
 				>
-					<MasterbarCartContents selectedSiteSlug={ selectedSiteSlug } />
+					<MasterbarCartContents
+						selectedSiteSlug={ selectedSiteSlug }
+						goToCheckout={ goToCheckout }
+					/>
 				</Popover>
 			</CheckoutErrorBoundary>
 		</div>
@@ -70,7 +78,13 @@ function MasterbarCartTotal( { responseCart }: { responseCart: ResponseCart } ) 
 	);
 }
 
-function MasterbarCartContents( { selectedSiteSlug }: { selectedSiteSlug: string } ) {
+function MasterbarCartContents( {
+	selectedSiteSlug,
+	goToCheckout,
+}: {
+	selectedSiteSlug: string;
+	goToCheckout: ( siteSlug: string ) => void;
+} ) {
 	const {
 		responseCart,
 		removeCoupon,
@@ -79,10 +93,6 @@ function MasterbarCartContents( { selectedSiteSlug }: { selectedSiteSlug: string
 		isPendingUpdate,
 	} = useShoppingCart( selectedSiteSlug );
 	const translate = useTranslate();
-	const goToCheckout = () => {
-		const checkoutUrl = `/checkout/${ selectedSiteSlug }`;
-		page( checkoutUrl );
-	};
 	const isDisabled = isLoading || isPendingUpdate;
 	const isPwpoUser = false; // TODO: deal with this properly
 
@@ -111,7 +121,7 @@ function MasterbarCartContents( { selectedSiteSlug }: { selectedSiteSlug: string
 						fullWidth
 						disabled={ isDisabled }
 						isBusy={ isDisabled }
-						onClick={ goToCheckout }
+						onClick={ () => goToCheckout( selectedSiteSlug ) }
 					>
 						{ translate( 'Checkout' ) }
 					</Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,6 +615,7 @@ __metadata:
   resolution: "@automattic/masterbar-cart@workspace:apps/masterbar-cart"
   dependencies:
     "@automattic/calypso-build": ^9.0.0
+    "@automattic/webpack-extensive-lodash-replacement-plugin": ^0.0.2
     autoprefixer: ^10.2.5
     calypso: ^0.17.0
     enzyme: ^3.11.0


### PR DESCRIPTION
@sirbrilling I'm offering three optimizations that reduce the bundle size of `apps/masterbar-cart` by 23%:

- avoid bundling the entire Lodash by using the `webpack-extensive-lodash-replacement-plugin` that replaces imports with `lodash-es` and bundles only the really used Lodash functions. Reduction of the production bundle by 7%, from 588kB to 547kB.
- avoid bundling the `page.js` module by extracting a `goToCheckout` prop. In Calypso it's implemented with `page()` navigation, in the widget it's a `window.location.href = ...`. In the final widget that is going to be iframed the implementation should send an event to parent frame that would in turn do a top-level navigation to Checkout. Reduces the bundle by 2%, from 547kB to 536kB.
- avoid bundling the entire `CalypsoShoppingCartProvider` by removing the `MasterbarCartWrapper` component from the module that's also imported by the widget app. Reduces the bundle by 15%, from 536kB to 456kB.
