### PR TITLE
Shopping Cart: Remove defaultCartKey from CalypsoShoppingCartProvider

### DIFF
--- a/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
@@ -42,4 +42,4 @@ const TransferDomainStepAuthCode = ( {
 
 export default connect( null, {
 	transferDomainActionHandler: transferDomainAction,
-} )( withShoppingCart( withCartKey( TransferDomainStepAuthCode ) ) );
+} )( withCartKey( withShoppingCart( TransferDomainStepAuthCode ) ) );

--- a/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
@@ -3,6 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { transferDomainAction } from 'calypso/components/domains/use-my-domain/utilities';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { authCodeStepDefaultDescription, stepsHeadingTransfer } from './constants';
 import DomainStepAuthCode from './domain-step-auth-code';
@@ -41,4 +42,4 @@ const TransferDomainStepAuthCode = ( {
 
 export default connect( null, {
 	transferDomainActionHandler: transferDomainAction,
-} )( withShoppingCart( TransferDomainStepAuthCode ) );
+} )( withShoppingCart( withCartKey( TransferDomainStepAuthCode ) ) );

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -277,4 +277,4 @@ export default connect(
 		recordInputFocusInMapDomain,
 		recordGoButtonClickInMapDomain,
 	}
-)( withShoppingCart( withCartKey( localize( MapDomainStep ) ) ) );
+)( withCartKey( withShoppingCart( localize( MapDomainStep ) ) ) );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1633,4 +1633,4 @@ export default connect(
 		hideSitePreview,
 		showSitePreview,
 	}
-)( withShoppingCart( withCartKey( localize( RegisterDomainStep ) ) ) );
+)( withCartKey( withShoppingCart( localize( RegisterDomainStep ) ) ) );

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -721,4 +721,4 @@ export default connect(
 		recordGoButtonClickInTransferDomain,
 		recordMapDomainButtonClick,
 	}
-)( withShoppingCart( withCartKey( localize( TransferDomainStep ) ) ) );
+)( withCartKey( withShoppingCart( localize( TransferDomainStep ) ) ) );

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -123,4 +123,4 @@ export default connect(
 		recordTransferButtonClickInUseYourDomain,
 		recordMappingButtonClickInUseYourDomain,
 	}
-)( withShoppingCart( withCartKey( DomainTransferOrConnect ) ) );
+)( withCartKey( withShoppingCart( DomainTransferOrConnect ) ) );

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -448,4 +448,4 @@ export default connect(
 		recordTransferButtonClickInUseYourDomain,
 		recordMappingButtonClickInUseYourDomain,
 	}
-)( withShoppingCart( withCartKey( localize( UseYourDomainStep ) ) ) );
+)( withCartKey( withShoppingCart( localize( UseYourDomainStep ) ) ) );

--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import * as React from 'react';
 import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 import { cartManagerClient } from './cart-manager-client';
-import useCartKey from './use-cart-key';
 
 // A convenience wrapper around ShoppingCartProvider to set the necessary props
 // for calypso and to display error and success messages returned from calls to
@@ -13,14 +12,11 @@ export default function CalypsoShoppingCartProvider( {
 }: {
 	children: React.ReactNode;
 } ): JSX.Element {
-	const defaultCartKey = useCartKey();
-
 	const options = useMemo(
 		() => ( {
 			refetchOnWindowFocus: true,
-			defaultCartKey,
 		} ),
-		[ defaultCartKey ]
+		[]
 	);
 
 	return (

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -43,4 +43,4 @@ class HeaderCart extends Component {
 	}
 }
 
-export default withShoppingCart( withCartKey( HeaderCart ) );
+export default withCartKey( withShoppingCart( HeaderCart ) );

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -158,4 +158,4 @@ class PopoverCart extends Component {
 	}
 }
 
-export default withShoppingCart( withCartKey( localize( PopoverCart ) ) );
+export default withCartKey( withShoppingCart( localize( PopoverCart ) ) );

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -538,4 +538,4 @@ export default connect(
 	{
 		trackUpsellButtonClick,
 	}
-)( withShoppingCart( withCartKey( localize( UpsellNudge ) ) ) );
+)( withCartKey( withShoppingCart( localize( UpsellNudge ) ) ) );

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -301,4 +301,4 @@ export default connect(
 		recordAddDomainButtonClick,
 		recordRemoveDomainButtonClick,
 	}
-)( withShoppingCart( withCartKey( localize( DomainSearch ) ) ) );
+)( withCartKey( withShoppingCart( localize( DomainSearch ) ) ) );

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -197,4 +197,4 @@ export default connect( null, {
 	recordInputFocus,
 	recordGoButtonClick,
 	recordFormSubmit,
-} )( withShoppingCart( withCartKey( localize( SiteRedirectStep ) ) ) );
+} )( withCartKey( withShoppingCart( localize( SiteRedirectStep ) ) ) );

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -254,4 +254,4 @@ export default connect(
 	{
 		successNotice,
 	}
-)( withShoppingCart( withCartKey( localize( MapDomain ) ) ) );
+)( withCartKey( withShoppingCart( localize( MapDomain ) ) ) );

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -193,4 +193,4 @@ export default connect( ( state ) => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 	productsList: getProductsList( state ),
-} ) )( withShoppingCart( withCartKey( TransferDomain ) ) );
+} ) )( withCartKey( withShoppingCart( TransferDomain ) ) );

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -777,4 +777,4 @@ export default connect(
 			errorNotice: ( text, options ) => dispatch( errorNotice( text, options ) ),
 		};
 	}
-)( withShoppingCart( withCartKey( localize( EmailProvidersComparison ) ) ) );
+)( withCartKey( withShoppingCart( localize( EmailProvidersComparison ) ) ) );

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -310,4 +310,4 @@ export default connect(
 		};
 	},
 	{ recordTracksEvent: recordTracksEventAction }
-)( withShoppingCart( withCartKey( localize( GSuiteAddUsers ) ) ) );
+)( withCartKey( withShoppingCart( localize( GSuiteAddUsers ) ) ) );

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -325,4 +325,4 @@ export default connect(
 		};
 	},
 	{ recordTracksEvent: recordTracksEventAction }
-)( withShoppingCart( withCartKey( withLocalizedMoment( localize( TitanAddMailboxes ) ) ) ) );
+)( withCartKey( withShoppingCart( withLocalizedMoment( localize( TitanAddMailboxes ) ) ) ) );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -1041,7 +1041,7 @@ const ConnectedPlanFeatures = connect(
 	{
 		recordTracksEvent,
 	}
-)( withShoppingCart( withCartKey( localize( PlanFeatures ) ) ) );
+)( withCartKey( withShoppingCart( localize( PlanFeatures ) ) ) );
 
 /* eslint-enable */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the shopping-cart package was refactored in https://github.com/Automattic/wp-calypso/pull/54667, it became necessary to specify the cart key every time a component requests access to the cart manager whereas previously the cart key was set in the provider. However, in order to make migration easier, a `defaultCartKey` option was added until all instances of `useShoppingCart` and `withShoppingCart` could be migrated.

Now that all the instances have been migrated, this removes the `defaultCartKey` option (although it remains available for tests).

#### Testing instructions

It's hard to test every place that might be affected by this change, so it's probably best to verify that there are no remaining locations outside of tests that have:

- `useShoppingCart()` without an argument.
- `withShoppingCart()` without being preceded by `withCartKey`.

It's also probably worth doing a quick check to verify that shopping cart operations work in general, like adding and removing a product from the cart.