### PR TITLE
Jetpack: update styles on siteless checkout thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -703,6 +703,8 @@
 	}
 	.jetpack-checkout-siteless-thank-you-completed__card {
 		padding: 0;
+		border-radius: 4px; /* stylelint-disable-line */
+		overflow: hidden;
 		box-shadow: 0 0 40px 0 #00000014;
 
 		width: 100%;
@@ -725,10 +727,15 @@
 				font-size: $font-headline-medium;
 			}
 		}
+
 		p {
 			@include break-mobile {
 				font-size: 18px; /* stylelint-disable-line */
 				line-height: 1.75rem;
+			}
+
+			&:last-of-type {
+				margin-bottom: 0;
 			}
 		}
 		.jetpack-checkout-siteless-thank-you-completed__button,
@@ -749,7 +756,7 @@
 		.jetpack-checkout-siteless-thank-you-completed__main-message {
 			font-size: 2.25rem;
 			font-weight: 700;
-			margin-bottom: 56px;
+			margin-bottom: 32px;
 			line-height: 1;
 			@include break-mobile {
 				font-size: 3rem;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update styles on the siteless checkout thank you page.

* Tweaks spacing between elements.
* Removes bottom margin from the last paragraph.
* Adds rounded corners.

#### Testing instructions

* Fire up this branch.
* Go to Jetpack.com and select a product.
* Go through the checkout process and complete the purchase.
* In the post-purchase process, replace `https://wordpress.com` for `http://calypso.localhost:3000` in the URL.
* Enter any valid URL when asked.
* In the final thank you screen, confirm you see the changes.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/137305039-54084de0-e4d2-40f2-990a-60097bfcdd9d.png) | ![image](https://user-images.githubusercontent.com/390760/137305104-84e13f80-bc5e-4641-91aa-11d5813464bf.png)
