### PR TITLE
A year of free domain is only included in annual plans.

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -51,7 +51,7 @@ class SiteOrDomain extends Component {
 				label: translate( 'Existing WordPress.com site' ),
 				image: <ExistingSiteImage />,
 				description: translate(
-					'Use with a site you already started. A free domain for one year is included with all plans.'
+					'Use with a site you already started. A free domain for one year is included with all annual plans.'
 				),
 			} );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR updates "all plans" to "all annual plans" since it is no longer accurate because of the introduction of monthly plans:
![image](https://user-images.githubusercontent.com/1842898/137441272-e74cfce6-e2e8-414e-8c70-5e6fde397e72.png)


#### Testing instructions

1. Log in as an account of your pick.
2. Visit /start/domain
3. Proceed to the 2nd step, and make sure the policy statement is updated as "Use with a site you already started. A free domain for one year is included with all annual plans."