### PR TITLE
Jetpack Checkout: support `:receiptId` as a valid value for thank you URL

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -153,7 +153,8 @@ export default function getThankYouPageUrl( {
 			productSlug ?? 'no_product'
 		}`;
 
-		const isValidReceiptId = ! isNaN( parseInt( pendingOrReceiptId ) );
+		const isValidReceiptId =
+			! isNaN( parseInt( pendingOrReceiptId ) ) || pendingOrReceiptId === ':receiptId';
 		return addQueryArgs(
 			{
 				receiptId: isValidReceiptId ? pendingOrReceiptId : undefined,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -1253,7 +1253,9 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				isJetpackCheckout: true,
 			} );
-			expect( url ).toBe( '/checkout/jetpack/thank-you/no-site/jetpack_backup_daily' );
+			expect( url ).toBe(
+				'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?receiptId=%3AreceiptId'
+			);
 		} );
 
 		it( 'redirects with receiptId query param when a valid receipt ID is provided', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the creation of a post-purchase thank you URL (`getThankYouPageUrl`) only includes a receipt ID if there is a numeric value available at the construction time. This PR makes the `:receiptId` string also a supported value.

##### Why?
WPCOM's transactions endpoints support the non-numeric value `:receiptId`. When they see that value in the redirect URL, they replace `:receiptId` with a valid/numeric receipt ID. For example, the URL `https://wordpress.com/checkout/jetpack/thank-you/no-site/jetpack_scan?receiptId=:receiptId` is transformed to `https://wordpress.com/checkout/jetpack/thank-you/no-site/jetpack_scan?receiptId=<someNumericValue>`. We will need this soon once we start fetching the user license key associated with the purchase which we will grab through the receipt ID.

#### Testing instructions

* Download this PR.
* Run tests with `yarn test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js`.

**(optional)**
* Download this PR.
* Sandbox `public-api.wordpress.com`.
* Enable `define( 'USE_STORE_SANDBOX', true );` in `wp-content/mu-plugins/0-sandbox.php`.
* Go to `cloud.jetpack.com/pricing`.
* Select Jetpack Backup Daily (or any other paid product).
* Once you're on the Checkout page, replace `wordpress.com` with `calypso.localhost:3000`.
* Complete the purchase using PayPal.
* Make sure that when you're back on Calypso, the post-purchase Thank You page includes the receipt ID in the URL.

<img src="https://user-images.githubusercontent.com/3418513/138465156-a5faaba1-1f42-4be3-89dd-023e616e1676.png" width="500" />

Related to 1201096622142517-as-1201251904887416