### PR TITLE
Onboarding: Adjust styles of design picker according to feedback

### DIFF
--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -79,8 +79,9 @@
 		font-size: 0.875rem;
 		font-weight: 500; /* stylelint-disable-line */
 
-		.button {
+		&.button.is-primary {
 			border-radius: 4px; /* stylelint-disable-line scales/radii */
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
 		}
 
 		&.has-underline {

--- a/client/signup/steps/design-picker/icons.jsx
+++ b/client/signup/steps/design-picker/icons.jsx
@@ -1,45 +1,22 @@
-import { Path, SVG, Rect } from '@wordpress/components';
+import { SVG, Rect } from '@wordpress/components';
 
 export const computer = (
-	<SVG width="55" height="55" viewBox="0 0 55 55">
-		<Path
-			d="M10.4258 15.75C10.4258 15.0596 10.9854 14.5 11.6758 14.5H43.3239C44.0143 14.5 44.5739 15.0596 44.5739 15.75V38.463H10.4258V15.75Z"
-			stroke="currentColor"
-			strokeWidth="1.5"
-		/>
-		<Path
-			d="M4.58301 38.667C4.58301 37.5624 5.47844 36.667 6.58301 36.667H48.4163C49.5209 36.667 50.4163 37.5624 50.4163 38.667V40.1045H4.58301V38.667Z"
-			fill="currentColor"
-		/>
+	<SVG width="36" height="36" viewBox="0 0 36 36">
+		<Rect x="6" y="9" width="24" height="18" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
+		<Rect x="3" y="26.5" width="30" height="1.5" fill="currentColor" />
 	</SVG>
 );
 
 export const tablet = (
-	<SVG width="48" height="48" viewBox="0 0 48 48">
-		<Rect
-			x="10.75"
-			y="8.75"
-			width="26.5"
-			height="30.5"
-			rx="1.25"
-			stroke="currentColor"
-			strokeWidth="1.5"
-		/>
-		<Rect x="20" y="32" width="8" height="3" fill="currentColor" />
+	<SVG width="24" height="24" viewBox="0 0 24 24">
+		<Rect x="3" y="2" width="18" height="20" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
+		<Rect x="10" y="17" width="4" height="1.5" fill="currentColor" />
 	</SVG>
 );
 
 export const phone = (
-	<SVG width="40" height="40" viewBox="0 0 40 40">
-		<Rect
-			x="12.417"
-			y="7.41699"
-			width="16"
-			height="25.1667"
-			rx="1.25"
-			stroke="currentColor"
-			strokeWidth="1.5"
-		/>
-		<Rect x="18.333" y="26.667" width="5" height="2.5" fill="currentColor" />
+	<SVG width="24" height="24" viewBox="0 0 24 24">
+		<Rect x="6" y="3" width="12" height="18" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
+		<Rect x="11" y="17" width="2" height="1.5" fill="currentColor" />
 	</SVG>
 );

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, { isBlankCanvasDesign, getDesignUrl } from '@automattic/design-picker';
 import { compose } from '@wordpress/compose';
 import { withViewportMatch } from '@wordpress/viewport';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -11,6 +11,7 @@ import WebPreview from 'calypso/components/web-preview';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getRecommendedThemes as fetchRecommendedThemes } from 'calypso/state/themes/actions';
 import { getRecommendedThemes } from 'calypso/state/themes/selectors';
@@ -185,7 +186,7 @@ class DesignPickerStep extends Component {
 	}
 
 	render() {
-		const { isReskinned, isMobile, translate } = this.props;
+		const { flowName, stepName, userLoggedIn, isReskinned, isMobile, translate } = this.props;
 		const { selectedDesign } = this.state;
 		const headerText = this.headerText();
 		const subHeaderText = this.subHeaderText();
@@ -194,6 +195,7 @@ class DesignPickerStep extends Component {
 			const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 			const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
 			const defaultDependencies = { selectedDesign };
+			const locale = ! userLoggedIn ? getLocaleSlug() : '';
 
 			return (
 				<StepWrapper
@@ -211,6 +213,7 @@ class DesignPickerStep extends Component {
 						args: { designTitle },
 					} ) }
 					defaultDependencies={ defaultDependencies }
+					backUrl={ getStepUrl( flowName, stepName, '', locale ) }
 					goToNextStep={ this.submitDesign }
 				/>
 			);
@@ -236,6 +239,7 @@ export default compose(
 		( state ) => {
 			return {
 				themes: getRecommendedThemes( state, 'auto-loading-homepage' ),
+				userLoggedIn: isUserLoggedIn( state ),
 			};
 		},
 		{ fetchRecommendedThemes, saveSignupStep, submitSignupStep }

--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -17,9 +17,9 @@ const DesignPickerPreviewToolbar = ( {
 	translate,
 } ) => {
 	const devices = React.useRef( {
-		computer: { title: translate( 'Desktop' ), icon: computer },
-		tablet: { title: translate( 'Tablet' ), icon: tablet },
-		phone: { title: translate( 'Phone' ), icon: phone },
+		computer: { title: translate( 'Desktop' ), icon: computer, iconSize: 36 },
+		tablet: { title: translate( 'Tablet' ), icon: tablet, iconSize: 24 },
+		phone: { title: translate( 'Phone' ), icon: phone, iconSize: 24 },
 	} );
 
 	return (
@@ -37,7 +37,7 @@ const DesignPickerPreviewToolbar = ( {
 							onClick={ () => setDeviceViewport( device ) }
 						>
 							<Icon
-								size={ device === 'computer' ? 36 : 24 }
+								size={ devices.current[ device ].iconSize }
 								icon={ devices.current[ device ].icon }
 							/>
 						</Button>

--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -36,7 +36,10 @@ const DesignPickerPreviewToolbar = ( {
 							} ) }
 							onClick={ () => setDeviceViewport( device ) }
 						>
-							<Icon size={ 24 } icon={ devices.current[ device ].icon } />
+							<Icon
+								size={ device === 'computer' ? 36 : 24 }
+								icon={ devices.current[ device ].icon }
+							/>
 						</Button>
 					) ) }
 				</div>

--- a/client/signup/steps/design-picker/preview-toolbar.scss
+++ b/client/signup/steps/design-picker/preview-toolbar.scss
@@ -4,12 +4,13 @@
 .preview-toolbar__toolbar {
 	// Move spinner to the bottom of browser header
 	& ~ hr.spinner-line {
+		width: calc( 100% - 1px );
 		top: 16px;
 		left: 50%;
 		transform: translateX( -50% );
 
 		@include break-small {
-			top: 68px;
+			top: 82px;
 		}
 	}
 
@@ -35,7 +36,7 @@
 .button.preview-toolbar__button {
 	color: var( --studio-gray-10 );
 	height: auto;
-	margin: 0 13px;
+	margin: 0 9px;
 	transition: color 0.1s ease-in-out;
 
 	&.is-selected,

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -783,12 +783,12 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		.design-picker__preview .step-wrapper__header {
 			margin-top: 40px;
 
-			@include break-mobile {
-				margin-top: 11px;
+			.formatted-header__title {
+				font-size: 2rem; /* stylelint-disable-line */
 			}
 
-			@include break-xlarge {
-				margin-top: 6px;
+			@include break-mobile {
+				margin-top: 12px;
 			}
 		}
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -793,7 +793,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 
-	button.is-primary {
+	button.is-borderless {
 		box-shadow: none;
 		border: 0;
 	}

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -71,6 +71,15 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			data-e2e-button={ design.is_premium ? 'paidOption' : 'freeOption' }
 			onClick={ () => onSelect( design ) }
 		>
+			<span className="design-picker__design-option-header">
+				<svg width="28" height="6">
+					<g>
+						<rect width="6" height="6" rx="3" />
+						<rect x="11" width="6" height="6" rx="3" />
+						<rect x="22" width="6" height="6" rx="3" />
+					</g>
+				</svg>
+			</span>
 			<span
 				className={ classnames(
 					'design-picker__image-frame',

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -132,6 +132,12 @@ const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
 
 	return (
 		<div className="design-button-cover">
+			{ /* Make all of design button clickable and default behavior is preview  */ }
+			<button
+				className="design-button-cover__button-overlay"
+				tabIndex={ -1 }
+				onClick={ () => onPreview( design ) }
+			/>
 			<div className="design-button-cover__button-groups">
 				<Button
 					className="design-button-cover__button"

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -128,7 +128,11 @@ const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
 } ) => {
 	const { __ } = useI18n();
 	const isBlankCanvas = isBlankCanvasDesign( design );
-	const designTitle = isBlankCanvas ? __( 'Blank Canvas' ) : design.title;
+
+	// We don't need preview for blank canvas
+	if ( isBlankCanvas ) {
+		return null;
+	}
 
 	return (
 		<div className="design-button-cover">
@@ -146,13 +150,13 @@ const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
 				>
 					{
 						// translators: %s is the title of design with currency. Eg: Alves
-						sprintf( __( 'Start with %s', __i18n_text_domain__ ), designTitle )
+						sprintf( __( 'Start with %s', __i18n_text_domain__ ), design.title )
 					}
 				</Button>
 				<Button className="design-button-cover__button" onClick={ () => onPreview( design ) }>
 					{
 						// translators: %s is the title of design with currency. Eg: Alves
-						sprintf( __( 'Preview %s', __i18n_text_domain__ ), designTitle )
+						sprintf( __( 'Preview %s', __i18n_text_domain__ ), design.title )
 					}
 				</Button>
 			</div>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -127,12 +127,6 @@ const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
 	onPreview,
 } ) => {
 	const { __ } = useI18n();
-	const isBlankCanvas = isBlankCanvasDesign( design );
-
-	// We don't need preview for blank canvas
-	if ( isBlankCanvas ) {
-		return null;
-	}
 
 	return (
 		<div className="design-button-cover">
@@ -173,6 +167,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	...props
 } ) => {
 	const isDesktop = useViewportMatch( 'large' );
+	const isBlankCanvas = isBlankCanvasDesign( props.design );
 
 	if ( ! onPreview ) {
 		return <DesignButton { ...props } />;
@@ -183,14 +178,17 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 		return <DesignButton { ...props } onSelect={ onPreview } />;
 	}
 
+	// We don't need preview for blank canvas
 	return (
 		<div className="design-button-container">
-			<DesignButtonCover
-				design={ props.design }
-				onSelect={ props.onSelect }
-				onPreview={ onPreview }
-			/>
-			<DesignButton { ...props } disabled />
+			{ ! isBlankCanvas && (
+				<DesignButtonCover
+					design={ props.design }
+					onSelect={ props.onSelect }
+					onPreview={ onPreview }
+				/>
+			) }
+			<DesignButton { ...props } disabled={ ! isBlankCanvas } />
 		</div>
 	);
 };

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -53,6 +53,28 @@
 		}
 	}
 
+	.design-picker__design-option-header {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: relative;
+		max-width: 100%;
+		height: 22px;
+		border: 1px solid rgba( 0, 0, 0, 0.12 );
+		border-radius: 4px 4px 0 0; /* stylelint-disable-line scales/radii */
+		margin: 0 auto;
+		box-sizing: border-box;
+		transition: border-color 0.15s ease-in-out;
+
+		svg {
+			position: absolute;
+			left: 12px;
+			top: 50%;
+			transform: translateY( -50% );
+			fill: rgba( 0, 0, 0, 0.12 );
+		}
+	}
+
 	@supports ( display: grid ) {
 		.design-picker__grid {
 			display: grid;
@@ -105,12 +127,10 @@
 		display: block;
 		width: 100%;
 		height: 0;
-		border: 1px solid;
 		box-sizing: border-box;
 		position: relative;
 		overflow: hidden;
-		border-radius: 4px; /* stylelint-disable-line scales/radii */
-		transition: border-color 0.15s ease-in-out;
+		border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
 
 		img {
 			position: absolute;
@@ -120,6 +140,21 @@
 			margin: 0 auto;
 			width: 100%;
 			height: auto;
+		}
+
+		&::after {
+			content: '';
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			border: 1px solid;
+			border-top-width: 0;
+			border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
+			box-sizing: border-box;
+			background-color: transparent;
+			transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 		}
 	}
 
@@ -196,12 +231,19 @@
 		color: var( --studio-white );
 	}
 	.design-picker__design-option {
-		.design-picker__image-frame {
+		.design-picker__design-option-header svg {
+			fill: var( --studio-gray-40 );
+		}
+
+		.design-picker__design-option-header,
+		.design-picker__image-frame::after {
 			border-color: var( --studio-gray-40 );
 		}
+
 		&:hover,
 		&:focus {
-			.design-picker__image-frame {
+			.design-picker__design-option-header,
+			.design-picker__image-frame::after {
 				border-color: var( --studio-white );
 			}
 		}
@@ -209,8 +251,13 @@
 
 	.design-button-container:hover,
 	.design-button-container:focus-within {
-		.design-picker__design-option .design-picker__image-frame {
+		.design-picker__design-option-header,
+		.design-picker__image-frame::after {
 			border-color: var( --studio-white );
+		}
+
+		.design-picker__design-option .design-picker__image-frame::after {
+			background-color: rgba( 255, 255, 255, 0.42 );
 		}
 	}
 }
@@ -222,45 +269,32 @@
 	}
 	.design-picker__design-option {
 		.design-picker__image-frame {
-			border-color: transparent;
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.03 );
-
-			&::after {
-				content: '';
-				position: absolute;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height: 100%;
-				box-shadow: inset 0 0 0 1px var( --studio-black );
-				border-radius: 4px; /* stylelint-disable-line scales/radii */
-				opacity: 0.12;
-			}
 		}
-		&:hover {
-			.design-picker__image-frame {
-				border-color: transparent;
 
-				&::after {
-					opacity: 0.24;
-				}
-			}
+		.design-picker__design-option-header,
+		.design-picker__image-frame::after {
+			border-color: rgba( 0, 0, 0, 0.12 );
 		}
+
+		&:hover,
 		&:focus {
-			.design-picker__image-frame {
+			.design-picker__design-option-header,
+			.design-picker__image-frame::after {
 				border-color: var( --studio-blue-20 );
-
-				&::after {
-					opacity: 0;
-				}
 			}
 		}
 	}
 
 	.design-button-container:hover,
 	.design-button-container:focus-within {
-		.design-picker__design-option .design-picker__image-frame {
-			border-color: var( --studio-blue-20 );
+		.design-picker__design-option-header,
+		.design-picker__image-frame::after {
+			border-color: #a7aaad;
+		}
+
+		.design-picker__design-option .design-picker__image-frame::after {
+			background-color: rgba( 255, 255, 255, 0.72 );
 		}
 	}
 }
@@ -287,16 +321,6 @@
 		opacity: 0;
 		transition: opacity 0.15s ease-in-out;
 
-		&::before {
-			content: '';
-			position: absolute;
-			top: 0;
-			width: 100%;
-			padding-top: 66%;
-			background-color: rgba( 255, 255, 255, 0.72 );
-			z-index: -1;
-		}
-
 		@include break-medium {
 			display: flex;
 		}
@@ -313,6 +337,7 @@
 
 	.design-button-cover__button {
 		justify-content: center;
+		border-radius: 4px; /* stylelint-disable-line scales/radii */
 		font-size: inherit;
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */
 		line-height: 20px;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -326,6 +326,14 @@
 		}
 	}
 
+	.design-button-cover__button-overlay {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		cursor: pointer;
+		z-index: -1;
+	}
+
 	.design-button-cover__button-groups {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

According to the Pod sync document, we need to refine some styles of Design Picker as followed
- [x] Design picker
  - [x] Hover needs dark border
  - [x] Hovering anywhere in the card link to the preview, but the ‘Start..’ button should still do as intended.
- [x] Design preview
  - [x] Device icons look shrunken
  - [x] Theme name in header is too big
  - [x] Pressing < Back takes you to the intent screen, not to the design picker as intended.

##### Hover on the design and its border is dark
![image](https://user-images.githubusercontent.com/13596067/137441490-3f1e7602-58fa-44ab-b2d7-8dccf505758d.png)

##### Current theme name and devices icon
![image](https://user-images.githubusercontent.com/13596067/137441517-49ec560f-f4c4-4b71-8fc5-aac8b5a01657.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?flags=signup/hero-flow&siteSlug=<your_site>`
* Select build intent
* Play with design picker and its preview to check the above behavior is correct

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56957
