### PR TITLE
State: Move AT middleware to a dynamic import

### DIFF
--- a/client/state/lib/automated-transfer-middleware.js
+++ b/client/state/lib/automated-transfer-middleware.js
@@ -1,0 +1,14 @@
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
+import { isFetchingAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
+import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export const fetchAutomatedTransferStatusForSelectedSite = ( dispatch, getState ) => {
+	const state = getState();
+	const siteId = getSelectedSiteId( state );
+	const isFetchingATStatus = isFetchingAutomatedTransferStatus( state, siteId );
+
+	if ( ! isFetchingATStatus && hasSitePendingAutomatedTransfer( state, siteId ) ) {
+		dispatch( fetchAutomatedTransferStatus( siteId ) );
+	}
+};

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -72,7 +72,7 @@ const updateNotificationsOpenForKeyboardShortcuts = ( dispatch, action, getState
 	keyboardShortcuts.setNotificationsOpen( toggledState );
 };
 
-const handler = ( dispatch, action, getState ) => {
+const handler = async ( dispatch, action, getState ) => {
 	switch ( action.type ) {
 		case ROUTE_SET:
 			return notifyAboutImmediateLoginLinkEffects( dispatch, action, getState );
@@ -83,16 +83,14 @@ const handler = ( dispatch, action, getState ) => {
 
 		case SELECTED_SITE_SET:
 		case SITE_RECEIVE:
-		case SITES_RECEIVE:
-			// Wait a tick for the reducer to update the state tree
-			setTimeout( async () => {
-				const { fetchAutomatedTransferStatusForSelectedSite } = await import(
-					/* webpackChunkName: "automated-transfer-state-middleware" */
-					'calypso/state/lib/automated-transfer-middleware'
-				);
-				fetchAutomatedTransferStatusForSelectedSite( dispatch, getState );
-			}, 0 );
+		case SITES_RECEIVE: {
+			const { fetchAutomatedTransferStatusForSelectedSite } = await import(
+				/* webpackChunkName: "automated-transfer-state-middleware" */
+				'calypso/state/lib/automated-transfer-middleware'
+			);
+			fetchAutomatedTransferStatusForSelectedSite( dispatch, getState );
 			return;
+		}
 	}
 };
 

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -8,8 +8,6 @@ import {
 	SITE_RECEIVE,
 	SITES_RECEIVE,
 } from 'calypso/state/action-types';
-import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
-import { isFetchingAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { saveImmediateLoginInformation } from 'calypso/state/immediate-login/actions';
 import {
@@ -17,9 +15,7 @@ import {
 	createPathWithoutImmediateLoginInformation,
 } from 'calypso/state/immediate-login/utils';
 import { successNotice } from 'calypso/state/notices/actions';
-import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Notifies user about the fact that they were automatically logged in
@@ -76,16 +72,6 @@ const updateNotificationsOpenForKeyboardShortcuts = ( dispatch, action, getState
 	keyboardShortcuts.setNotificationsOpen( toggledState );
 };
 
-const fetchAutomatedTransferStatusForSelectedSite = ( dispatch, getState ) => {
-	const state = getState();
-	const siteId = getSelectedSiteId( state );
-	const isFetchingATStatus = isFetchingAutomatedTransferStatus( state, siteId );
-
-	if ( ! isFetchingATStatus && hasSitePendingAutomatedTransfer( state, siteId ) ) {
-		dispatch( fetchAutomatedTransferStatus( siteId ) );
-	}
-};
-
 const handler = ( dispatch, action, getState ) => {
 	switch ( action.type ) {
 		case ROUTE_SET:
@@ -99,7 +85,11 @@ const handler = ( dispatch, action, getState ) => {
 		case SITE_RECEIVE:
 		case SITES_RECEIVE:
 			// Wait a tick for the reducer to update the state tree
-			setTimeout( () => {
+			setTimeout( async () => {
+				const { fetchAutomatedTransferStatusForSelectedSite } = await import(
+					/* webpackChunkName: "automated-transfer-state-middleware" */
+					'calypso/state/lib/automated-transfer-middleware'
+				);
 				fetchAutomatedTransferStatusForSelectedSite( dispatch, getState );
 			}, 0 );
 			return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the automated transfer state middleware is always loaded, just to check the status on every occasion where we change the selected site or load one or all of the sites. However, I believe this action is not critical at all, so the related code could be deferred to a separate chunk. This offers a good opportunity for optimizing the main entry point chunk, because the AT state is the only one guilty for pulling the plugin state into the main entry point, and it isn't one of the smallest trees 😉  

So, in a nutshell, this PR moves the AT state middleware to a dynamic import, and that removes the AT and related plugins state from the main entry point.

#### Testing instructions

* cc @lamosty - #18896 contains an explanation on how to test this flow, but is that still up to date?
* Also, go through some `/plugins` routes for Jetpack / atomic sites and verify they still work well.

