### PR TITLE
Theme: don't crash in site selection if theme not found

### DIFF
--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -7,7 +7,7 @@ import {
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import { createNavigation, selectSiteIfLoggedIn, siteSelection } from 'calypso/my-sites/controller';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { getTheme } from 'calypso/state/themes/selectors';
 import { details, fetchThemeDetailsData } from './controller';
 
 function redirectToLoginIfSiteRequested( context, next ) {
@@ -28,16 +28,16 @@ function addNavigationIfLoggedIn( context, next ) {
 }
 
 function setTitleAndSelectSiteIfLoggedIn( context, next ) {
-	const state = context.store.getState();
-	const theme = getCanonicalTheme( state, null, context.params.slug );
-	const themeName = theme.name;
+	const theme = getTheme( context.store.getState(), 'wpcom', context.params.slug );
+	if ( theme ) {
+		const themeName = theme.name;
 
-	context.getSiteSelectionHeaderText = () =>
-		translate( 'Select a site to view {{strong}}%(themeName)s{{/strong}}', {
-			args: { themeName },
-			components: { strong: <strong /> },
-		} );
-
+		context.getSiteSelectionHeaderText = () =>
+			translate( 'Select a site to view {{strong}}%(themeName)s{{/strong}}', {
+				args: { themeName },
+				components: { strong: <strong /> },
+			} );
+	}
 	selectSiteIfLoggedIn( context, next );
 }
 


### PR DESCRIPTION
Fixes a bug where going to a URL for a non-existent theme, `/theme/go-away`, will crash with a type error trying to access `theme.name`:
```
TypeError: can't access property "name", c.a(...) is null
```
The reason is that the `setTitleAndSelectSiteIfLoggedIn` handler cannot rely on the `theme` being available: at this place, it's available only if the SSR handler was able to fetch it (on server) and hand it over to client in the `window.initialReduxState` object. The client itself does any fetching only _after_ this handler is executed.

The theme will be `null` not only when it doesn't exist, but at also when it's a `wporg` theme or a theme installed only on a specific `siteId`. The `fetchThemeDetailsData` fetches only `wpcom` themes.

That's why I also updated the `getCanonicalTheme` selector call to a `getTheme( state, 'wpcom', themeId )`: that's exactly the selector that `fetchThemeDetailsData` calls, too, and the only theme state it fetches and sets.