### PR TITLE
Titan: Update post-checkout upsell for eCommerce plans and domains from cart

### DIFF
--- a/client/lib/gsuite/get-eligible-gsuite-domain.js
+++ b/client/lib/gsuite/get-eligible-gsuite-domain.js
@@ -3,7 +3,7 @@ import { canDomainAddGSuite } from './can-domain-add-gsuite';
 import { getGSuiteSupportedDomains } from './gsuite-supported-domain';
 
 /**
- * Retrieves the first domain that is eligible to G Suite in this order:
+ * Retrieves the first domain that is eligible for G Suite in this order:
  *
  *   - The domain from the site currently selected, if eligible
  *   - The primary domain of the site, if eligible

--- a/client/lib/gsuite/get-eligible-gsuite-domain.js
+++ b/client/lib/gsuite/get-eligible-gsuite-domain.js
@@ -9,7 +9,7 @@ import { getGSuiteSupportedDomains } from './gsuite-supported-domain';
  *   - The primary domain of the site, if eligible
  *   - The first non-primary domain eligible found
  *
- * @param {string} selectedDomainName - domain name for the site currently selected by the user
+ * @param {string} selectedDomainName - domain name of the site currently selected by the user
  * @param {Array} domains - list of domain objects
  * @returns {string} - the name of the first eligible domain found
  */

--- a/client/lib/titan/get-eligible-titan-domain.js
+++ b/client/lib/titan/get-eligible-titan-domain.js
@@ -1,5 +1,33 @@
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { hasPaidEmailWithUs } from 'calypso/lib/emails';
+import { isDomainEligibleForTitanFreeTrial } from 'calypso/lib/titan';
+
+/**
+ * Determines whether the specified domain is eligible for Titan.
+ *
+ * @param {object} domain - domain object
+ * @param {boolean} mustBeEligibleForFreeTrial - whether the domain should also be eligible for the 3-month free trial
+ * @returns {boolean} - true if the domain is eligible, false otherwise
+ */
+function isEligibleTitanDomain( domain, mustBeEligibleForFreeTrial ) {
+	if ( domain.expired || domain.isWpcomStagingDomain ) {
+		return false;
+	}
+
+	if ( hasPaidEmailWithUs( domain ) ) {
+		return false;
+	}
+
+	if ( ! canCurrentUserAddEmail( domain ) ) {
+		return false;
+	}
+
+	if ( mustBeEligibleForFreeTrial ) {
+		return isDomainEligibleForTitanFreeTrial( domain );
+	}
+
+	return true;
+}
 
 /**
  * Retrieves the first domain that is eligible for Titan in this order:
@@ -8,28 +36,19 @@ import { hasPaidEmailWithUs } from 'calypso/lib/emails';
  *   - The primary domain of the site, if eligible
  *   - The first non-primary domain eligible found
  *
- * Note this method doesn't check if a domain is eligible for the 3-month free trial.
- *
- * @param {string} selectedDomainName - domain name for the site currently selected by the user
+ * @param {string} selectedDomainName - domain name of the site currently selected by the user
  * @param {Array} domains - list of domain objects
+ * @param {boolean} mustBeEligibleForFreeTrial - whether the domain should also be eligible for the 3-month free trial
  * @returns {?object} - the first eligible domain found, null otherwise
  */
-export function getEligibleTitanDomain( selectedDomainName, domains ) {
+export function getEligibleTitanDomain( selectedDomainName, domains, mustBeEligibleForFreeTrial ) {
 	if ( ! domains ) {
 		return null;
 	}
 
-	const eligibleDomains = domains.filter( ( domain ) => {
-		if ( domain.expired || domain.isWpcomStagingDomain ) {
-			return false;
-		}
-
-		if ( hasPaidEmailWithUs( domain ) ) {
-			return false;
-		}
-
-		return canCurrentUserAddEmail( domain );
-	} );
+	const eligibleDomains = domains.filter( ( domain ) =>
+		isEligibleTitanDomain( domain, mustBeEligibleForFreeTrial )
+	);
 
 	if ( eligibleDomains.length === 0 ) {
 		return null;

--- a/client/lib/titan/get-eligible-titan-domain.js
+++ b/client/lib/titan/get-eligible-titan-domain.js
@@ -34,7 +34,7 @@ function isEligibleTitanDomain( domain, mustBeEligibleForFreeTrial ) {
  *
  *   - The domain from the site currently selected, if eligible
  *   - The primary domain of the site, if eligible
- *   - The first non-primary domain eligible found
+ *   - The most recent non-primary domain eligible found
  *
  * @param {string} selectedDomainName - domain name of the site currently selected by the user
  * @param {Array} domains - list of domain objects
@@ -60,8 +60,13 @@ export function getEligibleTitanDomain( selectedDomainName, domains, mustBeEligi
 		return selectedDomain;
 	}
 
-	// Orders domains with the primary domain in first position, if any, and returns the first domain
-	return eligibleDomains.sort(
-		( a, b ) => Number( b.isPrimary ?? false ) - Number( a.isPrimary ?? false )
-	)[ 0 ];
+	return eligibleDomains
+		.sort(
+			// Orders domains by most recent registration date
+			( a, b ) => new Date( b.registrationDate ) - new Date( a.registrationDate )
+		)
+		.sort(
+			// Moves the primary domain in first position of this list of domains
+			( a, b ) => Number( b.isPrimary ?? false ) - Number( a.isPrimary ?? false )
+		)[ 0 ];
 }

--- a/client/lib/titan/get-eligible-titan-domain.js
+++ b/client/lib/titan/get-eligible-titan-domain.js
@@ -2,13 +2,13 @@ import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { hasPaidEmailWithUs } from 'calypso/lib/emails';
 
 /**
- * Retrieves the first domain that is eligible to Titan in this order:
+ * Retrieves the first domain that is eligible for Titan in this order:
  *
  *   - The domain from the site currently selected, if eligible
  *   - The primary domain of the site, if eligible
  *   - The first non-primary domain eligible found
  *
- * Note this method doesn't check if a domain is eligible to the 3-month free trial.
+ * Note this method doesn't check if a domain is eligible for the 3-month free trial.
  *
  * @param {string} selectedDomainName - domain name for the site currently selected by the user
  * @param {Array} domains - list of domain objects

--- a/client/lib/titan/is-domain-eligible-for-titan-free-trial.js
+++ b/client/lib/titan/is-domain-eligible-for-titan-free-trial.js
@@ -1,5 +1,5 @@
 /**
- * Determines if the specified domain is eligible to the Titan 3-month free trial.
+ * Determines if the specified domain is eligible for the Titan 3-month free trial.
  *
  * @param {object} domain - domain object
  * @returns {boolean} whether the domain is eligible or not

--- a/client/lib/titan/test/index.ts
+++ b/client/lib/titan/test/index.ts
@@ -166,4 +166,53 @@ describe( 'getEligibleTitanDomain()', () => {
 
 		expect( getEligibleTitanDomain( 'foo.bar', domains, true ) ).toBe( domain );
 	} );
+
+	test( 'return most recent non-primary domain eligible first', () => {
+		const domain = {
+			name: 'domain-eligible-most-recent.com',
+			currentUserCanAddEmail: true,
+			registrationDate: '2021-03-25T10:58:17+00:00',
+		};
+
+		const domains = [
+			{
+				name: 'domain-eligible.com',
+				currentUserCanAddEmail: true,
+				registrationDate: '2021-01-25T17:53:49+00:00',
+			},
+			{
+				name: 'another-domain-eligible.com',
+				currentUserCanAddEmail: true,
+				registrationDate: '2021-01-26T14:14:43+00:00',
+			},
+			domain,
+		];
+
+		expect( getEligibleTitanDomain( 'foo.bar', domains ) ).toBe( domain );
+	} );
+
+	test( 'return primary domain eligible instead of most recent eligible domains', () => {
+		const domain = {
+			name: 'domain-eligible-primary.com',
+			currentUserCanAddEmail: true,
+			registrationDate: '2020-06-01T11:48:49+00:00',
+			isPrimary: true,
+		};
+
+		const domains = [
+			{
+				name: 'domain-eligible.com',
+				currentUserCanAddEmail: true,
+				registrationDate: '2021-01-25T17:53:49+00:00',
+			},
+			{
+				name: 'domain-eligible-most-recent.com',
+				currentUserCanAddEmail: true,
+				registrationDate: '2021-03-25T10:58:17+00:00',
+			},
+			domain,
+		];
+
+		expect( getEligibleTitanDomain( 'foo.bar', domains ) ).toBe( domain );
+	} );
 } );

--- a/client/lib/titan/test/index.ts
+++ b/client/lib/titan/test/index.ts
@@ -101,7 +101,7 @@ describe( 'getEligibleTitanDomain()', () => {
 
 	test( 'return selected domain instead of other eligible domains', () => {
 		const domain = {
-			name: 'foo.bar',
+			name: 'domain-eligible-selected.com',
 			currentUserCanAddEmail: true,
 		};
 
@@ -118,7 +118,7 @@ describe( 'getEligibleTitanDomain()', () => {
 			domain,
 		];
 
-		expect( getEligibleTitanDomain( 'foo.bar', domains ) ).toBe( domain );
+		expect( getEligibleTitanDomain( 'domain-eligible-selected.com', domains ) ).toBe( domain );
 	} );
 
 	test( 'return first domain instead of other eligible domains when selected domain differs', () => {
@@ -140,5 +140,30 @@ describe( 'getEligibleTitanDomain()', () => {
 		];
 
 		expect( getEligibleTitanDomain( 'bar.bar', domains ) ).toBe( domain );
+	} );
+
+	test( 'return primary domain eligible for 3-month free trial instead of other eligible domains', () => {
+		const domain = {
+			name: 'domain-eligible-primary.com',
+			currentUserCanAddEmail: true,
+			isPrimary: true,
+			titanMailSubscription: { isEligibleForIntroductoryOffer: true },
+		};
+
+		const domains = [
+			{
+				name: 'domain-eligible.com',
+				currentUserCanAddEmail: true,
+				titanMailSubscription: { isEligibleForIntroductoryOffer: true },
+			},
+			{
+				name: 'another-domain-eligible.com',
+				currentUserCanAddEmail: true,
+				titanMailSubscription: { isEligibleForIntroductoryOffer: false },
+			},
+			domain,
+		];
+
+		expect( getEligibleTitanDomain( 'foo.bar', domains, true ) ).toBe( domain );
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -507,7 +507,12 @@ function getProfessionalEmailUpsellUrl( {
 		return;
 	}
 
-	if ( ! hasBloggerPlan( cart ) && ! hasPersonalPlan( cart ) && ! hasBusinessPlan( cart ) ) {
+	if (
+		! hasBloggerPlan( cart ) &&
+		! hasPersonalPlan( cart ) &&
+		! hasBusinessPlan( cart ) &&
+		! hasEcommercePlan( cart )
+	) {
 		return;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -15,6 +15,7 @@ import debugFactory from 'debug';
 import {
 	hasRenewalItem,
 	getAllCartItems,
+	getDomainRegistrations,
 	getRenewalItems,
 	hasConciergeSession,
 	hasJetpackPlan,
@@ -516,13 +517,26 @@ function getProfessionalEmailUpsellUrl( {
 		return;
 	}
 
-	const domain = getEligibleTitanDomain( siteSlug, domains );
+	const domainRegistrations = getDomainRegistrations( cart );
 
-	if ( ! domain ) {
+	let domainName = null;
+
+	// Uses either a domain being purchased, or the first domain eligible found in site domains
+	if ( domainRegistrations.length > 0 ) {
+		domainName = domainRegistrations[ 0 ].meta;
+	} else {
+		const domain = getEligibleTitanDomain( siteSlug, domains, true );
+
+		if ( domain ) {
+			domainName = domain.name;
+		}
+	}
+
+	if ( ! domainName ) {
 		return;
 	}
 
-	return `/checkout/offer-professional-email/${ pendingOrReceiptId }/${ siteSlug }`;
+	return `/checkout/offer-professional-email/${ domainName }/${ pendingOrReceiptId }/${ siteSlug }`;
 }
 
 function getDisplayModeParamFromCart( cart: ResponseCart | undefined ): Record< string, string > {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -9,7 +9,9 @@ import {
 	JETPACK_REDIRECT_URL,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 	PLAN_BLOGGER,
+	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
+	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	redirectCheckoutToWpAdmin,
 	TITAN_MAIL_MONTHLY_SLUG,
@@ -862,11 +864,71 @@ describe( 'getThankYouPageUrl', () => {
 			},
 		];
 
-		it( 'Is displayed if site has eligible domain and eligible plan is in the cart', () => {
+		it( 'Is displayed if site has eligible domain and Blogger plan is in the cart', () => {
 			const cart = {
 				products: [
 					{
 						product_slug: PLAN_BLOGGER,
+					},
+				],
+			};
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				cart,
+				domains,
+				receiptId: '1234abcd',
+				siteSlug: 'foo.bar',
+			} );
+
+			expect( url ).toBe( '/checkout/offer-professional-email/1234abcd/foo.bar' );
+		} );
+
+		it( 'Is displayed if site has eligible domain and Personal plan is in the cart', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: PLAN_PERSONAL,
+					},
+				],
+			};
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				cart,
+				domains,
+				receiptId: '1234abcd',
+				siteSlug: 'foo.bar',
+			} );
+
+			expect( url ).toBe( '/checkout/offer-professional-email/1234abcd/foo.bar' );
+		} );
+
+		it( 'Is displayed if site has eligible domain and Business plan is in the cart', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: PLAN_BUSINESS,
+					},
+				],
+			};
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				cart,
+				domains,
+				receiptId: '1234abcd',
+				siteSlug: 'foo.bar',
+			} );
+
+			expect( url ).toBe( '/checkout/offer-professional-email/1234abcd/foo.bar' );
+		} );
+
+		it( 'Is displayed if site has eligible domain and eCommerce plan is in the cart', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: PLAN_ECOMMERCE,
 					},
 				],
 			};

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -853,6 +853,11 @@ describe( 'getThankYouPageUrl', () => {
 				isPrimary: true,
 			},
 			{
+				name: 'domain-eligible-for-free-trial.com',
+				currentUserCanAddEmail: true,
+				titanMailSubscription: { isEligibleForIntroductoryOffer: true },
+			},
+			{
 				name: 'domain-expired.com',
 				currentUserCanAddEmail: true,
 				expired: true,
@@ -881,7 +886,9 @@ describe( 'getThankYouPageUrl', () => {
 				siteSlug: 'foo.bar',
 			} );
 
-			expect( url ).toBe( '/checkout/offer-professional-email/1234abcd/foo.bar' );
+			expect( url ).toBe(
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+			);
 		} );
 
 		it( 'Is displayed if site has eligible domain and Personal plan is in the cart', () => {
@@ -901,7 +908,9 @@ describe( 'getThankYouPageUrl', () => {
 				siteSlug: 'foo.bar',
 			} );
 
-			expect( url ).toBe( '/checkout/offer-professional-email/1234abcd/foo.bar' );
+			expect( url ).toBe(
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+			);
 		} );
 
 		it( 'Is displayed if site has eligible domain and Business plan is in the cart', () => {
@@ -921,7 +930,9 @@ describe( 'getThankYouPageUrl', () => {
 				siteSlug: 'foo.bar',
 			} );
 
-			expect( url ).toBe( '/checkout/offer-professional-email/1234abcd/foo.bar' );
+			expect( url ).toBe(
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+			);
 		} );
 
 		it( 'Is displayed if site has eligible domain and eCommerce plan is in the cart', () => {
@@ -941,7 +952,35 @@ describe( 'getThankYouPageUrl', () => {
 				siteSlug: 'foo.bar',
 			} );
 
-			expect( url ).toBe( '/checkout/offer-professional-email/1234abcd/foo.bar' );
+			expect( url ).toBe(
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+			);
+		} );
+
+		it( 'Is displayed if site has domain registration and eligble plan in the cart', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: PLAN_PERSONAL,
+					},
+					{
+						meta: 'domain-from-cart.com',
+						is_domain_registration: true,
+					},
+				],
+			};
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				cart,
+				domains,
+				receiptId: '1234abcd',
+				siteSlug: 'foo.bar',
+			} );
+
+			expect( url ).toBe(
+				'/checkout/offer-professional-email/domain-from-cart.com/1234abcd/foo.bar'
+			);
 		} );
 
 		it( 'Is not displayed if cart is missing', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -957,7 +957,7 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
-		it( 'Is displayed if site has domain registration and eligble plan in the cart', () => {
+		it( 'Is displayed if site has domain registration and eligible plan in the cart', () => {
 			const cart = {
 				products: [
 					{

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -254,7 +254,7 @@ export function upsellNudge( context, next ) {
 		}
 	} else if ( context.path.includes( 'offer-professional-email' ) ) {
 		upsellType = PROFESSIONAL_EMAIL_UPSELL;
-		upgradeItem = null;
+		upgradeItem = context.params.domain;
 	}
 
 	setSectionMiddleware( { name: upsellType } )( context );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -161,7 +161,7 @@ export default function () {
 	}
 
 	page(
-		'/checkout/offer-professional-email/:receiptId/:site',
+		'/checkout/offer-professional-email/:domain/:receiptId/:site',
 		redirectLoggedOut,
 		siteSelection,
 		upsellNudge,

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -11,13 +11,11 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
 import Main from 'calypso/components/main';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
-import { getEligibleTitanDomain } from 'calypso/lib/titan';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url';
 import {
@@ -42,7 +40,6 @@ import {
 } from 'calypso/state/products-list/selectors';
 import getUpgradePlanSlugFromPath from 'calypso/state/selectors/get-upgrade-plan-slug-from-path';
 import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
 	isRequestingSitePlans,
 	getPlansBySiteId,
@@ -84,10 +81,8 @@ export class UpsellNudge extends Component {
 
 		// Below are provided by HOCs
 		currencyCode: PropTypes.string,
-		domains: PropTypes.array,
 		isLoading: PropTypes.bool,
 		hasProductsList: PropTypes.bool,
-		hasSiteDomains: PropTypes.bool,
 		hasSitePlans: PropTypes.bool,
 		product: PropTypes.object,
 		productCost: PropTypes.number,
@@ -187,14 +182,7 @@ export class UpsellNudge extends Component {
 	};
 
 	render() {
-		const {
-			selectedSiteId,
-			isLoading,
-			hasProductsList,
-			hasSiteDomains,
-			hasSitePlans,
-			upsellType,
-		} = this.props;
+		const { selectedSiteId, isLoading, hasProductsList, hasSitePlans, upsellType } = this.props;
 
 		return (
 			<Main className={ upsellType }>
@@ -202,7 +190,6 @@ export class UpsellNudge extends Component {
 				<QueryStoredCards />
 				{ ! hasProductsList && <QueryProductsList /> }
 				{ ! hasSitePlans && <QuerySitePlans siteId={ selectedSiteId } /> }
-				{ ! hasSiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 				{ isLoading ? this.renderPlaceholders() : this.renderContent() }
 				{ this.state.showPurchaseModal && this.renderPurchaseModal() }
 				{ this.preloadIconsForPurchaseModal() }
@@ -260,13 +247,13 @@ export class UpsellNudge extends Component {
 		const {
 			receiptId,
 			currencyCode,
-			domains,
 			productCost,
 			productDisplayCost,
 			planRawPrice,
 			planDiscountedRawPrice,
 			isLoggedIn,
 			upsellType,
+			upgradeItem,
 			translate,
 			siteSlug,
 			hasSevenDayRefundPeriod,
@@ -321,7 +308,7 @@ export class UpsellNudge extends Component {
 				return (
 					<ProfessionalEmailUpsell
 						currencyCode={ currencyCode }
-						domain={ getEligibleTitanDomain( siteSlug, domains ) }
+						domainName={ upgradeItem }
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }
 						productCost={ productCost }
@@ -504,7 +491,6 @@ export default connect(
 		const selectedSiteId = getSelectedSiteId( state );
 		const productsList = getProductsList( state );
 		const sitePlans = getPlansBySiteId( state ).data;
-		const domains = getDomainsBySiteId( state, selectedSiteId );
 		const siteSlug = selectedSiteId ? getSiteSlug( state, selectedSiteId ) : siteSlugParam;
 		const planSlug = getUpgradePlanSlugFromPath( state, selectedSiteId, props.upgradeItem );
 		const annualDiscountPrice = getPlanDiscountedRawPrice( state, selectedSiteId, planSlug, {
@@ -534,13 +520,11 @@ export default connect(
 			isFetchingStoredCards: areStoredCardsLoading,
 			cards,
 			currencyCode: getCurrentUserCurrencyCode( state ),
-			domains,
 			isLoading:
 				isFetchingCards ||
 				isProductsListFetching( state ) ||
 				isRequestingSitePlans( state, selectedSiteId ),
 			hasProductsList: Object.keys( productsList ).length > 0,
-			hasSiteDomains: domains.length > 0,
 			hasSitePlans: sitePlans && sitePlans.length > 0,
 			product,
 			productCost: getProductCost( state, productSlug ),

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
@@ -13,7 +13,6 @@ import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
-import { isDomainEligibleForTitanFreeTrial } from 'calypso/lib/titan';
 import {
 	areAllMailboxesValid,
 	buildNewTitanMailbox,
@@ -39,7 +38,7 @@ const ProfessionalEmailFeature = ( { children } ) => {
 
 const ProfessionalEmailUpsell = ( {
 	currencyCode,
-	domain,
+	domainName,
 	handleClickAccept,
 	handleClickDecline,
 	productCost,
@@ -47,8 +46,6 @@ const ProfessionalEmailUpsell = ( {
 } ) => {
 	const translate = useTranslate();
 	const productsList = useSelector( getProductsList );
-
-	const domainName = domain.name;
 
 	const [ mailboxData, setMailboxData ] = useState( buildNewTitanMailbox( domainName, false ) );
 	const [ showAllErrors, setShowAllErrors ] = useState( false );
@@ -73,14 +70,6 @@ const ProfessionalEmailUpsell = ( {
 		},
 		comment: '{{price/}} is the formatted price, e.g. $20',
 	} );
-
-	const isEligibleForFreeTrial = isDomainEligibleForTitanFreeTrial( domain );
-
-	const discountBadge = isEligibleForFreeTrial ? (
-		<span>
-			<Badge type="success">{ translate( '3 months free' ) }</Badge>
-		</span>
-	) : null;
 
 	const onMailboxValueChange = ( fieldName, fieldValue ) => {
 		const updatedMailboxData = {
@@ -141,12 +130,15 @@ const ProfessionalEmailUpsell = ( {
 				<div className="professional-email-upsell__pricing">
 					<span
 						className={ classNames( 'professional-email-upsell__standard-price', {
-							'is-discounted': isEligibleForFreeTrial,
+							'is-discounted': true,
 						} ) }
 					>
 						{ formattedPrice }
 					</span>
-					{ discountBadge }
+
+					<span>
+						<Badge type="success">{ translate( '3 months free' ) }</Badge>
+					</span>
 				</div>
 			</header>
 			<div className="professional-email-upsell__content">

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,6 +130,7 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
+		"upsell/professional-email": true,
 		"upsell/nudge-component": true,
 		"upsell/troubleshooting": false,
 		"use-translation-chunks": true,


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/56794 which updates the post-checkout upsell for Professional Email to:

* Show for eCommerce plans
* Show for a domain present in the shopping cart, if any
* Show only for domains eligible for the 3-month free trial
* Show for the most recent domain registered
* Pass the name of the domain in the url to simplify data handling

It also enables this upsell in `wpcalypso` and `calypso.live`:

<img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/136393399-e560cc63-6b39-4535-be8f-f40be57f7de5.png">

#### Testing instructions

You can run unit tests with:

```javascript
npm run test-client client/lib/titan
npm run test-client client/my-sites/checkout/composite-checkout
```

Otherwise you can:

1. Run `git checkout update/post-checkout-titan-upsell` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/57113#issuecomment-945899648)
2. Log into a WordPress.com account that has a site with an eligible domain
3. Open the [`Plans` page](http://calypso.localhost:3000/plans)
4. Purchase a Personal plan
5. Assert that you are presented with the Professional Email upsell for your domain
6. Assert that that page still works if you refresh it
7. Navigate to the [`Domains Search` page](http://calypso.localhost:3000/domains/add)
8. Add a domain to your shopping cart but do not purchase it
9. Head back to the `Plans` page, and upgrade your plan
9. Assert that you are presented with the Professional Email upsell
10. Assert that that page still works if you refresh it
11. Assert that the domain used by this upsell is the one just purchased