### PR TITLE
Display loading spinner instead of the (W) logo before site setup flow

### DIFF
--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -22,6 +22,10 @@
 	width: 80px;
 	height: 80px;
 
+	&.wpcom-site__logo {
+		position: fixed;
+	}
+
 	> div {
 		position: absolute;
 		top: 33px;

--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -1,5 +1,6 @@
 .wpcom-site__logo {
 	fill: var( --color-neutral-10 );
+	color: var( --color-neutral-10 );
 	position: fixed;
 	top: 50%;
 	left: 50%;
@@ -12,5 +13,64 @@
 	@include breakpoint-deprecated( '>960px' ) {
 		width: 100px;
 		height: 100px;
+	}
+}
+
+.wpcom__loading-ellipsis {
+	display: inline-block;
+	position: relative;
+	width: 80px;
+	height: 80px;
+
+	> div {
+		position: absolute;
+		top: 33px;
+		width: 13px;
+		height: 13px;
+		border-radius: 50%; /*stylelint-disable-line declaration-property-unit-allowed-list*/
+		background: var( --studio-gray-60 );
+		animation-timing-function: cubic-bezier( 0, 1, 1, 0 );
+
+		&:nth-child( 1 ) {
+			left: 8px;
+			animation: wpcom__loading-ellipsis-grow 0.6s infinite;
+		}
+		&:nth-child( 2 ) {
+			left: 8px;
+			animation: wpcom__loading-ellipsis-move 0.6s infinite;
+		}
+		&:nth-child( 3 ) {
+			left: 32px;
+			animation: wpcom__loading-ellipsis-move 0.6s infinite;
+		}
+		&:nth-child( 4 ) {
+			left: 56px;
+			animation: wpcom__loading-ellipsis-shrink 0.6s infinite;
+		}
+	}
+}
+
+@keyframes wpcom__loading-ellipsis-grow {
+	0% {
+		transform: scale( 0 );
+	}
+	100% {
+		transform: scale( 1 );
+	}
+}
+@keyframes wpcom__loading-ellipsis-move {
+	0% {
+		transform: translate( 0, 0 );
+	}
+	100% {
+		transform: translate( 24px, 0 );
+	}
+}
+@keyframes wpcom__loading-ellipsis-shrink {
+	0% {
+		transform: scale( 1 );
+	}
+	100% {
+		transform: scale( 0 );
 	}
 }

--- a/client/components/loading-ellipsis/index.tsx
+++ b/client/components/loading-ellipsis/index.tsx
@@ -1,0 +1,16 @@
+import classnames from 'classnames';
+import type { ReactNode } from 'react';
+
+export function LoadingEllipsis( { className }: { className?: string } ): ReactNode {
+	return (
+		// Styles are defined globally in _loading.scss so that this component
+		// can be rendered on the server and will appear immediately.
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+		<div className={ classnames( 'wpcom__loading-ellipsis', className ) }>
+			<div></div>
+			<div></div>
+			<div></div>
+			<div></div>
+		</div>
+	);
+}

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -11,6 +11,7 @@ import EnvironmentBadge, {
 } from 'calypso/components/environment-badge';
 import Head from 'calypso/components/head';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
 import { isBilmurEnabled, getBilmurUrl } from './utils/bilmur';
@@ -82,7 +83,7 @@ class Document extends Component {
 
 		const theme = config( 'theme' );
 
-		const LoadingLogo = config.isEnabled( 'jetpack-cloud' ) ? JetpackLogo : WordPressLogo;
+		const LoadingLogo = chooseLoadingLogo( this.props );
 
 		return (
 			<html
@@ -243,6 +244,17 @@ class Document extends Component {
 			</html>
 		);
 	}
+}
+
+function chooseLoadingLogo( { useLoadingEllipsis } ) {
+	if ( useLoadingEllipsis ) {
+		return LoadingEllipsis;
+	}
+	if ( config.isEnabled( 'jetpack-cloud' ) ) {
+		return JetpackLogo;
+	}
+
+	return WordPressLogo;
 }
 
 export default Document;

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -148,6 +148,7 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 			config.isEnabled( 'use-translation-chunks' ) ||
 			flags.includes( 'use-translation-chunks' ) ||
 			request.query.hasOwnProperty( 'useTranslationChunks' ),
+		useLoadingEllipsis: !! request.query[ 'loading-ellipsis' ],
 	} );
 
 	context.app = {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -148,7 +148,7 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 			config.isEnabled( 'use-translation-chunks' ) ||
 			flags.includes( 'use-translation-chunks' ) ||
 			request.query.hasOwnProperty( 'useTranslationChunks' ),
-		useLoadingEllipsis: !! request.query[ 'loading-ellipsis' ],
+		useLoadingEllipsis: !! request.query.loading_ellipsis,
 	} );
 
 	context.app = {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -61,7 +61,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug } ) {
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
-	let queryParam = { siteSlug };
+	let queryParam = { siteSlug, 'loading-ellipsis': 1 };
 	if ( domainItem ) {
 		// If the user is purchasing a domain then the site's primary url might change from
 		// `siteSlug` to something else during the checkout process, which means the

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -61,7 +61,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug } ) {
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
-	let queryParam = { siteSlug, 'loading-ellipsis': 1 };
+	let queryParam = { siteSlug, loading_ellipsis: 1 };
 	if ( domainItem ) {
 		// If the user is purchasing a domain then the site's primary url might change from
 		// `siteSlug` to something else during the checkout process, which means the

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -2,6 +2,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import './style.scss';
 
@@ -80,14 +81,7 @@ export default function ReskinnedProcessingScreen( props ) {
 			<h1 className="reskinned-processing-screen__progress-step">
 				{ steps.current[ currentStep ] }
 			</h1>
-			{ shouldShowNewSpinner && (
-				<div className="reskinned-processing-screen__loading-elipsis">
-					<div></div>
-					<div></div>
-					<div></div>
-					<div></div>
-				</div>
-			) }
+			{ shouldShowNewSpinner && <LoadingEllipsis /> }
 			{ ! shouldShowNewSpinner && (
 				<>
 					<div

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,5 +1,6 @@
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -77,7 +78,11 @@ export default function ReskinnedProcessingScreen( props ) {
 	}, [] );
 
 	return (
-		<div className="reskinned-processing-screen">
+		<div
+			className={ classnames( 'reskinned-processing-screen', {
+				'is-force-centered': shouldShowNewSpinner && totalSteps === 0,
+			} ) }
+		>
 			<h1 className="reskinned-processing-screen__progress-step">
 				{ steps.current[ currentStep ] }
 			</h1>

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -35,7 +35,7 @@ $progress-duration: 800ms;
 		text-align: center;
 		color: var( --studio-gray-40 );
 	}
-	
+
 	&__progress-step {
 		@include onboarding-font-recoleta;
 		/* stylelint-disable-next-line scales/font-sizes */
@@ -44,62 +44,5 @@ $progress-duration: 800ms;
 		text-align: center;
 		vertical-align: middle;
 		margin: 0;
-	}
-
-	&__loading-elipsis {
-		display: inline-block;
-		position: relative;
-		width: 80px;
-		height: 80px;
-		> div {
-			position: absolute;
-			top: 33px;
-			width: 13px;
-			height: 13px;
-			border-radius: 50%; /*stylelint-disable-line declaration-property-unit-allowed-list*/
-			background: var( --studio-gray-60 );
-			animation-timing-function: cubic-bezier( 0, 1, 1, 0 );
-			&:nth-child( 1 ) {
-				left: 8px;
-				animation: loading-ellipsis-grow 0.6s infinite;
-			}
-			&:nth-child( 2 ) {
-				left: 8px;
-				animation: loading-ellipsis-move 0.6s infinite;
-			}
-			&:nth-child( 3 ) {
-				left: 32px;
-				animation: loading-ellipsis-move 0.6s infinite;
-			}
-			&:nth-child( 4 ) {
-				left: 56px;
-				animation: loading-ellipsis-shrink 0.6s infinite;
-			}
-		}
-	}
-}
-
-@keyframes loading-ellipsis-grow {
-	0% {
-		transform: scale( 0 );
-	}
-	100% {
-		transform: scale( 1 );
-	}
-}
-@keyframes loading-ellipsis-move {
-	0% {
-		transform: translate( 0, 0 );
-	}
-	100% {
-		transform: translate( 24px, 0 );
-	}
-}
-@keyframes loading-ellipsis-shrink {
-	0% {
-		transform: scale( 1 );
-	}
-	100% {
-		transform: scale( 0 );
 	}
 }

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -8,6 +8,17 @@ $progress-duration: 800ms;
 	text-align: center;
 	margin: 32vh auto;
 
+	&.is-force-centered {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
 	&__progress-bar {
 		position: relative;
 		overflow: hidden;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -11,6 +11,7 @@ body.is-section-signup {
 
 		.layout:not( .dops ) .wpcom-site__logo {
 			fill: var( --color-neutral-10 );
+			color: var( --color-neutral-10 );
 			opacity: 1;
 
 			path {
@@ -106,6 +107,7 @@ body.is-section-signup .layout.gravatar {
 	// to match the homepage, using primary-dark with opacity.
 	.wpcom-site__logo {
 		fill: var( --color-primary-dark );
+		color: var( --color-primary-dark );
 		opacity: 0.3;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Still a work in progress. Ideally we will find a way to not have the CSS load on every page.
Change colour to grey30 if possible p1634273235332300/1634086694.194100-slack-C029SB8JT8S

* Adds `?loading-spinner` to the signup destination url when navigating to the `site-setup` flow
* SSR will show a spinner instead of the (W) logo when the `loading-spinner` query param is present

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn start` again to rebuild the node server

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->