### PR TITLE
Add a minimal variant to Pagination component.

### DIFF
--- a/client/components/pagination/README.md
+++ b/client/components/pagination/README.md
@@ -14,15 +14,16 @@ function render() {
 
 ### Props
 
-| Name          | Type       | Default | Description                                                                                      |
-| ------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------ |
-| `page`\*      | `integer`  | null    | The current active page number.                                                                  |
-| `perPage`\*   | `integer`  | null    | Number of records shown per page.                                                                |
-| `total`\*     | `integer`  | null    | Total number of records.                                                                         |
-| `pageClick`\* | `function` | null    | Function called when a pagination item is clicked - the page clicked is provided as an argument. |
-| `compact`     | `bool`     | false   | Render a smaller version.                                                                        |
-| `nextLabel`   | `string`   | null    | Overrides the "Next" button label.                                                               |
-| `prevLabel`   | `string`   | null    | Overrides the "Previous" button label.                                                           |
+| Name          | Type                    | Default  | Description                                                                                      |
+| ------------- | ----------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `page`\*      | `integer`               | null     | The current active page number.                                                                  |
+| `perPage`\*   | `integer`               | null     | Number of records shown per page.                                                                |
+| `total`\*     | `integer`               | null     | Total number of records.                                                                         |
+| `pageClick`\* | `function`              | null     | Function called when a pagination item is clicked - the page clicked is provided as an argument. |
+| `compact`     | `bool`                  | false    | Render a smaller version.                                                                        |
+| `nextLabel`   | `string`                | null     | Overrides the "Next" button label.                                                               |
+| `prevLabel`   | `string`                | null     | Overrides the "Previous" button label.                                                           |
+| `variant`     | `"outlined"\|"minimal"` | outlined | Sets the style of the component                                                                  |
 
 ### General guidelines
 

--- a/client/components/pagination/README.md
+++ b/client/components/pagination/README.md
@@ -23,7 +23,7 @@ function render() {
 | `compact`     | `bool`                  | false    | Render a smaller version.                                                                        |
 | `nextLabel`   | `string`                | null     | Overrides the "Next" button label.                                                               |
 | `prevLabel`   | `string`                | null     | Overrides the "Previous" button label.                                                           |
-| `variant`     | `"outlined"\|"minimal"` | outlined | Sets the style of the component                                                                  |
+| `variant`     | `PaginationVariant`     | outlined | Sets the style of the component                                                                  |
 
 ### General guidelines
 

--- a/client/components/pagination/constants.ts
+++ b/client/components/pagination/constants.ts
@@ -1,0 +1,4 @@
+export enum PaginationVariant {
+	outlined = 'outlined',
+	minimal = 'minimal',
+}

--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -6,6 +6,9 @@ import PaginationPage from './pagination-page';
 import './style.scss';
 
 class Pagination extends Component {
+	static VARIANT_OUTLINED = 'outlined';
+	static VARIANT_MINIMAL = 'minimal';
+
 	static propTypes = {
 		compact: PropTypes.bool,
 		nextLabel: PropTypes.string,
@@ -14,6 +17,11 @@ class Pagination extends Component {
 		perPage: PropTypes.number.isRequired,
 		prevLabel: PropTypes.string,
 		total: PropTypes.number,
+		variant: PropTypes.oneOf( [ this.VARIANT_OUTLINED, this.VARIANT_MINIMAL ] ),
+	};
+
+	static defaultProps = {
+		variant: this.VARIANT_OUTLINED,
 	};
 
 	getPageList = ( page, pageCount ) => {
@@ -56,6 +64,7 @@ class Pagination extends Component {
 			perPage,
 			prevLabel,
 			total,
+			variant,
 		} = this.props;
 		const pageCount = Math.ceil( total / perPage );
 
@@ -80,7 +89,12 @@ class Pagination extends Component {
 		} );
 
 		return (
-			<div className={ classnames( 'pagination', className, { 'is-compact': compact } ) }>
+			<div
+				className={ classnames( 'pagination', className, {
+					'is-compact': compact,
+					'is-minimal': variant === Pagination.VARIANT_MINIMAL,
+				} ) }
+			>
 				<ul className="pagination__list">{ pageListRendered }</ul>
 			</div>
 		);

--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -15,7 +15,7 @@ class Pagination extends Component {
 		perPage: PropTypes.number.isRequired,
 		prevLabel: PropTypes.string,
 		total: PropTypes.number,
-		variant: PropTypes.oneOf( [ PaginationVariant.outlined, PaginationVariant.minimal ] ),
+		variant: PropTypes.oneOf( Object.values( PaginationVariant ) ),
 	};
 
 	static defaultProps = {

--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -1,14 +1,12 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import { PaginationVariant } from './constants';
 import PaginationPage from './pagination-page';
 
 import './style.scss';
 
 class Pagination extends Component {
-	static VARIANT_OUTLINED = 'outlined';
-	static VARIANT_MINIMAL = 'minimal';
-
 	static propTypes = {
 		compact: PropTypes.bool,
 		nextLabel: PropTypes.string,
@@ -17,11 +15,11 @@ class Pagination extends Component {
 		perPage: PropTypes.number.isRequired,
 		prevLabel: PropTypes.string,
 		total: PropTypes.number,
-		variant: PropTypes.oneOf( [ this.VARIANT_OUTLINED, this.VARIANT_MINIMAL ] ),
+		variant: PropTypes.oneOf( [ PaginationVariant.outlined, PaginationVariant.minimal ] ),
 	};
 
 	static defaultProps = {
-		variant: this.VARIANT_OUTLINED,
+		variant: PaginationVariant.outlined,
 	};
 
 	getPageList = ( page, pageCount ) => {
@@ -92,7 +90,7 @@ class Pagination extends Component {
 			<div
 				className={ classnames( 'pagination', className, {
 					'is-compact': compact,
-					'is-minimal': variant === Pagination.VARIANT_MINIMAL,
+					'is-minimal': variant === PaginationVariant.minimal,
 				} ) }
 			>
 				<ul className="pagination__list">{ pageListRendered }</ul>

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -1,6 +1,11 @@
 // Stats Pagination
 // I like lamp.
 
+$minimal-active: var( --studio-black );
+$minimal-inactive: var( --studio-gray-30 );
+$minimal-arrow-color: var( --studio-gray-50 );
+$minimal-arrow-size: 24px;
+
 .pagination {
 	width: 100%;
 
@@ -23,34 +28,48 @@
 		.pagination__list-item:first-child,
 		.pagination__list-item:last-child {
 			.pagination__list-button.button {
+				padding: 8px 16px;
 				background-color: transparent;
 				border: none;
-				color: var( --studio-gray-30 );
+				color: $minimal-inactive;
 
 				&:hover {
-					color: var( --studio-black );
+					color: $minimal-active;
 				}
 
 				&:disabled {
-					color: var( --studio-gray-30 ); // don't highlight on hover when disabled
+					color: $minimal-inactive; // don't highlight on hover when disabled
 				}
 			}
 
 			&.pagination__ellipsis span {
+				padding: 8px 16px;
 				background-color: transparent;
 				border: none;
-				color: var( --studio-gray-30 );
+				color: $minimal-inactive;
 			}
 
 
 			&.is-selected {
 				.pagination__list-button.button {
 					background-color: transparent;
-					color: var( --studio-black );
+					color: $minimal-active;
 	
 					&:hover {
-						color: var( --studio-black );
+						color: $minimal-active;
 					}
+				}
+			}
+
+			&.pagination__arrow {
+				.pagination__list-button {
+					color: $minimal-arrow-color;
+					line-height: $minimal-arrow-size;
+				}
+
+				.gridicon {
+					width: $minimal-arrow-size;
+					height: $minimal-arrow-size;
 				}
 			}
 		}

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -17,6 +17,44 @@
 			padding: 6px;
 		}
 	}
+
+	&.is-minimal {
+		.pagination__list-item,
+		.pagination__list-item:first-child,
+		.pagination__list-item:last-child {
+			.pagination__list-button.button {
+				background-color: transparent;
+				border: none;
+				color: var( --studio-gray-30 );
+
+				&:hover {
+					color: var( --studio-black );
+				}
+
+				&:disabled {
+					color: var( --studio-gray-30 ); // don't highlight on hover when disabled
+				}
+			}
+
+			&.pagination__ellipsis span {
+				background-color: transparent;
+				border: none;
+				color: var( --studio-gray-30 );
+			}
+
+
+			&.is-selected {
+				.pagination__list-button.button {
+					background-color: transparent;
+					color: var( --studio-black );
+	
+					&:hover {
+						color: var( --studio-black );
+					}
+				}
+			}
+		}
+	}
 }
 
 .pagination__list {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -220,6 +220,7 @@ export class PluginsBrowser extends Component {
 							pageClick={ ( page ) => {
 								fetchPlugins( null, page, searchTerm, SEARCH_RESULTS_LIST_LENGTH );
 							} }
+							variant={ Pagination.VARIANT_MINIMAL }
 						/>
 					) }
 				</>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -24,6 +24,7 @@ import InfiniteScroll from 'calypso/components/infinite-scroll';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
+import { PaginationVariant } from 'calypso/components/pagination/constants';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -220,7 +221,7 @@ export class PluginsBrowser extends Component {
 							pageClick={ ( page ) => {
 								fetchPlugins( null, page, searchTerm, SEARCH_RESULTS_LIST_LENGTH );
 							} }
-							variant={ Pagination.VARIANT_MINIMAL }
+							variant={ PaginationVariant.minimal }
 						/>
 					) }
 				</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new property to the Pagination component that allows a variant to be set.
* The default variant (when none is passed) is still the past design which is now called outlined.
* Update the Pagination component documentation to add the `variant` property.

#### Testing instructions

**Check if the outlined version still being used in other parts**
1. Go to `Jetpack -> Activity log`
2. You should be able to see the outlined (past) version of the Pagination component.

**Check if the minimal version is being used on the plugins page**
1. Go to the **plugins** page on calypso and search for a plugin.
2. You should be able to see the minimal version f the Pagination component.



#### Before
<img alt="Screen Shot 2021-10-20 at 16 43 58" src="https://user-images.githubusercontent.com/5039531/138169495-82bb20a1-0fcc-47f3-be1d-0d739ff5f3ec.png">

#### After

<img alt="Screen Shot 2021-10-20 at 16 43 33" src="https://user-images.githubusercontent.com/5039531/138169633-946b559c-e431-4aa1-87ee-8bba2321de87.png">

---

Related to  [Support a minimal theme variant for the pagination component](https://github.com/Automattic/wp-calypso/issues/57100).
