### PR TITLE
Add loading spinner and multiple loading steps to setup-site flow

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -587,9 +587,7 @@ class Signup extends Component {
 				<ReskinnedProcessingScreen
 					flowName={ this.props.flowName }
 					hasPaidDomain={ hasPaidDomain }
-					// If destination is not setup-site flow, we'll apply default design now
-					// because the user cannot choose design in current flow
-					hasAppliedDesign={ ! destination.startsWith( '/start/setup-site' ) }
+					isSetupSiteFlow={ destination.startsWith( '/start/setup-site' ) }
 				/>
 			);
 		}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -587,7 +587,7 @@ class Signup extends Component {
 				<ReskinnedProcessingScreen
 					flowName={ this.props.flowName }
 					hasPaidDomain={ hasPaidDomain }
-					isSetupSiteFlow={ destination.startsWith( '/start/setup-site' ) }
+					isDestinationSetupSiteFlow={ destination.startsWith( '/start/setup-site' ) }
 				/>
 			);
 		}

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -9,7 +9,7 @@ import './style.scss';
 const DURATION_IN_MS = 6000;
 const HEADSTART_DURATION_IN_MS = 80000;
 
-const useSteps = ( { flowName, hasPaidDomain, isSetupSiteFlow } ) => {
+const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => {
 	const { __ } = useI18n();
 	let steps = [];
 
@@ -34,11 +34,9 @@ const useSteps = ( { flowName, hasPaidDomain, isSetupSiteFlow } ) => {
 			break;
 		default:
 			steps = [
-				__( 'Building your site' ),
+				! isDestinationSetupSiteFlow && __( 'Building your site' ),
 				hasPaidDomain && __( 'Getting your domain' ),
-				// If destination is not setup-site flow, we'll apply default design now
-				// because the user cannot choose design in current flow
-				! isSetupSiteFlow && __( 'Applying design' ),
+				! isDestinationSetupSiteFlow && __( 'Applying design' ),
 			];
 	}
 
@@ -51,10 +49,11 @@ export default function ReskinnedProcessingScreen( props ) {
 	const { __ } = useI18n();
 
 	const steps = useSteps( props );
-	const { isSetupSiteFlow } = props;
+	const { isDestinationSetupSiteFlow, flowName } = props;
 	const totalSteps = steps.current.length;
+	const shouldShowNewSpinner = isDestinationSetupSiteFlow || flowName === 'setup-site';
 
-	const duration = isSetupSiteFlow ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
+	const duration = isDestinationSetupSiteFlow ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 
 	/**
@@ -81,7 +80,7 @@ export default function ReskinnedProcessingScreen( props ) {
 			<h1 className="reskinned-processing-screen__progress-step">
 				{ steps.current[ currentStep ] }
 			</h1>
-			{ isSetupSiteFlow && (
+			{ shouldShowNewSpinner && (
 				<div className="reskinned-processing-screen__loading-elipsis">
 					<div></div>
 					<div></div>
@@ -89,7 +88,7 @@ export default function ReskinnedProcessingScreen( props ) {
 					<div></div>
 				</div>
 			) }
-			{ ! isSetupSiteFlow && (
+			{ ! shouldShowNewSpinner && (
 				<>
 					<div
 						className="reskinned-processing-screen__progress-bar"
@@ -117,5 +116,5 @@ export default function ReskinnedProcessingScreen( props ) {
 ReskinnedProcessingScreen.propTypes = {
 	flowName: PropTypes.string,
 	hasPaidDomain: PropTypes.bool,
-	isSetupSiteFlow: PropTypes.bool,
+	isDestinationSetupSiteFlow: PropTypes.bool,
 };

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
@@ -10,7 +9,7 @@ import './style.scss';
 const DURATION_IN_MS = 6000;
 const HEADSTART_DURATION_IN_MS = 80000;
 
-const useSteps = ( { flowName, hasPaidDomain, hasAppliedDesign } ) => {
+const useSteps = ( { flowName, hasPaidDomain, isSetupSiteFlow } ) => {
 	const { __ } = useI18n();
 	let steps = [];
 
@@ -37,7 +36,9 @@ const useSteps = ( { flowName, hasPaidDomain, hasAppliedDesign } ) => {
 			steps = [
 				__( 'Building your site' ),
 				hasPaidDomain && __( 'Getting your domain' ),
-				hasAppliedDesign && __( 'Applying design' ),
+				// If destination is not setup-site flow, we'll apply default design now
+				// because the user cannot choose design in current flow
+				! isSetupSiteFlow && __( 'Applying design' ),
 			];
 	}
 
@@ -48,14 +49,12 @@ const useSteps = ( { flowName, hasPaidDomain, hasAppliedDesign } ) => {
 // to work with the onboarding signup flow.
 export default function ReskinnedProcessingScreen( props ) {
 	const { __ } = useI18n();
-	const setupSiteFeatureEnabled = isEnabled( 'signup/setup-site-after-checkout' );
 
 	const steps = useSteps( props );
+	const { isSetupSiteFlow } = props;
 	const totalSteps = steps.current.length;
-	const isSetupSite =
-		props.flowName === 'setup-site' ||
-		( props.flowName === 'onboarding' && setupSiteFeatureEnabled );
-	const duration = isSetupSite ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
+
+	const duration = isSetupSiteFlow ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 
 	/**
@@ -82,7 +81,7 @@ export default function ReskinnedProcessingScreen( props ) {
 			<h1 className="reskinned-processing-screen__progress-step">
 				{ steps.current[ currentStep ] }
 			</h1>
-			{ isSetupSite && (
+			{ isSetupSiteFlow && (
 				<div className="reskinned-processing-screen__loading-elipsis">
 					<div></div>
 					<div></div>
@@ -90,7 +89,7 @@ export default function ReskinnedProcessingScreen( props ) {
 					<div></div>
 				</div>
 			) }
-			{ ! isSetupSite && (
+			{ ! isSetupSiteFlow && (
 				<>
 					<div
 						className="reskinned-processing-screen__progress-bar"
@@ -118,5 +117,5 @@ export default function ReskinnedProcessingScreen( props ) {
 ReskinnedProcessingScreen.propTypes = {
 	flowName: PropTypes.string,
 	hasPaidDomain: PropTypes.bool,
-	hasAppliedDesign: PropTypes.bool,
+	isSetupSiteFlow: PropTypes.bool,
 };

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -53,7 +53,7 @@ export default function ReskinnedProcessingScreen( props ) {
 	const totalSteps = steps.current.length;
 	const shouldShowNewSpinner = isDestinationSetupSiteFlow || flowName === 'setup-site';
 
-	const duration = isDestinationSetupSiteFlow ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
+	const duration = flowName === 'setup-site' ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 
 	/**

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
@@ -47,10 +48,13 @@ const useSteps = ( { flowName, hasPaidDomain, hasAppliedDesign } ) => {
 // to work with the onboarding signup flow.
 export default function ReskinnedProcessingScreen( props ) {
 	const { __ } = useI18n();
+	const setupSiteFeatureEnabled = isEnabled( 'signup/setup-site-after-checkout' );
 
 	const steps = useSteps( props );
 	const totalSteps = steps.current.length;
-	const isSetupSite = props.flowName === 'setup-site';
+	const isSetupSite =
+		props.flowName === 'setup-site' ||
+		( props.flowName === 'onboarding' && setupSiteFeatureEnabled );
 	const duration = isSetupSite ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -94,15 +94,17 @@ export default function ReskinnedProcessingScreen( props ) {
 							'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
 						} }
 					/>
-					<p className="reskinned-processing-screen__progress-numbered-steps">
-						{
-							// translators: these are progress steps. Eg: step 1 of 4.
-							sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
-								currentStep: currentStep + 1,
-								totalSteps,
-							} )
-						}
-					</p>
+					{ totalSteps > 1 && (
+						<p className="reskinned-processing-screen__progress-numbered-steps">
+							{
+								// translators: these are progress steps. Eg: step 1 of 4.
+								sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
+									currentStep: currentStep + 1,
+									totalSteps,
+								} )
+							}
+						</p>
+					) }
 				</>
 			) }
 		</div>

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -7,6 +7,7 @@ import './style.scss';
 
 // Total time to perform "loading"
 const DURATION_IN_MS = 6000;
+const HEADSTART_DURATION_IN_MS = 80000;
 
 const useSteps = ( { flowName, hasPaidDomain, hasAppliedDesign } ) => {
 	const { __ } = useI18n();
@@ -17,7 +18,19 @@ const useSteps = ( { flowName, hasPaidDomain, hasAppliedDesign } ) => {
 			steps = [ __( 'Your site will be live shortly.' ) ]; // copy from 'packages/launch/src/focused-launch/success'
 			break;
 		case 'setup-site':
-			steps = [ __( 'Applying design' ) ];
+			steps = [
+				__( 'Personalizing your site' ),
+				__( 'Applying your theme' ),
+				__( 'Turning on hosting' ),
+				__( 'Enabling SSL encryption' ),
+				__( 'Switching on email' ),
+				__( 'Applying Jetpack essentials' ),
+				__( 'Adding a domain' ),
+				__( 'Applying a plan' ),
+				__( 'Securing your information' ),
+				__( 'Optimizing your content' ),
+				__( 'Closing the loop' ),
+			];
 			break;
 		default:
 			steps = [
@@ -37,7 +50,8 @@ export default function ReskinnedProcessingScreen( props ) {
 
 	const steps = useSteps( props );
 	const totalSteps = steps.current.length;
-
+	const isSetupSite = props.flowName === 'setup-site';
+	const duration = isSetupSite ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 
 	/**
@@ -49,7 +63,7 @@ export default function ReskinnedProcessingScreen( props ) {
 	useInterval(
 		() => setCurrentStep( ( s ) => s + 1 ),
 		// Enable the interval when progress is incomplete
-		isComplete ? null : DURATION_IN_MS / totalSteps
+		isComplete ? null : duration / totalSteps
 	);
 
 	// Force animated progress bar to start at 0
@@ -64,21 +78,33 @@ export default function ReskinnedProcessingScreen( props ) {
 			<h1 className="reskinned-processing-screen__progress-step">
 				{ steps.current[ currentStep ] }
 			</h1>
-			<div
-				className="reskinned-processing-screen__progress-bar"
-				style={ {
-					'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
-				} }
-			/>
-			<p className="reskinned-processing-screen__progress-numbered-steps">
-				{
-					// translators: these are progress steps. Eg: step 1 of 4.
-					sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
-						currentStep: currentStep + 1,
-						totalSteps,
-					} )
-				}
-			</p>
+			{ isSetupSite && (
+				<div className="reskinned-processing-screen__loading-elipsis">
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+				</div>
+			) }
+			{ ! isSetupSite && (
+				<>
+					<div
+						className="reskinned-processing-screen__progress-bar"
+						style={ {
+							'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
+						} }
+					/>
+					<p className="reskinned-processing-screen__progress-numbered-steps">
+						{
+							// translators: these are progress steps. Eg: step 1 of 4.
+							sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
+								currentStep: currentStep + 1,
+								totalSteps,
+							} )
+						}
+					</p>
+				</>
+			) }
 		</div>
 	);
 }

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -5,7 +5,7 @@ $progress-duration: 800ms;
 .reskinned-processing-screen {
 	padding: 1em;
 	max-width: 540px;
-
+	text-align: center;
 	margin: 32vh auto;
 
 	&__progress-bar {
@@ -31,17 +31,68 @@ $progress-duration: 800ms;
 
 	&__progress-step {
 		@include onboarding-font-recoleta;
-		font-size: 26px;
+		/* stylelint-disable-next-line scales/font-sizes */
+		font-size: 1.625rem;
 		line-height: 40px;
 		text-align: center;
 		vertical-align: middle;
 		margin: 0;
 	}
 
-	&__progress-numbered-steps {
-		margin-top: 0.7em;
-		padding: 1em;
-		text-align: center;
-		color: var( --studio-gray-40 );
+	&__loading-elipsis {
+		display: inline-block;
+		position: relative;
+		width: 80px;
+		height: 80px;
+		> div {
+			position: absolute;
+			top: 33px;
+			width: 13px;
+			height: 13px;
+			border-radius: 50%; /*stylelint-disable-line declaration-property-unit-allowed-list*/
+			background: var( --studio-gray-60 );
+			animation-timing-function: cubic-bezier( 0, 1, 1, 0 );
+			&:nth-child( 1 ) {
+				left: 8px;
+				animation: loading-ellipsis-grow 0.6s infinite;
+			}
+			&:nth-child( 2 ) {
+				left: 8px;
+				animation: loading-ellipsis-move 0.6s infinite;
+			}
+			&:nth-child( 3 ) {
+				left: 32px;
+				animation: loading-ellipsis-move 0.6s infinite;
+			}
+			&:nth-child( 4 ) {
+				left: 56px;
+				animation: loading-ellipsis-shrink 0.6s infinite;
+			}
+		}
+	}
+}
+
+@keyframes loading-ellipsis-grow {
+	0% {
+		transform: scale( 0 );
+	}
+	100% {
+		transform: scale( 1 );
+	}
+}
+@keyframes loading-ellipsis-move {
+	0% {
+		transform: translate( 0, 0 );
+	}
+	100% {
+		transform: translate( 24px, 0 );
+	}
+}
+@keyframes loading-ellipsis-shrink {
+	0% {
+		transform: scale( 1 );
+	}
+	100% {
+		transform: scale( 0 );
 	}
 }

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -29,6 +29,13 @@ $progress-duration: 800ms;
 		}
 	}
 
+	&__progress-numbered-steps {
+		margin-top: 0.7em;
+		padding: 1em;
+		text-align: center;
+		color: var( --studio-gray-40 );
+	}
+	
 	&__progress-step {
 		@include onboarding-font-recoleta;
 		/* stylelint-disable-next-line scales/font-sizes */


### PR DESCRIPTION
change the loading progress bar to a spinner animation and add more loading steps. This handles the case of very long loading times better.

#### Testing instructions 
test the hero flow with:
`/start/domains?flags=signup/hero-flow`
