### PR TITLE
Disable template editing for universal themes.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -75,7 +75,6 @@ function load_core_fse() {
 	remove_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
 	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
-	remove_filter( 'block_editor_settings', __NAMESPACE__ . '\hide_template_editing', 11 );
 }
 
 /**
@@ -99,7 +98,6 @@ function unload_core_fse() {
 	}
 	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
 	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
-	add_filter( 'block_editor_settings', __NAMESPACE__ . '\hide_template_editing', 11 );
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -74,6 +74,8 @@ function load_core_fse() {
 	remove_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	remove_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
+	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
+	remove_filter( 'block_editor_settings', __NAMESPACE__ . '\hide_template_editing', 11 );
 }
 
 /**
@@ -96,6 +98,8 @@ function unload_core_fse() {
 		add_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	}
 	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
+	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
+	add_filter( 'block_editor_settings', __NAMESPACE__ . '\hide_template_editing', 11 );
 }
 
 /**
@@ -192,6 +196,22 @@ function hide_fse_blocks( $editor_settings ) {
 		return $editor_settings;
 	}
 	$editor_settings['__unstableEnableFullSiteEditingBlocks'] = false;
+	return $editor_settings;
+}
+
+/**
+ * Filter for `block_editor_settings_all` in order to prevent template
+ * editing from showing up in the post editor when FSE is inactive.
+ *∂
+ * @param [array] $editor_settings Editor settings.
+ * @return array Possibly modified editor settings.
+ */
+function hide_template_editing( $editor_settings ) {
+	// this shouldn't even be hooked under this condition, but let's be sure.
+	if ( is_core_fse_active() ) {
+		return $editor_settings;
+	}
+	$editor_settings['supportsTemplateMode'] = false;
 	return $editor_settings;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a filter to turn off the editor setting for `supportsTemplateMode` for sites not using the Site editor (site has a universal theme being used in "classic" mode).

Follow-up TODOs: remove deprecated template editing sticker and associated toggles from dotcom and MC.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Patch this ETK build to your sandbox:
* Using a site that is not FSE beta eligible, activate a Universal theme.
* Load the post editor, and verify that the page sidebar's "Template" section does not allow opening the template editor.  It should look like the following:
![Screen Shot 2021-10-14 at 10 23 06 AM](https://user-images.githubusercontent.com/28742426/137339315-306af443-44f2-4406-bc83-985efbf2e762.png)

* Load the post editor on a site running the FSE beta and verify the entry points to the template editor exist:
![Screen Shot 2021-10-14 at 10 21 55 AM](https://user-images.githubusercontent.com/28742426/137339296-22192b96-ed87-4870-a563-eb1043a78142.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
