### PR TITLE
Hide arrow options from pagination when they are disabled

### DIFF
--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -38,7 +38,7 @@ $minimal-arrow-size: 24px;
 				}
 
 				&:disabled {
-					color: $minimal-inactive; // don't highlight on hover when disabled
+					visibility: hidden;
 				}
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hide arrow options from pagination when they are disabled.
Those options shouldn't be shown once they are not clickable.

As per oU6nEIeiKSg8CayhEtgR6b-fi-6450%3A38266


#### Testing instructions

* Go to plugins search page
* Search for a plugin (You can try typing 'jetpack')
* Verify if when you are on the first page the **previous** option is **not** shown.
* Click on the last page and verify if the **next** option is **not** shown.
* Click in one of the pages in the middle (can be '2') and verify the options **previous** and **next** are shown.

#### Demo

![Kapture 2021-10-23 at 12 19 48](https://user-images.githubusercontent.com/5039531/138564435-d5c8d799-04f8-4a3b-9af3-7f5796dbac34.gif)


Fixes #57297