### PR TITLE
Adding a label to the toggle component for using the WordPress.com na…

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -6,7 +6,7 @@
 
 .name-servers__dns {
 	.name-servers__toggle {
-		.components-toggle-control .components-base-control__field {
+		.components-base-control__field {
 			justify-content: space-between;
 			margin-bottom: 0;
 			.components-toggle-control__label {

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -8,7 +8,6 @@
 	.name-servers__toggle {
 		.components-base-control__field {
 			justify-content: space-between;
-			margin-right: 0;
 
 			.components-toggle-control__label {
 				font-size: $font-body;

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -5,12 +5,24 @@
 }
 
 .name-servers__dns {
-	.name-servers__toggle {
-		display: inline-block;
-		float: right;
+	display: flex;
+	flex-direction: column;
 
-		.components-toggle-control .components-base-control__field .components-form-toggle {
-			margin-right: 0;
+	.name-servers__toggle {
+		display: block;
+		.components-toggle-control .components-base-control__field {
+			display: flex;
+			justify-content: space-between;
+			.components-form-toggle {
+				order: 1;
+			}
+			.components-toggle-control__label {
+				order: 0;
+				border: 0;
+				font-size: 16px;
+				font-style: inherit;
+				font-weight: 400;
+			}
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -7,11 +7,13 @@
 .name-servers__dns {
 	.name-servers__toggle {
 		.components-toggle-control .components-base-control__field {
+			justify-content: space-between;
+			margin-bottom: 0;
 			.components-toggle-control__label {
 				font-size: $font-body;
 			}
-			.components-form-toggle__input {
-				align-self: center;
+			.components-form-toggle {
+				order: 1;
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -9,11 +9,13 @@
 		.components-base-control__field {
 			justify-content: space-between;
 			margin-right: 0;
+
 			.components-toggle-control__label {
 				font-size: $font-body;
 			}
 			.components-form-toggle {
 				order: 1;
+				margin-right: 0;
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -5,27 +5,16 @@
 }
 
 .name-servers__dns {
-	display: flex;
-	flex-direction: column;
-
 	.name-servers__toggle {
-		display: block;
 		.components-toggle-control .components-base-control__field {
-			display: flex;
-			justify-content: space-between;
-			.components-form-toggle {
-				order: 1;
-			}
 			.components-toggle-control__label {
-				order: 0;
-				border: 0;
-				font-size: 16px;
-				font-style: inherit;
-				font-weight: 400;
+				font-size: $font-body;
+			}
+			.components-form-toggle__input {
+				align-self: center;
 			}
 		}
 	}
-
 	.name-servers__explanation {
 		animation: appear 0.5s ease-in-out;
 		color: var( --color-text-subtle );

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -8,7 +8,7 @@
 	.name-servers__toggle {
 		.components-base-control__field {
 			justify-content: space-between;
-			margin-bottom: 0;
+			margin-right: 0;
 			.components-toggle-control__label {
 				font-size: $font-body;
 			}

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -31,6 +31,7 @@ class NameserversToggle extends PureComponent {
 						onChange={ this.handleToggle }
 						checked={ this.props.enabled }
 						value="active"
+						label={ this.props.translate( 'On' ) }
 					/>
 				</form>
 				{ this.renderExplanation() }

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -18,7 +18,6 @@ class NameserversToggle extends PureComponent {
 	};
 
 	render() {
-		const toggleTitle = this.props.translate( 'Use WordPress.com Name Servers' );
 		return (
 			<Card compact className="name-servers__dns">
 				<form className="name-servers__toggle">
@@ -28,7 +27,7 @@ class NameserversToggle extends PureComponent {
 						onChange={ this.handleToggle }
 						checked={ this.props.enabled }
 						value="active"
-						label={ toggleTitle }
+						label={ this.props.translate( 'Use WordPress.com Name Servers' ) }
 					/>
 				</form>
 				{ this.renderExplanation() }

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -1,4 +1,4 @@
-import { Card, ScreenReaderText } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -29,10 +29,7 @@ class NameserversToggle extends PureComponent {
 						checked={ this.props.enabled }
 						value="active"
 						label={ toggleTitle }
-						className="name-servers__title"
-						onClick={ this.handleToggle }
 					/>
-					<ScreenReaderText>{ toggleTitle }</ScreenReaderText>
 				</form>
 				{ this.renderExplanation() }
 			</Card>

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Card, ScreenReaderText } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -26,7 +26,7 @@ class NameserversToggle extends PureComponent {
 				</span>
 
 				<form className="name-servers__toggle">
-					<FormLabel className="name-servers__toggle">
+					<FormLabel>
 						<ToggleControl
 							id="wp-nameservers"
 							name="wp-nameservers"
@@ -34,6 +34,9 @@ class NameserversToggle extends PureComponent {
 							checked={ this.props.enabled }
 							value="active"
 						/>
+						<ScreenReaderText>
+							{ this.props.translate( 'Use WordPress.com Name Servers' ) }
+						</ScreenReaderText>
 					</FormLabel>
 				</form>
 				{ this.renderExplanation() }

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -25,14 +25,16 @@ class NameserversToggle extends PureComponent {
 				</span>
 
 				<form className="name-servers__toggle">
-					<ToggleControl
-						id="wp-nameservers"
-						name="wp-nameservers"
-						onChange={ this.handleToggle }
-						checked={ this.props.enabled }
-						value="active"
-						label={ this.props.translate( 'On' ) }
-					/>
+					<label>
+						<ToggleControl
+							id="wp-nameservers"
+							name="wp-nameservers"
+							git
+							onChange={ this.handleToggle }
+							checked={ this.props.enabled }
+							value="active"
+						/>
+					</label>
 				</form>
 				{ this.renderExplanation() }
 			</Card>

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -22,21 +22,18 @@ class NameserversToggle extends PureComponent {
 	render() {
 		return (
 			<Card compact className="name-servers__dns">
-				<span className="name-servers__title" onClick={ this.handleToggle }>
-					{ NAMESERVERS_TOGGLE_TITLE }
-				</span>
-
 				<form className="name-servers__toggle">
-					<FormLabel>
-						<ToggleControl
-							id="wp-nameservers"
-							name="wp-nameservers"
-							onChange={ this.handleToggle }
-							checked={ this.props.enabled }
-							value="active"
-						/>
-						<ScreenReaderText>{ NAMESERVERS_TOGGLE_TITLE }</ScreenReaderText>
-					</FormLabel>
+					<ToggleControl
+						id="wp-nameservers"
+						name="wp-nameservers"
+						onChange={ this.handleToggle }
+						checked={ this.props.enabled }
+						value="active"
+						label={ this.props.translate( NAMESERVERS_TOGGLE_TITLE ) }
+						className="name-servers__title"
+						onClick={ this.handleToggle }
+					/>
+					<ScreenReaderText>{ this.props.translate( NAMESERVERS_TOGGLE_TITLE ) }</ScreenReaderText>
 				</form>
 				{ this.renderExplanation() }
 			</Card>

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -4,6 +4,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import FormLabel from 'calypso/components/forms/form-label';
 import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
 import {
 	composeAnalytics,
@@ -25,16 +26,15 @@ class NameserversToggle extends PureComponent {
 				</span>
 
 				<form className="name-servers__toggle">
-					<label>
+					<FormLabel className="name-servers__toggle">
 						<ToggleControl
 							id="wp-nameservers"
 							name="wp-nameservers"
-							git
 							onChange={ this.handleToggle }
 							checked={ this.props.enabled }
 							value="active"
 						/>
-					</label>
+					</FormLabel>
 				</form>
 				{ this.renderExplanation() }
 			</Card>

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -4,14 +4,12 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import FormLabel from 'calypso/components/forms/form-label';
 import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
-const NAMESERVERS_TOGGLE_TITLE = 'Use WordPress.com Name Servers';
 
 class NameserversToggle extends PureComponent {
 	static propTypes = {
@@ -20,6 +18,7 @@ class NameserversToggle extends PureComponent {
 	};
 
 	render() {
+		const toggleTitle = this.props.translate( 'Use WordPress.com Name Servers' );
 		return (
 			<Card compact className="name-servers__dns">
 				<form className="name-servers__toggle">
@@ -29,11 +28,11 @@ class NameserversToggle extends PureComponent {
 						onChange={ this.handleToggle }
 						checked={ this.props.enabled }
 						value="active"
-						label={ this.props.translate( NAMESERVERS_TOGGLE_TITLE ) }
+						label={ toggleTitle }
 						className="name-servers__title"
 						onClick={ this.handleToggle }
 					/>
-					<ScreenReaderText>{ this.props.translate( NAMESERVERS_TOGGLE_TITLE ) }</ScreenReaderText>
+					<ScreenReaderText>{ toggleTitle }</ScreenReaderText>
 				</form>
 				{ this.renderExplanation() }
 			</Card>

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -11,6 +11,7 @@ import {
 	recordGoogleEvent,
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
+const NAMESERVERS_TOGGLE_TITLE = 'Use WordPress.com Name Servers';
 
 class NameserversToggle extends PureComponent {
 	static propTypes = {
@@ -21,8 +22,8 @@ class NameserversToggle extends PureComponent {
 	render() {
 		return (
 			<Card compact className="name-servers__dns">
-				<span className="name-servers__title">
-					{ this.props.translate( 'Use WordPress.com Name Servers' ) }
+				<span className="name-servers__title" onClick={ this.handleToggle }>
+					{ NAMESERVERS_TOGGLE_TITLE }
 				</span>
 
 				<form className="name-servers__toggle">
@@ -34,9 +35,7 @@ class NameserversToggle extends PureComponent {
 							checked={ this.props.enabled }
 							value="active"
 						/>
-						<ScreenReaderText>
-							{ this.props.translate( 'Use WordPress.com Name Servers' ) }
-						</ScreenReaderText>
+						<ScreenReaderText>{ NAMESERVERS_TOGGLE_TITLE }</ScreenReaderText>
 					</FormLabel>
 				</form>
 				{ this.renderExplanation() }


### PR DESCRIPTION

#### Changes proposed in this Pull Request

This PR adds a label to the Toggle component available on /domains/manage/:domain/name-servers/:site , it addresses #53003

#### Testing instructions

* Goto /domains/manage/:domain/name-servers/:site
* We should now be able to see a label for the toggle button like this ![](https://d.pr/i/72OzPq+)
[Direct Link](https://d.pr/i/72OzPq+)



Related to #53003
Request review from @tyxla 