### PR TITLE
Domains: Add dot before TLD on the Domain Upsell nudge text

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -161,7 +161,7 @@ export class SiteNotice extends Component {
 
 		if ( priceAndSaleInfo.minSalePrice ) {
 			if ( get( priceAndSaleInfo, 'saleTlds.length', 0 ) === 1 ) {
-				noticeText = translate( 'Get a %(tld)s domain for just %(salePrice)s for a limited time', {
+				noticeText = translate( 'Get a .%(tld)s domain for just %(salePrice)s for a limited time', {
 					args: {
 						tld: priceAndSaleInfo.saleTlds[ 0 ],
 						salePrice: formatCurrency( priceAndSaleInfo.minSalePrice, currencyCode ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Just adds a `.` before the TLD. 

#### Testing instructions
Check that the `.` is shown before the TLD on the domain upsell nudge.

#### Before
![image](https://user-images.githubusercontent.com/18705930/138759331-da5acc48-124f-40f8-abcc-835f580279a8.png)

#### After
![image](https://user-images.githubusercontent.com/18705930/138759244-833029aa-6ca0-4a24-82ef-fe001f2c1213.png)