### PR TITLE
Fix and re-enable Site Editor Tracking tests for global styles update/save events

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -223,15 +223,24 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 	}
 
 	async clickGlobalStylesResetButton() {
-		return await driverHelper.clickIfPresent(
+		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css(
-				'.edit-site-global-styles-sidebar .edit-site-global-styles-sidebar__reset-button:enabled'
-			)
+			By.css( '.edit-site-global-styles-sidebar button[aria-label="More Global Styles Actions"' )
 		);
+		const resetButtonLocator = driverHelper.createTextLocator(
+			By.css( '.popover-slot button.components-dropdown-menu__menu-item' ),
+			'Reset to defaults'
+		);
+		return await driverHelper.clickWhenClickable( this.driver, resetButtonLocator );
 	}
 
-	async changeGlobalStylesFontSize( value ) {
+	async changeGlobalStylesFontSize( value, blocksLevel ) {
+		if ( ! blocksLevel ) {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.edit-site-global-styles-sidebar button[aria-label="Set custom size"]' )
+			);
+		}
 		return await driverHelper.setWhenSettable(
 			this.driver,
 			By.css( '.edit-site-global-styles-sidebar .components-font-size-picker input' ),
@@ -239,11 +248,12 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		);
 	}
 
-	async changeGlobalStylesColor( { typeIndex = 1, valueIndex = 1 } ) {
+	async changeGlobalStylesColor( colorType, { valueIndex = 1 } ) {
+		await this.clickGlobalStylesMenuItem( colorType );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css(
-				`.edit-site-global-styles-sidebar .block-editor-color-gradient-control:nth-of-type(${ typeIndex }) .components-circular-option-picker__option-wrapper:nth-of-type(${ valueIndex }) .components-circular-option-picker__option`
+				`.edit-site-global-styles-sidebar .components-circular-option-picker .components-circular-option-picker__option-wrapper:nth-of-type(${ valueIndex }) button`
 			)
 		);
 	}
@@ -284,6 +294,10 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 				By.css(
 					'.edit-site-global-styles-sidebar .components-base-control:last-of-type .components-color-edit__color-option button'
 				)
+			);
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.components-color-picker button[aria-label="Show detailed inputs"]' )
 			);
 		}
 

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -239,16 +239,16 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		);
 	}
 
-	async changeGlobalStylesColor( colorTypeIndex, colorValueIndex ) {
+	async changeGlobalStylesColor( { typeIndex = 1, valueIndex = 1 } ) {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css(
-				`.edit-site-global-styles-sidebar .block-editor-color-gradient-control:nth-of-type(${ colorTypeIndex }) .components-circular-option-picker__option-wrapper:nth-of-type(${ colorValueIndex }) .components-circular-option-picker__option`
+				`.edit-site-global-styles-sidebar .block-editor-color-gradient-control:nth-of-type(${ typeIndex }) .components-circular-option-picker__option-wrapper:nth-of-type(${ valueIndex }) .components-circular-option-picker__option`
 			)
 		);
 	}
 
-	async saveGlobalStyles( pauseAfter = false ) {
+	async saveGlobalStyles( { pauseAfter = false } = {} ) {
 		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '.edit-site-save-button__button' )
@@ -277,7 +277,7 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		return saveClicked;
 	}
 
-	async changeGlobalStylesFirstColorPaletteItem( value, pickerOpened = false ) {
+	async changeGlobalStylesFirstColorPaletteItem( value, { pickerOpened = false } = {} ) {
 		if ( ! pickerOpened ) {
 			await driverHelper.clickWhenClickable(
 				this.driver,

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -222,6 +222,93 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		);
 	}
 
+	async clickGlobalStylesResetButton() {
+		return await driverHelper.clickIfPresent(
+			this.driver,
+			By.css(
+				'.edit-site-global-styles-sidebar .edit-site-global-styles-sidebar__reset-button:enabled'
+			)
+		);
+	}
+
+	async changeGlobalStylesFontSize( value ) {
+		return await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.edit-site-global-styles-sidebar .components-font-size-picker input' ),
+			value
+		);
+	}
+
+	async changeGlobalStylesColor( colorTypeIndex, colorValueIndex ) {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css(
+				`.edit-site-global-styles-sidebar .block-editor-color-gradient-control:nth-of-type(${ colorTypeIndex }) .components-circular-option-picker__option-wrapper:nth-of-type(${ colorValueIndex }) .components-circular-option-picker__option`
+			)
+		);
+	}
+
+	async saveGlobalStyles( pauseAfter = false ) {
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.edit-site-save-button__button' )
+		);
+		const allCheckboxes = await this.driver.findElements(
+			By.css( '.entities-saved-states__panel .components-checkbox-control__input' )
+		);
+		for ( const checkbox of allCheckboxes ) {
+			await driverHelper.setCheckbox( this.driver, () => checkbox, false );
+		}
+		const locator = driverHelper.createTextLocator(
+			By.css( '.entities-saved-states__panel .components-checkbox-control__label' ),
+			'Custom Styles'
+		);
+		await driverHelper.clickWhenClickable( this.driver, locator );
+		const saveClicked = await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-entities-saved-states__save-button' )
+		);
+
+		if ( pauseAfter ) {
+			// The pause ensures there is enough time for the debounced tracking function to run,
+			// and get/compare entities to create the tracks event.
+			return await this.driver.sleep( 500 );
+		}
+		return saveClicked;
+	}
+
+	async changeGlobalStylesFirstColorPaletteItem( value, pickerOpened = false ) {
+		if ( ! pickerOpened ) {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css(
+					'.edit-site-global-styles-sidebar .components-base-control:last-of-type .components-color-edit__color-option button'
+				)
+			);
+		}
+
+		return await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.components-color-picker input' ),
+			value
+		);
+	}
+
+	async clickGlobalStylesMenuItem( menuTitle ) {
+		const locator = driverHelper.createTextLocator(
+			By.css( '.edit-site-global-styles-sidebar button' ),
+			menuTitle
+		);
+		return await driverHelper.clickWhenClickable( this.driver, locator );
+	}
+
+	async clickGlobalStylesBackButton() {
+		const backButtonLocator = By.css(
+			'.edit-site-global-styles-sidebar button[aria-label="Navigate to the previous view"]'
+		);
+		return await driverHelper.clickWhenClickable( this.driver, backButtonLocator );
+	}
+
 	/**
 	 * Alias for `toggleNavigationSidebar`. We need to have the same function
 	 * name in both this and gutenberg editor component to make sure general

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -480,8 +480,6 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 		} );
 
-		// Temporarily skip these tests until we can update track events / tests to handle the new
-		// interface.  https://github.com/Automattic/wp-calypso/pull/56544
 		describe( 'Tracks "wpcom_block_editor_global_styles_save"', function () {
 			before( async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -84,7 +84,11 @@ const getGlobalStylesUpdateEvents = async ( driver ) => {
 	);
 };
 
-const testGlobalStylesColorAndTypography = async ( driver, editor, blocksLevel = false ) => {
+const testGlobalStylesColorAndTypography = async (
+	driver,
+	editor,
+	{ blocksLevel = false } = {}
+) => {
 	if ( blocksLevel ) {
 		await editor.clickGlobalStylesMenuItem( 'Blocks' );
 		await editor.clickGlobalStylesMenuItem( 'Button' );
@@ -99,7 +103,7 @@ const testGlobalStylesColorAndTypography = async ( driver, editor, blocksLevel =
 
 	// Update text color option.
 	await editor.clickGlobalStylesMenuItem( 'Colors' );
-	await editor.changeGlobalStylesColor( 1, 1 );
+	await editor.changeGlobalStylesColor( { typeIndex: 1, valueIndex: 1 } );
 
 	await driver.sleep( 100 );
 
@@ -111,7 +115,7 @@ const testGlobalStylesColorAndTypography = async ( driver, editor, blocksLevel =
 	}
 
 	// Update link color option.
-	await editor.changeGlobalStylesColor( 3, 2 );
+	await editor.changeGlobalStylesColor( { typeIndex: 3, valueIndex: 2 } );
 	// The last sleep before accessing the event stack must be longer to ensure there is
 	// enough time for the function to retrieve entities and compare.
 	await driver.sleep( 500 );
@@ -258,7 +262,7 @@ const testGlobalStylesColorPalette = async ( driver, editor, blockName = undefin
 		} )
 	);
 	await clearEventsStack( driver );
-	await editor.changeGlobalStylesFirstColorPaletteItem( '#a1a1a1', true );
+	await editor.changeGlobalStylesFirstColorPaletteItem( '#a1a1a1', { pickerOpened: true } );
 	await driver.sleep( 500 );
 	updateEvents = await getGlobalStylesUpdateEvents( driver );
 
@@ -439,7 +443,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				}
 				// Reset Global Styles before testing.
 				await editor.clickGlobalStylesResetButton();
-				await editor.saveGlobalStyles( true );
+				await editor.saveGlobalStyles( { pauseAfter: true } );
 				await clearEventsStack( this.driver );
 
 				await testGlobalStylesColorAndTypography( this.driver, editor );
@@ -461,7 +465,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				if ( editor.screenSize === 'mobile' ) {
 					return this.skip();
 				}
-				await testGlobalStylesColorAndTypography( this.driver, editor, true );
+				await testGlobalStylesColorAndTypography( this.driver, editor, { blocksLevel: true } );
 			} );
 
 			it( 'block level color palette settings', async function () {
@@ -497,16 +501,16 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 				// Reset global styles before testing.
 				await editor.clickGlobalStylesResetButton();
-				await editor.saveGlobalStyles( true );
+				await editor.saveGlobalStyles( { pauseAfter: true } );
 				await clearEventsStack( this.driver );
 
 				await editor.clickGlobalStylesMenuItem( 'Typography' );
 				await editor.changeGlobalStylesFontSize( '11' );
 				await editor.clickGlobalStylesBackButton();
 				await editor.clickGlobalStylesMenuItem( 'Colors' );
-				await editor.changeGlobalStylesColor( 1, 1 );
-				await editor.changeGlobalStylesColor( 3, 2 );
-				await editor.saveGlobalStyles( true );
+				await editor.changeGlobalStylesColor( { typeIndex: 1, valueIndex: 1 } );
+				await editor.changeGlobalStylesColor( { typeIndex: 3, valueIndex: 2 } );
+				await editor.saveGlobalStyles( { pauseAfter: true } );
 				const saveEvents = ( await getEventsStack( this.driver ) ).filter(
 					( event ) => event[ 0 ] === 'wpcom_block_editor_global_styles_save'
 				);
@@ -514,7 +518,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 				// Clean up by resetting to be safe.
 				await editor.clickGlobalStylesResetButton();
-				await editor.saveGlobalStyles( true );
+				await editor.saveGlobalStyles( { pauseAfter: true } );
 			} );
 
 			after( async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -36,43 +36,6 @@ const navigationSidebarBackToRoot = async ( driver ) => {
 	}
 };
 
-const clickGlobalStylesResetButton = async ( driver ) => {
-	await driverHelper.clickIfPresent(
-		driver,
-		By.css(
-			'.edit-site-global-styles-sidebar .edit-site-global-styles-sidebar__reset-button:enabled'
-		)
-	);
-};
-
-const changeGlobalStylesFontSize = async ( driver, value ) =>
-	await driverHelper.setWhenSettable(
-		driver,
-		By.css( '.edit-site-global-styles-sidebar .components-font-size-picker input' ),
-		value
-	);
-
-const changeGlobalStylesColor = async ( driver, colorTypeIndex, colorValueIndex ) =>
-	await driverHelper.clickWhenClickable(
-		driver,
-		By.css(
-			`.edit-site-global-styles-sidebar .block-editor-color-gradient-control:nth-of-type(${ colorTypeIndex }) .components-circular-option-picker__option-wrapper:nth-of-type(${ colorValueIndex }) .components-circular-option-picker__option`
-		)
-	);
-
-const changeGlobalStylesFirstColorPaletteItem = async ( driver, value, pickerOpened = false ) => {
-	if ( ! pickerOpened ) {
-		await driverHelper.clickWhenClickable(
-			driver,
-			By.css(
-				'.edit-site-global-styles-sidebar .components-base-control:last-of-type .components-color-edit__color-option button'
-			)
-		);
-	}
-
-	await driverHelper.setWhenSettable( driver, By.css( '.components-color-picker input' ), value );
-};
-
 const deleteCustomEntities = async function ( driver, entityName ) {
 	await SiteEditorComponent.Expect( driver );
 	const getAndDeleteEntities = async ( name ) => {
@@ -100,21 +63,6 @@ const clickBlockSettingsButton = async ( driver ) =>
 		By.css( '.edit-site-header__actions button[aria-label="Settings"]' )
 	);
 
-const clickGlobalStylesMenuItem = async ( driver, menuTitle ) => {
-	const locator = driverHelper.createTextLocator(
-		By.css( '.edit-site-global-styles-sidebar button' ),
-		menuTitle
-	);
-	return await driverHelper.clickWhenClickable( driver, locator );
-};
-
-const clickGlobalStylesBackButton = async ( driver ) => {
-	const backButtonLocator = By.css(
-		'.edit-site-global-styles-sidebar button[aria-label="Navigate to the previous view"]'
-	);
-	return await driverHelper.clickWhenClickable( driver, backButtonLocator );
-};
-
 const getGlobalStylesToggleEvents = async ( driver ) => {
 	const eventsStack = await getEventsStack( driver );
 	return eventsStack.filter(
@@ -136,56 +84,34 @@ const getGlobalStylesUpdateEvents = async ( driver ) => {
 	);
 };
 
-const saveGlobalStyles = async ( driver ) => {
-	await driverHelper.clickWhenClickable( driver, By.css( '.edit-site-save-button__button' ) );
-	const allCheckboxes = await driver.findElements(
-		By.css( '.entities-saved-states__panel .components-checkbox-control__input' )
-	);
-	for ( const checkbox of allCheckboxes ) {
-		await driverHelper.setCheckbox( driver, () => checkbox, false );
-	}
-	const locator = driverHelper.createTextLocator(
-		By.css( '.entities-saved-states__panel .components-checkbox-control__label' ),
-		'Custom Styles'
-	);
-	await driverHelper.clickWhenClickable( driver, locator );
-	await driverHelper.clickWhenClickable(
-		driver,
-		By.css( '.editor-entities-saved-states__save-button' )
-	);
-	// Ensure there is enough time for the debounced function to run, and get/compare entities to
-	// create the track event.
-	await driver.sleep( 500 );
-};
-
-const testGlobalStylesColorAndTypography = async ( driver, blocksLevel = false ) => {
+const testGlobalStylesColorAndTypography = async ( driver, editor, blocksLevel = false ) => {
 	if ( blocksLevel ) {
-		await clickGlobalStylesMenuItem( driver, 'Blocks' );
-		await clickGlobalStylesMenuItem( driver, 'Button' );
+		await editor.clickGlobalStylesMenuItem( 'Blocks' );
+		await editor.clickGlobalStylesMenuItem( 'Button' );
 	}
 
-	await clickGlobalStylesMenuItem( driver, 'Typography' );
-	await changeGlobalStylesFontSize( driver, '11' );
-	await clickGlobalStylesBackButton( driver );
+	await editor.clickGlobalStylesMenuItem( 'Typography' );
+	await editor.changeGlobalStylesFontSize( '11' );
+	await editor.clickGlobalStylesBackButton();
 	// Update events are debounced to avoid event spam when items are updated using
 	// slider inputs. Therefore we must wait so this update event is not debounced.
 	await driver.sleep( 100 );
 
 	// Update text color option.
-	await clickGlobalStylesMenuItem( driver, 'Colors' );
-	await changeGlobalStylesColor( driver, 1, 1 );
+	await editor.clickGlobalStylesMenuItem( 'Colors' );
+	await editor.changeGlobalStylesColor( 1, 1 );
 
 	await driver.sleep( 100 );
 
 	if ( blocksLevel ) {
-		await clickGlobalStylesBackButton( driver );
-		await clickGlobalStylesBackButton( driver );
-		await clickGlobalStylesMenuItem( driver, 'Column' );
-		await clickGlobalStylesMenuItem( driver, 'Colors' );
+		await editor.clickGlobalStylesBackButton();
+		await editor.clickGlobalStylesBackButton();
+		await editor.clickGlobalStylesMenuItem( 'Column' );
+		await editor.clickGlobalStylesMenuItem( 'Colors' );
 	}
 
 	// Update link color option.
-	await changeGlobalStylesColor( driver, 3, 2 );
+	await editor.changeGlobalStylesColor( 3, 2 );
 	// The last sleep before accessing the event stack must be longer to ensure there is
 	// enough time for the function to retrieve entities and compare.
 	await driver.sleep( 500 );
@@ -241,7 +167,7 @@ const testGlobalStylesColorAndTypography = async ( driver, blocksLevel = false )
 	);
 
 	await clearEventsStack( driver );
-	await clickGlobalStylesResetButton( driver );
+	await editor.clickGlobalStylesResetButton();
 	await driver.sleep( 500 );
 	updateEvents = await getGlobalStylesUpdateEvents( driver );
 
@@ -288,13 +214,13 @@ const testGlobalStylesColorAndTypography = async ( driver, blocksLevel = false )
 };
 
 const testGlobalStylesColorPalette = async ( driver, editor, blockName = undefined ) => {
-	await clickGlobalStylesMenuItem( driver, 'Colors' );
+	await editor.clickGlobalStylesMenuItem( 'Colors' );
 	const colorPaletteLocator = By.css(
 		'.edit-site-global-styles-sidebar .edit-site-global-style-palette button'
 	);
 	await driverHelper.clickWhenClickable( driver, colorPaletteLocator );
 
-	await changeGlobalStylesFirstColorPaletteItem( driver, '#ff0ff0' );
+	await editor.changeGlobalStylesFirstColorPaletteItem( '#ff0ff0' );
 
 	// A timeout is necessary both because the function is debounced and needs time to retrieve
 	// entities to compare.
@@ -332,7 +258,7 @@ const testGlobalStylesColorPalette = async ( driver, editor, blockName = undefin
 		} )
 	);
 	await clearEventsStack( driver );
-	await changeGlobalStylesFirstColorPaletteItem( driver, '#a1a1a1', true );
+	await editor.changeGlobalStylesFirstColorPaletteItem( '#a1a1a1', true );
 	await driver.sleep( 500 );
 	updateEvents = await getGlobalStylesUpdateEvents( driver );
 
@@ -369,7 +295,7 @@ const testGlobalStylesColorPalette = async ( driver, editor, blockName = undefin
 
 	await clearEventsStack( driver );
 
-	await clickGlobalStylesResetButton( driver );
+	await editor.clickGlobalStylesResetButton();
 	await driver.sleep( 500 );
 
 	updateEvents = await getGlobalStylesUpdateEvents( driver );
@@ -470,11 +396,11 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 					await editor.toggleGlobalStyles();
 
-					await clickGlobalStylesMenuItem( this.driver, 'Typography' );
-					await clickGlobalStylesBackButton( this.driver );
-					await clickGlobalStylesMenuItem( this.driver, 'Colors' );
-					await clickGlobalStylesBackButton( this.driver );
-					await clickGlobalStylesMenuItem( this.driver, 'Blocks' );
+					await editor.clickGlobalStylesMenuItem( 'Typography' );
+					await editor.clickGlobalStylesBackButton();
+					await editor.clickGlobalStylesMenuItem( 'Colors' );
+					await editor.clickGlobalStylesBackButton();
+					await editor.clickGlobalStylesMenuItem( 'Blocks' );
 
 					const globalStylesMenuEvents = await getGlobalStylesMenuEvents( this.driver );
 					assert.strictEqual( globalStylesMenuEvents.length, 3 );
@@ -512,14 +438,16 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 					return this.skip();
 				}
 				// Reset Global Styles before testing.
-				await clickGlobalStylesResetButton( this.driver );
-				await saveGlobalStyles( this.driver );
+				await editor.clickGlobalStylesResetButton();
+				await editor.saveGlobalStyles( true );
 				await clearEventsStack( this.driver );
 
-				await testGlobalStylesColorAndTypography( this.driver );
+				await testGlobalStylesColorAndTypography( this.driver, editor );
 			} );
 
-			// Keep this skipped for now as changing global palette crashes editor. investigating...
+			// Updating a global color palette item crashes the editor in gutenberg v11.7.0.  We
+			// will move to re-introduce this test once the issue is resolved
+			// https://github.com/Automattic/wp-calypso/issues/57194
 			it.skip( 'global color palette settings', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
 				if ( editor.screenSize === 'mobile' ) {
@@ -533,7 +461,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				if ( editor.screenSize === 'mobile' ) {
 					return this.skip();
 				}
-				await testGlobalStylesColorAndTypography( this.driver, true );
+				await testGlobalStylesColorAndTypography( this.driver, editor, true );
 			} );
 
 			it( 'block level color palette settings', async function () {
@@ -541,8 +469,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				if ( editor.screenSize === 'mobile' ) {
 					return this.skip();
 				}
-				await clickGlobalStylesMenuItem( this.driver, 'Blocks' );
-				await clickGlobalStylesMenuItem( this.driver, 'Column' );
+				await editor.clickGlobalStylesMenuItem( 'Blocks' );
+				await editor.clickGlobalStylesMenuItem( 'Column' );
 				await testGlobalStylesColorPalette( this.driver, editor, 'core/column' );
 			} );
 
@@ -570,25 +498,25 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				}
 
 				// Reset global styles before testing.
-				await clickGlobalStylesResetButton( this.driver );
-				await saveGlobalStyles( this.driver );
+				await editor.clickGlobalStylesResetButton();
+				await editor.saveGlobalStyles( true );
 				await clearEventsStack( this.driver );
 
-				await clickGlobalStylesMenuItem( this.driver, 'Typography' );
-				await changeGlobalStylesFontSize( this.driver, '11' );
-				await clickGlobalStylesBackButton( this.driver );
-				await clickGlobalStylesMenuItem( this.driver, 'Colors' );
-				await changeGlobalStylesColor( this.driver, 1, 1 );
-				await changeGlobalStylesColor( this.driver, 3, 2 );
-				await saveGlobalStyles( this.driver );
+				await editor.clickGlobalStylesMenuItem( 'Typography' );
+				await editor.changeGlobalStylesFontSize( '11' );
+				await editor.clickGlobalStylesBackButton();
+				await editor.clickGlobalStylesMenuItem( 'Colors' );
+				await editor.changeGlobalStylesColor( 1, 1 );
+				await editor.changeGlobalStylesColor( 3, 2 );
+				await editor.saveGlobalStyles( true );
 				const saveEvents = ( await getEventsStack( this.driver ) ).filter(
 					( event ) => event[ 0 ] === 'wpcom_block_editor_global_styles_save'
 				);
 				assert.strictEqual( saveEvents.length, 3 );
 
 				// Clean up by resetting to be safe.
-				await clickGlobalStylesResetButton( this.driver );
-				await saveGlobalStyles( this.driver );
+				await editor.clickGlobalStylesResetButton();
+				await editor.saveGlobalStyles( true );
 			} );
 
 			after( async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -506,7 +506,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 				// Clean up by resetting to be safe.
 				await editor.clickGlobalStylesResetButton();
-				await editor.saveGlobalStyles( { pauseAfter: true } );
+				await editor.saveGlobalStyles();
 			} );
 
 			after( async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A Follow up to the test skips we introduced in https://github.com/Automattic/wp-calypso/pull/56544

* Re-enables global styles update/save tracks tests by updating them for the new interface and removing the skips. 
* Cleanup - moves global styles interface helper functions into the site editor component and out of the test file.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the test file altered in this PR (`wp-calypso-gutenberg-site-editor-tracking-spec`) with the `GUTENBERG_EDGE=true` (for v11.8 or higher) flag and verify it passes.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56540
