### PR TITLE
Remove unused import of the Pagination type.

### DIFF
--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -1,5 +1,4 @@
 import 'calypso/state/plugins/init';
-import { Pagination } from './types';
 
 export function getAllPlugins( state ) {
 	return state?.plugins.wporg.items;
@@ -66,9 +65,9 @@ export function getNextPluginsListPage( state, category ) {
 /**
  * Retrieve the current state of pagination.
  *
- * @param {object} state		State object
- * @param {string} searchTerm	Plugin search term
- * @returns {Pagination}		Pagination object, including current page, total pages, and total results
+ * @param {object} state                   State object
+ * @param {string} searchTerm              Plugin search term
+ * @returns {import('./types').Pagination} Pagination object, including current page, total pages, and total results
  */
 export function getPluginsListPagination( state, searchTerm ) {
 	return state.plugins.wporg.listsPagination?.search?.[ searchTerm ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Pagination type was being used for documentation purposes only, making it an unnecessary import.
Now, this import is being made inline on JSDoc.

---

Follow-up [discussed in PR 56938](https://github.com/Automattic/wp-calypso/pull/56938#discussion_r731563636) .