### PR TITLE
Customer Home: Optimize re-renders of StatsV2 card

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { createSelector } from '@automattic/state-utils';
 import classnames from 'classnames';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -173,82 +174,92 @@ export const StatsV2 = ( {
 	);
 };
 
-const getStatsQueries = ( state, siteId ) => {
-	const period = 'day';
-	const quantity = 7;
+const getStatsQueries = createSelector(
+	( state, siteId ) => {
+		const period = 'day';
+		const quantity = 7;
 
-	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
-	const date = moment()
-		.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
-		.format( 'YYYY-MM-DD' );
+		const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
+		const date = moment()
+			.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
+			.format( 'YYYY-MM-DD' );
 
-	const chartQuery = {
-		chartTab: 'views',
-		date,
-		period,
-		quantity,
-		siteId,
-		statFields: [ 'views' ],
-	};
+		const chartQuery = {
+			chartTab: 'views',
+			date,
+			period,
+			quantity,
+			siteId,
+			statFields: [ 'views' ],
+		};
 
-	const insightsQuery = {};
+		const insightsQuery = {};
 
-	const topPostsQuery = {
-		date,
-		num: quantity,
-		period,
-	};
+		const topPostsQuery = {
+			date,
+			num: quantity,
+			period,
+		};
 
-	const visitsQuery = {
-		unit: period,
-		quantity: quantity,
-		stat_fields: 'views,visitors',
-	};
+		const visitsQuery = {
+			unit: period,
+			quantity: quantity,
+			stat_fields: 'views,visitors',
+		};
 
-	return {
-		chartQuery,
+		return {
+			chartQuery,
+			insightsQuery,
+			topPostsQuery,
+			visitsQuery,
+		};
+	},
+	( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' )
+);
+
+const getStatsData = createSelector(
+	( state, siteId, chartQuery, insightsQuery, topPostsQuery ) => {
+		const counts = getCountRecords( state, siteId, chartQuery.period );
+		const chartData = buildChartData(
+			[],
+			chartQuery.chartTab,
+			counts,
+			chartQuery.period,
+			chartQuery.date
+		);
+		const views = chartData.reduce(
+			( acummulatedViews, { data } ) => acummulatedViews + data.views,
+			0
+		);
+		const visitors = chartData.reduce(
+			( acummulatedVisitors, { data } ) => acummulatedVisitors + data.visitors,
+			0
+		);
+
+		const { day: mostPopularDay, time: mostPopularTime } = getMostPopularDatetime(
+			state,
+			siteId,
+			insightsQuery
+		);
+
+		const { post: topPost, page: topPage } = getTopPostAndPage( state, siteId, topPostsQuery );
+
+		return {
+			chartData,
+			mostPopularDay,
+			mostPopularTime,
+			topPost,
+			topPage,
+			views,
+			visitors,
+		};
+	},
+	( state, siteId, chartQuery, insightsQuery, topPostsQuery ) => [
+		getCountRecords( state, siteId, chartQuery.period ),
 		insightsQuery,
 		topPostsQuery,
-		visitsQuery,
-	};
-};
-
-const getStatsData = ( state, siteId, chartQuery, insightsQuery, topPostsQuery ) => {
-	const counts = getCountRecords( state, siteId, chartQuery.period );
-	const chartData = buildChartData(
-		[],
-		chartQuery.chartTab,
-		counts,
-		chartQuery.period,
-		chartQuery.date
-	);
-	const views = chartData.reduce(
-		( acummulatedViews, { data } ) => acummulatedViews + data.views,
-		0
-	);
-	const visitors = chartData.reduce(
-		( acummulatedVisitors, { data } ) => acummulatedVisitors + data.visitors,
-		0
-	);
-
-	const { day: mostPopularDay, time: mostPopularTime } = getMostPopularDatetime(
-		state,
-		siteId,
-		insightsQuery
-	);
-
-	const { post: topPost, page: topPage } = getTopPostAndPage( state, siteId, topPostsQuery );
-
-	return {
-		chartData,
-		mostPopularDay,
-		mostPopularTime,
-		topPost,
-		topPage,
-		views,
-		visitors,
-	};
-};
+	]
+);
 
 const isLoadingStats = ( state, siteId, chartQuery, insightsQuery, topPostsQuery ) =>
 	getLoadingTabs( state, siteId, chartQuery.period ).includes( chartQuery.chartTab ) ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While I was dogfooding our Customer Home page, I noticed that when collapsing and expanding the Quick Links accordion, the `StatsV2` component on the left re-renders multiple times. It seemed like it would rerender tens of times without necessarily changing anything. 

When I dug deeper into it, I noticed that we're needlessly creating new objects with the chart queries and the chart data. So the data in them is the same every time, but because it's a different object every time, it would always re-render multiple times when one of the objects changes. 

This PR does a minor optimization to how that works by wrapping those expensive selectors in a couple of `createSelector` calls to memoize those objects. While this isn't ideal, it prevents further needless re-rendering of the stats component.

A better solution would be to go deeper down into each selector and memoize all the different levels that are necessary in order to maintain the same objects when the same data is passed to the selectors. However, I concluded that this would be a bigger task than it would be worth it for such an optimization, hence the solution I came up with. I'm happy to abandon this in favor of a better solution if that's the consensus.

#### Testing instructions

* Make sure you have React DevTools enabled. 
* Make sure you have the "Highlight updates when components render." option enabled.
* Load `/home/:site` where `:site` is one of your WP.com sites.
* Play with expanding and collapsing the Quick Links accordion with some delay between those actions.
* Verify the Stats component to the left doesn't re-render.