### PR TITLE
Payment methods: pass event source param to update card endpoint

### DIFF
--- a/client/me/purchases/add-new-payment-method/index.jsx
+++ b/client/me/purchases/add-new-payment-method/index.jsx
@@ -64,6 +64,7 @@ function AddNewPaymentMethod() {
 					<PaymentMethodSelector
 						paymentMethods={ paymentMethodList }
 						successCallback={ goToPaymentMethods }
+						eventContext={ '/me/purchases/add-payment-method' }
 					/>
 				</Column>
 				<Column type="sidebar">

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -109,6 +109,7 @@ function ChangePaymentMethod( {
 						purchase={ purchase }
 						paymentMethods={ paymentMethods }
 						successCallback={ successCallback }
+						eventContext={ '/me/purchases/:site/:purchaseId/payment-method/change/:cardId' }
 					/>
 				</Column>
 				<Column type="sidebar">

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -96,6 +96,7 @@ export async function assignNewCardProcessor(
 				token,
 				stripeConfiguration,
 				useForAllSubscriptions: Boolean( useForAllSubscriptions ),
+				eventSource,
 			} );
 
 			return makeSuccessResponse( result );

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -43,6 +43,7 @@ export async function assignNewCardProcessor(
 		stripeConfiguration,
 		cardNumberElement,
 		reduxDispatch,
+		eventSource,
 	}: {
 		purchase: Purchase | undefined;
 		translate: ReturnType< typeof useTranslate >;
@@ -50,6 +51,7 @@ export async function assignNewCardProcessor(
 		stripeConfiguration: StripeConfiguration | null;
 		cardNumberElement: StripeCardNumberElement | undefined;
 		reduxDispatch: ReturnType< typeof useDispatch >;
+		eventSource?: string;
 	},
 	submitData: unknown
 ): Promise< PaymentProcessorResponse > {
@@ -103,6 +105,7 @@ export async function assignNewCardProcessor(
 			token,
 			stripeConfiguration,
 			useForAllSubscriptions: Boolean( useForAllSubscriptions ),
+			eventSource,
 		} );
 
 		return makeSuccessResponse( result );

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -103,9 +103,9 @@ export default function PaymentMethodSelector( {
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {
 				paypal: () => assignPayPalProcessor( purchase, reduxDispatch ),
-				'existing-card': ( data: any ) =>
+				'existing-card': ( data: unknown ) =>
 					assignExistingCardProcessor( purchase, reduxDispatch, data ),
-				card: ( data: any ) =>
+				card: ( data: unknown ) =>
 					assignNewCardProcessor(
 						{
 							purchase,

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -101,8 +101,9 @@ export default function PaymentMethodSelector( {
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {
 				paypal: () => assignPayPalProcessor( purchase, reduxDispatch ),
-				'existing-card': ( data ) => assignExistingCardProcessor( purchase, reduxDispatch, data ),
-				card: ( data ) =>
+				'existing-card': ( data: any ) =>
+					assignExistingCardProcessor( purchase, reduxDispatch, data ),
+				card: ( data: any ) =>
 					assignNewCardProcessor(
 						{
 							purchase,

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -36,10 +36,12 @@ export default function PaymentMethodSelector( {
 	purchase,
 	paymentMethods,
 	successCallback,
+	eventContext,
 }: {
 	purchase?: Purchase;
 	paymentMethods: PaymentMethod[];
 	successCallback: () => void;
+	eventContext?: string;
 } ): JSX.Element {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
@@ -112,6 +114,7 @@ export default function PaymentMethodSelector( {
 							stripeConfiguration,
 							cardNumberElement: elements?.getElement( CardNumberElement ) ?? undefined,
 							reduxDispatch,
+							eventSource: eventContext,
 						},
 						data
 					),

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -45,22 +45,32 @@ export async function updateCreditCard( {
 	token,
 	stripeConfiguration,
 	useForAllSubscriptions,
+	eventSource,
 }: {
 	purchase: Purchase;
 	token: string;
 	stripeConfiguration: StripeConfiguration;
 	useForAllSubscriptions: boolean;
+	eventSource?: string;
 } ): Promise< StoredCardEndpointResponse > {
-	const { purchaseId, payment_partner, paygate_token, use_for_existing } = getParamsForApi( {
+	const {
+		purchaseId,
+		payment_partner,
+		paygate_token,
+		use_for_existing,
+		event_source,
+	} = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
 		purchase,
 		useForAllSubscriptions,
+		eventSource,
 	} );
 	const response = await wp.req.post( '/upgrades/' + purchaseId + '/update-credit-card', {
 		payment_partner,
 		paygate_token,
 		use_for_existing,
+		event_source,
 	} );
 	if ( response.error ) {
 		recordTracksEvent( 'calypso_purchases_save_new_payment_method_error' );

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -9,15 +9,18 @@ export async function saveCreditCard( {
 	token,
 	stripeConfiguration,
 	useForAllSubscriptions,
+	eventSource,
 }: {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
 	useForAllSubscriptions: boolean;
+	eventSource?: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const additionalData = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
 		useForAllSubscriptions,
+		eventSource,
 	} );
 	const response = await wp.req.post(
 		{
@@ -72,11 +75,13 @@ function getParamsForApi( {
 	stripeConfiguration,
 	purchase,
 	useForAllSubscriptions,
+	eventSource,
 }: {
 	cardToken: string;
 	stripeConfiguration: StripeConfiguration;
 	purchase?: Purchase | undefined;
 	useForAllSubscriptions?: boolean;
+	eventSource?: string;
 } ) {
 	return {
 		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
@@ -84,5 +89,6 @@ function getParamsForApi( {
 		...( useForAllSubscriptions === true ? { use_for_existing: true } : {} ),
 		...( useForAllSubscriptions === false ? { use_for_existing: false } : {} ), // if undefined, we do not add this property
 		...( purchase ? { purchaseId: purchase.id } : {} ),
+		...( eventSource ? { event_source: eventSource } : {} ),
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -195,6 +195,7 @@ export function createTransactionEndpointRequestPayload( {
 	gstin,
 	nik,
 	useForAllSubscriptions,
+	eventSource,
 }: TransactionRequest ): WPCOMTransactionEndpointRequestPayload {
 	return {
 		cart,
@@ -225,6 +226,7 @@ export function createTransactionEndpointRequestPayload( {
 			gstin,
 			nik,
 			useForAllSubscriptions,
+			eventSource,
 		},
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -55,6 +55,7 @@ export default function CreditCardPayButton( {
 							countryCode: fields?.countryCode?.value,
 							postalCode: fields?.postalCode?.value,
 							useForAllSubscriptions,
+							eventSource: 'checkout',
 						} );
 						return;
 					}

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -146,6 +146,7 @@ function SiteLevelAddNewPaymentMethodForm( { siteSlug }: { siteSlug: string } ):
 						<PaymentMethodSelector
 							paymentMethods={ paymentMethodList }
 							successCallback={ goToBillingHistory }
+							eventContext={ '/purchases/add-payment-method' }
 						/>
 					</Column>
 					<Column type="sidebar">

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -80,6 +80,7 @@ export interface TransactionRequest {
 	gstin?: string | undefined;
 	nik?: string | undefined;
 	useForAllSubscriptions?: boolean;
+	eventSource?: string;
 }
 
 export type WPCOMTransactionEndpoint = (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For the Add/Change Payment Method screens, pass an event source parameter to the appropriate endpoint for backend analytics.

#### Testing instructions

Apply D68480-code to your sandbox, and log in as a test user with at least one subscription purchase.

Note that the new prop was renamed from `source` to `event_source` after these screenshots were taken.

1. Account level add card
    - Navigate to the account level add card screen (Purchases > Payment Methods > Add Payment Method)
    - Complete the add card form but /do not/ check the checkbox
    - Watch your test user's tracks events and verify that no events with name `wpcom_subscription_payment_method_update` fire. You should still see `calypso_add_credit_card_form_submit` (added in a previous PR) with prop `use_for_all_subs: false`.
    - Complete the add card form again, this time check the checkbox
    - Watch your test user's tracks events and verify that at least one `wpcom_subscription_payment_method_update` event fires, with sensible event props. (There should be one event per subscription.)

<img width="494" alt="Screen Shot 2021-10-18 at 12 56 05 PM" src="https://user-images.githubusercontent.com/9310939/137782716-a9b54102-0ec6-4b32-9e56-2dd0ae9c9b0c.png">

2. Site level add card
    - Navigate to the site level add card screen (Upgrades > Purchases > Payment Methods > Add Payment Method)
    - Complete the add card form but do not check the checkbox
    - Watch your test user's tracks events; make sure the new event does not fire
    - Complete the add card form again, this time checking the box
    - Watch your test user's tracks and verify the new event fires at least once and has sensible props.

<img width="479" alt="Screen Shot 2021-10-18 at 1 11 41 PM" src="https://user-images.githubusercontent.com/9310939/137784614-a271a5f3-4d72-43c0-ab4f-3136961f68e4.png">

3. Subscription level add card
    - We need to get a subscription without an attached payment method to trigger the add card page; one way to do this is to make a subscription purchase using full credits.
    - Navigate to the sub level add card page on the newly purchased subscription (Upgrades > Purchases > select the purchase > Add Payment Method)
    - Complete the new credit card form, making sure the checkbox is checked.
    - Watch your test user's tracks and verify the new event fires at least once with sensible props.

<img width="645" alt="Screen Shot 2021-10-18 at 1 39 37 PM" src="https://user-images.githubusercontent.com/9310939/137788059-075aba69-d3a0-4595-8064-a1c2e27d0e25.png">

4. Subscription level change card
    - Navigate to the subscription level change payment method screen (Upgrades > Purchases > select a subscription with an attached payment method > Change Payment Method)
    - Complete the add card form with the checkbox checked. In the network tab, the call to the `update-credit-card` endpoint should have an `event_source` parameter.
    - Watch your user's tracks and verify the new event fires at least once and has sensible props.

<img width="664" alt="Screen Shot 2021-10-18 at 2 09 57 PM" src="https://user-images.githubusercontent.com/9310939/137792170-91a98e17-481b-45b8-b9a2-8fc24a299e0f.png">

5. Checkout
    - Complete checkout, using the new card payment method and making sure the box is checked before submitting.
    - Watch your user's tracks and verify the new event fires at least once and has sensible props.

<img width="418" alt="Screen Shot 2021-10-20 at 2 15 40 PM" src="https://user-images.githubusercontent.com/9310939/138157875-6d10341d-1938-4685-bbc5-7d16a3d5d72e.png">

Related to #56736