### PR TITLE
Fix: Mobile Plans - show popular plan first

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -319,13 +319,23 @@ export class PlanFeatures extends Component {
 
 		// move any free plan to last place in mobile view
 		let freePlanProperties;
+		let popularPlanProperties;
 		const reorderedPlans = planProperties.filter( ( properties ) => {
 			if ( isFreePlan( properties.planName ) ) {
 				freePlanProperties = properties;
 				return false;
 			}
+			// remove the popular plan.
+			if ( properties.popular && ! popularPlanProperties ) {
+				popularPlanProperties = properties;
+				return false;
+			}
 			return true;
 		} );
+
+		if ( popularPlanProperties ) {
+			reorderedPlans.unshift( popularPlanProperties );
+		}
 
 		if ( freePlanProperties ) {
 			reorderedPlans.push( freePlanProperties );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -319,6 +319,8 @@ export class PlanFeatures extends Component {
 
 		// move any free plan to last place in mobile view
 		let freePlanProperties;
+
+		// move any popular plan to the first place in the mobile view.
 		let popularPlanProperties;
 		const reorderedPlans = planProperties.filter( ( properties ) => {
 			if ( isFreePlan( properties.planName ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Move the popular plan to the top! 

#### Testing instructions

* Visit `/start/plans?intervalType=monthly` page to see the plans. 
* Does everything still work as expected? 
* Do you see the Popular plan at the top.

Screenshots:
<table>
<tr><td>Before</td><td>After</td></tr>
<tr><td>

![Screenshot 2021-10-15 at 10-52-00 Create a site — WordPress com](https://user-images.githubusercontent.com/115071/137532544-b23c83fc-47ca-441b-bdc8-543530fc05de.png)

</td><td>

![Screenshot 2021-10-15 at 10-51-26 Create a site — WordPress com](https://user-images.githubusercontent.com/115071/137532710-ae9d02ba-2320-4364-8a4c-cb8a5662de52.png)

</td></tr>
</table>

Related to https://github.com/Automattic/wp-calypso/issues/57069
