### PR TITLE
New Plugin Browser styles

### DIFF
--- a/client/components/fixed-navigation-header/README.md
+++ b/client/components/fixed-navigation-header/README.md
@@ -1,0 +1,22 @@
+# FixedNavigationHeader (JSX)
+
+This component displays a header with navigation items. 
+It can also include children items which will be positioned to the far right.
+
+## How to use
+
+```js
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+
+function render() {
+	return <FixedNavigationHeader headerText="A main title">Children Item</FixedNavigationHeader>;
+}
+```
+
+## Props
+
+- `headerText` (`string`) - The main header text
+- `brandFont` (`bool`) - use the WP.com brand font for `headerText`
+- `id` (`string`) - ID for the header (optional)
+- `className` (`string`) - A class name for the wrapped component (optional)
+- `children` (`nodes`) – Any children elements which are being rendered to the far right (optional)

--- a/client/components/fixed-navigation-header/docs/example.jsx
+++ b/client/components/fixed-navigation-header/docs/example.jsx
@@ -1,0 +1,11 @@
+import { Fragment } from 'react';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+
+export default function FixedNavigationHeaderExample() {
+	return (
+		<Fragment>
+			<FixedNavigationHeader headerText="This is the header." />
+			<FixedNavigationHeader headerText="This is the header with branded font" brandFont />
+		</Fragment>
+	);
+}

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -1,0 +1,78 @@
+import styled from '@emotion/styled';
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import { preventWidows } from 'calypso/lib/formatting';
+
+const Header = styled.header`
+	position: fixed;
+	z-index: 1;
+	top: var( --masterbar-height );
+	left: var( --sidebar-width-max );
+	width: calc( 100% - var( --sidebar-width-max ) );
+	padding: 0 32px;
+	box-sizing: border-box;
+	border-bottom: 1px solid var( --studio-gray-5 );
+	background-color: var( --studio-white );
+
+	@media ( max-width: 782px ) {
+		width: 100%;
+		left: 0;
+	}
+
+	@media ( max-width: 660px ) {
+		padding: 0 16px;
+	}
+`;
+
+const Container = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	min-height: 70px;
+
+	@media ( max-width: 660px ) {
+		min-height: 60px;
+	}
+
+	.main.is-wide-layout & {
+		max-width: 1040px;
+		margin: auto;
+	}
+`;
+
+const H1 = styled.h1``;
+
+const ActionsContainer = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+interface Props {
+	brandFont?: boolean;
+	id?: string;
+	headerText: string | ReactNode;
+	className?: string;
+	children?: ReactNode;
+}
+
+const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
+	const { brandFont, id, headerText, className, children } = props;
+	const headerClasses = classNames( { 'wp-brand-font': brandFont } );
+
+	return (
+		<Header id={ id } className={ className }>
+			<Container>
+				<H1 className={ headerClasses }>{ preventWidows( headerText, 2 ) }</H1>
+				<ActionsContainer>{ children }</ActionsContainer>
+			</Container>
+		</Header>
+	);
+};
+
+FixedNavigationHeader.defaultProps = {
+	id: '',
+	className: '',
+	brandFont: false,
+};
+
+export default FixedNavigationHeader;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -304,10 +304,13 @@ export class PluginsMain extends Component {
 
 		let searchTitle;
 		if ( search ) {
-			searchTitle = this.props.translate( 'Suggested plugins for: %(searchQuery)s', {
+			searchTitle = this.props.translate( 'Suggested plugins for: {{b}}%(searchQuery)s{{/b}}', {
 				textOnly: true,
 				args: {
 					searchQuery: search,
+				},
+				components: {
+					b: <b />,
 				},
 			} );
 		}

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -7,8 +7,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
-import InlineSupportLink from 'calypso/components/inline-support-link';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
@@ -402,29 +401,17 @@ export class PluginsMain extends Component {
 				<QueryJetpackPlugins siteIds={ this.props.siteIds } />
 				{ this.renderPageViewTracking() }
 				<SidebarNavigation />
-				<div className="plugins__main">
-					<div className="plugins__header">
-						<FormattedHeader
-							brandFont
-							className="plugins__page-heading"
-							headerText={ this.props.translate( 'Plugins' ) }
-							align="left"
-							subHeaderText={ this.props.translate(
-								'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="plugins" showIcon={ false } />
-										),
-									},
-								}
-							) }
-						/>
-						<div className="plugins__main-buttons">
-							{ this.renderAddPluginButton() }
-							{ this.renderUploadPluginButton() }
-						</div>
+				<FixedNavigationHeader
+					brandFont
+					className="plugins__page-heading"
+					headerText={ this.props.translate( 'Plugins' ) }
+				>
+					<div className="plugins__main-buttons">
+						{ this.renderAddPluginButton() }
+						{ this.renderUploadPluginButton() }
 					</div>
+				</FixedNavigationHeader>
+				<div className="plugins__main">
 					<div className="plugins__main-header">
 						<SectionNav selectedText={ this.getSelectedText() }>
 							<NavTabs>{ navItems }</NavTabs>

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -26,3 +26,9 @@ function render() {
 - `key`: Unique plugin key, this help react render a list better.
 - `isPlaceholder`: Boolean, it marks if the item is a placeholder
 - `iconSize`: number with the size of the icon. Defaulted to 40, since all the intertal css are adjusted around that value, it would be better to not change the default
+- `variant`: the component can be used in compact or extended view. Defaults to `Compact`.
+
+  | variant        | displays                                                                  |
+  | -------------- | ------------------------------------------------------------------------- |
+  | Compact        | Icon, Name, Short Description
+  | Extended       | Icon, Name, Author, Short Description, Pricing Info              |

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -30,5 +30,5 @@ function render() {
 
   | variant        | displays                                                                  |
   | -------------- | ------------------------------------------------------------------------- |
-  | Compact        | Icon, Name, Short Description
-  | Extended       | Icon, Name, Author, Short Description, Pricing Info              |
+  | Compact        | Icon, Name, Short Description                                             |
+  | Extended       | Icon, Name, Author, Short Description, Pricing Info                       |

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,15 +1,16 @@
 import { Button, Gridicon } from '@automattic/components';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose, includes } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import Rating from 'calypso/components/rating';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { PluginsBrowserElementVariant } from './types';
 
 import './style.scss';
 
@@ -18,6 +19,7 @@ const PREINSTALLED_PLUGINS = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPres
 class PluginsBrowserListElement extends Component {
 	static defaultProps = {
 		iconSize: 40,
+		variant: PluginsBrowserElementVariant.Compact,
 	};
 
 	getPluginLink() {
@@ -87,8 +89,8 @@ class PluginsBrowserListElement extends Component {
 						<PluginIcon size={ this.props.iconSize } isPlaceholder={ true } />
 						<div className="plugins-browser-item__title">…</div>
 						<div className="plugins-browser-item__author">…</div>
+						<div className="plugins-browser-item__description">…</div>
 					</div>
-					<Rating rating={ 0 } size={ 12 } />
 				</span>
 			</li>
 		);
@@ -96,27 +98,36 @@ class PluginsBrowserListElement extends Component {
 	}
 
 	render() {
-		if ( this.props.isPlaceholder ) {
+		const { isPlaceholder, plugin, iconSize, variant, translate } = this.props;
+		if ( isPlaceholder ) {
 			return this.renderPlaceholder();
 		}
+
+		const classNames = classnames( 'plugins-browser-item', variant );
+
 		return (
-			<li className="plugins-browser-item">
+			<li className={ classNames }>
 				<a
 					href={ this.getPluginLink() }
 					className="plugins-browser-item__link"
 					onClick={ this.trackPluginLinkClick }
 				>
 					<div className="plugins-browser-item__info">
-						<PluginIcon
-							size={ this.props.iconSize }
-							image={ this.props.plugin.icon }
-							isPlaceholder={ this.props.isPlaceholder }
-						/>
-						<div className="plugins-browser-item__title">{ this.props.plugin.name }</div>
-						<div className="plugins-browser-item__author">{ this.props.plugin.author_name }</div>
-						{ this.renderInstalledIn() }
+						<PluginIcon size={ iconSize } image={ plugin.icon } isPlaceholder={ isPlaceholder } />
+						<div className="plugins-browser-item__title">{ plugin.name }</div>
+						{ variant === PluginsBrowserElementVariant.Extended && (
+							<div className="plugins-browser-item__author">
+								{ translate( 'by ' ) }
+								<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
+							</div>
+						) }
+						<div className="plugins-browser-item__description">{ plugin.short_description }</div>
+						{ variant === PluginsBrowserElementVariant.Extended && this.renderInstalledIn() }
 					</div>
-					<Rating rating={ this.props.plugin.rating } size={ 12 } />
+
+					{ variant === PluginsBrowserElementVariant.Extended && (
+						<div className="plugins-browser-item__pricing">{ translate( 'Free' ) }</div>
+					) }
 				</a>
 				{ this.renderUpgradeButton() }
 			</li>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -54,8 +54,8 @@ class PluginsBrowserListElement extends Component {
 		return ! this.props.isJetpackSite && includes( PREINSTALLED_PLUGINS, this.props.plugin.name );
 	}
 
-	renderInstalledIn() {
-		const { sitesWithPlugin } = this.props;
+	renderInstalledInOrPricing() {
+		const { sitesWithPlugin, translate } = this.props;
 		if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || this.isWpcomPreinstalled() ) {
 			return (
 				<div className="plugins-browser-item__installed">
@@ -64,7 +64,8 @@ class PluginsBrowserListElement extends Component {
 				</div>
 			);
 		}
-		return null;
+
+		return <div className="plugins-browser-item__pricing">{ translate( 'Free' ) }</div>;
 	}
 
 	renderUpgradeButton() {
@@ -122,12 +123,8 @@ class PluginsBrowserListElement extends Component {
 							</div>
 						) }
 						<div className="plugins-browser-item__description">{ plugin.short_description }</div>
-						{ variant === PluginsBrowserElementVariant.Extended && this.renderInstalledIn() }
 					</div>
-
-					{ variant === PluginsBrowserElementVariant.Extended && (
-						<div className="plugins-browser-item__pricing">{ translate( 'Free' ) }</div>
-					) }
+					{ variant === PluginsBrowserElementVariant.Extended && this.renderInstalledInOrPricing() }
 				</a>
 				{ this.renderUpgradeButton() }
 			</li>

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -69,8 +69,11 @@
 }
 
 .plugins-browser-item__link {
-	display: block;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 	padding: 30px;
+	box-sizing: border-box;
 }
 
 .plugins-browser-item__title,
@@ -102,6 +105,7 @@
 }
 
 .plugins-browser-item__pricing {
+	margin-top: auto;
 	font-weight: 600;
 	font-size: $font-body;
 	color: $studio-black;

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -104,7 +104,8 @@
 	color: $studio-blue-40;
 }
 
-.plugins-browser-item__pricing {
+.plugins-browser-item__pricing,
+.plugins-browser-item__installed {
 	margin-top: auto;
 	font-weight: 600;
 	font-size: $font-body;
@@ -114,16 +115,13 @@
 .plugins-browser-item__installed {
 	display: flex;
 	align-items: center;
-	position: absolute;
-	bottom: 16px;
-	right: 16px;
 	color: var( --color-success );
-	font-size: $font-body-extra-small;
-	font-weight: 600;
 	animation: appear 0.15s ease-in;
 
 	.gridicon {
 		margin-right: 3px;
+		border: 2px solid var( --color-success );
+		border-radius: 50%; /* stylelint-disable-line */
 	}
 }
 

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -1,55 +1,65 @@
+@import '@automattic/color-studio/dist/color-variables';
+
 .plugins-browser-item {
-	border-left: 1px solid var( --color-neutral-0 );
 	box-sizing: border-box;
 	cursor: pointer;
 	display: block;
 	float: left;
-	margin: 0;
+	margin: 10px 0;
 	position: relative;
 	overflow: hidden;
+	border: 1px solid var( --studio-gray-5 );
+	border-radius: 5px; /* stylelint-disable-line scales/radii */
 
 	&.is-placeholder,
 	&.is-empty {
 		cursor: default;
 	}
 
-	.plugins-browser-item__link {
-		padding: 16px 16px 48px;
-		display: block;
+	.plugin-icon {
+		width: 48px;
+		height: 48px;
+		margin-right: 0;
+
+		&.is-placeholder {
+			animation: loading-fade 1.6s ease-in-out infinite;
+		}
+	}
+
+	.plugin-icon {
+		width: 60px;
+		height: 60px;
+	}
+
+	.plugins-browser-item__title,
+	.plugins-browser-item__author {
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		margin-left: calc( 60px + 16px ); // icon width + margin
+	}
+
+	.plugins-browser-item__description {
+		margin: 32px 0 20px;
+		font-size: $font-body-small;
+		font-weight: 400;
+		color: $studio-gray-60;
+	}
+
+	&.compact {
+		.plugins-browser-item__description {
+			margin: 5px 0 0 calc( 60px + 16px ); // icon width + margin
+		}
 	}
 
 	@include breakpoint-deprecated( '>960px' ) {
-		width: 33.33%;
-
-		&:nth-child( 3n + 1 ) {
-			border-left: 0;
-		}
-
-		&:nth-child( n + 4 ) {
-			border-top: 1px solid var( --color-neutral-0 );
-		}
+		width: calc( 50% - 10px ); // 2 column grid with 20px gutter
 	}
 
 	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
 
-		&:nth-child( n + 2 ) {
-			border-top: 1px solid var( --color-neutral-0 );
-		}
-
 		&.is-empty {
 			display: none;
-		}
-	}
-}
-
-.plugins-browser-item {
-	.plugin-icon {
-		width: 48px;
-		height: 48px;
-
-		&.is-placeholder {
-			animation: loading-fade 1.6s ease-in-out infinite;
 		}
 	}
 }
@@ -58,12 +68,15 @@
 	overflow: hidden; // lazy clearfix
 }
 
+.plugins-browser-item__link {
+	display: block;
+	padding: 30px;
+}
+
 .plugins-browser-item__title,
-.plugins-browser-item__author {
-	text-overflow: ellipsis;
-	white-space: nowrap;
+.plugins-browser-item__author,
+.plugins-browser-item__description {
 	overflow: hidden;
-	margin-left: 60px;
 
 	.is-placeholder & {
 		color: transparent;
@@ -84,13 +97,14 @@
 	font-size: $font-body-small;
 }
 
-.plugins-browser-item .plugin-icon {
-	margin-right: 0;
+.plugins-browser-item__author-name {
+	color: $studio-blue-40;
 }
 
-.plugins-browser-item .rating {
-	margin-top: 12px;
-	position: absolute;
+.plugins-browser-item__pricing {
+	font-weight: 600;
+	font-size: $font-body;
+	color: $studio-black;
 }
 
 .plugins-browser-item__installed {

--- a/client/my-sites/plugins/plugins-browser-item/types.ts
+++ b/client/my-sites/plugins/plugins-browser-item/types.ts
@@ -1,0 +1,4 @@
+export enum PluginsBrowserElementVariant {
+	Compact = 'compact',
+	Extended = 'extended',
+}

--- a/client/my-sites/plugins/plugins-browser-list/README.md
+++ b/client/my-sites/plugins/plugins-browser-list/README.md
@@ -31,6 +31,7 @@ export default localize( MyPluginsList );
 - `size`: a number, the amount of plugins to be shown
 - `site`: a string containing the slug of the selected site
 - `addPlaceholders`: if present, indicates that there should placeholders inserted after the real components list
+- `extended`: if present, the PluginBrowserElement will contain extended info. Else, it will default to compact
 - `variant`: the component can be used with pagination or infinite scroll. This prop controls how to show placeholders when fetching additional data. Defaults to `Fixed`.
 
   | variant        | behavior                                                                  |

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,10 +1,11 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import SectionHeader from 'calypso/components/section-header';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
+import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
 import { PluginsBrowserListVariant } from './types';
 import './style.scss';
 
@@ -16,6 +17,7 @@ class PluginsBrowserList extends Component {
 	static propTypes = {
 		plugins: PropTypes.array.isRequired,
 		variant: PropTypes.oneOf( Object.values( PluginsBrowserListVariant ) ).isRequired,
+		extended: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -33,6 +35,11 @@ class PluginsBrowserList extends Component {
 					plugin={ plugin }
 					currentSites={ this.props.currentSites }
 					listName={ this.props.listName }
+					variant={
+						this.props.extended
+							? PluginsBrowserElementVariant.Extended
+							: PluginsBrowserElementVariant.Compact
+					}
 				/>
 			);
 		} );
@@ -83,24 +90,10 @@ class PluginsBrowserList extends Component {
 		}
 	}
 
-	renderLink() {
-		if ( this.props.expandedListLink ) {
-			return (
-				<a
-					className="button is-link plugins-browser-list__select-all"
-					href={ this.props.expandedListLink + ( this.props.site || '' ) }
-				>
-					{ this.props.translate( 'See All' ) }
-					<Gridicon icon="chevron-right" size={ 18 } />
-				</a>
-			);
-		}
-	}
-
 	render() {
 		return (
 			<div className="plugins-browser-list">
-				<SectionHeader label={ this.props.title }>{ this.renderLink() }</SectionHeader>
+				<SectionHeader label={ this.props.title } />
 				<Card className="plugins-browser-list__elements">{ this.renderViews() }</Card>
 			</div>
 		);

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -3,7 +3,6 @@ import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import SectionHeader from 'calypso/components/section-header';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
 import { PluginsBrowserListVariant } from './types';
@@ -93,7 +92,10 @@ class PluginsBrowserList extends Component {
 	render() {
 		return (
 			<div className="plugins-browser-list">
-				<SectionHeader label={ this.props.title } />
+				<div className="plugins-browser-list__header">
+					<div className="plugins-browser-list__title">{ this.props.title }</div>
+					<div className="plugins-browser-list__subtitle">{ this.props.subtitle }</div>
+				</div>
 				<Card className="plugins-browser-list__elements">{ this.renderViews() }</Card>
 			</div>
 		);

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,20 +1,33 @@
 .plugins-browser-list {
 	margin-bottom: 16px;
-	background: var( --color-surface );
-	box-shadow: 0 1px 2px var( --color-neutral-0 );
 
 	.feature-example & {
 		margin: 0;
 	}
+
+	.plugins-browser-list__header {
+		overflow: hidden; // lazy clearfix
+	}
+
+	.section-header {
+		background: none;
+		box-shadow: none;
+		padding: 24px 0;
+
+		.section-header__label {
+			font-size: $font-title-small;
+			line-height: 28px;
+			/* stylelint-disable-next-line scales/font-weights */
+			font-weight: 500;
+			color: var( --studio-gray-80 );
+		}
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		padding: 0 16px;
+	}
 }
 
-.plugins-browser-list__header {
-	background: var( --color-neutral-0 );
-	border-bottom: 1px solid var( --color-neutral-0 );
-	overflow: hidden; // lazy clearfix
-}
-
-.button.plugins-browser-list__select-all,
 .plugins-browser-list__title {
 	display: inline-block;
 	padding: 5px 0;
@@ -33,12 +46,15 @@
 	}
 }
 
-.button.plugins-browser-list__select-all {
-	float: right;
-}
-
 .plugins-browser-list__elements {
 	display: flex;
 	flex-wrap: wrap;
+	justify-content: space-between;
 	padding: 0;
+	box-shadow: none;
+	background: none;
+
+	&::after {
+		display: none;
+	}
 }

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -30,7 +30,8 @@
 
 .plugins-browser-list__header {
 	color: var( --color-gray-90 );
-	padding: 34px 0;
+	padding-top: 34px;
+	padding-bottom: 30px;
 
 	.plugins-browser-list__subtitle {
 		font-size: $font-body-small;

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -28,21 +28,12 @@
 	}
 }
 
-.plugins-browser-list__title {
-	display: inline-block;
-	padding: 5px 0;
-	color: var( --color-neutral-70 );
-	font-size: $font-body-extra-small;
-	line-height: 1.5;
+.plugins-browser-list__header {
+	color: var( --color-gray-90 );
+	padding: 34px 0;
 
-	&.is-expanded {
-		padding-left: 24px;
-		padding-right: 24px;
-	}
-	.gridicon {
-		float: right;
-		top: 2px;
-		margin-left: 3px;
+	.plugins-browser-list__subtitle {
+		font-size: $font-body-small;
 	}
 }
 

--- a/client/my-sites/plugins/plugins-browser-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/test/index.jsx
@@ -22,6 +22,7 @@ const props = {
 	plugins,
 	listName: 'woocommerce',
 	title: 'woocommerce',
+	subtitle: '100 plugins',
 	site: {
 		plan: PLAN_FREE,
 	},
@@ -29,9 +30,14 @@ const props = {
 };
 
 describe( 'PluginsBrowserList basic tests', () => {
-	test( 'should render the section header', () => {
+	test( 'should render the section header with title', () => {
 		const comp = shallow( <PluginsBrowserList { ...props } /> );
-		expect( comp.find( 'SectionHeader[label="woocommerce"]' ).length ).toBe( 1 );
+		expect( comp.find( '.plugins-browser-list__title' ).text() ).toBe( 'woocommerce' );
+	} );
+
+	test( 'should render the section header with subtitle', () => {
+		const comp = shallow( <PluginsBrowserList { ...props } /> );
+		expect( comp.find( '.plugins-browser-list__subtitle' ).text() ).toBe( '100 plugins' );
 	} );
 
 	test( 'should render a given number of list items when the size prop is set', () => {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -88,7 +88,7 @@ export class PluginsBrowser extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			isMobile: isWithinBreakpoint( '<660px' ),
+			isMobile: isWithinBreakpoint( '<960px' ),
 		};
 	}
 
@@ -112,7 +112,7 @@ export class PluginsBrowser extends Component {
 		}
 
 		// Change the isMobile state when the size of the browser changes.
-		this.unsubscribe = subscribeIsWithinBreakpoint( '<660px', ( isMobile ) => {
+		this.unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobile ) => {
 			this.setState( { isMobile } );
 		} );
 	}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -393,7 +393,7 @@ export class PluginsBrowser extends Component {
 		this.props.recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' );
 	};
 
-	renderUploadPluginButton() {
+	renderUploadPluginButton( isMobile ) {
 		const { siteSlug, translate } = this.props;
 		const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
 
@@ -403,8 +403,10 @@ export class PluginsBrowser extends Component {
 				onClick={ this.handleUploadPluginButtonClick }
 				href={ uploadUrl }
 			>
-				<Icon className="plugins-browser__button-icon" icon={ upload } width={ 16 } height={ 16 } />
-				<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
+				<Icon className="plugins-browser__button-icon" icon={ upload } width={ 18 } height={ 18 } />
+				{ ! isMobile && (
+					<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
+				) }
 			</Button>
 		);
 	}
@@ -490,9 +492,11 @@ export class PluginsBrowser extends Component {
 							align="left"
 						/>
 
-						<div className="plugins-browser__main-buttons">
+						<div className="plugins-browser__main-buttons manage-plugins-button">
 							{ this.renderManageButton() }
-							{ this.renderUploadPluginButton() }
+						</div>
+						<div className="plugins-browser__main-buttons upload-plugin-button">
+							{ this.renderUploadPluginButton( this.state.isMobile ) }
 						</div>
 
 						<div className="plugins-browser__searchbox">

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -24,9 +24,6 @@ import InfiniteScroll from 'calypso/components/infinite-scroll';
 import MainComponent from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
 import { PaginationVariant } from 'calypso/components/pagination/constants';
-import SectionNav from 'calypso/components/section-nav';
-import NavItem from 'calypso/components/section-nav/item';
-import NavTabs from 'calypso/components/section-nav/tabs';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import urlSearch from 'calypso/lib/url-search';
 import NoResults from 'calypso/my-sites/no-results';
@@ -456,8 +453,10 @@ export class PluginsBrowser extends Component {
 							headerText={ this.props.translate( 'Plugins' ) }
 							align="left"
 						/>
+
+						<div className="plugins-browser__searchbox">{ this.getSearchBox() }</div>
+
 						<div className="plugins-browser__main-buttons">
-							{ this.getSearchBox() }
 							{ this.renderManageButton() }
 							{ this.renderUploadPluginButton() }
 						</div>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -192,18 +192,32 @@ export class PluginsBrowser extends Component {
 		if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
 			const searchTitle =
 				this.props.searchTitle ||
-				this.props.translate( 'Results for: %(searchTerm)s', {
+				this.props.translate( 'Search results for {{b}}%(searchTerm)s{{/b}}', {
 					textOnly: true,
 					args: {
 						searchTerm,
 					},
+					components: {
+						b: <b />,
+					},
 				} );
+
+			const subtitle =
+				pluginsPagination &&
+				this.props.translate( '%(total)s plugins', {
+					textOnly: true,
+					args: {
+						total: pluginsPagination.results,
+					},
+				} );
+
 			return (
 				<>
 					<PluginsBrowserList
 						plugins={ pluginsBySearchTerm }
 						listName={ searchTerm }
 						title={ searchTitle }
+						subtitle={ subtitle }
 						site={ this.props.siteSlug }
 						showPlaceholders={ isFetchingPluginsBySearchTerm }
 						size={ SEARCH_RESULTS_LIST_LENGTH }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -10,6 +10,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import Search from '@automattic/search';
+import { Icon, upload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { flow, get } from 'lodash';
 import PropTypes from 'prop-types';
@@ -383,6 +384,7 @@ export class PluginsBrowser extends Component {
 				onClick={ this.handleUploadPluginButtonClick }
 				href={ uploadUrl }
 			>
+				<Icon className="plugins-browser__button-icon" icon={ upload } width={ 16 } height={ 16 } />
 				<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
 			</Button>
 		);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -21,7 +21,7 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteRecommendedPlugins from 'calypso/components/data/query-site-recommended-plugins';
 import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
-import FormattedHeader from 'calypso/components/formatted-header';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import MainComponent from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
@@ -484,25 +484,20 @@ export class PluginsBrowser extends Component {
 				<DocumentHead title={ this.props.translate( 'Plugins', { textOnly: true } ) } />
 				<SidebarNavigation />
 				{ ! this.props.hideHeader && (
-					<div className="plugins-browser__header">
-						<FormattedHeader
-							brandFont
-							className="plugins-browser__page-heading"
-							headerText={ this.props.translate( 'Plugins' ) }
-							align="left"
-						/>
-
-						<div className="plugins-browser__main-buttons manage-plugins-button">
+					<FixedNavigationHeader
+						brandFont
+						className="plugins-browser__header"
+						headerText={ this.props.translate( 'Plugins' ) }
+					>
+						<div className="plugins-browser__main-buttons">
 							{ this.renderManageButton() }
-						</div>
-						<div className="plugins-browser__main-buttons upload-plugin-button">
 							{ this.renderUploadPluginButton( this.state.isMobile ) }
 						</div>
 
 						<div className="plugins-browser__searchbox">
 							{ this.getSearchBox( this.state.isMobile ) }
 						</div>
-					</div>
+					</FixedNavigationHeader>
 				) }
 				{ this.renderUpgradeNudge() }
 				{ this.getPluginBrowserContent() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -21,7 +21,6 @@ import QuerySiteRecommendedPlugins from 'calypso/components/data/query-site-reco
 import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
 import { PaginationVariant } from 'calypso/components/pagination/constants';
@@ -179,6 +178,7 @@ export class PluginsBrowser extends Component {
 					showPlaceholders={ isFetchingPluginsByCategory }
 					currentSites={ this.props.sites }
 					variant={ PluginsBrowserListVariant.InfiniteScroll }
+					extended
 				/>
 			);
 		}
@@ -212,6 +212,7 @@ export class PluginsBrowser extends Component {
 						size={ SEARCH_RESULTS_LIST_LENGTH }
 						currentSites={ this.props.sites }
 						variant={ PluginsBrowserListVariant.Paginated }
+						extended
 					/>
 					{ pluginsPagination && (
 						<Pagination
@@ -265,6 +266,7 @@ export class PluginsBrowser extends Component {
 				showPlaceholders={ isFetching }
 				currentSites={ this.props.sites }
 				variant={ PluginsBrowserListVariant.Fixed }
+				extended
 			/>
 		);
 	}
@@ -286,20 +288,21 @@ export class PluginsBrowser extends Component {
 				size={ SHORT_LIST_LENGTH }
 				title={ this.translateCategory( 'recommended' ) }
 				variant={ PluginsBrowserListVariant.Fixed }
+				extended
 			/>
 		);
 	}
 
 	getShortListsView() {
 		return (
-			<span>
+			<>
 				{ this.isRecommendedPluginsEnabled()
 					? this.getRecommendedPluginListView()
 					: this.getPluginSingleListView( 'featured' ) }
 
 				{ this.getPluginSingleListView( 'popular' ) }
 				{ this.getPluginSingleListView( 'new' ) }
-			</span>
+			</>
 		);
 	}
 
@@ -310,50 +313,12 @@ export class PluginsBrowser extends Component {
 
 		return (
 			<WrappedSearch
-				pinned
-				fitsContainer
 				onSearch={ this.props.doSearch }
 				initialValue={ this.props.search }
-				placeholder={ this.props.translate( 'Search Plugins' ) }
+				placeholder={ this.props.translate( 'Try searching ‘ecommerce’' ) }
 				delaySearch={ true }
 				recordEvent={ this.recordSearchEvent }
 			/>
-		);
-	}
-
-	getNavigationBar() {
-		const site = this.props.siteSlug ? '/' + this.props.siteSlug : '';
-		return (
-			<SectionNav
-				selectedText={ this.props.translate( 'Category', {
-					context: 'Category of plugins to be filtered by',
-				} ) }
-			>
-				<NavTabs label="Category">
-					<NavItem path={ '/plugins' + site } selected={ false }>
-						{ this.props.translate( 'All', { context: 'Filter all plugins' } ) }
-					</NavItem>
-					<NavItem
-						path={ '/plugins/featured' + site }
-						selected={ this.props.path === '/plugins/featured' + site }
-					>
-						{ this.props.translate( 'Featured', { context: 'Filter featured plugins' } ) }
-					</NavItem>
-					<NavItem
-						path={ '/plugins/popular' + site }
-						selected={ this.props.path === '/plugins/popular' + site }
-					>
-						{ this.props.translate( 'Popular', { context: 'Filter popular plugins' } ) }
-					</NavItem>
-					<NavItem
-						path={ '/plugins/new' + site }
-						selected={ this.props.path === '/plugins/new' + site }
-					>
-						{ this.props.translate( 'New', { context: 'Filter new plugins' } ) }
-					</NavItem>
-				</NavTabs>
-				{ this.getSearchBox() }
-			</SectionNav>
 		);
 	}
 
@@ -361,32 +326,6 @@ export class PluginsBrowser extends Component {
 		this.reinitializeSearch();
 		this.props.doSearch( term );
 	};
-
-	getSearchBar() {
-		const suggestedSearches = [
-			this.props.translate( 'Engagement', { context: 'Plugins suggested search term' } ),
-			this.props.translate( 'Security', { context: 'Plugins suggested search term' } ),
-			this.props.translate( 'Appearance', { context: 'Plugins suggested search term' } ),
-			this.props.translate( 'Writing', { context: 'Plugins suggested search term' } ),
-		];
-
-		return (
-			<SectionNav
-				selectedText={ this.props.translate( 'Suggested Searches', {
-					context: 'Suggested searches for plugins',
-				} ) }
-			>
-				<NavTabs label="Suggested Searches">
-					{ suggestedSearches.map( ( term ) => (
-						<NavItem key={ term } onClick={ this.handleSuggestedSearch( term ) }>
-							{ term }
-						</NavItem>
-					) ) }
-				</NavTabs>
-				{ this.getSearchBox() }
-			</SectionNav>
-		);
-	}
 
 	shouldShowManageButton() {
 		if ( this.props.isJetpackSite ) {
@@ -433,27 +372,9 @@ export class PluginsBrowser extends Component {
 				onClick={ this.handleUploadPluginButtonClick }
 				href={ uploadUrl }
 			>
-				<span className="plugins-browser__button-text">{ translate( 'Install plugin' ) }</span>
+				<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
 			</Button>
 		);
-	}
-
-	getPageHeaderView() {
-		if ( this.props.hideSearchForm ) {
-			return null;
-		}
-
-		const navigation = this.props.category ? this.getNavigationBar() : this.getSearchBar();
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<div className="plugins-browser__main">
-				<div className="plugins-browser__main-header">
-					<div className="plugins__header-navigation">{ navigation }</div>
-				</div>
-			</div>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	renderUpgradeNudge() {
@@ -534,25 +455,15 @@ export class PluginsBrowser extends Component {
 							className="plugins-browser__page-heading"
 							headerText={ this.props.translate( 'Plugins' ) }
 							align="left"
-							subHeaderText={ this.props.translate(
-								'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="plugins" showIcon={ false } />
-										),
-									},
-								}
-							) }
 						/>
 						<div className="plugins-browser__main-buttons">
+							{ this.getSearchBox() }
 							{ this.renderManageButton() }
 							{ this.renderUploadPluginButton() }
 						</div>
 					</div>
 				) }
 				{ this.renderUpgradeNudge() }
-				{ this.getPageHeaderView() }
 				{ this.getPluginBrowserContent() }
 				<InfiniteScroll nextPageMethod={ this.fetchNextPagePlugins } />
 			</MainComponent>

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -10,12 +10,27 @@
 	}
 }
 
-.plugins-browser__main-buttons {
+.plugins-browser__searchbox {
+	width: 250px;
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-end;
 	align-items: stretch;
 	margin: auto;
+	margin-right: 15px;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		flex-direction: row;
+		align-items: flex-end;
+		margin-bottom: 17px;
+	}
+}
+
+.plugins-browser__main-buttons {
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	align-items: stretch;
 	margin-right: 15px;
 
 	@include breakpoint-deprecated( '>480px' ) {

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -4,6 +4,7 @@
 	justify-content: flex-start;
 	align-items: center;
 	border-bottom: 1px solid var( --studio-gray-5 );
+	position: relative;
 
 	.plugins-browser__page-heading {
 		margin-bottom: 24px;
@@ -16,19 +17,33 @@
 	flex-direction: column;
 	justify-content: flex-end;
 	align-items: stretch;
-	margin: auto;
-	margin-right: 15px;
+	margin-bottom: 20px;
 
 	.search-component {
-		height: 40px;
+		height: 30px;
 		box-shadow: 0 0 0 1px var( --studio-gray-10 );
+
+		.search-component__open-icon, .search-component__close-icon {
+			color: var( --studio-black );
+		}
+
+		&.is-open input.search-component__input[type=search] {
+			font-size: $font-body-extra-small;
+		}
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 		align-items: flex-end;
-		margin-bottom: 17px;
 	}
+
+	@media screen and ( max-width: 660px ) {
+		width: 50px;
+		.search-component {
+			width: 50px;
+		}
+	}
+
 }
 
 .plugins-browser__main-buttons {
@@ -36,19 +51,24 @@
 	flex-direction: column;
 	justify-content: flex-end;
 	align-items: stretch;
+	margin: auto;
 	margin-right: 15px;
+	margin-bottom: 20px;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 		align-items: flex-end;
-		margin-right: 0;
-		margin-bottom: 17px;
+	}
+
+	@media screen and ( max-width: 660px ) {
+		margin-bottom: 13px;
 	}
 
 	.plugins-browser__button {
 		white-space: nowrap;
 		display: flex;
 		align-items: center;
+		height: 32px;
 
 		.plugins-browser__button-icon {
 			margin-right: 5px;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -19,7 +19,7 @@
 		}
 	}
 
-	@media screen and ( max-width: 660px ) {
+	@media screen and ( max-width: 960px ) {
 		width: 30px;
 
 		.search-component {
@@ -32,15 +32,15 @@
 	display: flex;
 	margin-right: 15px;
 
-	@include breakpoint-deprecated( '>480px' ) {
-		flex-direction: row;
-		align-items: flex-end;
-	}
-
-	@media screen and ( max-width: 660px ) {
+	@media screen and ( max-width: 960px ) {
 		.plugins-browser__button {
 			border: none;
 		}
+	}
+
+	@include breakpoint-deprecated( '>480px' ) {
+		flex-direction: row;
+		align-items: flex-end;
 	}
 
 	.plugins-browser__button {

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -3,32 +3,11 @@
 	flex: 1 1 auto;
 	justify-content: flex-start;
 	align-items: center;
+	border-bottom: 1px solid var( --studio-gray-5 );
 
 	.plugins-browser__page-heading {
-		width: 100%;
+		margin-bottom: 24px;
 	}
-}
-
-.plugins-browser__main-header {
-	background: var( --color-surface );
-	flex-direction: column;
-	display: flex;
-	margin-bottom: 9px;
-
-	@include breakpoint-deprecated( '>480px' ) {
-		flex-direction: row;
-		margin-bottom: 17px;
-	}
-}
-
-.plugins-browser__page-heading .formatted-header__subtitle {
-	margin: 0;
-}
-
-.plugins-browser__main-header .section-nav {
-	box-shadow: none;
-	flex: auto;
-	margin: 0;
 }
 
 .plugins-browser__main-buttons {

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -47,6 +47,12 @@
 
 	.plugins-browser__button {
 		white-space: nowrap;
+		display: flex;
+		align-items: center;
+
+		.plugins-browser__button-icon {
+			margin-right: 5px;
+		}
 
 		&:not( :last-child ) {
 			margin-bottom: 8px;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -13,10 +13,6 @@
 
 .plugins-browser__searchbox {
 	width: 250px;
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
-	align-items: stretch;
 	margin-bottom: 20px;
 
 	.search-component {
@@ -32,16 +28,10 @@
 		}
 	}
 
-	@include breakpoint-deprecated( '>480px' ) {
-		flex-direction: row;
-		align-items: flex-end;
-	}
-
 	@media screen and ( max-width: 660px ) {
 		width: 30px;
 
 		.search-component {
-			width: 50px;
 			box-shadow: none;
 		}
 	}

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -19,6 +19,11 @@
 	margin: auto;
 	margin-right: 15px;
 
+	.search-component {
+		height: 40px;
+		box-shadow: 0 0 0 1px var( --studio-gray-10 );
+	}
+
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 		align-items: flex-end;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,29 +1,20 @@
-.plugins-browser__header {
-	display: flex;
-	flex: 1 1 auto;
-	justify-content: flex-start;
-	align-items: center;
-	border-bottom: 1px solid var( --studio-gray-5 );
-	position: relative;
-
-	.plugins-browser__page-heading {
-		margin-bottom: 24px;
-	}
-}
-
 .plugins-browser__searchbox {
 	width: 250px;
-	margin-bottom: 20px;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	align-items: stretch;
 
 	.search-component {
 		height: 30px;
 		box-shadow: 0 0 0 1px var( --studio-gray-10 );
 
-		.search-component__open-icon, .search-component__close-icon {
+		.search-component__open-icon,
+		.search-component__close-icon {
 			color: var( --studio-black );
 		}
 
-		&.is-open input.search-component__input[type=search] {
+		&.is-open input.search-component__input[type='search'] {
 			font-size: $font-body-extra-small;
 		}
 	}
@@ -35,20 +26,11 @@
 			box-shadow: none;
 		}
 	}
-
 }
 
 .plugins-browser__main-buttons {
 	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
-	align-items: stretch;
 	margin-right: 15px;
-	margin-bottom: 20px;
-
-	&.manage-plugins-button {
-		margin-left: auto;
-	}
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
@@ -56,11 +38,8 @@
 	}
 
 	@media screen and ( max-width: 660px ) {
-		margin-bottom: 0;
-
-		&.upload-plugin-button .plugins-browser__button {
+		.plugins-browser__button {
 			border: none;
-			margin-right: 0;
 		}
 	}
 
@@ -75,10 +54,7 @@
 		}
 
 		&:not( :last-child ) {
-			margin-bottom: 8px;
-
 			@include breakpoint-deprecated( '>480px' ) {
-				margin-bottom: 0;
 				margin-right: 10px;
 			}
 		}

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -38,9 +38,11 @@
 	}
 
 	@media screen and ( max-width: 660px ) {
-		width: 50px;
+		width: 30px;
+
 		.search-component {
 			width: 50px;
+			box-shadow: none;
 		}
 	}
 
@@ -51,9 +53,12 @@
 	flex-direction: column;
 	justify-content: flex-end;
 	align-items: stretch;
-	margin: auto;
 	margin-right: 15px;
 	margin-bottom: 20px;
+
+	&.manage-plugins-button {
+		margin-left: auto;
+	}
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
@@ -61,7 +66,12 @@
 	}
 
 	@media screen and ( max-width: 660px ) {
-		margin-bottom: 13px;
+		margin-bottom: 0;
+
+		&.upload-plugin-button .plugins-browser__button {
+			border: none;
+			margin-right: 0;
+		}
 	}
 
 	.plugins-browser__button {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,3 +1,15 @@
+.is-section-plugins .main {
+	padding-top: 35px; // Compensate for the fixed header.
+
+	@media ( max-width: 782px ) {
+		padding-top: 50px;
+	}
+
+	@media ( max-width: 660px ) {
+		padding-top: 70px;
+	}
+}
+
 .is-section-plugins.color-scheme.is-nav-unification {
 	--color-surface-backdrop: --studio-white;
 }
@@ -16,17 +28,6 @@
 
 .plugins__plugin-list-state {
 	white-space: nowrap;
-}
-
-.plugins__header {
-	display: flex;
-	flex: 1 1 auto;
-	justify-content: flex-start;
-	align-items: center;
-
-	.plugins__page-heading {
-		width: 100%;
-	}
 }
 
 .plugins__main-header {
@@ -87,12 +88,6 @@
 			}
 		}
 	}
-}
-
-.plugins__header-navigation {
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
-		0 1px 2px var( --color-neutral-0 );
-	width: 100%;
 }
 
 .plugins__more-header {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,3 +1,13 @@
+.is-section-plugins.color-scheme.is-nav-unification {
+	--color-surface-backdrop: --studio-white;
+}
+
+.upsell-nudge {
+	@include breakpoint-deprecated( '<660px' ) {
+		margin: 16px;
+	}
+}
+
 .plugin__installed-on {
 	margin-bottom: 16px;
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -3,6 +3,8 @@
 }
 
 .upsell-nudge {
+	margin-top: 16px;
+
 	@include breakpoint-deprecated( '<660px' ) {
 		margin: 16px;
 	}

--- a/test/e2e/lib/pages/plugins-browser-page.js
+++ b/test/e2e/lib/pages/plugins-browser-page.js
@@ -5,17 +5,17 @@ import * as SlackNotifier from '../slack-notifier';
 
 export default class PluginsBrowserPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.plugins-browser__main-header' ) );
+		super( driver, By.css( '.plugins-browser__header' ) );
 	}
 
 	async searchForPlugin( searchTerm ) {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.plugins-browser__main-header .search-component__icon-navigation' )
+			By.css( '.plugins-browser__header .search-component__icon-navigation' )
 		);
 		return await driverHelper.setWhenSettable(
 			this.driver,
-			By.css( '.plugins-browser__main-header input[type="search"]' ),
+			By.css( '.plugins-browser__header input[type="search"]' ),
 			searchTerm,
 			{ pauseBetweenKeysMS: 100 }
 		);


### PR DESCRIPTION
### Overview 
Update the header and plugin lists of the Plugins Browser screen as per oU6nEIeiKSg8CayhEtgR6b-fi-6450%3A3880

### Changes proposed in this Pull Request

* Add the themes compact and extended to Plugins Browser
* Apply the created theme to the header
* Update the search results text and show the total of results
* Add an icon on the upload button
* Proper handling of search on the mobile version 


### Differences from design
* The place of search input and search button layout on mobile 
  * It is on the right edge of the screen, to match the current behavior of the search input on mobile
* The manage and upload buttons
  * We are still awaiting a response from the design team.
* The changes placed at #57101.

### Screenshots

#### Desktop version

|Before | After|
|-------|------|
|![Screen Shot 2021-10-26 at 17 53 00](https://user-images.githubusercontent.com/5039531/138967172-00b53553-2e3c-4d4c-bc44-17bcc0fb0900.png)|![Screen Shot 2021-10-27 at 14 13 38](https://user-images.githubusercontent.com/5039531/139123210-38039bfd-c1d3-4779-8c9d-5e8cb8e994e7.png)|



#### Mobile version
|Before | After| After when searching |
|-------|------|----------------|
|![Screen Shot 2021-10-26 at 17 53 44](https://user-images.githubusercontent.com/5039531/138967408-2ba792c6-bdc5-4778-8b97-caeb5c96a216.png)|![Screen Shot 2021-10-27 at 14 14 00](https://user-images.githubusercontent.com/5039531/139123515-99fd3f75-fddd-40b1-bea1-3a867592bd55.png)|![Screen Shot 2021-10-26 at 17 54 25](https://user-images.githubusercontent.com/5039531/138967446-502beb57-3fb0-44dc-9ab8-96f0dcddb43c.png)

### Testing instructions

* Go to the plugins browse page, verify if it matches the design and screenshot above
* Search for a plugin (You can try typing 'jetpack')
* Enable the simulation of a mobile device on your browser. If you are a chrome user, you can [follow this guide](https://developer.chrome.com/docs/devtools/device-mode/)
* Go to the plugins browse page, verify if it matches the design and screenshot above
* Search for a plugin, verify if it matches the design and screenshot above


### Pending
- [x] remove the search box border on mobile when closed
- [x] keep only the upload icon in mobile
- [x] on the first-page load, the search input looks lifted up by a few pixels
- [x] fixed height for a short description aka excerpt content
- [x] the section headers have uneven margin/padding
- [x] flickering on mobile when clicking the search icon

The PR  #57101  Needs to be merged first.

---

Fixes #57103
Fixes #57067