### PR TITLE
ETK: Site Editor overrides - remove unnecessary css rule and file.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/index.php
@@ -10,7 +10,7 @@ namespace A8C\FSE;
 /**
  * Enqueue block editor assets.
  */
-function wpcom_site_editor_script_and_style() {
+function wpcom_site_editor_script() {
 	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/wpcom-site-editor.asset.php';
 	$script_dependencies = $asset_file['dependencies'];
 	$version             = $asset_file['version'];
@@ -22,13 +22,5 @@ function wpcom_site_editor_script_and_style() {
 		$version,
 		true
 	);
-
-	$style_path = 'dist/wpcom-site-editor' . ( is_rtl() ? '.rtl' : '' ) . '.css';
-	wp_enqueue_style(
-		'wpcom-site-editor-style',
-		plugins_url( $style_path, __FILE__ ),
-		array(),
-		filemtime( plugin_dir_path( __FILE__ ) . $style_path )
-	);
 }
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\wpcom_site_editor_script_and_style' );
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\wpcom_site_editor_script' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/navigation-toggle/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/navigation-toggle/index.js
@@ -1,5 +1,4 @@
 import domReady from '@wordpress/dom-ready';
-import './style.scss';
 
 function injectNavigationToggleOnClickHandler() {
 	// Prevent adding the event listener multiple times

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/navigation-toggle/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/navigation-toggle/style.scss
@@ -1,3 +1,0 @@
-.edit-site-template-details__show-all-button.components-button {
-	display: none !important;
-}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/navigation-toggle/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/navigation-toggle/style.scss
@@ -1,3 +1,3 @@
 .edit-site-template-details__show-all-button.components-button {
-	display: none;
+	display: none !important;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We previously hid the "Browse all templates" button in the site editor as part of the effort to remove the navigation sidebar on dotcom.  Recently, css added to core has overridden our `display: none` due to specificity and has caused the menu to reappear.  After team discussions, we have decided to keep the button visible and are removing the css that hid it.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this ETK build to your sandbox.
* Smoke test, there should be no visible changes.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
