### PR TITLE
Fix yarn dependencies

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -74,21 +74,18 @@ logFilters:
 nodeLinker: node-modules
 
 packageExtensions:
-  jest-resolve@^27.0.6:
-    dependencies:
-      jest-haste-map: '^27.0.6'
   '@emotion/native@10.0.27':
     peerDependencies:
       '@emotion/core': '*'
       react: '*'
-  '@storybook/csf-tools@6.3.8':
+  '@storybook/csf-tools@6.3.11':
     peerDependencies:
       webpack: '*'
       '@babel/core': '*'
-  '@storybook/core-server@6.3.8':
+  '@storybook/core-server@6.3.11':
     peerDependencies:
       '@babel/core': '*'
-  '@storybook/core@6.3.8':
+  '@storybook/core@6.3.11':
     peerDependencies:
       '@babel/core': '*'
       'webpack': '*'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the warnings

```
➤ YN0069: │ jest-resolve ➤ dependencies ➤ jest-haste-map: This rule seems redundant when applied on the original package; the extension may have been applied upstream.
➤ YN0068: │ @storybook/csf-tools ➤ peerDependencies ➤ webpack: No matching package in the dependency tree; you may not need this rule anymore.
➤ YN0068: │ @storybook/csf-tools ➤ peerDependencies ➤ @babel/core: No matching package in the dependency tree; you may not need this rule anymore.
➤ YN0068: │ @storybook/core-server ➤ peerDependencies ➤ @babel/core: No matching package in the dependency tree; you may not need this rule anymore.
➤ YN0068: │ @storybook/core ➤ peerDependencies ➤ @babel/core: No matching package in the dependency tree; you may not need this rule anymore.
➤ YN0068: │ @storybook/core ➤ peerDependencies ➤ webpack: No matching package in the dependency tree; you may not need this rule anymore.
```


#### Testing instructions

Checkout this branch and run `yarn`, the above warnings shouldn't be there.