### PR TITLE
Reader: Fix ConversationCommentList default state

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -63,6 +63,10 @@ export class ConversationCommentList extends Component {
 		setActiveReply: noop,
 	};
 
+	state = {
+		commentText: null,
+	};
+
 	onUpdateCommentText = ( commentText ) => this.setState( { commentText: commentText } );
 
 	onReplyClick = ( commentId ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #57317 we removed the last component state property, so we also removed the state object. However, there was still component state being set in that component, so when accessed early, it would fail because the component state object was not defined at all. This PR brings back the state object with the `commentText` set as a default.

Kudos to @michaelbutler for noticing and to @westi for diagnosing the offensive PR.

#### Testing instructions

* Verify `/read/conversations` and `/read/a8c` work well and don't fail. 
* Try smoke testing, accessing some full reader posts, commenting, etc.