### PR TITLE
Playwright: wait for placeholder to disappear in support dialog preview.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -23,6 +23,7 @@ const selectors = {
 
 	// Article
 	readMoreButton: 'text=Read more',
+	supportArticlePlaceholder: 'p.support-article-dialog__placeholder-text',
 	visitArticleButton: 'text="Visit article"',
 	closeButton: 'button:text("Close")',
 };
@@ -161,10 +162,15 @@ export class SupportComponent {
 		}
 
 		await this.page.click( `:nth-match(${ selector }, ${ target })` );
+	}
 
-		if ( category === 'article' ) {
-			await this.page.click( selectors.readMoreButton );
-		}
+	/**
+	 * Click on the `Read More` button shown on the support popover.
+	 *
+	 * The target button is shown only for Article type results.
+	 */
+	async clickReadMore(): Promise< void > {
+		await this.page.click( selectors.readMoreButton );
 	}
 
 	/**
@@ -173,14 +179,18 @@ export class SupportComponent {
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
-		await this.page.waitForSelector( selectors.visitArticleButton );
+		// Wait for the placeholder to disappear from the Support article preview.
+		await this.page.waitForSelector( selectors.supportArticlePlaceholder, { state: 'hidden' } );
 
 		const browserContext = this.page.context();
+		// `Visit article` launches a new page.
 		const [ newPage ] = await Promise.all( [
 			browserContext.waitForEvent( 'page' ),
 			this.page.click( selectors.visitArticleButton ),
 		] );
 		await newPage.waitForLoadState( 'domcontentloaded' );
+
+		// Return handler to the new tab.
 		return newPage;
 	}
 

--- a/test/e2e/specs/specs-playwright/wp-support__popover-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-spec.ts
@@ -56,6 +56,7 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 
 		it( 'Click and visit first support article', async function () {
 			await supportComponent.clickResult( 'article', 1 );
+			await supportComponent.clickReadMore();
 			// Obtain handle to the popup page.
 			supportArticlePage = await supportComponent.visitArticle();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a wait to the POM code in `SupportComponent.visitArticle` prior to clicking on the button.

Key changes:
- adds a wait for the placeholder selector to disappear from page prior to clicking the button to visit the article.

#### CI

- [x] stress test
  - [x] mobile https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_mobile/6885388
  - [x] desktop https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_desktop/6885404
- [x] normal test
  - [x] mobile
  - [x] desktop


Fixes #57342.
