### PR TITLE
Backup, Scan: Update upsell copy when real-time products are enabled

### DIFF
--- a/client/my-sites/backup/backup-upsell/index.tsx
+++ b/client/my-sites/backup/backup-upsell/index.tsx
@@ -7,6 +7,10 @@ import JetpackDisconnected from 'calypso/components/jetpack/jetpack-disconnected
 import Upsell from 'calypso/components/jetpack/upsell';
 import { UpsellComponentProps } from 'calypso/components/jetpack/upsell-switch';
 import Main from 'calypso/components/main';
+import {
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -59,12 +63,20 @@ const BackupsUpsellBody: FunctionComponent = () => {
 	const translate = useTranslate();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const dispatch = useDispatch();
+
+	const bodyText =
+		getForCurrentCROIteration( {
+			[ Iterations.ONLY_REALTIME_PRODUCTS ]: translate(
+				'Get peace of mind knowing your work will be saved, add backups today.'
+			),
+		} ) ??
+		translate(
+			'Get peace of mind knowing your work will be saved, add backups today. Choose from real time or daily backups.'
+		);
 	return (
 		<Upsell
 			headerText={ translate( 'Your site does not have backups' ) }
-			bodyText={ translate(
-				'Get peace of mind knowing your work will be saved, add backups today. Choose from real time or daily backups.'
-			) }
+			bodyText={ bodyText }
 			buttonLink={ `https://jetpack.com/upgrade/backup/?site=${ selectedSiteSlug }` }
 			onClick={ () => dispatch( recordTracksEvent( 'calypso_jetpack_backup_upsell_click' ) ) }
 			iconComponent={ <BackupsUpsellIcon /> }

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -14,6 +14,10 @@ import PromoCard from 'calypso/components/promo-section/promo-card';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import {
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -74,6 +78,44 @@ const BackupUpsellBody: FunctionComponent = () => {
 	);
 	const translate = useTranslate();
 	const postCheckoutUrl = window.location.pathname + window.location.search;
+
+	const upsellButtons = getForCurrentCROIteration( {
+		[ Iterations.ONLY_REALTIME_PRODUCTS ]: (
+			<Button
+				className="backup__wpcom-cta"
+				href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_t1_yearly`, {
+					redirect_to: postCheckoutUrl,
+				} ) }
+				onClick={ onUpgradeClick }
+				primary
+			>
+				{ translate( 'Get backups' ) }
+			</Button>
+		),
+	} ) ?? (
+		<>
+			<Button
+				className="backup__wpcom-cta backup__wpcom-realtime-cta"
+				href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_realtime`, {
+					redirect_to: postCheckoutUrl,
+				} ) }
+				onClick={ onUpgradeClick }
+				primary
+			>
+				{ translate( 'Get real-time backups' ) }
+			</Button>
+			<Button
+				className="backup__wpcom-cta backup__wpcom-daily-cta"
+				href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_daily`, {
+					redirect_to: postCheckoutUrl,
+				} ) }
+				onClick={ onUpgradeClick }
+			>
+				{ translate( 'Get daily backups' ) }
+			</Button>
+		</>
+	);
+
 	return (
 		<PromoCard
 			title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
@@ -96,29 +138,7 @@ const BackupUpsellBody: FunctionComponent = () => {
 				/>
 			) }
 
-			{ isAdmin && (
-				<div className="backup__wpcom-ctas">
-					<Button
-						className="backup__wpcom-cta backup__wpcom-realtime-cta"
-						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_realtime`, {
-							redirect_to: postCheckoutUrl,
-						} ) }
-						onClick={ onUpgradeClick }
-						primary
-					>
-						{ translate( 'Get real-time backups' ) }
-					</Button>
-					<Button
-						className="backup__wpcom-cta backup__wpcom-daily-cta"
-						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_daily`, {
-							redirect_to: postCheckoutUrl,
-						} ) }
-						onClick={ onUpgradeClick }
-					>
-						{ translate( 'Get daily backups' ) }
-					</Button>
-				</div>
-			) }
+			{ isAdmin && <div className="backup__wpcom-ctas">{ upsellButtons }</div> }
 		</PromoCard>
 	);
 };

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -16,6 +16,10 @@ import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import {
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -81,6 +85,17 @@ const ScanUpsellBody: FunctionComponent = () => {
 	const translate = useTranslate();
 	const postCheckoutUrl = window.location.pathname + window.location.search;
 
+	const nonAdminNoticeText =
+		getForCurrentCROIteration( {
+			[ Iterations.ONLY_REALTIME_PRODUCTS ]: translate(
+				'Only site administrators can upgrade to access security scanning.'
+			),
+		} ) ?? translate( 'Only site administrators can upgrade to access daily scanning.' );
+	const buttonText =
+		getForCurrentCROIteration( {
+			[ Iterations.ONLY_REALTIME_PRODUCTS ]: translate( 'Get Jetpack Scan' ),
+		} ) ?? translate( 'Get daily scanning' );
+
 	return (
 		<PromoCard
 			title={ translate( 'We guard your site. You run your business.' ) }
@@ -95,17 +110,13 @@ const ScanUpsellBody: FunctionComponent = () => {
 			</p>
 
 			{ ! isAdmin && (
-				<Notice
-					status="is-warning"
-					text={ translate( 'Only site administrators can upgrade to access daily scanning.' ) }
-					showDismiss={ false }
-				/>
+				<Notice status="is-warning" text={ nonAdminNoticeText } showDismiss={ false } />
 			) }
 
 			{ isAdmin && (
 				<PromoCardCTA
 					cta={ {
-						text: translate( 'Get daily scanning' ),
+						text: buttonText,
 						action: {
 							url: addQueryArgs( `/checkout/${ siteSlug }/jetpack_scan`, {
 								redirect_to: postCheckoutUrl,


### PR DESCRIPTION
Resolves `1200412004370260-as-1201247946218251`.

#### Changes proposed in this Pull Request

* On the upsell page for Backup (in both Calypso Blue and Calypso Green), when real-time products are enabled, substitute alternative copy to remove references to "daily" or "real-time."
* On the upsell page for Scan in Calypso Green, when real-time products are enabled, substitute alternative copy to remove references to "daily" scanning.

#### Testing instructions

**Prerequisite:** In the following test cases, you must select a Jetpack site that does NOT have Jetpack Backup or Jetpack Scan.

##### Calypso Blue

1. Visit `/backup/:site?flags=jetpack/only-realtime-products`.
2. Verify you see the Backup upsell as pictured below.
3. Verify the "Get backups" button sends you to checkout for Jetpack Backup (10 GB) with a yearly billing term.
4. Remove `?flags=jetpack/only-realtime-products` from your browser URL and refresh the page.
5. Verify the upsell appears as it does in production, and the upsell buttons function as in production.

<img width="325" alt="Screen Shot 2021-10-25 at 08 06 55" src="https://user-images.githubusercontent.com/670067/138704122-afaff57d-f787-4155-9f50-863525c27abd.png"> <img width="450" alt="Screen Shot 2021-10-25 at 08 06 46" src="https://user-images.githubusercontent.com/670067/138704105-5f81f6bc-15ba-4c52-ae53-3677e298e532.png">

6. Visit `/scan/:site?flags=jetpack/only-realtime-products`.
7. Verify you see the Scan upsell as pictured below.
8. Verify the "Get Jetpack Scan" button sends you to checkout for Jetpack Scan with a yearly billing term.
9. Remove `?flags=jetpack/only-realtime-products` from your browser URL and refresh the page.
10. Verify the upsell appears as it does in production, and the upsell buttons function as in production.

<img width="325" alt="Screen Shot 2021-10-25 at 08 06 34" src="https://user-images.githubusercontent.com/670067/138704251-7e07dfa8-8948-489e-8ea6-c37c53f740af.png"> <img width="450" alt="Screen Shot 2021-10-25 at 08 06 18" src="https://user-images.githubusercontent.com/670067/138704218-c9c3b4e5-71c2-4943-9445-30b17f873add.png">

##### Calypso Green

11. Visit `/backup/:site?flags=jetpack/only-realtime-products`.
12. Verify you see the Backup upsell as pictured below.
13. Verify the "Upgrade now" button sends you to `https://jetpack.com/upgrade/backup/?site=:site`.
14. Remove `?flags=jetpack/only-realtime-products` from your browser URL and refresh the page.
15. Verify the upsell appears as it does in production, and the upsell buttons function as in production.

<img width="325" alt="Screen Shot 2021-10-25 at 08 11 41" src="https://user-images.githubusercontent.com/670067/138704427-d949cc27-f8e0-4673-b34d-1becde45cae8.png"> <img width="450" alt="Screen Shot 2021-10-25 at 08 11 32" src="https://user-images.githubusercontent.com/670067/138704388-6dd53716-65f3-403e-8da5-794a9d1a1be4.png">