### PR TITLE
Removed is_locked property from subscriptions list

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -37,7 +37,6 @@ function createPurchaseObject( purchase ) {
 			: null,
 		isCancelable: Boolean( purchase.is_cancelable ),
 		isDomainRegistration: Boolean( purchase.is_domain_registration ),
-		isLocked: Boolean( purchase.is_locked ),
 		isRechargeable: Boolean( purchase.is_rechargable ),
 		isRefundable: Boolean( purchase.is_refundable ),
 		isRenewable: Boolean( purchase.is_renewable ),

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -86,7 +86,6 @@ import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
 	hasLoadedSitePurchasesFromServer,
-	isPurchaseManagementLocked,
 	getRenewableSitePurchases,
 	shouldRevertAtomicSiteBeforeDeactivation,
 } from 'calypso/state/purchases/selectors';
@@ -705,7 +704,6 @@ class ManagePurchase extends Component {
 			siteSlug,
 			getChangePaymentMethodUrlFor,
 			hasLoadedPurchasesFromServer,
-			canManagePurchase,
 		} = this.props;
 
 		const classes = classNames( 'manage-purchase__info', {
@@ -760,7 +758,7 @@ class ManagePurchase extends Component {
 							getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
 						/>
 					) }
-					{ isProductOwner && canManagePurchase && (
+					{ isProductOwner && (
 						<>
 							{ preventRenewal && this.renderSelectNewButton() }
 							{ ! preventRenewal && this.renderRenewButton() }
@@ -772,7 +770,7 @@ class ManagePurchase extends Component {
 					isProductOwner={ isProductOwner }
 				/>
 
-				{ isProductOwner && canManagePurchase && (
+				{ isProductOwner && (
 					<>
 						{ preventRenewal && this.renderSelectNewNavItem() }
 						{ ! preventRenewal && ! renderMonthlyRenewalOption && this.renderRenewNowNavItem() }
@@ -930,6 +928,5 @@ export default connect( ( state, props ) => {
 			state,
 			purchase?.id
 		),
-		canManagePurchase: ! isPurchaseManagementLocked( state, purchase?.id ),
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -37,7 +37,7 @@ import {
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getByPurchaseId, isPurchaseManagementLocked } from 'calypso/state/purchases/selectors';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
 import { canEditPaymentDetails, isJetpackTemporarySitePurchase } from '../utils';
@@ -381,9 +381,6 @@ function PurchaseMetaExpiration( {
 	const isAutorenewalEnabled = purchase ? ! isExpiring( purchase ) : null;
 	const hideAutoRenew =
 		purchase && JETPACK_LEGACY_PLANS.includes( purchase.productSlug ) && ! isRenewable( purchase );
-	const canManagePurchase = useSelector(
-		( state ) => ! isPurchaseManagementLocked( state, purchase?.id )
-	);
 
 	if ( isDomainTransfer( purchase ) ) {
 		return null;
@@ -423,7 +420,7 @@ function PurchaseMetaExpiration( {
 				>
 					{ subsBillingText }
 				</span>
-				{ site && ! hideAutoRenew && isProductOwner && canManagePurchase && (
+				{ site && ! hideAutoRenew && isProductOwner && (
 					<span className="manage-purchase__detail">
 						<AutoRenewToggle
 							planName={ site.plan.product_name_short }

--- a/client/state/purchases/selectors/index.js
+++ b/client/state/purchases/selectors/index.js
@@ -15,7 +15,6 @@ export { getPurchasesError } from './get-purchases-error';
 export { getRenewableSitePurchases } from './get-renewable-site-purchases';
 export { getSitePurchases } from './get-site-purchases';
 export { getUserPurchases } from './get-user-purchases';
-export { isPurchaseManagementLocked } from './is-purchase-management-locked';
 export { isUserPaid } from './is-user-paid';
 export { shouldRevertAtomicSiteBeforeDeactivation } from './should-revert-atomic-site-before-deactivation';
 export { siteHasBackupProductPurchase } from './site-has-backup-product-purchase';

--- a/client/state/purchases/selectors/is-purchase-management-locked.js
+++ b/client/state/purchases/selectors/is-purchase-management-locked.js
@@ -1,4 +1,0 @@
-export const isPurchaseManagementLocked = () => {
-	// @todo: This function should be removed.
-	return false;
-};

--- a/client/state/purchases/selectors/is-purchase-management-locked.js
+++ b/client/state/purchases/selectors/is-purchase-management-locked.js
@@ -1,14 +1,4 @@
-import { getByPurchaseId } from 'calypso/state/purchases/selectors/get-by-purchase-id';
-
-export const isPurchaseManagementLocked = ( state, purchaseId ) => {
-	if ( ! purchaseId ) {
-		return false;
-	}
-
-	const purchase = getByPurchaseId( state, purchaseId );
-	if ( ! purchase ) {
-		return false;
-	}
-
-	return purchase.isLocked;
+export const isPurchaseManagementLocked = () => {
+	// @todo: This function should be removed.
+	return false;
 };

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -88,7 +88,6 @@ describe( 'selectors', () => {
 				introductoryOffer: null,
 				isCancelable: false,
 				isDomainRegistration: false,
-				isLocked: false,
 				isRechargeable: true,
 				isRefundable: false,
 				isRenewable: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the usage `is_locked` property from Subscriptions since the implementation is no longer needed. The purpose of it was to mark a subscription that was pending for cancellation in the async Atomic flow. However, the Atomic plan cancellation implementation was refactored and no longer needs to expose this property.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D68749-code on your sandbox
* Use the Calypso live link
* Go to Upgrades > Purchases
* Click on an Atomic subscription
* Add the `flags=atomic/automated-revert` in the url
* Make sure that there are no errors in the console (Dev Tools).
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
