### PR TITLE
P2: Add pre-approved domains setting for hubs

### DIFF
--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -4,14 +4,14 @@ import GeneralForm from 'calypso/my-sites/site-settings/form-general';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import P2GeneralSettingsForm from './settings-p2';
+import P2PreapprovedDomainsForm from './settings-p2/preapproved-domains';
 import SiteTools from './site-tools';
 
 const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2HubSite } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
 		{ isWPForTeamsSite && isP2HubSite && config.isEnabled( 'p2/settings/preapproved-domains' ) && (
-			<P2GeneralSettingsForm site={ site } />
+			<P2PreapprovedDomainsForm site={ site } />
 		) }
 		<SiteTools />
 	</div>

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -9,7 +9,7 @@ import SiteTools from './site-tools';
 const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2HubSite } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
-		{ !! isWPForTeamsSite && !! isP2HubSite && <P2GeneralSettingsForm site={ site } /> }
+		{ isWPForTeamsSite && isP2HubSite && <P2GeneralSettingsForm site={ site } /> }
 		<SiteTools />
 	</div>
 );

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { connect } from 'react-redux';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -9,7 +10,9 @@ import SiteTools from './site-tools';
 const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2HubSite } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
-		{ isWPForTeamsSite && isP2HubSite && <P2GeneralSettingsForm site={ site } /> }
+		{ isWPForTeamsSite && isP2HubSite && config.isEnabled( 'p2/settings/preapproved-domains' ) && (
+			<P2GeneralSettingsForm site={ site } />
+		) }
 		<SiteTools />
 	</div>
 );

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -1,15 +1,24 @@
 import { connect } from 'react-redux';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import P2GeneralSettingsForm from './settings-p2';
 import SiteTools from './site-tools';
 
-const SiteSettingsGeneral = ( { site } ) => (
+const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2HubSite } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
+		{ !! isWPForTeamsSite && !! isP2HubSite && <P2GeneralSettingsForm site={ site } /> }
 		<SiteTools />
 	</div>
 );
 
-export default connect( ( state ) => ( {
-	site: getSelectedSite( state ),
-} ) )( SiteSettingsGeneral );
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		site: getSelectedSite( state ),
+		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
+		isP2HubSite: isSiteP2Hub( state, siteId ),
+	};
+} )( SiteSettingsGeneral );

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -11,7 +11,7 @@ const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
 		{ isWPForTeamsSite && isP2Hub && isEnabled( 'p2/preapproved-domains' ) && (
-			<P2PreapprovedDomainsForm site={ site } />
+			<P2PreapprovedDomainsForm siteId={ site?.ID } />
 		) }
 		<SiteTools />
 	</div>

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import { connect } from 'react-redux';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -7,10 +7,10 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import P2PreapprovedDomainsForm from './settings-p2/preapproved-domains';
 import SiteTools from './site-tools';
 
-const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2HubSite } ) => (
+const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
-		{ isWPForTeamsSite && isP2HubSite && config.isEnabled( 'p2/preapproved-domains' ) && (
+		{ isWPForTeamsSite && isP2Hub && isEnabled( 'p2/preapproved-domains' ) && (
 			<P2PreapprovedDomainsForm site={ site } />
 		) }
 		<SiteTools />
@@ -22,6 +22,6 @@ export default connect( ( state ) => {
 	return {
 		site: getSelectedSite( state ),
 		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
-		isP2HubSite: isSiteP2Hub( state, siteId ),
+		isP2Hub: isSiteP2Hub( state, siteId ),
 	};
 } )( SiteSettingsGeneral );

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -10,7 +10,7 @@ import SiteTools from './site-tools';
 const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2HubSite } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
-		{ isWPForTeamsSite && isP2HubSite && config.isEnabled( 'p2/settings/preapproved-domains' ) && (
+		{ isWPForTeamsSite && isP2HubSite && config.isEnabled( 'p2/preapproved-domains' ) && (
 			<P2PreapprovedDomainsForm site={ site } />
 		) }
 		<SiteTools />

--- a/client/my-sites/site-settings/settings-p2/index.jsx
+++ b/client/my-sites/site-settings/settings-p2/index.jsx
@@ -148,7 +148,9 @@ export class P2GeneralSettingsForm extends Component {
 
 				<SettingsSectionHeader
 					data-tip-target="settings-site-profile-save"
-					disabled={ isRequestingSettings || isSavingSettings }
+					disabled={
+						isRequestingSettings || isSavingSettings || Object.keys( this.state.errors ).length > 0
+					}
 					isSaving={ isSavingSettings }
 					onButtonClick={ this.handleSubmitForm }
 					showButton

--- a/client/my-sites/site-settings/settings-p2/index.jsx
+++ b/client/my-sites/site-settings/settings-p2/index.jsx
@@ -97,8 +97,7 @@ export class P2GeneralSettingsForm extends Component {
 		}
 
 		try {
-			// TODO Should this be GET? Technically we are not creating anything.
-			const { success, errors } = await wpcom.req.post(
+			const { success, errors } = await wpcom.req.get(
 				{
 					path: `/p2/hub-settings/domains/validate`,
 					apiNamespace: 'wpcom/v2',

--- a/client/my-sites/site-settings/settings-p2/index.jsx
+++ b/client/my-sites/site-settings/settings-p2/index.jsx
@@ -23,6 +23,7 @@ export class P2GeneralSettingsForm extends Component {
 
 	state = {
 		isDomainsToggledOn: false,
+		isValidating: false,
 		success: [],
 		errors: {},
 		errorToDisplay: '',
@@ -43,6 +44,12 @@ export class P2GeneralSettingsForm extends Component {
 			return { isDomainsToggledOn: true };
 		}
 	}
+
+	handleSubmitForm = ( event ) => {
+		if ( ! this.state.isValidating ) {
+			this.props.handleSubmitForm( event );
+		}
+	};
 
 	getPreapprovedDomains = () => {
 		const { fields } = this.props;
@@ -82,6 +89,8 @@ export class P2GeneralSettingsForm extends Component {
 	};
 
 	async validateDomains( domains ) {
+		this.setState( { isValidating: true } );
+
 		if ( domains.length < 1 ) {
 			this.refreshDomainsValidation( [], {} );
 			return;
@@ -102,6 +111,8 @@ export class P2GeneralSettingsForm extends Component {
 			// this.props.recordTracksEvent( 'calypso_p2_preapproved_domain_validation_success' );
 		} catch ( error ) {
 			// this.props.recordTracksEvent( 'calypso_p2_preapproved_domain_validation_failed' );
+		} finally {
+			this.setState( { isValidating: false } );
 		}
 	}
 
@@ -188,7 +199,7 @@ export class P2GeneralSettingsForm extends Component {
 						isRequestingSettings || isSavingSettings || Object.keys( this.state.errors ).length > 0
 					}
 					isSaving={ isSavingSettings }
-					onButtonClick={ this.props.handleSubmitForm }
+					onButtonClick={ this.handleSubmitForm }
 					showButton
 					title={ translate( 'Joining this workspace' ) }
 				/>

--- a/client/my-sites/site-settings/settings-p2/index.jsx
+++ b/client/my-sites/site-settings/settings-p2/index.jsx
@@ -193,7 +193,6 @@ export class P2GeneralSettingsForm extends Component {
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
 
 				<SettingsSectionHeader
-					data-tip-target="settings-site-profile-save"
 					disabled={
 						isRequestingSettings || isSavingSettings || Object.keys( this.state.errors ).length > 0
 					}

--- a/client/my-sites/site-settings/settings-p2/index.jsx
+++ b/client/my-sites/site-settings/settings-p2/index.jsx
@@ -107,9 +107,9 @@ export class P2GeneralSettingsForm extends Component {
 
 			this.refreshDomainsValidation( success, errors );
 
-			this.props.recordTracksEvent( 'calypso_p2_preapproved_domains_validation_success' );
+			this.props.recordTracksEvent( 'calypso_p2_settings_validate_preapproved_domains_success' );
 		} catch ( error ) {
-			this.props.recordTracksEvent( 'calypso_p2_preapproved_domains_validation_failed' );
+			this.props.recordTracksEvent( 'calypso_p2_settings_validate_preapproved_domains_failed' );
 		} finally {
 			this.setState( { isValidating: false } );
 		}

--- a/client/my-sites/site-settings/settings-p2/index.jsx
+++ b/client/my-sites/site-settings/settings-p2/index.jsx
@@ -1,0 +1,131 @@
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import classNames from 'classnames';
+import { flowRight } from 'lodash';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormInput from 'calypso/components/forms/form-text-input';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import wrapSettingsForm from '../wrap-settings-form';
+
+export class P2GeneralSettingsForm extends Component {
+	state = {
+		showPreapprovedDomainsTextBox: false,
+	};
+
+	handleSubmitForm = () => {
+		// TODO
+	};
+
+	handleP2PreapprovedDomainsToggle = () => {
+		this.setState( { showPreapprovedDomainsTextBox: ! this.state.showPreapprovedDomainsTextBox } );
+	};
+
+	render() {
+		const {
+			fields,
+			isRequestingSettings,
+			isSavingSettings,
+			site,
+			translate,
+			isWPForTeamsSite,
+			isP2HubSite,
+		} = this.props;
+
+		if ( ! isWPForTeamsSite || ! isP2HubSite ) {
+			return <></>;
+		}
+
+		const classes = classNames( 'site-settings__general-settings', {
+			'is-loading': isRequestingSettings,
+		} );
+
+		return (
+			<div className={ classNames( classes ) }>
+				{ site && <QuerySiteSettings siteId={ site.ID } /> }
+
+				<SettingsSectionHeader
+					data-tip-target="settings-site-profile-save"
+					disabled={ isRequestingSettings || isSavingSettings }
+					isSaving={ isSavingSettings }
+					onButtonClick={ this.handleSubmitForm }
+					showButton
+					title={ translate( 'Joining this workspace' ) }
+				/>
+				<Card>
+					<form>
+						<div className="settings-p2__preapproved-domains">
+							<FormFieldset>
+								<ToggleControl
+									checked={ this.state.showPreapprovedDomainsTextBox }
+									disabled={ isRequestingSettings || isSavingSettings }
+									onChange={ this.handleP2PreapprovedDomainsToggle }
+									label={ translate(
+										'Allow people with an email address from specified domains to join this workspace.'
+									) }
+								></ToggleControl>
+								{ this.state.showPreapprovedDomainsTextBox && (
+									<>
+										<FormLabel htmlFor="blogname">{ translate( 'Approved domains' ) }</FormLabel>
+										<FormInput
+											name="p2_preapproved_domains"
+											id="p2-preapproved-domains"
+											data-tip-target="p2-preapproved-domains-input"
+											value={ fields.p2_preapproved_domains || '' }
+											onChange={ null } // TODO
+											disabled={ isRequestingSettings }
+											onClick={ null } // TODO
+											onKeyPress={ null } // TODO
+										/>
+										<FormSettingExplanation>
+											{ translate(
+												'If you enter automattic.com, anybody using an automattic.com email will be able to join this workspace. To add multiple domains, separate them with a comma.'
+											) }
+										</FormSettingExplanation>
+									</>
+								) }
+							</FormFieldset>
+						</div>
+					</form>
+				</Card>
+			</div>
+		);
+	}
+}
+
+const connectComponent = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
+		isP2HubSite: isSiteP2Hub( state, siteId ),
+	};
+} );
+
+const getFormSettings = ( settings ) => {
+	const defaultSettings = {
+		p2_preapproved_domains: '',
+	};
+
+	if ( ! settings ) {
+		return defaultSettings;
+	}
+
+	const formSettings = {
+		p2_preapproved_domains: settings.p2_preapproved_domains,
+	};
+
+	return formSettings;
+};
+
+export default flowRight(
+	connectComponent,
+	wrapSettingsForm( getFormSettings )
+)( P2GeneralSettingsForm );

--- a/client/my-sites/site-settings/settings-p2/index.jsx
+++ b/client/my-sites/site-settings/settings-p2/index.jsx
@@ -108,9 +108,9 @@ export class P2GeneralSettingsForm extends Component {
 
 			this.refreshDomainsValidation( success, errors );
 
-			// this.props.recordTracksEvent( 'calypso_p2_preapproved_domain_validation_success' );
+			this.props.recordTracksEvent( 'calypso_p2_preapproved_domains_validation_success' );
 		} catch ( error ) {
-			// this.props.recordTracksEvent( 'calypso_p2_preapproved_domain_validation_failed' );
+			this.props.recordTracksEvent( 'calypso_p2_preapproved_domains_validation_failed' );
 		} finally {
 			this.setState( { isValidating: false } );
 		}

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -18,11 +18,11 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import wrapSettingsForm from '../wrap-settings-form';
 
 const debug = debugModule( 'calypso:my-sites:settings:p2-settings' );
-export class P2GeneralSettingsForm extends Component {
+export class P2PreapprovedDomainsForm extends Component {
 	SETTING_KEY_PREAPPROVED_DOMAINS = 'p2_preapproved_domains';
 
 	state = {
-		isDomainsToggledOn: false,
+		isToggledOn: false,
 		isValidating: false,
 		success: [],
 		errors: {},
@@ -34,14 +34,14 @@ export class P2GeneralSettingsForm extends Component {
 			return null;
 		}
 
-		if ( state.isDomainsToggledOn === !! props.fields?.p2_preapproved_domains ) {
+		if ( state.isToggledOn === !! props.fields?.p2_preapproved_domains ) {
 			return null;
 		}
 
 		// Domains should always be toggled on if text field is not empty.
 		// The reverse is not true -- can be toggled on even if empty.
 		if ( props.fields?.p2_preapproved_domains?.length > 0 ) {
-			return { isDomainsToggledOn: true };
+			return { isToggledOn: true };
 		}
 	}
 
@@ -72,7 +72,7 @@ export class P2GeneralSettingsForm extends Component {
 		updateFields( { [ this.SETTING_KEY_PREAPPROVED_DOMAINS ]: [] } );
 
 		this.setState( {
-			isDomainsToggledOn: ! this.state.isDomainsToggledOn,
+			isToggledOn: ! this.state.isToggledOn,
 		} );
 	};
 
@@ -184,7 +184,7 @@ export class P2GeneralSettingsForm extends Component {
 			return <></>;
 		}
 
-		const classes = classNames( 'site-settings__p2-settings', {
+		const classes = classNames( 'site-settings__p2-preapproved-domains', {
 			'is-loading': isRequestingSettings,
 		} );
 
@@ -206,14 +206,14 @@ export class P2GeneralSettingsForm extends Component {
 						<div className="settings-p2__preapproved-domains">
 							<FormFieldset>
 								<ToggleControl
-									checked={ this.state.isDomainsToggledOn }
+									checked={ this.state.isToggledOn }
 									disabled={ isRequestingSettings || isSavingSettings }
 									onChange={ this.handleDomainsToggle }
 									label={ translate(
 										'Allow people with an email address from specified domains to join this workspace.'
 									) }
 								></ToggleControl>
-								{ this.state.isDomainsToggledOn && (
+								{ this.state.isToggledOn && (
 									<>
 										<FormLabel htmlFor="blogname">{ translate( 'Approved domains' ) }</FormLabel>
 										<TokenField
@@ -274,4 +274,4 @@ const getFormSettings = ( settings ) => {
 export default flowRight(
 	connectComponent,
 	wrapSettingsForm( getFormSettings )
-)( P2GeneralSettingsForm );
+)( P2PreapprovedDomainsForm );

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -171,7 +171,7 @@ const P2PreapprovedDomainsForm = ( {
 		return tokens;
 	};
 
-	const classes = classNames( 'site-settings__p2-preapproved-domains', {
+	const classes = classNames( 'p2-preapproved-domains', {
 		'is-loading': isRequestingSettings,
 	} );
 

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -89,12 +89,12 @@ const P2PreapprovedDomainsForm = ( {
 	};
 
 	const validateTokens = async ( tokens ) => {
-		setIsValidating( true );
-
 		if ( tokens.length < 1 ) {
 			refreshValidation( [], {} );
 			return;
 		}
+
+		setIsValidating( true );
 
 		// Prior to sending off a validation API request,
 		// first quickly remove old, now-deleted tokens from validation lists.

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -171,12 +171,12 @@ const P2PreapprovedDomainsForm = ( {
 		return tokens;
 	};
 
-	const classes = classNames( 'p2-preapproved-domains', {
-		'is-loading': isRequestingSettings,
-	} );
-
 	return (
-		<div className={ classNames( classes ) }>
+		<div
+			className={ classNames( 'p2-preapproved-domains', {
+				'is-loading': isRequestingSettings,
+			} ) }
+		>
 			{ siteId && <QuerySiteSettings siteId={ siteId } /> }
 
 			<SettingsSectionHeader

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -190,7 +190,7 @@ const P2PreapprovedDomainsForm = ( {
 			/>
 			<Card>
 				<form>
-					<div className="settings-p2__preapproved-domains">
+					<div className="preapproved-domains__form">
 						<FormFieldset>
 							<ToggleControl
 								checked={ isToggledOn }

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -1,9 +1,15 @@
+/**
+ * External Dependencies
+ */
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { flowRight, includes, pickBy, filter } from 'lodash';
 import { useSelector } from 'react-redux';
+/**
+ * Internal Dependencies
+ */
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -1,9 +1,9 @@
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { flowRight, includes, pickBy, filter } from 'lodash';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -13,22 +13,22 @@ import wpcom from 'calypso/lib/wp';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import wrapSettingsForm from '../wrap-settings-form';
 
 const P2PreapprovedDomainsForm = ( {
 	fields,
 	handleSubmitForm,
-	isP2HubSite,
 	isRequestingSettings,
 	isSavingSettings,
-	isWPForTeamsSite,
 	recordTracksEvent,
-	site,
+	siteId,
 	translate,
 	updateFields,
 } ) => {
 	const SETTING_KEY_PREAPPROVED_DOMAINS = 'p2_preapproved_domains';
+
+	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
+	const isP2Hub = useSelector( ( state ) => isSiteP2Hub( state, siteId ) );
 
 	const [ isToggledOn, setIsToggledOn ] = useState( false );
 	const [ isValidating, setIsValidating ] = useState( false );
@@ -48,7 +48,7 @@ const P2PreapprovedDomainsForm = ( {
 		}
 	}, [ fields ] );
 
-	if ( ! isWPForTeamsSite || ! isP2HubSite ) {
+	if ( ! isWPForTeamsSite || ! isP2Hub ) {
 		return <></>;
 	}
 
@@ -171,7 +171,7 @@ const P2PreapprovedDomainsForm = ( {
 
 	return (
 		<div className={ classNames( classes ) }>
-			{ site && <QuerySiteSettings siteId={ site.ID } /> }
+			{ siteId && <QuerySiteSettings siteId={ siteId } /> }
 
 			<SettingsSectionHeader
 				disabled={
@@ -231,15 +231,6 @@ const P2PreapprovedDomainsForm = ( {
 	);
 };
 
-const connectComponent = connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-
-	return {
-		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
-		isP2HubSite: isSiteP2Hub( state, siteId ),
-	};
-} );
-
 const getFormSettings = ( settings ) => {
 	const defaultSettings = {
 		p2_preapproved_domains: '',
@@ -256,7 +247,4 @@ const getFormSettings = ( settings ) => {
 	return formSettings;
 };
 
-export default flowRight(
-	connectComponent,
-	wrapSettingsForm( getFormSettings )
-)( P2PreapprovedDomainsForm );
+export default flowRight( wrapSettingsForm( getFormSettings ) )( P2PreapprovedDomainsForm );

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -5,7 +5,7 @@ import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import classNames from 'classnames';
-import { flowRight, includes, pickBy, filter } from 'lodash';
+import { includes, pickBy, filter } from 'lodash';
 import { useSelector } from 'react-redux';
 /**
  * Internal Dependencies
@@ -253,4 +253,4 @@ const getFormSettings = ( settings ) => {
 	return formSettings;
 };
 
-export default flowRight( wrapSettingsForm( getFormSettings ) )( P2PreapprovedDomainsForm );
+export default wrapSettingsForm( getFormSettings )( P2PreapprovedDomainsForm );

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -16,21 +16,19 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import wrapSettingsForm from '../wrap-settings-form';
 
-const P2PreapprovedDomainsForm = ( props ) => {
+const P2PreapprovedDomainsForm = ( {
+	fields,
+	handleSubmitForm,
+	isP2HubSite,
+	isRequestingSettings,
+	isSavingSettings,
+	isWPForTeamsSite,
+	recordTracksEvent,
+	site,
+	translate,
+	updateFields,
+} ) => {
 	const SETTING_KEY_PREAPPROVED_DOMAINS = 'p2_preapproved_domains';
-
-	const {
-		fields,
-		handleSubmitForm,
-		isP2HubSite,
-		isRequestingSettings,
-		isSavingSettings,
-		isWPForTeamsSite,
-		recordTracksEvent,
-		site,
-		translate,
-		updateFields,
-	} = props;
 
 	const [ isToggledOn, setIsToggledOn ] = useState( false );
 	const [ isValidating, setIsValidating ] = useState( false );

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -43,7 +43,7 @@ const P2PreapprovedDomainsForm = ( {
 	const [ error, setError ] = useState( {} );
 
 	useEffect( () => {
-		if ( ! fields || ! fields.p2_preapproved_domains ) {
+		if ( ! fields?.p2_preapproved_domains ) {
 			return;
 		}
 

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -46,7 +46,7 @@ const P2PreapprovedDomainsForm = ( {
 		if ( fields.p2_preapproved_domains.length > 0 ) {
 			setIsToggledOn( true );
 		}
-	} );
+	}, [ fields ] );
 
 	if ( ! isWPForTeamsSite || ! isP2HubSite ) {
 		return <></>;

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -55,7 +55,7 @@ const P2PreapprovedDomainsForm = ( {
 	}, [ fields ] );
 
 	if ( ! isWPForTeamsSite || ! isP2Hub ) {
-		return <></>;
+		return null;
 	}
 
 	const getFormField = () => {

--- a/config/development.json
+++ b/config/development.json
@@ -121,6 +121,7 @@
 		"network-connection": true,
 		"oauth": false,
 		"p2/p2-plus": true,
+		"p2/settings/preapproved-domains": true,
 		"page/export": true,
 		"perfmon": false,
 		"plans/personal-plan": true,

--- a/config/development.json
+++ b/config/development.json
@@ -121,7 +121,7 @@
 		"network-connection": true,
 		"oauth": false,
 		"p2/p2-plus": true,
-		"p2/settings/preapproved-domains": true,
+		"p2/preapproved-domains": true,
 		"page/export": true,
 		"perfmon": false,
 		"plans/personal-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,6 +78,7 @@
 		"me/vat-details": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
+		"p2/settings/preapproved-domains": false,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,7 +78,7 @@
 		"me/vat-details": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
-		"p2/settings/preapproved-domains": false,
+		"p2/preapproved-domains": false,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -79,6 +79,7 @@
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"p2/p2-plus": true,
+		"p2/settings/preapproved-domains": false,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -79,7 +79,7 @@
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"p2/p2-plus": true,
-		"p2/settings/preapproved-domains": false,
+		"p2/preapproved-domains": false,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,6 +78,7 @@
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"p2/p2-plus": true,
+		"p2/settings/preapproved-domains": false,
 		"page/export": true,
 		"perfmon": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,7 +78,7 @@
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"p2/p2-plus": true,
-		"p2/settings/preapproved-domains": false,
+		"p2/preapproved-domains": true,
 		"page/export": true,
 		"perfmon": true,
 		"plans/personal-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -64,6 +64,7 @@
 		"me/account-close": true,
 		"me/vat-details": true,
 		"network-connection": true,
+		"p2/settings/preapproved-domains": false,
 		"perfmon": false,
 		"plans/personal-plan": true,
 		"press-this": true,

--- a/config/test.json
+++ b/config/test.json
@@ -64,7 +64,7 @@
 		"me/account-close": true,
 		"me/vat-details": true,
 		"network-connection": true,
-		"p2/settings/preapproved-domains": false,
+		"p2/preapproved-domains": true,
 		"perfmon": false,
 		"plans/personal-plan": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -89,6 +89,7 @@
 		"my-sites/checkout/web-payment/basic-card": false,
 		"network-connection": true,
 		"p2/p2-plus": true,
+		"p2/settings/preapproved-domains": false,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -89,7 +89,7 @@
 		"my-sites/checkout/web-payment/basic-card": false,
 		"network-connection": true,
 		"p2/p2-plus": true,
-		"p2/settings/preapproved-domains": false,
+		"p2/preapproved-domains": true,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Adds a new setting to P2 hubs for controlling pre-approved domains
* This is part of a new P2 feature that will allow users with specific email domains to join a P2 on their own (no need for invites).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Only P2 hubs should have this setting available.
* Validation should work as expected. Rejected domains should display why they are rejected.
* Saving and loading should work as expected.

### Screens

<img width="737" alt="Screen Shot 2021-10-27 at 7 03 37 PM" src="https://user-images.githubusercontent.com/730823/139053952-2878aca9-82ec-44c1-8e5d-e885fac48968.png">

<img width="737" alt="Screen Shot 2021-10-27 at 7 04 04 PM" src="https://user-images.githubusercontent.com/730823/139053978-43657391-c79a-4790-8e8a-993c03f1be1e.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3887-gh-Automattic/p2