### PR TITLE
VideoPress: remove X-18 rating

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -187,14 +187,15 @@ class EditorMediaModalDetailFields extends Component {
 				label: 'R',
 				value: 'R-17',
 			},
-			{
-				label: 'X',
-				value: 'X-18',
-			},
 		];
-		const rating = this.getItemValue( 'rating' );
+		let rating = this.getItemValue( 'rating' );
 		if ( ! rating ) {
 			return;
+		}
+
+		// X-18 was previously supported but is now removed to better comply with our TOS.
+		if ( 'X-18' === rating ) {
+			rating = 'R-17';
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove X-18 rating option for VideoPress videos.

#### Testing instructions

* On a sandboxed wpcom site with a video plan
* Go to your sandboxed Calypso media library 
* Upload a video or select a video uploaded with VideoPress and click "Edit"
* ✅ No "X" or "X-18" rating option should appear
* ✅ If you previously selected X-18, the video should now appear as R (R-17)

Related to Automattic/greenhouse#954
