### PR TITLE
Redirect to My Home when the user clicks I'm not ready

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
@@ -9,7 +9,8 @@ import './style.scss';
 const DraftPostModal = () => {
 	const [ isOpen, setIsOpen ] = useState( true );
 	const closeModal = () => setIsOpen( false );
-	const closeEditor = () => doAction( 'a8c.wpcom-block-editor.closeEditor' );
+	const closeEditor = () =>
+		doAction( 'a8c.wpcom-block-editor.closeEditor', `/home/${ window.location.hostname }` );
 
 	return (
 		<NuxModal

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { doAction, hasAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -9,7 +10,12 @@ import './style.scss';
 const CLOSE_EDITOR_ACTION = 'a8c.wpcom-block-editor.closeEditor';
 
 const DraftPostModal = () => {
-	const homeUrl = `/home/${ window.location.hostname }`;
+	const siteId = window._currentSiteId;
+	const primaryDomain = useSelect( ( select ) =>
+		select( 'automattic/site' ).getPrimarySiteDomain( siteId )
+	);
+
+	const homeUrl = `/home/${ primaryDomain?.domain || window.location.hostname }`;
 	const [ isOpen, setIsOpen ] = useState( true );
 	const closeModal = () => setIsOpen( false );
 	const closeEditor = () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
@@ -1,16 +1,24 @@
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { doAction } from '@wordpress/hooks';
+import { doAction, hasAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import NuxModal from '../nux-modal';
 import draftPostImage from './images/draft-post.svg';
 import './style.scss';
 
+const CLOSE_EDITOR_ACTION = 'a8c.wpcom-block-editor.closeEditor';
+
 const DraftPostModal = () => {
+	const homeUrl = `/home/${ window.location.hostname }`;
 	const [ isOpen, setIsOpen ] = useState( true );
 	const closeModal = () => setIsOpen( false );
-	const closeEditor = () =>
-		doAction( 'a8c.wpcom-block-editor.closeEditor', `/home/${ window.location.hostname }` );
+	const closeEditor = () => {
+		if ( hasAction( CLOSE_EDITOR_ACTION ) ) {
+			doAction( CLOSE_EDITOR_ACTION, homeUrl );
+		} else {
+			window.location.href = `https://wordpress.com${ homeUrl }`;
+		}
+	};
 
 	return (
 		<NuxModal

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/style.scss
@@ -8,6 +8,13 @@
 		padding: 10px;
 		border-bottom: 0;
 
+		// Fix styles when Gutenberg is deactivated
+		position: absolute;
+		left: 0;
+		right: 0;
+		margin: 0;
+		background-color: transparent;
+
 		button {
 			left: unset;
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -465,20 +465,25 @@ function handleInsertClassicBlockMedia( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function handleCloseEditor( calypsoPort ) {
-	addAction( 'a8c.wpcom-block-editor.closeEditor', 'a8c/wpcom-block-editor/closeEditor', () => {
-		const { port2 } = new MessageChannel();
-		calypsoPort.postMessage(
-			{
-				action: 'closeEditor',
-				payload: {
-					unsavedChanges:
-						select( 'core' ).__experimentalGetDirtyEntityRecords?.().length > 0 ||
-						select( 'core/editor' ).isEditedPostDirty(),
+	addAction(
+		'a8c.wpcom-block-editor.closeEditor',
+		'a8c/wpcom-block-editor/closeEditor',
+		( destinationUrl ) => {
+			const { port2 } = new MessageChannel();
+			calypsoPort.postMessage(
+				{
+					action: 'closeEditor',
+					payload: {
+						unsavedChanges:
+							select( 'core' ).__experimentalGetDirtyEntityRecords?.().length > 0 ||
+							select( 'core/editor' ).isEditedPostDirty(),
+						destinationUrl,
+					},
 				},
-			},
-			[ port2 ]
-		);
-	} );
+				[ port2 ]
+			);
+		}
+	);
 
 	const dispatchAction = ( e ) => {
 		e.preventDefault();

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -369,9 +369,9 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		}
 
 		if ( EditorActions.CloseEditor === action || EditorActions.GoToAllPosts === action ) {
-			const { unsavedChanges = false } = payload;
+			const { unsavedChanges = false, destinationUrl = this.props.closeUrl } = payload;
 			this.props.setEditorIframeLoaded( false );
-			this.navigate( this.props.closeUrl, unsavedChanges );
+			this.navigate( destinationUrl, unsavedChanges );
 		}
 
 		if ( EditorActions.OpenRevisions === action ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding optional `destinationUrl` as args of `closeEditor` action so that we can control the destination to My Home after the user clicks “I'm not ready”.

https://user-images.githubusercontent.com/13596067/138849443-e9831a8c-0945-4d3f-b8e9-9fc638317574.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a terminal and run `cd apps/wpcom-block-editor && yarn dev --sync`
* Open a terminal and run `cd apps/editing-toolkit && yarn dev --sync`
* Go to `/start?flags=signup/hero-flow`
* Select “write” intent and choose a design as a starting point
* Before choosing the design, ensure your domain points to your sandbox
* Click “I'm not ready” of the draft a post modal
* Check it redirects to My Home or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1635172690160700-slack-C029SB8JT8S