### PR TITLE
Credit Card Forms: Show "use for all subscriptions" checkbox for Jetpack products

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -67,10 +67,7 @@ function ChangePaymentMethod( {
 
 	const currentPaymentMethodId = getPaymentMethodIdFromPayment( payment );
 	const changePaymentMethodTitle = getChangePaymentMethodTitleCopy( currentPaymentMethodId );
-	const paymentMethods = useCreateAssignablePaymentMethods(
-		currentPaymentMethodId,
-		purchase?.productSlug ?? ''
-	);
+	const paymentMethods = useCreateAssignablePaymentMethods( currentPaymentMethodId );
 	const reduxDispatch = useDispatch();
 
 	if ( isDataLoading || ! isDataValid ) {

--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -1,4 +1,3 @@
-import { isJetpackProductSlug } from '@automattic/calypso-products';
 import { useStripe } from '@automattic/calypso-stripe';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -15,8 +14,7 @@ import useFetchAvailablePaymentMethods from './use-fetch-available-payment-metho
 import type { PaymentMethod } from '@automattic/composite-checkout';
 
 export default function useCreateAssignablePaymentMethods(
-	currentPaymentMethodId: string,
-	productSlug: string
+	currentPaymentMethodId: string
 ): PaymentMethod[] {
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
@@ -35,7 +33,7 @@ export default function useCreateAssignablePaymentMethods(
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
 		activePayButtonText: String( translate( 'Save card' ) ),
-		allowUseForAllSubscriptions: ! isJetpackProductSlug( productSlug ),
+		allowUseForAllSubscriptions: true,
 	} );
 
 	const payPalMethod = useCreatePayPal( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { isJetpackProduct } from '@automattic/calypso-products';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	createApplePayMethod,
@@ -443,7 +442,7 @@ export default function useCreatePaymentMethods( {
 	const shouldUseEbanx = responseCart.allowed_payment_methods.includes(
 		translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' ) ?? ''
 	);
-	const allowUseForAllSubscriptions = ! responseCart.products.some( isJetpackProduct );
+	const allowUseForAllSubscriptions = true;
 	const stripeMethod = useCreateCreditCard( {
 		isStripeLoading,
 		stripeLoadingError,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/56736 we added a "Use this payment method for all subscriptions" checkbox to all credit card forms (checkout, add/change payment method). We limited the checkbox to wpcom purchases. However, the functionality of the endpoints in question affects Jetpack products just the same as wpcom products, so this limitation does not seem very useful after all.

This PR removes that limitation.


<img width="584" alt="Screen Shot 2021-10-20 at 4 45 59 PM" src="https://user-images.githubusercontent.com/2036909/138169608-616363bf-32a0-4cd2-b015-740da29781e5.png">

#### Testing instructions

To test subscription payment method management:

- Use a site that has an existing non-wpcom purchase (eg: a Jetpack site).
- Visit `/me/purchases`, select your existing purchase, click "Change payment method", and verify that you do see the "Use this payment method for all subscriptions on my account." checkbox in the new card form.
