### PR TITLE
Fix contractor select key

### DIFF
--- a/client/my-sites/people/contractor-select/index.tsx
+++ b/client/my-sites/people/contractor-select/index.tsx
@@ -6,7 +6,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import SupportInfo from 'calypso/components/support-info';
 
 interface Props {
-	key: string;
+	id: string;
 	checked: boolean;
 	onChange: ( event ) => void;
 	disabled: boolean;
@@ -14,11 +14,11 @@ interface Props {
 
 import './style.scss';
 
-const ContractorSelect: FunctionComponent< Props > = ( { key, checked, onChange, disabled } ) => {
+const ContractorSelect: FunctionComponent< Props > = ( { id, checked, onChange, disabled } ) => {
 	const translate = useTranslate();
 
 	return (
-		<FormFieldset key={ key } className="contractor-select">
+		<FormFieldset key={ id } className="contractor-select">
 			<FormLabel>
 				<FormCheckbox
 					className="contractor-select__checkbox"

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -194,7 +194,7 @@ class EditUserForm extends Component {
 			case fieldKeys.isExternalContributor:
 				returnField = (
 					<ContractorSelect
-						key={ fieldKeys.isExternalContributor }
+						id={ fieldKeys.isExternalContributor }
 						onChange={ this.handleExternalChange }
 						checked={ this.state.isExternalContributor }
 						disabled={ isDisabled }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `key` prop was returning the following error

```
Warning: ContractorSelect: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)
```

* switched to an `id` prop instead of `key` prop

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot calypso in **local environment**
* Try editing a User in `https://wordpress.com/people/team/:site`
* Make sure that the console doesn't display any error for the `ContractorSelect` component

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/53281#discussion_r730141800
