### PR TITLE
Boot: Remove unused reader unseen status

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -42,7 +42,6 @@ import { getInitialState, persistOnChange } from 'calypso/state/initial-state';
 import { loadPersistedState } from 'calypso/state/persisted-state';
 import { init as pushNotificationsInit } from 'calypso/state/push-notifications/actions';
 import { createQueryClient } from 'calypso/state/query-client';
-import { requestUnseenStatus } from 'calypso/state/reader-ui/seen-posts/actions';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { setRoute } from 'calypso/state/route/actions';
@@ -362,10 +361,6 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 	}
 
 	const state = reduxStore.getState();
-	// get reader unread status
-	if ( config.isEnabled( 'reader/seen-posts' ) ) {
-		reduxStore.dispatch( requestUnseenStatus() );
-	}
 
 	if ( config.isEnabled( 'happychat' ) ) {
 		reduxStore.dispatch( requestHappychatEligibility() );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -13,7 +13,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { requestHttpData } from 'calypso/state/data-layer/http-data';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { hasUnseen } from 'calypso/state/reader-ui/seen-posts/selectors';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path.js';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
@@ -48,7 +47,6 @@ class MasterbarLoggedIn extends Component {
 		siteSlug: PropTypes.string,
 		hasMoreThanOneSite: PropTypes.bool,
 		isCheckout: PropTypes.bool,
-		hasUnseen: PropTypes.bool,
 	};
 
 	handleLayoutFocus = ( currentSection ) => {
@@ -252,7 +250,6 @@ class MasterbarLoggedIn extends Component {
 						isActive={ this.isActive( 'reader' ) }
 						tooltip={ translate( 'Read the blogs and topics you follow' ) }
 						preloadSection={ this.preloadReader }
-						hasUnseen={ this.props.hasUnseen }
 					>
 						{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 					</Item>
@@ -329,7 +326,6 @@ export default connect(
 			isSiteMigrationActiveRoute( state );
 
 		return {
-			hasUnseen: hasUnseen( state ),
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			siteSlug: getSiteSlug( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As discussed with @unDemian in #57219 and p1634800526003800-slack-C9UMZ71QD, the masterbar unseen status is practucally unused, so we could remove requesting the status from boot time. 

I'm intentionally not removing the related state itself because it's still used here and there, and the UI bit for the dot because it can actually be useful in the future. This PR is just aiming at cutting another small chunk off the main entry point bundle size.

#### Testing instructions

* Smoke test Reader and verify it still works well.