### PR TITLE
only show first post modal on post editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -11,6 +11,8 @@ import './style.scss';
  */
 const PostPublishedModal: React.FC = () => {
 	const { link } = useSelect( ( select ) => select( 'core/editor' ).getCurrentPost() );
+	const postType = useSelect( ( select ) => select( 'core/editor' ).getCurrentPostType() );
+
 	const isCurrentPostPublished = useSelect( ( select ) =>
 		select( 'core/editor' ).isCurrentPostPublished()
 	);
@@ -27,14 +29,14 @@ const PostPublishedModal: React.FC = () => {
 	useEffect( () => {
 		fetchSiteHasNeverPublishedPost();
 	}, [ fetchSiteHasNeverPublishedPost ] );
-
 	useEffect( () => {
 		// If the user never published any post before and the current post status changed to publish,
 		// open the post publish modal
 		if (
 			siteHasNeverPublishedPost &&
 			! previousIsCurrentPostPublished.current &&
-			isCurrentPostPublished
+			isCurrentPostPublished &&
+			postType === 'post'
 		) {
 			previousIsCurrentPostPublished.current = isCurrentPostPublished;
 			setSiteHasNeverPublishedPost( false );
@@ -46,7 +48,12 @@ const PostPublishedModal: React.FC = () => {
 				setIsOpen( true );
 			} );
 		}
-	}, [ siteHasNeverPublishedPost, isCurrentPostPublished, setSiteHasNeverPublishedPost ] );
+	}, [
+		postType,
+		siteHasNeverPublishedPost,
+		isCurrentPostPublished,
+		setSiteHasNeverPublishedPost,
+	] );
 
 	return (
 		<NuxModal


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently the first post congratulations modal is incorrectly shown when publishing a page.
https://github.com/Automattic/wp-calypso/issues/57356

This adds a test to only show the modal on posts, not pages

#### Testing instructions
Create a new site, you can check that the site option `has_never_published_post` is set to true.
Do not publish a post
Go to the `/page` editor and create & publish a new page.
You should not see the modal.
Create and publish a new **post**.
You should see the modal