### PR TITLE
Purchases: Remove support of asynchronous purchase deactivations

### DIFF
--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -105,7 +105,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 	removePurchase = async () => {
 		const { domain, productName, purchase, translate, userId } = this.props;
 
-		const response = await this.props.removePurchase( purchase.id, userId );
+		await this.props.removePurchase( purchase.id, userId );
 
 		const { purchasesError } = this.props;
 
@@ -114,27 +114,10 @@ class GSuiteCancelPurchaseDialog extends Component {
 			return false;
 		}
 
-		let successMessage;
-		if ( response.status === 'completed' ) {
-			successMessage = translate( '%(productName)s was removed from {{domain/}}.', {
-				args: { productName },
-				components: { domain: <em>{ domain }</em> },
-			} );
-		} else if ( response.status === 'queued' ) {
-			successMessage = translate(
-				'We are removing %(productName)s from {{domain/}}.{{br/}}' +
-					'Please give it some time for changes to take effect. ' +
-					'An email will be sent once the process is complete.',
-				{
-					args: { productName },
-					components: { br: <br />, domain: <em>{ domain }</em> },
-				}
-			);
-		} else {
-			this.props.errorNotice( translate( 'There was an error removing the purchase.' ) );
-			return false;
-		}
-
+		const successMessage = translate( '%(productName)s was removed from {{domain/}}.', {
+			args: { productName },
+			components: { domain: <em>{ domain }</em> },
+		} );
 		this.props.successNotice( successMessage, { isPersistent: true } );
 
 		return true;

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -157,17 +157,12 @@ class CancelPurchaseButton extends Component {
 
 				if ( error ) {
 					this.props.errorNotice( error.message );
-
 					this.cancellationFailed();
-
 					return;
 				}
 
-				if ( response.status === 'completed' ) {
-					this.props.refreshSitePlans( purchase.siteId );
-					this.props.clearPurchases();
-				}
-
+				this.props.refreshSitePlans( purchase.siteId );
+				this.props.clearPurchases();
 				this.props.successNotice( response.message, { displayOnNextPage: true } );
 				page.redirect( this.props.purchaseListUrl );
 			}
@@ -192,17 +187,12 @@ class CancelPurchaseButton extends Component {
 
 				if ( error ) {
 					this.props.errorNotice( error.message );
-
 					this.cancellationFailed();
-
 					return;
 				}
 
-				if ( response.status === 'completed' ) {
-					this.props.refreshSitePlans( purchase.siteId );
-					this.props.clearPurchases();
-				}
-
+				this.props.refreshSitePlans( purchase.siteId );
+				this.props.clearPurchases();
 				this.props.successNotice( response.message, { displayOnNextPage: true } );
 				page.redirect( this.props.purchaseListUrl );
 			}

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -114,7 +114,7 @@ class ConfirmCancelDomain extends Component {
 
 		this.setState( { submitting: true } );
 
-		cancelAndRefundPurchase( purchase.id, data, ( error, response ) => {
+		cancelAndRefundPurchase( purchase.id, data, ( error ) => {
 			this.setState( { submitting: false } );
 
 			const { isDomainOnlySite, translate, selectedSite } = this.props;
@@ -135,27 +135,17 @@ class ConfirmCancelDomain extends Component {
 				return;
 			}
 
-			let successMessage;
-			if ( response.status === 'completed' ) {
-				successMessage = translate( '%(purchaseName)s was successfully cancelled and refunded.', {
-					args: { purchaseName },
-				} );
-
-				this.props.refreshSitePlans( purchase.siteId );
-				this.props.clearPurchases();
-			} else if ( response.status === 'queued' ) {
-				successMessage = translate(
-					'We are cancelling %(purchaseName)s and processing your refund.{{br/}}' +
-						'Please give it some time for changes to take effect. ' +
-						'An email will be sent once the process is complete.',
-					{ args: { purchaseName }, components: { br: <br /> } }
-				);
-			}
+			this.props.refreshSitePlans( purchase.siteId );
+			this.props.clearPurchases();
 
 			recordTracksEvent( 'calypso_domain_cancel_form_submit', {
 				product_slug: purchase.productSlug,
 			} );
 
+			const successMessage = translate(
+				'%(purchaseName)s was successfully cancelled and refunded.',
+				{ args: { purchaseName } }
+			);
 			this.props.successNotice( successMessage, { displayOnNextPage: true } );
 			page.redirect( this.props.purchaseListUrl );
 		} );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -116,7 +116,7 @@ class RemovePurchase extends Component {
 
 		const { isDomainOnlySite, purchase, translate } = this.props;
 
-		const response = await this.props.removePurchase( purchase.id, this.props.userId );
+		await this.props.removePurchase( purchase.id, this.props.userId );
 
 		const productName = getName( purchase );
 		const { purchasesError, purchaseListUrl } = this.props;
@@ -129,46 +129,20 @@ class RemovePurchase extends Component {
 			return;
 		}
 
-		if ( response.status === 'completed' ) {
-			if ( isDomainRegistration( purchase ) ) {
-				if ( isDomainOnlySite ) {
-					this.props.receiveDeletedSite( purchase.siteId );
-					this.props.setAllSitesSelected();
-				}
+		if ( isDomainRegistration( purchase ) ) {
+			if ( isDomainOnlySite ) {
+				this.props.receiveDeletedSite( purchase.siteId );
+				this.props.setAllSitesSelected();
+			}
 
-				successMessage = translate( 'The domain {{domain/}} was removed from your account.', {
-					components: { domain: <em>{ productName }</em> },
-				} );
-			} else {
-				successMessage = translate( '%(productName)s was removed from {{siteName/}}.', {
-					args: { productName },
-					components: { siteName: <em>{ purchase.domain }</em> },
-				} );
-			}
-		} else if ( response.status === 'queued' ) {
-			if ( isDomainRegistration( purchase ) ) {
-				successMessage = translate(
-					'We are removing the domain {{domain/}} from your account.{{br/}}' +
-						'Please give it some time for changes to take effect. ' +
-						'An email will be sent once the process is complete.',
-					{ components: { br: <br />, domain: <em>{ productName }</em> } }
-				);
-			} else {
-				successMessage = translate(
-					'We are removing %(productName)s from {{siteName/}}.{{br/}}' +
-						'Please give it some time for changes to take effect. ' +
-						'An email will be sent once the process is complete.',
-					{
-						args: { productName },
-						components: { br: <br />, siteName: <em>{ purchase.domain }</em> },
-					}
-				);
-			}
+			successMessage = translate( 'The domain {{domain/}} was removed from your account.', {
+				components: { domain: <em>{ productName }</em> },
+			} );
 		} else {
-			this.setState( { isRemoving: false } );
-			this.closeDialog();
-			this.props.errorNotice( translate( 'There was an error removing the purchase.' ) );
-			return;
+			successMessage = translate( '%(productName)s was removed from {{siteName/}}.', {
+				args: { productName },
+				components: { siteName: <em>{ purchase.domain }</em> },
+			} );
 		}
 
 		this.props.successNotice( successMessage, { isPersistent: true } );

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -83,9 +83,7 @@ export const removePurchase = ( purchaseId, userId ) => ( dispatch ) => {
 					userId,
 				} );
 
-				if ( data.status === 'completed' ) {
-					dispatch( requestHappychatEligibility() );
-				}
+				dispatch( requestHappychatEligibility() );
 
 				resolve( data );
 			} )

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -87,7 +87,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#removePurchase success', () => {
-		const response = { status: 'completed', purchases };
+		const response = { purchases };
 
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/57259

#### Changes proposed in this Pull Request

As of D68501-code, we no longer deactivate a subscription from an Atomic site after an lossless revert, since we now immediately remove it before triggering the lossless revert.

That means that we don't need to support asynchronous purchase deactivations anymore, so this PR effectively reverts parts of the logic introduced by https://github.com/Automattic/wp-calypso/pull/55531 and https://github.com/Automattic/wp-calypso/pull/55381 (originally added for supporting the async flows) in order to simplify the overall maintenance of the code.

#### Testing instructions

- Use the Calypso live link below.
- Switch to a Simple site.
- Go to Upgrades > Purchases.
- Select the site plan.
- Remove it.
- Make sure the plan is immediately removed.
- Make sure you get a success notification.
- Switch to an Atomic site now.
- Append `?flags=atomic/automated-revert` at the end of the URL and reload.
- Go to Upgrades > Purchases.
- Select the site plan.
- Remove it.
- Make sure the plan is immediately removed.
- Make sure there are no regressions (you should get a notification indicating the plan has been deactivated).
- Make sure the Atomic lossless revert is triggered afterwards.
