### PR TITLE
Add logomaker CTA

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -92,7 +92,7 @@ export class SiteSettingsFormGeneral extends Component {
 		} = this.props;
 
 		return (
-			<div>
+			<>
 				<div className="site-settings__site-options">
 					<div className="site-settings__site-title-tagline">
 						<FormFieldset>
@@ -153,7 +153,7 @@ export class SiteSettingsFormGeneral extends Component {
 						</Button>
 					</div>
 				</div>
-			</div>
+			</>
 		);
 	}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import { flowRight, get, has } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
@@ -91,37 +92,66 @@ export class SiteSettingsFormGeneral extends Component {
 		} = this.props;
 
 		return (
-			<div className="site-settings__site-options">
-				<div className="site-settings__site-title-tagline">
-					<FormFieldset>
-						<FormLabel htmlFor="blogname">{ translate( 'Site title' ) }</FormLabel>
-						<FormInput
-							name="blogname"
-							id="blogname"
-							data-tip-target="site-title-input"
-							value={ fields.blogname || '' }
-							onChange={ onChangeField( 'blogname' ) }
-							disabled={ isRequestingSettings }
-							onClick={ eventTracker( 'Clicked Site Title Field' ) }
-							onKeyPress={ uniqueEventTracker( 'Typed in Site Title Field' ) }
+			<>
+				<div className="site-settings__site-options">
+					<div className="site-settings__site-title-tagline">
+						<FormFieldset>
+							<FormLabel htmlFor="blogname">{ translate( 'Site title' ) }</FormLabel>
+							<FormInput
+								name="blogname"
+								id="blogname"
+								data-tip-target="site-title-input"
+								value={ fields.blogname || '' }
+								onChange={ onChangeField( 'blogname' ) }
+								disabled={ isRequestingSettings }
+								onClick={ eventTracker( 'Clicked Site Title Field' ) }
+								onKeyPress={ uniqueEventTracker( 'Typed in Site Title Field' ) }
+							/>
+						</FormFieldset>
+						<FormFieldset>
+							<FormLabel htmlFor="blogdescription">{ translate( 'Site tagline' ) }</FormLabel>
+							<FormInput
+								name="blogdescription"
+								id="blogdescription"
+								data-tip-target="site-tagline-input"
+								value={ fields.blogdescription || '' }
+								onChange={ onChangeField( 'blogdescription' ) }
+								disabled={ isRequestingSettings }
+								onClick={ eventTracker( 'Clicked Site Tagline Field' ) }
+								onKeyPress={ uniqueEventTracker( 'Typed in Site Tagline Field' ) }
+							/>
+							<FormSettingExplanation>
+								{ translate( 'In a few words, explain what this site is about.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+					</div>
+					<SiteIconSetting />
+				</div>
+				<div className="site-settings__fiverr-logo-maker-cta">
+					<div className="site-settings__fiverr-logo-icon">
+						<img
+							className="site-settings__fiverr-logo-cta"
+							src={ fiverrLogo }
+							alt="fiverr small logo"
 						/>
-					</FormFieldset>
-					<FormFieldset>
-						<FormLabel htmlFor="blogdescription">{ translate( 'Site tagline' ) }</FormLabel>
-						<FormInput
-							name="blogdescription"
-							id="blogdescription"
-							data-tip-target="site-tagline-input"
-							value={ fields.blogdescription || '' }
-							onChange={ onChangeField( 'blogdescription' ) }
-							disabled={ isRequestingSettings }
-							onClick={ eventTracker( 'Clicked Site Tagline Field' ) }
-							onKeyPress={ uniqueEventTracker( 'Typed in Site Tagline Field' ) }
-						/>
-						<FormSettingExplanation>
-							{ translate( 'In a few words, explain what this site is about.' ) }
-						</FormSettingExplanation>
-					</FormFieldset>
+					</div>
+					<div className="site-settings__fiverr-logo-maker-cta-text">
+						<div className="site-settings__fiverr-logo-maker-cta-text-title">
+							{ translate( 'Make an incredible logo in minutes' ) }
+						</div>
+						<div className="site-settings__fiverr-logo-maker-cta-text-subhead">
+							{ translate( 'Pre-designed by top talent. Just add your touch.' ) }
+						</div>
+					</div>
+					<div className="site-settings__fiver-cta-button">
+						<Button
+							href={ 'https://wp.me/logo-maker/?utm_campaign=general_settings' }
+							onClick={ this.trackFiverrLogoMakerClick }
+						>
+							<Gridicon icon="external" />
+							{ translate( ' Try Fiverr Logo Maker' ) }
+						</Button>
+					</div>
 				</div>
 				<SiteIconSetting />
 			</div>
@@ -214,6 +244,12 @@ export class SiteSettingsFormGeneral extends Component {
 	trackUpgradeClick = () => {
 		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
 			cta_name: 'settings_site_address',
+		} );
+	};
+
+	trackFiverrLogoMakerClick = () => {
+		this.props.recordTracksEvent( 'calypso_site_icon_fiverr_logo_maker_cta_click', {
+			cta_name: 'site_icon_fiverr_logo_maker',
 		} );
 	};
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -149,7 +149,7 @@ export class SiteSettingsFormGeneral extends Component {
 							onClick={ this.trackFiverrLogoMakerClick }
 						>
 							<Gridicon icon="external" />
-							{ translate( ' Try Fiverr Logo Maker' ) }
+							{ translate( 'Try Fiverr Logo Maker' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -92,7 +92,7 @@ export class SiteSettingsFormGeneral extends Component {
 		} = this.props;
 
 		return (
-			<>
+			<div>
 				<div className="site-settings__site-options">
 					<div className="site-settings__site-title-tagline">
 						<FormFieldset>
@@ -153,7 +153,6 @@ export class SiteSettingsFormGeneral extends Component {
 						</Button>
 					</div>
 				</div>
-				<SiteIconSetting />
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -145,6 +145,7 @@ export class SiteSettingsFormGeneral extends Component {
 					</div>
 					<div className="site-settings__fiver-cta-button">
 						<Button
+							target="_blank"
 							href={ 'https://wp.me/logo-maker/?utm_campaign=general_settings' }
 							onClick={ this.trackFiverrLogoMakerClick }
 						>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -275,6 +275,9 @@
 }
 
 .site-settings__site-options {
+	border-bottom: 1px var( --color-neutral-0 ) solid;
+	border-width: 1px 0;
+	padding-bottom: 10px;
 	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 	}
@@ -285,6 +288,41 @@
 		}
 	}
 }
+
+.site-settings__fiverr-logo-maker-cta {
+	margin-top: 10px;
+	margin-bottom: 20px;
+	display: flex;
+	align-items: center;
+}
+
+.site-settings__fiverr-logo-icon {
+	width: 32px;
+	height: 32px;
+	padding-right: 15px;
+}
+
+.site-settings__fiverr-logo-maker-cta-text-title {
+	line-height: 17.9px;
+	font-weight: 600;
+	font-size: 15px;
+	margin-bottom: 5px;
+}
+
+.site-settings__fiverr-logo-maker-cta-text-subhead {
+	line-height: 15.51px;
+	font-weight: 400;
+	font-size: 13px;
+	margin-top: 5px;
+}
+
+.site-settings__fiver-cta-button {
+	width: 195px;
+	height: 40px;
+	text-align: center;
+	margin-left: auto;
+}
+
 
 .site-settings__site-title-tagline {
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .site-settings {
 	font-size: $font-body-small;
 
@@ -292,27 +295,35 @@
 .site-settings__fiverr-logo-maker-cta {
 	margin-top: 10px;
 	margin-bottom: 20px;
-	display: flex;
-	align-items: center;
+
+	@include break-small {
+		display: flex;
+		align-items: center;
+	}
 }
 
 .site-settings__fiverr-logo-icon {
 	width: 32px;
 	height: 32px;
 	padding-right: 15px;
+	margin-bottom: 10px;
+
+	@include break-small {
+		margin-bottom: 0;
+	}
 }
 
 .site-settings__fiverr-logo-maker-cta-text-title {
 	line-height: 17.9px;
 	font-weight: 600;
-	font-size: 15px;
+	font-size: $font-body-small;
 	margin-bottom: 5px;
 }
 
 .site-settings__fiverr-logo-maker-cta-text-subhead {
 	line-height: 15.51px;
 	font-weight: 400;
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin-top: 5px;
 }
 
@@ -320,9 +331,13 @@
 	width: 195px;
 	height: 40px;
 	text-align: center;
-	margin-left: auto;
-}
+	margin-top: 10px;
 
+	@include break-small {
+		margin-left: auto;
+		margin-top: 0;
+	}
+}
 
 .site-settings__site-title-tagline {
 	@include breakpoint-deprecated( '>660px' ) {


### PR DESCRIPTION
We are experimenting with adding a button in site options that will allow users an easy way to get to our Fiverr logo maker offering.

#### Changes proposed in this Pull Request

We are adding a CTA button, as well as some text and a small Fiverr logo to encourage people to explore our partnership with Fiverr to build a custom site icon. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Open Settings --> General
<img width="279" alt="Screen Shot 2021-10-27 at 5 34 08 PM" src="https://user-images.githubusercontent.com/48809176/139162370-f73c12a3-a027-4718-8b85-25b843e1243a.png">

Confirm you see the new text, Fiverr logo, and the new button
<img width="734" alt="Screen Shot 2021-10-27 at 5 37 09 PM" src="https://user-images.githubusercontent.com/48809176/139162446-ed4853f5-c280-4cb3-bbf9-1e32df17a33a.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
