### PR TITLE
Layout: AsyncLoad PopupSearch

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -30,7 +30,6 @@ import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import PopUpSearch from '../popup-search';
 import Item from './item';
 import Masterbar from './masterbar';
 import Notifications from './notifications';
@@ -236,7 +235,11 @@ class MasterbarLoggedIn extends Component {
 		return (
 			<>
 				{ isWordPressActionSearchFeatureEnabled && isActionSearchVisible ? (
-					<PopUpSearch onClose={ this.onSearchActionsClose } />
+					<AsyncLoad
+						require="calypso/layout/popup-search"
+						placeholder={ null }
+						onClose={ this.onSearchActionsClose }
+					/>
 				) : null }
 				<Masterbar>
 					{ this.renderMySites() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we introduced the WP action search popup in #50952, we directly added it to the primary logged in user layout. However, the feature is:

* Not currently enabled in any environment.
* Not immediately necessary, so can be asynchronously loaded.

Anyway, its code is being loaded in the main entry point, which loads for most of Calypso's routes. 

This PR alters it to load asynchronously. That will happen only if the `wordpress-action-search` feature is enabled currently.

#### Testing instructions

* Smoke test Calypso.
* Verify the Calypso top bar still looks and works as it did before.
* Add `?flags=wordpress-action-search` to your URL and verify the search form still appears in the Calypso top bar. Note that it's broken if you try to use it, but that's how it is in `trunk` currently, so that's expected.

#### Further discussion

It's interesting to observe that while we're shaving a bit off the main entry point, there are a bunch of sections that are increased in size. I'd love some opinions from @sgomes and @Automattic/team-calypso-frameworks on the tradeoffs of such a change.