### PR TITLE
FSE beta: ramp up opt-in percentage to 10%

### DIFF
--- a/client/landing/gutenboarding/hooks/use-fse-beta-eligibility.ts
+++ b/client/landing/gutenboarding/hooks/use-fse-beta-eligibility.ts
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { USER_STORE } from '../stores/user';
 
-const FSE_BETA_ROLLOUT_PERCENTAGE = 1;
+const FSE_BETA_ROLLOUT_PERCENTAGE = 10;
 
 export default function useFseBetaEligibility(): boolean {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Increase the percentage of existing users that get FSE beta opt-in to 10%.

#### Testing instructions

Same as https://github.com/Automattic/wp-calypso/pull/56585.
