### PR TITLE
E2E: Update spec `wp-domains__add` to match new experience introduced in #56949.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/domains-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/domains-page.ts
@@ -7,8 +7,12 @@ const selectors = {
 	removeItemButton: 'button[aria-label="Remove item"]',
 	popOverCartPlaceholder: '.cart-item__loading-placeholder',
 
+	// Domain actions
 	searchForDomainButton: `a:text-matches("search", "i")`,
 	useADomainIOwnButton: `text=I have a domain`,
+
+	// Purchased domains
+	purchasedDomains: ( domain: string ) => `div.card:has-text("${ domain }")`,
 };
 
 /**
@@ -26,6 +30,8 @@ export class DomainsPage {
 		this.page = page;
 	}
 
+	/* Initiate a domain action */
+
 	/**
 	 * Clicks on the button to add a domain to the site.
 	 */
@@ -35,6 +41,15 @@ export class DomainsPage {
 			this.page.click( selectors.searchForDomainButton ),
 		] );
 	}
+
+	/**
+	 * Click initial button to use a domain already owned by the user (make connection or transfer)
+	 */
+	async useADomainIOwn(): Promise< void > {
+		await this.page.click( selectors.useADomainIOwnButton );
+	}
+
+	/* Cart methods */
 
 	/**
 	 * Returns whether the cart is visible.
@@ -89,10 +104,14 @@ export class DomainsPage {
 		}
 	}
 
+	/* Interact with purchased domains */
+
 	/**
-	 * Click initial button to use a domain already owned by the user (make connection or transfer)
+	 * Given a partially matching string, locates and clicks on the matching purchased domain card.
+	 *
+	 * @param {string} domain Domain string to match on.
 	 */
-	async useADomainIOwn(): Promise< void > {
-		await this.page.click( selectors.useADomainIOwnButton );
+	async click( domain: string ): Promise< void > {
+		await this.page.click( selectors.purchasedDomains( domain ) );
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-domains__add.ts
+++ b/test/e2e/specs/specs-playwright/wp-domains__add.ts
@@ -12,6 +12,7 @@ import {
 	setupHooks,
 	CartCheckoutPage,
 	IndividualPurchasePage,
+	NavbarComponent,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
@@ -39,60 +40,75 @@ describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), functio
 		await BrowserManager.setStoreCookie( page );
 	} );
 
-	it( 'Navigate to Upgrades > Domains', async function () {
-		sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Upgrades', 'Domains' );
+	describe( 'Purchase domain', function () {
+		it( 'Navigate to Upgrades > Domains', async function () {
+			sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Upgrades', 'Domains' );
+		} );
+
+		it( 'If required, clear the cart', async function () {
+			domainsPage = new DomainsPage( page );
+			const cartOpened = await domainsPage.openCart();
+			// The cart popover existing implies there are some items that need to be removed.
+			if ( cartOpened ) {
+				await domainsPage.emptyCart();
+			}
+		} );
+
+		it( 'Add domain to site', async function () {
+			await domainsPage.addDomain();
+		} );
+
+		it( 'Search for a domain name', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( blogName + '.live' );
+		} );
+
+		it( 'Choose the .live TLD', async function () {
+			selectedDomain = await domainSearchComponent.selectDomain( '.live' );
+		} );
+
+		it( 'Decline Titan Email upsell', async function () {
+			await domainSearchComponent.clickButton( 'Skip' );
+		} );
+
+		it( 'See secure payment', async function () {
+			cartCheckoutPage = new CartCheckoutPage( page );
+			await cartCheckoutPage.validateCartItem( selectedDomain );
+		} );
+
+		it( 'Make purchase', async function () {
+			await Promise.all( [
+				page.waitForNavigation( {
+					url: '**/checkout/thank-you/**',
+					waitUntil: 'networkidle',
+					// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
+					timeout: 90 * 1000,
+				} ),
+				cartCheckoutPage.purchase(),
+			] );
+		} );
 	} );
 
-	it( 'If required, clear the cart', async function () {
-		domainsPage = new DomainsPage( page );
-		const cartOpened = await domainsPage.openCart();
-		// The cart popover existing implies there are some items that need to be removed.
-		if ( cartOpened ) {
-			await domainsPage.emptyCart();
-		}
-	} );
+	describe( 'Cancel domain', function () {
+		it( 'Return to Home dashbaoard', async function () {
+			const navbarComponent = new NavbarComponent( page );
+			await navbarComponent.clickMySites();
+		} );
 
-	it( 'Add domain to site', async function () {
-		await domainsPage.addDomain();
-	} );
+		it( 'Navigate to Upgrades > Domains', async function () {
+			sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Upgrades', 'Domains' );
+		} );
 
-	it( 'Search for a domain name', async function () {
-		domainSearchComponent = new DomainSearchComponent( page );
-		await domainSearchComponent.search( blogName + '.live' );
-	} );
+		it( 'Click on purchased domain', async function () {
+			const domainsPage = new DomainsPage( page );
+			await domainsPage.click( selectedDomain );
+		} );
 
-	it( 'Choose the .live TLD', async function () {
-		selectedDomain = await domainSearchComponent.selectDomain( '.live' );
-	} );
-
-	it( 'Decline Titan Email upsell', async function () {
-		await domainSearchComponent.clickButton( 'Skip' );
-	} );
-
-	it( 'See secure payment', async function () {
-		cartCheckoutPage = new CartCheckoutPage( page );
-		await cartCheckoutPage.validateCartItem( selectedDomain );
-	} );
-
-	it( 'Make purchase', async function () {
-		await Promise.all( [
-			page.waitForNavigation( {
-				url: '**/checkout/thank-you/**',
-				waitUntil: 'networkidle',
-				// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
-				timeout: 90 * 1000,
-			} ),
-			cartCheckoutPage.purchase(),
-		] );
-	} );
-
-	it( 'Manage domain', async function () {
-		await page.click( 'button:text("Manage domain")' );
-	} );
-
-	it( 'Cancel domain', async function () {
-		const individualPurchasePage = new IndividualPurchasePage( page );
-		await individualPurchasePage.deleteDomain();
+		it( 'Cancel domain', async function () {
+			const individualPurchasePage = new IndividualPurchasePage( page );
+			await individualPurchasePage.deleteDomain();
+		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-domains__add.ts
+++ b/test/e2e/specs/specs-playwright/wp-domains__add.ts
@@ -91,7 +91,7 @@ describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), functio
 	} );
 
 	describe( 'Cancel domain', function () {
-		it( 'Return to Home dashbaoard', async function () {
+		it( 'Return to Home dashboard', async function () {
 			const navbarComponent = new NavbarComponent( page );
 			await navbarComponent.clickMySites();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the flow of the `Domains: Add` spec to match the new screen.

Key changes:
- add second level `describe` blocks to group test steps.
- update test steps to navigate to home dashboard from the purchase thank you screen.
- implement new method to click on purchased domain by name.

![cancel-domain-2021-10-21T17-43-43](https://user-images.githubusercontent.com/6549265/138335217-139fb262-4e8c-47b2-8815-04ad6fa81596.png)


#### Testing instructions

- [x] pre-release
- [ ] desktop
- [ ] mobile

Fixes  #57239
