### PR TITLE
Domain Picker: fix broken UI for HSTS notice popover (#55860)

### DIFF
--- a/packages/domain-picker/src/components/info-tooltip/style.scss
+++ b/packages/domain-picker/src/components/info-tooltip/style.scss
@@ -1,18 +1,19 @@
 @import '@automattic/onboarding/styles/variables';
 
 .info-tooltip {
-    &.components-button.has-icon.has-text svg {
-        margin-right: 0;
-    }
+	&.components-button.has-icon.has-text svg {
+		margin-right: 0;
+	}
 
 	.components-popover__content > div {
-        color: var( --color-neutral-50 );
-        font-size: $font-body-small;
-        padding: 16px;
-        text-align: left;
-
-        a {
-            color: var( --studio-blue-40 );
-        }
-    }
+		color: var( --color-neutral-50 );
+		font-size: $font-body-small;
+		padding: 16px;
+		text-align: left;
+		width: 232px;
+		word-break: keep-all;
+		a {
+			color: var( --studio-blue-40 );
+		}
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the broken UI for HSTS notice popover

#### Testing instructions

1. Start wp-locally
2. navigate to `http://calypso.localhost:3000/new/domains-modal`
3. enter `mysite.page` in the searchbar
4. click on the tooltip icon beside `mysite.page`

The UI should now be fixed and the whole blurb isn't in a single column
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before:
![image](https://user-images.githubusercontent.com/18711727/137248441-3a7ddb57-2485-4acf-b3a5-77fb541317a4.png)

After:
Desktop:
![image](https://user-images.githubusercontent.com/18711727/137248328-508ae609-31c2-4f02-b0da-8476138ba459.png)

Mobile:
![image](https://user-images.githubusercontent.com/18711727/137248343-dbf218a0-9a27-4af6-8773-edf73bf87b23.png)

iPad:
![image](https://user-images.githubusercontent.com/18711727/137248978-f9bb9281-63ab-46f9-b8ec-a3b06fae3526.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #55860
