### PR TITLE
Add onboarding importer route with importers list screen

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -344,7 +344,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'importer',
-			steps: [ 'list' ],
+			steps: isEnabled( 'gutenboarding/import' ) ? [ 'list' ] : [],
 			destination: '/',
 			description: 'A new import flow that can be used from the onboarding flow',
 			disallowResume: true,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -343,6 +343,15 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'importer',
+			steps: [ 'list' ],
+			destination: '/',
+			description: 'A new import flow that can be used from the onboarding flow',
+			disallowResume: true,
+			lastModified: '2021-10-18',
+			showRecaptcha: true,
+		},
+		{
 			name: 'reader',
 			steps: [ 'reader-landing', 'user' ],
 			destination: '/',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -76,6 +76,7 @@ const stepNameToModuleName = {
 	'difm-design': 'difm-design-picker',
 	'site-info-collection': 'site-info-collection',
 	intent: 'intent',
+	list: 'import',
 };
 
 export function getStepModuleName( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -744,6 +744,11 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			apiRequestFunction: addPlanToCart,
 		},
+
+		list: {
+			stepName: 'list',
+			providesDependencies: [ 'siteSlug' ],
+		},
 	};
 }
 

--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import ListStep from './list';
+import './style.scss';
 
 export default function ImportOnboarding(): React.ReactNode {
-	return <h1>Onboarding importer module placeholder</h1>;
+	return (
+		<div className="import__onboarding-page">
+			<ListStep />
+		</div>
+	);
 }

--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ImportOnboarding(): React.ReactNode {
+	return <h1>Onboarding importer module placeholder</h1>;
+}

--- a/client/signup/steps/import/list/index.tsx
+++ b/client/signup/steps/import/list/index.tsx
@@ -1,0 +1,94 @@
+import { Title } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import { useHistory } from 'react-router-dom';
+import ActionCard from 'calypso/components/action-card';
+import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
+import type * as React from 'react';
+import './style.scss';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+const ListStep: React.FunctionComponent = () => {
+	const { __ } = useI18n();
+	const history = useHistory();
+
+	return (
+		<>
+			<div className={ 'import-layout list__wrapper' }>
+				<div className={ 'import-layout__column' }>
+					<div className="import__heading">
+						<Title>{ __( 'Import your content from another platform' ) }</Title>
+
+						<img alt="" src="/calypso/images/importer/onboarding.svg" />
+					</div>
+				</div>
+				<div className={ 'import-layout__column' }>
+					<div className={ 'list__importers list__importers-primary' }>
+						<ImporterLogo icon={ 'wordpress' } />
+						<ActionCard
+							classNames={ 'list__importer-action' }
+							headerText={ 'WordPress' }
+							mainText={ 'www.wordpress.org' }
+							buttonIcon={ 'chevron-right' }
+						/>
+						<ImporterLogo icon={ 'blogger-alt' } />
+						<ActionCard
+							classNames={ 'list__importer-action' }
+							headerText={ 'Blogger' }
+							mainText={ 'www.blogger.com' }
+							buttonIcon={ 'chevron-right' }
+						/>
+						<ImporterLogo icon={ 'medium' } />
+						<ActionCard
+							classNames={ 'list__importer-action' }
+							headerText={ 'Medium' }
+							mainText={ 'www.medium.com' }
+							buttonIcon={ 'chevron-right' }
+						/>
+						<ImporterLogo icon={ 'squarespace' } />
+						<ActionCard
+							classNames={ 'list__importer-action' }
+							headerText={ 'Squarespace' }
+							mainText={ 'www.squarespace.com' }
+							buttonIcon={ 'chevron-right' }
+						/>
+						<ImporterLogo icon={ 'wix' } />
+						<ActionCard
+							classNames={ 'list__importer-action' }
+							headerText={ 'Wix' }
+							mainText={ 'www.wix.com' }
+							buttonIcon={ 'chevron-right' }
+							buttonOnClick={ () => history.push( '/import?step=capture' ) }
+						/>
+					</div>
+
+					<div className={ 'list__importers list__importers-secondary' }>
+						<h3>Other platforms</h3>
+						<ul>
+							<li>
+								<a href={ '#temp' }>Blogroll</a>
+							</li>
+							<li>
+								<a href={ '#temp' }>Ghost</a>
+							</li>
+							<li>
+								<a href={ '#temp' }>Tumblr</a>
+							</li>
+							<li>
+								<a href={ '#temp' }>LiveJournal</a>
+							</li>
+							<li>
+								<a href={ '#temp' }>Movable Type & TypePad</a>
+							</li>
+							<li>
+								<a href={ '#temp' }>Xanga</a>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default ListStep;

--- a/client/signup/steps/import/list/style.scss
+++ b/client/signup/steps/import/list/style.scss
@@ -1,0 +1,72 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+.import__onboarding-page {
+	.list__wrapper {
+		margin-left: auto !important;
+		margin-right: auto !important;
+
+		.import__heading {
+			max-width: 420px;
+
+			.onboarding-title {
+				margin-bottom: 40px;
+				width: 100%;
+			}
+		}
+
+		@include break-wide {
+			max-width: 1032px;
+		}
+
+		h3 {
+			font-size: 1.125em; /* stylelint-disable-line */
+			color: var( --studio-gray-90 );
+			margin-bottom: 1em;
+		}
+
+		img {
+			display: none;
+
+			@include break-small {
+				display: block;
+			}
+		}
+
+		ul {
+			margin: 0;
+
+			li {
+				margin-bottom: 10px;
+				list-style: none;
+				line-height: 1.25em;
+			}
+
+			a {
+				font-size: 0.875em; /* stylelint-disable-line */
+				font-weight: 500; /* stylelint-disable-line */
+				text-decoration: underline;
+				color: var( --studio-gray-100 );
+			}
+		}
+
+		.importer__service-icon {
+			width: 48px;
+			height: 48px;
+			margin-top: 10px;
+			border-radius: 4px; /* stylelint-disable-line */
+		}
+
+		.list__importers-primary {
+			margin-bottom: 1.5em;
+		}
+
+		.list__importers-secondary {
+			padding-left: 0;
+
+			@include break-small {
+				padding-left: 72px;
+			}
+		}
+	}
+}

--- a/client/signup/steps/import/mixins.scss
+++ b/client/signup/steps/import/mixins.scss
@@ -1,0 +1,13 @@
+@import '@automattic/onboarding/styles/mixins.scss';
+
+@mixin onboarding-import-heading-text {
+	@include onboarding-font-recoleta;
+	font-size: 2.25rem; // 36px /* stylelint-disable-line */
+	line-height: 1.0833em; // 52px
+	letter-spacing: 0.2px;
+	color: var( --studio-gray-100 );
+
+	@include break-small {
+		font-size: 3rem; // 48px /* stylelint-disable-line */
+	}
+}

--- a/client/signup/steps/import/style.scss
+++ b/client/signup/steps/import/style.scss
@@ -1,0 +1,205 @@
+@import '@automattic/onboarding/styles/base-styles.scss';
+@import '@automattic/onboarding/styles/mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+@import './mixins.scss';
+
+.import__onboarding-page {
+	@include onboarding-block-margin;
+
+	.import__header {
+		@include onboarding-heading-padding;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.import__heading {
+		flex-grow: 1;
+
+		@include break-medium {
+			h1 {
+				width: 492px;
+				margin: auto;
+			}
+
+			h2 {
+				width: 560px;
+				margin: auto;
+			}
+		}
+
+		&.center {
+			text-align: center;
+		}
+
+		strong {
+			font-weight: 500; /* stylelint-disable-line */
+			color: var( --studio-gray-100 );
+		}
+
+		.onboarding-title {
+			@include onboarding-import-heading-text;
+			margin-bottom: 20px;
+		}
+
+		.import__buttons-group {
+			margin: 28px 0;
+		}
+
+		.action-buttons__next {
+			margin-bottom: 10px;
+		}
+
+		.action-buttons__back {
+			color: var( --studio-gray-100 );
+			font-weight: 500; /* stylelint-disable-line */
+
+			&:hover {
+				text-decoration: none;
+			}
+		}
+	}
+
+	.import__heading-center {
+		text-align: center;
+	}
+
+	// Layout
+	.import-layout {
+		@include onboarding-block-margin;
+		@include onboarding-heading-padding;
+		display: flex;
+		flex-direction: column;
+
+		@include break-small {
+			flex-direction: row;
+		}
+	}
+
+	.import-layout__column {
+		display: flex;
+		flex-direction: column;
+		flex-basis: 100%;
+	}
+
+	.import-layout__center {
+		background-color: var( --contrastColor );
+		tab-size: 4;
+		min-height: calc( 100vh - 2 * #{$onboarding-header-height} );
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+}
+
+/**
+ * New components style
+ 	- it's mostly style overrides
+ */
+
+// ActionCard component
+.card.action-card {
+	box-shadow: 0 1px 0 var( --studio-gray-5 );
+
+	&.is-compact {
+		display: flex;
+		padding: 12px 0;
+	}
+
+	&:last-child {
+		box-shadow: none;
+	}
+
+	.action-card__heading {
+		margin: 0 0 2px;
+		line-height: 1.2em;
+		color: 0 1px 0 var( --studio-gray-100 );
+	}
+
+	.action-card__main p {
+		color: var( --studio-gray-40 );
+		font-size: 0.875em; /* stylelint-disable-line */
+		margin-bottom: 0;
+	}
+
+	.action-card__button-container {
+		text-align: right;
+		margin-bottom: 0;
+	}
+
+	.action-card__button-container button {
+		text-align: right;
+		padding-right: 0;
+		border: none;
+	}
+
+	.action-card__button-container button svg {
+		fill: var( --studio-gray-30 );
+	}
+}
+
+// Modal component
+.components-modal__frame.components-modal-new__frame {
+	border-radius: 4px; /* stylelint-disable-line */
+
+	p {
+		font-size: 1rem; /* stylelint-disable-line */
+		color: var( --studio-gray-70 );
+		margin-bottom: 1em;
+
+		@include break-small {
+			font-size: 1.125rem; /* stylelint-disable-line */
+			line-height: 1.4444em;
+		}
+	}
+
+	strong {
+		font-weight: 500; /* stylelint-disable-line */
+	}
+
+	.components-modal__content {
+		display: block;
+		margin-top: 0;
+		padding: 40px;
+		overflow: auto;
+
+		&::before {
+			margin: 0;
+		}
+	}
+
+	.components-modal__header {
+		position: static;
+		display: block;
+		height: auto;
+		border: none;
+		margin-top: 0;
+		padding: 0;
+
+		button {
+			position: absolute;
+			top: 10px;
+			right: 10px;
+			left: auto;
+			padding: 0;
+
+			svg {
+				width: 34px;
+				height: 34px;
+			}
+		}
+
+		.components-modal__header-heading-container {
+			display: block;
+		}
+
+		.components-modal__header-heading {
+			font-size: 2rem;
+			font-weight: normal;
+			line-height: 1.25em;
+			margin-bottom: 0.75em;
+		}
+	}
+}

--- a/config/development.json
+++ b/config/development.json
@@ -78,6 +78,7 @@
 		"google-drive": true,
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/show-vertical-input": false,
+		"gutenboarding/import": true,
 		"help": true,
 		"home/layout-dev": true,
 		"importers/substack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,6 +51,7 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,
+		"gutenboarding/import": true,
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Changes introduce a new onboarding step named "importer". The step lives on `/start/importer` path. In this stage, idea is to provide UI without business logic. There is a `gutenboarding/import` feature flag which is only turn on for the development and wpcalypso environments.

In addition to the main imports route, there is a step route (sub route) importers list screen and you can reach it on `/start/importer/list` URL. 

**Desired Import Flow:**
Finish Signup -> Intent Screen -> Click "Import your site content" -> List / Capture / Scanning / Ready screens

#### Testing instructions

**Manual testing:**
- go to the path `/start/importer/list`
- resize the screen to see how it looks on mobile

#### Screenshots
<img width="1531" alt="Screenshot 2021-10-19 at 00 15 27" src="https://user-images.githubusercontent.com/1241413/137814066-5ee2795b-9a2f-41bd-9104-97db7dc4213f.png">

<img width="420" alt="Screenshot 2021-10-19 at 00 16 05" src="https://user-images.githubusercontent.com/1241413/137814089-fe5ee6da-55a4-47f4-bf6b-94fc4050b4ac.png">


Related to #
- [Figma design](https://www.figma.com/file/TAK5FpwTvfbENJDfHc7Aq1/Site-Importing?node-id=1930%3A21706)