### PR TITLE
Change the Google Workspace domain suffix font to normal for RTL

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -54,8 +54,9 @@
 	.form-fieldset .form-label {
 		color: var( --color-text );
 
-		.form-text-input-with-affixes__suffix {
-			font-weight: normal;
+		.form-text-input-with-affixes__suffix,
+		.form-text-input-with-affixes__prefix {
+				font-weight: normal;
 		}
 
 		> div, > input {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes the font in domain suffix when adding new Google Workspace mailboxes. The same issue for Titan Email was fixed in https://github.com/Automattic/wp-calypso/pull/55986

Before:
<img width="887" alt="gsuite_before" src="https://user-images.githubusercontent.com/7847633/137490702-933efddc-1301-47b5-914e-ecaa0c8a8ff7.png">

After:
<img width="887" alt="gsuite_after" src="https://user-images.githubusercontent.com/7847633/137490725-f9462607-1684-4f64-9e68-22ebcdfefa4c.png">

#### Testing instructions

Follow the testing instructions from https://github.com/Automattic/wp-calypso/pull/55986 and pay attention to the Google Workspace forms.

Related to #https://github.com/Automattic/wp-calypso/pull/55986

