### PR TITLE
Domains: Update DomainItem component

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -104,5 +104,6 @@ export const sslStatuses = {
 
 export const domainInfoContext = {
 	DOMAIN_ITEM: 'DOMAIN_ITEM',
+	DOMAIN_ROW: 'DOMAIN_ROW',
 	PAGE_TITLE: 'PAGE_TITLE',
 };

--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -29,7 +29,7 @@ export function getDomainTypeText(
 				return __( 'Connected Domain' );
 			}
 
-			return __( 'Managed by external provider' );
+			return __( 'Registered with an external provider' );
 
 		case domainTypes.REGISTERED:
 			if ( domain?.isPremium ) {

--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -36,6 +36,10 @@ export function getDomainTypeText(
 				return __( 'Premium Domain' );
 			}
 
+			// Registered domains don't show any type text in the domain row component
+			if ( context === domainInfoContext.DOMAIN_ROW ) {
+				return null;
+			}
 			return __( 'Registered Domain' );
 
 		case domainTypes.SITE_REDIRECT:

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -55,6 +55,8 @@ export function resolveDomainStatus(
 					return {
 						statusText: expiresMessage,
 						statusClass: 'status-error',
+						status: 'Expiring soon',
+						statusColor: 'warning',
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
@@ -65,6 +67,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: expiresMessage,
 					statusClass: 'status-warning',
+					status: 'Expiring soon',
+					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
@@ -130,6 +134,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Verifying connection' ),
 					statusClass: 'status-verifying',
+					status: 'Verifying',
+					statusColor: 'ok',
 					icon: 'verifying',
 					listStatusText: status,
 					listStatusClass: 'verifying',
@@ -141,6 +147,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
+					status: 'Action required',
+					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -148,6 +156,8 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
+				status: 'Active',
+				statusColor: 'ok',
 				icon: 'check_circle',
 			};
 
@@ -157,6 +167,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: pendingRenewalMessage,
 					statusClass: 'status-warning',
+					status: 'Renewing',
+					statusColor: 'ok',
 					icon: 'info',
 					listStatusText: pendingRenewalMessage,
 					listStatusClass: 'warning',
@@ -168,6 +180,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Outbound transfer initiated' ),
 					statusClass: 'status-error',
+					status: 'In progress',
+					statusColor: 'ok',
 					icon: 'cached',
 				};
 			}
@@ -176,6 +190,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
+					status: 'Action required',
+					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -184,6 +200,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
+					status: 'Action required',
+					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -192,6 +210,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
+					status: 'Expired',
+					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: translate( 'Expired %(timeSinceExpiry)s', {
 						args: {
@@ -214,6 +234,8 @@ export function resolveDomainStatus(
 					return {
 						statusText: expiresMessage,
 						statusClass: 'status-error',
+						status: 'Expiring soon',
+						statusColor: 'warning',
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
@@ -224,6 +246,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: expiresMessage,
 					statusClass: 'status-warning',
+					status: 'Expiring soon',
+					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
@@ -235,6 +259,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Activating' ),
 					statusClass: 'status-success',
+					status: 'Activating',
+					statusColor: 'ok',
 					icon: 'cloud_upload',
 					listStatusText: translate( 'Activating' ),
 					listStatusClass: 'info',
@@ -246,6 +272,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
+					status: 'Action required',
+					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -254,6 +282,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Parked' ),
 					statusClass: 'status-neutral',
+					status: 'Parked',
+					statusColor: 'warning',
 					icon: 'download_done',
 				};
 			}
@@ -262,6 +292,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Active' ),
 					statusClass: 'status-premium',
+					status: 'Active',
+					statusColor: 'ok',
 					icon: 'check_circle',
 					listStatusClass: 'premium',
 				};
@@ -271,6 +303,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-warning',
+					status: 'Complete setup',
+					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Point to WordPress.com:{{/strong}} To point this domain to your WordPress.com site, you need to update the name servers. {{a}}Update now{{/a}} or do this later.',
@@ -294,6 +328,8 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
+				status: 'Active',
+				statusColor: 'ok',
 				icon: 'check_circle',
 			};
 
@@ -302,6 +338,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
+					status: 'Action required',
+					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -309,6 +347,8 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
+				status: 'Active',
+				statusColor: 'ok',
 				icon: 'check_circle',
 			};
 
@@ -316,6 +356,8 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
+				status: 'Active',
+				statusColor: 'ok',
 				icon: 'check_circle',
 			};
 
@@ -324,6 +366,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-warning',
+					status: 'Action required',
+					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer waiting:{{/strong}} Follow {{a}}these steps{{/a}} by %(beginTransferUntilDate)s to start the transfer.',
@@ -351,6 +395,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Transfer failed' ),
 					statusClass: 'status-error',
+					status: 'Failed',
+					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer failed:{{/strong}} this transfer has failed. {{a}}Learn more{{/a}}',
@@ -364,6 +410,8 @@ export function resolveDomainStatus(
 					return {
 						statusText: translate( 'Transfer in progress' ),
 						statusClass: 'status-success',
+						status: 'In progress',
+						statusColor: 'ok',
 						icon: 'info',
 						listStatusText: translate(
 							'{{strong}}Transfer in progress:{{/strong}} the transfer should be completed by %(transferFinishDate)s. We are waiting for approval from your current domain provider to proceed. {{a}}Learn more{{/a}}',
@@ -376,6 +424,8 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Transfer in progress' ),
 					statusClass: 'status-success',
+					status: 'In progress',
+					statusColor: 'ok',
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer in progress:{{/strong}} We are waiting for approval from your current domain provider to proceed. {{a}}Learn more{{/a}}',
@@ -389,6 +439,8 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Transfer in progress' ),
 				statusClass: 'status-success',
+				status: 'In progress',
+				statusColor: 'ok',
 				icon: 'cached',
 				listStatusText: translate(
 					'{{strong}}Transfer in progress.{{/strong}} {{a}}Learn more{{/a}}',

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -55,7 +55,7 @@ export function resolveDomainStatus(
 					return {
 						statusText: expiresMessage,
 						statusClass: 'status-error',
-						status: 'Expiring soon',
+						status: translate( 'Expiring soon' ),
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
@@ -66,7 +66,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: expiresMessage,
 					statusClass: 'status-warning',
-					status: 'Expiring soon',
+					status: translate( 'Expiring soon' ),
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
@@ -112,6 +112,7 @@ export function resolveDomainStatus(
 					return {
 						statusText: translate( 'Connection error' ),
 						statusClass: 'status-alert',
+						status: translate( 'Verifying' ),
 						icon: 'info',
 						listStatusText: status,
 						listStatusClass: 'alert',
@@ -132,7 +133,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Verifying connection' ),
 					statusClass: 'status-verifying',
-					status: 'Verifying',
+					status: translate( 'Verifying' ),
 					icon: 'verifying',
 					listStatusText: status,
 					listStatusClass: 'verifying',
@@ -144,7 +145,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
-					status: 'Action required',
+					status: translate( 'Action required' ),
 					icon: 'info',
 				};
 			}
@@ -152,7 +153,7 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
-				status: 'Active',
+				status: translate( 'Active' ),
 				icon: 'check_circle',
 			};
 
@@ -162,7 +163,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: pendingRenewalMessage,
 					statusClass: 'status-warning',
-					status: 'Renewing',
+					status: translate( 'Renewing' ),
 					icon: 'info',
 					listStatusText: pendingRenewalMessage,
 					listStatusClass: 'warning',
@@ -174,7 +175,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Outbound transfer initiated' ),
 					statusClass: 'status-error',
-					status: 'In progress',
+					status: translate( 'In progress' ),
 					icon: 'cached',
 				};
 			}
@@ -183,7 +184,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
-					status: 'Action required',
+					status: translate( 'Action required' ),
 					icon: 'info',
 				};
 			}
@@ -192,7 +193,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
-					status: 'Action required',
+					status: translate( 'Action required' ),
 					icon: 'info',
 				};
 			}
@@ -201,7 +202,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
-					status: 'Expired',
+					status: translate( 'Expired' ),
 					icon: 'info',
 					listStatusText: translate( 'Expired %(timeSinceExpiry)s', {
 						args: {
@@ -224,7 +225,7 @@ export function resolveDomainStatus(
 					return {
 						statusText: expiresMessage,
 						statusClass: 'status-error',
-						status: 'Expiring soon',
+						status: translate( 'Expiring soon' ),
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
@@ -235,7 +236,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: expiresMessage,
 					statusClass: 'status-warning',
-					status: 'Expiring soon',
+					status: translate( 'Expiring soon' ),
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
@@ -247,7 +248,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Activating' ),
 					statusClass: 'status-success',
-					status: 'Activating',
+					status: translate( 'Activating' ),
 					icon: 'cloud_upload',
 					listStatusText: translate( 'Activating' ),
 					listStatusClass: 'info',
@@ -259,7 +260,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
-					status: 'Action required',
+					status: translate( 'Action required' ),
 					icon: 'info',
 				};
 			}
@@ -268,7 +269,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Parked' ),
 					statusClass: 'status-neutral',
-					status: 'Parked',
+					status: translate( 'Parked' ),
 					icon: 'download_done',
 				};
 			}
@@ -277,7 +278,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Active' ),
 					statusClass: 'status-premium',
-					status: 'Active',
+					status: translate( 'Active' ),
 					icon: 'check_circle',
 					listStatusClass: 'premium',
 				};
@@ -287,7 +288,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-warning',
-					status: 'Complete setup',
+					status: translate( 'Complete setup' ),
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Point to WordPress.com:{{/strong}} To point this domain to your WordPress.com site, you need to update the name servers. {{a}}Update now{{/a}} or do this later.',
@@ -311,7 +312,7 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
-				status: 'Active',
+				status: translate( 'Active' ),
 				icon: 'check_circle',
 			};
 
@@ -320,7 +321,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
-					status: 'Action required',
+					status: translate( 'Action required' ),
 					icon: 'info',
 				};
 			}
@@ -328,7 +329,7 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
-				status: 'Active',
+				status: translate( 'Active' ),
 				icon: 'check_circle',
 			};
 
@@ -336,7 +337,7 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
-				status: 'Active',
+				status: translate( 'Active' ),
 				icon: 'check_circle',
 			};
 
@@ -345,7 +346,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-warning',
-					status: 'Action required',
+					status: translate( 'Action required' ),
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer waiting:{{/strong}} Follow {{a}}these steps{{/a}} by %(beginTransferUntilDate)s to start the transfer.',
@@ -373,7 +374,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Transfer failed' ),
 					statusClass: 'status-error',
-					status: 'Failed',
+					status: translate( 'Failed' ),
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer failed:{{/strong}} this transfer has failed. {{a}}Learn more{{/a}}',
@@ -387,7 +388,7 @@ export function resolveDomainStatus(
 					return {
 						statusText: translate( 'Transfer in progress' ),
 						statusClass: 'status-success',
-						status: 'In progress',
+						status: translate( 'In progress' ),
 						icon: 'info',
 						listStatusText: translate(
 							'{{strong}}Transfer in progress:{{/strong}} the transfer should be completed by %(transferFinishDate)s. We are waiting for approval from your current domain provider to proceed. {{a}}Learn more{{/a}}',
@@ -400,7 +401,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Transfer in progress' ),
 					statusClass: 'status-success',
-					status: 'In progress',
+					status: translate( 'In progress' ),
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer in progress:{{/strong}} We are waiting for approval from your current domain provider to proceed. {{a}}Learn more{{/a}}',
@@ -414,7 +415,7 @@ export function resolveDomainStatus(
 			return {
 				statusText: translate( 'Transfer in progress' ),
 				statusClass: 'status-success',
-				status: 'In progress',
+				status: translate( 'In progress' ),
 				icon: 'cached',
 				listStatusText: translate(
 					'{{strong}}Transfer in progress.{{/strong}} {{a}}Learn more{{/a}}',

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -56,7 +56,6 @@ export function resolveDomainStatus(
 						statusText: expiresMessage,
 						statusClass: 'status-error',
 						status: 'Expiring soon',
-						statusColor: 'warning',
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
@@ -68,7 +67,6 @@ export function resolveDomainStatus(
 					statusText: expiresMessage,
 					statusClass: 'status-warning',
 					status: 'Expiring soon',
-					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
@@ -135,7 +133,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Verifying connection' ),
 					statusClass: 'status-verifying',
 					status: 'Verifying',
-					statusColor: 'ok',
 					icon: 'verifying',
 					listStatusText: status,
 					listStatusClass: 'verifying',
@@ -148,7 +145,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: 'Action required',
-					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -157,7 +153,6 @@ export function resolveDomainStatus(
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
 				status: 'Active',
-				statusColor: 'ok',
 				icon: 'check_circle',
 			};
 
@@ -168,7 +163,6 @@ export function resolveDomainStatus(
 					statusText: pendingRenewalMessage,
 					statusClass: 'status-warning',
 					status: 'Renewing',
-					statusColor: 'ok',
 					icon: 'info',
 					listStatusText: pendingRenewalMessage,
 					listStatusClass: 'warning',
@@ -181,7 +175,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Outbound transfer initiated' ),
 					statusClass: 'status-error',
 					status: 'In progress',
-					statusColor: 'ok',
 					icon: 'cached',
 				};
 			}
@@ -191,7 +184,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: 'Action required',
-					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -201,7 +193,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: 'Action required',
-					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -211,7 +202,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: 'Expired',
-					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: translate( 'Expired %(timeSinceExpiry)s', {
 						args: {
@@ -235,7 +225,6 @@ export function resolveDomainStatus(
 						statusText: expiresMessage,
 						statusClass: 'status-error',
 						status: 'Expiring soon',
-						statusColor: 'warning',
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
@@ -247,7 +236,6 @@ export function resolveDomainStatus(
 					statusText: expiresMessage,
 					statusClass: 'status-warning',
 					status: 'Expiring soon',
-					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
@@ -260,7 +248,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Activating' ),
 					statusClass: 'status-success',
 					status: 'Activating',
-					statusColor: 'ok',
 					icon: 'cloud_upload',
 					listStatusText: translate( 'Activating' ),
 					listStatusClass: 'info',
@@ -273,7 +260,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: 'Action required',
-					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -283,7 +269,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Parked' ),
 					statusClass: 'status-neutral',
 					status: 'Parked',
-					statusColor: 'warning',
 					icon: 'download_done',
 				};
 			}
@@ -293,7 +278,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Active' ),
 					statusClass: 'status-premium',
 					status: 'Active',
-					statusColor: 'ok',
 					icon: 'check_circle',
 					listStatusClass: 'premium',
 				};
@@ -304,7 +288,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-warning',
 					status: 'Complete setup',
-					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Point to WordPress.com:{{/strong}} To point this domain to your WordPress.com site, you need to update the name servers. {{a}}Update now{{/a}} or do this later.',
@@ -329,7 +312,6 @@ export function resolveDomainStatus(
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
 				status: 'Active',
-				statusColor: 'ok',
 				icon: 'check_circle',
 			};
 
@@ -339,7 +321,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: 'Action required',
-					statusColor: 'warning',
 					icon: 'info',
 				};
 			}
@@ -348,7 +329,6 @@ export function resolveDomainStatus(
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
 				status: 'Active',
-				statusColor: 'ok',
 				icon: 'check_circle',
 			};
 
@@ -357,7 +337,6 @@ export function resolveDomainStatus(
 				statusText: translate( 'Active' ),
 				statusClass: 'status-success',
 				status: 'Active',
-				statusColor: 'ok',
 				icon: 'check_circle',
 			};
 
@@ -367,7 +346,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-warning',
 					status: 'Action required',
-					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer waiting:{{/strong}} Follow {{a}}these steps{{/a}} by %(beginTransferUntilDate)s to start the transfer.',
@@ -396,7 +374,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Transfer failed' ),
 					statusClass: 'status-error',
 					status: 'Failed',
-					statusColor: 'warning',
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer failed:{{/strong}} this transfer has failed. {{a}}Learn more{{/a}}',
@@ -411,7 +388,6 @@ export function resolveDomainStatus(
 						statusText: translate( 'Transfer in progress' ),
 						statusClass: 'status-success',
 						status: 'In progress',
-						statusColor: 'ok',
 						icon: 'info',
 						listStatusText: translate(
 							'{{strong}}Transfer in progress:{{/strong}} the transfer should be completed by %(transferFinishDate)s. We are waiting for approval from your current domain provider to proceed. {{a}}Learn more{{/a}}',
@@ -425,7 +401,6 @@ export function resolveDomainStatus(
 					statusText: translate( 'Transfer in progress' ),
 					statusClass: 'status-success',
 					status: 'In progress',
-					statusColor: 'ok',
 					icon: 'info',
 					listStatusText: translate(
 						'{{strong}}Transfer in progress:{{/strong}} We are waiting for approval from your current domain provider to proceed. {{a}}Learn more{{/a}}',
@@ -440,7 +415,6 @@ export function resolveDomainStatus(
 				statusText: translate( 'Transfer in progress' ),
 				statusClass: 'status-success',
 				status: 'In progress',
-				statusColor: 'ok',
 				icon: 'cached',
 				listStatusText: translate(
 					'{{strong}}Transfer in progress.{{/strong}} {{a}}Learn more{{/a}}',

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -68,10 +68,15 @@ class DomainRow extends PureComponent {
 
 	renderDomainName() {
 		const { domain, domainDetails, isManagingAllSites, translate } = this.props;
+		const domainTypeText = getDomainTypeText(
+			domainDetails,
+			translate,
+			domainInfoContext.DOMAIN_ROW
+		);
 		return (
 			<div className="domain-row__domain-cell">
 				<span className="domain-row__domain-name">{ domain.domain }</span>
-				<div>{ getDomainTypeText( domainDetails, translate, domainInfoContext.DOMAIN_ROW ) }</div>
+				{ domainTypeText && <div>{ domainTypeText }</div> }
 				{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,4 +1,5 @@
 import { Button, CompactCard } from '@automattic/components';
+import { Icon, home } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -413,8 +414,8 @@ class DomainRow extends PureComponent {
 
 	renderPrimaryBadge() {
 		return (
-			<Badge className="domain-item__primary-badge" type="info-green">
-				{ this.props.translate( 'Primary site address' ) }
+			<Badge className="domain-row__primary-badge" type="info-green">
+				<Icon icon={ home } size={ 14 } /> { this.props.translate( 'Primary site address' ) }
 			</Badge>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -369,15 +369,16 @@ class DomainRow extends PureComponent {
 			<div className="domain-row">
 				<div className="domain-row__mobile-container">
 					{ this.renderDomainName( domainTypeText ) }
-					<div className="domain-row__mobile-status-container">
-						{ this.renderDomainStatus() }
-						{ this.renderExpiryDate( expiryDate ) }
-						{ this.renderMobileExtraInfo( expiryDate, domainTypeText ) }
-					</div>
+					{ this.renderDomainStatus() }
+					{ this.renderExpiryDate( expiryDate ) }
 					{ this.renderAutoRenew() }
 					{ this.renderEmail() }
+					{ this.renderEllipsisMenu() }
 				</div>
-				{ this.renderEllipsisMenu() }
+				<div className="domain-row__mobile-container2">
+					{ this.renderDomainStatus() }
+					{ this.renderMobileExtraInfo( expiryDate, domainTypeText ) }
+				</div>
 				{ this.renderOverlay() }
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -332,21 +332,19 @@ class DomainRow extends PureComponent {
 
 	busyMessage() {
 		if ( this.props.isBusy && this.props.busyMessage ) {
-			return <div className="domain-item__busy-message">{ this.props.busyMessage }</div>;
+			return <div className="domain-row__busy-message">{ this.props.busyMessage }</div>;
 		}
 	}
 
 	renderOverlay() {
-		const { isBusy } = this.props;
-		if ( isBusy ) {
-			return (
-				<div className="domain-item__overlay">
+		return (
+			this.props.isBusy && (
+				<div className="domain-row__overlay">
 					{ this.busyMessage() }
-					<Spinner className="domain-item__spinner" size={ 20 } />
+					<Spinner size={ 20 } />
 				</div>
-			);
-		}
-		return null;
+			)
+		);
 	}
 
 	renderActionResult() {

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -80,7 +80,8 @@ class DomainRow extends PureComponent {
 	renderPrimaryBadge() {
 		return (
 			<Badge className="domain-row__primary-badge" type="info-green">
-				<Icon icon={ home } size={ 14 } /> { this.props.translate( 'Primary site address' ) }
+				<Icon icon={ home } size={ 14 } />
+				{ this.props.translate( 'Primary site address' ) }
 			</Badge>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -146,7 +146,7 @@ class DomainRow extends PureComponent {
 		const { translate, domainDetails } = this.props;
 
 		if ( ! this.shouldShowAutoRenewStatus() ) {
-			return <span className="domain-row__auto-renew-cell"></span>;
+			return <span className="domain-row__auto-renew-cell">-</span>;
 		}
 
 		const autoRenewLabel = domainDetails?.isAutoRenewing
@@ -249,7 +249,7 @@ class DomainRow extends PureComponent {
 		const { translate } = this.props;
 
 		if ( [ domainTypes.MAPPED, domainTypes.REGISTERED ].indexOf( domainDetails.type ) === -1 ) {
-			return <span className="domain-row__email-cell"></span>;
+			return <span className="domain-row__email-cell">-</span>;
 		}
 
 		if ( hasGSuiteWithUs( domainDetails ) ) {
@@ -296,7 +296,7 @@ class DomainRow extends PureComponent {
 		}
 
 		if ( ! canCurrentUserAddEmail( domainDetails ) ) {
-			return <span className="domain-row__email-cell"></span>;
+			return <span className="domain-row__email-cell">-</span>;
 		}
 
 		return (
@@ -467,7 +467,7 @@ class DomainRow extends PureComponent {
 					{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
 				</div>
 				<div className="domain-row__status-cell">status</div>
-				<div className="domain-row__registered-until-cell">{ expiryDate }</div>
+				<div className="domain-row__registered-until-cell">{ expiryDate || '-' }</div>
 				{ this.renderAutoRenew() }
 				{ this.renderEmail( domainDetails ) }
 				{ /* 

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -144,7 +144,7 @@ class DomainRow extends PureComponent {
 	}
 
 	renderAutoRenew() {
-		const { site, purchase, translate, domainDetails } = this.props;
+		const { site, purchase } = this.props;
 
 		if ( ! this.shouldShowAutoRenewStatus() ) {
 			return <span className="domain-row__auto-renew-cell">-</span>;
@@ -188,34 +188,37 @@ class DomainRow extends PureComponent {
 					onClick={ this.stopPropagation }
 					toggleTitle={ translate( 'Options' ) }
 				>
+					<PopoverMenuItem icon="domains">{ translate( 'View settings' ) }</PopoverMenuItem>
 					{ this.canSetAsPrimary() && (
-						<PopoverMenuItem icon="domains" onClick={ this.makePrimary }>
-							{ translate( 'Make primary address' ) }
+						<PopoverMenuItem onClick={ this.makePrimary }>
+							{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
+							<Icon icon={ home } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+							{ /* eslint-enable wpcalypso/jsx-classname-namespace */ }
+							{ translate( 'Make primary site address' ) }
 						</PopoverMenuItem>
 					) }
-					{ this.canRenewDomain() && (
+					{ /* { this.canRenewDomain() && (
 						<PopoverMenuItem icon="refresh" onClick={ this.renewDomain }>
 							{ translate( 'Renew now' ) }
 						</PopoverMenuItem>
-					) }
-					<PopoverMenuItem icon="pencil">{ translate( 'Edit settings' ) }</PopoverMenuItem>
-					{ domain.type === domainTypes.MAPPED && (
+					) } */ }
+					{ /* { domain.type === domainTypes.MAPPED && (
 						<PopoverMenuItem
 							icon="list-unordered"
 							href={ domainManagementDns( site.slug, domain.domain, currentRoute ) }
 						>
 							{ translate( 'DNS Records' ) }
 						</PopoverMenuItem>
-					) }
-					{ domain.type === domainTypes.WPCOM && ! domainDetails?.isWpcomStagingDomain && (
+					) } */ }
+					{ /* { domain.type === domainTypes.WPCOM && ! domainDetails?.isWpcomStagingDomain && (
 						<PopoverMenuItem
 							icon="reblog"
 							href={ domainManagementChangeSiteAddress( site.slug, domain.domain, currentRoute ) }
 						>
 							{ translate( 'Change site address' ) }
 						</PopoverMenuItem>
-					) }
-					{ domain.type === domainTypes.REGISTERED &&
+					) } */ }
+					{ /* { domain.type === domainTypes.REGISTERED &&
 						( isDomainUpdateable( domainDetails ) || isDomainInGracePeriod( domainDetails ) ) && (
 							<PopoverMenuItem
 								icon="domains"
@@ -223,8 +226,8 @@ class DomainRow extends PureComponent {
 							>
 								{ translate( 'Name servers' ) }
 							</PopoverMenuItem>
-						) }
-					{ domain.type === domainTypes.REGISTERED &&
+						) } */ }
+					{ /* { domain.type === domainTypes.REGISTERED &&
 						( isDomainUpdateable( domainDetails ) || isDomainInGracePeriod( domainDetails ) ) && (
 							<PopoverMenuItem
 								icon="reader"
@@ -232,8 +235,8 @@ class DomainRow extends PureComponent {
 							>
 								{ translate( 'Contact information' ) }
 							</PopoverMenuItem>
-						) }
-					{ domain.type === domainTypes.REGISTERED &&
+						) } */ }
+					{ /* { domain.type === domainTypes.REGISTERED &&
 						! ( domainDetails?.expired && ! isDomainInGracePeriod( domainDetails ) ) && (
 							<PopoverMenuItem
 								icon="reply"
@@ -241,8 +244,8 @@ class DomainRow extends PureComponent {
 							>
 								{ translate( 'Transfer domain' ) }
 							</PopoverMenuItem>
-						) }
-					{ [ domainTypes.REGISTERED, domainTypes.MAPPED ].includes( domain.type ) &&
+						) } */ }
+					{ /* { [ domainTypes.REGISTERED, domainTypes.MAPPED ].includes( domain.type ) &&
 						domainDetails?.pointsToWpcom &&
 						domainDetails?.sslStatus && (
 							<PopoverMenuItem
@@ -251,7 +254,7 @@ class DomainRow extends PureComponent {
 							>
 								{ translate( 'Security' ) }
 							</PopoverMenuItem>
-						) }
+						) } */ }
 				</EllipsisMenu>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { Icon, home } from '@wordpress/icons';
+import { Icon, home, moreVertical } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import page from 'page';
@@ -264,6 +264,7 @@ class DomainRow extends PureComponent {
 					disabled={ disabled || isBusy }
 					onClick={ ( e ) => e.stopPropagation() }
 					toggleTitle={ translate( 'Options' ) }
+					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
 				>
 					<PopoverMenuItem icon="domains">{ translate( 'View settings' ) }</PopoverMenuItem>
 					{ this.canSetAsPrimary() && (

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -51,6 +51,10 @@ class DomainRow extends PureComponent {
 		showDomainDetails: true,
 	};
 
+	stopPropagation = ( event ) => {
+		event.stopPropagation();
+	};
+
 	hasMappingError( domain ) {
 		const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
 		return (
@@ -145,7 +149,7 @@ class DomainRow extends PureComponent {
 
 		return (
 			/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
-			<div className="domain-row__auto-renew-cell" onClick={ ( e ) => e.stopPropagation() }>
+			<div className="domain-row__auto-renew-cell" onClick={ this.stopPropagation }>
 				<AutoRenewToggle
 					planName={ site.plan.product_name_short }
 					siteDomain={ site.domain }
@@ -293,7 +297,7 @@ class DomainRow extends PureComponent {
 			<div className="domain-row__action-cell">
 				<EllipsisMenu
 					disabled={ disabled || isBusy }
-					onClick={ ( e ) => e.stopPropagation() }
+					onClick={ this.stopPropagation }
 					toggleTitle={ translate( 'Options' ) }
 					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
 					popoverClassName="domain-row__popover"

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -151,7 +151,11 @@ class DomainRow extends PureComponent {
 		}
 
 		if ( ! purchase ) {
-			return <span className="domain-row__auto-renew-cell">ldng</span>;
+			return (
+				<span className="domain-row__auto-renew-cell">
+					<p className="domain-row__auto-renew-placeholder" />
+				</span>
+			);
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -302,11 +302,15 @@ class DomainRow extends PureComponent {
 
 		return (
 			<div className="domain-row" onClick={ this.handleClick }>
-				{ this.renderDomainName() }
-				{ this.renderDomainStatus( status, statusClass ) }
-				{ this.renderExpiryDate() }
-				{ this.renderAutoRenew() }
-				{ this.renderEmail() }
+				<div className="domain-row__mobile-container">
+					{ this.renderDomainName() }
+					<div className="domain-row__mobile-status-container">
+						{ this.renderDomainStatus( status, statusClass ) }
+						{ this.renderExpiryDate() }
+					</div>
+					{ this.renderAutoRenew() }
+					{ this.renderEmail() }
+				</div>
 				{ this.renderEllipsisMenu() }
 				{ this.renderOverlay() }
 			</div>

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -90,7 +90,13 @@ class DomainRow extends PureComponent {
 		);
 	}
 
-	renderDomainStatus( status, statusClass ) {
+	renderDomainStatus() {
+		const { domain, domainDetails, site } = this.props;
+		const { status, statusClass } = resolveDomainStatus( domainDetails || domain, null, {
+			siteSlug: site?.slug,
+			hasMappingError: this.hasMappingError( domain ),
+		} );
+
 		return (
 			<div className="domain-row__status-cell">
 				<span className={ `domain-row__${ statusClass }-dot` }></span> { status }
@@ -327,18 +333,12 @@ class DomainRow extends PureComponent {
 	}
 
 	render() {
-		const { domain, domainDetails, site } = this.props;
-		const { status, statusClass } = resolveDomainStatus( domainDetails || domain, null, {
-			siteSlug: site?.slug,
-			hasMappingError: this.hasMappingError( domain ),
-		} );
-
 		return (
 			<div className="domain-row" onClick={ this.handleClick }>
 				<div className="domain-row__mobile-container">
 					{ this.renderDomainName() }
 					<div className="domain-row__mobile-status-container">
-						{ this.renderDomainStatus( status, statusClass ) }
+						{ this.renderDomainStatus() }
 						{ this.renderExpiryDateOrExtraInfo() }
 					</div>
 					{ this.renderAutoRenew() }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -55,15 +55,6 @@ class DomainRow extends PureComponent {
 		event.stopPropagation();
 	};
 
-	hasMappingError( domain ) {
-		const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
-		return (
-			domain.type === domainTypes.MAPPED &&
-			! domain.pointsToWpcom &&
-			moment.utc().isAfter( registrationDatePlus3Days )
-		);
-	}
-
 	handleClick = () => {
 		const { onClick, domainDetails } = this.props;
 		onClick( domainDetails );
@@ -99,7 +90,7 @@ class DomainRow extends PureComponent {
 		const { domain, domainDetails, site } = this.props;
 		const { status, statusClass } = resolveDomainStatus( domainDetails || domain, null, {
 			siteSlug: site?.slug,
-			hasMappingError: this.hasMappingError( domain ),
+			getMappingErrors: true,
 		} );
 
 		return (

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -170,13 +170,17 @@ class DomainRow extends PureComponent {
 	};
 
 	renderEmail() {
+		return <span className="domain-row__email-cell">{ this.renderEmailLabel() }</span>;
+	}
+
+	/* eslint-disable jsx-a11y/anchor-is-valid */
+	renderEmailLabel = () => {
 		const { domainDetails, translate } = this.props;
 
 		if ( [ domainTypes.MAPPED, domainTypes.REGISTERED ].indexOf( domainDetails.type ) === -1 ) {
-			return <span className="domain-row__email-cell">-</span>;
+			return null;
 		}
 
-		/* eslint-disable jsx-a11y/anchor-is-valid */
 		if ( hasGSuiteWithUs( domainDetails ) ) {
 			const gSuiteMailboxCount = getGSuiteMailboxCount( domainDetails );
 
@@ -192,11 +196,9 @@ class DomainRow extends PureComponent {
 				}
 			);
 			return (
-				<span className="domain-row__email-cell">
-					<a href="#" onClick={ this.goToEmailPage }>
-						{ text }
-					</a>
-				</span>
+				<a href="#" onClick={ this.goToEmailPage }>
+					{ text }
+				</a>
 			);
 		}
 
@@ -211,11 +213,9 @@ class DomainRow extends PureComponent {
 				comment: '%(titanMailboxCount)d is the number of mailboxes for the current domain',
 			} );
 			return (
-				<span className="domain-row__email-cell">
-					<a href="#" onClick={ this.goToEmailPage }>
-						{ text }
-					</a>
-				</span>
+				<a href="#" onClick={ this.goToEmailPage }>
+					{ text }
+				</a>
 			);
 		}
 
@@ -230,27 +230,23 @@ class DomainRow extends PureComponent {
 				comment: 'The number of email forwards active for the current domain',
 			} );
 			return (
-				<span className="domain-row__email-cell">
-					<a href="#" onClick={ this.goToEmailPage }>
-						{ text }
-					</a>
-				</span>
+				<a href="#" onClick={ this.goToEmailPage }>
+					{ text }
+				</a>
 			);
 		}
 
 		if ( ! canCurrentUserAddEmail( domainDetails ) ) {
-			return <span className="domain-row__email-cell">-</span>;
+			return null;
 		}
 
 		return (
-			<span className="domain-row__email-cell">
-				<a href="#" onClick={ this.addEmailClick }>
-					{ translate( 'Add +', { context: 'Button label' } ) }
-				</a>
-			</span>
+			<a href="#" onClick={ this.addEmailClick }>
+				{ translate( 'Add +', { context: 'Button label' } ) }
+			</a>
 		);
-		/* eslint-enable jsx-a11y/anchor-is-valid */
-	}
+	};
+	/* eslint-enable jsx-a11y/anchor-is-valid */
 
 	addEmailClick = ( event ) => {
 		const { trackAddEmailClick, domain } = this.props;

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -76,7 +76,7 @@ class DomainRow extends PureComponent {
 		return (
 			<div className="domain-row__domain-cell">
 				<div className="domain-row__domain-name">{ domain.domain }</div>
-				{ domainTypeText && <div>{ domainTypeText }</div> }
+				{ domainTypeText && <div className="domain-row__domain-type-text">{ domainTypeText }</div> }
 				{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
 			</div>
 		);
@@ -101,7 +101,27 @@ class DomainRow extends PureComponent {
 	renderExpiryDate() {
 		const { domain, domainDetails } = this.props;
 		const expiryDate = moment.utc( domainDetails?.expiry || domain?.expiry ).format( 'LL' );
-		return <div className="domain-row__registered-until-cell">{ expiryDate || '-' }</div>;
+
+		return [
+			<div className="domain-row__registered-until-cell">{ expiryDate || '-' }</div>,
+			<div className="domain-row__mobile-extra-info-cell">
+				{ this.renderMobileExtraInfo( expiryDate ) }
+			</div>,
+		];
+	}
+
+	renderMobileExtraInfo( expiryDate ) {
+		const { domain, domainDetails, isManagingAllSites, translate } = this.props;
+		const domainTypeText = getDomainTypeText(
+			domainDetails,
+			translate,
+			domainInfoContext.DOMAIN_ROW
+		);
+
+		if ( domainTypeText ) {
+			return domainTypeText;
+		}
+		return 'Expires on ' + expiryDate;
 	}
 
 	renderAutoRenew() {

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -19,7 +19,7 @@ import {
 	getDomainTypeText,
 	resolveDomainStatus,
 } from 'calypso/lib/domains';
-import { type as domainTypes } from 'calypso/lib/domains/constants';
+import { type as domainTypes, domainInfoContext } from 'calypso/lib/domains/constants';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import { handleRenewNowClick } from 'calypso/lib/purchases';
@@ -428,6 +428,15 @@ class DomainRow extends PureComponent {
 		);
 	}
 
+	getSiteMeta2() {
+		const { domainDetails, translate } = this.props;
+		return (
+			<Fragment>
+				{ getDomainTypeText( domainDetails, translate, domainInfoContext.DOMAIN_ROW ) }
+			</Fragment>
+		);
+	}
+
 	render() {
 		const {
 			domain,
@@ -452,8 +461,8 @@ class DomainRow extends PureComponent {
 		return (
 			<div className={ rowClasses } onClick={ this.handleClick }>
 				<div className="domain-row__domain-cell">
-					<div>{ domain.domain }</div>
-					<div>{ this.getSiteMeta() }</div>
+					<span className="domain-row__domain-name">{ domain.domain }</span>
+					<div>{ this.getSiteMeta2() }</div>
 					{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
 				</div>
 				<div className="domain-row__status-cell">status</div>

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -266,6 +266,7 @@ class DomainRow extends PureComponent {
 					onClick={ ( e ) => e.stopPropagation() }
 					toggleTitle={ translate( 'Options' ) }
 					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
+					popoverClassName="domain-row__popover"
 				>
 					<PopoverMenuItem icon="domains">{ translate( 'View settings' ) }</PopoverMenuItem>
 					{ this.canSetAsPrimary() && (

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -85,10 +85,10 @@ class DomainRow extends PureComponent {
 		);
 	}
 
-	renderDomainStatus( status, statusColor ) {
+	renderDomainStatus( status, statusClass ) {
 		return (
 			<div className="domain-row__status-cell">
-				<span className={ `domain-row__${ statusColor }-dot` }></span> { status }
+				<span className={ `domain-row__${ statusClass }-dot` }></span> { status }
 			</div>
 		);
 	}
@@ -295,7 +295,7 @@ class DomainRow extends PureComponent {
 
 	render() {
 		const { domain, domainDetails, site } = this.props;
-		const { status, statusColor } = resolveDomainStatus( domainDetails || domain, null, {
+		const { status, statusClass } = resolveDomainStatus( domainDetails || domain, null, {
 			siteSlug: site?.slug,
 			hasMappingError: this.hasMappingError( domain ),
 		} );
@@ -303,7 +303,7 @@ class DomainRow extends PureComponent {
 		return (
 			<div className="domain-row" onClick={ this.handleClick }>
 				{ this.renderDomainName() }
-				{ this.renderDomainStatus( status, statusColor ) }
+				{ this.renderDomainStatus( status, statusClass ) }
 				{ this.renderExpiryDate() }
 				{ this.renderAutoRenew() }
 				{ this.renderEmail() }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -70,7 +70,13 @@ class DomainRow extends PureComponent {
 		const { domain, domainDetails, isManagingAllSites } = this.props;
 		return (
 			<div className="domain-row__domain-cell">
-				<div className="domain-row__domain-name">{ domain.domain }</div>
+				<div className="domain-row__domain-name">
+					{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
+					<a href="#" onClick={ this.handleClick }>
+						{ domain.domain }
+					</a>
+					{ /* eslint-enable jsx-a11y/anchor-is-valid */ }
+				</div>
 				{ domainTypeText && <div className="domain-row__domain-type-text">{ domainTypeText }</div> }
 				{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
 			</div>
@@ -268,7 +274,9 @@ class DomainRow extends PureComponent {
 					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
 					popoverClassName="domain-row__popover"
 				>
-					<PopoverMenuItem icon="domains">{ translate( 'View settings' ) }</PopoverMenuItem>
+					<PopoverMenuItem icon="domains" onClick={ this.handleClick }>
+						{ translate( 'View settings' ) }
+					</PopoverMenuItem>
 					{ this.canSetAsPrimary() && (
 						<PopoverMenuItem onClick={ this.makePrimary }>
 							{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
@@ -329,7 +337,7 @@ class DomainRow extends PureComponent {
 		const expiryDate = moment.utc( domainDetails?.expiry || domain?.expiry );
 
 		return (
-			<div className="domain-row" onClick={ this.handleClick }>
+			<div className="domain-row">
 				<div className="domain-row__mobile-container">
 					{ this.renderDomainName( domainTypeText ) }
 					<div className="domain-row__mobile-status-container">

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -42,7 +42,6 @@ class DomainRow extends PureComponent {
 		isLoadingDomainDetails: PropTypes.bool,
 		selectionIndex: PropTypes.number,
 		showDomainDetails: PropTypes.bool,
-		actionResult: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -225,7 +224,7 @@ class DomainRow extends PureComponent {
 		} = this.props;
 
 		if ( ! showDomainDetails ) {
-			return;
+			return <div className="domain-row__action-cell"></div>;
 		}
 
 		if ( isLoadingDomainDetails || ! domainDetails ) {

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -15,8 +15,6 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import Spinner from 'calypso/components/spinner';
 import {
 	canCurrentUserAddEmail,
-	isDomainInGracePeriod,
-	isDomainUpdateable,
 	getDomainTypeText,
 	resolveDomainStatus,
 } from 'calypso/lib/domains';
@@ -28,14 +26,6 @@ import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { withoutHttp } from 'calypso/lib/url';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import DomainNotice from 'calypso/my-sites/domains/domain-management/components/domain-notice';
-import {
-	domainManagementChangeSiteAddress,
-	domainManagementContactsPrivacy,
-	domainManagementNameServers,
-	domainManagementTransfer,
-	domainManagementDns,
-	domainManagementSecurity,
-} from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -112,10 +102,9 @@ class DomainRow extends PureComponent {
 	};
 
 	makePrimary = ( event ) => {
-		const { domainDetails, selectionIndex, onMakePrimaryClick } = this.props;
-
 		event.stopPropagation();
 
+		const { domainDetails, selectionIndex, onMakePrimaryClick } = this.props;
 		if ( onMakePrimaryClick ) {
 			onMakePrimaryClick( selectionIndex, domainDetails );
 		}
@@ -183,7 +172,7 @@ class DomainRow extends PureComponent {
 	};
 
 	renderOptionsButton() {
-		const { disabled, isBusy, site, domain, domainDetails, currentRoute, translate } = this.props;
+		const { disabled, isBusy, translate } = this.props;
 
 		return (
 			<div className="domain-row__action-cell">
@@ -201,64 +190,6 @@ class DomainRow extends PureComponent {
 							{ translate( 'Make primary site address' ) }
 						</PopoverMenuItem>
 					) }
-					{ /* { this.canRenewDomain() && (
-						<PopoverMenuItem icon="refresh" onClick={ this.renewDomain }>
-							{ translate( 'Renew now' ) }
-						</PopoverMenuItem>
-					) } */ }
-					{ /* { domain.type === domainTypes.MAPPED && (
-						<PopoverMenuItem
-							icon="list-unordered"
-							href={ domainManagementDns( site.slug, domain.domain, currentRoute ) }
-						>
-							{ translate( 'DNS Records' ) }
-						</PopoverMenuItem>
-					) } */ }
-					{ /* { domain.type === domainTypes.WPCOM && ! domainDetails?.isWpcomStagingDomain && (
-						<PopoverMenuItem
-							icon="reblog"
-							href={ domainManagementChangeSiteAddress( site.slug, domain.domain, currentRoute ) }
-						>
-							{ translate( 'Change site address' ) }
-						</PopoverMenuItem>
-					) } */ }
-					{ /* { domain.type === domainTypes.REGISTERED &&
-						( isDomainUpdateable( domainDetails ) || isDomainInGracePeriod( domainDetails ) ) && (
-							<PopoverMenuItem
-								icon="domains"
-								href={ domainManagementNameServers( site.slug, domain.domain, currentRoute ) }
-							>
-								{ translate( 'Name servers' ) }
-							</PopoverMenuItem>
-						) } */ }
-					{ /* { domain.type === domainTypes.REGISTERED &&
-						( isDomainUpdateable( domainDetails ) || isDomainInGracePeriod( domainDetails ) ) && (
-							<PopoverMenuItem
-								icon="reader"
-								href={ domainManagementContactsPrivacy( site.slug, domain.domain, currentRoute ) }
-							>
-								{ translate( 'Contact information' ) }
-							</PopoverMenuItem>
-						) } */ }
-					{ /* { domain.type === domainTypes.REGISTERED &&
-						! ( domainDetails?.expired && ! isDomainInGracePeriod( domainDetails ) ) && (
-							<PopoverMenuItem
-								icon="reply"
-								href={ domainManagementTransfer( site.slug, domain.domain, currentRoute ) }
-							>
-								{ translate( 'Transfer domain' ) }
-							</PopoverMenuItem>
-						) } */ }
-					{ /* { [ domainTypes.REGISTERED, domainTypes.MAPPED ].includes( domain.type ) &&
-						domainDetails?.pointsToWpcom &&
-						domainDetails?.sslStatus && (
-							<PopoverMenuItem
-								icon="lock"
-								href={ domainManagementSecurity( site.slug, domain.domain, currentRoute ) }
-							>
-								{ translate( 'Security' ) }
-							</PopoverMenuItem>
-						) } */ }
 				</EllipsisMenu>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -98,20 +98,20 @@ class DomainRow extends PureComponent {
 		);
 	}
 
-	renderExpiryDate() {
+	renderExpiryDateOrExtraInfo() {
 		const { domain, domainDetails } = this.props;
 		const expiryDate = moment.utc( domainDetails?.expiry || domain?.expiry ).format( 'LL' );
 
-		return [
-			<div className="domain-row__registered-until-cell">{ expiryDate || '-' }</div>,
-			<div className="domain-row__mobile-extra-info-cell">
-				{ this.renderMobileExtraInfo( expiryDate ) }
-			</div>,
-		];
+		return (
+			<>
+				<div className="domain-row__registered-until-cell">{ expiryDate || '-' }</div>
+				<div className="domain-row__mobile-extra-info-cell">{ this.renderMobileExtraInfo() }</div>
+			</>
+		);
 	}
 
-	renderMobileExtraInfo( expiryDate ) {
-		const { domain, domainDetails, isManagingAllSites, translate } = this.props;
+	renderMobileExtraInfo() {
+		const { domain, domainDetails, translate } = this.props;
 		const domainTypeText = getDomainTypeText(
 			domainDetails,
 			translate,
@@ -121,7 +121,15 @@ class DomainRow extends PureComponent {
 		if ( domainTypeText ) {
 			return domainTypeText;
 		}
-		return 'Expires on ' + expiryDate;
+
+		const expiryDate = moment.utc( domainDetails?.expiry || domain?.expiry );
+		if ( domain.expired ) {
+			return 'Expired on ' + expiryDate.format( 'LL' );
+		}
+		if ( domain.isAutoRenewing && domain.autoRenewalDate ) {
+			return 'Renews on ' + moment.utc( domain.autoRenewalDate ).format( 'LL' );
+		}
+		return 'Expires on ' + expiryDate.format( 'LL' );
 	}
 
 	renderAutoRenew() {
@@ -331,7 +339,7 @@ class DomainRow extends PureComponent {
 					{ this.renderDomainName() }
 					<div className="domain-row__mobile-status-container">
 						{ this.renderDomainStatus( status, statusClass ) }
-						{ this.renderExpiryDate() }
+						{ this.renderExpiryDateOrExtraInfo() }
 					</div>
 					{ this.renderAutoRenew() }
 					{ this.renderEmail() }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,0 +1,498 @@
+import { Button, CompactCard } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import moment from 'moment';
+import page from 'page';
+import PropTypes from 'prop-types';
+import { Fragment, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import Badge from 'calypso/components/badge';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import InfoPopover from 'calypso/components/info-popover';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import Spinner from 'calypso/components/spinner';
+import {
+	canCurrentUserAddEmail,
+	isDomainInGracePeriod,
+	isDomainUpdateable,
+	getDomainTypeText,
+	resolveDomainStatus,
+} from 'calypso/lib/domains';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
+import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
+import { handleRenewNowClick } from 'calypso/lib/purchases';
+import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { withoutHttp } from 'calypso/lib/url';
+import DomainNotice from 'calypso/my-sites/domains/domain-management/components/domain-notice';
+import {
+	domainManagementChangeSiteAddress,
+	domainManagementContactsPrivacy,
+	domainManagementNameServers,
+	domainManagementTransfer,
+	domainManagementDns,
+	domainManagementSecurity,
+} from 'calypso/my-sites/domains/paths';
+import { emailManagement } from 'calypso/my-sites/email/paths';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './domain-row.scss';
+
+class DomainRow extends PureComponent {
+	static propTypes = {
+		busyMessage: PropTypes.string,
+		currentRoute: PropTypes.string,
+		disabled: PropTypes.bool,
+		domain: PropTypes.object.isRequired,
+		domainDetails: PropTypes.object,
+		site: PropTypes.object,
+		isManagingAllSites: PropTypes.bool,
+		isBusy: PropTypes.bool,
+		showCheckbox: PropTypes.bool,
+		onClick: PropTypes.func.isRequired,
+		onMakePrimaryClick: PropTypes.func,
+		onToggle: PropTypes.func,
+		shouldUpgradeToMakePrimary: PropTypes.bool,
+		purchase: PropTypes.object,
+		isLoadingDomainDetails: PropTypes.bool,
+		selectionIndex: PropTypes.number,
+		isChecked: PropTypes.bool,
+		showDomainDetails: PropTypes.bool,
+		actionResult: PropTypes.object,
+	};
+
+	static defaultProps = {
+		disabled: false,
+		isManagingAllSites: false,
+		showCheckbox: false,
+		onToggle: null,
+		isLoadingDomainDetails: false,
+		isBusy: false,
+		isChecked: false,
+		showDomainDetails: true,
+	};
+
+	handleClick = () => {
+		const { onClick, domainDetails, showCheckbox, domain, isChecked, onToggle } = this.props;
+
+		onClick( domainDetails );
+		showCheckbox && onToggle( domain.domain, ! isChecked );
+	};
+
+	stopPropagation = ( event ) => {
+		event.stopPropagation();
+	};
+
+	onToggle = ( event ) => {
+		if ( this.props.onToggle ) {
+			this.props.onToggle( this.props.domain.domain, event.target.checked );
+		}
+	};
+
+	addEmailClick = ( event ) => {
+		const { trackAddEmailClick, currentRoute, disabled, domain, site } = this.props;
+		event.stopPropagation();
+
+		trackAddEmailClick( domain ); // analytics/tracks
+
+		if ( disabled ) {
+			return;
+		}
+		page( emailManagement( site.slug, domain.domain, currentRoute ) );
+	};
+
+	renewDomain = ( event ) => {
+		event.stopPropagation();
+
+		const { purchase, site } = this.props;
+		handleRenewNowClick( purchase, site.slug );
+	};
+
+	makePrimary = ( event ) => {
+		const { domainDetails, selectionIndex, onMakePrimaryClick } = this.props;
+
+		event.stopPropagation();
+
+		if ( onMakePrimaryClick ) {
+			onMakePrimaryClick( selectionIndex, domainDetails );
+		}
+	};
+
+	canRenewDomain() {
+		const { domainDetails, purchase } = this.props;
+		return (
+			domainDetails &&
+			purchase &&
+			domainDetails.currentUserCanManage &&
+			[ domainTypes.WPCOM, domainTypes.TRANSFER ].indexOf( domainDetails.type ) === -1 &&
+			! domainDetails.bundledPlanSubscriptionId
+		);
+	}
+
+	canSetAsPrimary() {
+		const { domainDetails, isManagingAllSites, shouldUpgradeToMakePrimary } = this.props;
+		return (
+			! isManagingAllSites &&
+			domainDetails &&
+			domainDetails.canSetAsPrimary &&
+			! domainDetails.isPrimary &&
+			! shouldUpgradeToMakePrimary
+		);
+	}
+
+	renderAutoRenew() {
+		const { translate, domainDetails } = this.props;
+
+		if ( ! this.shouldShowAutoRenewStatus() ) {
+			return;
+		}
+
+		const autoRenewLabel = domainDetails?.isAutoRenewing
+			? translate( '(on)' )
+			: translate( '(off)' );
+		return <span className="domain-row__auto-renew-cell">{ autoRenewLabel }</span>;
+	}
+
+	shouldShowAutoRenewStatus = () => {
+		const { domainDetails } = this.props;
+		if (
+			domainDetails?.type === domainTypes.WPCOM ||
+			domainDetails?.type === domainTypes.TRANSFER
+		) {
+			return false;
+		}
+		return ! domainDetails?.bundledPlanSubscriptionId;
+	};
+
+	renderOptionsButton() {
+		const { disabled, isBusy, site, domain, domainDetails, currentRoute, translate } = this.props;
+
+		return (
+			<div className="domain-row__action-cell">
+				<EllipsisMenu
+					disabled={ disabled || isBusy }
+					onClick={ this.stopPropagation }
+					toggleTitle={ translate( 'Options' ) }
+				>
+					{ this.canSetAsPrimary() && (
+						<PopoverMenuItem icon="domains" onClick={ this.makePrimary }>
+							{ translate( 'Make primary address' ) }
+						</PopoverMenuItem>
+					) }
+					{ this.canRenewDomain() && (
+						<PopoverMenuItem icon="refresh" onClick={ this.renewDomain }>
+							{ translate( 'Renew now' ) }
+						</PopoverMenuItem>
+					) }
+					<PopoverMenuItem icon="pencil">{ translate( 'Edit settings' ) }</PopoverMenuItem>
+					{ domain.type === domainTypes.MAPPED && (
+						<PopoverMenuItem
+							icon="list-unordered"
+							href={ domainManagementDns( site.slug, domain.domain, currentRoute ) }
+						>
+							{ translate( 'DNS Records' ) }
+						</PopoverMenuItem>
+					) }
+					{ domain.type === domainTypes.WPCOM && ! domainDetails?.isWpcomStagingDomain && (
+						<PopoverMenuItem
+							icon="reblog"
+							href={ domainManagementChangeSiteAddress( site.slug, domain.domain, currentRoute ) }
+						>
+							{ translate( 'Change site address' ) }
+						</PopoverMenuItem>
+					) }
+					{ domain.type === domainTypes.REGISTERED &&
+						( isDomainUpdateable( domainDetails ) || isDomainInGracePeriod( domainDetails ) ) && (
+							<PopoverMenuItem
+								icon="domains"
+								href={ domainManagementNameServers( site.slug, domain.domain, currentRoute ) }
+							>
+								{ translate( 'Name servers' ) }
+							</PopoverMenuItem>
+						) }
+					{ domain.type === domainTypes.REGISTERED &&
+						( isDomainUpdateable( domainDetails ) || isDomainInGracePeriod( domainDetails ) ) && (
+							<PopoverMenuItem
+								icon="reader"
+								href={ domainManagementContactsPrivacy( site.slug, domain.domain, currentRoute ) }
+							>
+								{ translate( 'Contact information' ) }
+							</PopoverMenuItem>
+						) }
+					{ domain.type === domainTypes.REGISTERED &&
+						! ( domainDetails?.expired && ! isDomainInGracePeriod( domainDetails ) ) && (
+							<PopoverMenuItem
+								icon="reply"
+								href={ domainManagementTransfer( site.slug, domain.domain, currentRoute ) }
+							>
+								{ translate( 'Transfer domain' ) }
+							</PopoverMenuItem>
+						) }
+					{ [ domainTypes.REGISTERED, domainTypes.MAPPED ].includes( domain.type ) &&
+						domainDetails?.pointsToWpcom &&
+						domainDetails?.sslStatus && (
+							<PopoverMenuItem
+								icon="lock"
+								href={ domainManagementSecurity( site.slug, domain.domain, currentRoute ) }
+							>
+								{ translate( 'Security' ) }
+							</PopoverMenuItem>
+						) }
+				</EllipsisMenu>
+			</div>
+		);
+	}
+
+	renderEmail( domainDetails ) {
+		const { translate } = this.props;
+
+		if ( [ domainTypes.MAPPED, domainTypes.REGISTERED ].indexOf( domainDetails.type ) === -1 ) {
+			return;
+		}
+
+		if ( hasGSuiteWithUs( domainDetails ) ) {
+			const gSuiteMailboxCount = getGSuiteMailboxCount( domainDetails );
+
+			const text = translate(
+				'%(gSuiteMailboxCount)d mailbox',
+				'%(gSuiteMailboxCount)d mailboxes',
+				{
+					count: gSuiteMailboxCount,
+					args: {
+						gSuiteMailboxCount,
+					},
+					comment: 'The number of GSuite mailboxes active for the current domain',
+				}
+			);
+			return <span className="domain-row__email-cell">{ text }</span>;
+		}
+
+		if ( hasTitanMailWithUs( domainDetails ) ) {
+			const titanMailboxCount = getMaxTitanMailboxCount( domainDetails );
+
+			const text = translate( '%(titanMailboxCount)d mailbox', '%(titanMailboxCount)d mailboxes', {
+				args: {
+					titanMailboxCount,
+				},
+				count: titanMailboxCount,
+				comment: '%(titanMailboxCount)d is the number of mailboxes for the current domain',
+			} );
+			return <span className="domain-row__email-cell">{ text }</span>;
+		}
+
+		if ( hasEmailForwards( domainDetails ) ) {
+			const emailForwardsCount = getEmailForwardsCount( domainDetails );
+
+			const text = translate( '%(emailForwardsCount)d forward', '%(emailForwardsCount)d forwards', {
+				count: emailForwardsCount,
+				args: {
+					emailForwardsCount,
+				},
+				comment: 'The number of email forwards active for the current domain',
+			} );
+			return <span className="domain-row__email-cell">{ text }</span>;
+		}
+
+		if ( ! canCurrentUserAddEmail( domainDetails ) ) {
+			return;
+		}
+
+		return (
+			<span className="domain-row__email-cell">
+				<Button compact onClick={ this.addEmailClick } className="domain-row__email-button">
+					{ translate( 'Add +', { context: 'Button label' } ) }
+				</Button>
+			</span>
+		);
+	}
+
+	renderActionItems() {
+		const { isLoadingDomainDetails, domainDetails, showDomainDetails } = this.props;
+
+		if ( ! showDomainDetails ) {
+			return;
+		}
+
+		if ( isLoadingDomainDetails || ! domainDetails ) {
+			return <div className="list__domain-options list__action_item_placeholder" />;
+		}
+
+		return this.renderOptionsButton();
+	}
+
+	getSiteName( site ) {
+		if ( site.name ) {
+			return `${ site.name } (${ withoutHttp( site.URL ) })`;
+		}
+		return withoutHttp( site.URL );
+	}
+
+	renderSiteMeta() {
+		const { showDomainDetails, isLoadingDomainDetails, domainDetails } = this.props;
+
+		if ( ! showDomainDetails ) {
+			return;
+		}
+
+		if ( isLoadingDomainDetails || ! domainDetails ) {
+			return <div className="domain-item__meta domain-item__meta-placeholder" />;
+		}
+
+		return (
+			<div className="domain-item__meta">
+				{ this.getSiteMeta() }
+				{ this.renderAutoRenew() }
+				{ this.renderEmail( domainDetails ) }
+			</div>
+		);
+	}
+
+	getSiteMeta() {
+		const { domainDetails, isManagingAllSites, site, translate } = this.props;
+
+		if ( isManagingAllSites ) {
+			return translate( 'Site: %(siteName)s', {
+				args: {
+					siteName: this.getSiteName( site ),
+				},
+				comment: '%(siteName)s is the site name and URL or just the URL used to identify a site',
+			} );
+		}
+
+		if ( domainDetails.isWPCOMDomain ) {
+			return (
+				<div className="domain-item__meta">
+					{ translate( 'Free site address' ) }
+
+					<InfoPopover iconSize={ 18 }>
+						{ translate(
+							'Your WordPress.com site comes with a free address using a WordPress.com subdomain. As ' +
+								'an alternative to using the free subdomain, you can instead use a custom domain ' +
+								'name for your site, for example: yourgroovydomain.com.'
+						) }
+					</InfoPopover>
+				</div>
+			);
+		}
+
+		return <Fragment>{ getDomainTypeText( domainDetails, translate ) }</Fragment>;
+	}
+
+	busyMessage() {
+		if ( this.props.isBusy && this.props.busyMessage ) {
+			return <div className="domain-item__busy-message">{ this.props.busyMessage }</div>;
+		}
+	}
+
+	renderOverlay() {
+		const { isBusy } = this.props;
+		if ( isBusy ) {
+			return (
+				<div className="domain-item__overlay">
+					{ this.busyMessage() }
+					<Spinner className="domain-item__spinner" size={ 20 } />
+				</div>
+			);
+		}
+		return null;
+	}
+
+	renderActionResult() {
+		const { actionResult } = this.props;
+
+		if ( ! actionResult?.type || ! actionResult?.message ) {
+			return;
+		}
+
+		const { type, message } = actionResult;
+		const statusClass = 'error' === type ? 'alert' : 'success';
+
+		return <DomainNotice status={ statusClass } text={ message } />;
+	}
+
+	renderPrimaryBadge() {
+		return (
+			<Badge className="domain-item__primary-badge" type="info-green">
+				{ this.props.translate( 'Primary site address' ) }
+			</Badge>
+		);
+	}
+
+	hasMappingError( domain ) {
+		const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
+		return (
+			domain.type === domainTypes.MAPPED &&
+			! domain.pointsToWpcom &&
+			moment.utc().isAfter( registrationDatePlus3Days )
+		);
+	}
+
+	render() {
+		const {
+			domain,
+			domainDetails,
+			disabled,
+			isBusy,
+			isChecked,
+			isManagingAllSites,
+			showCheckbox,
+			site,
+		} = this.props;
+		const { listStatusText, listStatusClass } = resolveDomainStatus(
+			domainDetails || domain,
+			null,
+			{ siteSlug: site?.slug, hasMappingError: this.hasMappingError( domain ) }
+		);
+
+		const rowClasses = classNames( 'domain-row', `domain-row__status-${ listStatusClass }` );
+
+		const expiryDate = moment.utc( domainDetails?.expiry || domain?.expiry ).format( 'LL' );
+
+		return (
+			<div className={ rowClasses } onClick={ this.handleClick }>
+				<div className="domain-row__domain-cell">
+					<div>{ domain.domain }</div>
+					<div>{ this.getSiteMeta() }</div>
+					{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
+				</div>
+				<div className="domain-row__status-cell">status</div>
+				<div className="domain-row__registered-until-cell">{ expiryDate }</div>
+				{ this.renderAutoRenew() }
+				{ this.renderEmail( domainDetails ) }
+				{ /* 
+				{ showCheckbox && (
+					<FormCheckbox
+						className="domain-item__checkbox"
+						onChange={ this.onToggle }
+						onClick={ this.stopPropagation }
+						checked={ isChecked }
+						disabled={ disabled || isBusy }
+					/>
+				) }
+				<div className="list__domain-link">
+					<div className="domain-item__status">
+						<div className="domain-item__title">{ domain.domain }</div>
+						{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
+						{ this.renderActionResult() }
+					</div>
+					{ this.renderSiteMeta() }
+					{ listStatusText && (
+						<DomainNotice status={ listStatusClass || 'info' } text={ listStatusText } />
+					) }
+				</div> */ }
+				{ this.renderActionItems() }
+				{ this.renderOverlay() }
+			</div>
+		);
+	}
+}
+
+const trackAddEmailClick = ( domain ) =>
+	recordTracksEvent( 'calypso_domain_management_domain_item_add_email_click', {
+		section: domain.type,
+	} );
+
+export default connect( null, {
+	trackAddEmailClick,
+} )( localize( DomainRow ) );

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -66,13 +66,8 @@ class DomainRow extends PureComponent {
 		onClick( domainDetails );
 	};
 
-	renderDomainName() {
-		const { domain, domainDetails, isManagingAllSites, translate } = this.props;
-		const domainTypeText = getDomainTypeText(
-			domainDetails,
-			translate,
-			domainInfoContext.DOMAIN_ROW
-		);
+	renderDomainName( domainTypeText ) {
+		const { domain, domainDetails, isManagingAllSites } = this.props;
 		return (
 			<div className="domain-row__domain-cell">
 				<div className="domain-row__domain-name">{ domain.domain }</div>
@@ -104,38 +99,27 @@ class DomainRow extends PureComponent {
 		);
 	}
 
-	renderExpiryDateOrExtraInfo() {
-		const { domain, domainDetails } = this.props;
-		const expiryDate = moment.utc( domainDetails?.expiry || domain?.expiry ).format( 'LL' );
-
+	renderExpiryDate( expiryDate ) {
 		return (
-			<>
-				<div className="domain-row__registered-until-cell">{ expiryDate || '-' }</div>
-				<div className="domain-row__mobile-extra-info-cell">{ this.renderMobileExtraInfo() }</div>
-			</>
+			<div className="domain-row__registered-until-cell">{ expiryDate.format( 'LL' ) || '-' }</div>
 		);
 	}
 
-	renderMobileExtraInfo() {
-		const { domain, domainDetails, translate } = this.props;
-		const domainTypeText = getDomainTypeText(
-			domainDetails,
-			translate,
-			domainInfoContext.DOMAIN_ROW
-		);
+	renderMobileExtraInfo( expiryDate, domainTypeText ) {
+		const { domain } = this.props;
 
+		let extraInfo = '';
 		if ( domainTypeText ) {
-			return domainTypeText;
+			extraInfo = domainTypeText;
+		} else if ( domain.expired ) {
+			extraInfo = 'Expired on ' + expiryDate.format( 'LL' );
+		} else if ( domain.isAutoRenewing && domain.autoRenewalDate ) {
+			extraInfo = 'Renews on ' + moment.utc( domain.autoRenewalDate ).format( 'LL' );
+		} else {
+			extraInfo = 'Expires on ' + expiryDate.format( 'LL' );
 		}
 
-		const expiryDate = moment.utc( domainDetails?.expiry || domain?.expiry );
-		if ( domain.expired ) {
-			return 'Expired on ' + expiryDate.format( 'LL' );
-		}
-		if ( domain.isAutoRenewing && domain.autoRenewalDate ) {
-			return 'Renews on ' + moment.utc( domain.autoRenewalDate ).format( 'LL' );
-		}
-		return 'Expires on ' + expiryDate.format( 'LL' );
+		return <div className="domain-row__mobile-extra-info">{ extraInfo }</div>;
 	}
 
 	renderAutoRenew() {
@@ -333,13 +317,22 @@ class DomainRow extends PureComponent {
 	}
 
 	render() {
+		const { domain, domainDetails, translate } = this.props;
+		const domainTypeText = getDomainTypeText(
+			domainDetails,
+			translate,
+			domainInfoContext.DOMAIN_ROW
+		);
+		const expiryDate = moment.utc( domainDetails?.expiry || domain?.expiry );
+
 		return (
 			<div className="domain-row" onClick={ this.handleClick }>
 				<div className="domain-row__mobile-container">
-					{ this.renderDomainName() }
+					{ this.renderDomainName( domainTypeText ) }
 					<div className="domain-row__mobile-status-container">
 						{ this.renderDomainStatus() }
-						{ this.renderExpiryDateOrExtraInfo() }
+						{ this.renderExpiryDate( expiryDate ) }
+						{ this.renderMobileExtraInfo( expiryDate, domainTypeText ) }
 					</div>
 					{ this.renderAutoRenew() }
 					{ this.renderEmail() }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -145,6 +145,7 @@ class DomainRow extends PureComponent {
 		}
 
 		return (
+			/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 			<div className="domain-row__auto-renew-cell" onClick={ ( e ) => e.stopPropagation() }>
 				<AutoRenewToggle
 					planName={ site.plan.product_name_short }
@@ -154,6 +155,7 @@ class DomainRow extends PureComponent {
 					toggleSource="registered-domain-status"
 				/>
 			</div>
+			/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 		);
 	}
 
@@ -265,6 +267,7 @@ class DomainRow extends PureComponent {
 			);
 		}
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="domain-row__action-cell">
 				<EllipsisMenu
@@ -288,6 +291,7 @@ class DomainRow extends PureComponent {
 				</EllipsisMenu>
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	canSetAsPrimary() {

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -75,7 +75,7 @@ class DomainRow extends PureComponent {
 		);
 		return (
 			<div className="domain-row__domain-cell">
-				<span className="domain-row__domain-name">{ domain.domain }</span>
+				<div className="domain-row__domain-name">{ domain.domain }</div>
 				{ domainTypeText && <div>{ domainTypeText }</div> }
 				{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
 			</div>

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -449,10 +449,13 @@ class DomainRow extends PureComponent {
 			showCheckbox,
 			site,
 		} = this.props;
-		const { listStatusText, listStatusClass } = resolveDomainStatus(
+		const { listStatusText, listStatusClass, status, statusColor } = resolveDomainStatus(
 			domainDetails || domain,
 			null,
-			{ siteSlug: site?.slug, hasMappingError: this.hasMappingError( domain ) }
+			{
+				siteSlug: site?.slug,
+				hasMappingError: this.hasMappingError( domain ),
+			}
 		);
 
 		const rowClasses = classNames( 'domain-row', `domain-row__status-${ listStatusClass }` );
@@ -466,7 +469,9 @@ class DomainRow extends PureComponent {
 					<div>{ this.getSiteMeta2() }</div>
 					{ domainDetails?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }
 				</div>
-				<div className="domain-row__status-cell">status</div>
+				<div className="domain-row__status-cell">
+					<span className={ `domain-row__${ statusColor }-dot` }></span> { status }
+				</div>
 				<div className="domain-row__registered-until-cell">{ expiryDate || '-' }</div>
 				{ this.renderAutoRenew() }
 				{ this.renderEmail( domainDetails ) }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { Icon, home, moreVertical } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -177,6 +176,7 @@ class DomainRow extends PureComponent {
 			return <span className="domain-row__email-cell">-</span>;
 		}
 
+		/* eslint-disable jsx-a11y/anchor-is-valid */
 		if ( hasGSuiteWithUs( domainDetails ) ) {
 			const gSuiteMailboxCount = getGSuiteMailboxCount( domainDetails );
 
@@ -191,7 +191,13 @@ class DomainRow extends PureComponent {
 					comment: 'The number of GSuite mailboxes active for the current domain',
 				}
 			);
-			return <span className="domain-row__email-cell">{ text }</span>;
+			return (
+				<span className="domain-row__email-cell">
+					<a href="#" onClick={ this.goToEmailPage }>
+						{ text }
+					</a>
+				</span>
+			);
 		}
 
 		if ( hasTitanMailWithUs( domainDetails ) ) {
@@ -204,7 +210,13 @@ class DomainRow extends PureComponent {
 				count: titanMailboxCount,
 				comment: '%(titanMailboxCount)d is the number of mailboxes for the current domain',
 			} );
-			return <span className="domain-row__email-cell">{ text }</span>;
+			return (
+				<span className="domain-row__email-cell">
+					<a href="#" onClick={ this.goToEmailPage }>
+						{ text }
+					</a>
+				</span>
+			);
 		}
 
 		if ( hasEmailForwards( domainDetails ) ) {
@@ -217,7 +229,13 @@ class DomainRow extends PureComponent {
 				},
 				comment: 'The number of email forwards active for the current domain',
 			} );
-			return <span className="domain-row__email-cell">{ text }</span>;
+			return (
+				<span className="domain-row__email-cell">
+					<a href="#" onClick={ this.goToEmailPage }>
+						{ text }
+					</a>
+				</span>
+			);
 		}
 
 		if ( ! canCurrentUserAddEmail( domainDetails ) ) {
@@ -226,18 +244,25 @@ class DomainRow extends PureComponent {
 
 		return (
 			<span className="domain-row__email-cell">
-				<Button compact onClick={ this.addEmailClick } className="domain-row__email-button">
+				<a href="#" onClick={ this.addEmailClick }>
 					{ translate( 'Add +', { context: 'Button label' } ) }
-				</Button>
+				</a>
 			</span>
 		);
+		/* eslint-enable jsx-a11y/anchor-is-valid */
 	}
 
 	addEmailClick = ( event ) => {
-		const { trackAddEmailClick, currentRoute, disabled, domain, site } = this.props;
+		const { trackAddEmailClick, domain } = this.props;
 		event.stopPropagation();
 
 		trackAddEmailClick( domain ); // analytics/tracks
+		this.goToEmailPage( event );
+	};
+
+	goToEmailPage = ( event ) => {
+		const { currentRoute, disabled, domain, site } = this.props;
+		event.stopPropagation();
 
 		if ( disabled ) {
 			return;

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -26,6 +26,7 @@ import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import { handleRenewNowClick } from 'calypso/lib/purchases';
 import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { withoutHttp } from 'calypso/lib/url';
+import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import DomainNotice from 'calypso/my-sites/domains/domain-management/components/domain-notice';
 import {
 	domainManagementChangeSiteAddress,
@@ -143,16 +144,27 @@ class DomainRow extends PureComponent {
 	}
 
 	renderAutoRenew() {
-		const { translate, domainDetails } = this.props;
+		const { site, purchase, translate, domainDetails } = this.props;
 
 		if ( ! this.shouldShowAutoRenewStatus() ) {
 			return <span className="domain-row__auto-renew-cell">-</span>;
 		}
 
-		const autoRenewLabel = domainDetails?.isAutoRenewing
-			? translate( '(on)' )
-			: translate( '(off)' );
-		return <span className="domain-row__auto-renew-cell">{ autoRenewLabel }</span>;
+		if ( ! purchase ) {
+			return <span className="domain-row__auto-renew-cell">ldng</span>;
+		}
+
+		return (
+			<div className="domain-row__auto-renew-cell" onClick={ ( e ) => e.stopPropagation() }>
+				<AutoRenewToggle
+					planName={ site.plan.product_name_short }
+					siteDomain={ site.domain }
+					purchase={ purchase }
+					withTextStatus={ false }
+					toggleSource="registered-domain-status"
+				/>
+			</div>
+		);
 	}
 
 	shouldShowAutoRenewStatus = () => {
@@ -163,7 +175,7 @@ class DomainRow extends PureComponent {
 		) {
 			return false;
 		}
-		return ! domainDetails?.bundledPlanSubscriptionId;
+		return ! domainDetails?.bundledPlanSubscriptionId && domainDetails.currentUserCanManage;
 	};
 
 	renderOptionsButton() {

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -145,7 +145,7 @@ class DomainRow extends PureComponent {
 		const { translate, domainDetails } = this.props;
 
 		if ( ! this.shouldShowAutoRenewStatus() ) {
-			return;
+			return <span className="domain-row__auto-renew-cell"></span>;
 		}
 
 		const autoRenewLabel = domainDetails?.isAutoRenewing
@@ -248,7 +248,7 @@ class DomainRow extends PureComponent {
 		const { translate } = this.props;
 
 		if ( [ domainTypes.MAPPED, domainTypes.REGISTERED ].indexOf( domainDetails.type ) === -1 ) {
-			return;
+			return <span className="domain-row__email-cell"></span>;
 		}
 
 		if ( hasGSuiteWithUs( domainDetails ) ) {
@@ -295,7 +295,7 @@ class DomainRow extends PureComponent {
 		}
 
 		if ( ! canCurrentUserAddEmail( domainDetails ) ) {
-			return;
+			return <span className="domain-row__email-cell"></span>;
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -2,11 +2,15 @@
 
 .domain-row {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	padding: 16px 0;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	font-size: $font-body-small;
 	cursor: pointer;
+
+	@include break-mobile {
+		padding: 20px 0;
+	}
 
 	&__primary-badge {
 		font-size: $font-body-extra-small;
@@ -45,14 +49,17 @@
 		font-weight: 500; /* stylelint-disable-line */
 	}
 }
+
 .domain-row__status-cell {
 	flex: 40 40 0;
 	display: flex;
 	align-items: center;
 }
+
 .domain-row__registered-until-cell {
 	flex: 50 50 0;
 }
+
 .domain-row__auto-renew-cell {
 	flex: 30 30 0;
 
@@ -66,6 +73,7 @@
 		margin-bottom: 0;
 	}
 }
+
 .domain-row__email-cell {
 	flex: 30 30 0;
 
@@ -84,6 +92,13 @@
 		}
 	}
 }
+
 .domain-row__action-cell {
 	flex: 6 6 0;
+	height: 20px;
+
+	.ellipsis-menu__toggle {
+		transform: translateY( -4px );
+		padding: 0;
+	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -4,7 +4,7 @@
 	position: relative;
 	display: flex;
 	align-items: flex-start;
-	padding: 16px 0;
+	padding: 16px;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	font-size: $font-body-small;
 	cursor: pointer;
@@ -54,6 +54,27 @@
 	}
 }
 
+.domain-row__mobile-container {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	flex: 233 233 0;
+
+	@include break-mobile {
+		flex-direction: row;
+	}
+}
+
+.domain-row__mobile-status-container {
+	display: flex;
+	width: 100%;
+	margin-top: 8px;
+
+	@include break-mobile {
+		flex-direction: row;
+	}
+}
+
 .domain-row__overlay {
 	z-index: 2;
 	background-color: rgba( 255, 255, 255, 0.8 );
@@ -83,13 +104,20 @@
 }
 
 .domain-row__status-cell {
-	flex: 40 40 0;
-	display: flex;
-	align-items: center;
+	@include break-mobile {
+		flex: 40 40 0;
+		display: flex;
+		align-items: center;
+	}
 }
 
 .domain-row__registered-until-cell {
-	flex: 50 50 0;
+	margin-left: 16px;
+
+	@include break-mobile {
+		flex: 50 50 0;
+		margin: 0;
+	}
 }
 
 .domain-row__auto-renew-cell {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -31,8 +31,13 @@
 		margin: 0;
 	}
 
-	&__ok-dot,
-	&__warning-dot {
+	&__status-success-dot,
+	&__status-verifying-dot,
+	&__status-premium-dot,
+	&__status-neutral-dot,
+	&__status-alert-dot,
+	&__status-warning-dot,
+	&__status-error-dot {
 		display: inline-block;
 		width: 8px;
 		height: 8px;
@@ -40,7 +45,11 @@
 		border-radius: 50%; /* stylelint-disable-line */
 		background-color: var( --studio-green-50 );
 	}
-	&__warning-dot {
+
+	&__status-neutral-dot,
+	&__status-alert-dot,
+	&__status-warning-dot,
+	&__status-error-dot {
 		background-color: var( --studio-orange-40 );
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -141,7 +141,7 @@
 }
 
 .domain-row__registered-until-cell,
-.domain-row__mobile-extra-info-cell {
+.domain-row__mobile-extra-info {
 	display: none;
 	margin-left: 16px;
 
@@ -152,7 +152,7 @@
 	}
 }
 
-.domain-row__mobile-extra-info-cell {
+.domain-row__mobile-extra-info {
 	display: inline;
 
 	@include break-mobile {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -73,6 +73,7 @@
 		flex: 90 90 0;
 		flex-direction: row;
 		margin-top: 0;
+		padding-top: 2px;
 	}
 }
 
@@ -142,6 +143,7 @@
 
 	@include break-mobile {
 		display: flex;
+		padding-top: 2px;
 
 		.components-base-control__field {
 			margin-bottom: 0;
@@ -155,6 +157,7 @@
 
 	@include break-mobile {
 		display: block;
+		padding-top: 2px;
 	}
 
 	button.domain-row__email-button {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -19,7 +19,11 @@
 		font-size: $font-body-extra-small;
 		border-radius: 4px; /* stylelint-disable-line */
 		font-weight: 500; /* stylelint-disable-line */
-		margin-top: 8px;
+		margin: 4px 0;
+
+		@include break-mobile {
+			margin-top: 8px;
+		}
 
 		svg {
 			transform: translateY( 2px );
@@ -67,7 +71,7 @@
 
 .domain-row__mobile-status-container {
 	display: flex;
-	margin-top: 8px;
+	margin-top: 4px;
 
 	@include break-mobile {
 		flex: 90 90 0;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -93,28 +93,37 @@
 }
 
 .domain-row__auto-renew-cell {
+	display: none;
 	flex: 30 30 0;
 
-	.components-base-control__field {
-		margin-bottom: 0;
+	@include break-mobile {
+		display: flex;
+
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
 	}
 }
 
 .domain-row__email-cell {
+	display: none;
 	flex: 30 30 0;
 
-	button.domain-row__email-button {
-		color: var( --color-text );
-		background: none;
-		border: none;
-		padding: 0;
-		line-height: 1.5;
-		box-shadow: none;
-		font-size: $font-body-small;
+	@include break-mobile {
+		display: flex;
 
-		&:hover {
-			color: var( --color-link );
-			// color: var( --color-link-dark );
+		button.domain-row__email-button {
+			color: var( --color-text );
+			background: none;
+			border: none;
+			padding: 0;
+			line-height: 1.5;
+			box-shadow: none;
+			font-size: $font-body-small;
+
+			&:hover {
+				color: var( --color-link );
+			}
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -8,7 +8,10 @@
 
 .domain-row__domain-cell {
 	flex: 83 83 0;
-	font-weight: 500; /* stylelint-disable-line */
+
+	.domain-row__domain-name {
+		font-weight: 500; /* stylelint-disable-line */
+	}
 }
 .domain-row__status-cell {
 	flex: 40 40 0;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -25,6 +25,12 @@
 		}
 	}
 
+	&__placeholder {
+		width: 30%;
+		@include placeholder( --color-neutral-5 );
+		margin: 0;
+	}
+
 	&__ok-dot,
 	&__warning-dot {
 		display: inline-block;
@@ -79,12 +85,6 @@
 
 .domain-row__auto-renew-cell {
 	flex: 30 30 0;
-
-	.domain-row__auto-renew-placeholder {
-		width: 30%;
-		@include placeholder( --color-neutral-5 );
-		margin: 0;
-	}
 
 	.components-base-control__field {
 		margin-bottom: 0;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -1,6 +1,7 @@
 @import '@automattic/onboarding/styles/mixins';
 
 .domain-row {
+	position: relative;
 	display: flex;
 	align-items: flex-start;
 	padding: 16px 0;
@@ -39,6 +40,26 @@
 		margin-right: 8px;
 		border-radius: 50%; /* stylelint-disable-line */
 		background-color: var( --studio-orange-40 );
+	}
+}
+
+.domain-row__overlay {
+	z-index: 2;
+	background-color: rgba( 255, 255, 255, 0.8 );
+	box-sizing: border-box;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	padding: 16px 24px;
+	display: flex;
+	align-items: center;
+
+	.domain-row__busy-message {
+		font-size: $font-body-small;
+		margin-left: auto;
+		margin-right: 5px;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -59,6 +59,14 @@
 	&__status-error-dot {
 		background-color: var( --studio-orange-40 );
 	}
+
+	.popover__menu-item {
+		color: var( --studio-gray-90 );
+
+		& svg {
+			color: var( --studio-gray-90 );
+		}
+	}
 }
 
 .domain-row__mobile-container {
@@ -214,5 +222,22 @@
 	@include break-mobile {
 		flex: 6 6 0;
 		margin: 0;
+	}
+}
+
+.domain-row__popover {
+	.popover__menu-item {
+		color: var( --studio-gray-90 );
+		svg {
+			fill: var( --studio-gray-90 );
+		}
+	}
+
+	.popover__menu-item.is-selected,
+	.popover__menu-item:hover,
+	.popover__menu-item:focus {
+		svg {
+			fill: var( --studio-white );
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -2,14 +2,15 @@
 
 .domain-row {
 	position: relative;
-	display: flex;
-	align-items: flex-start;
+	display: block;
 	padding: 16px;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
 
 	@include break-mobile {
+		display: flex;
+		align-items: flex-start;
 		padding: 20px 0;
 	}
 
@@ -71,21 +72,19 @@
 .domain-row__mobile-container {
 	flex: 233 233 0;
 	overflow: hidden;
-
-	@include break-mobile {
-		display: flex;
-	}
+	display: flex;
 }
 
-.domain-row__mobile-status-container {
-	display: flex;
+.domain-row__mobile-container2 {
+	display: block;
 	margin-top: 4px;
 
+	.domain-row__status-cell {
+		display: inline;
+	}
+
 	@include break-mobile {
-		flex: 90 90 0;
-		flex-direction: row;
-		margin-top: 0;
-		padding-top: 2px;
+		display: none;
 	}
 }
 
@@ -111,6 +110,7 @@
 
 .domain-row__domain-cell {
 	overflow: hidden;
+	flex: 1;
 
 	@include break-mobile {
 		flex: 83 83 0;
@@ -148,10 +148,13 @@
 }
 
 .domain-row__status-cell {
+	display: none;
+
 	@include break-mobile {
 		flex: 40 40 0;
 		display: block;
 		align-items: center;
+		padding-top: 2px;
 		font-size: $font-body-small;
 	}
 }
@@ -164,6 +167,7 @@
 	@include break-mobile {
 		flex: 50 50 0;
 		margin: 0;
+		padding-top: 2px;
 		display: inline;
 		font-size: $font-body-small;
 	}
@@ -209,7 +213,6 @@
 }
 
 .domain-row__action-cell {
-	flex: 1 1 0;
 	height: 20px;
 	margin-left: 20px;
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -115,6 +115,7 @@
 	@include break-mobile {
 		flex: 83 83 0;
 		font-size: $font-body-small;
+		padding-top: 2px;
 	}
 
 	.domain-row__domain-name {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -8,7 +8,7 @@
 	font-size: $font-body-small;
 	cursor: pointer;
 
-	& &__primary-badge {
+	&__primary-badge {
 		font-size: $font-body-extra-small;
 		border-radius: 4px; /* stylelint-disable-line */
 		font-weight: 500; /* stylelint-disable-line */
@@ -18,6 +18,23 @@
 			transform: translateY( 2px );
 			margin-right: 4px;
 		}
+	}
+
+	&__ok-dot {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		margin-right: 8px;
+		border-radius: 50%; /* stylelint-disable-line */
+		background-color: var( --studio-green-50 );
+	}
+	&__warning-dot {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		margin-right: 8px;
+		border-radius: 50%; /* stylelint-disable-line */
+		background-color: var( --studio-orange-40 );
 	}
 }
 
@@ -30,6 +47,8 @@
 }
 .domain-row__status-cell {
 	flex: 40 40 0;
+	display: flex;
+	align-items: center;
 }
 .domain-row__registered-until-cell {
 	flex: 50 50 0;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -1,0 +1,41 @@
+.domain-row {
+	display: flex;
+	align-items: center;
+	padding: 16px 0;
+	border-bottom: 1px solid var( --studio-gray-5 );
+	font-size: $font-body-small;
+}
+
+.domain-row__domain-cell {
+	flex: 83 83 0;
+	font-weight: 500; /* stylelint-disable-line */
+}
+.domain-row__status-cell {
+	flex: 40 40 0;
+}
+.domain-row__registered-until-cell {
+	flex: 50 50 0;
+}
+.domain-row__auto-renew-cell {
+	flex: 30 30 0;
+}
+.domain-row__email-cell {
+	flex: 30 30 0;
+
+	button.domain-row__email-button {
+		color: var( --color-link );
+		background: none;
+		border: none;
+		padding: 0;
+		line-height: 1.5;
+		box-shadow: none;
+		font-size: $font-body-small;
+
+		&:hover {
+			color: var( --color-link-dark );
+		}
+	}
+}
+.domain-row__action-cell {
+	flex: 6 6 0;
+}

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -57,23 +57,15 @@
 
 .domain-row__mobile-container {
 	flex: 233 233 0;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
 	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 
 	@include break-mobile {
-		overflow: visible;
-		text-overflow: inherit;
-		flex-direction: row;
+		display: flex;
 	}
 }
 
 .domain-row__mobile-status-container {
 	display: flex;
-	width: 100%;
 	margin-top: 8px;
 
 	@include break-mobile {
@@ -104,15 +96,24 @@
 }
 
 .domain-row__domain-cell {
-	flex: 83 83 0;
+	overflow: hidden;
+
+	@include break-mobile {
+		flex: 83 83 0;
+		font-size: $font-body-small;
+	}
 
 	.domain-row__domain-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
 		color: var( --studio-gray-90 );
 		font-size: $font-body-large;
 		font-weight: 500; /* stylelint-disable-line */
 
 		@include break-mobile {
-			font-size: $font-body-small;
+			font-size: $font-body;
 		}
 	}
 }
@@ -120,7 +121,7 @@
 .domain-row__status-cell {
 	@include break-mobile {
 		flex: 40 40 0;
-		display: flex;
+		display: block;
 		align-items: center;
 	}
 }
@@ -152,7 +153,7 @@
 	flex: 30 30 0;
 
 	@include break-mobile {
-		display: flex;
+		display: block;
 	}
 
 	button.domain-row__email-button {
@@ -171,6 +172,7 @@
 }
 
 .domain-row__action-cell {
+	flex: 1 1 0;
 	height: 20px;
 	margin-left: 20px;
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -26,6 +26,7 @@
 		}
 
 		svg {
+			fill: var( --studio-green-80 );
 			transform: translateY( 2px );
 			margin-right: 4px;
 		}

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -198,18 +198,12 @@
 		padding-top: 2px;
 	}
 
-	button.domain-row__email-button {
-		color: var( --color-text );
-		background: none;
-		border: none;
-		padding: 0;
-		line-height: 1.5;
-		box-shadow: none;
+	a {
 		font-size: $font-body-small;
-
-		&:hover {
-			color: var( --color-link );
-		}
+		color: var( --studio-gray-90 );
+	}
+	a:hover {
+		color: var( --color-link );
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -130,6 +130,10 @@
 		@include break-mobile {
 			font-size: $font-body-small;
 		}
+
+		&:hover {
+			color: var( --color-link );
+		}
 	}
 
 	.domain-row__domain-type-text {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -153,19 +153,19 @@
 
 	@include break-mobile {
 		display: flex;
+	}
 
-		button.domain-row__email-button {
-			color: var( --color-text );
-			background: none;
-			border: none;
-			padding: 0;
-			line-height: 1.5;
-			box-shadow: none;
-			font-size: $font-body-small;
+	button.domain-row__email-button {
+		color: var( --color-text );
+		background: none;
+		border: none;
+		padding: 0;
+		line-height: 1.5;
+		box-shadow: none;
+		font-size: $font-body-small;
 
-			&:hover {
-				color: var( --color-link );
-			}
+		&:hover {
+			color: var( --color-link );
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -55,6 +55,16 @@
 }
 .domain-row__auto-renew-cell {
 	flex: 30 30 0;
+
+	.domain-row__auto-renew-placeholder {
+		width: 30%;
+		@include placeholder( --color-neutral-5 );
+		margin: 0;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
 }
 .domain-row__email-cell {
 	flex: 30 30 0;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -1,9 +1,23 @@
+@import '@automattic/onboarding/styles/mixins';
+
 .domain-row {
 	display: flex;
 	align-items: center;
 	padding: 16px 0;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	font-size: $font-body-small;
+
+	& &__primary-badge {
+		font-size: $font-body-extra-small;
+		border-radius: 4px; /* stylelint-disable-line */
+		font-weight: 500; /* stylelint-disable-line */
+		margin-top: 8px;
+
+		svg {
+			transform: translateY( 2px );
+			margin-right: 4px;
+		}
+	}
 }
 
 .domain-row__domain-cell {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -122,6 +122,14 @@
 			font-size: $font-body-small;
 		}
 	}
+
+	.domain-row__domain-type-text {
+		display: none;
+
+		@include break-mobile {
+			display: block;
+		}
+	}
 }
 
 .domain-row__status-cell {
@@ -132,12 +140,23 @@
 	}
 }
 
-.domain-row__registered-until-cell {
+.domain-row__registered-until-cell,
+.domain-row__mobile-extra-info-cell {
+	display: none;
 	margin-left: 16px;
 
 	@include break-mobile {
 		flex: 50 50 0;
 		margin: 0;
+		display: inline;
+	}
+}
+
+.domain-row__mobile-extra-info-cell {
+	display: inline;
+
+	@include break-mobile {
+		display: none;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -8,7 +8,6 @@
 	border-bottom: 1px solid var( --studio-gray-5 );
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
-	cursor: pointer;
 
 	@include break-mobile {
 		padding: 20px 0;
@@ -122,17 +121,18 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-
-		color: var( --studio-gray-90 );
 		font-size: $font-body-large;
 		font-weight: 500; /* stylelint-disable-line */
 
-		@include break-mobile {
-			font-size: $font-body-small;
+		a {
+			color: var( --studio-gray-90 );
+		}
+		a:hover {
+			color: var( --color-link );
 		}
 
-		&:hover {
-			color: var( --color-link );
+		@include break-mobile {
+			font-size: $font-body-small;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -25,7 +25,8 @@
 		}
 	}
 
-	&__ok-dot {
+	&__ok-dot,
+	&__warning-dot {
 		display: inline-block;
 		width: 8px;
 		height: 8px;
@@ -34,11 +35,6 @@
 		background-color: var( --studio-green-50 );
 	}
 	&__warning-dot {
-		display: inline-block;
-		width: 8px;
-		height: 8px;
-		margin-right: 8px;
-		border-radius: 50%; /* stylelint-disable-line */
 		background-color: var( --studio-orange-40 );
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -224,6 +224,11 @@
 	@include break-mobile {
 		flex: 6 6 0;
 		margin: 0;
+
+		.ellipsis-menu {
+			position: relative;
+			right: 16px;
+		}
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -182,10 +182,9 @@
 
 	@include break-mobile {
 		display: flex;
-		padding-top: 2px;
 
 		.components-base-control__field {
-			margin-bottom: 0;
+			margin: 4px 0;
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -6,7 +6,8 @@
 	align-items: flex-start;
 	padding: 16px;
 	border-bottom: 1px solid var( --studio-gray-5 );
-	font-size: $font-body-small;
+	font-size: $font-body-extra-small;
+	color: var( --studio-gray-50 );
 	cursor: pointer;
 
 	@include break-mobile {
@@ -55,12 +56,17 @@
 }
 
 .domain-row__mobile-container {
+	flex: 233 233 0;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	flex: 233 233 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 
 	@include break-mobile {
+		overflow: visible;
+		text-overflow: inherit;
 		flex-direction: row;
 	}
 }
@@ -71,7 +77,9 @@
 	margin-top: 8px;
 
 	@include break-mobile {
+		flex: 90 90 0;
 		flex-direction: row;
+		margin-top: 0;
 	}
 }
 
@@ -99,7 +107,13 @@
 	flex: 83 83 0;
 
 	.domain-row__domain-name {
+		color: var( --studio-gray-90 );
+		font-size: $font-body-large;
 		font-weight: 500; /* stylelint-disable-line */
+
+		@include break-mobile {
+			font-size: $font-body-small;
+		}
 	}
 }
 
@@ -157,11 +171,16 @@
 }
 
 .domain-row__action-cell {
-	flex: 6 6 0;
 	height: 20px;
+	margin-left: 20px;
 
 	.ellipsis-menu__toggle {
 		transform: translateY( -4px );
 		padding: 0;
+	}
+
+	@include break-mobile {
+		flex: 6 6 0;
+		margin: 0;
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -6,6 +6,7 @@
 	padding: 16px 0;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	font-size: $font-body-small;
+	cursor: pointer;
 
 	& &__primary-badge {
 		font-size: $font-body-extra-small;
@@ -40,7 +41,7 @@
 	flex: 30 30 0;
 
 	button.domain-row__email-button {
-		color: var( --color-link );
+		color: var( --color-text );
 		background: none;
 		border: none;
 		padding: 0;
@@ -49,7 +50,8 @@
 		font-size: $font-body-small;
 
 		&:hover {
-			color: var( --color-link-dark );
+			color: var( --color-link );
+			// color: var( --color-link-dark );
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -134,6 +134,7 @@
 
 	.domain-row__domain-type-text {
 		display: none;
+		font-size: $font-body-extra-small;
 
 		@include break-mobile {
 			display: block;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -14,7 +14,8 @@
 		padding: 20px 0;
 	}
 
-	&__primary-badge {
+	/* div. for increased specificity */
+	div.domain-row__primary-badge {
 		font-size: $font-body-extra-small;
 		border-radius: 4px; /* stylelint-disable-line */
 		font-weight: 500; /* stylelint-disable-line */
@@ -113,7 +114,7 @@
 		font-weight: 500; /* stylelint-disable-line */
 
 		@include break-mobile {
-			font-size: $font-body;
+			font-size: $font-body-small;
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -48,7 +48,7 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-	padding: 16px 24px;
+	padding: 20px 8px;
 	display: flex;
 	align-items: center;
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -137,6 +137,7 @@
 		flex: 40 40 0;
 		display: block;
 		align-items: center;
+		font-size: $font-body-small;
 	}
 }
 
@@ -149,6 +150,7 @@
 		flex: 50 50 0;
 		margin: 0;
 		display: inline;
+		font-size: $font-body-small;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -2,7 +2,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import DomainItem from './domain-item';
+import DomainRow from './domain-row';
 import DomainsTableHeader from './domains-table-header';
 import ListItemPlaceholder from './item-placeholder';
 import { filterOutWpcomDomains } from './utils';
@@ -106,7 +106,7 @@ class DomainsTable extends PureComponent {
 		}
 
 		const domainListItems = domainItems.map( ( domain, index ) => (
-			<DomainItem
+			<DomainRow
 				key={ `${ domain.name }-${ index }` }
 				currentRoute={ currentRoute }
 				domain={ domain }

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -121,7 +121,7 @@ class DomainsTable extends PureComponent {
 					isManagingAllSites={ false }
 					onClick={ settingPrimaryDomain ? noop : goToEditDomainRoot }
 					isBusy={ settingPrimaryDomain && index === primaryDomainIndex }
-					busyMessage={ translate( 'Setting Primary Domain…', {
+					busyMessage={ translate( 'Setting primary site address…', {
 						context: 'Shows up when the primary domain is changing and the user is waiting',
 					} ) }
 					disabled={ settingPrimaryDomain }

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -105,25 +105,33 @@ class DomainsTable extends PureComponent {
 			} );
 		}
 
-		const domainListItems = domainItems.map( ( domain, index ) => (
-			<DomainRow
-				key={ `${ domain.name }-${ index }` }
-				currentRoute={ currentRoute }
-				domain={ domain }
-				domainDetails={ domain }
-				site={ selectedSite }
-				isManagingAllSites={ false }
-				onClick={ settingPrimaryDomain ? noop : goToEditDomainRoot }
-				isBusy={ settingPrimaryDomain && index === primaryDomainIndex }
-				busyMessage={ translate( 'Setting Primary Domain…', {
-					context: 'Shows up when the primary domain is changing and the user is waiting',
-				} ) }
-				disabled={ settingPrimaryDomain }
-				selectionIndex={ index }
-				onMakePrimaryClick={ handleUpdatePrimaryDomainOptionClick }
-				shouldUpgradeToMakePrimary={ shouldUpgradeToMakeDomainPrimary( domain ) }
-			/>
-		) );
+		const domainListItems = domainItems.map( ( domain, index ) => {
+			const purchase = this.props.purchases
+				? this.props.purchases.find(
+						( purchase ) => purchase.id === parseInt( domain.subscriptionId, 10 )
+				  )
+				: null;
+			return (
+				<DomainRow
+					key={ `${ domain.name }-${ index }` }
+					currentRoute={ currentRoute }
+					domain={ domain }
+					domainDetails={ domain }
+					site={ selectedSite }
+					isManagingAllSites={ false }
+					onClick={ settingPrimaryDomain ? noop : goToEditDomainRoot }
+					isBusy={ settingPrimaryDomain && index === primaryDomainIndex }
+					busyMessage={ translate( 'Setting Primary Domain…', {
+						context: 'Shows up when the primary domain is changing and the user is waiting',
+					} ) }
+					disabled={ settingPrimaryDomain }
+					selectionIndex={ index }
+					onMakePrimaryClick={ handleUpdatePrimaryDomainOptionClick }
+					shouldUpgradeToMakePrimary={ shouldUpgradeToMakeDomainPrimary( domain ) }
+					purchase={ purchase }
+				/>
+			);
+		} );
 
 		return [
 			<QuerySitePurchases key="query-purchases" siteId={ selectedSite.ID } />,

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -74,6 +74,7 @@ class DomainsTable extends PureComponent {
 			shouldUpgradeToMakeDomainPrimary,
 			goToEditDomainRoot,
 			handleUpdatePrimaryDomainOptionClick,
+			purchases,
 		} = this.props;
 
 		const { sortKey, sortOrder } = this.state;
@@ -106,10 +107,8 @@ class DomainsTable extends PureComponent {
 		}
 
 		const domainListItems = domainItems.map( ( domain, index ) => {
-			const purchase = this.props.purchases
-				? this.props.purchases.find(
-						( purchase ) => purchase.id === parseInt( domain.subscriptionId, 10 )
-				  )
+			const purchase = purchases
+				? purchases.find( ( p ) => p.id === parseInt( domain.subscriptionId, 10 ) )
 				: null;
 			return (
 				<DomainRow

--- a/client/my-sites/domains/domain-management/list/free-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.jsx
@@ -42,7 +42,8 @@ export default function FreeDomainItem( {
 				) }
 				{ domain.isPrimary && (
 					<Badge className="free-domain-item__primary-badge" type="info-green">
-						<Icon icon={ home } size={ 14 } /> { __( 'Primary site address' ) }
+						<Icon icon={ home } size={ 14 } />
+						{ __( 'Primary site address' ) }
 					</Badge>
 				) }
 			</span>

--- a/client/my-sites/domains/domain-management/list/free-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.jsx
@@ -53,6 +53,7 @@ export default function FreeDomainItem( {
 					disabled={ isBusy || disabled }
 					toggleTitle={ __( 'Free WordPress address options' ) }
 					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
+					popoverClassName="free-domain-item__popover"
 				>
 					{ canMakePrimary && (
 						<PopoverMenuItem onClick={ handleMakePrimary }>

--- a/client/my-sites/domains/domain-management/list/free-domain-item.scss
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.scss
@@ -76,3 +76,20 @@
 		padding: 0;
 	}
 }
+
+.free-domain-item__popover {
+	.popover__menu-item {
+		color: var( --studio-gray-90 );
+		svg {
+			fill: var( --studio-gray-90 );
+		}
+	}
+
+	.popover__menu-item.is-selected,
+	.popover__menu-item:hover,
+	.popover__menu-item:focus {
+		svg {
+			fill: var( --studio-white );
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/list/free-domain-item.scss
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.scss
@@ -32,6 +32,7 @@
 		margin-top: 8px;
 
 		svg {
+			fill: var( --studio-green-80 );
 			transform: translateY( 2px );
 			margin-right: 4px;
 		}

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -18,7 +18,6 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { resolveDomainStatus } from 'calypso/lib/domains';
 import { type } from 'calypso/lib/domains/constants';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
-import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
 import EmptyDomainsListCard from 'calypso/my-sites/domains/domain-management/list/empty-domains-list-card';
 import FreeDomainItem from 'calypso/my-sites/domains/domain-management/list/free-domain-item';
 import OptionsDomainButton from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
@@ -77,27 +76,6 @@ export class SiteDomains extends Component {
 
 	isLoading() {
 		return this.props.isRequestingSiteDomains && this.props.domains.length === 0;
-	}
-
-	domainWarnings() {
-		// TODO: We should remove this
-		if ( ! this.isLoading() ) {
-			return (
-				<DomainWarnings
-					domains={ this.props.domains }
-					position="domain-list"
-					selectedSite={ this.props.selectedSite }
-					allowedRules={ [
-						'unverifiedDomainsCanManage',
-						'pendingGSuiteTosAcceptanceDomains',
-						'unverifiedDomainsCannotManage',
-						'transferStatus',
-						'newTransfersWrongNS',
-						'pendingConsent',
-					] }
-				/>
-			);
-		}
 	}
 
 	renderNewDesign() {
@@ -176,8 +154,6 @@ export class SiteDomains extends Component {
 						{ this.optionsDomainButton() }
 					</div>
 				</div>
-
-				{ this.domainWarnings() }
 
 				{ ! this.isLoading() && nonWpcomDomains.length === 0 && (
 					<EmptyDomainsListCard

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -9,7 +9,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -279,9 +278,6 @@ export class SiteDomains extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Main wideLayout>
-				{ this.props.selectedSite.ID && ! this.props.purchases && (
-					<QuerySitePurchases siteId={ this.props.selectedSite.ID } />
-				) }
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<DocumentHead title={ headerText } />
 				<SidebarNavigation />

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -9,6 +9,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -32,6 +33,7 @@ import {
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { getPurchases } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -198,6 +200,7 @@ export class SiteDomains extends Component {
 						shouldUpgradeToMakeDomainPrimary={ this.shouldUpgradeToMakeDomainPrimary }
 						goToEditDomainRoot={ this.goToEditDomainRoot }
 						handleUpdatePrimaryDomainOptionClick={ this.handleUpdatePrimaryDomainOptionClick }
+						purchases={ this.props.purchases }
 					/>
 				</div>
 
@@ -276,6 +279,9 @@ export class SiteDomains extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Main wideLayout>
+				{ this.props.selectedSite.ID && ! this.props.purchases && (
+					<QuerySitePurchases siteId={ this.props.selectedSite.ID } />
+				) }
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<DocumentHead title={ headerText } />
 				<SidebarNavigation />
@@ -434,6 +440,7 @@ export default connect(
 		const selectedSite = ownProps?.selectedSite || null;
 		const isOnFreePlan = selectedSite?.plan?.is_free || false;
 		const siteCount = getSites( state )?.length || 0;
+		const purchases = getPurchases( state );
 
 		return {
 			currentRoute: getCurrentRoute( state ),
@@ -447,6 +454,7 @@ export default connect(
 			isOnFreePlan,
 			userCanManageOptions,
 			canSetPrimaryDomain: hasActiveSiteFeature( state, siteId, FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ),
+			purchases,
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR redesigns the domain item component used in the site domains management page ("Upgrades > Domains") and in the all domains management page. The old `DomainItem` component will be replaced by a new `DomainRow` component, which has a more tabular layout.

Current design:

<img width="1076" alt="Screen Shot 2021-10-25 at 22 48 39" src="https://user-images.githubusercontent.com/5324818/138794985-429ab2c1-f829-482b-9e38-eef946f9294b.png">

<img src="https://user-images.githubusercontent.com/5324818/138795183-b84f0912-3c22-4cf0-9c22-e4200da72b42.png">

New design:

<img width="1082" alt="Screen Shot 2021-10-25 at 22 37 30" src="https://user-images.githubusercontent.com/5324818/138794778-e432da1f-e534-4a20-bef3-ae7dc5f8ae6c.png">

<img src="https://user-images.githubusercontent.com/5324818/138795231-6f144251-f0fd-421a-92af-9a0df4dc8aa4.png">

This is part of the domain managements page redesign project, detailed in pcYYhz-m2-p2.

#### Testing instructions

This is best tested with `D68679-code` applied to your sandbox so that you can check domains in many different states.

Access the live Calypso link and go to "Upgrades > Domains". Ensure the page looks like the designs in the Figma project (`hlVh2q24ad6MCwlwNnE9PQ-fi`) and screenshots above. Please check the page in mobile view too.

If you had applied `D68679-code` to your sandbox, remove it in order to test the domain actions. Make sure all domain functionalities are working as they should - access domain details, change primary site address, click the add mailbox link, etc. Also verify if the informations being shown are correct: domain expiration or renewal date, auto-renew state, mailboxes, etc.