### PR TITLE
Added key to component to prevent react warning

### DIFF
--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -61,7 +61,9 @@ class People extends Component {
 							'Invite contributors to your site and manage their access settings. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 							{
 								components: {
-									learnMoreLink: <InlineSupportLink supportContext="team" showIcon={ false } />,
+									learnMoreLink: (
+										<InlineSupportLink key="learnMore" supportContext="team" showIcon={ false } />
+									),
 								},
 							}
 					  );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* React was throwing a warning about a component needing a "key" so it was added.

#### Testing instructions

* Go into Users -> All Users - The warning shouldn't be there anymore.
