### PR TITLE
Reader: Remove deprecated lifecycle methods from `QueryReaderPost`

### DIFF
--- a/client/components/data/query-reader-post/index.jsx
+++ b/client/components/data/query-reader-post/index.jsx
@@ -14,8 +14,8 @@ class QueryReaderPost extends Component {
 		this.maybeFetch();
 	}
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.maybeFetch( nextProps );
+	componentDidUpdate() {
+		this.maybeFetch();
 	}
 
 	maybeFetch = ( props = this.props ) => {

--- a/client/components/data/query-reader-post/index.jsx
+++ b/client/components/data/query-reader-post/index.jsx
@@ -18,9 +18,11 @@ class QueryReaderPost extends Component {
 		this.maybeFetch();
 	}
 
-	maybeFetch = ( props = this.props ) => {
-		if ( isPostKeyLike( props.postKey ) && ( ! props.post || props.post._state === 'minimal' ) ) {
-			this.props.fetchPost( props.postKey );
+	maybeFetch = () => {
+		const { post, postKey } = this.props;
+
+		if ( isPostKeyLike( postKey ) && ( ! post || post._state === 'minimal' ) ) {
+			this.props.fetchPost( postKey );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're in the process of removing deprecated React component lifecycle methods from Calypso. 

This PR removes `UNSAFE_componentWillReceiveProps` from `QueryReaderPost` in favor of using `componentDidUpdate` which is [recommended](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops) in the case when we're performing a side effect.

#### Testing instructions

* Go to `/read`
* Scroll down a little bit.
* Verify posts under "Recommended posts" still load properly.
* cc @Automattic/reader what is a good way to trigger a new fetch to test the updated lifecycle method?