### PR TITLE
Mobile Web: Signup remove the back button

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -804,3 +804,16 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 }
+/**
+ * Removed the navigation back button step from mobile viewports.
+ * This is done because the there is usally already a back button displayed to the user (Browser back button)
+ * and the current back button is redundent.
+*/
+body.is-section-signup.is-white-signup {
+	.signup__step.is-plans .step-wrapper__navigation,
+	.signup__step.is-domains .step-wrapper__navigation {
+		@include breakpoint-deprecated( '<660px' ) {
+			display: none;
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the action bar from the domain and pricing plans page in start up on mobile. 

Currently, on mobile, you see a bottom bar that looks something like this. 
<img src="https://user-images.githubusercontent.com/115071/138521423-edefc2a0-3e31-4f8e-a6de-58c8fea40a55.png" width="300" />

Before:

<img width="300" src="https://user-images.githubusercontent.com/115071/138355125-6626a4df-c5bd-480d-b487-6937eb2cfc82.PNG" />
<img width="300" src="https://user-images.githubusercontent.com/115071/138355130-4f49f52a-1bae-48d6-b302-4b9b8f5dcdd0.PNG" />


After:
<img width="300" src="https://user-images.githubusercontent.com/115071/138521674-fbe9645a-2c23-46c5-9a2e-75acf8043af9.png" />
<img width="300" src="https://user-images.githubusercontent.com/115071/138521678-5e4de3d6-35d0-4448-aff0-c2c751ea0956.png" />


#### Testing instructions

* Go through the sign-up flow on a mobile viewport notice that the bottom bar is gone from the domains selection and the plan selection steps. 


Related to https://github.com/Automattic/wp-calypso/issues/57248
