### PR TITLE
Onboarding: Change beta enrollment selector name

### DIFF
--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -14,7 +14,7 @@ export default function useSteps(): Array< StepType > {
 			return {
 				hasSiteTitle: onboardSelect.hasSiteTitle(),
 				hasSelectedDesignWithoutFonts: onboardSelect.hasSelectedDesignWithoutFonts(),
-				isEnrollingInFse: onboardSelect.shouldEnrollInFseBeta(),
+				isEnrollingInFse: onboardSelect.isEnrollingInFseBeta(),
 			};
 		},
 		[ ONBOARD_STORE ]

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -32,7 +32,7 @@ const Designs: React.FunctionComponent = () => {
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	const selectedDesign = getSelectedDesign();
-	const isEnrollingInFseBeta = isEnrollingInFseBeta();
+	const isFse = isEnrollingInFseBeta();
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: selectedDesign?.slug,
@@ -55,11 +55,11 @@ const Designs: React.FunctionComponent = () => {
 		// Make sure we're using the right designs since we can't rely on config variables
 		// any more and `getRandomizedDesigns` is auto-populated in a state-agnostic way.
 		const availableDesigns = getAvailableDesigns( {
-			useFseDesigns: isEnrollingInFseBeta,
+			useFseDesigns: isFse,
 			randomize: true,
 		} );
 		setRandomizedDesigns( availableDesigns );
-	}, [ isEnrollingInFseBeta, setRandomizedDesigns ] );
+	}, [ isFse, setRandomizedDesigns ] );
 
 	return (
 		<div className="gutenboarding-page designs">

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -27,12 +27,12 @@ const Designs: React.FunctionComponent = () => {
 		getSelectedDesign,
 		hasPaidDesign,
 		getRandomizedDesigns,
-		shouldEnrollInFseBeta,
+		isEnrollingInFseBeta,
 	} = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	const selectedDesign = getSelectedDesign();
-	const isEnrollingInFseBeta = shouldEnrollInFseBeta();
+	const isEnrollingInFseBeta = isEnrollingInFseBeta();
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: selectedDesign?.slug,

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -49,7 +49,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				hasSelectedDesign: onboardSelect.hasSelectedDesign(),
 				hasSelectedDesignWithoutFonts: onboardSelect.hasSelectedDesignWithoutFonts(),
 				isRedirecting: onboardSelect.getIsRedirecting(),
-				isEnrollingInFse: onboardSelect.shouldEnrollInFseBeta(),
+				isEnrollingInFse: onboardSelect.isEnrollingInFseBeta(),
 			};
 		},
 		[ STORE_KEY ]

--- a/client/landing/gutenboarding/onboarding-block/fse-beta-opt-in/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/fse-beta-opt-in/index.tsx
@@ -21,7 +21,7 @@ const FseBetaOptIn: FunctionComponent = () => {
 	const { __ } = useI18n();
 	const { goNext, goBack } = useStepNavigation();
 	const { enrollInFseBeta } = useDispatch( ONBOARD_STORE );
-	const { shouldEnrollInFseBeta } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { isEnrollingInFseBeta } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const pickBeta = ( shouldEnroll: boolean ) => {
 		enrollInFseBeta( shouldEnroll );
 		trackEventWithFlow( 'calypso_fse_beta_opt_in', {
@@ -31,7 +31,7 @@ const FseBetaOptIn: FunctionComponent = () => {
 	};
 
 	useTrackStep( 'FseBetaOptIn', () => ( {
-		selected_fse_beta_opt_in: shouldEnrollInFseBeta(),
+		selected_fse_beta_opt_in: isEnrollingInFseBeta(),
 	} ) );
 
 	return (

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -54,7 +54,7 @@ export function* createSite( {
 		siteTitle,
 		siteVertical,
 		selectedFeatures,
-		shouldEnrollInFseBeta,
+		isEnrollingInFseBeta,
 	}: State = yield select( ONBOARD_STORE, 'getState' );
 
 	const siteUrl = domain?.domain_name || siteTitle || username;
@@ -79,7 +79,7 @@ export function* createSite( {
 			},
 			lang_id: lang_id,
 			site_creation_flow: 'gutenboarding',
-			enable_fse: shouldEnrollInFseBeta,
+			enable_fse: isEnrollingInFseBeta,
 			theme: `pub/${ selectedDesign?.theme || defaultTheme }`,
 			timezone_string: guessTimezone(),
 			...( selectedDesign?.template && { template: selectedDesign.template } ),

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -33,7 +33,7 @@ registerStore< State >( STORE_KEY, {
 		'siteTitle',
 		'siteVertical',
 		'wasVerticalSkipped',
-		'shouldEnrollInFseBeta',
+		'isEnrollingInFseBeta',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -229,7 +229,7 @@ const lastLocation: Reducer< string, OnboardAction > = ( state = '', action ) =>
 	return state;
 };
 
-const shouldEnrollInFseBeta: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+const isEnrollingInFseBeta: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
 	if ( action.type === 'SET_ENROLL_IN_FSE_BETA' ) {
 		return action.enrollInFseBeta;
 	}
@@ -256,7 +256,7 @@ const reducer = combineReducers( {
 	randomizedDesigns,
 	hasOnboardingStarted,
 	lastLocation,
-	shouldEnrollInFseBeta,
+	isEnrollingInFseBeta,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -39,4 +39,4 @@ export const hasSelectedDesign = ( state: State ) => !! state.selectedDesign;
 export const hasSelectedDesignWithoutFonts = ( state: State ) =>
 	hasSelectedDesign( state ) && ! state.selectedFonts;
 
-export const shouldEnrollInFseBeta = ( state: State ): boolean => state.shouldEnrollInFseBeta;
+export const isEnrollingInFseBeta = ( state: State ): boolean => state.isEnrollingInFseBeta;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `shouldEnrollInFseBeta` → `isEnrollingInFseBeta`

#### Testing instructions

Go to `/new` - ensure that beta enrollment still works properly, both enrolling and not.

Followup from [@copons' comment](https://github.com/Automattic/wp-calypso/pull/56969#discussion_r728133028) in #56969
