### PR TITLE
Stats: Cache hourly views for `StatsSparkline`

### DIFF
--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -53,11 +54,17 @@ const StatsSparklineChart = ( { className, hourlyViews, height = DEFAULT_HEIGHT 
 		</div>
 	);
 };
-const StatsSparkline = ( { className, siteId } ) => {
-	const hourlyViews = useSelector( ( state ) => {
+
+const getStatsInsightsHourlyViews = createSelector(
+	( state, siteId ) => {
 		const statsInsights = getSiteStatsNormalizedData( state, siteId, 'statsInsights' );
 		return statsInsights.hourlyViews ? Object.values( statsInsights.hourlyViews ) : null;
-	} );
+	},
+	( state, siteId ) => getSiteStatsNormalizedData( state, siteId, 'statsInsights' )
+);
+
+const StatsSparkline = ( { className, siteId } ) => {
+	const hourlyViews = useSelector( ( state ) => getStatsInsightsHourlyViews( state, siteId ) );
 
 	return (
 		<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While profiling Calypso, I noticed there are several components that needlessly re-render when any state change occurs.  One of them is `StatsSparkline`. This happens because the relevant selector essentially generates a new object every time, even if the state is the same.

This PR improves the hourly views selector to be memoized, so it would use the same object when the same data is used, reducing the number of re-renders of the My Home page.

#### Testing instructions

* Make sure you have React DevTools enabled. 
* Make sure you have the "Highlight updates when components render." option enabled.
* Load `/home/:site` where `:site` is one of your WP.com sites that has some visits.
* Play with expanding and collapsing the Quick Links accordion with some delay between those actions.
* Verify the StatsSparkline component (the little chart in the sidebar in the Stats menu item) doesn't re-render.