### PR TITLE
Add new domain management styles for a redesign we're working on

### DIFF
--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -1,3 +1,34 @@
+@import '../../../customer-home/grid-mixins.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+
+.edit__container {
+	@include break-xlarge {
+		@include grid-row( 1, 1 );
+		@include grid-column( 1, 12 );
+		@include display-grid;
+		@include grid-template-columns( 12, 24px, 1fr );
+		grid-gap: 24px;
+		.edit__main {
+			@include grid-column( 1, 8 );
+		}
+		.edit__sidebar {
+			@include grid-column( 9, 4 );
+		}
+		.edit__fullwidth {
+			@include grid-column( 1, 12 );
+		}
+	}
+}
+
+body.edit__body-white {
+	background: var( --studio-white );
+	&.is-nav-unification .sidebar .sidebar__heading::after,
+	&.is-nav-unification .sidebar .sidebar__menu-link::after {
+		border-right-color: var( --studio-white );
+	}
+}
+
 .domain-details-card {
 	.flag {
 		font-size: $font-body-extra-small;


### PR DESCRIPTION
Instead of creating a separate component I decided that just defining the styles should be good enough. Though we can always create wrapper component if we believe it is needed.

#### Changes proposed in this Pull Request

* Add two column layout for the new domain management redesign
* Add styles for white background ( `edit__body-white` ). That way we can enable the white background only on the screens we want to (instead of the whole section as it is for the home section).
 
#### Testing instructions

* We'll need to set the correct styles for this to work. The classes we care are:
  * `edit__container` - this is grid container
  * `edit__main` - the first (wider) column
  * `edit__sidebar` - the sidebar column
  * `edit__fullwidth` - this is the class for full width column

You can try this with editing `client/my-sites/domains/domain-management/edit/index.jsx` and replacing the `render` method with:
```
	render() {
		const domain = this.props.domains && getSelectedDomain( this.props );
		return (
			<Main wideLayout className="edit__container">
				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
				<div className="edit__fullwidth">
					<Header onClick={ this.goToDomainManagement }>
						{ this.props.translate( '%(domainType)s Settings', {
							args: {
								domainType: this.getDomainTypeText( domain ),
							},
						} ) }
					</Header>
				</div>
				<div className="edit__main">col1</div>
				<div className="edit__sidebar">col2</div>
			</Main>
		);
	}
```
and also don't forget to add `import BodySectionCssClass from 'calypso/layout/body-section-css-class';` in the imports section.

You should see a 2 column layout that will reflow to a single column on a smaller monitors or in mobile - I'm using the same breakpoints as the home screen.

Also the page background and the navigation arrow should be white (siimlar to how the home screen looks) - this is due to the `<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />` which adds that class to the body

