### PR TITLE
Reuse the site-setup processing screen steps for the DIFM signup flow.

### DIFF
--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -11,6 +11,8 @@ import './style.scss';
 const DURATION_IN_MS = 6000;
 const HEADSTART_DURATION_IN_MS = 60000;
 
+const flowsWithDesignPicker = [ 'setup-site', 'do-it-for-me' ];
+
 const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => {
 	const { __ } = useI18n();
 	let steps = [];
@@ -19,26 +21,27 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 		case 'launch-site':
 			steps = [ __( 'Your site will be live shortly.' ) ]; // copy from 'packages/launch/src/focused-launch/success'
 			break;
-		case 'setup-site':
-			steps = [
-				__( 'Laying the foundations' ),
-				__( 'Turning on the lights' ),
-				__( 'Making it beautiful' ),
-				__( 'Personalizing your site' ),
-				__( 'Sprinkling some magic' ),
-				__( 'Securing your data' ),
-				__( 'Enabling encryption' ),
-				__( 'Optimizing your content' ),
-				__( 'Applying a shiny top coat' ),
-				__( 'Closing the loop' ),
-			];
-			break;
 		default:
 			steps = [
 				! isDestinationSetupSiteFlow && __( 'Building your site' ),
 				hasPaidDomain && __( 'Getting your domain' ),
 				! isDestinationSetupSiteFlow && __( 'Applying design' ),
 			];
+	}
+
+	if ( flowsWithDesignPicker.includes( flowName ) ) {
+		steps = [
+			__( 'Laying the foundations' ),
+			__( 'Turning on the lights' ),
+			__( 'Making it beautiful' ),
+			__( 'Personalizing your site' ),
+			__( 'Sprinkling some magic' ),
+			__( 'Securing your data' ),
+			__( 'Enabling encryption' ),
+			__( 'Optimizing your content' ),
+			__( 'Applying a shiny top coat' ),
+			__( 'Closing the loop' ),
+		];
 	}
 
 	return useRef( steps.filter( Boolean ) );
@@ -52,9 +55,12 @@ export default function ReskinnedProcessingScreen( props ) {
 	const steps = useSteps( props );
 	const { isDestinationSetupSiteFlow, flowName } = props;
 	const totalSteps = steps.current.length;
-	const shouldShowNewSpinner = isDestinationSetupSiteFlow || flowName === 'setup-site';
+	const shouldShowNewSpinner =
+		isDestinationSetupSiteFlow || flowsWithDesignPicker.includes( flowName );
 
-	const duration = flowName === 'setup-site' ? HEADSTART_DURATION_IN_MS : DURATION_IN_MS;
+	const duration = flowsWithDesignPicker.includes( flowName )
+		? HEADSTART_DURATION_IN_MS
+		: DURATION_IN_MS;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Small refactor to use the same steps ('Laying the foundations', 'Turning on the lights') as those used by the `setup-site` flow for the `do-it-for-me` flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Start the flow at /start/do-it-for-me in an incognito window.
* Go through the flow steps.
* Confirm that the processing screen looks like this:

https://user-images.githubusercontent.com/5436027/138688794-382ffee2-c178-4954-8511-aecc60019b24.mp4

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


