### PR TITLE
Jetpack pricing page: align navigation to the left

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -62,6 +62,7 @@
 }
 
 .jpcom-masterbar__logo {
+	margin-right: 1rem;
 	padding-top: 0.25em;
 
 	svg {
@@ -94,7 +95,7 @@
 	@include break-large {
 		display: flex;
 		flex-direction: row;
-		justify-content: flex-end;
+		justify-content: flex-start;
 
 		padding: 0;
 		margin: 0.5em 0;
@@ -121,7 +122,7 @@
 		border-radius: 0;
 		color: var( --studio-gray-60 );
 
-		font-size: 1.1rem;
+		font-size: 1.1rem; /* stylelint-disable scales/font-sizes */
 
 		transition: all 0.2s ease-in-out;
 
@@ -203,7 +204,7 @@
 		height: 3px;
 		background-color: black;
 
-		border-radius: 4px;
+		border-radius: 4px; /* stylelint-disable scales/radii */
 		position: absolute;
 		transition-property: transform;
 		transition-duration: 0.15s;
@@ -309,8 +310,8 @@
 				content: '';
 
 				position: absolute;
-				right: 22rem;
-				top: calc( 100% + 22px ); // nav bottom padding
+				left: 3rem;
+				top: calc( 100% + 12px ); // nav bottom padding
 
 				display: block;
 
@@ -351,8 +352,8 @@
 
 	@include break-large {
 		position: absolute;
-		top: calc( 100% - 2px );
-		right: 0;
+		top: calc( 100% - 12px );
+		left: 8px;
 
 		padding-top: 1.5rem;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Aligns the top navigation to the left on cloud.jetpack.com/pricing.
* Replicates the changes to the Jetpack.com theme in D68529-code.

#### Testing instructions

* Fire up this branch.
* Head to http://jetpack.cloud.localhost:3000/pricing
* Ensure the top navigation is fully accessible on all screen resolutions.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/137740052-0f1725bc-9628-4b9a-9248-b1f5a2d95c98.png)| ![image](https://user-images.githubusercontent.com/390760/137740060-af31dc0b-e84d-4f89-a936-88c04ac4ecc4.png)

