### PR TITLE
ETK - Fixes lint error in universal-themes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -200,7 +200,7 @@ function hide_fse_blocks( $editor_settings ) {
 /**
  * Filter for `block_editor_settings_all` in order to prevent template
  * editing from showing up in the post editor when FSE is inactive.
- *∂
+ *
  * @param [array] $editor_settings Editor settings.
  * @return array Possibly modified editor settings.
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a minor lint error accidentally introduced in https://github.com/Automattic/wp-calypso/pull/57025 preventing ETK plugin from building.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
