### PR TITLE
Emails: Allow to upgrade from forward email to hosted one in domain o…

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -37,6 +37,7 @@ import {
 	emailManagementManageTitanAccount,
 	emailManagementManageTitanMailboxes,
 	emailManagementNewTitanAccount,
+	emailManagementPurchaseNewEmailAccount,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
 import NavigationComponent from 'calypso/my-sites/navigation';
@@ -171,6 +172,7 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		emailManagementManageTitanAccount,
 		emailManagementManageTitanMailboxes,
 		emailManagementNewTitanAccount,
+		emailManagementPurchaseNewEmailAccount,
 		emailManagementTitanControlPanelRedirect,
 	];
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Allows the path /email/:domain/purchase/:site in domain only sites to upgrade from forward email to a hosted email

#### Testing instructions

1. Have a domain only site (created through http://wordpess.com/domains)
2. Add a forward email to it
3. Check that upgrading to a hosted domains leads you to below page

![image](https://user-images.githubusercontent.com/5689927/138082277-576e1a69-4649-498a-9bd7-736a3e1a4b38.png)

Related to {1200182182542585-as-1201193196839809}
