### PR TITLE
Add labels to Jetpack Products in Cart

### DIFF
--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -7,6 +7,7 @@ import {
 	isTitanMail,
 	isP2Plus,
 	isJetpackSearch,
+	isJetpackProductSlug,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { isWpComProductRenewal as isRenewal } from './is-wpcom-product-renewal';
@@ -14,7 +15,7 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 	const isRenewalItem = isRenewal( serverCartItem );
-	const { meta, product_name: productName } = serverCartItem;
+	const { meta, product_name: productName, product_slug: productSlug } = serverCartItem;
 
 	// Jetpack Search has its own special sublabel
 	if ( ! isRenewalItem && isJetpackSearch( serverCartItem ) ) {
@@ -27,7 +28,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		}
 	}
 
-	if ( isPlan( serverCartItem ) ) {
+	if ( isPlan( serverCartItem ) || isJetpackProductSlug( productSlug ) ) {
 		if ( isP2Plus( serverCartItem ) ) {
 			return String( translate( 'Monthly subscription' ) );
 		}

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -11,6 +11,7 @@ import {
 	isGoogleWorkspaceProductSlug,
 	isGSuiteOrExtraLicenseProductSlug,
 	isGSuiteOrGoogleWorkspaceProductSlug,
+	isJetpackProductSlug,
 } from '@automattic/calypso-products';
 import {
 	CheckoutModal,
@@ -500,7 +501,7 @@ function LineItemSublabelAndPrice( {
 	// This is the price for one item for products with a quantity (eg. seats in a license).
 	const itemPrice = product.item_original_cost_for_quantity_one_display;
 
-	if ( isPlan( product ) ) {
+	if ( isPlan( product ) || isJetpackProductSlug( productSlug ) ) {
 		if ( isP2Plus( product ) ) {
 			const members = product?.current_quantity || 1;
 			const p2Options = {
@@ -578,7 +579,12 @@ function FirstTermDiscountCallout( {
 	const cost = product.product_cost_integer;
 	const isRenewal = product.is_renewal;
 
-	if ( ! isWpComPlan( planSlug ) || origCost <= cost || isRenewal || isCouponApplied( product ) ) {
+	if (
+		( ! isWpComPlan( planSlug ) && ! isJetpackProductSlug( planSlug ) ) ||
+		origCost <= cost ||
+		isRenewal ||
+		isCouponApplied( product )
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Jetpack Products don't get labels in cart with yearly subscription, discounts, etc. This PR adds those labels for Jetpack Products for which they apply.


**Plan Subscription - monthly**
<img width="574" alt="Screen Shot 2021-10-14 at 3 32 48 PM" src="https://user-images.githubusercontent.com/2810519/137405063-a7e97c33-6499-4a09-8dc3-9043802fe869.png">
**Plan Subscription - monthly with discount**
<img width="574" alt="Screen Shot 2021-10-14 at 3 32 29 PM" src="https://user-images.githubusercontent.com/2810519/137405065-ccaba4a9-f825-4551-980b-7fd092b6578b.png">
**Plan Subscription - yearly with discount**
<img width="574" alt="Screen Shot 2021-10-14 at 3 32 07 PM" src="https://user-images.githubusercontent.com/2810519/137405069-142b0885-a6cc-4685-9d9f-0a71a8169ab1.png">

#### Testing instructions

* Boot the branch
* Load various Jetpack Products into the cart ( with and without coupons ) and verify that the labels match the screenshots
