### PR TITLE
Themes Showcase: Remove unnecessary margin for current theme action button

### DIFF
--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -176,7 +176,6 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	.current-theme__button {
 		display: flex;
 		margin-right: 10px;
-		margin-top: 12px;
 		font-weight: normal;
 		position: relative;
 		border-width: 1px;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Remove top margin from current theme card action buttons

#### Before
<img width="788" alt="Screen Shot 2021-10-20 at 12 05 02 PM" src="https://user-images.githubusercontent.com/5414230/138156565-f8d7192f-7a75-43c0-b276-f8eb55bdb034.png">

#### After
<img width="790" alt="Screen Shot 2021-10-20 at 12 05 29 PM" src="https://user-images.githubusercontent.com/5414230/138156579-97c18d0b-2dcf-47d1-9db9-fe069eef70a9.png">

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create an FSE eligible site
2. Navigate to the themes showcase in Appearance > Themes
3. Verify that the alignment of the current theme card description and action buttons

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/56890#issuecomment-947902885
