### PR TITLE
Add icon property to `EllipsisMenu`

### DIFF
--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -21,11 +21,12 @@ export default function MyComponent( { onMenuItemClick } ) {
 
 ## Props
 
-| property      | type           | required | default | comment                                                                                                                                             |
-| ------------- | -------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `onClick`     | Function       | no       | noop    | Callback that will be invoked when menu button is clicked. Will be passed the click event.                                                          |
-| `onToggle`    | Function       | no       | noop    | Callback that will be invoked when menu is toggled. Will be passed the boolean visibility of the menu.                                              |
-| `toggleTitle` | String         | no       | `null`  | Override for the default "Toggle menu" `title` attribute on the toggle button.                                                                      |
-| `position`    | String         | no       | `null`  | The position at which the menu should be rendered. If omitted, uses the default `position` from [the `<PopoverMenu />` component](../popover-menu). |
-| `children`    | PropTypes.node | no       | `null`  | Menu children to be rendered.                                                                                                                       |
-| `disabled`    | PropTypes.bool | no       | `null`  | If `true`, then the menu icon will be displayed in light gray and will not be clickable.                                                            |
+| property      | type              | required | default | comment                                                                                                                                             |
+| ------------- | ----------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `onClick`     | Function          | no       | noop    | Callback that will be invoked when menu button is clicked. Will be passed the click event.                                                          |
+| `onToggle`    | Function          | no       | noop    | Callback that will be invoked when menu is toggled. Will be passed the boolean visibility of the menu.                                              |
+| `toggleTitle` | String            | no       | `null`  | Override for the default "Toggle menu" `title` attribute on the toggle button.                                                                      |
+| `position`    | String            | no       | `null`  | The position at which the menu should be rendered. If omitted, uses the default `position` from [the `<PopoverMenu />` component](../popover-menu). |
+| `children`    | PropTypes.node    | no       | `null`  | Menu children to be rendered.                                                                                                                       |
+| `disabled`    | PropTypes.bool    | no       | `null`  | If `true`, then the menu icon will be displayed in light gray and will not be clickable.                                                            |
+| `icon`        | PropTypes.element | no       | `null`  | A custom element to be rendered instead of the default ellipsis icon.                                                                               |

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -18,6 +18,7 @@ class EllipsisMenu extends Component {
 		onClick: PropTypes.func,
 		onToggle: PropTypes.func,
 		popoverClassName: PropTypes.string,
+		icon: PropTypes.element,
 	};
 
 	static defaultProps = {
@@ -62,6 +63,7 @@ class EllipsisMenu extends Component {
 			position,
 			children,
 			disabled,
+			icon,
 			className,
 			popoverClassName,
 		} = this.props;
@@ -82,7 +84,8 @@ class EllipsisMenu extends Component {
 					disabled={ disabled }
 					className="ellipsis-menu__toggle"
 				>
-					<Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" />
+					{ ! icon && <Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" /> }
+					{ icon }
 				</Button>
 				{ isMenuVisible && (
 					<PopoverMenu

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -84,8 +84,7 @@ class EllipsisMenu extends Component {
 					disabled={ disabled }
 					className="ellipsis-menu__toggle"
 				>
-					{ ! icon && <Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" /> }
-					{ icon }
+					{ icon ? icon : <Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" /> }
 				</Button>
 				{ isMenuVisible && (
 					<PopoverMenu


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds an `icon` property to the `EllipsisMenu` component. When provided, that `icon` will be rendered in place of the default ellipsis icon.

#### Testing instructions

Test by passing an `icon` property to an `EllipsisIcon` and ensure it's rendered and works correctly. Any `GridIcon`, `MaterialIcon` or `Icon` from `@wordpress/components` should look fine.

This is the default ellipsis icon:

<img width="292" alt="Screen Shot 2021-10-26 at 19 10 15" src="https://user-images.githubusercontent.com/5324818/138970575-5f6fb46c-69d7-42ed-a89c-473c1acc868e.png">

This is the same component with an `icon={ <Gridicon icon="search" /> }` property:

<img width="286" alt="Screen Shot 2021-10-26 at 19 10 50" src="https://user-images.githubusercontent.com/5324818/138970627-51660ff3-6670-4311-8302-83b9d4abe127.png">

And with an `icon={ <Icon icon={ moreVertical } size={ 24 } /> }` property:

<img width="293" alt="Screen Shot 2021-10-26 at 19 49 19" src="https://user-images.githubusercontent.com/5324818/138971983-a3cee502-a492-4ac2-b673-a58ad40a1ef5.png">
