### PR TITLE
Disabling monthly billing on Premium and Personal plans

### DIFF
--- a/client/my-sites/plan-features-comparison/actions.jsx
+++ b/client/my-sites/plan-features-comparison/actions.jsx
@@ -20,6 +20,7 @@ const PlanFeaturesActionsButton = ( {
 	className,
 	current = false,
 	freePlan = false,
+	isDisabled = false,
 	isPlaceholder = false,
 	isPopular,
 	isInSignup,
@@ -54,7 +55,11 @@ const PlanFeaturesActionsButton = ( {
 
 	if ( ( availableForPurchase || isPlaceholder ) && ! isLaunchPage && isInSignup ) {
 		return (
-			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+			<Button
+				className={ classes }
+				onClick={ handleUpgradeButtonClick }
+				disabled={ isPlaceholder || isDisabled }
+			>
 				{ translate( 'Select', {
 					args: {
 						plan: planName,

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -55,7 +55,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 			disabledClasses,
 		} = this.props;
 
-		if ( disabledClasses[ 'plan-monthly-disabled-experiment' ] ) {
+		if ( disabledClasses ) {
 			return null;
 		}
 
@@ -85,7 +85,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 			translate,
 		} = this.props;
 
-		if ( disabledClasses[ 'plan-monthly-disabled-experiment' ] ) {
+		if ( disabledClasses ) {
 			return (
 				<div className="plan-features-comparison__not-available-with-monthly-disclaimer">
 					This plan is only available with annual billing
@@ -106,9 +106,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 			return (
 				<div
 					className={ classNames( {
-						'plan-features-comparison__header-annual-discount': ! disabledClasses[
-							'plan-monthly-disabled-experiment'
-						],
+						'plan-features-comparison__header-annual-discount': ! disabledClasses,
 						'plan-features-comparison__header-annual-discount-is-loading': isLoading,
 					} ) }
 				>
@@ -131,7 +129,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 
 	renderPriceGroup() {
 		const { currencyCode, disabledClasses, rawPrice, discountPrice } = this.props;
-		const displayNotation = ! disabledClasses[ 'plan-monthly-disabled-experiment' ];
+		const displayNotation = ! disabledClasses;
 
 		if ( discountPrice ) {
 			return (

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -55,7 +55,9 @@ export class PlanFeaturesComparisonHeader extends Component {
 			disabledClasses,
 		} = this.props;
 
-		if ( disabledClasses ) return null;
+		if ( disabledClasses[ 'plan-monthly-disabled-experiment' ] ) {
+			return null;
+		}
 
 		if ( isMonthlyPlan && annualPricePerMonth < rawPrice ) {
 			const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
@@ -83,9 +85,9 @@ export class PlanFeaturesComparisonHeader extends Component {
 			translate,
 		} = this.props;
 
-		if ( disabledClasses ) {
+		if ( disabledClasses[ 'plan-monthly-disabled-experiment' ] ) {
 			return (
-				<div className={ classNames( 'not-available-with-monthly-disclaimer' ) }>
+				<div className="plan-features-comparison__not-available-with-monthly-disclaimer">
 					This plan is only available with annual billing
 				</div>
 			);
@@ -115,15 +117,11 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	getBillingTimeframe() {
-		const { billingTimeFrame, isDisabled } = this.props;
+		const { billingTimeFrame } = this.props;
 		const perMonthDescription = this.getPerMonthDescription() || billingTimeFrame;
 
 		return (
-			<div
-				className={ classNames( 'plan-features-comparison__header-billing-info', {
-					'not-available-with-monthly-disclaimer': isDisabled,
-				} ) }
-			>
+			<div className="plan-features-comparison__header-billing-info">
 				<span>{ perMonthDescription }</span>
 			</div>
 		);
@@ -131,7 +129,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 
 	renderPriceGroup() {
 		const { currencyCode, disabledClasses, rawPrice, discountPrice } = this.props;
-		const displayNotation = ! disabledClasses;
+		const displayNotation = ! disabledClasses[ 'plan-monthly-disabled-experiment' ];
 
 		if ( discountPrice ) {
 			return (
@@ -167,7 +165,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 }
 
 PlanFeaturesComparisonHeader.propTypes = {
-	billingTimeFrame: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ).isRequired,
+	billingTimeFrame: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 	currencyCode: PropTypes.string,
 	discountPrice: PropTypes.number,
 	planType: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
@@ -175,6 +173,7 @@ PlanFeaturesComparisonHeader.propTypes = {
 	rawPrice: PropTypes.number,
 	title: PropTypes.string.isRequired,
 	translate: PropTypes.func,
+	disabledClasses: PropTypes.object,
 
 	// For Monthly Pricing test
 	annualPricePerMonth: PropTypes.number,

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -106,7 +106,9 @@ export class PlanFeaturesComparisonHeader extends Component {
 			return (
 				<div
 					className={ classNames( {
-						'plan-features-comparison__header-annual-discount': ! disabledClasses,
+						'plan-features-comparison__header-annual-discount': ! disabledClasses[
+							'plan-monthly-disabled-experiment'
+						],
 						'plan-features-comparison__header-annual-discount-is-loading': isLoading,
 					} ) }
 				>

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -15,11 +15,12 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	renderPlansHeaderNoTabs() {
-		const { planType, popular, selectedPlan, title, translate } = this.props;
+		const { disabledClasses, planType, popular, selectedPlan, title, translate } = this.props;
 
 		const headerClasses = classNames(
 			'plan-features-comparison__header',
-			getPlanClass( planType )
+			getPlanClass( planType ),
+			disabledClasses
 		);
 
 		return (
@@ -30,13 +31,15 @@ export class PlanFeaturesComparisonHeader extends Component {
 					) }
 				</div>
 				<header className={ headerClasses }>
-					<h4 className="plan-features-comparison__header-title">{ title }</h4>
+					<h4 className={ classNames( 'plan-features-comparison__header-title', disabledClasses ) }>
+						{ title }
+					</h4>
 				</header>
-				<div className="plan-features-comparison__pricing">
+				<div className={ classNames( 'plan-features-comparison__pricing', disabledClasses ) }>
 					{ this.renderPriceGroup() }
 					{ this.getBillingTimeframe() }
-					{ this.getAnnualDiscount() }
 				</div>
+				{ this.getAnnualDiscount() }
 			</span>
 		);
 	}
@@ -49,7 +52,10 @@ export class PlanFeaturesComparisonHeader extends Component {
 			translate,
 			annualPricePerMonth,
 			isMonthlyPlan,
+			disabledClasses,
 		} = this.props;
+
+		if ( disabledClasses ) return null;
 
 		if ( isMonthlyPlan && annualPricePerMonth < rawPrice ) {
 			const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
@@ -69,7 +75,21 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	getAnnualDiscount() {
-		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate } = this.props;
+		const {
+			disabledClasses,
+			isMonthlyPlan,
+			rawPriceForMonthlyPlan,
+			annualPricePerMonth,
+			translate,
+		} = this.props;
+
+		if ( disabledClasses ) {
+			return (
+				<div className={ classNames( 'not-available-with-monthly-disclaimer' ) }>
+					This plan is only available with annual billing
+				</div>
+			);
+		}
 
 		if ( ! isMonthlyPlan ) {
 			const isLoading = typeof rawPriceForMonthlyPlan !== 'number';
@@ -83,7 +103,8 @@ export class PlanFeaturesComparisonHeader extends Component {
 
 			return (
 				<div
-					className={ classNames( 'plan-features-comparison__header-annual-discount', {
+					className={ classNames( {
+						'plan-features-comparison__header-annual-discount': ! disabledClasses,
 						'plan-features-comparison__header-annual-discount-is-loading': isLoading,
 					} ) }
 				>
@@ -94,33 +115,38 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	getBillingTimeframe() {
-		const { billingTimeFrame } = this.props;
+		const { billingTimeFrame, isDisabled } = this.props;
 		const perMonthDescription = this.getPerMonthDescription() || billingTimeFrame;
 
 		return (
-			<div className={ 'plan-features-comparison__header-billing-info' }>
+			<div
+				className={ classNames( 'plan-features-comparison__header-billing-info', {
+					'not-available-with-monthly-disclaimer': isDisabled,
+				} ) }
+			>
 				<span>{ perMonthDescription }</span>
 			</div>
 		);
 	}
 
 	renderPriceGroup() {
-		const { currencyCode, rawPrice, discountPrice } = this.props;
+		const { currencyCode, disabledClasses, rawPrice, discountPrice } = this.props;
+		const displayNotation = ! disabledClasses;
 
 		if ( discountPrice ) {
 			return (
 				<span className="plan-features-comparison__header-price-group">
-					<div className="plan-features-comparison__header-price-group-prices">
+					<div className={ classNames( 'plan-features-comparison__header-price-group-prices' ) }>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ rawPrice }
-							displayPerMonthNotation={ true }
+							displayPerMonthNotation={ displayNotation }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountPrice }
-							displayPerMonthNotation={ true }
+							displayPerMonthNotation={ displayNotation }
 							discounted
 						/>
 					</div>
@@ -129,11 +155,13 @@ export class PlanFeaturesComparisonHeader extends Component {
 		}
 
 		return (
-			<PlanPrice
-				currencyCode={ currencyCode }
-				rawPrice={ rawPrice }
-				displayPerMonthNotation={ true }
-			/>
+			<div className={ classNames( disabledClasses ) }>
+				<PlanPrice
+					currencyCode={ currencyCode }
+					rawPrice={ rawPrice }
+					displayPerMonthNotation={ displayNotation }
+				/>
+			</div>
 		);
 	}
 }

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -107,9 +107,7 @@ export class PlanFeaturesComparison extends Component {
 				'has-border-top': ! isReskinned,
 			} );
 			const audience = planConstantObj.getAudience?.();
-			const billingTimeFrame = ! disabledClasses[ 'plan-monthly-disabled-experiment' ]
-				? planConstantObj.getBillingTimeFrame()
-				: null;
+			const billingTimeFrame = ! disabledClasses ? planConstantObj.getBillingTimeFrame() : null;
 
 			return (
 				<th scope="col" key={ planName } className={ classes }>
@@ -178,7 +176,7 @@ export class PlanFeaturesComparison extends Component {
 						className={ getPlanClass( planName ) }
 						current={ current }
 						freePlan={ isFreePlan( planName ) }
-						isDisabled={ disabledClasses[ 'plan-monthly-disabled-experiment' ] }
+						isDisabled={ disabledClasses }
 						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						isInSignup={ isInSignup }
@@ -193,11 +191,11 @@ export class PlanFeaturesComparison extends Component {
 		} );
 	}
 	getDisabledClasses( planName ) {
-		return {
+		return classNames( {
 			'plan-monthly-disabled-experiment':
 				this.props.monthlyDisabled &&
 				[ 'personal-bundle-monthly', 'value_bundle_monthly' ].includes( planName ),
-		};
+		} );
 	}
 
 	getLongestFeaturesList() {

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -85,26 +85,29 @@ export class PlanFeaturesComparison extends Component {
 
 		return map( planProperties, ( properties ) => {
 			const {
+				annualPricePerMonth,
 				availableForPurchase,
 				currencyCode,
 				current,
+				discountPrice,
 				planConstantObj,
 				planName,
 				popular,
 				relatedMonthlyPlan,
+				isMonthlyPlan,
 				isPlaceholder,
 				hideMonthly,
 				rawPrice,
 				rawPriceAnnual,
 				rawPriceForMonthlyPlan,
 			} = properties;
-			const { discountPrice } = properties;
+
+			const disabledClasses = this.getDisabledClasses( planName );
 			const classes = classNames( 'plan-features-comparison__table-item', {
 				'has-border-top': ! isReskinned,
 			} );
 			const audience = planConstantObj.getAudience?.();
-			const billingTimeFrame = planConstantObj.getBillingTimeFrame();
-			const { annualPricePerMonth, isMonthlyPlan } = properties;
+			const billingTimeFrame = ! disabledClasses ? planConstantObj.getBillingTimeFrame() : null;
 
 			return (
 				<th scope="col" key={ planName } className={ classes }>
@@ -117,6 +120,7 @@ export class PlanFeaturesComparison extends Component {
 						currencyCode={ currencyCode }
 						discountPrice={ discountPrice }
 						hideMonthly={ hideMonthly }
+						disabledClasses={ disabledClasses }
 						isPlaceholder={ isPlaceholder }
 						planType={ planName }
 						popular={ popular }
@@ -149,8 +153,8 @@ export class PlanFeaturesComparison extends Component {
 		const { isInSignup, isLaunchPage, planProperties } = this.props;
 
 		return map( planProperties, ( properties ) => {
-			const { availableForPurchase } = properties;
 			const {
+				availableForPurchase,
 				current,
 				planName,
 				primaryUpgrade,
@@ -158,8 +162,12 @@ export class PlanFeaturesComparison extends Component {
 				planConstantObj,
 				popular,
 			} = properties;
-
-			const classes = classNames( 'plan-features-comparison__table-item', 'is-top-buttons' );
+			const isDisabled = this.getDisabledClasses( planName );
+			const classes = classNames(
+				'plan-features-comparison__table-item',
+				'is-top-buttons',
+				isDisabled
+			);
 
 			return (
 				<td key={ planName } className={ classes }>
@@ -168,6 +176,7 @@ export class PlanFeaturesComparison extends Component {
 						className={ getPlanClass( planName ) }
 						current={ current }
 						freePlan={ isFreePlan( planName ) }
+						isDisabled={ isDisabled }
 						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						isInSignup={ isInSignup }
@@ -180,6 +189,16 @@ export class PlanFeaturesComparison extends Component {
 				</td>
 			);
 		} );
+	}
+	getDisabledClasses( planName ) {
+		const { monthlyDisabled } = this.props;
+		const disabledPlans = [ 'personal-bundle-monthly', 'value_bundle_monthly' ];
+		if ( monthlyDisabled && disabledPlans.includes( planName ) ) {
+			return {
+				'plan-monthly-disabled-experiment': true,
+			};
+		}
+		return false;
 	}
 
 	getLongestFeaturesList() {
@@ -264,7 +283,8 @@ export class PlanFeaturesComparison extends Component {
 					'is-highlighted':
 						selectedFeature && currentFeature && selectedFeature === currentFeature.getSlug(),
 					'is-bold': rowIndex === 0,
-				}
+				},
+				this.getDisabledClasses( planName )
 			);
 
 			return currentFeature ? (
@@ -334,6 +354,7 @@ export default connect(
 			siteId,
 			visiblePlans,
 			popularPlanSpec,
+			monthlyDisabled,
 		} = ownProps;
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteType = signupDependencies.designType;
@@ -349,7 +370,12 @@ export default connect(
 				const relatedMonthlyPlan = showMonthly
 					? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
 					: null;
-				const popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
+				let popular;
+				if ( monthlyDisabled && planObject.product_name_short === 'Business' ) {
+					popular = true;
+				} else if ( monthlyDisabled ) {
+					popular = false;
+				} else popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
 
 				// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
 				const showMonthlyPrice = true;

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -107,7 +107,9 @@ export class PlanFeaturesComparison extends Component {
 				'has-border-top': ! isReskinned,
 			} );
 			const audience = planConstantObj.getAudience?.();
-			const billingTimeFrame = ! disabledClasses ? planConstantObj.getBillingTimeFrame() : null;
+			const billingTimeFrame = ! disabledClasses[ 'plan-monthly-disabled-experiment' ]
+				? planConstantObj.getBillingTimeFrame()
+				: null;
 
 			return (
 				<th scope="col" key={ planName } className={ classes }>
@@ -162,11 +164,11 @@ export class PlanFeaturesComparison extends Component {
 				planConstantObj,
 				popular,
 			} = properties;
-			const isDisabled = this.getDisabledClasses( planName );
+			const disabledClasses = this.getDisabledClasses( planName );
 			const classes = classNames(
 				'plan-features-comparison__table-item',
 				'is-top-buttons',
-				isDisabled
+				disabledClasses
 			);
 
 			return (
@@ -176,7 +178,7 @@ export class PlanFeaturesComparison extends Component {
 						className={ getPlanClass( planName ) }
 						current={ current }
 						freePlan={ isFreePlan( planName ) }
-						isDisabled={ isDisabled }
+						isDisabled={ disabledClasses[ 'plan-monthly-disabled-experiment' ] }
 						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						isInSignup={ isInSignup }
@@ -191,14 +193,11 @@ export class PlanFeaturesComparison extends Component {
 		} );
 	}
 	getDisabledClasses( planName ) {
-		const { monthlyDisabled } = this.props;
-		const disabledPlans = [ 'personal-bundle-monthly', 'value_bundle_monthly' ];
-		if ( monthlyDisabled && disabledPlans.includes( planName ) ) {
-			return {
-				'plan-monthly-disabled-experiment': true,
-			};
-		}
-		return false;
+		return {
+			'plan-monthly-disabled-experiment':
+				this.props.monthlyDisabled &&
+				[ 'personal-bundle-monthly', 'value_bundle_monthly' ].includes( planName ),
+		};
 	}
 
 	getLongestFeaturesList() {
@@ -315,6 +314,7 @@ PlanFeaturesComparison.propTypes = {
 	selectedFeature: PropTypes.string,
 	purchaseId: PropTypes.number,
 	siteId: PropTypes.number,
+	monthlyDisabled: PropTypes.bool,
 };
 
 PlanFeaturesComparison.defaultProps = {
@@ -322,6 +322,7 @@ PlanFeaturesComparison.defaultProps = {
 	isInSignup: true,
 	siteId: null,
 	onUpgradeClick: noop,
+	monthlyDisabled: false,
 };
 
 export const calculatePlanCredits = ( state, siteId, planProperties ) =>
@@ -370,12 +371,15 @@ export default connect(
 				const relatedMonthlyPlan = showMonthly
 					? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
 					: null;
+
 				let popular;
-				if ( monthlyDisabled && planObject.product_name_short === 'Business' ) {
+				if ( monthlyDisabled && planObject?.product_name_short === 'Business' ) {
 					popular = true;
 				} else if ( monthlyDisabled ) {
 					popular = false;
-				} else popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
+				} else {
+					popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
+				}
 
 				// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
 				const showMonthlyPrice = true;

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -194,7 +194,7 @@ $plan-features-sidebar-width: 272px;
 		}
 	}
 
-	.not-available-with-monthly-disclaimer {
+	.plan-features-comparison__not-available-with-monthly-disclaimer {
 		color: var( --studio-orange-40 );
 		width: 55%;
 		margin: auto;

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -173,13 +173,6 @@ $plan-features-sidebar-width: 272px;
 			padding-bottom: 5px;
 		}
 
-		.plan-features-comparison__header-annual-discount {
-			color: var( --studio-green-60 );
-			&-is-loading {
-				@include placeholder();
-			}
-		}
-
 		.plan-price.is-original {
 			color: var( --color-neutral-light );
 
@@ -192,6 +185,19 @@ $plan-features-sidebar-width: 272px;
 				color: var( --color-text-subtle );
 			}
 		}
+	}
+
+	.plan-features-comparison__header-annual-discount {
+		color: var( --studio-green-60 );
+		&-is-loading {
+			@include placeholder();
+		}
+	}
+
+	.not-available-with-monthly-disclaimer {
+		color: var( --studio-orange-40 );
+		width: 55%;
+		margin: auto;
 	}
 
 	.is-placeholder {
@@ -485,4 +491,8 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 	}
+}
+
+.plan-monthly-disabled-experiment {
+	opacity: 0.4;
 }

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -35,6 +35,7 @@ const PlanFeaturesActionsButton = ( {
 	freePlan = false,
 	manageHref,
 	isLandingPage,
+	isDisabled = false,
 	isPlaceholder = false,
 	isPopular,
 	isInSignup,
@@ -74,7 +75,7 @@ const PlanFeaturesActionsButton = ( {
 
 	if ( current && ! isInSignup && planType !== PLAN_P2_FREE ) {
 		return (
-			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
+			<Button className={ classes } href={ manageHref } disabled={ ! manageHref || isDisabled }>
 				{ canPurchase ? translate( 'Manage plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
@@ -86,7 +87,11 @@ const PlanFeaturesActionsButton = ( {
 		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
 	) {
 		return (
-			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+			<Button
+				className={ classes }
+				onClick={ handleUpgradeButtonClick }
+				disabled={ isPlaceholder || isDisabled }
+			>
 				{ props.buttonText || translate( 'Upgrade to Yearly' ) }
 			</Button>
 		);
@@ -94,7 +99,11 @@ const PlanFeaturesActionsButton = ( {
 
 	if ( ( availableForPurchase || isPlaceholder ) && ! isLaunchPage && isInSignup ) {
 		return (
-			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+			<Button
+				className={ classes }
+				onClick={ handleUpgradeButtonClick }
+				disabled={ isPlaceholder || isDisabled }
+			>
 				{ props.buttonText ||
 					translate( 'Start with %(plan)s', {
 						args: {
@@ -177,6 +186,7 @@ PlanFeaturesActions.propTypes = {
 	currentSitePlanSlug: PropTypes.string,
 	forceDisplayButton: PropTypes.bool,
 	freePlan: PropTypes.bool,
+	isDisabeled: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
 	isLaunchPage: PropTypes.bool,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -828,6 +828,8 @@ PlanFeatures.propTypes = {
 	siteId: PropTypes.number,
 	sitePlan: PropTypes.object,
 	kindOfPlanTypeSelector: PropTypes.oneOf( [ 'interval', 'customer' ] ),
+	monthlyDisabled: PropTypes.bool,
+	intervalType: PropTypes.string,
 };
 
 PlanFeatures.defaultProps = {
@@ -838,6 +840,7 @@ PlanFeatures.defaultProps = {
 	siteId: null,
 	onUpgradeClick: noop,
 	kindOfPlanTypeSelector: 'customer',
+	monthlyDisabled: false,
 };
 
 export const isPrimaryUpgradeByPlanDelta = ( currentPlan, plan ) =>
@@ -877,10 +880,13 @@ const ConnectedPlanFeatures = connect(
 			placeholder,
 			plans,
 			isLandingPage,
+			monthlyDisabled,
 			siteId,
 			visiblePlans,
 			popularPlanSpec,
 			kindOfPlanTypeSelector,
+			intervalType,
+			withScroll,
 		} = ownProps;
 		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
@@ -912,7 +918,22 @@ const ConnectedPlanFeatures = connect(
 				const relatedMonthlyPlan = showMonthly
 					? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
 					: null;
-				const popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
+
+				// remove Personal and Premium monthly plan options from the monthly disabled test
+				if (
+					! withScroll &&
+					intervalType === 'monthly' &&
+					( planObject?.product_name_short === 'Premium' ||
+						planObject?.product_name_short === 'Personal' )
+				) {
+					return;
+				}
+
+				// Make Business plan popular for the monthly plans disabled test
+				const popular = monthlyDisabled
+					? planObject?.product_name_short === 'Business'
+					: popularPlanSpec && planMatches( plan, popularPlanSpec );
+
 				const newPlan = false;
 				const bestValue = isBestValue( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -923,6 +923,7 @@ const ConnectedPlanFeatures = connect(
 				if (
 					! withScroll &&
 					intervalType === 'monthly' &&
+					monthlyDisabled &&
 					( planObject?.product_name_short === 'Premium' ||
 						planObject?.product_name_short === 'Personal' )
 				) {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -359,7 +359,6 @@ $plan-features-sidebar-width: 272px;
 	width: 56px;
 	height: 56px;
 	margin-right: 15px;
-	border-radius: 50%;
 }
 
 .is-section-plans .plan-features__header-figure {
@@ -1235,5 +1234,19 @@ button.plan-features__scroll-button {
 				color: var( --color-neutral-30 );
 			}
 		}
+	}
+}
+
+.plan-features__mobile-disabled {
+	.plan-features__header, .plan-features__pricing, .plan-features__description, .foldable-card {
+		opacity: 0.4;
+	}
+
+	.plan-features__not-available {
+		color: var( --studio-orange-40 );
+		font-weight: 600;
+		margin: auto;
+		padding-top: 10px;
+		text-align: center;
 	}
 }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -105,6 +105,7 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			isReskinned,
+			disableMonthlyExperiment = false,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -144,6 +145,7 @@ export class PlansFeaturesMain extends Component {
 					} ) }
 					siteId={ siteId }
 					isReskinned={ isReskinned }
+					monthlyDisabled={ disableMonthlyExperiment }
 				/>
 			</div>
 		);

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -105,7 +105,7 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			isReskinned,
-			disableMonthlyExperiment = false,
+			disableMonthlyExperiment,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -157,6 +157,7 @@ export class PlansFeaturesMain extends Component {
 			customerType,
 			disableBloggerPlanWithNonBlogDomain,
 			domainName,
+			intervalType,
 			isInSignup,
 			isJetpack,
 			isLandingPage,
@@ -171,6 +172,7 @@ export class PlansFeaturesMain extends Component {
 			plansWithScroll,
 			isInVerticalScrollingPlansExperiment,
 			redirectToAddDomainFlow,
+			disableMonthlyExperiment,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -215,6 +217,8 @@ export class PlansFeaturesMain extends Component {
 					siteId={ siteId }
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					kindOfPlanTypeSelector={ this.getKindOfPlanTypeSelector( this.props ) }
+					monthlyDisabled={ disableMonthlyExperiment }
+					intervalType={ intervalType }
 				/>
 			</div>
 		);
@@ -474,6 +478,7 @@ PlansFeaturesMain.propTypes = {
 	planTypes: PropTypes.array,
 	isReskinned: PropTypes.bool,
 	planTypeSelector: PropTypes.string,
+	disableMonthlyExperiment: PropTypes.bool,
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -489,6 +494,7 @@ PlansFeaturesMain.defaultProps = {
 	plansWithScroll: false,
 	isReskinned: false,
 	planTypeSelector: 'interval',
+	disableMonthlyExperiment: false,
 };
 
 export default connect(

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -20,6 +20,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug, TRUENAME_COUPONS, TRUENAME_TLDS } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -84,6 +85,7 @@ class DomainsStep extends Component {
 		const domain = get( props, 'queryObject.new', false );
 		const search = get( props, 'queryObject.search', false ) === 'yes';
 		const suggestedDomain = get( props, 'signupDependencies.suggestedDomain' );
+		loadExperimentAssignment( 'disabled_monthly_personal_premium' );
 
 		// If we landed anew from `/domains` and it's the `new-flow` variation
 		// or there's a suggestedDomain from previous steps, always rerun the search.

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -20,7 +20,6 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug, TRUENAME_COUPONS, TRUENAME_TLDS } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -85,7 +84,6 @@ class DomainsStep extends Component {
 		const domain = get( props, 'queryObject.new', false );
 		const search = get( props, 'queryObject.search', false ) === 'yes';
 		const suggestedDomain = get( props, 'signupDependencies.suggestedDomain' );
-		loadExperimentAssignment( 'disabled_monthly_personal_premium' );
 
 		// If we landed anew from `/domains` and it's the `new-flow` variation
 		// or there's a suggestedDomain from previous steps, always rerun the search.

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import { parse as parseQs } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import AsyncLoad from 'calypso/components/async-load';
 import QueryPlans from 'calypso/components/data/query-plans';
 import MarketingMessage from 'calypso/components/marketing-message';
 import PulsingDot from 'calypso/components/pulsing-dot';
@@ -138,20 +137,26 @@ export class PlansStep extends Component {
 		);
 
 		const treatmentPlanDisplay = (
-			<AsyncLoad
-				require="calypso/signup/steps/plans/tabbed-plans"
-				flowName={ flowName }
+			<PlansFeaturesMain
+				site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+				hideFreePlan={ hideFreePlan }
+				isInSignup={ true }
+				isLaunchPage={ isLaunchPage }
+				intervalType={ this.getIntervalType() }
 				onUpgradeClick={ this.onSelectPlan }
-				plans={ [
-					'personal-bundle',
-					'value_bundle',
-					'business-bundle',
-					'ecommerce-bundle',
-					'personal-bundle-monthly',
-					'value_bundle_monthly',
-					'business-bundle-monthly',
-					'ecommerce-bundle-monthly',
-				] }
+				showFAQ={ false }
+				domainName={ this.getDomainName() }
+				customerType={ this.getCustomerType() }
+				disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+				plansWithScroll={ this.state.isDesktop }
+				planTypes={ planTypes }
+				flowName={ flowName }
+				showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+				isAllPaidPlansShown={ true }
+				isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+				shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+				isReskinned={ isReskinned }
+				disableMonthlyExperiment={ true }
 			/>
 		);
 		const defaultPlanDisplay = (
@@ -181,7 +186,7 @@ export class PlansStep extends Component {
 			<div>
 				<QueryPlans />
 				<Experiment
-					name="tabbed_layout_plans_signup_v2"
+					name="disabled_monthly_personal_premium"
 					defaultExperience={ defaultPlanDisplay }
 					treatmentExperience={ treatmentPlanDisplay }
 					loadingExperience={ loadingPlanDisplay }
@@ -229,34 +234,6 @@ export class PlansStep extends Component {
 		return subHeaderText || translate( 'Choose a plan. Upgrade as you grow.' );
 	}
 
-	getHeaderTextForExperiment() {
-		const defaultHeaderText = this.getHeaderText();
-		const experimentHeaderText = 'Choose the right plan for you';
-
-		return (
-			<Experiment
-				name="tabbed_layout_plans_signup_v2"
-				defaultExperience={ defaultHeaderText }
-				treatmentExperience={ experimentHeaderText }
-				loadingExperience={ '\u00A0' } // &nbsp;
-			/>
-		);
-	}
-	getSubHeaderTextForExperiment() {
-		const defaultSubHeaderText = this.getSubHeaderText();
-		const experimentSubHeaderText =
-			'There’s a plan for everybody. Pick between our Professional or Starter plans.';
-
-		return (
-			<Experiment
-				name="tabbed_layout_plans_signup_v2"
-				defaultExperience={ defaultSubHeaderText }
-				treatmentExperience={ experimentSubHeaderText }
-				loadingExperience={ '\u00A0' } // &nbsp;
-			/>
-		);
-	}
-
 	plansFeaturesSelection() {
 		const {
 			flowName,
@@ -266,9 +243,9 @@ export class PlansStep extends Component {
 			hasInitializedSitesBackUrl,
 		} = this.props;
 
-		const headerText = this.getHeaderTextForExperiment();
+		const headerText = this.getHeaderText();
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
-		const subHeaderText = this.getSubHeaderTextForExperiment();
+		const subHeaderText = this.getSubHeaderText();
 		const fallbackSubHeaderText = this.props.fallbackSubHeaderText || subHeaderText;
 
 		let backUrl;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -11,9 +11,8 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import MarketingMessage from 'calypso/components/marketing-message';
-import PulsingDot from 'calypso/components/pulsing-dot';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
-import { Experiment } from 'calypso/lib/explat';
+import { dangerouslyGetExperimentAssignment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -129,67 +128,36 @@ export class PlansStep extends Component {
 			isInVerticalScrollingPlansExperiment,
 			isReskinned,
 		} = this.props;
-
-		const loadingPlanDisplay = (
-			<div className="plans__loading-container">
-				<PulsingDot delay={ 400 } active />
-			</div>
-		);
-
-		const treatmentPlanDisplay = (
-			<PlansFeaturesMain
-				site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-				hideFreePlan={ hideFreePlan }
-				isInSignup={ true }
-				isLaunchPage={ isLaunchPage }
-				intervalType={ this.getIntervalType() }
-				onUpgradeClick={ this.onSelectPlan }
-				showFAQ={ false }
-				domainName={ this.getDomainName() }
-				customerType={ this.getCustomerType() }
-				disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-				plansWithScroll={ this.state.isDesktop }
-				planTypes={ planTypes }
-				flowName={ flowName }
-				showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-				isAllPaidPlansShown={ true }
-				isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-				shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-				isReskinned={ isReskinned }
-				disableMonthlyExperiment={ true }
-			/>
-		);
-		const defaultPlanDisplay = (
-			<PlansFeaturesMain
-				site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-				hideFreePlan={ hideFreePlan }
-				isInSignup={ true }
-				isLaunchPage={ isLaunchPage }
-				intervalType={ this.getIntervalType() }
-				onUpgradeClick={ this.onSelectPlan }
-				showFAQ={ false }
-				domainName={ this.getDomainName() }
-				customerType={ this.getCustomerType() }
-				disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-				plansWithScroll={ this.state.isDesktop }
-				planTypes={ planTypes }
-				flowName={ flowName }
-				showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-				isAllPaidPlansShown={ true }
-				isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-				shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-				isReskinned={ isReskinned }
-			/>
-		);
+		let experiment;
+		try {
+			experiment = dangerouslyGetExperimentAssignment( 'disabled_monthly_personal_premium' );
+		} catch {
+			experiment = false;
+		}
 
 		return (
 			<div>
 				<QueryPlans />
-				<Experiment
-					name="disabled_monthly_personal_premium"
-					defaultExperience={ defaultPlanDisplay }
-					treatmentExperience={ treatmentPlanDisplay }
-					loadingExperience={ loadingPlanDisplay }
+				<PlansFeaturesMain
+					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+					hideFreePlan={ hideFreePlan }
+					isInSignup={ true }
+					isLaunchPage={ isLaunchPage }
+					intervalType={ this.getIntervalType() }
+					onUpgradeClick={ this.onSelectPlan }
+					showFAQ={ false }
+					domainName={ this.getDomainName() }
+					customerType={ this.getCustomerType() }
+					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+					plansWithScroll={ this.state.isDesktop }
+					planTypes={ planTypes }
+					flowName={ flowName }
+					showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+					isAllPaidPlansShown={ true }
+					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+					isReskinned={ isReskinned }
+					disableMonthlyExperiment={ experiment?.variationName !== null }
 				/>
 			</div>
 		);

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import MarketingMessage from 'calypso/components/marketing-message';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
-import { dangerouslyGetExperimentAssignment } from 'calypso/lib/explat';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -28,7 +28,14 @@ import './style.scss';
 export class PlansStep extends Component {
 	state = {
 		isDesktop: isDesktop(),
+		experiment: null,
 	};
+
+	componentWillMount() {
+		loadExperimentAssignment( 'disabled_monthly_personal_premium' ).then( ( experimentName ) => {
+			this.setState( { experiment: experimentName } );
+		} );
+	}
 
 	componentDidMount() {
 		this.unsubscribe = subscribeIsDesktop( ( matchesDesktop ) =>
@@ -128,12 +135,6 @@ export class PlansStep extends Component {
 			isInVerticalScrollingPlansExperiment,
 			isReskinned,
 		} = this.props;
-		let experiment;
-		try {
-			experiment = dangerouslyGetExperimentAssignment( 'disabled_monthly_personal_premium' );
-		} catch {
-			experiment = false;
-		}
 
 		return (
 			<div>
@@ -157,7 +158,7 @@ export class PlansStep extends Component {
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 					isReskinned={ isReskinned }
-					disableMonthlyExperiment={ experiment?.variationName !== null }
+					disableMonthlyExperiment={ this.state.experiment?.variationName !== null }
 				/>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The PR implements a test for disabling the monthly option for Premium and Personal plans on the plans page in the signup flow.
* Context for this test is available at p58i-bkW-p2.
* I'll update this PR with a link to the experiment post when it's up.

Here's a screenshot of the design provided by @lucasmdo:

<img width="1035" alt="disable-monthly-test" src="https://user-images.githubusercontent.com/35781181/138381933-6ba75f21-9ab0-49ea-ab5c-8ca1c41fc520.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso.
* Add yourself to the test variant for the Explat test named `disabled_monthly_personal_premium`.
* Navigate to the `/start/new` flow and continue to the Plans step.
* Click the Monthly tab and confirm that Personal and Premium are not selectable.
* Click back to the Annual tab and confirm that they are selectable.
* Add yourself to the control variant and confirm that it still works as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
