### PR TITLE
Layout: AsyncLoad keyboard shortcuts

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -17,7 +17,6 @@ import DesktopListeners from 'calypso/lib/desktop-listeners';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getLanguageSlugs } from 'calypso/lib/i18n-utils/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import setupGlobalKeyboardShortcuts from 'calypso/lib/keyboard-shortcuts/global';
 import { attachLogmein } from 'calypso/lib/logmein';
 import { getToken } from 'calypso/lib/oauth-token';
 import { checkFormHandler } from 'calypso/lib/protect-form';
@@ -370,7 +369,9 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 	}
 
 	if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
-		setupGlobalKeyboardShortcuts();
+		asyncRequire( 'calypso/lib/keyboard-shortcuts/global', ( setupGlobalKeyboardShortcuts ) => {
+			setupGlobalKeyboardShortcuts();
+		} );
 	}
 
 	if ( window.electron ) {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -20,7 +20,6 @@ import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
 import OfflineStatus from 'calypso/layout/offline-status';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import KeyboardShortcutsMenu from 'calypso/lib/keyboard-shortcuts/menu';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
@@ -275,7 +274,9 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/guided-tours' ) && (
 					<AsyncLoad require="calypso/layout/guided-tours" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
+				{ config.isEnabled( 'keyboard-shortcuts' ) && (
+					<AsyncLoad require="calypso/lib/keyboard-shortcuts/menu" placeholder={ null } />
+				) }
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
 				<LayoutLoader />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, we'll always require the Calypso keyboard shortcuts early at boot and in the logged-in layout. Keyboard shortcuts are great and I use them a lot to navigate in Calypso, but they're by no means critical and can be deferred. 

This PR defers both the actual global shortcut handlers and the menu to be asynchronously loaded separately from the critical pieces of code. An important change here is that this will happen only if the related feature flag is enabled - which in production is **not**.

This will nicely shave a few bytes off the main entry point chunk, while not interfering at all with the user experience of using the keyboard shortcuts feature.

#### Testing instructions

* Make sure Calypso still builds well and runs well.
* Verify keyboard shortcuts still work well - they're enabled in both local and wpcalypso environments. 
* Simultaneously press "shift" and `/` to open the menu with all available shortcuts.
* Try some other shortcuts and verify they still work well. Keep an eye on whether they have to be pressed simultaneously, or in a sequence.