### PR TITLE
Fix: Sign up background - social buttons

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -510,7 +510,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			padding-bottom: 0;
 			border: 0;
 			box-shadow: none;
-			background-color: #fdfdfd;
+			background-color: transparent;
 
 			@include break-small {
 				text-align: center;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -510,6 +510,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			padding-bottom: 0;
 			border: 0;
 			box-shadow: none;
+			background-color: #fdfdfd;
 
 			@include break-small {
 				text-align: center;
@@ -686,7 +687,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			}
 
 			.signup-form__separator-text {
-				background: var( --studio-white );
+				background-color: #fdfdfd;
 				text-transform: uppercase;
 				text-align: center;
 				padding: 24px 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Minor fix to the background colour in the user sign up flow.

#### Testing instructions

* Visit /start/user
* Notice that the background colour is what you would expect.

Before:

<img width="376" alt="Screen Shot 2021-10-15 at 12 41 41 PM" src="https://user-images.githubusercontent.com/115071/137550988-0643c070-03dd-45c2-8514-485bbf3856a4.png">


After:

<img src="https://user-images.githubusercontent.com/115071/137550976-959b904e-874e-40a7-9532-8720c852dbde.png" width="300" />


Related to https://github.com/Automattic/wp-calypso/issues/57075
