### PR TITLE
Checkout: Record several analytics events directly rather than using indirection

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -518,7 +518,6 @@ export default function CompositeCheckout( {
 	}
 
 	useRecordCheckoutLoaded( {
-		recordEvent,
 		isLoading,
 		isApplePayAvailable,
 		responseCart,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -23,6 +23,7 @@ import QueryPlans from 'calypso/components/data/query-plans';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import wp from 'calypso/lib/wp';
@@ -222,7 +223,6 @@ export default function CompositeCheckout( {
 	} );
 
 	useRecordCartLoaded( {
-		recordEvent,
 		responseCart,
 		productsForCart,
 		isInitialCartLoading,
@@ -409,13 +409,10 @@ export default function CompositeCheckout( {
 	const addItemWithEssentialProperties = useCallback(
 		( cartItem ) => {
 			const adjustedItem = fillInSingleCartItemAttributes( cartItem, products );
-			recordEvent( {
-				type: 'CART_ADD_ITEM',
-				payload: adjustedItem,
-			} );
+			recordAddEvent( adjustedItem );
 			addProductsToCart( [ adjustedItem ] );
 		},
-		[ addProductsToCart, products, recordEvent ]
+		[ addProductsToCart, products ]
 	);
 
 	const includeDomainDetails = contactDetailsType === 'domain';

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -25,18 +25,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'CHECKOUT_LOADED':
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_page_view', {
-							saved_cards: action.payload?.saved_cards,
-							is_renewal: action.payload?.is_renewal,
-							apple_pay_available: action.payload?.apple_pay_available,
-							product_slug: action.payload?.product_slug,
-							is_composite: true,
-							checkout_flow: action.payload?.checkout_flow,
-						} )
-					);
-					return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
 				case 'CART_INIT_COMPLETE':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_cart_loaded', {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -13,6 +13,13 @@ import {
 
 const debug = debugFactory( 'calypso:composite-checkout:record-analytics' );
 
+/**
+ * NOTE: This file should not be necessary and should slowly be reduced to
+ * nothing. Please try not to add anything new here.
+ *
+ * If you need to record an event, record it directly rather than sending an
+ * action to this handler.
+ */
 export default function createAnalyticsEventHandler( reduxDispatch ) {
 	return function recordEvent( action ) {
 		try {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import {
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	translateCheckoutPaymentMethodToTracksPaymentMethod,
@@ -25,14 +24,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'CART_INIT_COMPLETE':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_cart_loaded', {
-							products: action.payload.products
-								.map( ( product ) => product.product_slug )
-								.join( ',' ),
-						} )
-					);
 				case 'STEP_LOAD_ERROR':
 					reduxDispatch(
 						logStashLoadErrorEventAction( 'step_load', String( action.payload.message ), {
@@ -299,9 +290,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_summary_help_click' )
 					);
-				}
-				case 'CART_ADD_ITEM': {
-					return recordAddEvent( action.payload );
 				}
 				case 'CART_CHANGE_PLAN_LENGTH': {
 					return reduxDispatch(

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -25,17 +25,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'PRODUCTS_ADD_ERROR':
-					reduxDispatch(
-						logStashEventAction( 'calypso_composite_checkout_products_load_error', {
-							error_message: String( action.payload ),
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_products_load_error', {
-							error_message: String( action.payload ),
-						} )
-					);
 				case 'CHECKOUT_LOADED':
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_page_view', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the composite-checkout npm package was first introduced, it was originally designed as a less customizable system and so it seemed necessary for it to have a generic event emitter that consumer code could hook into. This ended up becoming the `onEvent` prop. However, it was only ever used for analytics and it was also mostly used outside of the package, where it's fairly easy to record analytics directly. Furthermore, it's something of a leaky abstraction and its original purpose would be better served by event-specific callbacks or customized components.

This PR begins dismantling it by removing a handful of checkout events and recording their analytics directly when they occur.

Related to https://github.com/Automattic/wp-calypso/pull/48282

#### Testing instructions

Verify that the following Tracks events are still triggered:

- `calypso_checkout_composite_products_load_error`; to trigger this visit `/checkout/YOURSITEHERE/fake_product_name`.
- `calypso_checkout_composite_cart_loaded`; to trigger this just load checkout.
- `calypso_checkout_composite_loaded`; to trigger this just load checkout.
- `calypso_cart_product_add`; to trigger this visit `/checkout/YOURSITEHERE/personal`.