### PR TITLE
App banner: Update the logic to display it

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
+import withBlockEditorNuxStatus from 'calypso/data/block-editor/with-block-editor-nux-status-query';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import versionCompare from 'calypso/lib/version-compare';
@@ -20,7 +21,7 @@ import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
-import { getSectionName, getSelectedSiteId, appBannerIsEnabled } from 'calypso/state/ui/selectors';
+import { getSectionName, appBannerIsEnabled } from 'calypso/state/ui/selectors';
 import {
 	ALLOWED_SECTIONS,
 	EDITOR,
@@ -51,6 +52,7 @@ export class AppBanner extends Component {
 		currentSection: PropTypes.string,
 		dismissedUntil: PropTypes.object,
 		fetchingPreferences: PropTypes.bool,
+		blockEditorNuxStatus: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -77,7 +79,13 @@ export class AppBanner extends Component {
 	};
 
 	isVisible() {
-		const { dismissedUntil, currentSection, isTosBannerVisible, isAppBannerEnabled } = this.props;
+		const {
+			dismissedUntil,
+			currentSection,
+			isTosBannerVisible,
+			isAppBannerEnabled,
+			blockEditorNuxStatus,
+		} = this.props;
 
 		// The ToS update banner is displayed in the same position as the mobile app banner. Since the ToS update
 		// has higher priority, we repress all other non-essential sticky banners if the ToS update banner needs to
@@ -88,6 +96,14 @@ export class AppBanner extends Component {
 
 		// In some cases such as error we want to hide the app banner completely.
 		if ( ! isAppBannerEnabled ) {
+			return false;
+		}
+
+		// Inside page/post editor, hide the banner until we know that welcome tour has been dimissed to avoid overlapping.
+		if (
+			[ EDITOR, GUTENBERG ].includes( currentSection ) &&
+			( ! blockEditorNuxStatus || blockEditorNuxStatus.show_welcome_guide )
+		) {
 			return false;
 		}
 
@@ -246,7 +262,6 @@ const mapStateToProps = ( state ) => {
 		currentSection: getCurrentSection( sectionName, isNotesOpen, currentRoute ),
 		currentRoute,
 		fetchingPreferences: isFetchingPreferences( state ),
-		siteId: getSelectedSiteId( state ),
 		isTosBannerVisible: shouldDisplayTosUpdateBanner( state ),
 		isAppBannerEnabled: appBannerIsEnabled( state ),
 	};
@@ -271,4 +286,9 @@ const mapDispatchToProps = {
 		),
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( AppBanner ) );
+const AppBannerWithEditorNuxStatus = withBlockEditorNuxStatus( AppBanner );
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( AppBannerWithEditorNuxStatus ) );

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -48,11 +48,13 @@ export class AppBanner extends Component {
 		translate: PropTypes.func,
 		recordAppBannerOpen: PropTypes.func,
 		userAgent: PropTypes.string,
+		blockEditorNuxStatus: PropTypes.shape( {
+			show_welcome_guide: PropTypes.bool,
+		} ),
 		// connected
 		currentSection: PropTypes.string,
 		dismissedUntil: PropTypes.object,
 		fetchingPreferences: PropTypes.bool,
-		blockEditorNuxStatus: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/data/block-editor/use-block-editor-nux-status-query.ts
+++ b/client/data/block-editor/use-block-editor-nux-status-query.ts
@@ -10,10 +10,14 @@ export const useBlockEditorNuxStatusQuery = (
 ): UseQueryResult< BlockEditorNuxStatus > => {
 	const queryKey = [ 'blockEditorNuxStatus', siteId ];
 
-	return useQuery< BlockEditorNuxStatus >( queryKey, () => {
-		return wpcom.req.get( {
-			path: `/sites/${ siteId }/block-editor/nux`,
-			apiNamespace: 'wpcom/v2',
-		} );
-	} );
+	return useQuery< BlockEditorNuxStatus >(
+		queryKey,
+		() => {
+			return wpcom.req.get( {
+				path: `/sites/${ siteId }/block-editor/nux`,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+		{ enabled: !! siteId }
+	);
 };

--- a/client/data/block-editor/use-block-editor-nux-status-query.ts
+++ b/client/data/block-editor/use-block-editor-nux-status-query.ts
@@ -1,0 +1,19 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+export type BlockEditorNuxStatus = {
+	show_welcome_guide: boolean;
+};
+
+export const useBlockEditorNuxStatusQuery = (
+	siteId: string
+): UseQueryResult< BlockEditorNuxStatus > => {
+	const queryKey = [ 'blockEditorNuxStatus', siteId ];
+
+	return useQuery< BlockEditorNuxStatus >( queryKey, () => {
+		return wpcom.req.get( {
+			path: `/sites/${ siteId }/block-editor/nux`,
+			apiNamespace: 'wpcom/v2',
+		} );
+	} );
+};

--- a/client/data/block-editor/with-block-editor-nux-status-query.js
+++ b/client/data/block-editor/with-block-editor-nux-status-query.js
@@ -1,0 +1,15 @@
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useBlockEditorNuxStatusQuery } from './use-block-editor-nux-status-query';
+
+const withBlockEditorNuxStatus = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const siteId = useSelector( getSelectedSiteId );
+		const { data } = useBlockEditorNuxStatusQuery( siteId );
+		return <Wrapped { ...props } blockEditorNuxStatus={ data } />;
+	},
+	'withBlockEditorNuxStatus'
+);
+
+export default withBlockEditorNuxStatus;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -39,13 +39,12 @@ import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
 	getSelectedSiteId,
 	masterbarIsVisible,
-	getSelectedSite,
 	getSidebarIsCollapsed,
 } from 'calypso/state/ui/selectors';
 import SupportUser from 'calypso/support/support-user';
 import BodySectionCssClass from './body-section-css-class';
 import LayoutLoader from './loader';
-import { getShouldShowAppBanner, handleScroll } from './utils';
+import { handleScroll } from './utils';
 // goofy import for environment badge, which is SSR'd
 import 'calypso/components/environment-badge/style.scss';
 import './style.scss';
@@ -116,7 +115,6 @@ class Layout extends Component {
 		sectionGroup: PropTypes.string,
 		sectionName: PropTypes.string,
 		colorSchemePreference: PropTypes.string,
-		shouldShowAppBanner: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -250,7 +248,6 @@ class Layout extends Component {
 				bodyClass,
 			};
 		};
-		const { shouldShowAppBanner } = this.props;
 
 		const loadInlineHelp = this.shouldLoadInlineHelp();
 
@@ -339,7 +336,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/support-article-dialog' ) && (
 					<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
 				) }
-				{ shouldShowAppBanner && config.isEnabled( 'layout/app-banner' ) && (
+				{ config.isEnabled( 'layout/app-banner' ) && (
 					<AsyncLoad require="calypso/blocks/app-banner" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'gdpr-banner' ) && (
@@ -358,7 +355,6 @@ export default withCurrentRoute(
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 		const siteId = getSelectedSiteId( state );
-		const shouldShowAppBanner = getShouldShowAppBanner( getSelectedSite( state ) );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isJetpack =
@@ -408,7 +404,6 @@ export default withCurrentRoute(
 			sectionGroup,
 			sectionName,
 			sectionJitmPath,
-			shouldShowAppBanner,
 			isOffline: isOffline( state ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			chatIsOpen: isHappychatOpen( state ),

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,20 +1,3 @@
-const HOUR_IN_MS = 60 * 60 * 1000;
-
-/**
- * Returns false if the site is unlaunched or is younger than 1 hour
- *
- * @param site the site object
- */
-export function getShouldShowAppBanner( site: any ): boolean {
-	if ( site && site.options ) {
-		const olderThanAnHour = Date.now() - new Date( site.options.created_at ).getTime() > HOUR_IN_MS;
-		const isLaunched = site.launch_status !== 'unlaunched';
-
-		return olderThanAnHour && isLaunched;
-	}
-	return true;
-}
-
 let lastScrollPosition = 0; // Used for calculating scroll direction.
 let sidebarTop = 0; // Current sidebar top position.
 let pinnedSidebarTop = true; // We pin sidebar to the top by default.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In Calypso, show the mobile app banner immediately for all sites, including the ones that haven't been launched
* In page/post editor, show the banner [after 30 minutes following site creation](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php#L91-L92) and only if the Welcome Tour has been dismissed

#### Testing instructions

* Create a new site and go to Stats page on mobile. Mobile app banner should be visible.
* Go to page/post editor. Only the Editor Welcome tour should be visible.
* Dismiss or complete the Editor welcome tour for a site that is at least 30 minutes old (or edit this [constant](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php#L17) in ETK while sandboxing the site and the public API)
* Visit the page/post editor once again (or refresh). Mobile app banner should be displayed.

#### Demos
* at site creation: https://cloudup.com/cAPQgcQREEp
* for a 30 minutes old site: https://cloudup.com/cAat5qZlsBi

Related: https://github.com/Automattic/wp-calypso/issues/54948
Context: p1633638703045100-slack-C01VA0R5NKY