### PR TITLE
Plans: Only highlight features if they have a defined isHighlighted function that returns true

### DIFF
--- a/client/my-sites/plans/jetpack-plans/build-card-features-from-item.ts
+++ b/client/my-sites/plans/jetpack-plans/build-card-features-from-item.ts
@@ -47,8 +47,7 @@ function buildCardFeatureItemFromFeatureKey(
 						.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
 						.filter( Boolean )
 				: undefined,
-			isHighlighted:
-				feature.isHighlighted?.() ?? feature.isProduct?.( variation ) ?? feature.isPlan,
+			isHighlighted: feature.isHighlighted?.() ?? false,
 		};
 	}
 }


### PR DESCRIPTION
Related to #56595.

When #56595 was deployed, I mistakenly left in some logic that allows feature list items to be highlighted if they refer to a plan. This led to "All Security Daily features" being highlighted on our pricing pages when it shouldn't have been. In fact, we want to be much more explicit about which features should be highlighted.

#### Changes proposed in this Pull Request

* Update the logic for the `isHighlighted` property when building feature list items on Jetpack product cards, such that it only returns true if the feature has an `isHighlighted` function property that returns true.

#### Testing instructions

1. In any Calypso experience, visit the pricing page.
2. Verify that no features are bolded, especially on the **Complete** and **Security Real-time** cards.

#### Reference screenshots (before / after)

<img width="275" alt="image" src="https://user-images.githubusercontent.com/670067/137171306-d4ba37c6-6668-4319-b769-f1f418ee3aaf.png"> <img width="275" alt="image" src="https://user-images.githubusercontent.com/670067/137171234-a39e5c2a-0425-4ebf-bfbf-3e26188ab34f.png">