### PR TITLE
Editor: Basic Flow: save post prior to publishing to circumvent post-publish sidebar closing automatically.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -595,7 +595,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					for i in {1..100}; do yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-editor__post-basic-flow; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -595,7 +595,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for i in {1..100}; do yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-editor__post-basic-flow; done
+					yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -195,7 +195,7 @@ export class GutenbergEditorPage {
 	 * Dismisses the Welcome Tour (card) if it is present.
 	 */
 	async dismissWelcomeTourIfPresent(): Promise< void > {
-		const frame = await this.getEditorFrame();
+		const frame = await this.waitUntilLoaded();
 		if ( await frame.isVisible( selectors.welcomeTourCloseButton ) ) {
 			await frame.click( selectors.welcomeTourCloseButton );
 		}

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -74,18 +74,22 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Publish post', function () {
-		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional
+		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
 		it( 'Close settings sidebar', async function () {
 			await editorSettingsSidebarComponent.closeSidebar();
 		} );
 
+		it( 'Save draft', async function () {
+			await gutenbergEditorPage.saveDraft();
+		} );
+
 		it( 'Publish and visit post', async function () {
 			const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
-			expect( publishedURL ).toBe( await page.url() );
-			publishedPostPage = new PublishedPostPage( page );
+			expect( publishedURL ).toBe( page.url() );
 		} );
 
 		it( 'Post content is found in published post', async function () {
+			publishedPostPage = new PublishedPostPage( page );
 			await publishedPostPage.validateTextInPost( title );
 			await publishedPostPage.validateTextInPost( quote );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a reliability issue with the `test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts`.

Key changes:
- save the post prior to publishing to work around the issue https://github.com/Automattic/wp-calypso/issues/50302.

Fixes #57119
