### PR TITLE
Hack to fix the glitch that appears on some design picker thumbnails

### DIFF
--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -35,7 +35,8 @@ export const mShotOptions = ( { preview }: Design, highRes: boolean ): MShotsOpt
 	return {
 		vpw: 1600,
 		vph: preview === 'static' ? 1040 : 1600,
-		w: highRes ? 1200 : 600,
+		// When `w` was 1200 it created a visual glitch on one thumbnail. #57261
+		w: highRes ? 1201 : 600,
 		screen_height: 3600,
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increase width of hi-res design picker thumbnails from 1200 to 1201

> Paxton seems to have a weird dark stroke on the right hand side
p1634786981003100-slack-C029SB8JT8S

<img width="786" alt="Screen Shot 2021-10-21 at 1 29 06 pm" src="https://user-images.githubusercontent.com/1500769/138427437-097ca350-0392-406b-a759-c67eac0dc6f2.png">

The underlying html returned by the pattern API doesn't have the stroke, so it appears to be introduced by the mshot process. My guess it's some sort of rounding issue that happens when scaling the image, so I just bumped the pixel size we request and the issue goes away.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start/setup-site/design-setup-site?siteSlug=<< test site >>`
* Take a look at all the thumbnails

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

