### PR TITLE
Coming Soon: Fix mobile web buttons spacing

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -185,6 +185,9 @@ nocache_headers();
 			.wpcom-coming-soon-marketing-buttons .button:focus {
 				opacity: .85;
 			}
+			.wpcom-coming-soon-marketing-buttons p {
+				margin: 1em 0;
+			}
 			@media screen and ( min-width: 660px ) {
 				.wpcom-coming-soon-description,
 				.wpcom-coming-soon-marketing-copy-text {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Fix mobile styles when hever theme is active on coming soon page.

#### Testing instructions
     
Requirements:

    Visit /new and create a free site that uses the Hever theme (e.g. "default theme")

To reproduce the bug:

    In an incognito window, visit https://[TEST_SITE_ID].wordpress.com
    Notice how the buttons are right on top of each.

To reproduce the fix:

    In the public_html folder of your sandbox, run install-plugin.sh etk fix/coming-soon-page-mobile
    Add [TEST_SITE_ID].wordpress.com to your sandbox and enable your sandbox
    In an incognito window, visit https://[TEST_SITE_ID].wordpress.com
    Notice that the buttons have space in between them now.
   
<img src="https://user-images.githubusercontent.com/115071/138152187-27eab12d-d1e5-4bed-9f73-7a7f0c9728a8.png" width="300" />
<img src="https://user-images.githubusercontent.com/115071/138152189-ed4a64ee-2b1f-4542-b758-7baa3aca64e0.png" width="300" />
 
    
Related to https://github.com/Automattic/wp-calypso/issues/57203
