### PR TITLE
Remove the reader/seen-posts feature flag

### DIFF
--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { connect, useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import Stream from 'calypso/reader/stream';
@@ -11,11 +11,15 @@ import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
 import { SECTION_A8C_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 
-const A8CFollowing = ( props ) => {
-	const { translate, teams } = props;
+export default function A8CFollowing( props ) {
+	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const teams = useSelector( getReaderTeams );
+	const feedsInfo = useSelector( ( state ) =>
+		getReaderOrganizationFeedsInfo( state, AUTOMATTIC_ORG_ID )
+	);
 
-	const markAllAsSeen = ( feedsInfo ) => {
+	const markAllAsSeen = () => {
 		const { feedIds, feedUrls } = feedsInfo;
 		dispatch( recordReaderTracksEvent( 'calypso_reader_mark_all_as_seen_clicked' ) );
 		dispatch( requestMarkAllAsSeen( { identifier: SECTION_A8C_FOLLOWING, feedIds, feedUrls } ) );
@@ -25,20 +29,11 @@ const A8CFollowing = ( props ) => {
 		<Stream { ...props } shouldCombineCards={ false }>
 			<SectionHeader label={ translate( 'Followed A8C Sites' ) }>
 				{ isEligibleForUnseen( { teams } ) && (
-					<Button
-						compact
-						onClick={ () => markAllAsSeen( props.feedsInfo ) }
-						disabled={ ! props.feedsInfo.unseenCount }
-					>
+					<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 						{ translate( 'Mark all as seen' ) }
 					</Button>
 				) }
 			</SectionHeader>
 		</Stream>
 	);
-};
-
-export default connect( ( state ) => ( {
-	teams: getReaderTeams( state ),
-	feedsInfo: getReaderOrganizationFeedsInfo( state, AUTOMATTIC_ORG_ID ),
-} ) )( localize( A8CFollowing ) );
+}

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,8 +1,8 @@
 import { CompactCard, Button } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { flatMap, trim } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
+import { trim } from 'lodash';
 import page from 'page';
-import { connect, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import SearchInput from 'calypso/components/search';
 import SectionHeader from 'calypso/components/section-header';
 import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
@@ -31,21 +31,28 @@ function handleSearch( query ) {
 	}
 }
 
-const FollowingStream = ( props ) => {
-	const suggestionList =
-		props.suggestions &&
-		flatMap( props.suggestions, ( query ) => [
-			<Suggestion suggestion={ query.text } source="following" railcar={ query.railcar } />,
-			', ',
-		] ).slice( 0, -1 );
-	const placeholderText = getSearchPlaceholderText();
-	const { translate, teams } = props;
+function FollowingStream( { suggestions, ...props } ) {
+	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const markAllAsSeen = ( feedsInfo ) => {
+	const teams = useSelector( getReaderTeams );
+	const feedsInfo = useSelector( ( state ) => getReaderOrganizationFeedsInfo( state, NO_ORG_ID ) );
+
+	const markAllAsSeen = () => {
 		const { feedIds, feedUrls } = feedsInfo;
 		dispatch( recordReaderTracksEvent( 'calypso_reader_mark_all_as_seen_clicked' ) );
 		dispatch( requestMarkAllAsSeen( { identifier: SECTION_FOLLOWING, feedIds, feedUrls } ) );
 	};
+
+	const suggestionList =
+		suggestions &&
+		suggestions
+			.flatMap( ( query ) => [
+				<Suggestion suggestion={ query.text } source="following" railcar={ query.railcar } />,
+				', ',
+			] )
+			.slice( 0, -1 );
+	const placeholderText = getSearchPlaceholderText();
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Stream { ...props }>
@@ -61,11 +68,7 @@ const FollowingStream = ( props ) => {
 			<BlankSuggestions suggestions={ suggestionList } />
 			<SectionHeader label={ translate( 'Followed Sites' ) }>
 				{ isEligibleForUnseen( { teams } ) && (
-					<Button
-						compact
-						onClick={ () => markAllAsSeen( props.feedsInfo ) }
-						disabled={ ! props.feedsInfo.unseenCount }
-					>
+					<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 						{ translate( 'Mark all as seen' ) }
 					</Button>
 				) }
@@ -76,9 +79,6 @@ const FollowingStream = ( props ) => {
 		</Stream>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
-};
+}
 
-export default connect( ( state ) => ( {
-	teams: getReaderTeams( state ),
-	feedsInfo: getReaderOrganizationFeedsInfo( state, NO_ORG_ID ),
-} ) )( SuggestionProvider( localize( FollowingStream ) ) );
+export default SuggestionProvider( FollowingStream );

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
@@ -101,7 +100,6 @@ export const getRoutesWithoutSeenSupport = () => {
  * Get default seen value given a route. FALSE if the route does not support seen functionality, TRUE otherwise.
  *
  * @param {string} currentRoute given route
- *
  * @returns {boolean} default seen value for given route
  */
 export const getDefaultSeenValue = ( currentRoute ) => {
@@ -115,14 +113,9 @@ export const getDefaultSeenValue = ( currentRoute ) => {
  * @param {object} flags eligibility data
  * @param {Array} flags.teams list of reader teams
  * @param {boolean} flags.isWPForTeamsItem id if exists
- *
  * @returns {boolean} whether or not the user can use the feature for the given site
  */
 export const isEligibleForUnseen = ( { teams, isWPForTeamsItem = false } ) => {
-	if ( ! config.isEnabled( 'reader/seen-posts' ) ) {
-		return false;
-	}
-
 	if ( isAutomatticTeamMember( teams ) ) {
 		return true;
 	}
@@ -137,7 +130,6 @@ export const isEligibleForUnseen = ( { teams, isWPForTeamsItem = false } ) => {
  * @param {Object} params.post object
  * @param {Array} params.posts list
  * @param {string} params.currentRoute given route
- *
  * @returns {boolean} whether or not the post can be marked as seen
  */
 export const canBeMarkedAsSeen = ( { post = null, posts = [], currentRoute = '' } ) => {
@@ -165,7 +157,6 @@ export const canBeMarkedAsSeen = ( { post = null, posts = [], currentRoute = '' 
  * Return Featured image alt text.
  *
  * @param {Object} post object containing post information
- *
  * @returns {string} Featured image alt text
  */
 export const getFeaturedImageAlt = ( post ) => {

--- a/client/reader/p2/main.jsx
+++ b/client/reader/p2/main.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { connect, useDispatch } from 'react-redux';
@@ -23,15 +22,13 @@ const P2Following = ( props ) => {
 	return (
 		<Stream { ...props } shouldCombineCards={ false }>
 			<SectionHeader label={ translate( 'Followed P2 Sites' ) }>
-				{ config.isEnabled( 'reader/seen-posts' ) && (
-					<Button
-						compact
-						onClick={ () => markAllAsSeen( props.feedsInfo ) }
-						disabled={ ! props.feedsInfo.unseenCount }
-					>
-						{ translate( 'Mark all as seen' ) }
-					</Button>
-				) }
+				<Button
+					compact
+					onClick={ () => markAllAsSeen( props.feedsInfo ) }
+					disabled={ ! props.feedsInfo.unseenCount }
+				>
+					{ translate( 'Mark all as seen' ) }
+				</Button>
 			</SectionHeader>
 		</Stream>
 	);

--- a/client/reader/p2/main.jsx
+++ b/client/reader/p2/main.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { connect, useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import Stream from 'calypso/reader/stream';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -9,11 +9,12 @@ import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizatio
 import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
 import { SECTION_P2_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 
-const P2Following = ( props ) => {
-	const { translate } = props;
+export default function P2Following( props ) {
+	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const feedsInfo = useSelector( ( state ) => getReaderOrganizationFeedsInfo( state, P2_ORG_ID ) );
 
-	const markAllAsSeen = ( feedsInfo ) => {
+	const markAllAsSeen = () => {
 		const { feedIds, feedUrls } = feedsInfo;
 		dispatch( recordReaderTracksEvent( 'calypso_reader_mark_all_as_seen_clicked' ) );
 		dispatch( requestMarkAllAsSeen( { identifier: SECTION_P2_FOLLOWING, feedIds, feedUrls } ) );
@@ -22,18 +23,10 @@ const P2Following = ( props ) => {
 	return (
 		<Stream { ...props } shouldCombineCards={ false }>
 			<SectionHeader label={ translate( 'Followed P2 Sites' ) }>
-				<Button
-					compact
-					onClick={ () => markAllAsSeen( props.feedsInfo ) }
-					disabled={ ! props.feedsInfo.unseenCount }
-				>
+				<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 					{ translate( 'Mark all as seen' ) }
 				</Button>
 			</SectionHeader>
 		</Stream>
 	);
-};
-
-export default connect( ( state ) => ( {
-	feedsInfo: getReaderOrganizationFeedsInfo( state, P2_ORG_ID ),
-} ) )( localize( P2Following ) );
+}

--- a/config/development.json
+++ b/config/development.json
@@ -140,7 +140,6 @@
 		"reader/full-errors": true,
 		"reader/gutenberg-for-comments": false,
 		"reader/list-management": true,
-		"reader/seen-posts": true,
 		"recommend-plugins": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -89,7 +89,6 @@
 		"privacy-policy": true,
 		"reader": true,
 		"reader/list-management": true,
-		"reader/seen-posts": true,
 		"republicize": true,
 		"safari-idb-mitigation": true,
 		"server-side-rendering": true,

--- a/config/production.json
+++ b/config/production.json
@@ -93,7 +93,6 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,
-		"reader/seen-posts": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -93,7 +93,6 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,
-		"reader/seen-posts": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,

--- a/config/test.json
+++ b/config/test.json
@@ -70,7 +70,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/seen-posts": true,
 		"republicize": true,
 		"rum-tracking/logstash": false,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -101,7 +101,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/seen-posts": true,
 		"recommend-plugins": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
A followup to #57220 that removes the `reader/seen-posts` feature flag. It's enabled in all Calypso environments and Jetpack Cloud never checks it because the flag is contained in Reader code.

There's a second commit that refactors some affected components to hooks: there were functional components with `useDispatch` that still used `connect` and `localize` despite being functional. I'm refactoring to use hooks consistently.

**How to test:**
When reviewing the Reader stream refactors, check how props are passed down to `<Stream {...props}/>`. Verify that the `Stream` component doesn't use any props that were previously injected with HOCs (like `feedsInfo` or `teams`), but only the ones that are passed through from above.