### PR TITLE
EditUserForm: Add key to RoleSelect

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -181,6 +181,7 @@ class EditUserForm extends Component {
 			case fieldKeys.roles:
 				returnField = (
 					<RoleSelect
+						key="role-select"
 						id={ fieldKeys.roles }
 						name={ fieldKeys.roles }
 						siteId={ this.props.siteId }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a `key` to roleSelect to stop an error on the edit user page (`/people/team/<url>` -> then click a person to edit them)

#### Testing instructions

* Visit the edit user page (`/people/team/<url>` -> then click a person to edit them)
* It should work the same as before with one fewer error in the JS console in dev mode