### PR TITLE
Redirect to site editor after primary button click on after theme change modal

### DIFF
--- a/client/data/block-editor/use-block-editor-settings-query.ts
+++ b/client/data/block-editor/use-block-editor-settings-query.ts
@@ -1,15 +1,20 @@
 import { useQuery, UseQueryResult } from 'react-query';
+import { useSelector } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
+import { getActiveTheme } from 'calypso/state/themes/selectors';
 
 export type BlockEditorSettings = {
 	is_fse_eligible: boolean;
+	is_fse_active: boolean;
 };
 
 export const useBlockEditorSettingsQuery = (
-	siteId: string,
+	siteId: number,
 	userLoggedIn = false
 ): UseQueryResult< BlockEditorSettings > => {
-	const queryKey = [ 'blockEditorSettings', siteId ];
+	const themeId = useSelector( ( state ) => getActiveTheme( state, siteId ) );
+
+	const queryKey = [ 'blockEditorSettings', siteId, themeId ];
 
 	return useQuery< BlockEditorSettings >(
 		queryKey,

--- a/client/data/block-editor/with-block-editor-settings.js
+++ b/client/data/block-editor/with-block-editor-settings.js
@@ -8,8 +8,15 @@ const withBlockEditorSettings = createHigherOrderComponent(
 	( Wrapped ) => ( props ) => {
 		const siteId = useSelector( getSelectedSiteId );
 		const userLoggedIn = useSelector( isUserLoggedIn );
-		const { data } = useBlockEditorSettingsQuery( siteId, userLoggedIn );
-		return <Wrapped { ...props } blockEditorSettings={ data } />;
+		const { data, isLoading } = useBlockEditorSettingsQuery( siteId, userLoggedIn );
+
+		return (
+			<Wrapped
+				{ ...props }
+				blockEditorSettings={ data }
+				areBlockEditorSettingsLoading={ isLoading }
+			/>
+		);
 	},
 	'withBlockEditorSettings'
 );

--- a/client/my-sites/themes/test/thanks-modal.jsx
+++ b/client/my-sites/themes/test/thanks-modal.jsx
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import ReactModal from 'react-modal';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import { setCurrentUser } from 'calypso/state/current-user/actions';
+import { setStore } from 'calypso/state/redux-store';
+import { receiveSite } from 'calypso/state/sites/actions';
+import { receiveTheme, themeActivated } from 'calypso/state/themes/actions';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import ThanksModal from '../thanks-modal';
+
+ReactModal.setAppElement( '*' ); // suppresses modal-related test warnings.
+
+const TestComponent = ( { store } ) => {
+	const queryClient = new QueryClient();
+	return (
+		<ReduxProvider store={ store }>
+			<QueryClientProvider client={ queryClient }>
+				<ThanksModal source="details" />
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+};
+
+const themeId = 'twentysixteen';
+const themeStyleSheet = `pub/${ themeId }`;
+const siteId = 123;
+const userId = 123;
+const source = 'unknown';
+const purchased = false;
+
+/**
+ * The `is_fse_active` flag depends on the theme that just
+ * got activated on the back-end, so we need to refetch
+ * that flag whenever the theme changes.
+ */
+const setupAPIResponse = ( { is_fse_active } ) => {
+	return nock( 'https://public-api.wordpress.com:443' )
+		.get( `/wpcom/v2/sites/${ siteId }/block-editor` )
+		.reply( 200, {
+			is_fse_eligible: true,
+			is_fse_active,
+		} );
+};
+
+const defaultSite = { ID: siteId, name: 'Example site', URL: 'https://example.com' };
+const defaultTheme = {
+	id: themeId,
+	name: 'Twenty Sixteen',
+	author: 'the WordPress team',
+	screenshot:
+		'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
+	description: 'Twenty Sixteen is a modernized take on an ever-popular WordPress layout — ...',
+	descriptionLong: '<p>Mumble Mumble</p>',
+	download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentysixteen.zip',
+	taxonomies: {},
+	stylesheet: themeStyleSheet,
+	demo_uri: 'https://twentysixteendemo.wordpress.com/',
+};
+
+const setupStore = ( { site = defaultSite, theme = defaultTheme } = {} ) => {
+	const store = createReduxStore();
+	setStore( store );
+
+	store.dispatch( receiveSite( site ) );
+	store.dispatch( receiveTheme( theme, 'wpcom' ) );
+	store.dispatch( receiveTheme( theme, siteId ) );
+	store.dispatch( setSelectedSiteId( siteId ) );
+	store.dispatch( setCurrentUser( { ID: userId } ) );
+	store.dispatch( themeActivated( theme.stylesheet, siteId, source, purchased ) );
+
+	return store;
+};
+
+describe( 'thanks-modal', () => {
+	describe( 'when activating an FSE theme', () => {
+		beforeEach( () => {
+			setupAPIResponse( { is_fse_active: true } );
+		} );
+
+		test( 'displays the "Edit site" call to action and links it to the site editor', async () => {
+			const store = setupStore();
+
+			render( <TestComponent store={ store } /> );
+
+			await waitFor( () => {
+				const editSiteCallToAction = screen.getByText( 'Edit site' );
+
+				expect( editSiteCallToAction ).toBeInTheDocument();
+				expect( editSiteCallToAction.closest( 'a' ) ).toHaveAttribute(
+					'href',
+					'/site-editor/example.com'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'when activating a Gutenberg-first theme that has a front page', () => {
+		beforeEach( () => {
+			setupAPIResponse( { is_fse_active: false } );
+		} );
+
+		test( 'displays the "Edit homepage" call to action and links it to the page editor', async () => {
+			const store = setupStore( {
+				site: {
+					...defaultSite,
+					options: { show_on_front: 'page' },
+				},
+				theme: {
+					...defaultTheme,
+					taxonomies: {
+						theme_feature: [
+							{
+								slug: 'auto-loading-homepage',
+							},
+							{
+								slug: 'global-styles',
+							},
+						],
+					},
+				},
+			} );
+
+			render( <TestComponent store={ store } /> );
+
+			await waitFor( () => {
+				const editHomepage = screen.getByText( 'Edit homepage' );
+
+				expect( editHomepage ).toBeInTheDocument();
+				expect( editHomepage.closest( 'a' ) ).toHaveAttribute( 'href', '/page/example.com' );
+			} );
+		} );
+	} );
+
+	describe( 'when activating a theme that is not FSE and does not have a front page', () => {
+		beforeEach( () => {
+			setupAPIResponse( { is_fse_active: false } );
+		} );
+
+		test( 'displays the "Customize site" call to action and links it to the customizer', async () => {
+			const store = setupStore();
+
+			render( <TestComponent store={ store } /> );
+
+			await waitFor( () => {
+				const customizeSiteCallToAction = screen.getByText( 'Customize site' );
+
+				expect( customizeSiteCallToAction ).toBeInTheDocument();
+				expect( customizeSiteCallToAction.closest( 'a' ) ).toHaveAttribute(
+					'href',
+					'/customize/example.com'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'when activating a theme', () => {
+		beforeEach( () => {
+			setupAPIResponse( { is_fse_active: false } );
+		} );
+
+		test( 'waits for isFSEActive response before displaying content', async () => {
+			const store = setupStore();
+
+			render( <TestComponent store={ store } /> );
+
+			expect( screen.getByTestId( 'loadingThanksModalContent' ) ).toBeInTheDocument();
+			expect( screen.queryByText( 'Customize site' ) ).not.toBeInTheDocument();
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Customize site' ) ).toBeInTheDocument();
+			} );
+		} );
+	} );
+} );

--- a/client/my-sites/themes/test/thanks-modal.jsx
+++ b/client/my-sites/themes/test/thanks-modal.jsx
@@ -32,7 +32,7 @@ const TestComponent = ( { store } ) => {
 const themeId = 'twentysixteen';
 const themeStyleSheet = `pub/${ themeId }`;
 const siteId = 123;
-const userId = 123;
+const userId = 456;
 const source = 'unknown';
 const purchased = false;
 

--- a/client/my-sites/themes/test/thanks-modal.jsx
+++ b/client/my-sites/themes/test/thanks-modal.jsx
@@ -102,7 +102,7 @@ describe( 'thanks-modal', () => {
 		} );
 	} );
 
-	describe( 'when activating a Gutenberg-first theme that has a front page', () => {
+	describe( 'when activating a non-FSE theme that has a front page', () => {
 		beforeEach( () => {
 			setupAPIResponse( { is_fse_active: false } );
 		} );
@@ -139,7 +139,7 @@ describe( 'thanks-modal', () => {
 		} );
 	} );
 
-	describe( 'when activating a theme that is not FSE and does not have a front page', () => {
+	describe( 'when activating a non-FSE theme that does not have a front page', () => {
 		beforeEach( () => {
 			setupAPIResponse( { is_fse_active: false } );
 		} );

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -176,8 +176,14 @@ class ThanksModal extends Component {
 	};
 
 	getEditSiteLabel = () => {
-		const { shouldEditHomepageWithGutenberg, hasActivated, isFSEActive } = this.props;
-		if ( ! hasActivated ) {
+		const {
+			shouldEditHomepageWithGutenberg,
+			hasActivated,
+			isFSEActive,
+			areBlockEditorSettingsLoading,
+		} = this.props;
+
+		if ( ! hasActivated || areBlockEditorSettingsLoading ) {
 			return this.props.translate( 'Activating theme…' );
 		}
 
@@ -248,7 +254,9 @@ class ThanksModal extends Component {
 	};
 
 	render() {
-		const { currentTheme, hasActivated, isActivating } = this.props;
+		const { currentTheme, hasActivated, isActivating, areBlockEditorSettingsLoading } = this.props;
+
+		const shouldDisplayContent = hasActivated && currentTheme && ! areBlockEditorSettingsLoading;
 
 		return (
 			<Dialog
@@ -257,7 +265,7 @@ class ThanksModal extends Component {
 				buttons={ this.getButtons() }
 				onClose={ this.onCloseModal }
 			>
-				{ hasActivated && currentTheme ? this.renderContent() : this.renderLoading() }
+				{ shouldDisplayContent ? this.renderContent() : this.renderLoading() }
 			</Dialog>
 		);
 	}

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -48,6 +48,8 @@ class ThanksModal extends Component {
 		isActivating: PropTypes.bool.isRequired,
 		isThemeWpcom: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
+		isFSEActive: PropTypes.bool,
+		areBlockEditorSettingsLoading: PropTypes.bool.isRequired,
 	};
 
 	componentDidUpdate( prevProps ) {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -169,7 +169,7 @@ class ThanksModal extends Component {
 
 	renderLoading = () => {
 		return (
-			<div className="themes__thanks-modal-loading">
+			<div className="themes__thanks-modal-loading" data-testid="loadingThanksModalContent">
 				<PulsingDot active={ true } />
 			</div>
 		);

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -1,4 +1,5 @@
 import getFrontPageEditorUrl from 'calypso/state/selectors/get-front-page-editor-url';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
 import shouldCustomizeHomepageWithGutenberg from 'calypso/state/selectors/should-customize-homepage-with-gutenberg';
 import { getThemeCustomizeUrl, isThemeActive } from 'calypso/state/themes/selectors';
@@ -10,13 +11,17 @@ import { getThemeCustomizeUrl, isThemeActive } from 'calypso/state/themes/select
  * @see getThemeCustomizeUrl is used as a drop-in replacement.
  *
  * Ensure that your view makes use of the `QueryBlogStickers` component to function properly.
- *
- * @param  {object}   state   Global state tree
- * @param  {string}   themeId Theme ID
- * @param  {number}   siteId  Site ID to open the customizer or block editor for
- * @returns {string}           Customizer or Block Editor URL
+ * @param  {object}   state       Global state tree
+ * @param  {string}   themeId     Theme ID
+ * @param  {number}   siteId      Site ID to open the customizer or block editor for
+ * @param  {boolean}  isFSEActive Whether full-site editing is enabled for the site
+ * @returns {string}              Customizer or Block Editor URL
  */
-export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId ) {
+export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId, isFSEActive ) {
+	if ( isFSEActive ) {
+		return getSiteEditorUrl( state, siteId );
+	}
+
 	const shouldUseGutenberg =
 		shouldCustomizeHomepageWithGutenberg( state, siteId ) ||
 		isSiteUsingFullSiteEditing( state, siteId );


### PR DESCRIPTION
#### Testing instructions

##### Redirect to site editor:

- Open a beta enrolled FSE site;
- Change the theme to a block-based one;
- Click on `Edit site` and you should be redirected to the site editor.

##### Redirect to Gutenberg/customizer:

- Open the same site;
- Change the theme to a classic one;
- Click on `Edit homepage` and you should be redirected to the page editor instead.

Closes #56873.