### PR TITLE
Fix order of withCartKey HOC in CartItem in PopoverCart

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -346,4 +346,4 @@ export class CartItem extends Component {
 	}
 }
 
-export default withShoppingCart( withCartKey( localize( withLocalizedMoment( CartItem ) ) ) );
+export default withCartKey( withShoppingCart( localize( withLocalizedMoment( CartItem ) ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/57039 we inverted the order of the `withCartKey` and `withShoppingCart` HOCs, but apparently we missed one. 

Props to @stephanethomas for noticing this!

#### Testing instructions

- Add a product to your cart and visit the `/plans` page.
- Click the popover cart and click the delete button on the product.
- Verify that the product is removed.