### PR TITLE
Emails: Remove EmailsHome placeholder when it's being loaded from Inbox screen

### DIFF
--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -20,8 +20,6 @@ import EmailListInactive from 'calypso/my-sites/email/email-management/home/emai
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
-import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
-import ProgressLine from 'calypso/my-sites/email/inbox/mailbox-selection-list/progress-line';
 import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -35,6 +35,7 @@ import {
 } from 'calypso/state/ui/selectors';
 
 import './style.scss';
+import ProgressLine from "calypso/my-sites/email/inbox/mailbox-selection-list/progress-line";
 
 class EmailManagementHome extends Component {
 	static propTypes = {
@@ -168,10 +169,10 @@ class EmailManagementHome extends Component {
 	}
 
 	renderLoadingPlaceholder() {
-		const { source } = this.props;
-		//Inbox has it's own loader, don't show any placeholder
+		const { source, translate } = this.props;
+
 		if ( source === INBOX_SOURCE ) {
-			return null;
+			return <ProgressLine statusText={ translate( 'Loading your email subscriptions' ) } />;
 		}
 		return this.renderContentWithHeader(
 			<>

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -21,6 +21,7 @@ import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
 import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
+import ProgressLine from 'calypso/my-sites/email/inbox/mailbox-selection-list/progress-line';
 import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -35,7 +36,6 @@ import {
 } from 'calypso/state/ui/selectors';
 
 import './style.scss';
-import ProgressLine from "calypso/my-sites/email/inbox/mailbox-selection-list/progress-line";
 
 class EmailManagementHome extends Component {
 	static propTypes = {
@@ -169,11 +169,6 @@ class EmailManagementHome extends Component {
 	}
 
 	renderLoadingPlaceholder() {
-		const { source, translate } = this.props;
-
-		if ( source === INBOX_SOURCE ) {
-			return <ProgressLine statusText={ translate( 'Loading your email subscriptions' ) } />;
-		}
 		return this.renderContentWithHeader(
 			<>
 				<SectionHeader className="email-home__section-placeholder is-placeholder" />

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -20,6 +20,7 @@ import EmailListInactive from 'calypso/my-sites/email/email-management/home/emai
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
+import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -167,6 +168,11 @@ class EmailManagementHome extends Component {
 	}
 
 	renderLoadingPlaceholder() {
+		const { source } = this.props;
+		//Inbox has it's own loader, don't show any placeholder
+		if ( source === INBOX_SOURCE ) {
+			return null;
+		}
 		return this.renderContentWithHeader(
 			<>
 				<SectionHeader className="email-home__section-placeholder is-placeholder" />

--- a/client/my-sites/email/inbox/index.jsx
+++ b/client/my-sites/email/inbox/index.jsx
@@ -12,9 +12,14 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
 import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import MailboxSelectionList from 'calypso/my-sites/email/inbox/mailbox-selection-list';
+import ProgressLine from 'calypso/my-sites/email/inbox/mailbox-selection-list/progress-line';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import {
+	getDomainsBySiteId,
+	hasLoadedSiteDomains,
+	isRequestingSiteDomains,
+} from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -82,6 +87,11 @@ const InboxManagement = () => {
 		canCurrentUser( state, selectedSiteId, 'manage_options' )
 	);
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSiteId ) );
+	const isLoadingDomains = useSelector(
+		( state ) =>
+			! hasLoadedSiteDomains( state, selectedSiteId ) ||
+			isRequestingSiteDomains( state, selectedSiteId )
+	);
 	const translate = useTranslate();
 
 	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state, selectedSiteId ) );
@@ -92,6 +102,10 @@ const InboxManagement = () => {
 
 	if ( ! canManageSite ) {
 		return <NoAccessCard />;
+	}
+
+	if ( isLoadingDomains ) {
+		return <ProgressLine statusText={ translate( 'Loading your mailboxes' ) } />;
 	}
 
 	const nonWPCOMDomains = domains.filter( ( domain ) => ! domain.isWPCOMDomain );

--- a/client/my-sites/email/inbox/index.jsx
+++ b/client/my-sites/email/inbox/index.jsx
@@ -88,9 +88,7 @@ const InboxManagement = () => {
 	);
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSiteId ) );
 	const isLoadingDomains = useSelector(
-		( state ) =>
-			! hasLoadedSiteDomains( state, selectedSiteId ) ||
-			isRequestingSiteDomains( state, selectedSiteId )
+		( state ) => ! hasLoadedSiteDomains( state, selectedSiteId )
 	);
 	const translate = useTranslate();
 

--- a/client/my-sites/email/inbox/index.jsx
+++ b/client/my-sites/email/inbox/index.jsx
@@ -15,11 +15,7 @@ import MailboxSelectionList from 'calypso/my-sites/email/inbox/mailbox-selection
 import ProgressLine from 'calypso/my-sites/email/inbox/mailbox-selection-list/progress-line';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import {
-	getDomainsBySiteId,
-	hasLoadedSiteDomains,
-	isRequestingSiteDomains,
-} from 'calypso/state/sites/domains/selectors';
+import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the placeholder shown in the EmailHome component when this component is being loaded from Inbox screen

#### Testing instructions

1. Do an initial load for Inbox (ensure nothing is cached)
2. Check that we are not showing this placeholder while loading.

If you are not able to see the loading screen after clearing caches, this method works well.

1. Navigate to Inbox or Upgrades -> Emails for the site
2. Copy the current URL
3. Open the browser developer tools and navigate to the IndexedDB section (it's under the Application tab in Chrome)
4. Clear the calypso_store database and immediately close the tab
5. Open a new tab and paste in the URL from above

![image](https://user-images.githubusercontent.com/5689927/137356244-6f4bcd0e-79bc-4ed2-b8c1-21b071adf443.png)

3. Check that the new placeholder is this one:
![image](https://user-images.githubusercontent.com/5689927/137871512-0e17a130-32a8-496c-965b-e03cc68cf3ca.png)


Related to {1200182182542585-as-1201164484498606}
