### PR TITLE
Editor: Basic Post: re-add Preview test steps but enable only for mobile device.

### DIFF
--- a/packages/calypso-e2e/src/index.ts
+++ b/packages/calypso-e2e/src/index.ts
@@ -8,6 +8,7 @@ export type { PaymentDetails } from './data-helper';
 
 export { BrowserHelper, BrowserManager, MediaHelper, DataHelper, ElementHelper };
 
+export * from './jest-conditionals';
 export * from './lib';
 export * from './hooks';
 export * from './email-client';

--- a/packages/calypso-e2e/src/jest-conditionals.ts
+++ b/packages/calypso-e2e/src/jest-conditionals.ts
@@ -1,0 +1,5 @@
+import { it } from '@jest/globals';
+
+// This allows a conditional skip based on the parameter input.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const itif = ( conditional: boolean ) => ( conditional ? it : it.skip );

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -25,7 +25,6 @@ const selectors = {
 	postToolbar: '.edit-post-header',
 	settingsToggle: '[aria-label="Settings"]',
 	saveDraftButton: '.editor-post-save-draft',
-	// There is a hidden button also with the "Preview" text, so using unique class name instead of text selector.
 	previewButton: ':is(button:text("Preview"), a:text("Preview"))',
 	publishButton: ( parentSelector: string ) =>
 		`${ parentSelector } button:text("Publish")[aria-disabled=false]`,

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -409,17 +409,24 @@ export class GutenbergEditorPage {
 	}
 
 	/**
+	 * Terminates the Post Preview mode.
 	 *
+	 * This method will click on the Preview button if required, then select the `Desktop` entry.
+	 * `Desktop` is the default editor setting.
 	 */
 	async closePreview(): Promise< void > {
 		const frame = await this.getEditorFrame();
 
 		const previewButtonHandle = await frame.waitForSelector( selectors.previewButton );
+		// Check if the Preview button has been clicked and that menu options are showing.
+		// If required, click and show the menu items.
 		if ( ( await previewButtonHandle.getAttribute( 'aria-expanded' ) ) === 'false' ) {
 			await frame.click( selectors.previewButton );
 		}
 		await frame.click( selectors.previewMenuItem( 'Desktop' ) );
+		// Dismiss the Preview button.
 		await previewButtonHandle.click();
+
 		assert.strictEqual( await previewButtonHandle.getAttribute( 'aria-expanded' ), 'false' );
 		await frame.waitForSelector( selectors.previewPane( 'Desktop' ) );
 	}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -1,7 +1,9 @@
 import assert from 'assert';
 import { Page, Frame, ElementHandle } from 'playwright';
+import { getTargetDeviceName } from '../../browser-helper';
 
 type ClickOptions = Parameters< Frame[ 'click' ] >[ 1 ];
+type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 
 const selectors = {
 	// iframe and editor
@@ -23,7 +25,8 @@ const selectors = {
 	postToolbar: '.edit-post-header',
 	settingsToggle: '[aria-label="Settings"]',
 	saveDraftButton: '.editor-post-save-draft',
-	// there's a hidden button also with the "Preview" text, so using unique class name instead of text selector
+	// There is a hidden button also with the "Preview" text, so using unique class name instead of text selector.
+	previewButton: ':is(button:text("Preview"), a:text("Preview"))',
 	publishButton: ( parentSelector: string ) =>
 		`${ parentSelector } button:text("Publish")[aria-disabled=false]`,
 
@@ -42,6 +45,10 @@ const selectors = {
 	// Block editor sidebar
 	openSidebarButton: 'button[aria-label="Block editor sidebar"]',
 	dashboardLink: 'a[aria-description="Returns to the dashboard"]',
+
+	// Preview
+	previewMenuItem: ( target: PreviewOptions ) => `button[role="menuitem"] span:text("${ target }")`,
+	previewPane: ( target: PreviewOptions ) => `.is-${ target.toLowerCase() }-preview`,
 };
 
 /**
@@ -353,5 +360,68 @@ export class GutenbergEditorPage {
 	async returnToDashboard(): Promise< void > {
 		const frame = await this.getEditorFrame();
 		await frame.click( selectors.dashboardLink );
+	}
+
+	/* Previews */
+
+	/**
+	 * Click on the `Preview` button on the editor toolbar.
+	 *
+	 * This method interacts with the mobile implementation of the editor preview,
+	 * which:
+	 * 	1. launch a new tab.
+	 * 	2. load the preview.
+	 *
+	 * This method will throw if used in a desktop environment.
+	 *
+	 * @throws {Error} If environment is not 'mobile'.
+	 */
+	async openPreviewAsMobile(): Promise< Page > {
+		if ( getTargetDeviceName() !== 'mobile' ) {
+			throw new Error( 'This method only works in a mobile environment.' );
+		}
+		const frame = await this.getEditorFrame();
+		const [ popup ] = await Promise.all( [
+			this.page.waitForEvent( 'popup' ),
+			frame.click( selectors.previewButton ),
+		] );
+		await popup.waitForLoadState( 'load' );
+		return popup;
+	}
+
+	/**
+	 * Click on the `Preview` button on the editor toolbar, then select requested the preview option.
+	 *
+	 * This method interacts with the non-mobile implementation of the editor preview,
+	 * which applies an attribute to the editor to simulate target device.
+	 *
+	 *
+	 * @param {PreviewOptions} target Preview option to be selected.
+	 * @throws {Error} If environment is 'mobile'.
+	 */
+	async openPreviewAsDesktop( target: PreviewOptions ): Promise< void > {
+		if ( getTargetDeviceName() === 'mobile' ) {
+			throw new Error( 'This method only works in a non-mobile environment.' );
+		}
+		const frame = await this.getEditorFrame();
+		await frame.click( selectors.previewButton );
+		await frame.click( selectors.previewMenuItem( target ) );
+		await frame.waitForSelector( selectors.previewPane( target ) );
+	}
+
+	/**
+	 *
+	 */
+	async closePreview(): Promise< void > {
+		const frame = await this.getEditorFrame();
+
+		const previewButtonHandle = await frame.waitForSelector( selectors.previewButton );
+		if ( ( await previewButtonHandle.getAttribute( 'aria-expanded' ) ) === 'false' ) {
+			await frame.click( selectors.previewButton );
+		}
+		await frame.click( selectors.previewMenuItem( 'Desktop' ) );
+		await previewButtonHandle.click();
+		assert.strictEqual( await previewButtonHandle.getAttribute( 'aria-expanded' ), 'false' );
+		await frame.waitForSelector( selectors.previewPane( 'Desktop' ) );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -411,23 +411,30 @@ export class GutenbergEditorPage {
 	/**
 	 * Terminates the Post Preview mode.
 	 *
-	 * This method will click on the Preview button if required, then select the `Desktop` entry.
-	 * `Desktop` is the default editor setting.
+	 * This method will click on the Preview button if required, then select the `Desktop` entry,
+	 * which is the default view setting when the editor is opened initially.
+	 *
+	 * @throws {Error} If environment is 'mobile'.
 	 */
 	async closePreview(): Promise< void > {
+		if ( getTargetDeviceName() === 'mobile' ) {
+			throw new Error( ' This method only works in a non-mobile environment.' );
+		}
 		const frame = await this.getEditorFrame();
 
 		const previewButtonHandle = await frame.waitForSelector( selectors.previewButton );
 		// Check if the Preview button has been clicked and that menu options are showing.
-		// If required, click and show the menu items.
+		// If required, click and show the menu items so that 'Desktop' can be clicked.
 		if ( ( await previewButtonHandle.getAttribute( 'aria-expanded' ) ) === 'false' ) {
 			await frame.click( selectors.previewButton );
 		}
+		// Select 'Desktop'.
 		await frame.click( selectors.previewMenuItem( 'Desktop' ) );
 		// Dismiss the Preview button.
 		await previewButtonHandle.click();
 
-		assert.strictEqual( await previewButtonHandle.getAttribute( 'aria-expanded' ), 'false' );
+		// Ensure the preview menu is closed and that preview settings are back to default.
+		await frame.waitForSelector( 'button[aria-expanded=false]' );
 		await frame.waitForSelector( selectors.previewPane( 'Desktop' ) );
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -16,6 +16,7 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
+// This allows a conditional skip based on the parameter input.
 const itif = ( device: string ) => ( device === 'mobile' ? it : it.skip );
 
 const quote =

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -107,13 +107,14 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 				await gutenbergEditorPage.closePreview();
 			}
 		} );
+
+		// TODO: step skipped for mobile, since previewing naturally saves the post, rendering this step unnecessary.
+		itif( targetDevice !== 'mobile' )( 'Save draft', async function () {
+			await gutenbergEditorPage.saveDraft();
+		} );
 	} );
 
 	describe( 'Publish post', function () {
-		it( 'Save draft', async function () {
-			await gutenbergEditorPage.saveDraft();
-		} );
-
 		it( 'Publish and visit post', async function () {
 			const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
 			expect( publishedURL ).toBe( page.url() );

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -13,11 +13,9 @@ import {
 	NewPostFlow,
 	setupHooks,
 	PublishedPostPage,
+	itif,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
-
-// This allows a conditional skip based on the parameter input.
-const itif = ( device: string ) => ( device === 'mobile' ? it : it.skip );
 
 const quote =
 	'The problem with quotes on the Internet is that it is hard to verify their authenticity. \n— Abraham Lincoln';
@@ -77,6 +75,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Preview post', function () {
+		const targetDevice = BrowserHelper.getTargetDeviceName();
 		let previewPage: Page;
 
 		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
@@ -84,12 +83,13 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			await editorSettingsSidebarComponent.closeSidebar();
 		} );
 
-		// The following two steps have conditiionals inside them, as how the Editor Preview behaves
-		// depends on the device type.
+		// The following two steps have conditiionals inside them, as how the
+		// Editor Preview behaves depends on the device type.
 		// On desktop and tablet, preview applies CSS attributes to modify the preview in-editor.
 		// On mobile web, preview button opens a new tab.
+
 		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
-		itif( BrowserHelper.getTargetDeviceName() )( 'Launch preview', async function () {
+		itif( targetDevice === 'mobile' )( 'Launch preview', async function () {
 			if ( BrowserHelper.getTargetDeviceName() === 'mobile' ) {
 				previewPage = await gutenbergEditorPage.openPreviewAsMobile();
 			} else {
@@ -98,9 +98,11 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 
 		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
-		itif( BrowserHelper.getTargetDeviceName() )( 'Close preview', async function () {
+		itif( targetDevice === 'mobile' )( 'Close preview', async function () {
+			// Mobile path.
 			if ( previewPage ) {
 				await previewPage.close();
+				// Desktop path.
 			} else {
 				await gutenbergEditorPage.closePreview();
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR re-implements the Preview Post steps, removed in #56980.

Key changes:
- readd an updated set of steps for the Preview Post test steps.
- implement preview methods in GutenbergEditorPage object.
- skip the test for desktops due to known issue: https://github.com/Automattic/wp-calypso/issues/57128

Details:

As outlined in the overview, the Preview steps were removed in a previous PR when the preview functionality was switched over to the native previews.

This PR was initially intended to restore the Preview test step but as it turns out, there is an issue related to Preview that crashes the editor at #57128, resulting in the re-added Preview steps being disabled on Desktop testing for the time being.

Fixes https://github.com/Automattic/wp-calypso/issues/57014 and https://github.com/Automattic/wp-calypso/issues/57289.