### PR TITLE
Show Jetpack end-user license in purchase section

### DIFF
--- a/client/data/jetpack-licensing/types.ts
+++ b/client/data/jetpack-licensing/types.ts
@@ -1,0 +1,13 @@
+export type UserLicenseApi = {
+	license_key: string;
+	product: string;
+	product_id: number;
+	subscription_id: number;
+};
+
+export type UserLicense = {
+	licenseKey: string;
+	product: string;
+	productId: number;
+	subscriptionId: number;
+};

--- a/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
+++ b/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
@@ -1,28 +1,7 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import wpcom from 'calypso/lib/wp';
-
-export type UserLicenseApi = {
-	license_key: string;
-	product: string;
-	product_id: number;
-	subscription_id: number;
-};
-
-export type UserLicense = {
-	licenseKey: string;
-	product: string;
-	productId: number;
-	subscriptionId: number;
-};
-
-function selectUserLicenseApiData( licenses: UserLicenseApi[] ): UserLicense[] {
-	return licenses.map( ( license ) => ( {
-		licenseKey: license.license_key,
-		product: license.product,
-		productId: license.product_id,
-		subscriptionId: license.subscription_id,
-	} ) );
-}
+import { mapManyLicenseApiToLicense } from './utils';
+import type { UserLicenseApi, UserLicense } from './types';
 
 const useUserLicenseByReceiptQuery = ( receiptId: number ): UseQueryResult< UserLicense[] > => {
 	const queryKey = [ 'user-license', receiptId ];
@@ -34,7 +13,9 @@ const useUserLicenseByReceiptQuery = ( receiptId: number ): UseQueryResult< User
 				apiNamespace: 'wpcom/v2',
 			} ),
 		{
-			select: selectUserLicenseApiData,
+			select: mapManyLicenseApiToLicense,
+			refetchIntervalInBackground: false,
+			refetchOnWindowFocus: false,
 		}
 	);
 };

--- a/client/data/jetpack-licensing/use-user-license-by-subscription-query.ts
+++ b/client/data/jetpack-licensing/use-user-license-by-subscription-query.ts
@@ -1,0 +1,25 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+import { mapSingleLicenseApiToLicense } from './utils';
+import type { UserLicenseApi, UserLicense } from './types';
+
+const useUserLicenseBySubscriptionQuery = (
+	subscriptionId: number
+): UseQueryResult< UserLicense > => {
+	const queryKey = [ 'user-license', subscriptionId ];
+	return useQuery< UserLicenseApi, unknown, UserLicense >(
+		queryKey,
+		async () =>
+			wpcom.req.get( {
+				path: `/jetpack-licensing/user/subscription/${ subscriptionId }`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			select: mapSingleLicenseApiToLicense,
+			refetchIntervalInBackground: false,
+			refetchOnWindowFocus: false,
+		}
+	);
+};
+
+export default useUserLicenseBySubscriptionQuery;

--- a/client/data/jetpack-licensing/utils.ts
+++ b/client/data/jetpack-licensing/utils.ts
@@ -1,0 +1,12 @@
+import type { UserLicenseApi, UserLicense } from './types';
+
+export const mapSingleLicenseApiToLicense = ( license: UserLicenseApi ): UserLicense => ( {
+	licenseKey: license.license_key,
+	product: license.product,
+	productId: license.product_id,
+	subscriptionId: license.subscription_id,
+} );
+
+export const mapManyLicenseApiToLicense = ( licenses: UserLicenseApi[] ): UserLicense[] => {
+	return licenses.map( mapSingleLicenseApiToLicense );
+};

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -333,3 +333,54 @@
 .manage-purchase__savings-badge {
 	margin-left: 12px;
 }
+
+.manage-purchase__jetpack-user-license {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+
+	margin-bottom: 0;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		flex-wrap: nowrap;
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		padding: 16px;
+
+		box-shadow: none;
+	}
+
+	strong {
+		color: var( --color-neutral-60 );
+	}
+}
+
+.manage-purchase__jetpack-user-license-clipboard {
+	display: flex;
+
+	margin-top: 16px;
+
+	input.form-text-input.manage-purchase__jetpack-user-license-input {
+		font-size: $font-body-small;
+
+		margin-right: 16px;
+
+		background-color: var( --studio-gray-0 );
+
+		border: none;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			margin: 0 16px;
+		}
+	}
+
+	.button {
+		min-width: 70px;
+	}
+
+	@include breakpoint-deprecated( '>480px' ) {
+		margin-top: 0;
+	}
+}
+

--- a/config/development.json
+++ b/config/development.json
@@ -97,7 +97,7 @@
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
-		"jetpack/user-licensing-m1": true,
+		"jetpack/user-licensing": true,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -61,7 +61,7 @@
 		"jetpack/magic-link-signup": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
-		"jetpack/user-licensing-m1": true,
+		"jetpack/user-licensing": true,
 		"jetpack/userless-checkout": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,

--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,7 @@
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
-		"jetpack/user-licensing-m1": false,
+		"jetpack/user-licensing": false,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -62,7 +62,7 @@
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
-		"jetpack/user-licensing-m1": false,
+		"jetpack/user-licensing": false,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,7 +67,7 @@
 		"jetpack/only-realtime-products": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
-		"jetpack/user-licensing-m1": false,
+		"jetpack/user-licensing": false,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Include below the purchase metadata (owner, price, renewal, and payment method) the end-user license key related to the subscription.
* Rename the `jetpack/user-licensing-m1` feature flag to `jetpack/user-licensing`.

#### Testing instructions

Prerequisites
* Access to a WPCOM sandbox.
* Add `add_filter( 'jetpack_license_checkout_m2_enabled', '__return_true' );` to your `0-sandbox.php`.
* Sandbox `public-api.wordpress.com`.

Instructions
* Download this PR.
* Start Calypso blue with `yarn start`.
* Make a standard Jetpack purchase.
* Go to `http://calypso.localhost:3000/purchases/subscriptions/:site`.
* Select the row that shows the subscription you just purchased.
* Verify that you see the license key associated with the subscription.
* Verify that if you click the `Copy` button, the license key is transferred to your clipboard.
* Verify that the UI looks fine on smaller viewports.
* Make sure these steps work for both plans and products.
* Verify that the UI has not changed for WPCOM plans (you can compare production against development to be sure).
* Verify that if there is no license key for the subscription, the app does not throw an error in the console or anywhere else (you can test this by "unsandboxing" `public-api.wordpress.com`).

Related to 1201096622142517-as-1201261928772896

#### Demo
<img width="962" alt="LicenseSubscription" src="https://user-images.githubusercontent.com/3418513/138951145-1b9cdf56-9dbe-47ea-a032-c49bb8379ad7.png">

<img width="962" alt="LicenseProduct" src="https://user-images.githubusercontent.com/3418513/138951148-61cc7ac1-ae47-44c1-853d-75bc01ac00eb.png">

