### PR TITLE
i18n: Fix translations on the Use my domain screen

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-advanced-records.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-advanced-records.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import ConnectDomainStepClipboardButton from './connect-domain-step-clipboard-button';
 import ConnectDomainStepVerificationNotice from './connect-domain-step-verification-error-notice';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepSlug, stepsHeadingAdvanced } from './constants';
+import { modeType, stepSlug, stepsHeading } from './constants';
 
 import './style.scss';
 
@@ -147,7 +147,7 @@ export default function ConnectDomainStepAdvancedRecords( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
-			heading={ stepsHeadingAdvanced }
+			heading={ stepsHeading.ADVANCED }
 			pageSlug={ pageSlug }
 			progressStepList={ progressStepList }
 			stepContent={ stepContent }

--- a/client/components/domains/connect-domain-step/connect-domain-step-advanced-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-advanced-start.jsx
@@ -7,7 +7,7 @@ import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepSlug, stepsHeadingAdvanced } from './constants';
+import { modeType, stepSlug, stepsHeading } from './constants';
 
 import './style.scss';
 
@@ -69,7 +69,7 @@ export default function ConnectDomainStepAdvancedStart( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
-			heading={ stepsHeadingAdvanced }
+			heading={ stepsHeading.ADVANCED }
 			mode={ mode }
 			progressStepList={ progressStepList }
 			pageSlug={ pageSlug }

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -8,14 +8,7 @@ import Notice from 'calypso/components/notice';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import wpcom from 'calypso/lib/wp';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import {
-	modeType,
-	stepsHeadingAdvanced,
-	stepsHeadingOwnershipVerification,
-	stepsHeadingSuggested,
-	stepsHeadingTransfer,
-	stepSlug,
-} from './constants';
+import { modeType, stepsHeading, stepSlug } from './constants';
 
 import './style.scss';
 
@@ -38,16 +31,16 @@ export default function ConnectDomainStepLogin( {
 	useEffect( () => {
 		switch ( mode ) {
 			case modeType.TRANSFER:
-				setHeading( stepsHeadingTransfer );
+				setHeading( stepsHeading.TRANSFER );
 				return;
 			case modeType.SUGGESTED:
-				setHeading( stepsHeadingSuggested );
+				setHeading( stepsHeading.SUGGESTED );
 				return;
 			case modeType.ADVANCED:
-				setHeading( stepsHeadingAdvanced );
+				setHeading( stepsHeading.ADVANCED );
 				return;
 			case modeType.OWNERSHIP_VERIFICATION:
-				setHeading( stepsHeadingOwnershipVerification );
+				setHeading( stepsHeading.OWNERSHIP_VERIFICATION );
 				return;
 		}
 	}, [ mode ] );

--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -27,7 +27,7 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 					'We will use your domain authorization code to verify that you are the domain owner.'
 				) }
 			</p>
-			<p className={ 'connect-domain-step__text' }>{ authCodeStepDefaultDescription }</p>
+			<p className={ 'connect-domain-step__text' }>{ authCodeStepDefaultDescription.label }</p>
 		</>
 	);
 	return (

--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-records.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-records.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import ConnectDomainStepClipboardButton from './connect-domain-step-clipboard-button';
 import ConnectDomainStepVerificationNotice from './connect-domain-step-verification-error-notice';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepSlug, stepsHeadingSuggested } from './constants';
+import { modeType, stepSlug, stepsHeading } from './constants';
 
 import './style.scss';
 
@@ -66,7 +66,7 @@ export default function ConnectDomainStepSuggestedRecords( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
-			heading={ stepsHeadingSuggested }
+			heading={ stepsHeading.SUGGESTED }
 			mode={ mode }
 			progressStepList={ progressStepList }
 			pageSlug={ pageSlug }

--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import CardHeading from 'calypso/components/card-heading';
 import {
 	modeType,
-	stepsHeadingSuggested,
+	stepsHeading,
 	stepSlug,
 } from 'calypso/components/domains/connect-domain-step/constants';
 import MaterialIcon from 'calypso/components/material-icon';
@@ -57,7 +57,7 @@ export default function ConnectDomainStepSuggestedStart( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
-			heading={ stepsHeadingSuggested }
+			heading={ stepsHeading.SUGGESTED }
 			mode={ mode }
 			progressStepList={ progressStepList }
 			pageSlug={ pageSlug }

--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -52,10 +52,19 @@ export const domainLockStatusType = {
 	UNKNOWN: 'unknown',
 } as const;
 
-export const stepsHeadingSuggested = __( 'Suggested setup' );
-export const stepsHeadingAdvanced = __( 'Advanced setup' );
-export const stepsHeadingOwnershipVerification = __( 'Verify domain ownership' );
-export const stepsHeadingTransfer = __( 'Initial setup' );
+const stepsHeadingLabels = {
+	SUGGESTED: () => __( 'Suggested setup' ),
+	ADVANCED: () => __( 'Advanced setup' ),
+	OWNERSHIP_VERIFICATION: () => __( 'Verify domain ownership' ),
+	TRANSFER: () => __( 'Initial setup' ),
+};
+
+export const stepsHeading = {
+	SUGGESTED: stepsHeadingLabels.SUGGESTED(),
+	ADVANCED: stepsHeadingLabels.ADVANCED(),
+	OWNERSHIP_VERIFICATION: stepsHeadingLabels.OWNERSHIP_VERIFICATION(),
+	TRANSFER: stepsHeadingLabels.TRANSFER(),
+} as const;
 
 export const authCodeStepDefaultDescription = __(
 	'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
@@ -68,8 +77,44 @@ export const useMyDomainInputMode = {
 	transferDomain: 'transfer-domain',
 } as const;
 
-export const transferDomainError = {
-	AUTH_CODE: __( 'Invalid auth code. Please check the specified code and try again.' ),
-	NO_SELECTED_SITE: __( 'Please specify a site.' ),
-	GENERIC_ERROR: __( 'We were unable to start the transfer.' ),
+const transferDomainErrorLabels = {
+	AUTH_CODE: () => __( 'Invalid auth code. Please check the specified code and try again.' ),
+	NO_SELECTED_SITE: () => __( 'Please specify a site.' ),
+	GENERIC_ERROR: () => __( 'We were unable to start the transfer.' ),
 };
+
+export const transferDomainError = {
+	AUTH_CODE: transferDomainErrorLabels.AUTH_CODE(),
+	NO_SELECTED_SITE: transferDomainErrorLabels.NO_SELECTED_SITE(),
+	GENERIC_ERROR: transferDomainErrorLabels.GENERIC_ERROR(),
+} as const;
+
+/**
+ * Define properties with translatable strings getters.
+ */
+Object.defineProperties( stepsHeading, {
+	SUGGESTED: {
+		get: () => stepsHeadingLabels.SUGGESTED(),
+	},
+	ADVANCED: {
+		get: () => stepsHeadingLabels.ADVANCED(),
+	},
+	OWNERSHIP_VERIFICATION: {
+		get: () => stepsHeadingLabels.OWNERSHIP_VERIFICATION(),
+	},
+	TRANSFER: {
+		get: () => stepsHeadingLabels.TRANSFER(),
+	},
+} );
+
+Object.defineProperties( transferDomainError, {
+	AUTH_CODE: {
+		get: () => transferDomainErrorLabels.AUTH_CODE(),
+	},
+	NO_SELECTED_SITE: {
+		get: () => transferDomainErrorLabels.NO_SELECTED_SITE(),
+	},
+	GENERIC_ERROR: {
+		get: () => transferDomainErrorLabels.GENERIC_ERROR(),
+	},
+} );

--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -52,27 +52,27 @@ export const domainLockStatusType = {
 	UNKNOWN: 'unknown',
 } as const;
 
-const stepsHeadingLabels = {
-	SUGGESTED: () => __( 'Suggested setup' ),
-	ADVANCED: () => __( 'Advanced setup' ),
-	OWNERSHIP_VERIFICATION: () => __( 'Verify domain ownership' ),
-	TRANSFER: () => __( 'Initial setup' ),
-};
-
 export const stepsHeading = {
-	SUGGESTED: stepsHeadingLabels.SUGGESTED(),
-	ADVANCED: stepsHeadingLabels.ADVANCED(),
-	OWNERSHIP_VERIFICATION: stepsHeadingLabels.OWNERSHIP_VERIFICATION(),
-	TRANSFER: stepsHeadingLabels.TRANSFER(),
+	get SUGGESTED() {
+		return __( 'Suggested setup' );
+	},
+	get ADVANCED() {
+		return __( 'Advanced setup' );
+	},
+	get OWNERSHIP_VERIFICATION() {
+		return __( 'Verify domain ownership' );
+	},
+	get TRANSFER() {
+		return __( 'Initial setup' );
+	},
 } as const;
 
-const authCodeStepDefaultDescriptionLabel = () =>
-	__(
-		'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
-	);
-
 export const authCodeStepDefaultDescription = {
-	label: authCodeStepDefaultDescriptionLabel(),
+	get label() {
+		return __(
+			'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
+		);
+	},
 } as const;
 
 export const useMyDomainInputMode = {
@@ -82,50 +82,14 @@ export const useMyDomainInputMode = {
 	transferDomain: 'transfer-domain',
 } as const;
 
-const transferDomainErrorLabels = {
-	AUTH_CODE: () => __( 'Invalid auth code. Please check the specified code and try again.' ),
-	NO_SELECTED_SITE: () => __( 'Please specify a site.' ),
-	GENERIC_ERROR: () => __( 'We were unable to start the transfer.' ),
-};
-
 export const transferDomainError = {
-	AUTH_CODE: transferDomainErrorLabels.AUTH_CODE(),
-	NO_SELECTED_SITE: transferDomainErrorLabels.NO_SELECTED_SITE(),
-	GENERIC_ERROR: transferDomainErrorLabels.GENERIC_ERROR(),
+	get AUTH_CODE() {
+		return __( 'Invalid auth code. Please check the specified code and try again.' );
+	},
+	get NO_SELECTED_SITE() {
+		return __( 'Please specify a site.' );
+	},
+	get GENERIC_ERROR() {
+		return __( 'We were unable to start the transfer.' );
+	},
 } as const;
-
-/**
- * Define properties with translatable strings getters.
- */
-Object.defineProperties( stepsHeading, {
-	SUGGESTED: {
-		get: () => stepsHeadingLabels.SUGGESTED(),
-	},
-	ADVANCED: {
-		get: () => stepsHeadingLabels.ADVANCED(),
-	},
-	OWNERSHIP_VERIFICATION: {
-		get: () => stepsHeadingLabels.OWNERSHIP_VERIFICATION(),
-	},
-	TRANSFER: {
-		get: () => stepsHeadingLabels.TRANSFER(),
-	},
-} );
-
-Object.defineProperties( transferDomainError, {
-	AUTH_CODE: {
-		get: () => transferDomainErrorLabels.AUTH_CODE(),
-	},
-	NO_SELECTED_SITE: {
-		get: () => transferDomainErrorLabels.NO_SELECTED_SITE(),
-	},
-	GENERIC_ERROR: {
-		get: () => transferDomainErrorLabels.GENERIC_ERROR(),
-	},
-} );
-
-Object.defineProperties( authCodeStepDefaultDescription, {
-	label: {
-		get: () => authCodeStepDefaultDescriptionLabel(),
-	},
-} );

--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -66,9 +66,14 @@ export const stepsHeading = {
 	TRANSFER: stepsHeadingLabels.TRANSFER(),
 } as const;
 
-export const authCodeStepDefaultDescription = __(
-	'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
-);
+const authCodeStepDefaultDescriptionLabel = () =>
+	__(
+		'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
+	);
+
+export const authCodeStepDefaultDescription = {
+	label: authCodeStepDefaultDescriptionLabel(),
+} as const;
 
 export const useMyDomainInputMode = {
 	domainInput: 'domain-input',
@@ -116,5 +121,11 @@ Object.defineProperties( transferDomainError, {
 	},
 	GENERIC_ERROR: {
 		get: () => transferDomainErrorLabels.GENERIC_ERROR(),
+	},
+} );
+
+Object.defineProperties( authCodeStepDefaultDescription, {
+	label: {
+		get: () => authCodeStepDefaultDescriptionLabel(),
 	},
 } );

--- a/client/components/domains/connect-domain-step/domain-step-auth-code.tsx
+++ b/client/components/domains/connect-domain-step/domain-step-auth-code.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { Input } from 'calypso/my-sites/domains/components/form';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { stepsHeadingOwnershipVerification } from './constants';
+import { stepsHeading } from './constants';
 import { DomainStepAuthCodeProps } from './types';
 
 import './style.scss';
@@ -28,7 +28,7 @@ const DomainStepAuthCode = ( {
 	const [ connectInProgress, setConnectInProgress ] = useState( false );
 	const [ authCodeError, setAuthCodeError ] = useState< ( string | undefined ) | null >( null );
 
-	const heading = customHeading ?? stepsHeadingOwnershipVerification;
+	const heading = customHeading ?? stepsHeading.OWNERSHIP_VERIFICATION;
 
 	const getVerificationData = () => {
 		return {

--- a/client/components/domains/connect-domain-step/page-definitions.js
+++ b/client/components/domains/connect-domain-step/page-definitions.js
@@ -12,6 +12,19 @@ import ConnectDomainStepSuggestedRecords from './connect-domain-step-suggested-r
 import ConnectDomainStepSuggestedStart from './connect-domain-step-suggested-start';
 import { modeType, stepSlug, stepType } from './constants';
 
+const labels = {
+	[ stepSlug.SUGGESTED_LOGIN ]: () => __( 'Log in to provider' ),
+	[ stepSlug.SUGGESTED_UPDATE ]: () => __( 'Update name servers' ),
+	[ stepSlug.ADVANCED_LOGIN ]: () => __( 'Log in to provider' ),
+	[ stepSlug.ADVANCED_UPDATE ]: () => __( 'Update root A records & CNAME record' ),
+	[ stepSlug.OWNERSHIP_VERIFICATION_LOGIN ]: () => __( 'Log in to provider' ),
+	[ stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE ]: () => __( 'Verify ownership' ),
+	[ stepSlug.TRANSFER_LOGIN ]: () => __( 'Log in to provider' ),
+	[ stepSlug.TRANSFER_UNLOCK ]: () => __( 'Unlock domain' ),
+	[ stepSlug.TRANSFER_AUTH_CODE ]: () => __( 'Authorize the transfer' ),
+	[ 'unused transfer domain step' ]: () => __( 'Finalize transfer' ),
+};
+
 export const connectADomainStepsDefinition = {
 	// Suggested flow
 	[ stepSlug.SUGGESTED_START ]: {
@@ -23,7 +36,7 @@ export const connectADomainStepsDefinition = {
 	[ stepSlug.SUGGESTED_LOGIN ]: {
 		mode: modeType.SUGGESTED,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: __( 'Log in to provider' ),
+		name: labels[ stepSlug.SUGGESTED_LOGIN ](),
 		component: ConnectDomainStepLogin,
 		next: stepSlug.SUGGESTED_UPDATE,
 		prev: stepSlug.SUGGESTED_START,
@@ -31,7 +44,7 @@ export const connectADomainStepsDefinition = {
 	[ stepSlug.SUGGESTED_UPDATE ]: {
 		mode: modeType.SUGGESTED,
 		step: stepType.UPDATE_NAME_SERVERS,
-		name: __( 'Update name servers' ),
+		name: labels[ stepSlug.SUGGESTED_UPDATE ](),
 		component: ConnectDomainStepSuggestedRecords,
 		prev: stepSlug.SUGGESTED_LOGIN,
 	},
@@ -59,7 +72,7 @@ export const connectADomainStepsDefinition = {
 	[ stepSlug.ADVANCED_LOGIN ]: {
 		mode: modeType.ADVANCED,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: __( 'Log in to provider' ),
+		name: labels[ stepSlug.ADVANCED_LOGIN ](),
 		component: ConnectDomainStepLogin,
 		next: stepSlug.ADVANCED_UPDATE,
 		prev: stepSlug.ADVANCED_START,
@@ -67,7 +80,7 @@ export const connectADomainStepsDefinition = {
 	[ stepSlug.ADVANCED_UPDATE ]: {
 		mode: modeType.ADVANCED,
 		step: stepType.UPDATE_A_RECORDS,
-		name: __( 'Update root A records & CNAME record' ),
+		name: labels[ stepSlug.ADVANCED_UPDATE ](),
 		component: ConnectDomainStepAdvancedRecords,
 		prev: stepSlug.ADVANCED_LOGIN,
 	},
@@ -94,14 +107,14 @@ export const connectADomainOwnershipVerificationStepsDefinition = {
 	[ stepSlug.OWNERSHIP_VERIFICATION_LOGIN ]: {
 		mode: modeType.OWNERSHIP_VERIFICATION,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: __( 'Log in to provider' ),
+		name: labels[ stepSlug.OWNERSHIP_VERIFICATION_LOGIN ](),
 		component: ConnectDomainStepLogin,
 		next: stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE,
 	},
 	[ stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE ]: {
 		mode: modeType.OWNERSHIP_VERIFICATION,
 		step: stepType.ENTER_AUTH_CODE,
-		name: __( 'Verify ownership' ),
+		name: labels[ stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE ](),
 		component: ConnectDomainStepOwnershipAuthCode,
 		prev: stepSlug.OWNERSHIP_VERIFICATION_LOGIN,
 	},
@@ -117,7 +130,7 @@ export const transferLockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_LOGIN ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: __( 'Log in to provider' ),
+		name: labels[ stepSlug.TRANSFER_LOGIN ](),
 		component: TransferDomainStepLogin,
 		next: stepSlug.TRANSFER_UNLOCK,
 		prev: stepSlug.TRANSFER_START,
@@ -125,7 +138,7 @@ export const transferLockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_UNLOCK ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.UNLOCK_DOMAIN,
-		name: __( 'Unlock domain' ),
+		name: labels[ stepSlug.TRANSFER_UNLOCK ](),
 		component: TransferDomainStepUnlock,
 		next: stepSlug.TRANSFER_AUTH_CODE,
 		prev: stepSlug.TRANSFER_LOGIN,
@@ -133,7 +146,7 @@ export const transferLockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_AUTH_CODE ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.ENTER_AUTH_CODE,
-		name: __( 'Authorize the transfer' ),
+		name: labels[ stepSlug.TRANSFER_AUTH_CODE ](),
 		component: TransferDomainStepAuthCode,
 		next: 'unused transfer domain step',
 		prev: stepSlug.TRANSFER_UNLOCK,
@@ -141,7 +154,7 @@ export const transferLockedDomainStepsDefinition = {
 	[ 'unused transfer domain step' ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.FINALIZE,
-		name: __( 'Finalize transfer' ),
+		name: labels[ 'unused transfer domain step' ](),
 	},
 };
 
@@ -155,7 +168,7 @@ export const transferUnlockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_LOGIN ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: __( 'Log in to provider' ),
+		name: labels[ stepSlug.TRANSFER_LOGIN ](),
 		component: TransferDomainStepLogin,
 		next: stepSlug.TRANSFER_AUTH_CODE,
 		prev: stepSlug.TRANSFER_START,
@@ -163,7 +176,7 @@ export const transferUnlockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_AUTH_CODE ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.ENTER_AUTH_CODE,
-		name: __( 'Authorize the transfer' ),
+		name: labels[ stepSlug.TRANSFER_AUTH_CODE ](),
 		component: TransferDomainStepAuthCode,
 		next: 'unused transfer domain step',
 		prev: stepSlug.TRANSFER_LOGIN,
@@ -171,7 +184,7 @@ export const transferUnlockedDomainStepsDefinition = {
 	[ 'unused transfer domain step' ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.FINALIZE,
-		name: __( 'Finalize transfer' ),
+		name: labels[ 'unused transfer domain step' ](),
 	},
 };
 
@@ -208,3 +221,25 @@ export const getProgressStepList = ( mode, stepsDefinition ) => {
 
 	return Object.fromEntries( stepList );
 };
+
+/**
+ * Define properties with translatable strings getters.
+ */
+[
+	connectADomainStepsDefinition,
+	connectADomainOwnershipVerificationStepsDefinition,
+	transferLockedDomainStepsDefinition,
+	transferUnlockedDomainStepsDefinition,
+].forEach( ( definition ) => {
+	Object.keys( definition ).forEach( ( slug ) => {
+		if ( labels.hasOwnProperty( slug ) ) {
+			const translationGetter = labels[ slug ];
+
+			Object.defineProperties( definition[ slug ], {
+				name: {
+					get: () => translationGetter(),
+				},
+			} );
+		}
+	} );
+} );

--- a/client/components/domains/connect-domain-step/page-definitions.js
+++ b/client/components/domains/connect-domain-step/page-definitions.js
@@ -12,19 +12,6 @@ import ConnectDomainStepSuggestedRecords from './connect-domain-step-suggested-r
 import ConnectDomainStepSuggestedStart from './connect-domain-step-suggested-start';
 import { modeType, stepSlug, stepType } from './constants';
 
-const labels = {
-	[ stepSlug.SUGGESTED_LOGIN ]: () => __( 'Log in to provider' ),
-	[ stepSlug.SUGGESTED_UPDATE ]: () => __( 'Update name servers' ),
-	[ stepSlug.ADVANCED_LOGIN ]: () => __( 'Log in to provider' ),
-	[ stepSlug.ADVANCED_UPDATE ]: () => __( 'Update root A records & CNAME record' ),
-	[ stepSlug.OWNERSHIP_VERIFICATION_LOGIN ]: () => __( 'Log in to provider' ),
-	[ stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE ]: () => __( 'Verify ownership' ),
-	[ stepSlug.TRANSFER_LOGIN ]: () => __( 'Log in to provider' ),
-	[ stepSlug.TRANSFER_UNLOCK ]: () => __( 'Unlock domain' ),
-	[ stepSlug.TRANSFER_AUTH_CODE ]: () => __( 'Authorize the transfer' ),
-	[ 'unused transfer domain step' ]: () => __( 'Finalize transfer' ),
-};
-
 export const connectADomainStepsDefinition = {
 	// Suggested flow
 	[ stepSlug.SUGGESTED_START ]: {
@@ -36,7 +23,9 @@ export const connectADomainStepsDefinition = {
 	[ stepSlug.SUGGESTED_LOGIN ]: {
 		mode: modeType.SUGGESTED,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: labels[ stepSlug.SUGGESTED_LOGIN ](),
+		get name() {
+			return __( 'Log in to provider' );
+		},
 		component: ConnectDomainStepLogin,
 		next: stepSlug.SUGGESTED_UPDATE,
 		prev: stepSlug.SUGGESTED_START,
@@ -44,7 +33,9 @@ export const connectADomainStepsDefinition = {
 	[ stepSlug.SUGGESTED_UPDATE ]: {
 		mode: modeType.SUGGESTED,
 		step: stepType.UPDATE_NAME_SERVERS,
-		name: labels[ stepSlug.SUGGESTED_UPDATE ](),
+		get name() {
+			return __( 'Update name servers' );
+		},
 		component: ConnectDomainStepSuggestedRecords,
 		prev: stepSlug.SUGGESTED_LOGIN,
 	},
@@ -72,7 +63,9 @@ export const connectADomainStepsDefinition = {
 	[ stepSlug.ADVANCED_LOGIN ]: {
 		mode: modeType.ADVANCED,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: labels[ stepSlug.ADVANCED_LOGIN ](),
+		get name() {
+			return __( 'Log in to provider' );
+		},
 		component: ConnectDomainStepLogin,
 		next: stepSlug.ADVANCED_UPDATE,
 		prev: stepSlug.ADVANCED_START,
@@ -80,7 +73,9 @@ export const connectADomainStepsDefinition = {
 	[ stepSlug.ADVANCED_UPDATE ]: {
 		mode: modeType.ADVANCED,
 		step: stepType.UPDATE_A_RECORDS,
-		name: labels[ stepSlug.ADVANCED_UPDATE ](),
+		get name() {
+			return __( 'Update root A records & CNAME record' );
+		},
 		component: ConnectDomainStepAdvancedRecords,
 		prev: stepSlug.ADVANCED_LOGIN,
 	},
@@ -107,14 +102,18 @@ export const connectADomainOwnershipVerificationStepsDefinition = {
 	[ stepSlug.OWNERSHIP_VERIFICATION_LOGIN ]: {
 		mode: modeType.OWNERSHIP_VERIFICATION,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: labels[ stepSlug.OWNERSHIP_VERIFICATION_LOGIN ](),
+		get name() {
+			return __( 'Log in to provider' );
+		},
 		component: ConnectDomainStepLogin,
 		next: stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE,
 	},
 	[ stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE ]: {
 		mode: modeType.OWNERSHIP_VERIFICATION,
 		step: stepType.ENTER_AUTH_CODE,
-		name: labels[ stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE ](),
+		get name() {
+			return __( 'Verify ownership' );
+		},
 		component: ConnectDomainStepOwnershipAuthCode,
 		prev: stepSlug.OWNERSHIP_VERIFICATION_LOGIN,
 	},
@@ -130,7 +129,9 @@ export const transferLockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_LOGIN ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: labels[ stepSlug.TRANSFER_LOGIN ](),
+		get name() {
+			return __( 'Log in to provider' );
+		},
 		component: TransferDomainStepLogin,
 		next: stepSlug.TRANSFER_UNLOCK,
 		prev: stepSlug.TRANSFER_START,
@@ -138,7 +139,9 @@ export const transferLockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_UNLOCK ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.UNLOCK_DOMAIN,
-		name: labels[ stepSlug.TRANSFER_UNLOCK ](),
+		get name() {
+			return __( 'Unlock domain' );
+		},
 		component: TransferDomainStepUnlock,
 		next: stepSlug.TRANSFER_AUTH_CODE,
 		prev: stepSlug.TRANSFER_LOGIN,
@@ -146,7 +149,9 @@ export const transferLockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_AUTH_CODE ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.ENTER_AUTH_CODE,
-		name: labels[ stepSlug.TRANSFER_AUTH_CODE ](),
+		get name() {
+			return __( 'Authorize the transfer' );
+		},
 		component: TransferDomainStepAuthCode,
 		next: 'unused transfer domain step',
 		prev: stepSlug.TRANSFER_UNLOCK,
@@ -154,7 +159,9 @@ export const transferLockedDomainStepsDefinition = {
 	[ 'unused transfer domain step' ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.FINALIZE,
-		name: labels[ 'unused transfer domain step' ](),
+		get name() {
+			return __( 'Finalize transfer' );
+		},
 	},
 };
 
@@ -168,7 +175,9 @@ export const transferUnlockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_LOGIN ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.LOG_IN_TO_PROVIDER,
-		name: labels[ stepSlug.TRANSFER_LOGIN ](),
+		get name() {
+			return __( 'Log in to provider' );
+		},
 		component: TransferDomainStepLogin,
 		next: stepSlug.TRANSFER_AUTH_CODE,
 		prev: stepSlug.TRANSFER_START,
@@ -176,7 +185,9 @@ export const transferUnlockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_AUTH_CODE ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.ENTER_AUTH_CODE,
-		name: labels[ stepSlug.TRANSFER_AUTH_CODE ](),
+		get name() {
+			return __( 'Authorize the transfer' );
+		},
 		component: TransferDomainStepAuthCode,
 		next: 'unused transfer domain step',
 		prev: stepSlug.TRANSFER_LOGIN,
@@ -184,7 +195,9 @@ export const transferUnlockedDomainStepsDefinition = {
 	[ 'unused transfer domain step' ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.FINALIZE,
-		name: labels[ 'unused transfer domain step' ](),
+		get name() {
+			return __( 'Finalize transfer' );
+		},
 	},
 };
 
@@ -221,25 +234,3 @@ export const getProgressStepList = ( mode, stepsDefinition ) => {
 
 	return Object.fromEntries( stepList );
 };
-
-/**
- * Define properties with translatable strings getters.
- */
-[
-	connectADomainStepsDefinition,
-	connectADomainOwnershipVerificationStepsDefinition,
-	transferLockedDomainStepsDefinition,
-	transferUnlockedDomainStepsDefinition,
-].forEach( ( definition ) => {
-	Object.keys( definition ).forEach( ( slug ) => {
-		if ( labels.hasOwnProperty( slug ) ) {
-			const translationGetter = labels[ slug ];
-
-			Object.defineProperties( definition[ slug ], {
-				name: {
-					get: () => translationGetter(),
-				},
-			} );
-		}
-	} );
-} );

--- a/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { transferDomainAction } from 'calypso/components/domains/use-my-domain/utilities';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { authCodeStepDefaultDescription, stepsHeadingTransfer } from './constants';
+import { authCodeStepDefaultDescription, stepsHeading } from './constants';
 import DomainStepAuthCode from './domain-step-auth-code';
 
 import './style.scss';
@@ -30,7 +30,7 @@ const TransferDomainStepAuthCode = ( {
 		<DomainStepAuthCode
 			{ ...props }
 			buttonMessage={ __( 'Check readiness for transfer' ) }
-			customHeading={ stepsHeadingTransfer }
+			customHeading={ stepsHeading.TRANSFER }
 			authCodeDescription={ authCodeDescription }
 			className={ className }
 			domain={ domain }

--- a/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
@@ -24,7 +24,7 @@ const TransferDomainStepAuthCode = ( {
 		[ domain ]
 	);
 	const authCodeDescription = (
-		<p className={ 'connect-domain-step__text' }>{ authCodeStepDefaultDescription }</p>
+		<p className={ 'connect-domain-step__text' }>{ authCodeStepDefaultDescription.label }</p>
 	);
 	return (
 		<DomainStepAuthCode

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -6,7 +6,7 @@ import page from 'page';
 import { useEffect, useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
-import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
+import { stepsHeading } from 'calypso/components/domains/connect-domain-step/constants';
 import {
 	getAvailabilityErrorMessage,
 	getDomainInboundTransferStatusInfo,
@@ -140,7 +140,7 @@ function TransferDomainStepStart( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
-			heading={ stepsHeadingTransfer }
+			heading={ stepsHeading.TRANSFER }
 			progressStepList={ progressStepList }
 			pageSlug={ pageSlug }
 			stepContent={ stepContent }

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import ConnectDomainStepWrapper from 'calypso/components/domains/connect-domain-step/connect-domain-step-wrapper';
 import {
-	stepsHeadingTransfer,
+	stepsHeading,
 	domainLockStatusType,
 } from 'calypso/components/domains/connect-domain-step/constants';
 import MaterialIcon from 'calypso/components/material-icon';
@@ -93,7 +93,7 @@ const TransferDomainStepUnlock = ( {
 
 	return (
 		<ConnectDomainStepWrapper
-			heading={ stepsHeadingTransfer }
+			heading={ stepsHeading.TRANSFER }
 			className={ className }
 			stepContent={ stepContent }
 			{ ...props }

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -38,6 +38,7 @@ function UseMyDomain( {
 	transferDomainUrl,
 	initialMode,
 } ) {
+	const { __ } = useI18n();
 	const [ domainAvailabilityData, setDomainAvailabilityData ] = useState( null );
 	const [ domainInboundTransferStatusInfo, setDomainInboundTransferStatusInfo ] = useState( null );
 	const [ domainName, setDomainName ] = useState( initialQuery ?? '' );
@@ -305,7 +306,7 @@ function UseMyDomain( {
 				/* translators: %s - the name of the domain the user will add to their site */
 				return sprintf( __( 'Use a domain I own: %s' ), domainName );
 		}
-	}, [ domainName, mode, inputMode, __ ] );
+	}, [ domainName, mode, __ ] );
 
 	return (
 		<>

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -1,6 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { BackButton } from '@automattic/onboarding';
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import { connect } from 'react-redux';
@@ -304,7 +305,7 @@ function UseMyDomain( {
 				/* translators: %s - the name of the domain the user will add to their site */
 				return sprintf( __( 'Use a domain I own: %s' ), domainName );
 		}
-	}, [ domainName, mode, inputMode ] );
+	}, [ domainName, mode, inputMode, __ ] );
 
 	return (
 		<>

--- a/client/components/domains/use-my-domain/utilities/option-info.js
+++ b/client/components/domains/use-my-domain/utilities/option-info.js
@@ -4,41 +4,65 @@ import connectIllustration from 'calypso/assets/images/illustrations/domain-conn
 import { INCOMING_DOMAIN_TRANSFER, MAP_EXISTING_DOMAIN } from 'calypso/lib/url/support';
 
 const optionTitleText = {
-	transfer: __( 'Transfer your domain' ),
-	connect: __( 'Connect your domain' ),
+	get transfer() {
+		return __( 'Transfer your domain' );
+	},
+	get connect() {
+		return __( 'Connect your domain' );
+	},
 };
 
 const transferSupported = {
 	illustration: transferIllustration,
-	titleText: optionTitleText.transfer,
-	topText: __( 'Manage your domain directly on WordPress.com' ),
+	get titleText() {
+		return optionTitleText.transfer;
+	},
+	get topText() {
+		return __( 'Manage your domain directly on WordPress.com' );
+	},
 	learnMoreLink: INCOMING_DOMAIN_TRANSFER,
-	benefits: [
-		__( "We'll renew your domain for another year" ),
-		__( 'Manage everything you need in one place' ),
-		__( 'Private domain registration and SSL certificate included for free' ),
-	],
+	get benefits() {
+		return [
+			__( "We'll renew your domain for another year" ),
+			__( 'Manage everything you need in one place' ),
+			__( 'Private domain registration and SSL certificate included for free' ),
+		];
+	},
 };
 
 const transferNotSupported = {
 	illustration: transferIllustration,
-	titleText: optionTitleText.transfer,
-	topText: __( 'This domain cannot be transfered.' ),
+	get titleText() {
+		return optionTitleText.transfer;
+	},
+	get topText() {
+		return __( 'This domain cannot be transfered.' );
+	},
 	learnMoreLink: INCOMING_DOMAIN_TRANSFER,
 };
 
 const connectSupported = {
 	illustration: connectIllustration,
-	titleText: optionTitleText.connect,
-	topText: __( 'Keep your domain with your current provider and point it to WordPress.com' ),
+	get titleText() {
+		return optionTitleText.connect;
+	},
+	get topText() {
+		return __( 'Keep your domain with your current provider and point it to WordPress.com' );
+	},
 	learnMoreLink: MAP_EXISTING_DOMAIN,
-	benefits: [ __( 'Keep your current provider' ), __( 'SSL certificate included for free' ) ],
+	get benefits() {
+		return [ __( 'Keep your current provider' ), __( 'SSL certificate included for free' ) ];
+	},
 };
 
 const connectNotSupported = {
 	illustration: connectIllustration,
-	titleText: optionTitleText.connect,
-	topText: __( 'This domain cannot be connected.' ),
+	get titleText() {
+		return optionTitleText.connect;
+	},
+	get topText() {
+		return __( 'This domain cannot be connected.' );
+	},
 	learnMoreLink: MAP_EXISTING_DOMAIN,
 };
 export const optionInfo = {
@@ -47,57 +71,3 @@ export const optionInfo = {
 	connectSupported,
 	connectNotSupported,
 };
-
-/**
- * Define properties with translatable strings getters.
- */
-Object.defineProperties( optionTitleText, {
-	transfer: {
-		get: () => __( 'Transfer your domain' ),
-	},
-	connect: {
-		get: () => __( 'Connect your domain' ),
-	},
-} );
-Object.defineProperties( transferSupported, {
-	topText: {
-		get: () => __( 'Manage your domain directly on WordPress.com' ),
-	},
-	benefits: {
-		get: () => [
-			__( "We'll renew your domain for another year" ),
-			__( 'Manage everything you need in one place' ),
-			__( 'Private domain registration and SSL certificate included for free' ),
-		],
-	},
-	titleText: {
-		get: () => optionTitleText.transfer,
-	},
-} );
-Object.defineProperties( transferNotSupported, {
-	topText: {
-		get: () => __( 'This domain cannot be transfered.' ),
-	},
-	titleText: {
-		get: () => optionTitleText.transfer,
-	},
-} );
-Object.defineProperties( connectSupported, {
-	topText: {
-		get: () => __( 'Keep your domain with your current provider and point it to WordPress.com' ),
-	},
-	benefits: {
-		get: () => [ __( 'Keep your current provider' ), __( 'SSL certificate included for free' ) ],
-	},
-	titleText: {
-		get: () => optionTitleText.connect,
-	},
-} );
-Object.defineProperties( connectNotSupported, {
-	topText: {
-		get: () => __( 'This domain cannot be connected.' ),
-	},
-	titleText: {
-		get: () => optionTitleText.connect,
-	},
-} );

--- a/client/components/domains/use-my-domain/utilities/option-info.js
+++ b/client/components/domains/use-my-domain/utilities/option-info.js
@@ -8,35 +8,96 @@ const optionTitleText = {
 	connect: __( 'Connect your domain' ),
 };
 
+const transferSupported = {
+	illustration: transferIllustration,
+	titleText: optionTitleText.transfer,
+	topText: __( 'Manage your domain directly on WordPress.com' ),
+	learnMoreLink: INCOMING_DOMAIN_TRANSFER,
+	benefits: [
+		__( "We'll renew your domain for another year" ),
+		__( 'Manage everything you need in one place' ),
+		__( 'Private domain registration and SSL certificate included for free' ),
+	],
+};
+
+const transferNotSupported = {
+	illustration: transferIllustration,
+	titleText: optionTitleText.transfer,
+	topText: __( 'This domain cannot be transfered.' ),
+	learnMoreLink: INCOMING_DOMAIN_TRANSFER,
+};
+
+const connectSupported = {
+	illustration: connectIllustration,
+	titleText: optionTitleText.connect,
+	topText: __( 'Keep your domain with your current provider and point it to WordPress.com' ),
+	learnMoreLink: MAP_EXISTING_DOMAIN,
+	benefits: [ __( 'Keep your current provider' ), __( 'SSL certificate included for free' ) ],
+};
+
+const connectNotSupported = {
+	illustration: connectIllustration,
+	titleText: optionTitleText.connect,
+	topText: __( 'This domain cannot be connected.' ),
+	learnMoreLink: MAP_EXISTING_DOMAIN,
+};
 export const optionInfo = {
-	transferSupported: {
-		illustration: transferIllustration,
-		titleText: optionTitleText.transfer,
-		topText: __( 'Manage your domain directly on WordPress.com' ),
-		learnMoreLink: INCOMING_DOMAIN_TRANSFER,
-		benefits: [
+	transferSupported,
+	transferNotSupported,
+	connectSupported,
+	connectNotSupported,
+};
+
+/**
+ * Define properties with translatable strings getters.
+ */
+Object.defineProperties( optionTitleText, {
+	transfer: {
+		get: () => __( 'Transfer your domain' ),
+	},
+	connect: {
+		get: () => __( 'Connect your domain' ),
+	},
+} );
+Object.defineProperties( transferSupported, {
+	topText: {
+		get: () => __( 'Manage your domain directly on WordPress.com' ),
+	},
+	benefits: {
+		get: () => [
 			__( "We'll renew your domain for another year" ),
 			__( 'Manage everything you need in one place' ),
 			__( 'Private domain registration and SSL certificate included for free' ),
 		],
 	},
-	transferNotSupported: {
-		illustration: transferIllustration,
-		titleText: optionTitleText.transfer,
-		topText: __( 'This domain cannot be transfered.' ),
-		learnMoreLink: INCOMING_DOMAIN_TRANSFER,
+	titleText: {
+		get: () => optionTitleText.transfer,
 	},
-	connectSupported: {
-		illustration: connectIllustration,
-		titleText: optionTitleText.connect,
-		topText: __( 'Keep your domain with your current provider and point it to WordPress.com' ),
-		learnMoreLink: MAP_EXISTING_DOMAIN,
-		benefits: [ __( 'Keep your current provider' ), __( 'SSL certificate included for free' ) ],
+} );
+Object.defineProperties( transferNotSupported, {
+	topText: {
+		get: () => __( 'This domain cannot be transfered.' ),
 	},
-	connectNotSupported: {
-		illustration: connectIllustration,
-		titleText: optionTitleText.connect,
-		topText: __( 'This domain cannot be connected.' ),
-		learnMoreLink: MAP_EXISTING_DOMAIN,
+	titleText: {
+		get: () => optionTitleText.transfer,
 	},
-};
+} );
+Object.defineProperties( connectSupported, {
+	topText: {
+		get: () => __( 'Keep your domain with your current provider and point it to WordPress.com' ),
+	},
+	benefits: {
+		get: () => [ __( 'Keep your current provider' ), __( 'SSL certificate included for free' ) ],
+	},
+	titleText: {
+		get: () => optionTitleText.connect,
+	},
+} );
+Object.defineProperties( connectNotSupported, {
+	topText: {
+		get: () => __( 'This domain cannot be connected.' ),
+	},
+	titleText: {
+		get: () => optionTitleText.connect,
+	},
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds dynamic getters to the translated properties of `optionInfo` objects so that `__` is called every time they are accessed, to make sure the text is refreshed when translations are loaded.

#### Testing instructions
1. Change your user language to a non-English language.
1. Go to https://wordpress.com/domains/add/use-my-domain/{site-URL}
1. Enter a test domain name, such as example.com.
1. Make sure the mapping options are translated:
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/23708351/137494796-a0d5017a-66e5-4c32-8119-b35557c19d89.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #325-gh-Automattic/i18n-issues
