### PR TITLE
Jetpack User Licensing: Update user licensing endpoint paths.

### DIFF
--- a/client/state/data-layer/wpcom/user-licensing/index.js
+++ b/client/state/data-layer/wpcom/user-licensing/index.js
@@ -28,7 +28,7 @@ export const requestLicenses = ( action ) =>
 		{
 			method: 'GET',
 			apiNamespace: 'wpcom/v2',
-			path: '/jetpack-licensing/licenses/user',
+			path: '/jetpack-licensing/user/licenses',
 			query: {
 				// Do not apply filters during search as search takes over (matches Calypso Blue Post search behavior).
 				...( action.search
@@ -76,7 +76,7 @@ export const requestCounts = ( action ) =>
 		{
 			method: 'GET',
 			apiNamespace: 'wpcom/v2',
-			path: '/jetpack-licensing/licenses/user/counts',
+			path: '/jetpack-licensing/user/licenses/counts',
 		},
 		action
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to avoid collision with partner licenses, the route paths for user licenses were updated in D68978-code.

This PR updates the endpoint paths to be consistent with D68978-code.

Endpoint paths **before**:
- `jetpack-licensing/licenses/user`
- `jetpack-licensing/licenses/user/counts`

Endpoint paths **after**:
- `jetpack-licensing/user/licenses`
- `jetpack-licensing/user/licenses/counts`


#### Testing instructions

- Checkout this branch and `yarn start`.
- Verify all unit tests are passing:
    - Run command: `yarn test-client client/state/user-licensing`

- I think it should be enough to Inspect code changes, and verify the endpoint path locations are consistent with D68978-code.

I personally tested to make sure these changes to the endpoint paths are correct and that the changes to these endpoints are returning the correct data, however if you would like to test this more thoroughly, you could query the user licenses data with the following instructions:

Prerequisites:
- [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) installed into your browser.
- Ideally you should have 1 or more Jetpack user licenses. (If you don't have one, you can still test, however you won't have any data in the `licenses` and `counts` properties. To create a user license, 1. you can log into your wpcom sandbox and create on in wp-shell(`wpsh`), instructions here: D68384-code. Or 2. you can enable a flag(`add_action`) in your sandbox and complete checkout with a jetpack product, instructions here: D67941-code).

Instructions:
- Open file: `client/my-sites/plans/jetpack-plans/selector.tsx`;
- Right after line 6, add `import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';`
- In the top of the `return` statement (line 168), add component: `<QueryJetpackUserLicenses />`  (just above the `<QueryJetpackSaleCoupon />` component).
- Go to: http://calypso.localhost:3000/plans/:site`  (replace `:site` with the site slug of any Jetpack site you own).
- Open your browser developer tools and open Redux DevTools. Inspect Calypso state and find `state.userLicensing`. Inspect the object and all the data. Verify it looks all good. (See screenshots below)

- 
<img width="821" alt="Screenshot on 2021-10-19 at 13-03-31" src="https://user-images.githubusercontent.com/11078128/137958115-28c7b2b4-f44f-42b9-b998-fc9c3942201c.png">

![Screenshot on 2021-10-19 at 13-06-03](https://user-images.githubusercontent.com/11078128/137958297-7d1fe8ec-c0e1-469e-9dd3-6a00da7ec544.png)