### PR TITLE
The initial theme for new sites is now Zoologist

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -59,7 +59,7 @@ export function* createSite( {
 
 	const siteUrl = domain?.domain_name || siteTitle || username;
 	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
-	const defaultTheme = 'quadrat';
+	const defaultTheme = 'zoologist';
 	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 
 	const params: CreateSiteParams = {

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -4,7 +4,7 @@ import { find, get } from 'lodash';
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
-			theme: 'pub/hever',
+			theme: 'pub/zoologist',
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -145,10 +145,6 @@ function getNewSiteParams( {
 		get( signupDependencies, 'themeSlugWithRepo', false ) ||
 		siteTypeTheme;
 
-	// We will use the default annotation instead of theme annotation as fallback,
-	// when segment and vertical values are not sent. Check pbAok1-p2#comment-834.
-	const shouldUseDefaultAnnotationAsFallback = true;
-
 	const newSiteParams = {
 		blog_title: siteTitle,
 		public: Visibility.PublicNotIndexed,
@@ -156,7 +152,6 @@ function getNewSiteParams( {
 			designType: designType || undefined,
 			theme,
 			use_theme_annotation: get( signupDependencies, 'useThemeHeadstart', false ),
-			default_annotation_as_primary_fallback: shouldUseDefaultAnnotationAsFallback,
 			siteGoals: siteGoals || undefined,
 			site_style: siteStyle || undefined,
 			site_segment: siteSegment || undefined,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<img width="1321" alt="Screenshot 2021-10-19 at 4 49 54 PM" src="https://user-images.githubusercontent.com/1500769/137840854-95693945-0c6a-4988-b842-9549fee2da77.png">

- Updates the default theme from Hever to Zoologist
- Uses the Zoologist theme's annotations for new sites, which are very minimal compared to the Headstart defaults

Links where this has been discussed:
- #55277
- pNEWy-ekS-p2#comment-53631
- pdgK6S-1h-p2

For the sake of comparison, here's the last time the default theme was changed: #39795

`/new` is largely unaffected because the design picker in that flow doesn't have a skip button; the user must make a selection so practically there's no default.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Can be tested using calypso.live
* Create a new site at `/start`
* New site should have Zoologist theme applied with minimal content (just 1 page and 1 post)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55277