### PR TITLE
E2E: extend iframed Gutenberg editor timeout to 60000ms.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -72,7 +72,7 @@ export class GutenbergEditorPage {
 	 */
 	async waitUntilLoaded(): Promise< Frame > {
 		const frame = await this.getEditorFrame();
-		await this.page.waitForLoadState( 'load' );
+		await this.page.waitForLoadState( 'load', { timeout: 60 * 1000 } );
 		// Traditionally we try to avoid waits not related to the current flow. However, we need a stable way to identify loading being done.
 		// NetworkIdle takes too long here, so the most reliable alternative is the title being visible.
 		await frame.waitForSelector( selectors.editorTitle );

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -71,8 +71,8 @@ export class GutenbergEditorPage {
 	 * @returns {Promise<Frame>} iframe holding the editor.
 	 */
 	async waitUntilLoaded(): Promise< Frame > {
+		await this.page.waitForLoadState( 'load' );
 		const frame = await this.getEditorFrame();
-		await this.page.waitForLoadState( 'load', { timeout: 60 * 1000 } );
 		// Traditionally we try to avoid waits not related to the current flow. However, we need a stable way to identify loading being done.
 		// NetworkIdle takes too long here, so the most reliable alternative is the title being visible.
 		await frame.waitForSelector( selectors.editorTitle );
@@ -85,7 +85,9 @@ export class GutenbergEditorPage {
 	 * @returns {Promise<Frame>} iframe holding the editor.
 	 */
 	async getEditorFrame(): Promise< Frame > {
-		const elementHandle = await this.page.waitForSelector( selectors.editorFrame );
+		const elementHandle = await this.page.waitForSelector( selectors.editorFrame, {
+			timeout: 60 * 1000,
+		} );
 		return ( await elementHandle.contentFrame() ) as Frame;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR extends the timeout used while waiting for the iframed Gutenberg editor to load in Calypso.

Key changes:
- extend the timeout from the default value of 30000ms to 60000ms.

#### Testing instructions

- [x] stress test
  - [x] mobile https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_mobile/6883054
  - [x] desktop https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_desktop/6883052
- [x] normal test
  - [x] mobile
  - [x] desktop


Fixes #57254.