### PR TITLE
update text on loading screen

### DIFF
--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -9,7 +9,7 @@ import './style.scss';
 
 // Total time to perform "loading"
 const DURATION_IN_MS = 6000;
-const HEADSTART_DURATION_IN_MS = 80000;
+const HEADSTART_DURATION_IN_MS = 60000;
 
 const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => {
 	const { __ } = useI18n();
@@ -21,16 +21,15 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 			break;
 		case 'setup-site':
 			steps = [
+				__( 'Laying the foundations' ),
+				__( 'Turning on the lights' ),
+				__( 'Making it beautiful' ),
 				__( 'Personalizing your site' ),
-				__( 'Applying your theme' ),
-				__( 'Turning on hosting' ),
-				__( 'Enabling SSL encryption' ),
-				__( 'Switching on email' ),
-				__( 'Applying Jetpack essentials' ),
-				__( 'Adding a domain' ),
-				__( 'Applying a plan' ),
-				__( 'Securing your information' ),
+				__( 'Sprinkling some magic' ),
+				__( 'Securing your data' ),
+				__( 'Enabling encryption' ),
 				__( 'Optimizing your content' ),
+				__( 'Applying a shiny top coat' ),
 				__( 'Closing the loop' ),
 			];
 			break;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Simply updates the text on the loading screen, and reduce the expected loading time for when HS is run. I may look at adding other improvements in future:

* Change the messages on the loading screen if no design is selected.
* Use specific times for each step to give a feeling of steps taking amounts of time

p1634769393106000-slack-C029SB8JT8S
#### Testing instructions

Go to the intent screen and select the build flow, select a theme such as twentytwenty which will have a long loading time. Observer that the text has been updated on the loading screen
`/start/setup-site/intent?flags=signup/hero-flow&siteSlug=YOUR_SITE.wordpress.com`
Related to #