### PR TITLE
Payments: Add error boundary logging to PaymentMethodSelector

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -5,7 +5,6 @@ import {
 	CheckoutProvider,
 	CheckoutPaymentMethods,
 	CheckoutSubmitButton,
-	CheckoutPageErrorCallback,
 } from '@automattic/composite-checkout';
 import { useElements, CardNumberElement } from '@stripe/react-stripe-js';
 import { useTranslate } from 'i18n-calypso';
@@ -29,7 +28,7 @@ import {
 	useHandleRedirectChangeError,
 	useHandleRedirectChangeComplete,
 } from './url-event-handlers';
-import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { CheckoutPageErrorCallback, PaymentMethod } from '@automattic/composite-checkout';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `PaymentMethodSelector` component uses a `CheckoutProvider` wrapper, which happens to have its own React error boundary in case of fatal errors. However, errors caught by that error boundary are not being logged like those in checkout. This PR adds logging of those errors.

Fixes https://github.com/Automattic/wp-calypso/issues/57088

#### Testing instructions

We'll need to cause an error boundary to trigger in order to verify that the handler is reporting it correctly. Apply the following change on top of this PR and load any page that uses `PaymentMethodSelector`, like `/me/purchases/add-payment-method`. Verify that a logstash network request is sent with the error to `https://public-api.wordpress.com/rest/v1.1/logstash`.

```diff
--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -172,6 +172,7 @@ function CheckoutProviderPropValidator( {
 }: {
        propsToValidate: CheckoutProviderProps;
 } ) {
+       throw new Error( 'testing' );
        const { total, items, paymentMethods, paymentProcessors } = propsToValidate;
        useEffect( () => {
                debug( 'propsToValidate', propsToValidate );
```
