### PR TITLE
Jetpack Checkout: add query to fetch user license by receipt Id

### DIFF
--- a/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
+++ b/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
@@ -1,0 +1,42 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+export type UserLicenseApi = {
+	license_key: string;
+	product: string;
+	product_id: number;
+	subscription_id: number;
+};
+
+export type UserLicense = {
+	licenseKey: string;
+	product: string;
+	productId: number;
+	subscriptionId: number;
+};
+
+function selectUserLicenseApiData( licenses: UserLicenseApi[] ): UserLicense[] {
+	return licenses.map( ( license ) => ( {
+		licenseKey: license.license_key,
+		product: license.product,
+		productId: license.product_id,
+		subscriptionId: license.subscription_id,
+	} ) );
+}
+
+const useUserLicenseByReceiptQuery = ( receiptId: number ): UseQueryResult< UserLicense[] > => {
+	const queryKey = [ 'user-license', receiptId ];
+	return useQuery< UserLicenseApi[], unknown, UserLicense[] >(
+		queryKey,
+		async () =>
+			wpcom.req.get( {
+				path: `/jetpack-licensing/receipt/${ receiptId }`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			select: selectUserLicenseApiData,
+		}
+	);
+};
+
+export default useUserLicenseByReceiptQuery;

--- a/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
+++ b/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
@@ -30,7 +30,7 @@ const useUserLicenseByReceiptQuery = ( receiptId: number ): UseQueryResult< User
 		queryKey,
 		async () =>
 			wpcom.req.get( {
-				path: `/jetpack-licensing/receipt/${ receiptId }`,
+				path: `/jetpack-licensing/user/receipt/${ receiptId }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		{

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -153,7 +153,8 @@ export default function getThankYouPageUrl( {
 			productSlug ?? 'no_product'
 		}`;
 
-		const isValidReceiptId = ! isNaN( parseInt( pendingOrReceiptId ) );
+		const isValidReceiptId =
+			! isNaN( parseInt( pendingOrReceiptId ) ) || pendingOrReceiptId === ':receiptId';
 		return addQueryArgs(
 			{
 				receiptId: isValidReceiptId ? pendingOrReceiptId : undefined,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -1253,7 +1253,9 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				isJetpackCheckout: true,
 			} );
-			expect( url ).toBe( '/checkout/jetpack/thank-you/no-site/jetpack_backup_daily' );
+			expect( url ).toBe(
+				'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?receiptId=%3AreceiptId'
+			);
 		} );
 
 		it( 'redirects with receiptId query param when a valid receipt ID is provided', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* After a Jetpack purchase has been completed, we soon will have to fetch the user license key by the receipt Id created after the purchase. This PR creates a hook based on `useQuery` from React Query that can be reused across Calypso that fetches a user license linked to a given receipt.

#### Testing instructions

* Download this PR.
* Open the `client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx` file locally, and add the following lines:
```
// add this line after line 13
import useUserLicenseByReceiptQuery from 'calypso/data/jetpack-licensing/use-user-license-by-receipt-query';

// add this line after line 60
console.log( useUserLicenseByReceiptQuery( receiptId ) );
```
* Start Calypso with `yarn start`.
* Sandbox `public-api.wordpress.com`.
* Add `add_filter( 'jetpack_license_checkout_m2_enabled', '__return_true' );` to your `0-sanbox.php` file.
* Visit `cloud.jetpack.com/pricing`.
* Select a Jetpack product.
* Once you're on the Checkout page, replace `wordpress.com` with `calypso.localhost:3000`.
* Complete the purchase (any payment method works).
* Once you're on the Thank You page, open the JS Console.
* Refresh the page.
* Verify that in the JS Console you see the user license linked to the receipt (you can see the receiptId as query parameter in the URL).

<img width="632" alt="Screen Shot 2021-10-22 at 19 57 10" src="https://user-images.githubusercontent.com/3418513/138531548-3d7da411-8db2-49f2-9fff-1b60111d24f9.png">

Related to 1201096622142517-as-1201096622142555