### PR TITLE
Ensure the long-content-fade on subscriber's usernames doesn't obscure the ellipsis menu

### DIFF
--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -203,6 +203,7 @@
 	white-space: pre;
 	text-overflow: clip;
 	overflow: hidden;
+	position: relative;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		font-size: $font-title-small;


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Make the three dot menu on `/earn/memberships` easier to see

On the `/earn/memberships` page, the username has a long-content-fade effect which is designed to make long usernames, which are truncated, fade out. However, this obscures the ellipsis menu placed on the same row as the username.
The fade effect is placed with absolute positioning. Here, I add a `position: relative` to ensure the fade effect only covers the username and not the ellipsis menu as well.

Fade
![2021-10-14_14-36](https://user-images.githubusercontent.com/937354/137385615-39a919ed-23ae-471c-87ed-47df6af126ab.png)

Before fix
![2021-10-14_14-37](https://user-images.githubusercontent.com/937354/137385641-0c047d6c-4567-4ddf-b524-233052f18d03.png)

After fix
![2021-10-14_14-38](https://user-images.githubusercontent.com/937354/137385663-d42342bc-2f63-4a92-a63b-6e2916869c35.png)


#### Testing instructions

* Have a site with a Personal plan or higher
* Apply this diff to fake having subscribers
```diff
diff --git a/client/my-sites/earn/memberships/index.jsx b/client/my-sites/earn/memberships/index.jsx
index 34fce9af79..14e603730d 100644
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -648,7 +648,41 @@ const mapStateToProps = ( state ) => {
                currency: earnings.currency,
                commission: earnings.commission,
                totalSubscribers: getTotalSubscribersForSiteId( state, siteId ),
-               subscribers: getOwnershipsForSiteId( state, siteId ),
+               subscribers: [
+                       {
+                               id: 1,
+                               user: {
+                                       ID: 1,
+                                       name: 'Alice',
+                                       user_email: 'alice@example.com',
+                               },
+                               user_email: 'alice@example.com',
+                               plan: {
+                                       renewal_price: 1,
+                                       currency: 'USD',
+                                       title: 'One Dollar Plan',
+                                       renew_interval: 'one-time',
+                               },
+                               start_date: 20200101,
+                       },
+                       {
+                               id: 2,
+                               user: {
+                                       ID: 2,
+                                       name: 'Bob',
+                                       user_email: 'bob@example.com',
+                               },
+                               user_email: 'bob@example.com',
+                               plan: {
+                                       renewal_price: 1,
+                                       currency: 'USD',
+                                       title: 'One Dollar Plan',
+                                       renew_interval: 'one-time',
+                               },
+                               start_date: 20200101,
+                       },
+               ],
+               //         getOwnershipsForSiteId( state, siteId ),
                connectedAccountId: getConnectedAccountIdForSiteId( state, siteId ),
                connectUrl: getConnectUrlForSiteId( state, siteId ),
                paidPlan: isSiteOnPaidPlan( state, siteId ),
```
* Visit `/earn/payments`
* Before the PR: The ellipses menu should be very difficult to see
* After the PR: The ellipses menu should be easy to see

Related to #43227
