### PR TITLE
Use `@emotion/babel-plugin`

### DIFF
--- a/client/signup/steps/difm-design-picker/demo-tile.tsx
+++ b/client/signup/steps/difm-design-picker/demo-tile.tsx
@@ -1,5 +1,3 @@
-/** @jsxImportSource @emotion/react */
-
 import { Button } from '@automattic/components';
 import { MShotsImage } from '@automattic/design-picker';
 import { css } from '@emotion/react';

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -25,7 +25,10 @@ module.exports = ( api, opts ) => ( {
 				exclude: [ 'transform-typeof-symbol' ],
 			},
 		],
-		[ require.resolve( '@babel/preset-react' ), { runtime: 'automatic' } ],
+		[
+			require.resolve( '@babel/preset-react' ),
+			{ runtime: 'automatic', importSource: '@emotion/react' },
+		],
 		require.resolve( '@babel/preset-typescript' ),
 	],
 	plugins: [
@@ -43,5 +46,6 @@ module.exports = ( api, opts ) => ( {
 			},
 		],
 		require.resolve( './babel-plugin-optimize-i18n' ),
+		require.resolve( '@emotion/babel-plugin' ),
 	],
 } );

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -46,6 +46,7 @@
 		"@babel/preset-env": "^7.15.0",
 		"@babel/preset-react": "^7.14.5",
 		"@babel/preset-typescript": "^7.15.0",
+		"@emotion/babel-plugin": "^11.3.0",
 		"@types/webpack-env": "^1.16.2",
 		"@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",
 		"@wordpress/babel-plugin-import-jsx-pragma": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,7 @@ __metadata:
     "@babel/preset-env": ^7.15.0
     "@babel/preset-react": ^7.14.5
     "@babel/preset-typescript": ^7.15.0
+    "@emotion/babel-plugin": ^11.3.0
     "@types/webpack-env": ^1.16.2
     "@wojtekmaj/enzyme-adapter-react-17": ^0.6.3
     "@wordpress/babel-plugin-import-jsx-pragma": ^3.1.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Uses `@emotion/babel-plugin` to compile Emotion and optimzie CSS. According to [the docs](https://emotion.sh/docs/@emotion/babel-plugin) this plugin "is highly recommended, but not required".

From my understanding, what this plugin does is replace the official `react/jsx-runtime` with an emotion version (`@emotion/react/jsx-runtime`) that wraps over the official one. It allows developers to use the prop `css` to style their components, as well as other nice features like optimizing the CSS or source maps.

The downside is that we'll use the wrapper on all files, even if they are not using Emotion. I don't think that will cause an immediate problem, but we are deviating from the standard React runtime and I can see how this may be problematic in the future if we want to update React to a version not supported yet by Emotion.

An alternative approach would be to use `/** @jsxImportSource @emotion/react */` on every file that wants to use Emotion. I think we'll miss some benefits like the CSS optimization, and can, potentially, cause some confusion when someone forgets to add it.

Another approach would be to not use the `css` prop. We have many usages of `styled`, but only one of `css`. Also, most components don't use Emotion but an external SASS file. I don't know if we want to allow both (emotion+sass) and which emotion "flavor" (`css` vs `styled`), or if we have a migration plan from sass to emotion.

Relevant docs:
- See note in https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#manual-babel-setup
- https://emotion.sh/docs/css-prop


#### Testing instructions

Load calypso.live and verify that the components that use Emotion are styled correctly