### PR TITLE
Layout: AsyncLoad all of community translator

### DIFF
--- a/client/layout/community-translator/index.jsx
+++ b/client/layout/community-translator/index.jsx
@@ -1,0 +1,17 @@
+import config from '@automattic/calypso-config';
+import { useSelector } from 'react-redux';
+import CommunityTranslator from 'calypso/components/community-translator';
+import CommunityTranslatorLauncher from 'calypso/layout/community-translator/launcher';
+import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
+
+export default function CommunityTranslatorMain() {
+	const communityTranslatorEnabled = useSelector( isCommunityTranslatorEnabled );
+
+	if ( config.isEnabled( 'i18n/community-translator' ) && communityTranslatorEnabled ) {
+		return <CommunityTranslator />;
+	} else if ( config( 'restricted_me_access' ) ) {
+		return <CommunityTranslatorLauncher />;
+	}
+
+	return null;
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -30,7 +30,6 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -304,16 +303,7 @@ class Layout extends Component {
 						{ this.props.primary }
 					</div>
 				</div>
-				{ config.isEnabled( 'i18n/community-translator' )
-					? this.props.isCommunityTranslatorEnabled && (
-							<AsyncLoad require="calypso/components/community-translator" />
-					  )
-					: config( 'restricted_me_access' ) && (
-							<AsyncLoad
-								require="calypso/layout/community-translator/launcher"
-								placeholder={ null }
-							/>
-					  ) }
+				<AsyncLoad require="calypso/layout/community-translator" placeholder={ null } />
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && (
 					<AsyncLoad require="calypso/components/happychat" />
 				) }
@@ -401,7 +391,6 @@ export default withCurrentRoute(
 			isJetpackWooDnaFlow,
 			isJetpackMobileFlow,
 			isEligibleForJITM,
-			isCommunityTranslatorEnabled: isCommunityTranslatorEnabled( state ),
 			oauth2Client,
 			wccomFrom,
 			isSupportSession: isSupportSession( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, we're async loading the community translator itself, and its launcher separately. However, the logic to determine whether the launcher or the community translator should be loaded is always loaded as part of the primary Calypso layout. Since the community translator is not critical and can load later, we're moving all its code and conditions to be asynchronously loaded. That way we're additionally asynchronously loading the following (and therefore excluding them from the main entry point bundle):

* [lib/i18n-utils/constants.js](https://github.com/Automattic/wp-calypso/tree/update/async-load-community-translator/client/lib/i18n-utils/constants.js)
* [state/selectors/can-display-community-translator.js](https://github.com/Automattic/wp-calypso/tree/update/async-load-community-translator/client/state/selectors/can-display-community-translator.js)
* [state/selectors/get-user-setting.js](https://github.com/Automattic/wp-calypso/tree/update/async-load-community-translator/client/state/selectors/get-user-setting.js)
* [state/selectors/is-community-translator-enabled.js](https://github.com/Automattic/wp-calypso/tree/update/async-load-community-translator/client/state/selectors/is-community-translator-enabled.js)
* [state/user-settings/helpers.js](https://github.com/Automattic/wp-calypso/tree/update/async-load-community-translator/client/state/user-settings/helpers.js)
* [state/user-settings/init.js](https://github.com/Automattic/wp-calypso/tree/update/async-load-community-translator/client/state/user-settings/init.js)
* [state/user-settings/reducer.js](https://github.com/Automattic/wp-calypso/tree/update/async-load-community-translator/client/state/user-settings/reducer.js)

#### Testing instructions

Verify the community translator and its launcher still work well.