### PR TITLE
Checkout: Remove isRequired property on checkout contact details form fields

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -56,7 +56,6 @@ export default function ContactDetailsContainer( {
 		updateDomainContactFields,
 		updateCountryCode,
 		updatePostalCode,
-		updateRequiredDomainFields,
 		updateEmail,
 	} = useDispatch( 'wpcom-checkout' );
 	const contactDetails = prepareDomainContactDetails( contactInfo );
@@ -66,9 +65,6 @@ export default function ContactDetailsContainer( {
 	const updateDomainContactRelatedData = ( details: DomainContactDetailsData ) => {
 		updateDomainContactFields( details );
 	};
-
-	const getIsFieldRequired = ( field: Exclude< keyof ManagedContactDetails, 'tldExtraFields' > ) =>
-		contactInfo[ field ]?.isRequired ?? false;
 
 	switch ( contactDetailsType ) {
 		case 'domain':
@@ -84,8 +80,6 @@ export default function ContactDetailsContainer( {
 						contactDetails={ contactDetails }
 						contactDetailsErrors={ contactDetailsErrors }
 						updateDomainContactFields={ updateDomainContactRelatedData }
-						updateRequiredDomainFields={ updateRequiredDomainFields }
-						getIsFieldRequired={ getIsFieldRequired }
 						shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
 						isDisabled={ isDisabled }
 						isLoggedOutCart={ isLoggedOutCart }

--- a/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
@@ -11,19 +11,13 @@ import {
 import { getTopLevelOfTld } from 'calypso/lib/domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
-import type {
-	DomainContactDetailsErrors,
-	ManagedContactDetails,
-	ManagedContactDetailsRequiredMask,
-} from '@automattic/wpcom-checkout';
+import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
 
 export default function DomainContactDetails( {
 	domainNames,
 	contactDetails,
 	contactDetailsErrors,
 	updateDomainContactFields,
-	updateRequiredDomainFields,
-	getIsFieldRequired,
 	shouldShowContactDetailsValidationErrors,
 	isDisabled,
 	isLoggedOutCart,
@@ -33,13 +27,6 @@ export default function DomainContactDetails( {
 	contactDetails: DomainContactDetailsData;
 	contactDetailsErrors: DomainContactDetailsErrors;
 	updateDomainContactFields: ( details: DomainContactDetailsData ) => void;
-	updateRequiredDomainFields?: (
-		details: ManagedContactDetails,
-		requiredMask: ManagedContactDetailsRequiredMask
-	) => ManagedContactDetails;
-	getIsFieldRequired?: (
-		field: Exclude< keyof ManagedContactDetails, 'tldExtraFields' >
-	) => boolean;
 	shouldShowContactDetailsValidationErrors: boolean;
 	isDisabled: boolean;
 	isLoggedOutCart: boolean;
@@ -66,7 +53,6 @@ export default function DomainContactDetails( {
 					shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
 				}
 				onContactDetailsChange={ updateDomainContactFields }
-				getIsFieldRequired={ getIsFieldRequired }
 				getIsFieldDisabled={ getIsFieldDisabled }
 				isLoggedOutCart={ isLoggedOutCart }
 				emailOnly={ emailOnly }
@@ -76,7 +62,6 @@ export default function DomainContactDetails( {
 					contactDetails={ contactDetails }
 					ccTldDetails={ contactDetails?.extra?.ca ?? {} }
 					onContactDetailsChange={ updateDomainContactFields }
-					updateRequiredDomainFields={ updateRequiredDomainFields }
 					contactDetailsValidationErrors={
 						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
 					}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -68,12 +68,7 @@ import weChatProcessor from './lib/we-chat-processor';
 import webPayProcessor from './lib/web-pay-processor';
 import createAnalyticsEventHandler from './record-analytics';
 import { StoredCard } from './types/stored-cards';
-import {
-	emptyManagedContactDetails,
-	applyContactDetailsRequiredMask,
-	domainRequiredContactDetails,
-	taxRequiredContactDetails,
-} from './types/wpcom-store-state';
+import { emptyManagedContactDetails } from './types/wpcom-store-state';
 import type { ReactStandardAction } from './types/analytics';
 import type { PaymentProcessorOptions } from './types/payment-processors';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
@@ -261,13 +256,7 @@ export default function CompositeCheckout( {
 
 	const contactDetailsType = getContactDetailsType( responseCart );
 
-	useWpcomStore(
-		applyContactDetailsRequiredMask(
-			emptyManagedContactDetails,
-			contactDetailsType === 'domain' ? domainRequiredContactDetails : taxRequiredContactDetails
-		),
-		updateContactDetailsCache
-	);
+	useWpcomStore( emptyManagedContactDetails, updateContactDetailsCache );
 
 	useDetectedCountryCode();
 	useCachedDomainContactDetails( updateLocation, countriesList );

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -10,7 +10,6 @@ import type {
 	WpcomStoreState,
 	ManagedContactDetails,
 	ManagedContactDetailsErrors,
-	ManagedContactDetailsRequiredMask,
 } from '@automattic/wpcom-checkout';
 
 type WpcomStoreAction =
@@ -25,7 +24,6 @@ type WpcomStoreAction =
 	| { type: 'UPDATE_PHONE'; payload: string }
 	| { type: 'UPDATE_PHONE_NUMBER_COUNTRY'; payload: string }
 	| { type: 'UPDATE_POSTAL_CODE'; payload: string }
-	| { type: 'UPDATE_REQUIRED_DOMAIN_FIELDS'; payload: ManagedContactDetailsRequiredMask }
 	| { type: 'TOUCH_CONTACT_DETAILS' }
 	| { type: 'CLEAR_DOMAIN_CONTACT_ERROR_MESSAGES' }
 	| { type: 'UPDATE_COUNTRY_CODE'; payload: string }
@@ -63,8 +61,6 @@ export function useWpcomStore(
 				return updaters.updatePhoneNumberCountry( state, action.payload );
 			case 'UPDATE_POSTAL_CODE':
 				return updaters.updatePostalCode( state, action.payload );
-			case 'UPDATE_REQUIRED_DOMAIN_FIELDS':
-				return updaters.updateRequiredDomainFields( state, action.payload );
 			case 'UPDATE_EMAIL':
 				return updaters.updateEmail( state, action.payload );
 			case 'UPDATE_COUNTRY_CODE':
@@ -132,10 +128,6 @@ export function useWpcomStore(
 
 			updatePostalCode( payload: string ): WpcomStoreAction {
 				return { type: 'UPDATE_POSTAL_CODE', payload };
-			},
-
-			updateRequiredDomainFields( payload: ManagedContactDetailsRequiredMask ): WpcomStoreAction {
-				return { type: 'UPDATE_REQUIRED_DOMAIN_FIELDS', payload };
 			},
 
 			updateEmail( payload: string ): WpcomStoreAction {

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -16,7 +16,6 @@ import wp from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	isCompleteAndValid,
-	areRequiredFieldsNotEmpty,
 	prepareDomainContactValidationRequest,
 	prepareGSuiteContactValidationRequest,
 	formatDomainContactValidationResponse,
@@ -144,7 +143,7 @@ export async function validateContactDetails(
 				clearDomainContactErrorMessages,
 			} );
 		}
-		return isContactValidationResponseValid( validationResult, contactInfo );
+		return isContactValidationResponseValid( validationResult );
 	};
 
 	if ( isLoggedOutCart ) {
@@ -165,7 +164,7 @@ export async function validateContactDetails(
 			} );
 		}
 
-		if ( ! isContactValidationResponseValid( loggedOutValidationResult, contactInfo ) ) {
+		if ( ! isContactValidationResponseValid( loggedOutValidationResult ) ) {
 			return false;
 		}
 	}
@@ -189,22 +188,12 @@ function isContactValidationResponse( data: unknown ): data is DomainContactVali
 	return true;
 }
 
-export function isContactValidationResponseValid(
-	data: unknown,
-	contactDetails: ManagedContactDetails
-): boolean {
+export function isContactValidationResponseValid( data: unknown ): boolean {
 	if ( ! isContactValidationResponse( data ) ) {
 		throw new Error( 'Invalid contact validation response.' );
 	}
 	if ( ! data.success ) {
 		debug( 'Validation response says that the contact details not valid' );
-		return false;
-	}
-	if ( ! areRequiredFieldsNotEmpty( contactDetails ) ) {
-		debug(
-			'Validation response says that the contact details are valid but there are empty required fields in',
-			contactDetails
-		);
 		return false;
 	}
 	return true;

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -34,9 +34,6 @@ export default function CreditCardFields( {
 	const getFieldValue = ( key ) => getField( key ).value ?? '';
 	const getErrorMessagesForField = ( key ) => {
 		const managedValue = getField( key );
-		if ( managedValue?.isRequired && managedValue?.value === '' ) {
-			return [ __( 'This field is required.' ) ];
-		}
 		return managedValue.errors ?? [];
 	};
 	const {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -137,9 +137,6 @@ function EbanxTefFields() {
 	const getFieldValue = ( key ) => getField( key ).value ?? '';
 	const getErrorMessagesForField = ( key ) => {
 		const managedValue = getField( key );
-		if ( managedValue?.isRequired && managedValue?.value === '' ) {
-			return [ __( 'This field is required.' ) ];
-		}
 		return managedValue.errors ?? [];
 	};
 	const { setFieldValue } = useDispatch( 'ebanx-tef' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -128,9 +128,6 @@ function NetBankingFields() {
 	const getFieldValue = ( key ) => getField( key ).value ?? '';
 	const getErrorMessagesForField = ( key ) => {
 		const managedValue = getField( key );
-		if ( managedValue?.isRequired && managedValue?.value === '' ) {
-			return [ __( 'This field is required.' ) ];
-		}
 		return managedValue.errors ?? [];
 	};
 	const { setFieldValue } = useDispatch( 'netbanking' );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -762,7 +762,7 @@ export const mockTransactionsRedirectResponse = () => [
 export const mockTransactionsSuccessResponse = () => [ 200, { success: 'true' } ];
 
 function getManagedValueFromString( value ) {
-	return { isTouched: true, value, errors: [], isRequired: true };
+	return { isTouched: true, value, errors: [] };
 }
 
 function getStringFromManagedValue( managedValue ) {

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -18,7 +18,6 @@ import type {
 	ManagedContactDetailsErrors,
 	ManagedContactDetailsUpdate,
 	ManagedContactDetailsUpdaters,
-	ManagedContactDetailsRequiredMask,
 	WpcomStoreState,
 	SignupValidationResponse,
 	DomainContactValidationRequest,
@@ -237,19 +236,17 @@ export function flattenManagedContactDetailsShape< A, B >(
 }
 
 export function isValid( arg: ManagedValue ): boolean {
-	return ( arg.errors?.length ?? 0 ) <= 0 && ( arg.value?.length > 0 || ! arg.isRequired );
+	return ( arg.errors?.length ?? 0 ) <= 0;
 }
 
 function getInitialManagedValue( initialProperties?: {
 	value?: string;
 	isTouched?: boolean;
 	errors?: Array< string | TranslateResult >;
-	isRequired?: boolean;
 } ): ManagedValue {
 	return {
 		value: '',
 		isTouched: false,
-		isRequired: false,
 		errors: [],
 		...initialProperties,
 	};
@@ -273,7 +270,7 @@ function touchIfDifferent(
 	if ( oldData !== undefined && newValue === oldData.value ) {
 		return oldData;
 	}
-	return { isRequired: false, ...oldData, value: newValue ?? '', isTouched: true, errors: [] };
+	return { ...oldData, value: newValue ?? '', isTouched: true, errors: [] };
 }
 
 function setValueUnlessTouched(
@@ -305,17 +302,6 @@ export function isCompleteAndValid( details: ManagedContactDetails ): boolean {
 export function isTouched( details: ManagedContactDetails ): boolean {
 	const values = getManagedValuesList( details );
 	return values.length > 0 && values.every( ( value ) => value.isTouched );
-}
-
-export function areRequiredFieldsNotEmpty( details: ManagedContactDetails ): boolean {
-	const values = getManagedValuesList( details );
-	if ( values.length === 0 ) {
-		return false;
-	}
-	if ( values.some( ( value ) => value.value?.length === 0 && value.isRequired ) ) {
-		return false;
-	}
-	return true;
 }
 
 function setManagedContactDetailsErrors(
@@ -727,13 +713,6 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		};
 	},
 
-	updateRequiredDomainFields: (
-		details: ManagedContactDetails,
-		requiredMask: ManagedContactDetailsRequiredMask
-	): ManagedContactDetails => {
-		return applyContactDetailsRequiredMask( details, requiredMask );
-	},
-
 	updateEmail: ( oldDetails: ManagedContactDetails, newEmail: string ): ManagedContactDetails => {
 		return {
 			...oldDetails,
@@ -832,58 +811,6 @@ export const emptyManagedContactDetails: ManagedContactDetails = {
 	countryCode: getInitialManagedValue(),
 	fax: getInitialManagedValue(),
 	vatId: getInitialManagedValue(),
-	tldExtraFields: {},
-};
-
-export function applyContactDetailsRequiredMask(
-	details: ManagedContactDetails,
-	requiredMask: ManagedContactDetailsRequiredMask
-): ManagedContactDetails {
-	return updateManagedContactDetailsShape(
-		( isRequired, managedValue ) => {
-			return { ...managedValue, isRequired };
-		},
-		( isRequired ) => getInitialManagedValue( { isRequired } ),
-		requiredMask,
-		details
-	);
-}
-
-export const domainRequiredContactDetails: ManagedContactDetailsRequiredMask = {
-	firstName: false,
-	lastName: false,
-	organization: false,
-	email: false,
-	alternateEmail: false,
-	phone: false,
-	phoneNumberCountry: false,
-	address1: false,
-	address2: false,
-	city: false,
-	state: false,
-	postalCode: false,
-	countryCode: false,
-	fax: false,
-	vatId: false,
-	tldExtraFields: {},
-};
-
-export const taxRequiredContactDetails: ManagedContactDetailsRequiredMask = {
-	firstName: false,
-	lastName: false,
-	organization: false,
-	email: false,
-	alternateEmail: false,
-	phone: false,
-	phoneNumberCountry: false,
-	address1: false,
-	address2: false,
-	city: false,
-	state: false,
-	postalCode: false,
-	countryCode: false,
-	fax: false,
-	vatId: false,
 	tldExtraFields: {},
 };
 

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -150,7 +150,7 @@ export class UpsellNudge extends Component {
 				},
 			};
 			const validationResult = await getTaxValidationResult( contactInfo );
-			return isContactValidationResponseValid( validationResult, contactInfo );
+			return isContactValidationResponseValid( validationResult );
 		};
 
 		validateContactDetails().then( ( isValid ) => {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -140,13 +140,11 @@ export class UpsellNudge extends Component {
 					value: postalCode,
 					isTouched: true,
 					errors: [],
-					isRequired: false,
 				},
 				countryCode: {
 					value: countryCode,
 					isTouched: true,
 					errors: [],
-					isRequired: false,
 				},
 			};
 			const validationResult = await getTaxValidationResult( contactInfo );

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -64,7 +64,6 @@ function wrapValueInManagedValue( value: string | undefined ): ManagedValue {
 	return {
 		value: value ?? '',
 		isTouched: true,
-		isRequired: false,
 		errors: [],
 	};
 }

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -306,12 +306,6 @@ export type ManagedContactDetailsErrors = ManagedContactDetailsShape<
 export type ManagedContactDetailsUpdate = ManagedContactDetailsShape< string >;
 
 /*
- * Different subsets of the details are mandatory depending on what is
- * in the cart. This type lets us define these subsets declaratively.
- */
-export type ManagedContactDetailsRequiredMask = ManagedContactDetailsShape< boolean >;
-
-/*
  * All child components in composite checkout are controlled -- they accept
  * data from their parents and evaluate callbacks when edited, rather than
  * managing their own state. Hooks providing this data in turn need some extra
@@ -322,7 +316,6 @@ export interface ManagedValue {
 	value: string;
 	isTouched: boolean; // Has value been edited by the user?
 	errors: string[] | TranslateResult[]; // Has value passed validation?
-	isRequired: boolean; // Is this field required?
 }
 
 export type WpcomStoreState = {
@@ -353,10 +346,6 @@ export type ManagedContactDetailsUpdaters = {
 	updateDomainContactFields: (
 		arg0: ManagedContactDetails,
 		arg1: DomainContactDetails
-	) => ManagedContactDetails;
-	updateRequiredDomainFields: (
-		arg0: ManagedContactDetails,
-		arg1: ManagedContactDetailsRequiredMask
 	) => ManagedContactDetails;
 	touchContactFields: ( arg0: ManagedContactDetails ) => ManagedContactDetails;
 	updateVatId: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we have much more reliable server-side contact validation, in https://github.com/Automattic/wp-calypso/pull/55904 we disabled all required fields in the checkout contact forms.

As there are no more required fields (at least as far as client side validation is concerned), this PR removes all the code that supported and maintained the concept of a required field.

#### Testing instructions

It's a little hard to test for this because there's so many different contact details form fields that are possible, and it's also not clear what we'd look for. Primarily we just want to make sure there's no fatal errors, and that there isn't anything that was removed which should not have been removed. But assuming the code changes are good, all the required fields should be disabled already so this shouldn't have any effect.

First, make sure that the removed functions/variables/types are not used anywhere:

- `updateRequiredDomainFields` (several things with this name)
- `getIsFieldRequired`
- `areRequiredFieldsNotEmpty`
- `applyContactDetailsRequiredMask`
- `domainRequiredContactDetails`
- `taxRequiredContactDetails`
- `ManagedContactDetailsRequiredMask`
- Any instance of `isRequired` except for PropTypes and component props

Next, make sure there are no instances of `isContactValidationResponseValid` which have more than one argument.

Then it's probably worth testing all the payment methods affected by this change that have their own contact fields to make sure that those fields still work as expected:

- Ebanx credit cards.
- Ebanx TEF.
- Netbanking.

Finally, the largest contact forms are those for CC TLD domains for countries like Canada, France, and the UK. So we should try some of those and verify that they still work as expected.