### PR TITLE
Playwright: Use Support card on home dashboard for the `Support: Show me` spec

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -62,17 +62,21 @@ export class SupportComponent {
 			return;
 		}
 
+		// This Promise.all wrapper contains many calls due to a certain level of uncertainty
+		// when the support popover is launched.
 		await Promise.all( [
+			// Waits for all placeholder CSS elements to be removed from the DOM.
 			this.waitForQueryComplete(),
+			// Waits for one of the network request (triggered by the opening of the popover) to complete.
 			this.page.waitForResponse(
 				( response ) => response.status() === 200 && response.url().includes( 'language-names?' )
 			),
-			this.page.waitForSelector( selectors.supportPopover ),
 			this.page.click( selectors.supportPopoverButton ),
 		] );
 
+		// Obtain the element handle for the Support popover, then wait until the `is-active` attribute
+		// is added.
 		const elementHandle = await this.page.waitForSelector( selectors.supportPopoverButton );
-
 		await this.page.waitForFunction(
 			( element: HTMLElement | SVGElement ) => element.classList.contains( 'is-active' ),
 			elementHandle

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -4,7 +4,7 @@ type SupportResultType = 'article' | 'where';
 
 const selectors = {
 	// Components
-	supportPopoverButton: '.inline-help__button',
+	supportPopoverButton: `button[title="Help"]`,
 	supportPopover: '.inline-help__popover',
 	searchInput: '[aria-label="Search"]',
 	clearSearch: '[aria-label="Close Search"]',
@@ -61,13 +61,22 @@ export class SupportComponent {
 		if ( await this.page.isVisible( selectors.supportPopover ) ) {
 			return;
 		}
+
 		await Promise.all( [
+			this.waitForQueryComplete(),
 			this.page.waitForResponse(
 				( response ) => response.status() === 200 && response.url().includes( 'language-names?' )
 			),
 			this.page.waitForSelector( selectors.supportPopover ),
 			this.page.click( selectors.supportPopoverButton ),
 		] );
+
+		const elementHandle = await this.page.waitForSelector( selectors.supportPopoverButton );
+
+		await this.page.waitForFunction(
+			( element: HTMLElement | SVGElement ) => element.classList.contains( 'is-active' ),
+			elementHandle
+		);
 	}
 
 	/**
@@ -140,6 +149,7 @@ export class SupportComponent {
 	 */
 	async clickResult( category: SupportResultType, target: number ): Promise< void > {
 		let selector: string;
+
 		if ( category === 'article' ) {
 			selector = selectors.results( selectors.supportCategory );
 		} else {
@@ -147,6 +157,7 @@ export class SupportComponent {
 		}
 
 		await this.page.click( `:nth-match(${ selector }, ${ target })` );
+
 		if ( category === 'article' ) {
 			await this.page.click( selectors.readMoreButton );
 		}

--- a/test/e2e/specs/specs-playwright/wp-support__showme-where.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__showme-where.ts
@@ -31,22 +31,16 @@ describe( DataHelper.createSuiteTitle( 'Support: Show me where' ), function () {
 			await loginPage.login( { account: user } );
 		} );
 
-		it( 'Navigate to Tools > Marketing', async function () {
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Tools', 'Marketing' );
-		} );
-
-		it( 'Open support popover', async function () {
-			supportComponent = new SupportComponent( page );
-			await supportComponent.openPopover();
-		} );
-
 		it( 'Search for help: Create a site', async function () {
+			supportComponent = new SupportComponent( page );
+			await supportComponent.showSupportCard();
 			await supportComponent.search( 'create a site' );
+			const results = await supportComponent.getResults( 'article' );
+			expect( results.length ).toBeGreaterThan( 0 );
 		} );
 
 		it( 'Click on result under Show me where', async function () {
-			await supportComponent.clickResult( 'where', 1 );
+			await Promise.all( [ page.waitForNavigation(), supportComponent.clickResult( 'where', 1 ) ] );
 		} );
 
 		it( 'Gutenboarding flow is started', async function () {

--- a/test/e2e/specs/specs-playwright/wp-support__showme-where.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__showme-where.ts
@@ -5,7 +5,6 @@
 import {
 	DataHelper,
 	LoginPage,
-	SidebarComponent,
 	SupportComponent,
 	setupHooks,
 	GutenboardingFlow,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes the `Support: Show me` spec to be more reliable.

Key changes:
- switch to using the Support card in the Home dashboard.
- update the selector used for the popover button.
- change the wait method used for asserting that the popover is open.

#### Testing instructions

- [x] desktop tests
- [x] mobile tests


Fixes #57122