### PR TITLE
Fix: Mobile web styling of the domain picker

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -391,6 +391,9 @@ body.is-section-signup.is-white-signup {
 				font-size: 1rem;
 			}
 		}
+		&.is-placeholder.card .domain-suggestion__action {
+			display: none;
+		}
 
 		& .domain-registration-suggestion__domain-title {
 			color: var( --studio-gray-90 );

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -412,10 +412,10 @@ body.is-section-signup.is-white-signup {
 			background: none;
 			border-bottom: 1px solid rgba( 220, 220, 222, 0.64 );
 			border-top: 1px solid #fff; //This white border is to prevent jumpiness while showing borders on hover
+			padding: 16px 20px;
 
 			@include break-mobile {
-				padding-left: 5px;
-				padding-right: 5px;
+				padding: 16px 5px;
 			}
 
 			.domain-registration-suggestion__domain-title {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -178,10 +178,10 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	align-items: center;
 	background: #ffffff;
 	border-bottom: 1px solid rgba( 220, 220, 222, 0.64 );
-	padding: 16px;
+	padding: 16px 20px;
 
 	@include break-mobile {
-		border-radius: 0;
+		border-radius: 4px; /* stylelint-disable-line */
 		margin-bottom: 12px;
 		box-sizing: border-box;
 		border: 1px solid #e2e4e7;
@@ -243,10 +243,16 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	}
 
 	&.featured-domain-suggestion--is-placeholder {
-		margin-bottom: 12px;
+		margin-bottom: 1px;
 		margin-top: 0;
 		border-radius: 0; /* stylelint-disable-line */
 		border-bottom: none;
+
+		@include break-mobile {
+			margin-bottom: 12px;
+			border-radius: 4px; /* stylelint-disable-line */
+			border: none;
+		}
 	}
 }
 
@@ -257,6 +263,10 @@ body.is-section-signup.is-white-signup .featured-domain-suggestions {
 	@include break-mobile {
 		margin: 0 20px;
 		border-top: none;
+	}
+
+	@include break-large {
+		margin: 0;
 	}
 }
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -173,7 +173,7 @@
 
 body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion.card {
 	border: none;
-	border-radius: 4px; /* stylelint-disable-line */
+	border-radius: 0; /* stylelint-disable-line */
 	margin: 0;
 	align-items: center;
 	background: #ffffff;
@@ -181,6 +181,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	padding: 16px;
 
 	@include break-mobile {
+		border-radius: 0;
 		margin-bottom: 12px;
 		box-sizing: border-box;
 		border: 1px solid #e2e4e7;
@@ -244,15 +245,18 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	&.featured-domain-suggestion--is-placeholder {
 		margin-bottom: 12px;
 		margin-top: 0;
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 0; /* stylelint-disable-line */
+		border-bottom: none;
 	}
 }
 
 body.is-section-signup.is-white-signup .featured-domain-suggestions {
 	margin: 0;
+	border-top: 1px solid rgba( 220, 220, 222, 0.64 );
 	
-	@include breakpoint-deprecated( '<960px' ) {
+	@include break-mobile {
 		margin: 0 20px;
+		border-top: none;
 	}
 }
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -22,8 +22,10 @@
 	}
 
 	.button.domain-suggestion__action {
-		min-width: 120px;
 		padding: 0;
+		@include break-mobile {
+			min-width: 120px;
+		}
 	}
 
 	.card {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes some of the stylings on the /start/domains screen for mobile web users. 
Currently, there seems to be inconsistency in the horizontal spacing. Between the "recommended" domains and the free. 

See:
![Screenshot_2021-10-15_at_14-15-11_Create_a_site_—_WordPress_com](https://user-images.githubusercontent.com/115071/137794231-df585cb4-c8e6-4385-822a-d42eacd29803.png)


#### Testing instructions

Visit /start/domains on responsive screen or iPhone simulator and notice that it looked more as expected. (The indentation doesn't seem off) 

Before:

<img src="https://user-images.githubusercontent.com/115071/137410080-86f8a9af-855e-4bac-b280-bd536a2e40ea.png" width="300" />
<img src="https://user-images.githubusercontent.com/115071/137410800-5fc67450-e4b3-4f54-916b-4eeefadcbde2.png" width="300" />


After:
<img src="https://user-images.githubusercontent.com/115071/137410047-5096e166-3b7d-42eb-97c9-3967a6264893.png" width="300" />



Fixes https://github.com/Automattic/wp-calypso/issues/57009
