### PR TITLE
Gutenboarding: Adjust components positions in the FSE Beta opt-in step

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/fse-beta-opt-in/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/fse-beta-opt-in/index.tsx
@@ -46,34 +46,38 @@ const FseBetaOptIn: FunctionComponent = () => {
 					<SkipButton onClick={ () => pickBeta( false ) } />
 				</ActionButtons>
 			</div>
-			<ol className="fse-beta-opt-in__content">
-				<li className="fse-beta-opt-in__item">
-					<Icon icon={ siteLogo } />
-					<h3>{ __( 'Edit Your Logo' ) }</h3>
-					<p>
-						{ __(
-							'Change and update your logo and other header elements without leaving the editor'
-						) }
-					</p>
-				</li>
-				<li className="fse-beta-opt-in__item">
-					<Icon icon={ header } />
-					<h3>{ __( 'Update Your Header and Footer' ) }</h3>
-					<p>
-						{ __( 'Full Site Editing allows you to make changes on your site header and footer.' ) }
-					</p>
-				</li>
-				<li className="fse-beta-opt-in__item">
-					<Icon icon={ navigation } />
-					<h3>{ __( 'Build Your Navigation' ) }</h3>
-					<p>{ __( 'Take your site menus to the next level by adding blocks to it.' ) }</p>
-				</li>
-			</ol>
+			<div className="fse-beta-opt-in__content">
+				<ol>
+					<li>
+						<Icon icon={ siteLogo } />
+						<h3>{ __( 'Edit Your Logo' ) }</h3>
+						<p>
+							{ __(
+								'Change and update your logo and other header elements without leaving the editor'
+							) }
+						</p>
+					</li>
+					<li>
+						<Icon icon={ header } />
+						<h3>{ __( 'Update Your Header and Footer' ) }</h3>
+						<p>
+							{ __(
+								'Full Site Editing allows you to make changes on your site header and footer.'
+							) }
+						</p>
+					</li>
+					<li>
+						<Icon icon={ navigation } />
+						<h3>{ __( 'Build Your Navigation' ) }</h3>
+						<p>{ __( 'Take your site menus to the next level by adding blocks to it.' ) }</p>
+					</li>
+				</ol>
 
-			<NextButton className="fse-beta-opt-in__submit" onClick={ () => pickBeta( true ) }>
-				{ __( 'Enroll in Beta' ) }
-				<Icon icon={ arrowRight } />
-			</NextButton>
+				<NextButton className="fse-beta-opt-in__submit" onClick={ () => pickBeta( true ) }>
+					{ __( 'Enroll in Beta' ) }
+					<Icon icon={ arrowRight } />
+				</NextButton>
+			</div>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/fse-beta-opt-in/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/fse-beta-opt-in/style.scss
@@ -1,65 +1,75 @@
 @import '../../mixins';
 
+.fse-beta-opt-in.gutenboarding-page {
+	max-width: 1260px;
+}
+
 .fse-beta-opt-in__header {
-	margin: 48px 0 30px;
+	align-items: center;
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	margin: 48px 0 30px;
 
 	@include break-large {
 		margin: 80px 0 64px;
 	}
 }
-@include break-large {
-	.fse-beta-opt-in__content {
-		margin: 0 auto;
+
+.fse-beta-opt-in__content {
+	position: relative;
+
+	ol {
 		display: flex;
-		padding-right: 33%;
 		flex-wrap: wrap;
-		position: relative;
-	
-		&::after {
-			content: '';
-			display: block;
-			width: 307px;
-			height: 307px;
-			background: url( '/calypso/images/signup/beta-wp-icon.png' ) no-repeat;
-			background-size: 307px 307px;
-			position: absolute;
-			right: 0;
-			top: -6px;
+
+		@include break-large {
+			padding-right: 25%;
 		}
 	}
-}
 
+	li {
+		padding: 0 10px 0 30px;
+		position: relative;
+		margin-bottom: 30px;
 
-.fse-beta-opt-in__item {
-	padding: 0 10px 0 30px;
-	position: relative;
-	margin-bottom: 30px;
+		@include break-large {
+			width: calc( 50% - 40px );
+			margin: 0 30px 30px 0;
+		}
+
+		svg {
+			position: absolute;
+			left: -2px;
+			top: -1px;
+			fill: var( --color-neutral-light );
+		}
+
+		p {
+			font-size: 0.875rem;
+			color: var( --color-neutral );
+		}
+
+		h3 {
+			font-size: 1rem;
+			font-weight: 600;
+			margin: 0 0 0.67em;
+			color: var( --color-neutral-dark );
+		}
+	}
 
 	@include break-large {
-		width: calc( 50% - 40px );
-		margin: 0 30px 30px 0;
-	}
-
-	svg {
-		position: absolute;
-		left: -2px;
-		top: -1px;
-		fill: var( --color-neutral-light );
-	}
-
-	p {
-		font-size: 0.875rem;
-		color: var( --color-neutral );
-	}
-
-	h3 {
-		font-size: 1rem;
-		font-weight: 600;
-		margin: 0 0 0.67em;
-		color: var( --color-neutral-dark );
+		&::after {
+			background: url( '/calypso/images/signup/beta-wp-icon.png' ) no-repeat;
+			background-position: top right;
+			background-size: contain;
+			content: '';
+			display: block;
+			height: 100%;
+			position: absolute;
+			right: 0;
+			top: 0;
+			width: 25%;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Align the components of the FSE Beta opt-in step in Gutenboarding.

Most notable changes:
- Added a new wrapper div to also consider the Submit button when calculating the WP logo's height.
- Decreased the specificity removing CSS classes rendered unnecessary by the new wrapper.
- Added `max-width: 1260px` to the step.
- The WP logo's size is now dynamic: 25% of the step's width, which seems to be enough to give a little more room to the features list (padding included), without any sacrifices.

@mattwiebe apologies for the full rewrite. It wasn't strictly necessary, but I'm generally quicker at writing from scratch, rather than tweaking existing CSS. 🙇‍♂️ 

| Before | After |
| - | - |
| <img width="1437" alt="Screenshot 2021-10-13 at 12 50 21" src="https://user-images.githubusercontent.com/2070010/137128023-239d4312-e448-48ca-ad4c-613c692433fb.png"> | <img width="1437" alt="Screenshot 2021-10-13 at 12 49 43" src="https://user-images.githubusercontent.com/2070010/137128044-287c6f93-8f7c-4db2-9856-9235f146e67c.png"> |

#### Testing instructions

* Open `http://calypso.localhost:3000/new/beta`.
* Fiddle with the page width and make sure the components feel better aligned than `https://wordpress.com/new/beta`

Fixes #56993