### PR TITLE
People: Add logic to hide editing details for site owners when not the site owner

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -83,10 +83,19 @@ class EditUserForm extends Component {
 			hasWPCOMAccountLinked,
 			isVip,
 			isWPForTeamsSite,
+			siteOwner,
 		} = this.props;
 		const allowedSettings = new Set();
 
 		if ( ! user.ID ) {
+			return [];
+		}
+
+		/*
+		 * If this is not a Jetpack site and the current user is not viewing their own profile,
+		 * the user should not be able to edit the site owner's details.
+		 */
+		if ( ! isJetpack && user.ID === siteOwner && user.ID !== currentUser.ID ) {
 			return [];
 		}
 
@@ -175,20 +184,6 @@ class EditUserForm extends Component {
 
 	isExternalRole = ( role ) =>
 		[ 'administrator', 'editor', 'author', 'contributor' ].includes( role );
-
-	canEditUser = () => {
-		const { user, isJetpack, siteOwner, currentUser } = this.props;
-
-		/*
-		 * If this is not a Jetpack site and the current user is not viewing their own profile,
-		 * the user should not be able to edit the site owner's details.
-		 */
-		if ( ! isJetpack && user.ID === siteOwner && user.ID !== currentUser.ID ) {
-			return false;
-		}
-
-		return true;
-	};
 
 	renderField = ( fieldId, isDisabled ) => {
 		let returnField = null;
@@ -285,9 +280,8 @@ class EditUserForm extends Component {
 		}
 
 		const editableFields = this.getAllowedSettingsToChange();
-		const canEditUser = this.canEditUser();
 
-		if ( ! editableFields.length || ! canEditUser ) {
+		if ( ! editableFields.length ) {
 			return null;
 		}
 

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -18,6 +18,7 @@ import {
 } from 'calypso/state/data-getters';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import { getSite } from 'calypso/state/sites/selectors';
 import withUpdateUser from './with-update-user';
 
 import './style.scss';
@@ -175,6 +176,20 @@ class EditUserForm extends Component {
 	isExternalRole = ( role ) =>
 		[ 'administrator', 'editor', 'author', 'contributor' ].includes( role );
 
+	canEditUser = () => {
+		const { user, isJetpack, siteOwner, currentUser } = this.props;
+
+		/*
+		 * If this is not a Jetpack site and the current user is not viewing their own profile,
+		 * the user should not be able to edit the site owner's details.
+		 */
+		if ( ! isJetpack && user.ID === siteOwner && user.ID !== currentUser.ID ) {
+			return false;
+		}
+
+		return true;
+	};
+
 	renderField = ( fieldId, isDisabled ) => {
 		let returnField = null;
 		switch ( fieldId ) {
@@ -270,8 +285,9 @@ class EditUserForm extends Component {
 		}
 
 		const editableFields = this.getAllowedSettingsToChange();
+		const canEditUser = this.canEditUser();
 
-		if ( ! editableFields.length ) {
+		if ( ! editableFields.length || ! canEditUser ) {
 			return null;
 		}
 
@@ -309,8 +325,10 @@ export default localize(
 		( state, { siteId, user } ) => {
 			const externalContributors = ( siteId && requestExternalContributors( siteId ).data ) || [];
 			const userId = user.linked_user_ID || user.ID;
+			const site = getSite( state, siteId );
 
 			return {
+				siteOwner: site?.site_owner,
 				currentUser: getCurrentUser( state ),
 				isExternalContributor: userId && externalContributors.includes( userId ),
 				isVip: isVipSite( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In combination with API changes in https://github.com/Automattic/jetpack/pull/21295, this adds logic checking for the site owner's UID before allowing a site administrator to edit site data. This prevents other admins from trying to edit the site owner's details.

**Before**

<img width="1666" alt="Screen Shot 2021-10-15 at 11 10 40 AM" src="https://user-images.githubusercontent.com/2124984/137510714-a265d033-8893-48a0-b5d0-09daed25eef9.png">

**After**

TBD

#### Testing instructions

* Switch to this PR
* Apply D67913-code to your sandbox and sandbox the API
* Invite a dummy account/user to a test site of which you are the owner
* Log in as the dummy account/user
* Go to Users and click on the site owner's account
* You should not see form fields to edit the site owner's info
* Log in as the site owner
* Go to Users and click on the site owner's account; you should be able to change the account info. You should also be able to change the account info for the dummy user/account.


Related to #41727
