### PR TITLE
Themes Showcase: Remove unused isSiteEditorActive prop

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -20,7 +20,6 @@ import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	getActiveTheme,
@@ -117,7 +116,6 @@ class ThemeShowcase extends Component {
 		trackMoreThemesClick: PropTypes.func,
 		loggedOutComponent: PropTypes.bool,
 		isJetpackSite: PropTypes.bool,
-		isSiteEditorActive: PropTypes.bool,
 		blockEditorSettings: PropTypes.shape( {
 			is_fse_eligible: PropTypes.bool,
 		} ),
@@ -438,7 +436,6 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 		filterString: prependThemeFilterKeys( state, filter ),
 		filterToTermTable: getThemeFilterToTermTable( state ),
 		themesBookmark: getThemesBookmark( state ),
-		isSiteEditorActive: isSiteUsingCoreSiteEditor( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
#### Description

There are no remaining `isSiteEditorActive` prop references in the themes view. This PR removes its associated selector and PropTypes validation.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a full site editing enabled site
* Navigate to Appearance > Themes
* Verify that the Full Site Editing Tab appears
* Remove the `fse-eligible` blog sticker from the site
* Verify that the Full Site Editing Tab disappears
* Smoke test general behavior of the themes view

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
