### PR TITLE
Titan: Add selector to determine if domain is eligible to the free trial

### DIFF
--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -8,3 +8,4 @@ export { getTitanProductName } from './get-titan-product-name';
 export { getTitanSubscriptionId } from './get-titan-subscription-id';
 export { getTitanCalendarlUrl, getTitanContactsUrl, getTitanEmailUrl } from './get-titan-urls';
 export { hasTitanMailWithUs } from './has-titan-mail-with-us';
+export { isDomainEligibleForTitanFreeTrial } from './is-domain-eligible-for-titan-free-trial';

--- a/client/lib/titan/is-domain-eligible-for-titan-free-trial.js
+++ b/client/lib/titan/is-domain-eligible-for-titan-free-trial.js
@@ -1,0 +1,9 @@
+/**
+ * Determines if the specified domain is eligible to the Titan 3-month free trial.
+ *
+ * @param {object} domain - domain object
+ * @returns {boolean} whether the domain is eligible or not
+ */
+export function isDomainEligibleForTitanFreeTrial( domain ) {
+	return domain?.titanMailSubscription?.isEligibleForIntroductoryOffer ?? false;
+}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -43,7 +43,7 @@ import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 } from 'calypso/lib/gsuite/constants';
 import { areAllUsersValid, getItemsForCart, newUsers } from 'calypso/lib/gsuite/new-users';
-import { getTitanProductName } from 'calypso/lib/titan';
+import { getTitanProductName, isDomainEligibleForTitanFreeTrial } from 'calypso/lib/titan';
 import { TITAN_MAIL_MONTHLY_SLUG, TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import {
 	areAllMailboxesValid,
@@ -462,8 +462,7 @@ class EmailProvidersComparison extends Component {
 			comment: '{{price/}} is the formatted price, e.g. $20',
 		} );
 
-		const isEligibleForFreeTrial =
-			hasCartDomain || domain?.titanMailSubscription?.isEligibleForIntroductoryOffer;
+		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
 		const discount = isEligibleForFreeTrial ? translate( '3 months free' ) : null;
 
 		const logo = (


### PR DESCRIPTION
This pull request introduces a new selector that can be used to determine if a domain is eligible to the Professional Email 3-month trial. Those changes were extracted from https://github.com/Automattic/wp-calypso/pull/56794.

#### Testing instructions

1. Run `git checkout add/professional-email-selector` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/57001#issuecomment-942438906)
2. Open the [`Emails` page](http://calypso.localhost:3000/email)
3. Click on the `Add Email` button in front of a domain without email
4. Assert that you are offered a 3-month free period if the domain is eligible*

> \* A domain will be ineligible if you already purchased Professional Email in the past (before canceling it). You can also modify the `is_eligible_for_introductory_offer` flag returned by our REST API to return a different value.