### PR TITLE
Help Center: Add help center modal

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -71,7 +71,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 			onRequestClose={ onClose }
 			title={ String( translate( 'Checkout modal' ) ) }
 			shouldCloseOnClickOutside={ false }
-			icon={ <Icon icon={ wordpress } size={ 36 } /> }
+			icon={ <Icon icon={ wordpress } size={ 29 } /> }
 		>
 			<CalypsoShoppingCartProvider>
 				<StripeHookProvider

--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -5,7 +5,22 @@
 .editor-checkout-modal {
 	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
 
+	.components-modal__header {
+		padding: 0 22px;
+
+		.components-modal__icon-container > svg {
+			vertical-align: middle;
+			fill: var( --color-text );
+		}
+
+		// hide border on desktop
+		@include break-medium {
+			border: none;
+		}
+	}
+
 	.components-modal__frame {
+		background: #fdfdfd;
 		top: auto;
 		right: auto;
 		bottom: auto;
@@ -17,12 +32,6 @@
 		transform: none;
 		width: 100%;
 		height: 100%;
-	}
-	.components-modal__header {
-		// hide border on desktop
-		@include break-medium {
-			border: none;
-		}
 	}
 
 	// @TODO: re-use onboarding-screen-reader-text()

--- a/client/blocks/help-center-modal/index.jsx
+++ b/client/blocks/help-center-modal/index.jsx
@@ -21,7 +21,7 @@ const HelpCentertModal = ( { isOpen } ) => {
 				onRequestClose={ onClose }
 				title={ String( translate( 'Help Center' ) ) }
 				shouldCloseOnClickOutside={ false }
-				icon={ <Icon icon={ wordpress } size={ 36 } /> }
+				icon={ <Icon icon={ wordpress } size={ 29 } /> }
 			>
 				<HelpComponent />
 			</Modal>

--- a/client/blocks/help-center-modal/index.jsx
+++ b/client/blocks/help-center-modal/index.jsx
@@ -1,0 +1,32 @@
+import { Modal } from '@wordpress/components';
+import { Icon, wordpress } from '@wordpress/icons';
+import { removeQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import HelpComponent from 'calypso/me/help/main';
+import './style.scss';
+
+const HelpCentertModal = ( { isOpen } ) => {
+	const translate = useTranslate();
+
+	const onClose = () =>
+		page.redirect(
+			removeQueryArgs( window.location.pathname + window.location.search, 'showHelpCenter' )
+		);
+
+	return (
+		isOpen && (
+			<Modal
+				overlayClassName="help-center-modal"
+				onRequestClose={ onClose }
+				title={ String( translate( 'Help Center' ) ) }
+				shouldCloseOnClickOutside={ false }
+				icon={ <Icon icon={ wordpress } size={ 36 } /> }
+			>
+				<HelpComponent />
+			</Modal>
+		)
+	);
+};
+
+export default HelpCentertModal;

--- a/client/blocks/help-center-modal/style.scss
+++ b/client/blocks/help-center-modal/style.scss
@@ -5,7 +5,17 @@
 .help-center-modal {
 	z-index: z-index( 'root', '#header.masterbar' );
 
+	.components-modal__header {
+		padding: 0 22px;
+
+		.components-modal__icon-container > svg {
+			vertical-align: middle;
+			fill: var( --color-text );
+		}
+	}
+
 	.components-modal__frame {
+		background: #fdfdfd;
 		top: auto;
 		right: auto;
 		bottom: auto;
@@ -17,12 +27,6 @@
 		transform: none;
 		width: 100%;
 		height: 100%;
-	}
-	.components-modal__header {
-		// hide border on desktop
-		@include break-medium {
-			border: none;
-		}
 	}
 
 	// @TODO: re-use onboarding-screen-reader-text()

--- a/client/blocks/help-center-modal/style.scss
+++ b/client/blocks/help-center-modal/style.scss
@@ -1,0 +1,41 @@
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.help-center-modal {
+	z-index: z-index( 'root', '#header.masterbar' );
+
+	.components-modal__frame {
+		top: auto;
+		right: auto;
+		bottom: auto;
+		left: auto;
+		min-width: auto;
+		min-height: auto;
+		max-height: none;
+		max-width: none;
+		transform: none;
+		width: 100%;
+		height: 100%;
+	}
+	.components-modal__header {
+		// hide border on desktop
+		@include break-medium {
+			border: none;
+		}
+	}
+
+	// @TODO: re-use onboarding-screen-reader-text()
+	// See https://github.com/Automattic/wp-calypso/pull/47601#discussion_r530570891
+	.components-modal__header-heading {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect( 0, 0, 0, 0 );
+		white-space: nowrap;
+		border-width: 0;
+	}
+}

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -1,8 +1,11 @@
+import config from '@automattic/calypso-config';
 import { Button, Popover, Gridicon } from '@automattic/components';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -48,11 +51,17 @@ class InlineHelpPopover extends Component {
 		onClose();
 	};
 
-	moreHelpClicked = () => {
+	moreHelpClicked = ( e ) => {
 		this.props.onClose();
 		this.props.recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
 			location: 'inline-help-popover',
 		} );
+		if ( config.isEnabled( 'help-center-modal' ) ) {
+			e.preventDefault();
+			page.redirect(
+				addQueryArgs( window.location.pathname + window.location.search, { showHelpCenter: 1 } )
+			);
+		}
 	};
 
 	openSecondaryView = ( secondaryViewKey ) => {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { getQueryArg } from '@wordpress/url';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { useEffect, Component } from 'react';
@@ -200,6 +201,10 @@ class Layout extends Component {
 		);
 	}
 
+	shouldShowHelpCenter() {
+		return !! getQueryArg( window.location.href, 'showHelpCenter' );
+	}
+
 	renderMasterbar() {
 		if ( this.props.masterbarIsHidden ) {
 			return <EmptyMasterbar />;
@@ -232,6 +237,7 @@ class Layout extends Component {
 			'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
 			'is-wccom-oauth-flow': isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom,
+			'is-modal-open': this.shouldShowHelpCenter(),
 		} );
 
 		const optionalBodyProps = () => {
@@ -335,7 +341,6 @@ class Layout extends Component {
 						} ) }
 					/>
 				) }
-
 				{ config.isEnabled( 'layout/support-article-dialog' ) && (
 					<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
 				) }
@@ -347,6 +352,13 @@ class Layout extends Component {
 				) }
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
+				) }
+				{ config.isEnabled( 'help-center-modal' ) && (
+					<AsyncLoad
+						require="calypso/blocks/help-center-modal"
+						isOpen={ this.shouldShowHelpCenter() }
+						placeholder={ null }
+					/>
 				) }
 			</div>
 		);

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -307,6 +307,12 @@
 	}
 }
 
+// Remove the vertical scroll when a full screen modal is open
+.layout.is-modal-open {
+	overflow: hidden;
+	height: 100%;
+}
+
 // Try to clean things up a bit when printing.
 .layout {
 	.masterbar,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Help Center behind a feature flag
* Use the content from `/help` page

#### Testing instructions

* Open the live link and add `?flags=help-center-modal` to the URL to enable the feature flag
* Open Help FAB and click on "More Help" button
* Explore the Help Center modal
  * Contact and upsell offers will redirect you to the correct page
  * Going back using the browser Back button will open the Help Center modal
  * All the links to support resources will open externally, similar as they do on `/help`

#### Demo

https://user-images.githubusercontent.com/14192054/138083916-f89decec-d061-4952-942c-634e8b7826be.mov