### PR TITLE
Remove post-checkout Quickstart upsell

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -29,7 +29,6 @@ import {
 	hasDIFMProduct,
 } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { badNaiveClientSideRollout } from 'calypso/lib/naive-client-side-rollout';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { getEligibleTitanDomain } from 'calypso/lib/titan';
 import { addQueryArgs, isExternal, resemblesUrl, urlToSlug } from 'calypso/lib/url';
@@ -454,9 +453,7 @@ function getRedirectUrlForPostCheckoutUpsell( {
 	}
 
 	if (
-		config.isEnabled( 'upsell/concierge-session' ) &&
 		cart &&
-		! hasConciergeSession( cart ) &&
 		! hasJetpackPlan( cart ) &&
 		! hasDIFMProduct( cart ) &&
 		( hasBloggerPlan( cart ) ||
@@ -476,44 +473,9 @@ function getRedirectUrlForPostCheckoutUpsell( {
 		if ( planUpgradeUpsellUrl ) {
 			return planUpgradeUpsellUrl;
 		}
-
-		const quickstartSessionUpsellUrl = getQuickstartSessionUpsellUrl( {
-			pendingOrReceiptId,
-			siteSlug,
-			orderId,
-		} );
-
-		if ( quickstartSessionUpsellUrl ) {
-			return quickstartSessionUpsellUrl;
-		}
 	}
 
 	return;
-}
-
-function getQuickstartSessionUpsellUrl( {
-	pendingOrReceiptId,
-	siteSlug,
-	orderId,
-}: {
-	pendingOrReceiptId: string;
-	siteSlug: string | undefined;
-	orderId: number | undefined;
-} ): string | undefined {
-	if ( orderId ) {
-		return;
-	}
-
-	// This is used when we need to quickly dial back the volume of concierge sessions
-	// being offered and sold, to be inline with HE availability.
-	// Change this percentage to change the amount of offers given out:
-	const percentConciergeOffers = 75;
-
-	if ( ! badNaiveClientSideRollout( 'conciergeUpsellDial', percentConciergeOffers ) ) {
-		return;
-	}
-
-	return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ siteSlug }`;
 }
 
 function getProfessionalEmailUpsellUrl( {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -721,7 +721,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
 
-	it( 'redirects to business upgrade nudge if concierge and jetpack are not in the cart, and premium is in the cart', () => {
+	it( 'redirects to business upgrade nudge if jetpack is not in the cart, and premium is in the cart', () => {
 		const cart = {
 			products: [
 				{
@@ -739,7 +739,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/1234abcd' );
 	} );
 
-	it( 'redirects to business monthly upgrade nudge if concierge and jetpack are not in the cart, and premium monthly is in the cart', () => {
+	it( 'redirects to business monthly upgrade nudge if jetpack is not in the cart, and premium monthly is in the cart', () => {
 		const cart = {
 			products: [
 				{
@@ -774,7 +774,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/pending/1234abcd' );
 	} );
 
-	it( 'redirects to the thank you page if concierge and jetpack are not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {
+	it( 'redirects to the thank you page if jetpack is not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {
 		const cart = {
 			products: [
 				{
@@ -791,7 +791,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
 
-	it( 'redirects to the thank you page if concierge and jetpack are not in the cart, personal is in the cart, and the previous route is not the nudge', () => {
+	it( 'redirects to the thank you page if jetpack is not in the cart, personal is in the cart, and the previous route is not the nudge', () => {
 		const cart = {
 			products: [
 				{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the logic that redirects users to the post-checkout upsell for Quick Start sessions as per p8hWIX-3FQ-p2
* The PR does not remove the ability to see the offer if you manually type the URL in, or prevent accessing the page from the browser history

#### Testing instructions

* Check this branch out locally
* Run the updated unit tests: `yarn run test-client client/my-sites/checkout/composite-checkout/`

* Either run this branch locally, or use the live branch
* Start from a site that doesn't have a plan
* Navigate to Upgrades -> Plans
* Select any plan other then the Premium plan (you can choose monthly or yearly billing)
* If you are running locally, add the following to the URL on the checkout page: `?flags=-upsell/professional-email` **Note:** ensure you add this _before_ any `#` symbol in the URL such as `#step2`; you can replace the trailing `#` fragment if needed.
* Check out
* Verify that you do not see the Quick Start upsell