### PR TITLE
Desktop: Downgrade node to 16.10.0 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ jobs:
 
   wp-desktop-linux:
     docker:
-      - image: circleci/node:16.11.1-browsers
+      - image: circleci/node:16.10.0-browsers
     <<: *desktop_defaults
     shell: /bin/bash --login
     environment:


### PR DESCRIPTION
Looks like docker image `circleci/node:16.11.1-browsers` is not published yet, and this is breaking wp-desktop-linux tests in `trunk`.

This PR downgrades it to the latest published image, circleci/node:16.11.1-browsers