### PR TITLE
Welcome Tour: Fix extra margin in mobile

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import '@wordpress/base-styles/colors';
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
@@ -130,7 +131,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 
 	.components-card__media {
 		height: 0;
-		padding-top: percentage( 1 / 1.53 ); // width:height ratio 
+		padding-top: math.percentage( math.div( math.ceil( math.div( 1, 1.53 ) * 100 ), 100 ) ); // img width:height ratio (1:1.53)
 		position: relative;
 		width: 100%;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -129,7 +129,17 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	}
 
 	.components-card__media {
-		min-height: 260px;
+		height: 0;
+		padding-top: 65%; // width:height ratio 1,53
+		position: relative;
+		width: 100%;
+
+		img {
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
 	}
 
 	.components-guide__page-control {
@@ -158,6 +168,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	padding: $grid-unit-15;
 	position: absolute;
 	right: 0;
+	z-index: 1;
 
 	.components-button {
 		width: 32px;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -168,7 +168,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	padding: $grid-unit-15;
 	position: absolute;
 	right: 0;
-	top: 0;
+	z-index: 1; // z-index is needed because overlay controls are written before components-card__media, and so ends up under the image
 
 	.components-button {
 		width: 32px;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -130,7 +130,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 
 	.components-card__media {
 		height: 0;
-		padding-top: 65%; // width:height ratio 1,53
+		padding-top: percentage( 1 / 1.53 ); // width:height ratio 
 		position: relative;
 		width: 100%;
 
@@ -168,7 +168,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	padding: $grid-unit-15;
 	position: absolute;
 	right: 0;
-	z-index: 1;
+	top: 0;
 
 	.components-button {
 		width: 32px;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -56,9 +56,9 @@ function WelcomeTourCard( {
 
 	return (
 		<Card className="welcome-tour-card" isElevated>
-			<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			<CardMedia>
 				<img alt={ __( 'Editor Welcome Tour', 'full-site-editing' ) } src={ imgSrc } />
+				<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			</CardMedia>
 			<CardBody>
 				<h2 className="welcome-tour-card__heading">{ heading }</h2>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -56,9 +56,9 @@ function WelcomeTourCard( {
 
 	return (
 		<Card className="welcome-tour-card" isElevated>
+			<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			<CardMedia>
 				<img alt={ __( 'Editor Welcome Tour', 'full-site-editing' ) } src={ imgSrc } />
-				<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			</CardMedia>
 			<CardBody>
 				<h2 className="welcome-tour-card__heading">{ heading }</h2>


### PR DESCRIPTION
### Changes proposed in this Pull Request

Addresses #57179

Fix strange welcome tour margin issue on mobile

https://user-images.githubusercontent.com/52076348/138438218-f6e2ed3c-548a-44d1-919c-8021b1d817e0.mov

### Images/Media

#### Before

#### After

### Technical Changes

- Removed "min-height" property in CardMedia in the Welcome Tour. It was used to have a "placeholder" while waiting for tour images/gifs to load.
* Used another approach with position absolute/relative and padding, knowing the aspect ration of the images/gifs.
* Added z-index to overlay commands.

### Testing instructions
1. Sandbox a site, checkout branch, and yarn dev --sync from apps/editing-toolkit to sync sandbox.
2. Go to the editor, open the sidebar, and from there click on “Welcome Guide”.
3. Validate that:
    - [ ] All animations work as expected.
    - [ ] There is no weird margin between the image and the body.
    - [ ] There is a white placeholder while images are still loading (disable cache and use simulate a slower connection).
4. Switch to a mobile viewport.
5. Repeat steps 1-4


Related to #57179
Fixes #57179