### PR TITLE
Media: Remove last `noop` usage from `EditorMediaModalDetailFields`

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { debounce, get, noop } from 'lodash';
+import { debounce, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReactDom from 'react-dom';
@@ -17,6 +17,8 @@ import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getMimePrefix, url } from 'calypso/lib/media/utils';
 import { updateMedia } from 'calypso/state/media/thunks';
 import EditorMediaModalFieldset from '../fieldset';
+
+const noop = () => {};
 
 class EditorMediaModalDetailFields extends Component {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `noop` is essentially an empty function. In #50755 we removed most of the `noop` usages but left one in `EditorMediaModalDetailFields` by accident. This PR removes it.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

Verify Calypso builds and you can still edit a media item by using the Calypso media modal.