### PR TITLE
Added key to EditUserForm to prevent react warning

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -205,6 +205,7 @@ class EditUserForm extends Component {
 			case fieldKeys.isExternalContributor:
 				returnField = (
 					<ContractorSelect
+						key="isExternalContributor"
 						id={ fieldKeys.isExternalContributor }
 						onChange={ this.handleExternalChange }
 						checked={ this.state.isExternalContributor }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

![image](https://user-images.githubusercontent.com/3801502/138461428-244e5e38-ae98-4d9f-9a9f-249dd229608d.png)

React was throwing a warning about `EditUserForm` needing a "key", so it was added.

#### Testing instructions

Go into Users -> All Users -> Click on any user -> The warning shouldn't be there anymore.