### PR TITLE
Composite Checkout: Replace using onEvent for error boundaries with onPageLoadError

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -77,6 +77,7 @@ import {
 } from './types/wpcom-store-state';
 import type { ReactStandardAction } from './types/analytics';
 import type { PaymentProcessorOptions } from './types/payment-processors';
+import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
@@ -528,14 +529,24 @@ export default function CompositeCheckout( {
 		checkoutFlow,
 	} );
 
-	const onPageLoadError = useCallback(
-		( error: string ) => {
-			reduxDispatch( logStashLoadErrorEventAction( 'page_load', error ) );
-			reduxDispatch(
-				recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
-					error_message: error,
-				} )
-			);
+	const onPageLoadError: CheckoutPageErrorCallback = useCallback(
+		( errorType, errorMessage, errorData ) => {
+			reduxDispatch( logStashLoadErrorEventAction( errorType, errorMessage, errorData ) );
+			switch ( errorType ) {
+				case 'page_load':
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
+							error_message: errorMessage,
+						} )
+					);
+				case 'step_load':
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
+							error_message: errorMessage,
+							...errorData,
+						} )
+					);
+			}
 		},
 		[ reduxDispatch ]
 	);

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -543,7 +543,9 @@ export default function CompositeCheckout( {
 					case 'payment_method_load':
 						return 'calypso_checkout_composite_payment_method_load_error';
 					default:
-						return 'unknown';
+						// These are important so we might as well use something that we'll
+						// notice even if we don't recognize the event.
+						return 'calypso_checkout_composite_page_load_error';
 				}
 			}
 			reduxDispatch(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -552,6 +552,12 @@ export default function CompositeCheckout( {
 							error_message: errorMessage,
 						} )
 					);
+				case 'payment_method_load':
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
+							error_message: errorMessage,
+						} )
+					);
 			}
 		},
 		[ reduxDispatch ]

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -532,33 +532,26 @@ export default function CompositeCheckout( {
 	const onPageLoadError: CheckoutPageErrorCallback = useCallback(
 		( errorType, errorMessage, errorData ) => {
 			reduxDispatch( logStashLoadErrorEventAction( errorType, errorMessage, errorData ) );
-			switch ( errorType ) {
-				case 'page_load':
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
-							error_message: errorMessage,
-						} )
-					);
-				case 'step_load':
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
-							error_message: errorMessage,
-							...errorData,
-						} )
-					);
-				case 'submit_button_load':
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_submit_button_load_error', {
-							error_message: errorMessage,
-						} )
-					);
-				case 'payment_method_load':
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
-							error_message: errorMessage,
-						} )
-					);
+			function errorTypeToTracksEventName( type: string ): string {
+				switch ( type ) {
+					case 'page_load':
+						return 'calypso_checkout_composite_page_load_error';
+					case 'step_load':
+						return 'calypso_checkout_composite_step_load_error';
+					case 'submit_button_load':
+						return 'calypso_checkout_composite_submit_button_load_error';
+					case 'payment_method_load':
+						return 'calypso_checkout_composite_payment_method_load_error';
+					default:
+						return 'unknown';
+				}
 			}
+			reduxDispatch(
+				recordTracksEvent( errorTypeToTracksEventName( errorType ), {
+					error_message: errorMessage,
+					...errorData,
+				} )
+			);
 		},
 		[ reduxDispatch ]
 	);

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -54,7 +54,7 @@ import useRecordCheckoutLoaded from './hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from './hooks/use-remove-from-cart-and-redirect';
 import useStoredCards from './hooks/use-stored-cards';
 import { useWpcomStore } from './hooks/wpcom-store';
-import { logStashEventAction } from './lib/analytics';
+import { logStashLoadErrorEventAction, logStashEventAction } from './lib/analytics';
 import existingCardProcessor from './lib/existing-card-processor';
 import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import freePurchaseProcessor from './lib/free-purchase-processor';
@@ -528,6 +528,18 @@ export default function CompositeCheckout( {
 		checkoutFlow,
 	} );
 
+	const onPageLoadError = useCallback(
+		( error: string ) => {
+			reduxDispatch( logStashLoadErrorEventAction( 'page_load', error ) );
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
+					error_message: error,
+				} )
+			);
+		},
+		[ reduxDispatch ]
+	);
+
 	const onPaymentComplete = useCreatePaymentCompleteCallback( {
 		createUserAndSiteBeforeTransaction,
 		productAliasFromUrl,
@@ -624,6 +636,7 @@ export default function CompositeCheckout( {
 				onPaymentComplete={ handlePaymentComplete }
 				onPaymentError={ handlePaymentError }
 				onPaymentRedirect={ handlePaymentRedirect }
+				onPageLoadError={ onPageLoadError }
 				onEvent={ recordEvent }
 				paymentMethods={ paymentMethods }
 				paymentProcessors={ paymentProcessors }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -546,6 +546,12 @@ export default function CompositeCheckout( {
 							...errorData,
 						} )
 					);
+				case 'submit_button_load':
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_submit_button_load_error', {
+							error_message: errorMessage,
+						} )
+					);
 			}
 		},
 		[ reduxDispatch ]

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -11,7 +11,7 @@ import type { CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 export function logStashLoadErrorEventAction(
 	errorType: string,
 	errorMessage: string,
-	additionalData: Record< string, string > = {}
+	additionalData: Record< string, string | number | undefined > = {}
 ): ReturnType< typeof logToLogstash > {
 	return logStashEventAction( 'composite checkout load error', {
 		...additionalData,

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -24,15 +24,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'SUBMIT_BUTTON_LOAD_ERROR':
-					reduxDispatch(
-						logStashLoadErrorEventAction( 'submit_button_load', String( action.payload ) )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_submit_button_load_error', {
-							error_message: String( action.payload ),
-						} )
-					);
 				case 'PAYMENT_METHOD_LOAD_ERROR':
 					reduxDispatch(
 						logStashLoadErrorEventAction( 'payment_method_load', String( action.payload ) )

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -4,11 +4,7 @@ import {
 	translateCheckoutPaymentMethodToTracksPaymentMethod,
 } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import {
-	logStashLoadErrorEventAction,
-	logStashEventAction,
-	recordCompositeCheckoutErrorDuringAnalytics,
-} from './lib/analytics';
+import { logStashEventAction, recordCompositeCheckoutErrorDuringAnalytics } from './lib/analytics';
 
 const debug = debugFactory( 'calypso:composite-checkout:record-analytics' );
 
@@ -24,15 +20,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'PAYMENT_METHOD_LOAD_ERROR':
-					reduxDispatch(
-						logStashLoadErrorEventAction( 'payment_method_load', String( action.payload ) )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
-							error_message: String( action.payload ),
-						} )
-					);
 				case 'PAYMENT_METHOD_SELECT': {
 					reduxDispatch(
 						logStashEventAction( 'payment_method_select', {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -24,18 +24,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'STEP_LOAD_ERROR':
-					reduxDispatch(
-						logStashLoadErrorEventAction( 'step_load', String( action.payload.message ), {
-							stepId: action.payload.stepId,
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
-							error_message: String( action.payload.message ),
-							step_id: String( action.payload.stepId ),
-						} )
-					);
 				case 'SUBMIT_BUTTON_LOAD_ERROR':
 					reduxDispatch(
 						logStashLoadErrorEventAction( 'submit_button_load', String( action.payload ) )

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -69,13 +69,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_switch_to_' + legacyPaymentMethodSlug )
 					);
 				}
-				case 'PAGE_LOAD_ERROR':
-					reduxDispatch( logStashLoadErrorEventAction( 'page_load', String( action.payload ) ) );
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
-							error_message: String( action.payload ),
-						} )
-					);
 				case 'STORED_CARD_ERROR':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_stored_card_error', {

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -166,7 +166,7 @@ It has the following props.
 - `onPaymentComplete?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for non-redirect payment methods when payment is successful. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentRedirect?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for redirect payment methods when payment begins to redirect. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentError?: ({paymentMethodId: string | null, transactionError: string | null }) => null`. A function to call for payment methods when payment is not successful.
-- `onPageLoadError?: ( errorType: string, errorMessage: string, errorData: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
+- `onPageLoadError?: ( errorType: string, errorMessage: string, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
 - `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -166,6 +166,7 @@ It has the following props.
 - `onPaymentComplete?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for non-redirect payment methods when payment is successful. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentRedirect?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for redirect payment methods when payment begins to redirect. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentError?: ({paymentMethodId: string | null, transactionError: string | null }) => null`. A function to call for payment methods when payment is not successful.
+- `onPageLoadError?: ( errorType: string, errorMessage: string, errorData: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
 - `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -3,8 +3,8 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
-import { useCallback } from 'react';
-import * as React from 'react';
+import { useCallback, useContext } from 'react';
+import CheckoutContext from '../lib/checkout-context';
 import joinClasses from '../lib/join-classes';
 import {
 	useAllPaymentMethods,
@@ -18,6 +18,7 @@ import {
 import { FormStatus } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import RadioButton from './radio-button';
+import type { ReactNode } from 'react';
 
 const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 
@@ -36,10 +37,10 @@ export default function CheckoutPaymentMethods( {
 } ): JSX.Element | null {
 	const { __ } = useI18n();
 	const onEvent = useEvents();
-	const onError = useCallback(
-		( error ) => onEvent( { type: 'PAYMENT_METHOD_LOAD_ERROR', payload: error } ),
-		[ onEvent ]
-	);
+	const { onPageLoadError } = useContext( CheckoutContext );
+	const onError = useCallback( ( error ) => onPageLoadError?.( 'payment_method_load', error ), [
+		onPageLoadError,
+	] );
 
 	const paymentMethod = usePaymentMethod();
 	const [ , setPaymentMethod ] = usePaymentMethodId();
@@ -176,8 +177,8 @@ interface PaymentMethodProps {
 	onClick?: ( id: string ) => void;
 	checked: boolean;
 	ariaLabel: string;
-	activeContent?: React.ReactNode;
-	label?: React.ReactNode;
-	inactiveContent?: React.ReactNode;
+	activeContent?: ReactNode;
+	label?: ReactNode;
+	inactiveContent?: ReactNode;
 	summary?: boolean;
 }

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from '@emotion/react';
 import { DataRegistry } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import { useFormStatusManager } from '../lib/form-status';
 import { LineItemsProvider } from '../lib/line-items';
@@ -125,6 +125,7 @@ export function CheckoutProvider( {
 			setFormStatus,
 			transactionStatusManager,
 			paymentProcessors,
+			onPageLoadError,
 		} ),
 		[
 			formStatus,
@@ -134,13 +135,20 @@ export function CheckoutProvider( {
 			setFormStatus,
 			transactionStatusManager,
 			paymentProcessors,
+			onPageLoadError,
 		]
 	);
 
 	const { __ } = useI18n();
 	const errorMessage = __( 'Sorry, there was an error loading this page.' );
+	const onLoadError = useCallback(
+		( errorMessage ) => {
+			onPageLoadError?.( 'page_load', errorMessage );
+		},
+		[ onPageLoadError ]
+	);
 	return (
-		<CheckoutErrorBoundary errorMessage={ errorMessage } onError={ onPageLoadError }>
+		<CheckoutErrorBoundary errorMessage={ errorMessage } onError={ onLoadError }>
 			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
 			<ThemeProvider theme={ theme || defaultTheme }>
 				<RegistryProvider value={ registryRef.current }>

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from '@emotion/react';
 import { DataRegistry } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import { useFormStatusManager } from '../lib/form-status';
 import { LineItemsProvider } from '../lib/line-items';
@@ -45,6 +45,7 @@ export function CheckoutProvider( {
 	onPaymentComplete,
 	onPaymentRedirect,
 	onPaymentError,
+	onPageLoadError,
 	redirectToUrl,
 	theme,
 	paymentMethods,
@@ -138,12 +139,8 @@ export function CheckoutProvider( {
 
 	const { __ } = useI18n();
 	const errorMessage = __( 'Sorry, there was an error loading this page.' );
-	const onError = useCallback(
-		( error ) => onEvent?.( { type: 'PAGE_LOAD_ERROR', payload: error } ),
-		[ onEvent ]
-	);
 	return (
-		<CheckoutErrorBoundary errorMessage={ errorMessage } onError={ onError }>
+		<CheckoutErrorBoundary errorMessage={ errorMessage } onError={ onPageLoadError }>
 			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
 			<ThemeProvider theme={ theme || defaultTheme }>
 				<RegistryProvider value={ registryRef.current }>

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -17,6 +17,7 @@ import {
 	useState,
 	createContext,
 } from 'react';
+import CheckoutContext from '../lib/checkout-context';
 import { useFormStatus } from '../lib/form-status';
 import joinClasses from '../lib/join-classes';
 import theme from '../lib/theme';
@@ -287,6 +288,7 @@ export const CheckoutStep = ( {
 	const { stepNumber, nextStepNumber, isStepActive, isStepComplete, areStepsActive } = useContext(
 		CheckoutSingleStepDataContext
 	);
+	const { onPageLoadError } = useContext( CheckoutContext );
 	const { formStatus, setFormValidating, setFormReady } = useFormStatus();
 	const setThisStepCompleteStatus = ( newStatus: boolean ) =>
 		setStepCompleteStatus( { ...stepCompleteStatus, [ stepNumber ]: newStatus } );
@@ -328,15 +330,8 @@ export const CheckoutStep = ( {
 	];
 
 	const onError = useCallback(
-		( error ) =>
-			onEvent( {
-				type: 'STEP_LOAD_ERROR',
-				payload: {
-					message: error,
-					stepId,
-				},
-			} ),
-		[ onEvent, stepId ]
+		( error ) => onPageLoadError?.( 'step_load', error, { step_id: stepId } ),
+		[ onPageLoadError, stepId ]
 	);
 
 	return (

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -488,15 +488,14 @@ export function CheckoutStepArea( {
 	submitButtonFooter?: ReactNode;
 	disableSubmitButton?: boolean;
 } ): JSX.Element {
-	const onEvent = useEvents();
-
+	const { onPageLoadError } = useContext( CheckoutContext );
 	const { activeStepNumber, totalSteps } = useContext( CheckoutStepDataContext );
 	const actualActiveStepNumber =
 		activeStepNumber > totalSteps && totalSteps > 0 ? totalSteps : activeStepNumber;
 	const isThereAnotherNumberedStep = actualActiveStepNumber < totalSteps;
 	const onSubmitButtonLoadError = useCallback(
-		( error ) => onEvent( { type: 'SUBMIT_BUTTON_LOAD_ERROR', payload: error } ),
-		[ onEvent ]
+		( error ) => onPageLoadError?.( 'submit_button_load', error ),
+		[ onPageLoadError ]
 	);
 
 	const classNames = joinClasses( [

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
 import {
+	CheckoutPageErrorCallback,
 	FormStatus,
 	PaymentMethod,
 	PaymentProcessorProp,
@@ -16,6 +17,7 @@ interface CheckoutContext {
 	setFormStatus: ( newStatus: FormStatus ) => void;
 	transactionStatusManager: TransactionStatusManager | null;
 	paymentProcessors: PaymentProcessorProp;
+	onPageLoadError?: CheckoutPageErrorCallback;
 }
 
 const defaultCheckoutContext: CheckoutContext = {

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -109,6 +109,7 @@ export interface CheckoutProviderProps {
 	onPaymentComplete?: PaymentEventCallback;
 	onPaymentRedirect?: PaymentEventCallback;
 	onPaymentError?: PaymentErrorCallback;
+	onPageLoadError?: CheckoutPageErrorCallback;
 	onEvent?: ( event: ReactStandardAction ) => void;
 	isLoading?: boolean;
 	redirectToUrl?: ( url: string ) => void;
@@ -127,6 +128,7 @@ export type PaymentErrorCallback = ( args: {
 	paymentMethodId: string | null;
 	transactionError: string | null;
 } ) => void;
+export type CheckoutPageErrorCallback = ( error: string ) => void;
 
 export type PaymentEventCallbackArguments = {
 	paymentMethodId: string | null;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -128,7 +128,11 @@ export type PaymentErrorCallback = ( args: {
 	paymentMethodId: string | null;
 	transactionError: string | null;
 } ) => void;
-export type CheckoutPageErrorCallback = ( error: string ) => void;
+export type CheckoutPageErrorCallback = (
+	errorType: string,
+	errorMessage: string,
+	errorData?: Record< string, string | number | undefined >
+) => void;
 
 export type PaymentEventCallbackArguments = {
 	paymentMethodId: string | null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `@automattic/composite-checkout` package includes components that contain their own React error boundaries. When one of those boundaries is triggered, it displays an error message and reports the error to the parent of `CheckoutProvider`. Currently that error is reported via various custom actions passed through the `onEvent` callback, which is a generic handler mainly used for analytics. That handler is a leaky abstraction, though, and it's not clear unless you read the code how to use it to handle these sorts of events.

This PR changes these error boundaries to instead call a new callback called `onPageLoadError` which includes the same information previously passed to the actions in `onEvent`. This then uses that new handler in calypso checkout.

Related to https://github.com/Automattic/wp-calypso/pull/48282 and also https://github.com/Automattic/wp-calypso/pull/57084

This is required to do the work in https://github.com/Automattic/wp-calypso/issues/57088

#### Testing instructions

First just load checkout and verify that there are no obvious errors with loading.

Next we'll need to cause the four error boundaries to trigger in order to verify that the handler is reporting them correctly. For each one, add the code `throw new Error('testing');` to the locations mentioned below and open checkout, one at a time. Verify that a Tracks event is sent with the key listed.

You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.

- `calypso_checkout_composite_page_load_error`: packages/composite-checkout/src/components/checkout-provider.tsx, line 175.
- `calypso_checkout_composite_step_load_error`: client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx, line 51.
- `calypso_checkout_composite_submit_button_load_error`: packages/wpcom-checkout/src/payment-methods/paypal.tsx, line 59 (and select PayPal as the payment method in checkout to trigger it).
- `calypso_checkout_composite_payment_method_load_error`: client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js, line 30 (and view the last step checkout to trigger it).

