### PR TITLE
Signup video showcase skeleton

### DIFF
--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -76,6 +76,7 @@ const stepNameToModuleName = {
 	'difm-design': 'difm-design-picker',
 	'site-info-collection': 'site-info-collection',
 	intent: 'intent',
+	'video-showcase': 'video-showcase',
 };
 
 export function getStepModuleName( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -743,6 +743,12 @@ export function generateSteps( {
 			stepName: 'intent-screen',
 			dependencies: [ 'siteSlug' ],
 		},
+		'video-showcase': {
+			stepName: 'video-showcase',
+			dependencies: [ 'siteSlug' ],
+			//providesDependencies: [ 'viewedVideos' ],
+			//apiRequestFunction: setOptionsOnSite,
+		},
 	};
 }
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -224,6 +224,9 @@ class Signup extends Component {
 		}
 
 		if ( isReskinnedFlow( flowName ) ) {
+			// Add a class here to make the background dark on the whole page.
+			// It could be triggered depending on the stepName
+			// document.body.classList.add( 'is-dark' );
 			document.body.classList.add( 'is-white-signup' );
 			debug( 'In componentWillReceiveProps, addded is-white-signup class' );
 		} else {

--- a/client/signup/steps/video-showcase/index.tsx
+++ b/client/signup/steps/video-showcase/index.tsx
@@ -1,0 +1,47 @@
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import siteOptionsImage from 'calypso/assets/images/onboarding/site-options.svg';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import VideoShowcase from './video-showcase';
+
+interface Props {
+	goToNextStep: () => void;
+	isReskinned: boolean;
+	signupDependencies: any;
+	stepName: string;
+}
+
+export default function VideoShowcaseStep( props: Props ): React.ReactNode {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const headerText = translate( 'Watch five videos.' );
+	const subHeaderText = translate( 'Save yourself hours.' );
+	const skipLabelText = translate( 'Draft your first post' );
+	const { stepName, signupDependencies, goToNextStep } = props;
+	const { siteTitle, tagline } = signupDependencies;
+	//const submitSiteOptions = ( { siteTitle, tagline }: SiteOptionsFormValues ) => {
+	const submitSiteOptions = () => {
+		//recordTracksEvent( 'calypso_signup_submit_site_options', { siteTitle, tagline } );
+		//dispatch( submitSignupStep( { stepName }, { siteTitle, tagline } ) );
+		goToNextStep();
+	};
+
+	return (
+		<StepWrapper
+			headerText={ headerText }
+			fallbackHeaderText={ headerText }
+			subHeaderText={ subHeaderText }
+			fallbackSubHeaderText={ '' }
+			hideFormattedHeader={ true }
+			stepContent={ <VideoShowcase /> }
+			align={ 'left' }
+			skipLabelText={ skipLabelText }
+			skipButtonAlign={ 'top' }
+			isHorizontalLayout={ true }
+			{ ...props }
+		/>
+	);
+}

--- a/client/signup/steps/video-showcase/video-showcase.scss
+++ b/client/signup/steps/video-showcase/video-showcase.scss
@@ -1,0 +1,9 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+//.video-showcase__header {
+//    background-color: #151B1E;
+//}
+// body.is-section-signup.is-white-signup {
+//     background-color: #101517;
+// }

--- a/client/signup/steps/video-showcase/video-showcase.tsx
+++ b/client/signup/steps/video-showcase/video-showcase.tsx
@@ -1,0 +1,60 @@
+import { Button } from '@automattic/components';
+import { Icon } from '@wordpress/icons';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import React from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormInput from 'calypso/components/forms/form-text-input';
+import { tip } from './icons';
+import type { SiteOptionsFormValues } from './types';
+import './video-showcase.scss';
+
+interface Props {
+	// 	defaultSiteTitle: string;
+	// 	defaultTagline: string;
+	// 	onSubmit: ( siteOptionsFormValues: SiteOptionsFormValues ) => void;
+	translate: LocalizeProps[ 'translate' ];
+}
+
+const VideoShowcase: React.FC< Props > = ( { translate } ) => {
+	// const [ formValues, setFormValues ] = React.useState( {
+	// 	siteTitle: defaultSiteTitle,
+	// 	tagline: defaultTagline,
+	// } );
+
+	// const onChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+	// 	setFormValues( ( value ) => ( {
+	// 		...value,
+	// 		[ event.target.name ]: event.target.value,
+	// 	} ) );
+	// };
+
+	// const handleSubmit = ( event: React.FormEvent ) => {
+	// 	event.preventDefault();
+	// 	onSubmit( formValues );
+	// };
+
+	const headerText = translate( 'Watch five videos.' );
+	const subHeaderText = translate( 'Save yourself hours.' );
+
+	return (
+		<>
+			<div className="video-showcase__header">
+				<FormattedHeader
+					id={ 'step-header' }
+					headerText={ headerText }
+					subHeaderText={ subHeaderText }
+					align={ 'left' }
+				/>
+				<div className="video-showcase__header-text"></div>
+			</div>
+			<div className="video-showcase__content">
+				<p> this is the content</p>
+			</div>
+		</>
+	);
+};
+
+export default localize( VideoShowcase );

--- a/config/development.json
+++ b/config/development.json
@@ -152,6 +152,7 @@
 		"signup/design-picker-categories": true,
 		"signup/setup-site-after-checkout": true,
 		"signup/hero-flow": false,
+		"signup/video-showcase": true,
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,


### PR DESCRIPTION
This is the skeleton of a new step in the signup flow. It's not meant to be merged but it might help as a reference.

In order to see this component you need to:
* Add this step to some flow on `client/signup/config/flows-pure.js`. I just replaced the `steps` key on the `setup-site` object by:
```js
steps: isEnabled( 'signup/video-showcase' ) ? [ 'video-showcase' ] : [ 'design-setup-site' ],
```
* Navigate to http://calypso.localhost:3000/start/setup-site/video-showcase?flags=signup/video-showcase&siteSlug=[YOUR_SITE]