### PR TITLE
Domains: Add individual state management for "Use My Domain" components

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -3,7 +3,10 @@ import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import Notice from 'calypso/components/notice';
+import { domainAvailability } from 'calypso/lib/domains/constants';
+import wpcom from 'calypso/lib/wp';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
 import {
 	modeType,
@@ -27,6 +30,10 @@ export default function ConnectDomainStepLogin( {
 } ) {
 	const { __ } = useI18n();
 	const [ heading, setHeading ] = useState();
+	const [ isFetching, setIsFetching ] = useState( false );
+	const [ isConnectSupported, setIsConnectSupported ] = useState( true );
+
+	const initialValidation = useRef( false );
 
 	useEffect( () => {
 		switch ( mode ) {
@@ -45,12 +52,42 @@ export default function ConnectDomainStepLogin( {
 		}
 	}, [ mode ] );
 
+	useEffect( () => {
+		( async () => {
+			if ( ! isOwnershipVerificationFlow || initialValidation.current ) return;
+
+			setIsFetching( true );
+
+			try {
+				const availability = await wpcom
+					.domain( domain )
+					.isAvailable( { apiVersion: '1.3', is_cart_pre_check: false } );
+
+				if ( domainAvailability.MAPPABLE !== availability.mappable ) {
+					setIsConnectSupported( false );
+				}
+			} catch {
+				setIsConnectSupported( false );
+			} finally {
+				setIsFetching( false );
+				initialValidation.current = true;
+			}
+		} )();
+	} );
+
 	const stepContent = (
 		<div className={ className + '__login' }>
 			{ isOwnershipVerificationFlow && (
 				<p className={ className + '__text' }>
 					{ __( 'We need to confirm that you are authorized to connect this domain.' ) }
 				</p>
+			) }
+			{ ! isFetching && ! isConnectSupported && (
+				<Notice
+					status="is-error"
+					showDismiss={ false }
+					text={ __( 'This domain cannot be connected.' ) }
+				></Notice>
 			) }
 			<p className={ className + '__text' }>
 				{ createInterpolateElement(
@@ -72,7 +109,12 @@ export default function ConnectDomainStepLogin( {
 					domain
 				) }
 			</p>
-			<Button primary onClick={ onNextStep }>
+			<Button
+				primary
+				onClick={ onNextStep }
+				busy={ isFetching }
+				disabled={ isFetching || ! isConnectSupported }
+			>
 				{ __( "I found the domain's settings page" ) }
 			</Button>
 		</div>

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -3,21 +3,26 @@ import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
 import {
+	getAvailabilityErrorMessage,
 	getDomainInboundTransferStatusInfo,
 	getDomainTransferrability,
 } from 'calypso/components/domains/use-my-domain/utilities';
 import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
 import { MAP_EXISTING_DOMAIN } from 'calypso/lib/url/support';
+import wpcom from 'calypso/lib/wp';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import './style.scss';
-import { StartStepProps } from './types';
+import { Maybe, StartStepProps } from './types';
 
-export default function TransferDomainStepStart( {
+import './style.scss';
+
+function TransferDomainStepStart( {
 	className,
 	pageSlug,
 	onNextStep,
@@ -25,30 +30,54 @@ export default function TransferDomainStepStart( {
 	domainInboundTransferStatusInfo,
 	domain,
 	isFetchingAvailability,
+	selectedSite,
 }: StartStepProps ): JSX.Element {
 	const { __ } = useI18n();
 	const switchToDomainConnect = () => page( MAP_EXISTING_DOMAIN );
-	const [ inboundTransferStatusInfo, setInboundTransferStatusInfo ] = useState(
-		domainInboundTransferStatusInfo
-	);
+	const [ inboundTransferStatusInfo, setInboundTransferStatusInfo ] = useState<
+		Maybe< typeof domainInboundTransferStatusInfo >
+	>( domainInboundTransferStatusInfo );
 	const [ isFetching, setIsFetching ] = useState( isFetchingAvailability );
-	const isDomainTransferrable = getDomainTransferrability( domainInboundTransferStatusInfo )
+	const isDomainTransferrable = getDomainTransferrability( inboundTransferStatusInfo )
 		.transferrable;
+
+	const initialValidation = useRef( false );
 
 	// retrieves the availability data by itself if not provided by the parent component
 	useEffect( () => {
 		( async () => {
-			try {
-				setIsFetching( true );
+			if ( initialValidation.current ) return;
+			setIsFetching( true );
 
-				if ( ! inboundTransferStatusInfo ) {
+			if ( ! inboundTransferStatusInfo ) {
+				try {
 					const inboundTransferStatusResult = await getDomainInboundTransferStatusInfo( domain );
+
 					setInboundTransferStatusInfo( inboundTransferStatusResult );
+				} catch {
+					setInboundTransferStatusInfo( {} );
 				}
-				setIsFetching( false );
+			}
+
+			try {
+				const availabilityData = await wpcom
+					.domain( domain )
+					.isAvailable( { apiVersion: '1.3', is_cart_pre_check: false } );
+
+				const availabilityErrorMessage = getAvailabilityErrorMessage( {
+					availabilityData,
+					domainName: domain,
+					selectedSite,
+				} );
+
+				if ( availabilityErrorMessage ) {
+					setInboundTransferStatusInfo( null );
+				}
 			} catch {
-				setIsFetching( false );
 				setInboundTransferStatusInfo( {} );
+			} finally {
+				initialValidation.current = true;
+				setIsFetching( false );
 			}
 		} )();
 	} );
@@ -99,8 +128,8 @@ export default function TransferDomainStepStart( {
 				<Button
 					primary
 					onClick={ onNextStep }
-					disabled={ ! isDomainTransferrable }
-					busy={ isFetchingAvailability }
+					disabled={ isFetching || ! isDomainTransferrable }
+					busy={ isFetching }
 				>
 					{ __( 'Start setup' ) }
 				</Button>
@@ -118,3 +147,7 @@ export default function TransferDomainStepStart( {
 		/>
 	);
 }
+
+export default connect( ( state ) => ( { selectedSite: getSelectedSite( state ) } ) )(
+	TransferDomainStepStart
+);

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -2,7 +2,7 @@ import { SiteData } from 'calypso/state/ui/selectors/site-data';
 import { stepSlug, useMyDomainInputMode } from '../constants';
 
 type ValueOf< T > = T[ keyof T ];
-type Maybe< T > = T | null;
+export type Maybe< T > = T | null;
 
 type PossibleSlugs = ValueOf< typeof stepSlug >;
 type PossibleInitialModes = ValueOf< typeof useMyDomainInputMode >;
@@ -56,6 +56,7 @@ export type StartStepProps = {
 	progressStepList: Record< PossibleSlugs, string >;
 	domainInboundTransferStatusInfo: Partial< InboundTransferStatusInfo >;
 	initialMode: PossibleInitialModes;
+	selectedSite: Maybe< SiteData >;
 	setPage: ( page: PossibleSlugs ) => void;
 };
 

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -38,7 +38,7 @@ function UseMyDomain( {
 	initialMode,
 } ) {
 	const [ domainAvailabilityData, setDomainAvailabilityData ] = useState( null );
-	const [ domainInboundTransferStatusInfo, setDomainInboundTransferStatusInfo ] = useState( {} );
+	const [ domainInboundTransferStatusInfo, setDomainInboundTransferStatusInfo ] = useState( null );
 	const [ domainName, setDomainName ] = useState( initialQuery ?? '' );
 	const [ domainNameValidationError, setDomainNameValidationError ] = useState();
 	const [ domainLockStatus, setDomainLockStatus ] = useState( domainLockStatusType.LOCKED );

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -37,7 +37,7 @@ function UseMyDomain( {
 	transferDomainUrl,
 	initialMode,
 } ) {
-	const [ domainAvailabilityData, setDomainAvailabilityData ] = useState( {} );
+	const [ domainAvailabilityData, setDomainAvailabilityData ] = useState( null );
 	const [ domainInboundTransferStatusInfo, setDomainInboundTransferStatusInfo ] = useState( {} );
 	const [ domainName, setDomainName ] = useState( initialQuery ?? '' );
 	const [ domainNameValidationError, setDomainNameValidationError ] = useState();
@@ -153,7 +153,7 @@ function UseMyDomain( {
 		}
 
 		setIsFetchingAvailability( true );
-		setDomainAvailabilityData( {} );
+		setDomainAvailabilityData( null );
 
 		try {
 			const availabilityData = await wpcom
@@ -239,7 +239,7 @@ function UseMyDomain( {
 				domain={ domainName }
 				isSignupStep={ isSignupStep }
 				onConnect={
-					'auth_code' === domainAvailabilityData.ownership_verification_type
+					'auth_code' === domainAvailabilityData?.ownership_verification_type
 						? showOwnershipVerificationFlow
 						: onConnect
 				}

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -89,8 +89,6 @@ function DomainTransferOrConnect( {
 			}
 
 			if ( ! inboundTransferStatusInfo ) {
-				// TODO: remove this try-catch when the next statuses get added on the API
-
 				const inboundTransferStatusResult = await wpcom
 					.undocumented()
 					.getInboundTransferStatus( domain );

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -79,36 +79,44 @@ function DomainTransferOrConnect( {
 	useEffect( () => {
 		( async () => {
 			if ( availabilityData && inboundTransferStatusInfo ) return;
-			setIsFetching( true );
-			if ( ! availabilityData ) {
-				const retrievedAvailabilityData = await wpcom
-					.domain( domain )
-					.isAvailable( { apiVersion: '1.3', blog_id: selectedSite.ID, is_cart_pre_check: false } );
+			try {
+				setIsFetching( true );
+				if ( ! availabilityData ) {
+					const retrievedAvailabilityData = await wpcom.domain( domain ).isAvailable( {
+						apiVersion: '1.3',
+						blog_id: selectedSite.ID,
+						is_cart_pre_check: false,
+					} );
 
-				setAvailabilityData( retrievedAvailabilityData );
+					setAvailabilityData( retrievedAvailabilityData );
+				}
+
+				if ( ! inboundTransferStatusInfo ) {
+					const inboundTransferStatusResult = await wpcom
+						.undocumented()
+						.getInboundTransferStatus( domain );
+
+					const retrievedInboundTransferStatusInfo = {
+						creationDate: inboundTransferStatusResult.creation_date,
+						email: inboundTransferStatusResult.admin_email,
+						inRedemption: inboundTransferStatusResult.in_redemption,
+						losingRegistrar: inboundTransferStatusResult.registrar,
+						losingRegistrarIanaId: inboundTransferStatusResult.registrar_iana_id,
+						privacy: inboundTransferStatusResult.privacy,
+						termMaximumInYears: inboundTransferStatusResult.term_maximum_in_years,
+						transferEligibleDate: inboundTransferStatusResult.transfer_eligible_date,
+						transferRestrictionStatus: inboundTransferStatusResult.transfer_restriction_status,
+						unlocked: inboundTransferStatusResult.unlocked,
+					};
+
+					setInboundTransferStatusInfo( retrievedInboundTransferStatusInfo );
+				}
+				setIsFetching( false );
+			} catch {
+				setIsFetching( false );
+				setAvailabilityData( {} );
+				setInboundTransferStatusInfo( {} );
 			}
-
-			if ( ! inboundTransferStatusInfo ) {
-				const inboundTransferStatusResult = await wpcom
-					.undocumented()
-					.getInboundTransferStatus( domain );
-
-				const retrievedInboundTransferStatusInfo = {
-					creationDate: inboundTransferStatusResult.creation_date,
-					email: inboundTransferStatusResult.admin_email,
-					inRedemption: inboundTransferStatusResult.in_redemption,
-					losingRegistrar: inboundTransferStatusResult.registrar,
-					losingRegistrarIanaId: inboundTransferStatusResult.registrar_iana_id,
-					privacy: inboundTransferStatusResult.privacy,
-					termMaximumInYears: inboundTransferStatusResult.term_maximum_in_years,
-					transferEligibleDate: inboundTransferStatusResult.transfer_eligible_date,
-					transferRestrictionStatus: inboundTransferStatusResult.transfer_restriction_status,
-					unlocked: inboundTransferStatusResult.unlocked,
-				};
-
-				setInboundTransferStatusInfo( retrievedInboundTransferStatusInfo );
-			}
-			setIsFetching( false );
 		} )();
 	} );
 

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -16,7 +16,11 @@ import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getOptionInfo, connectDomainAction } from '../utilities';
+import {
+	getDomainInboundTransferStatusInfo,
+	getOptionInfo,
+	connectDomainAction,
+} from '../utilities';
 import OptionContent from './option-content';
 
 import './style.scss';
@@ -92,24 +96,8 @@ function DomainTransferOrConnect( {
 				}
 
 				if ( ! inboundTransferStatusInfo ) {
-					const inboundTransferStatusResult = await wpcom
-						.undocumented()
-						.getInboundTransferStatus( domain );
-
-					const retrievedInboundTransferStatusInfo = {
-						creationDate: inboundTransferStatusResult.creation_date,
-						email: inboundTransferStatusResult.admin_email,
-						inRedemption: inboundTransferStatusResult.in_redemption,
-						losingRegistrar: inboundTransferStatusResult.registrar,
-						losingRegistrarIanaId: inboundTransferStatusResult.registrar_iana_id,
-						privacy: inboundTransferStatusResult.privacy,
-						termMaximumInYears: inboundTransferStatusResult.term_maximum_in_years,
-						transferEligibleDate: inboundTransferStatusResult.transfer_eligible_date,
-						transferRestrictionStatus: inboundTransferStatusResult.transfer_restriction_status,
-						unlocked: inboundTransferStatusResult.unlocked,
-					};
-
-					setInboundTransferStatusInfo( retrievedInboundTransferStatusInfo );
+					const inboundTransferStatusResult = await getDomainInboundTransferStatusInfo( domain );
+					setInboundTransferStatusInfo( inboundTransferStatusResult );
 				}
 				setIsFetching( false );
 			} catch {

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -94,7 +94,12 @@ function DomainTransferOrConnect( {
 			<QueryProductsList />
 			<Card className={ baseClassName + '__content' }>
 				{ content.map( ( optionProps, index ) => (
-					<OptionContent key={ 'option-' + index } disabled={ actionClicked } { ...optionProps } />
+					<OptionContent
+						isPlaceholder={ isFetching }
+						key={ 'option-' + index }
+						disabled={ actionClicked }
+						{ ...optionProps }
+					/>
 				) ) }
 				<div className={ baseClassName + '__support-link' }>
 					{ createInterpolateElement(

--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
@@ -12,6 +12,7 @@ export default function OptionContent( {
 	illustration,
 	learnMoreLink,
 	onSelect,
+	isPlaceholder,
 	pricing,
 	primary,
 	recommended,
@@ -24,13 +25,16 @@ export default function OptionContent( {
 	const pricingCostClasses = classNames( 'option-content__pricing-cost', {
 		[ 'has-sale-price' ]: pricing?.sale,
 	} );
+	const optionContentClasses = classNames( 'option-content__main', {
+		'is-placeholder': isPlaceholder,
+	} );
 
 	return (
 		<div className="option-content">
 			<div className="option-content__illustration">
 				{ illustration && <img src={ illustration } alt="" width={ 150 } /> }
 			</div>
-			<div className="option-content__main">
+			<div className={ optionContentClasses }>
 				<div className="option-content__header">
 					<h2>{ titleText }</h2>
 					{ recommended && <Badge type="info-green">{ __( 'Recommended' ) }</Badge> }

--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
@@ -29,7 +29,25 @@ export default function OptionContent( {
 		'is-placeholder': isPlaceholder,
 	} );
 
-	return (
+	return isPlaceholder ? (
+		<div className="option-content is-placeholder">
+			<div className="option-content__illustration" height={ 100 } width={ 150 }></div>
+			<div className="option-content__main">
+				<div className="option-content__header">
+					<h2> </h2>
+				</div>
+				<div className="option-content__top-text"></div>
+				<a
+					className="option-content__learn-more"
+					target="_blank"
+					href={ learnMoreLink }
+					rel="noopener noreferrer"
+				>
+					{ __( 'Learn more' ) }
+				</a>
+			</div>
+		</div>
+	) : (
 		<div className="option-content">
 			<div className="option-content__illustration">
 				{ illustration && <img src={ illustration } alt="" width={ 150 } /> }

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -168,6 +168,15 @@
 					}
 				}
 			}
+
+			.is-placeholder {
+				.option-content {
+					&__header, &__top-text, &__learn-more {
+						@include placeholder( --color-neutral-10 );
+						color: transparent;
+					}
+				}
+			}
 		}
 	}
 

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -169,9 +169,9 @@
 				}
 			}
 
-			.is-placeholder {
+			&.is-placeholder {
 				.option-content {
-					&__header, &__top-text, &__learn-more, &__benefits, &__pricing {
+					&__illustration, &__header, &__top-text, &__learn-more {
 						@include placeholder( --color-neutral-10 );
 						color: transparent;
 					}

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -171,7 +171,7 @@
 
 			.is-placeholder {
 				.option-content {
-					&__header, &__top-text, &__learn-more {
+					&__header, &__top-text, &__learn-more, &__benefits, &__pricing {
 						@include placeholder( --color-neutral-10 );
 						color: transparent;
 					}

--- a/client/components/domains/use-my-domain/utilities/get-domain-inbound-transfer-status-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-domain-inbound-transfer-status-info.js
@@ -1,0 +1,20 @@
+import wpcom from 'calypso/lib/wp';
+
+export async function getDomainInboundTransferStatusInfo( domainName ) {
+	const inboundTransferStatusResult = await wpcom
+		.undocumented()
+		.getInboundTransferStatus( domainName );
+
+	return {
+		creationDate: inboundTransferStatusResult.creation_date,
+		email: inboundTransferStatusResult.admin_email,
+		inRedemption: inboundTransferStatusResult.in_redemption,
+		losingRegistrar: inboundTransferStatusResult.registrar,
+		losingRegistrarIanaId: inboundTransferStatusResult.registrar_iana_id,
+		privacy: inboundTransferStatusResult.privacy,
+		termMaximumInYears: inboundTransferStatusResult.term_maximum_in_years,
+		transferEligibleDate: inboundTransferStatusResult.transfer_eligible_date,
+		transferRestrictionStatus: inboundTransferStatusResult.transfer_restriction_status,
+		unlocked: inboundTransferStatusResult.unlocked,
+	};
+}

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -14,6 +14,16 @@ import {
 } from './index';
 
 export const getDomainTransferrability = ( domainInboundTransferStatusInfo ) => {
+	if ( ! domainInboundTransferStatusInfo ) {
+		return {
+			transferrable: false,
+			domainTransferContent: {
+				...optionInfo.transferNotSupported,
+				topText: optionInfo.transferNotSupported.topText,
+			},
+		};
+	}
+
 	const { inRedemption, transferEligibleDate } = domainInboundTransferStatusInfo;
 
 	const result = {

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -46,6 +46,7 @@ export function getOptionInfo( {
 	selectedSite,
 	siteIsOnPaidPlan,
 } ) {
+	availability = availability ?? {};
 	const mappingFreeText = getMappingFreeText( {
 		cart,
 		domain,

--- a/client/components/domains/use-my-domain/utilities/index.js
+++ b/client/components/domains/use-my-domain/utilities/index.js
@@ -1,5 +1,6 @@
 export { connectDomainAction } from './connect-domain-action';
 export { getAvailabilityErrorMessage } from './get-availability-error-message';
+export { getDomainInboundTransferStatusInfo } from './get-domain-inbound-transfer-status-info';
 export { getDomainNameValidationErrorMessage } from './get-domain-name-validation-error-message';
 export { getMappingFreeText } from './get-mapping-free-text';
 export { getMappingPriceText } from './get-mapping-price-text';


### PR DESCRIPTION
#### Changes proposed in this Pull Request
As a part of #56366, we opted to have each component of the "Use My Domain" flow load its state individually. 

All this PR does is allow the child component to load its state - _if not already previously provided by its parent._

By doing this, we can allow them to be loaded directly, ensuring that the state will always be loaded correctly and that each component can be individually/directly loaded without having to go through each of its parent’s steps.

There are also a few confidence checks for each of the components: since they can be individually loaded now, the user can try to tamper with the query params: connect a domain they wouldn’t be able to normally, transfer a domain that they don't own, etc.

#### Testing instructions
- Go to `/domains/add/use-my-domain/<your_site>`
- Check that the flow is still working properly, same as before
- Try adding the two query parameters to the URL: 
  - `initialQuery`: the domain name used on the flow. Example: `rafaelgalani.dev`
  - `initialMode`: the mode that will be initially loaded. It can be any of the values listed in the `useMyDomainInputMode` variable on the `constants.ts` file:
  https://github.com/Automattic/wp-calypso/blob/80694f5dfebf1e0a14d835eaf571cf14502882e4/client/components/domains/connect-domain-step/constants.ts#L64-L69
- Check that using each mode loads the correct component and that the `busy` state/placeholder components are used whenever the state is being loaded
- Ensure that the flow still works properly with the query params
- Try tampering with the query params (e.g: transferring a domain you don't own, connecting a domain that can't be connected) and make sure that the edge cases are handled.
