### PR TITLE
Site editor tracks e2e - Re-enable global styles panel tests

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -171,7 +171,7 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		}
 
 		const pressedGlobalStylesButtonLocator = By.css(
-			'button[aria-label="Global Styles"][aria-expanded="true"]'
+			'button[aria-label="Styles"][aria-expanded="true"]'
 		);
 		return !! ( await driverHelper.clickIfPresent(
 			this.driver,
@@ -194,17 +194,11 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 
 				await driverHelper.clickWhenClickable(
 					this.driver,
-					driverHelper.createTextLocator(
-						By.css( 'button[role="menuitemcheckbox"]' ),
-						'Global Styles'
-					)
+					driverHelper.createTextLocator( By.css( 'button[role="menuitemcheckbox"]' ), 'Styles' )
 				);
 			}
 		} else {
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( 'button[aria-label="Global Styles"]' )
-			);
+			await driverHelper.clickWhenClickable( this.driver, By.css( 'button[aria-label="Styles"]' ) );
 		}
 	}
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -428,8 +428,6 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 		createGeneralTests( { it, editorType: 'site', baseContext: 'template' } );
 
-		// Temporarily skip these tests until we can deploy wpcom-block-editor changes from
-		// https://github.com/Automattic/wp-calypso/pull/56551
 		describe( 'Global styles panel events', function () {
 			describe( 'Tracks "wpcom_block_editor_global_styles_panel_toggle', function () {
 				it( 'when Global Styles sidebar is opened', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -430,7 +430,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 		// Temporarily skip these tests until we can deploy wpcom-block-editor changes from
 		// https://github.com/Automattic/wp-calypso/pull/56551
-		describe.skip( 'Global styles panel events', function () {
+		describe( 'Global styles panel events', function () {
 			describe( 'Tracks "wpcom_block_editor_global_styles_panel_toggle', function () {
 				it( 'when Global Styles sidebar is opened', async function () {
 					const editor = await SiteEditorComponent.Expect( this.driver );
@@ -478,10 +478,14 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 					await editor.toggleGlobalStyles();
 
+					const backButtonLocator = By.css(
+						'.edit-site-global-styles-sidebar button[aria-label="Navigate to the previous view"]'
+					);
+
 					await clickGlobalStylesMenuItem( this.driver, 'Typography' );
-					await clickGlobalStylesMenuItem( this.driver, 'Back' );
+					await driverHelper.clickWhenClickable( this.driver, backButtonLocator );
 					await clickGlobalStylesMenuItem( this.driver, 'Colors' );
-					await clickGlobalStylesMenuItem( this.driver, 'Back' );
+					await driverHelper.clickWhenClickable( this.driver, backButtonLocator );
 					await clickGlobalStylesMenuItem( this.driver, 'Blocks' );
 
 					const globalStylesMenuEvents = await getGlobalStylesMenuEvents( this.driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up to https://github.com/Automattic/wp-calypso/pull/56551 to update site editor tracking tests for the new events and interface.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run the site editor tracking spec and verify tests pass.  (ex `yarn mocha specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js` from the `test/e2e` directory.). Also, verify this works for mobile by prepending `env BROWSERSIZE=mobile` to the above command.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
