### PR TITLE
Share: Fix link to change site timezone

### DIFF
--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import PostSchedule from 'calypso/components/post-schedule';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import { getSite } from 'calypso/state/sites/selectors';
 
 import './style.scss';
 
@@ -101,6 +102,7 @@ class CalendarPopover extends Component {
 }
 
 export default connect( ( state, { siteId } ) => ( {
+	site: getSite( state, siteId ),
 	gmtOffset: getSiteGmtOffset( state, siteId ),
 	timezoneValue: getSiteTimezoneValue( state, siteId ),
 } ) )( CalendarPopover );

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -153,7 +153,7 @@ class PostScheduleClock extends Component {
 			{
 				args: { timezoneText },
 				components: {
-					a: <a href={ `/settings/general/${ siteSlug || siteId }` } />,
+					a: <a href={ `/settings/general/${ siteSlug ?? siteId ?? '' }` } />,
 				},
 			}
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the calendar->clock component that displays when sharing posts using publicize, there's a popover link that incorrectly links to `/settings/general/null`. Fix this link to bring you to the real settings page.
  * If siteId is not available, link to `/settings/general` which is not ideal as it brings you to a site picker, but it's better than the `/null` blank screen
  * Try to hook up the components to the site prop makes it to the clock component, so it brings you to `/settings/general/<SiteID>`
* Note I do not have any accounts on the services used by publicize, so I had to hack something together to show the component. Anyone who can test with an actual publicize connection is appreciated :bow:

#### Testing instructions

- Start with a Jetpack Premium plan site, or a WordPress.com site with WordPress.com Premium plan at the least
- **Edit to add**: This appears only when the site timezone on settings is different from that of the local time. Visit the site settings at https://wordpress.com/settings/general and choose a timezone that is different from that of your local timezone.
- Visit https://wordpress.com/posts
- Click on the 3 dots next to a blog post 
- Click `Share`
- Pop open the schedule datepicker
- Click the information icon beside the message about the timezone difference.
- Click `General settings` link shown

<img width="919" alt="screenshot 2018-11-17 at 15 45 54" src="https://user-images.githubusercontent.com/18581859/48660233-94eddf80-ea84-11e8-85e8-e812be26861b.png">

#### What is expected 

I am taken to https://wordpress.com/settings/general to edit the timezone

#### What happens instead 

I am take to https://wordpress.com/settings/general/null instead

Related to #28646
