### PR TITLE
E2E: add cron expression to run Playwright branch e2e tests every 30 minutes on trunk.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -18,6 +18,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 
 object WebApp : Project({
 	id("WebApp")
@@ -659,6 +660,14 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					-:pull*
 					-:trunk
 				""".trimIndent()
+			}
+			schedule {
+				schedulingPolicy = cron {
+					minutes = "0/30"
+				}
+				branchFilter = "+:trunk"
+				triggerBuild = always()
+				withPendingChangesOnly = false
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses #57336 to run the Playwright branch e2e tests on `trunk` branch every 30 minutes, every hour, every day.

Key changes:
- import `schedule`.
- add new policy based on `cron`-like syntax for `trunk` only.

Details:
In the sprint meeting of 2021/10/25, the topic of test reliability was discussed. While it was agreed that reliability has for the most part been good, it was preferable to have some more data points to ascertain whether any specs require additional scrutiny. 

It was decided that running the desktop and mobile tests on `trunk` every 30 minutes on `trunk` would be a good baseline for comparison.


Closes #57336.