### PR TITLE
Fixes infinite loading in the DIFM signup flow

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -1,3 +1,4 @@
+import debugModule from 'debug';
 import {
 	defer,
 	difference,
@@ -35,6 +36,8 @@ import {
 import { ProgressState } from 'calypso/state/signup/progress/schema';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+
+const debug = debugModule( 'calypso:signup' );
 
 interface Dependencies {
 	[ other: string ]: string[];
@@ -109,6 +112,7 @@ export default class SignupFlowController {
 		try {
 			this._assertFlowHasValidDependencies();
 		} catch ( ex ) {
+			debug( 'Invalid dependencies in flow : ' + ex.message );
 			if ( this._flowName !== flows.defaultFlowName ) {
 				// redirect to the default signup flow, hopefully it will be valid
 				page( getStepUrl() );

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -731,11 +731,11 @@ export function generateSteps( {
 		},
 		'difm-design': {
 			stepName: 'difm-design',
-			providesDependencies: [ 'username', 'selectedDesign', 'selectedVertical' ],
+			providesDependencies: [ 'selectedDIFMDesign', 'selectedVertical' ],
 		},
 		'site-info-collection': {
 			stepName: 'site-info-collection',
-			dependencies: [ 'siteSlug', 'username', 'selectedDesign', 'selectedVertical' ],
+			dependencies: [ 'siteSlug', 'username', 'selectedDIFMDesign', 'selectedVertical' ],
 			providesDependencies: [ 'cartItem' ],
 			apiRequestFunction: addPlanToCart,
 		},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -735,7 +735,7 @@ export function generateSteps( {
 		},
 		'site-info-collection': {
 			stepName: 'site-info-collection',
-			dependencies: [ 'siteSlug', 'username', 'selectedDIFMDesign', 'selectedVertical' ],
+			dependencies: [ 'siteSlug', 'selectedDIFMDesign', 'selectedVertical' ],
 			providesDependencies: [ 'cartItem' ],
 			apiRequestFunction: addPlanToCart,
 		},

--- a/client/signup/steps/difm-design-picker/index.jsx
+++ b/client/signup/steps/difm-design-picker/index.jsx
@@ -2,12 +2,14 @@
 
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import WebPreview from 'calypso/components/web-preview';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import DemoTile from 'calypso/signup/steps/difm-design-picker/demo-tile';
+import { saveSignupStep } from 'calypso/state/signup/progress/actions';
 import VerticalTemplateMapping from './vertical-template-mapping';
 
 const Container = styled.div`
@@ -33,9 +35,14 @@ const VerticalsGrid = styled.div`
 
 export default function DIFMDesignPickerStep( props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ sitePreviewURL, setSitePreviewURL ] = useState( null );
 	const [ selectedVertical, setSelectedVertical ] = useState( 'Local Services' );
 	const { templates } = VerticalTemplateMapping[ selectedVertical ] ?? [];
+
+	useEffect( () => {
+		dispatch( saveSignupStep( { stepName: props.stepName } ) );
+	}, [ dispatch, props.stepName ] );
 
 	const pickDesign = ( selectedDesign ) => {
 		props.submitSignupStep(
@@ -43,8 +50,8 @@ export default function DIFMDesignPickerStep( props ) {
 				stepName: props.stepName,
 			},
 			{
-				selectedDesign,
-				selectedVertical,
+				selectedDIFMDesign: selectedDesign,
+				selectedVertical: selectedVertical,
 			}
 		);
 

--- a/client/signup/steps/site-info-collection/index.jsx
+++ b/client/signup/steps/site-info-collection/index.jsx
@@ -8,9 +8,9 @@ import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import Spinner from 'calypso/components/spinner';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
+import { saveSignupStep } from 'calypso/state/signup/progress/actions';
 
 import './style.scss';
 
@@ -43,15 +43,15 @@ function SiteInformationCollection( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { selectedDesign, username: signupUserName, selectedVertical } = useSelector(
+	const { selectedDIFMDesign, username: signupUserName, selectedVertical } = useSelector(
 		getSignupDependencyStore
 	);
 	const username = useSelector( getCurrentUserName );
 	const [ isFormSubmitted, setIsFormSubmitted ] = useState( false );
 
 	useEffect( () => {
-		dispatch( fetchCurrentUser() );
-	}, [ dispatch ] );
+		dispatch( saveSignupStep( { stepName } ) );
+	}, [ dispatch, stepName ] );
 
 	const nextStep = () => {
 		setIsFormSubmitted( true );
@@ -59,10 +59,10 @@ function SiteInformationCollection( {
 		const step = {
 			stepName,
 			cartItem,
-		};
-
-		submitSignupStep( step, {
 			...additionalStepData,
+		};
+		submitSignupStep( step, {
+			cartItem,
 		} );
 		goToNextStep();
 	};
@@ -80,7 +80,7 @@ function SiteInformationCollection( {
 				<Widget
 					hidden={ {
 						username: username ? username : signupUserName,
-						design: selectedDesign,
+						design: selectedDIFMDesign,
 						vertical: selectedVertical,
 					} }
 					id={ getTypeformId() }

--- a/client/signup/steps/site-info-collection/index.jsx
+++ b/client/signup/steps/site-info-collection/index.jsx
@@ -11,6 +11,7 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
+import { fetchCurrentUser } from '../../../state/current-user/actions';
 
 import './style.scss';
 
@@ -51,6 +52,7 @@ function SiteInformationCollection( {
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
+		dispatch( fetchCurrentUser() );
 	}, [ dispatch, stepName ] );
 
 	const nextStep = () => {

--- a/client/signup/steps/site-info-collection/index.jsx
+++ b/client/signup/steps/site-info-collection/index.jsx
@@ -44,9 +44,7 @@ function SiteInformationCollection( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { selectedDIFMDesign, username: signupUserName, selectedVertical } = useSelector(
-		getSignupDependencyStore
-	);
+	const { selectedDIFMDesign, selectedVertical } = useSelector( getSignupDependencyStore );
 	const username = useSelector( getCurrentUserName );
 	const [ isFormSubmitted, setIsFormSubmitted ] = useState( false );
 
@@ -81,7 +79,7 @@ function SiteInformationCollection( {
 			) : (
 				<Widget
 					hidden={ {
-						username: username ? username : signupUserName,
+						username,
 						design: selectedDIFMDesign,
 						vertical: selectedVertical,
 					} }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renames the ` selectedDesign` dependency to `selectedDIFMDesign` to avoid conflicts. The conflict will be caused [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/signup/step-actions/index.js#L196).
* Adds `saveSignupStep` to save progress. (IMO) This fixes the bug where the domains step was not being shown.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the DIFM Lite sign up flow **as a new user** by navigating to `/start/do-it-for-me`.
* Go through the flow steps, confirm that the domains step is shown before the loading screen.
* Due to a server limitation, only free domains can be chosen in this flow. To test with a real domain, also apply D67890-code
* Confirm that after adding the domain, the loading screen is shown and then you are taken to the checkout page.
* Confirm that the DIFM product and a Premium plan are already in the cart.
* Repeat the above steps as an existing user. (Login first, and then navigate to `/start/do-it-for-me`.)