### PR TITLE
Domains: Add breadcrumb component to DNS management pages

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
@@ -32,9 +32,16 @@ import './style.scss';
 const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } ) => {
 	const renderItemLabel = ( item ) => {
 		if ( item.href ) {
-			return <a href={ item.href }>{ item.label }</a>;
+			return (
+				<a
+					className="breadcrumbs__item-label breadcrumbs__item-label--clickable"
+					href={ item.href }
+				>
+					{ item.label }
+				</a>
+			);
 		}
-		return item.label || item;
+		return <span className="breadcrumbs__item-label">{ item.label || item }</span>;
 	};
 
 	const renderHelpBubble = ( item ) => {
@@ -64,7 +71,7 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 
 	const renderItem = ( item, index ) => (
 		<React.Fragment key={ `breadcrumb${ index }` }>
-			<span>{ renderItemLabel( item ) }</span>
+			<span className="breadcrumbs__item">{ renderItemLabel( item ) }</span>
 			{ renderHelpBubble( item ) }
 			{ renderSeparator( index ) }
 		</React.Fragment>
@@ -87,7 +94,7 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 		return (
 			<>
 				{ renderBackArrow() }
-				<span>{ renderItemLabel( mobileItem ) }</span>
+				<span className="breadcrumbs__item--mobile">{ renderItemLabel( mobileItem ) }</span>
 				{ renderHelpBubble( mobileItem ) }
 			</>
 		);

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
@@ -81,7 +81,7 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 		if ( mobileItem.showBackArrow && mobileItem.href ) {
 			/* eslint-disable wpcalypso/jsx-gridicon-size */
 			return (
-				<a href={ mobileItem.href }>
+				<a className="breadcrumbs__item" href={ mobileItem.href }>
 					<Gridicon className="breadcrumbs__back-arrow" icon="chevron-left" size={ 14 } />
 				</a>
 			);

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
@@ -94,7 +94,9 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 		return (
 			<>
 				{ renderBackArrow() }
-				<span className="breadcrumbs__item--mobile">{ renderItemLabel( mobileItem ) }</span>
+				<span className="breadcrumbs__item breadcrumbs__item--mobile">
+					{ renderItemLabel( mobileItem ) }
+				</span>
 				{ renderHelpBubble( mobileItem ) }
 			</>
 		);

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { Icon, chevronLeft } from '@wordpress/icons';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -82,7 +83,7 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 			/* eslint-disable wpcalypso/jsx-gridicon-size */
 			return (
 				<a className="breadcrumbs__item" href={ mobileItem.href }>
-					<Gridicon className="breadcrumbs__back-arrow" icon="chevron-left" size={ 14 } />
+					<Icon className="breadcrumbs__back-arrow" icon={ chevronLeft } size={ 20 } />
 				</a>
 			);
 			/* eslint-enable wpcalypso/jsx-gridicon-size */

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -32,15 +32,27 @@
 		align-items: center;
 		font-size: 13px; /* stylelint-disable-line */
 		font-weight: 500; /* stylelint-disable-line */
-		color: var( --color-neutral-50 );
-
-		& .breadcrumbs__item-link {
-			color: var( --color-neutral-50 );
-		}
-		& .breadcrumbs__item:first-child {
-			font-size: $font-body;
-			font-weight: 600;
+		color: var( --color-neutral-80 );
+		
+		& .breadcrumbs__item {
 			color: var( --color-neutral-80 );
+			
+			& .breadcrumbs__item-label {
+				color: var( --color-neutral-80 );
+			}
+			
+			&:first-child {
+				.breadcrumbs__item-label {
+					font-size: $font-body;
+					font-weight: 600;
+				}
+			}
+
+			&:last-child {
+				.breadcrumbs__item-label {
+					color: var( --color-neutral-50 );
+				}
+			}
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -5,7 +5,27 @@
 	margin: 0;
 
 	@include break-mobile {
+		position: sticky;
+		top: 0;
+		margin-top: 0;
+	}
+
+	@include breakpoint-deprecated( '480px-660px' ) {
+		position: sticky;
+		top: 0;
+		margin-top: -22px;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		position: sticky;
 		/* hack to make the breadcrumbs closer to the top of the content area */
+		top: -22px;
+		margin-top: -22px;
+	}
+
+	@include break-medium {
+		position: sticky;
+		top: -44px;
 		margin-top: -44px;
 	}
 }
@@ -15,6 +35,14 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: 16px;
+
+	@include break-mobile {
+		padding: 16px 0;
+	}
+
+	@include breakpoint-deprecated( '480px-660px' ) {
+		padding: 16px;
+	}
 }
 
 .breadcrumbs__bottom-border {

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -34,10 +34,10 @@
 		font-weight: 500; /* stylelint-disable-line */
 		color: var( --color-neutral-50 );
 
-		& a {
+		& .breadcrumbs__item-link {
 			color: var( --color-neutral-50 );
 		}
-		& span:first-child {
+		& .breadcrumbs__item:first-child {
 			font-size: $font-body;
 			font-weight: 600;
 			color: var( --color-neutral-80 );
@@ -49,8 +49,13 @@
 	display: flex;
 	align-items: center;
 
-	& a {
+	& .breadcrumbs__item-link {
 		color: var( --color-neutral-50 );
+	}
+	& .breadcrumbs__item:first-child {
+		font-size: $font-body;
+		font-weight: 600;
+		color: var( --color-neutral-80 );
 	}
 
 	@include break-mobile {

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -89,13 +89,24 @@
 	display: flex;
 	align-items: center;
 
-	& .breadcrumbs__item-link {
-		color: var( --color-neutral-50 );
+	& .breadcrumbs__item {
+		display: flex;
+		align-items: center;
 	}
+
+	& .breadcrumbs__item-label {
+		color: var( --color-neutral-80 );
+		font-size: 13px; /* stylelint-disable-line */
+	}
+
 	& .breadcrumbs__item:first-child {
 		font-size: $font-body;
 		font-weight: 600;
-		color: var( --color-neutral-80 );
+		color: var( --color-neutral-50 );
+
+		& .breadcrumbs__item-label {
+			font-size: $font-body;
+		}
 	}
 
 	@include break-mobile {

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { CompactCard as Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { some } from 'lodash';
@@ -14,6 +15,7 @@ import { getSelectedDomain, isMappedDomain, isRegisteredDomain } from 'calypso/l
 import { domainConnect } from 'calypso/lib/domains/constants';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
+import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import {
 	domainManagementEdit,
 	domainManagementNameServers,
@@ -52,6 +54,13 @@ class Dns extends Component {
 				<DnsTemplates selectedDomainName={ this.props.selectedDomainName } />
 			</VerticalNav>
 		);
+	}
+
+	renderHeader() {
+		const { translate, selectedDomainName } = this.props;
+		<Header onClick={ this.goBack } selectedDomainName={ selectedDomainName }>
+			{ translate( 'DNS Records' ) }
+		</Header>;
 	}
 
 	renderBreadcrumbs() {
@@ -98,7 +107,9 @@ class Dns extends Component {
 
 		return (
 			<Main className="dns">
-				{ this.renderBreadcrumbs() }
+				{ config.isEnabled( 'domains/management-list-redesign' )
+					? this.renderBreadcrumbs()
+					: this.renderHeader() }
 				<Card>
 					<DnsDetails />
 					<DnsList

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -7,13 +7,18 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import VerticalNav from 'calypso/components/vertical-nav';
 import { getSelectedDomain, isMappedDomain, isRegisteredDomain } from 'calypso/lib/domains';
 import { domainConnect } from 'calypso/lib/domains/constants';
+import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
-import Header from 'calypso/my-sites/domains/domain-management/components/header';
-import { domainManagementEdit, domainManagementNameServers } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementNameServers,
+	domainManagementDns,
+} from 'calypso/my-sites/domains/paths';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
@@ -49,8 +54,40 @@ class Dns extends Component {
 		);
 	}
 
+	renderBreadcrumbs() {
+		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
+		const previousPath = domainManagementDns( selectedSite.slug, selectedDomainName, currentRoute );
+
+		const items = [
+			{
+				label: translate( 'Domains' ),
+				helpBubble: translate(
+					'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
+						},
+					}
+				),
+			},
+			{
+				label: selectedDomainName,
+				href: previousPath,
+			},
+			{ label: translate( 'DNS records' ) },
+		];
+
+		const mobileItem = {
+			label: translate( 'Back' ),
+			href: previousPath,
+			showBackArrow: true,
+		};
+
+		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
+	}
+
 	renderMain() {
-		const { dns, selectedDomainName, selectedSite, translate } = this.props;
+		const { dns, selectedDomainName, selectedSite } = this.props;
 		const domain = getSelectedDomain( this.props );
 		const hasWpcomNameservers = domain?.hasWpcomNameservers ?? false;
 		const domainConnectEnabled = some( dns.records, {
@@ -61,9 +98,7 @@ class Dns extends Component {
 
 		return (
 			<Main className="dns">
-				<Header onClick={ this.goBack } selectedDomainName={ selectedDomainName }>
-					{ translate( 'DNS Records' ) }
-				</Header>
+				{ this.renderBreadcrumbs() }
 				<Card>
 					<DnsDetails />
 					<DnsList

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -107,7 +107,7 @@ class Dns extends Component {
 
 		return (
 			<Main className="dns">
-				{ config.isEnabled( 'domains/management-list-redesign' )
+				{ config.isEnabled( 'domains/dns-records-redesign' )
 					? this.renderBreadcrumbs()
 					: this.renderHeader() }
 				<Card>

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -19,7 +19,6 @@ import {
 	domainManagementEdit,
 	domainManagementNameServers,
 	domainManagementList,
-	domainManagementDns,
 } from 'calypso/my-sites/domains/paths';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -65,7 +64,6 @@ class Dns extends Component {
 
 	renderBreadcrumbs() {
 		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
-		const previousPath = domainManagementDns( selectedSite.slug, selectedDomainName, currentRoute );
 
 		const items = [
 			{
@@ -74,14 +72,14 @@ class Dns extends Component {
 			},
 			{
 				label: selectedDomainName,
-				href: previousPath,
+				href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
 			},
 			{ label: translate( 'DNS records' ) },
 		];
 
 		const mobileItem = {
 			label: translate( 'Back' ),
-			href: previousPath,
+			href: domainManagementNameServers( selectedSite.slug, selectedDomainName, currentRoute ),
 			showBackArrow: true,
 		};
 

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -8,7 +8,6 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import VerticalNav from 'calypso/components/vertical-nav';
 import { getSelectedDomain, isMappedDomain, isRegisteredDomain } from 'calypso/lib/domains';
@@ -19,6 +18,7 @@ import Header from 'calypso/my-sites/domains/domain-management/components/header
 import {
 	domainManagementEdit,
 	domainManagementNameServers,
+	domainManagementList,
 	domainManagementDns,
 } from 'calypso/my-sites/domains/paths';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
@@ -70,14 +70,7 @@ class Dns extends Component {
 		const items = [
 			{
 				label: translate( 'Domains' ),
-				helpBubble: translate(
-					'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
-						},
-					}
-				),
+				href: domainManagementList( selectedSite.slug, selectedDomainName ),
 			},
 			{
 				label: selectedDomainName,

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -99,7 +99,7 @@ class Dns extends Component {
 		} );
 
 		return (
-			<Main className="dns">
+			<Main wideLayout className="dns">
 				{ config.isEnabled( 'domains/dns-records-redesign' )
 					? this.renderBreadcrumbs()
 					: this.renderHeader() }

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -175,7 +175,7 @@ class NameServers extends Component {
 		} );
 
 		return (
-			<Main className={ classes }>
+			<Main wideLayout className={ classes }>
 				{ config.isEnabled( 'domains/dns-records-redesign' )
 					? this.renderBreadcrumbs()
 					: this.header() }

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -173,7 +173,7 @@ class NameServers extends Component {
 
 		return (
 			<Main className={ classes }>
-				{ config.isEnabled( 'domains/management-list-redesign' )
+				{ config.isEnabled( 'domains/dns-records-redesign' )
 					? this.renderBreadcrumbs()
 					: this.header() }
 				{ this.getContent() }

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -5,6 +5,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import VerticalNav from 'calypso/components/vertical-nav';
@@ -12,8 +13,8 @@ import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
+import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import NonPrimaryDomainPlanUpsell from 'calypso/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell';
-import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import IcannVerificationCard from 'calypso/my-sites/domains/domain-management/components/icann-verification';
 import { domainManagementEdit, domainManagementDns } from 'calypso/my-sites/domains/paths';
 import {
@@ -170,7 +171,7 @@ class NameServers extends Component {
 
 		return (
 			<Main className={ classes }>
-				{ this.header() }
+				{ this.renderBreadcrumbs() }
 				{ this.getContent() }
 			</Main>
 		);
@@ -208,19 +209,47 @@ class NameServers extends Component {
 		}
 	};
 
+	renderBreadcrumbs() {
+		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
+		const previousPath = domainManagementEdit(
+			selectedSite.slug,
+			selectedDomainName,
+			currentRoute
+		);
+
+		const items = [
+			{
+				label: translate( 'Domains' ),
+				helpBubble: translate(
+					'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
+						},
+					}
+				),
+			},
+			{
+				label: selectedDomainName,
+				href: previousPath,
+			},
+			{ label: translate( 'DNS records' ) },
+		];
+
+		const mobileItem = {
+			label: translate( 'Back' ),
+			href: previousPath,
+			showBackArrow: true,
+		};
+
+		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
+	}
+
 	saveNameservers = () => {
 		const { nameservers } = this.state;
 
 		this.props.updateNameservers( nameservers );
 	};
-
-	header() {
-		return (
-			<Header onClick={ this.back } selectedDomainName={ this.props.selectedDomainName }>
-				{ this.props.translate( 'Name Servers and DNS' ) }
-			</Header>
-		);
-	}
 
 	back = () => {
 		page(

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
@@ -15,6 +16,7 @@ import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import NonPrimaryDomainPlanUpsell from 'calypso/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell';
+import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import IcannVerificationCard from 'calypso/my-sites/domains/domain-management/components/icann-verification';
 import { domainManagementEdit, domainManagementDns } from 'calypso/my-sites/domains/paths';
 import {
@@ -171,7 +173,9 @@ class NameServers extends Component {
 
 		return (
 			<Main className={ classes }>
-				{ this.renderBreadcrumbs() }
+				{ config.isEnabled( 'domains/management-list-redesign' )
+					? this.renderBreadcrumbs()
+					: this.header() }
 				{ this.getContent() }
 			</Main>
 		);
@@ -250,6 +254,14 @@ class NameServers extends Component {
 
 		this.props.updateNameservers( nameservers );
 	};
+
+	header() {
+		return (
+			<Header onClick={ this.back } selectedDomainName={ this.props.selectedDomainName }>
+				{ this.props.translate( 'Name Servers and DNS' ) }
+			</Header>
+		);
+	}
 
 	back = () => {
 		page(

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -6,7 +6,6 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import VerticalNav from 'calypso/components/vertical-nav';
@@ -18,7 +17,11 @@ import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/b
 import NonPrimaryDomainPlanUpsell from 'calypso/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import IcannVerificationCard from 'calypso/my-sites/domains/domain-management/components/icann-verification';
-import { domainManagementEdit, domainManagementDns } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainManagementDns,
+} from 'calypso/my-sites/domains/paths';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -224,14 +227,7 @@ class NameServers extends Component {
 		const items = [
 			{
 				label: translate( 'Domains' ),
-				helpBubble: translate(
-					'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
-						},
-					}
-				),
+				href: domainManagementList( selectedSite.slug, selectedDomainName ),
 			},
 			{
 				label: selectedDomainName,


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds the breadcrumbs navigation for the DNS management pages. This is part of the domain management pages redesign described in pcYYhz-m2-p2.

### Preview
#### Mobile
![image](https://user-images.githubusercontent.com/18705930/138746062-8e1926c4-43e7-4b14-8b8b-47fd729e810c.png)

#### Desktop
![image](https://user-images.githubusercontent.com/18705930/138745995-fb2b8087-37b2-4494-a7ba-5551841e83af.png)

Note: some of the styles/layouts will have some changes after #57082 is merged. I opted to base this PR on `trunk` so the review is easier and they can be independently deployed.

### Testing instructions

- Access the live Calypso link;
- Select any domain from the domains list and go to its DNS records management 
(`/domains/manage/:site/name-servers/:domain`);
- Append this feature flag to your browser's URL: `?flags=domains/dns-records-redesign`;
- Ensure the page contains the breadcrumbs as shown in the screenshots above and that the navigation still works as expected.