### PR TITLE
Domains: Refactor site redirect `wpcom.undocumented` methods to `wpcom.req`

### DIFF
--- a/client/lib/domains/can-redirect.js
+++ b/client/lib/domains/can-redirect.js
@@ -24,13 +24,23 @@ export function canRedirect( siteId, domainName, onComplete ) {
 		return;
 	}
 
-	wpcom.undocumented().canRedirect( siteId, domainName, function ( serverError, data ) {
-		if ( serverError ) {
-			onComplete( new ValidationError( serverError.error ) );
-		} else if ( ! data.can_redirect ) {
-			onComplete( new ValidationError( 'cannot_redirect' ) );
-		} else {
-			onComplete( null );
+	wpcom.req.get(
+		{
+			path:
+				'/domains/' +
+				siteId +
+				'/' +
+				encodeURIComponent( domainName.toLowerCase() ) +
+				'/can-redirect',
+		},
+		function ( serverError, data ) {
+			if ( serverError ) {
+				onComplete( new ValidationError( serverError.error ) );
+			} else if ( ! data.can_redirect ) {
+				onComplete( new ValidationError( 'cannot_redirect' ) );
+			} else {
+				onComplete( null );
+			}
 		}
-	} );
+	);
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -457,49 +457,6 @@ Undocumented.prototype.getAvailableTlds = function ( query = {} ) {
 };
 
 /**
- * Determine whether a domain name can be used for Site Redirect
- *
- * @param {number|string} siteId The site ID
- * @param {string} domain The domain name to check
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.canRedirect = function ( siteId, domain, fn ) {
-	domain = encodeURIComponent( domain.toLowerCase() );
-
-	return this.wpcom.req.get( { path: '/domains/' + siteId + '/' + domain + '/can-redirect' }, fn );
-};
-
-/**
- * Retrieves the target of the site redirect.
- *
- * @param {number|string} siteId The site ID
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.getSiteRedirect = function ( siteId, fn ) {
-	debug( '/sites/:site_id/domains/redirect query' );
-
-	return this.wpcom.req.get( { path: '/sites/' + siteId + '/domains/redirect' }, fn );
-};
-
-/**
- * Points the site redirect to the specified location.
- *
- * @param {number|string} siteId The site ID
- * @param {string} location The location to redirect the site to
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.setSiteRedirect = function ( siteId, location, fn ) {
-	debug( '/sites/:site_id/domains/redirect' );
-
-	return this.wpcom.req.post(
-		{ path: '/sites/' + siteId + '/domains/redirect' },
-		{ location },
-		fn
-	);
-};
-
-/**
  * Retrieves the domain contact information of the user.
  *
  * @param {Function} fn The callback function

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -111,7 +111,7 @@ class SiteRedirect extends Component {
 	render() {
 		const { location, translate } = this.props;
 		const { isUpdating, notice } = location;
-		const isFetching = location.isFetching || this.state.redirectUrl.length === 0;
+		const isFetching = location.isFetching;
 
 		const classes = classNames( 'site-redirect-card', { fetching: isFetching } );
 

--- a/client/state/domains/site-redirect/actions.js
+++ b/client/state/domains/site-redirect/actions.js
@@ -22,61 +22,55 @@ export function closeSiteRedirectNotice( siteId ) {
 export const fetchSiteRedirect = ( siteId ) => ( dispatch ) => {
 	dispatch( { type: DOMAINS_SITE_REDIRECT_FETCH, siteId } );
 
-	wpcom
-		.undocumented()
-		.getSiteRedirect( siteId )
-		.then(
-			( { location } ) => {
-				dispatch( { type: DOMAINS_SITE_REDIRECT_FETCH_COMPLETED, siteId, location } );
-			},
-			( error ) => {
-				dispatch( {
-					type: DOMAINS_SITE_REDIRECT_FETCH_FAILED,
-					siteId,
-					error: error
-						? error.message
-						: i18n.translate(
-								'There was a problem retrieving the redirect settings. Please try again later or contact support.'
-						  ),
-				} );
-			}
-		);
+	wpcom.req.get( { path: '/sites/' + siteId + '/domains/redirect' } ).then(
+		( { location } ) => {
+			dispatch( { type: DOMAINS_SITE_REDIRECT_FETCH_COMPLETED, siteId, location } );
+		},
+		( error ) => {
+			dispatch( {
+				type: DOMAINS_SITE_REDIRECT_FETCH_FAILED,
+				siteId,
+				error: error
+					? error.message
+					: i18n.translate(
+							'There was a problem retrieving the redirect settings. Please try again later or contact support.'
+					  ),
+			} );
+		}
+	);
 };
 
 export const updateSiteRedirect = ( siteId, location ) => ( dispatch ) => {
 	dispatch( { type: DOMAINS_SITE_REDIRECT_UPDATE, siteId } );
 
-	return wpcom
-		.undocumented()
-		.setSiteRedirect( siteId, location )
-		.then(
-			( data ) => {
-				if ( data.success ) {
-					dispatch( {
-						type: DOMAINS_SITE_REDIRECT_UPDATE_COMPLETED,
-						siteId,
-						location,
-						success: i18n.translate( 'The redirect settings were updated successfully.' ),
-					} );
-					return true;
-				}
-
+	return wpcom.req.post( { path: '/sites/' + siteId + '/domains/redirect' }, { location } ).then(
+		( data ) => {
+			if ( data.success ) {
 				dispatch( {
-					type: DOMAINS_SITE_REDIRECT_UPDATE_FAILED,
+					type: DOMAINS_SITE_REDIRECT_UPDATE_COMPLETED,
 					siteId,
-					error: i18n.translate(
-						'There was a problem updating the redirect settings. Please try again later or contact support.'
-					),
+					location,
+					success: i18n.translate( 'The redirect settings were updated successfully.' ),
 				} );
-				return false;
-			},
-			( error ) => {
-				dispatch( {
-					type: DOMAINS_SITE_REDIRECT_UPDATE_FAILED,
-					siteId,
-					error: error.message,
-				} );
-				return false;
+				return true;
 			}
-		);
+
+			dispatch( {
+				type: DOMAINS_SITE_REDIRECT_UPDATE_FAILED,
+				siteId,
+				error: i18n.translate(
+					'There was a problem updating the redirect settings. Please try again later or contact support.'
+				),
+			} );
+			return false;
+		},
+		( error ) => {
+			dispatch( {
+				type: DOMAINS_SITE_REDIRECT_UPDATE_FAILED,
+				siteId,
+				error: error.message,
+			} );
+			return false;
+		}
+	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `wpcom.undocumented` methods used for site redirect to use `wpcom.req.get()` and `wpcom.req.post()` as part of our effort to get rid of the monolithic `wpcom.undocumented`.

We're also fixing the edge case where the redirect URL field gets disabled when empty.

The PR looks a bit larger than it is, mostly because of the whitespace changes.

#### Testing instructions

* Go to `/domains/manage/:site/redirect-settings/:site` where `:site` is a simple WP.com site of yours.
* Verify retrieving the current value works.
* Verify you can still update the redirect like before.
* Verify that when the field is empty, it doesn't get disabled anymore.