### PR TITLE
Onboarding: Turn on `signup/hero-flow` for wpcalypso

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -156,7 +156,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/setup-site-after-checkout": true,
-		"signup/hero-flow": false,
+		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
 		"titan/iframe-control-panel": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,7 +100,7 @@
 		"signup/reskin": true,
 		"signup/social": true,
 		"signup/setup-site-after-checkout": true,
-		"signup/hero-flow": false,
+		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
 		"upgrades/checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -116,7 +116,7 @@
 		"signup/reskin": true,
 		"signup/social": true,
 		"signup/setup-site-after-checkout": true,
-		"signup/hero-flow": false,
+		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turn on the `signup/hero-flow` for wpcalypso so that we can easily test the new onboarding flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the link to calypso live from [here](https://github.com/Automattic/wp-calypso/pull/57310#issuecomment-950741011)
* Go to `/start`
* Check you can go through the entire onboarding flow including choosing an intent, giving your blog a name, picking your start point, showing draft post modal and the first post published modal after checkout.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56568
