### PR TITLE
Requesting /me/sites asks for the site_owner field

### DIFF
--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -18,6 +18,7 @@ export const SITE_REQUEST_FIELDS = [
 	'lang',
 	'launch_status',
 	'site_migration',
+	'site_owner',
 	'is_fse_active',
 	'is_fse_eligible',
 	'is_core_site_editor_enabled',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When asking for a list of all sites using `/rest/v1.2/me/sites`, request the site_owner field be added

#### Testing instructions

* Create a site
* Add a secondary account as an admin to the site
* Log in as the secondary account
* Visit `/people/team/<url>`
* Click on the owner account as to edit them
* BEFORE PR: You would see a flash of content of being able to edit/delete the user before the page updates to tell you you cannot
* AFTER PR: From the moment you move to the new screen, the page should tell you you cannot edit the owner user

![2021-10-21_11-43](https://user-images.githubusercontent.com/937354/138321423-ac577be9-44a8-40ce-9bb9-c97a42dc9289.png)

The root cause was when asking the API for one site, the site owner information would be returned, but when asking the API for all sites, it would not be returned.