### PR TITLE
Payments: Fix stripeLoadingError reporting in PaymentMethodSelector

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -85,7 +85,7 @@ export default function PaymentMethodSelector( {
 
 	useEffect( () => {
 		if ( stripeLoadingError ) {
-			reduxDispatch( errorNotice( stripeLoadingError ) );
+			reduxDispatch( errorNotice( stripeLoadingError.message ) );
 		}
 	}, [ stripeLoadingError, reduxDispatch ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There is a bug in the `PaymentMethodSelector` component which will cause a fatal error and a blank screen if accessed by a user who has not confirmed their email address. This is because the change payment method form requires a Stripe Setup Intent and the stripe configuration endpoint will refuse to provide one without a confirmed email; it will return an error message which will ultimately be returned by the `useStripe` hook. It's up to the consumer to display that error message, but the data returned is not a string, it's an `Error` object. Other locations that display that error (eg: checkout), correctly send the object's `message` property to the notices module, but the `PaymentMethodSelector` accidentally sends the whole `Error` instead. When the notices module attempts to display that object as a React node, it throws a fatal error.

This PR fixes the call to display the `message` property instead of the object.

Before:

<img width="961" alt="Screen Shot 2021-10-18 at 12 09 37 PM" src="https://user-images.githubusercontent.com/2036909/137771844-861b2693-bd96-40aa-84f3-dc52dc15f3f5.png">


After:


<img width="962" alt="Screen Shot 2021-10-18 at 12 21 56 PM" src="https://user-images.githubusercontent.com/2036909/137771864-17b9d6a3-76f1-4946-bda1-1b9a84c55390.png">

Fixes https://github.com/Automattic/wp-calypso/issues/57087

#### Testing instructions

- Use a wp.com account that has not confirmed their email address.
- Make sure the account has at least one active purchase.
- Visit `/me/purchases` and click through to the purchase.
- Click "Change payment method" at the bottom of the page.
- Verify that you see an error message displayed saying that your email address must be confirmed.