### PR TITLE
ExPlat: Clean up LocalStorage on startup of ExPlat client

### DIFF
--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -1,6 +1,7 @@
 import {
 	retrieveExperimentAssignment,
 	storeExperimentAssignment,
+	removeExpiredExperimentAssignments,
 } from './internal/experiment-assignment-store';
 import * as ExperimentAssignments from './internal/experiment-assignments';
 import { createFallbackExperimentAssignment as createFallbackExperimentAssignment } from './internal/experiment-assignments';
@@ -92,6 +93,9 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 			config.logError( ...args );
 		} catch ( e ) {}
 	};
+
+	// Clean up LocalStorage on start up
+	removeExpiredExperimentAssignments();
 
 	return {
 		loadExperimentAssignment: async ( experimentName: string ): Promise< ExperimentAssignment > => {

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -95,7 +95,14 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 	};
 
 	// Clean up LocalStorage on start up
-	removeExpiredExperimentAssignments();
+	try {
+		removeExpiredExperimentAssignments();
+	} catch ( error ) {
+		safeLogError( {
+			message: ( error as Error ).message,
+			source: 'removeExpiredExperimentAssignments-error',
+		} );
+	}
 
 	return {
 		loadExperimentAssignment: async ( experimentName: string ): Promise< ExperimentAssignment > => {

--- a/packages/explat-client/src/internal/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/experiment-assignment-store.ts
@@ -3,10 +3,14 @@ import localStorage from './local-storage';
 import * as Validations from './validations';
 import type { ExperimentAssignment } from '../types';
 
-// Only exported for testing purposes
+/**
+ * Exported for testing purposes only.
+ */
 export const localStorageExperimentAssignmentKeyPrefix = 'explat-experiment-';
 
-// Only exported for testing purposes
+/**
+ * Exported for testing purposes only.
+ */
 export const localStorageExperimentAssignmentKey = ( experimentName: string ): string =>
 	`${ localStorageExperimentAssignmentKeyPrefix }-${ experimentName }`;
 
@@ -56,17 +60,23 @@ export function retrieveExperimentAssignment(
 
 const range = ( i: number ) => [ ...Array( i ).keys() ];
 
-// Only exported for testing purposes
+/**
+ * Exported for testing purposes only.
+ */
 export function getAllLocalStorageKeys(): string[] {
 	return range( localStorage.length ).map( ( i ) => localStorage.key( i ) as string );
 }
 
-// Only exported for testing purposes
+/**
+ * Exported for testing purposes only.
+ */
 export function isLocalStorageExperimentAssignmentKey( key: string ): boolean {
 	return key.startsWith( localStorageExperimentAssignmentKeyPrefix );
 }
 
-// Only exported for testing purposes
+/**
+ * Exported for testing purposes only.
+ */
 export function experimentNameFromLocalStorageExperimentAssignmentKey( key: string ): string {
 	return key.slice( localStorageExperimentAssignmentKeyPrefix.length + 1 );
 }

--- a/packages/explat-client/src/internal/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/experiment-assignment-store.ts
@@ -1,3 +1,4 @@
+import * as ExperimentAssignments from './experiment-assignments';
 import localStorage from './local-storage';
 import * as Validations from './validations';
 import type { ExperimentAssignment } from '../types';
@@ -49,4 +50,27 @@ export function retrieveExperimentAssignment(
 	}
 
 	return Validations.validateExperimentAssignment( JSON.parse( maybeExperimentAssignmentJson ) );
+}
+
+/**
+ * Removes all expired and invalid experiment assignments in LocalStorage.
+ */
+export function removeExpiredExperimentAssignments(): void {
+	for ( let i = localStorage.length - 1; i >= 0; i-- ) {
+		const key = localStorage.key( i );
+
+		if ( key?.startsWith( localStorageExperimentAssignmentKeyPrefix ) ) {
+			const experimentName = key.slice( localStorageExperimentAssignmentKeyPrefix.length + 1 );
+			const storedExperimentAssignment = retrieveExperimentAssignment( experimentName );
+
+			// Remove the assignment if it is expired or undefined
+			if (
+				( storedExperimentAssignment &&
+					! ExperimentAssignments.isAlive( storedExperimentAssignment ) ) ||
+				typeof storedExperimentAssignment === 'undefined'
+			) {
+				localStorage.removeItem( key );
+			}
+		}
+	}
 }

--- a/packages/explat-client/src/internal/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/experiment-assignment-store.ts
@@ -3,8 +3,10 @@ import localStorage from './local-storage';
 import * as Validations from './validations';
 import type { ExperimentAssignment } from '../types';
 
+// Only exported for testing purposes
 export const localStorageExperimentAssignmentKeyPrefix = 'explat-experiment-';
 
+// Only exported for testing purposes
 export const localStorageExperimentAssignmentKey = ( experimentName: string ): string =>
 	`${ localStorageExperimentAssignmentKeyPrefix }-${ experimentName }`;
 
@@ -52,31 +54,19 @@ export function retrieveExperimentAssignment(
 	return Validations.validateExperimentAssignment( JSON.parse( maybeExperimentAssignmentJson ) );
 }
 
-/**
- * Returns all keys in localStorage as an array.
- */
-export function getAllLocalStorageKeys(): string[] {
-	const range = ( i: number ) => [ ...Array( i ).keys() ];
+const range = ( i: number ) => [ ...Array( i ).keys() ];
 
+// Only exported for testing purposes
+export function getAllLocalStorageKeys(): string[] {
 	return range( localStorage.length ).map( ( i ) => localStorage.key( i ) as string );
 }
 
-/**
- * Checks to see if the key is an experiment assignment key, or more
- * accurately, if it starts with the localStorage experiment assignment key prefix.
- *
- * @param key the key to check
- */
+// Only exported for testing purposes
 export function isLocalStorageExperimentAssignmentKey( key: string ): boolean {
 	return key.startsWith( localStorageExperimentAssignmentKeyPrefix );
 }
 
-/**
- * Returns the experiment name from a localStorage key assuming that the key begins with
- * the localStorage experiment assignment key prefix.
- *
- * @param key the key from which to retrieve the experiment name
- */
+// Only exported for testing purposes
 export function experimentNameFromLocalStorageExperimentAssignmentKey( key: string ): string {
 	return key.slice( localStorageExperimentAssignmentKeyPrefix.length + 1 );
 }

--- a/packages/explat-client/src/internal/local-storage.ts
+++ b/packages/explat-client/src/internal/local-storage.ts
@@ -1,32 +1,37 @@
 /**
+ * LocalStorage polyfill from https://gist.github.com/juliocesar/926500
+ * length and key methods were added to allow for implementing removeExpiredExperimentAssignments
+ * Exported only for testing purposes
+ */
+export const polyfilledLocalStorage = {
+	_data: {} as Record< string, string >,
+	setItem: function ( id: string, val: string ): void {
+		this._data[ id ] = val;
+	},
+	getItem: function ( id: string ): string | undefined {
+		return this._data.hasOwnProperty( id ) ? this._data[ id ] : undefined;
+	},
+	removeItem: function ( id: string ): void {
+		delete this._data[ id ];
+	},
+	clear: function (): void {
+		this._data = {};
+	},
+	get length(): number {
+		return Object.keys( this._data ).length;
+	},
+	key: function ( index: number ): string | undefined {
+		return Object.keys( this._data )[ index ];
+	},
+};
+
+/**
  * A polyfilled LocalStorage.
  * The polyfill is required at least for testing.
  */
 const localStorage =
 	typeof window !== 'undefined' && window.localStorage
 		? window.localStorage
-		: // LocalStorage polyfill from https://gist.github.com/juliocesar/926500
-		  {
-				_data: {} as Record< string, string >,
-				setItem: function ( id: string, val: string ) {
-					this._data[ id ] = val;
-				},
-				getItem: function ( id: string ) {
-					return this._data.hasOwnProperty( id ) ? this._data[ id ] : undefined;
-				},
-				removeItem: function ( id: string ) {
-					delete this._data[ id ];
-				},
-				clear: function () {
-					this._data = {};
-				},
-				get length() {
-					return Object.keys( this._data ).length;
-				},
-				key: function ( index: number ): string | undefined {
-					const arr = this._data.keys;
-					return arr[ index ];
-				},
-		  };
+		: polyfilledLocalStorage;
 
 export default localStorage;

--- a/packages/explat-client/src/internal/local-storage.ts
+++ b/packages/explat-client/src/internal/local-storage.ts
@@ -20,6 +20,13 @@ const localStorage =
 				clear: function () {
 					this._data = {};
 				},
+				get length() {
+					return Object.keys( this._data ).length;
+				},
+				key: function ( index: number ): string | undefined {
+					const arr = this._data.keys;
+					return arr[ index ];
+				},
 		  };
 
 export default localStorage;

--- a/packages/explat-client/src/internal/test/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/test/experiment-assignment-store.ts
@@ -6,6 +6,11 @@ import {
 	retrieveExperimentAssignment,
 	storeExperimentAssignment,
 	removeExpiredExperimentAssignments,
+	localStorageExperimentAssignmentKeyPrefix,
+	localStorageExperimentAssignmentKey,
+	getAllLocalStorageKeys,
+	isLocalStorageExperimentAssignmentKey,
+	experimentNameFromLocalStorageExperimentAssignmentKey,
 } from '../experiment-assignment-store';
 import localStorage from '../local-storage';
 import { validExperimentAssignment, validFallbackExperimentAssignment } from '../test-common';
@@ -14,7 +19,7 @@ beforeEach( () => {
 	localStorage.clear();
 } );
 
-describe( 'experiment-assignment-store', () => {
+describe( 'storeExperimentAssignment and retrieveExperimentAssignment', () => {
 	it( 'should save and retrieve valid ExperimentAssignments', () => {
 		expect( retrieveExperimentAssignment( validExperimentAssignment.experimentName ) ).toBe(
 			undefined
@@ -56,7 +61,64 @@ describe( 'experiment-assignment-store', () => {
 			} )
 		).toThrowErrorMatchingInlineSnapshot( `"Invalid ExperimentAssignment"` );
 	} );
+} );
 
+describe( 'getAllLocalStorageKeys', () => {
+	it( 'should return an empty array if there are no stored keys', () => {
+		expect( getAllLocalStorageKeys().length ).toBe( 0 );
+	} );
+
+	it( 'should return an array of all of the stored keys', () => {
+		const keys = [ 'key1', 'key2', 'key3', 'key4', 'key5' ];
+		keys.map( ( key ) => localStorage.setItem( key, 'test value' ) );
+		const result = getAllLocalStorageKeys();
+		expect( result ).toStrictEqual( keys );
+	} );
+} );
+
+describe( 'isLocalStorageExperimentAssignmentKey', () => {
+	it( 'should return false if key is an empty string', () => {
+		expect( isLocalStorageExperimentAssignmentKey( '' ) ).toBe( false );
+	} );
+
+	it( 'should return false if key is shorter than the experiment assignment key prefix', () => {
+		expect(
+			isLocalStorageExperimentAssignmentKey(
+				localStorageExperimentAssignmentKeyPrefix.slice( 0, -1 )
+			)
+		).toBe( false );
+	} );
+
+	it( 'should return true if key is the same as the experiment assignment key prefix', () => {
+		expect(
+			isLocalStorageExperimentAssignmentKey( localStorageExperimentAssignmentKeyPrefix )
+		).toBe( true );
+	} );
+
+	it( 'should return true if key starts with the experiment assignment key prefix', () => {
+		expect(
+			isLocalStorageExperimentAssignmentKey(
+				localStorageExperimentAssignmentKeyPrefix + 'an-experiment'
+			)
+		).toBe( true );
+	} );
+} );
+
+describe( 'experimentNameFromLocalStorageExperimentAssignmentKey', () => {
+	it( 'should return the experiment name if it begins with the experiment assignment key prefix', () => {
+		const experimentName = 'test1';
+		const key = `${ localStorageExperimentAssignmentKeyPrefix }-${ experimentName }`;
+		expect( experimentNameFromLocalStorageExperimentAssignmentKey( key ) ).toBe( experimentName );
+	} );
+
+	it( 'should return an empty string if the key is shorter than the experiment assignment key prefix', () => {
+		expect( experimentNameFromLocalStorageExperimentAssignmentKey( 'a' ) ).toBe( '' );
+
+		expect( experimentNameFromLocalStorageExperimentAssignmentKey( '' ) ).toBe( '' );
+	} );
+} );
+
+describe( 'removeExpiredExperimentAssignments', () => {
 	it( 'should remove all stored ExperimentAssignments that are past their ttl', () => {
 		storeExperimentAssignment( {
 			...validExperimentAssignment,
@@ -80,6 +142,76 @@ describe( 'experiment-assignment-store', () => {
 			experimentName: 'experiment4',
 			retrievedTimestamp: Date.now() - 1000 * 60,
 		} );
+		storeExperimentAssignment( validExperimentAssignment );
+		removeExpiredExperimentAssignments();
+		expect( localStorage.length ).toBe( 1 );
+	} );
+
+	it( 'should remove all stored ExperimentAssignments that are invalid', () => {
+		const invalidExperimentAssignments = [
+			{
+				...validExperimentAssignment,
+				experimentName: undefined,
+			},
+			{
+				...validFallbackExperimentAssignment,
+				experimentName: null,
+			},
+			{
+				...validExperimentAssignment,
+				experimentName: 42,
+			},
+			{
+				...validExperimentAssignment,
+				variationName: undefined,
+			},
+			{
+				...validFallbackExperimentAssignment,
+				variationName: 0,
+			},
+			{
+				...validExperimentAssignment,
+				retrievedTimestamp: undefined,
+			},
+			{
+				...validFallbackExperimentAssignment,
+				retrievedTimestamp: 'string',
+			},
+			{
+				...validExperimentAssignment,
+				ttl: undefined,
+			},
+			{
+				...validExperimentAssignment,
+				ttl: 'string',
+			},
+			{
+				...validFallbackExperimentAssignment,
+				ttl: 0,
+			},
+		];
+
+		localStorage.setItem(
+			localStorageExperimentAssignmentKey( 'invalid-experiment1' ),
+			JSON.stringify( invalidExperimentAssignments[ 0 ] )
+		);
+		removeExpiredExperimentAssignments();
+		expect( localStorage.length ).toBe( 0 );
+
+		invalidExperimentAssignments.map( ( experiment, index ) => {
+			localStorage.setItem(
+				localStorageExperimentAssignmentKey( `invalid-experiment${ index }` ),
+				JSON.stringify( experiment )
+			);
+		} );
+		removeExpiredExperimentAssignments();
+		expect( localStorage.length ).toBe( 0 );
+
+		localStorage.clear();
+		localStorage.setItem(
+			localStorageExperimentAssignmentKey( 'invalid-experiment2' ),
+			JSON.stringify( invalidExperimentAssignments[ 1 ] )
+		);
 		storeExperimentAssignment( validExperimentAssignment );
 		removeExpiredExperimentAssignments();
 		expect( localStorage.length ).toBe( 1 );

--- a/packages/explat-client/src/internal/test/local-storage.ts
+++ b/packages/explat-client/src/internal/test/local-storage.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { polyfilledLocalStorage as localStorage } from '../local-storage';
+
+beforeEach( () => {
+	localStorage.clear();
+} );
+
+describe( 'length', () => {
+	it( 'should return 0 when localStorage is empty', () => {
+		expect( localStorage.length ).toBe( 0 );
+	} );
+
+	it( 'should return the correct length after items are added', () => {
+		localStorage.setItem( 'key1', 'value1' );
+		expect( localStorage.length ).toBe( 1 );
+
+		localStorage.setItem( 'key2', 'value2' );
+		expect( localStorage.length ).toBe( 2 );
+
+		localStorage.setItem( 'key3', 'value3' );
+		localStorage.setItem( 'key4', 'value4' );
+		expect( localStorage.length ).toBe( 4 );
+	} );
+
+	it( 'should return the correct length after items are added and removed', () => {
+		localStorage.setItem( 'key1', 'value1' );
+		localStorage.setItem( 'key2', 'value2' );
+		localStorage.removeItem( 'key1' );
+		expect( localStorage.length ).toBe( 1 );
+
+		localStorage.setItem( 'key3', 'value3' );
+		localStorage.setItem( 'key4', 'value4' );
+		localStorage.removeItem( 'key3' );
+		expect( localStorage.length ).toBe( 2 );
+	} );
+} );
+
+describe( 'key', () => {
+	it( 'should return undefined for any index if localStorage is empty', () => {
+		expect( localStorage.key( 0 ) ).toBe( undefined );
+		expect( localStorage.key( 5 ) ).toBe( undefined );
+		expect( localStorage.key( 200 ) ).toBe( undefined );
+		expect( localStorage.key( -1 ) ).toBe( undefined );
+	} );
+
+	it( 'should return the key at the given index if there are elements in localStorage', () => {
+		localStorage.setItem( 'key1', 'value1' );
+		localStorage.setItem( 'key2', 'value2' );
+		expect( localStorage.key( 0 ) ).toBe( 'key1' );
+		expect( localStorage.key( 1 ) ).toBe( 'key2' );
+	} );
+
+	it( 'should return undefined if there are elements in localStorage and the index is out of bounds', () => {
+		localStorage.setItem( 'key1', 'value1' );
+		localStorage.setItem( 'key2', 'value2' );
+		expect( localStorage.key( 2 ) ).toBe( undefined );
+		expect( localStorage.key( -1 ) ).toBe( undefined );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, old ExperimentAssignments that have been stored in LocalStorage will continue to exist even after the experiment is over. The ExPlat team is concerned that the extra items in LocalStorage may be contributing to client errors related to exceeding the LocalStorage limit (though these are relatively rare).

* Removes all expired ExperimentAssignments that are stored in LocalStorage when the ExPlat client is initialized
* Added functions to the LocalStorage polyfill for testing purposes
* Added unit test for the new `removeExpiredExperimentAssignments` function

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Added unit test for `experiment-assignment-store.ts` in the `explat-client` package

Addresses [this ExPlat issue](https://github.com/Automattic/experimentation-platform/issues/622)
