### PR TITLE
`QueryUserPurchases`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -219,7 +219,7 @@ function HelpSearchResults( {
 
 	return (
 		<>
-			{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
+			<QueryUserPurchases />
 			{ renderSearchResults() }
 		</>
 	);

--- a/client/components/data/query-user-purchases/README.md
+++ b/client/components/data/query-user-purchases/README.md
@@ -1,7 +1,7 @@
 # Query User Purchases
 
-`<QueryUserPurchases />` is a React component used in managing network requests for user purchases.
+`<QueryUserPurchases />` is a React component used in managing network requests purchases of the current user.
 
 ## Usage
 
-Render the component, passing `userId`. It does not accept any children, nor does it render any elements to the page.
+Render the component. It does not accept any props or children, nor does it render any elements to the page.

--- a/client/components/data/query-user-purchases/index.jsx
+++ b/client/components/data/query-user-purchases/index.jsx
@@ -1,33 +1,32 @@
-import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { fetchUserPurchases } from 'calypso/state/purchases/actions';
 import {
 	hasLoadedUserPurchasesFromServer,
 	isFetchingUserPurchases,
 } from 'calypso/state/purchases/selectors';
 
-const request = ( userId ) => ( dispatch, getState ) => {
-	const isFetching = isFetchingUserPurchases( getState() );
-	const hasLoaded = hasLoadedUserPurchasesFromServer( getState() );
+const request = ( dispatch, getState ) => {
+	const state = getState();
+
+	const userId = getCurrentUserId( state );
+	const isFetching = isFetchingUserPurchases( state );
+	const hasLoaded = hasLoadedUserPurchasesFromServer( state );
 
 	if ( userId && ! isFetching && ! hasLoaded ) {
 		dispatch( fetchUserPurchases( userId ) );
 	}
 };
 
-function QueryUserPurchases( { userId } ) {
+function QueryUserPurchases() {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( request( userId ) );
+		dispatch( request );
 	} );
 
 	return null;
 }
-
-QueryUserPurchases.propTypes = {
-	userId: PropTypes.number.isRequired,
-};
 
 export default QueryUserPurchases;

--- a/client/components/data/query-user-purchases/index.jsx
+++ b/client/components/data/query-user-purchases/index.jsx
@@ -21,7 +21,7 @@ function QueryUserPurchases( { userId } ) {
 
 	useEffect( () => {
 		dispatch( request( userId ) );
-	}, [ dispatch, userId ] );
+	} );
 
 	return null;
 }

--- a/client/components/data/query-user-purchases/index.jsx
+++ b/client/components/data/query-user-purchases/index.jsx
@@ -1,51 +1,33 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { fetchUserPurchases } from 'calypso/state/purchases/actions';
 import {
 	hasLoadedUserPurchasesFromServer,
 	isFetchingUserPurchases,
 } from 'calypso/state/purchases/selectors';
 
-class QueryUserPurchases extends Component {
-	requestUserPurchases( nextProps ) {
-		const userChanged = nextProps && this.props.userId !== nextProps.userId;
-		const props = nextProps || this.props;
+const request = ( userId ) => ( dispatch, getState ) => {
+	const isFetching = isFetchingUserPurchases( getState() );
+	const hasLoaded = hasLoadedUserPurchasesFromServer( getState() );
 
-		if (
-			( ! props.isFetchingUserPurchases && ! props.hasLoadedUserPurchasesFromServer ) ||
-			userChanged
-		) {
-			this.props.fetchUserPurchases( props.userId );
-		}
+	if ( userId && ! isFetching && ! hasLoaded ) {
+		dispatch( fetchUserPurchases( userId ) );
 	}
+};
 
-	UNSAFE_componentWillMount() {
-		this.requestUserPurchases();
-	}
+function QueryUserPurchases( { userId } ) {
+	const dispatch = useDispatch();
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.requestUserPurchases( nextProps );
-	}
+	useEffect( () => {
+		dispatch( request( userId ) );
+	}, [ dispatch, userId ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QueryUserPurchases.propTypes = {
 	userId: PropTypes.number.isRequired,
-	hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
-	isFetchingUserPurchases: PropTypes.bool.isRequired,
-	fetchUserPurchases: PropTypes.func.isRequired,
 };
 
-export default connect(
-	( state ) => {
-		return {
-			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-			isFetchingUserPurchases: isFetchingUserPurchases( state ),
-		};
-	},
-	{ fetchUserPurchases }
-)( QueryUserPurchases );
+export default QueryUserPurchases;

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -17,7 +17,7 @@ import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { hasLoadedUserPurchasesFromServer } from 'calypso/state/purchases/selectors';
 import getAccountClosureSites from 'calypso/state/selectors/get-account-closure-sites';
 import getUserPurchasedPremiumThemes from 'calypso/state/selectors/get-user-purchased-premium-themes';
@@ -70,7 +70,6 @@ class AccountSettingsClose extends Component {
 	render() {
 		const {
 			translate,
-			currentUserId,
 			hasAtomicSites,
 			hasCancelablePurchases,
 			isLoading,
@@ -84,7 +83,7 @@ class AccountSettingsClose extends Component {
 
 		return (
 			<div className={ containerClasses } role="main">
-				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
+				<QueryUserPurchases />
 				<FormattedHeader brandFont headerText={ translate( 'Account Settings' ) } align="left" />
 
 				<HeaderCake onClick={ this.goBack }>
@@ -262,8 +261,7 @@ class AccountSettingsClose extends Component {
 
 export default connect(
 	( state ) => {
-		const user = getCurrentUser( state );
-		const currentUserId = user && user.ID;
+		const currentUserId = getCurrentUserId( state );
 		const purchasedPremiumThemes = getUserPurchasedPremiumThemes( state, currentUserId );
 		const isLoading =
 			! purchasedPremiumThemes ||
@@ -271,14 +269,12 @@ export default connect(
 			! hasLoadedUserPurchasesFromServer( state );
 
 		return {
-			currentUserId: user && user.ID,
 			isLoading,
 			hasCancelablePurchases: hasCancelableUserPurchases( state, currentUserId ),
 			purchasedPremiumThemes,
 			hasAtomicSites: userHasAnyAtomicSites( state ),
 			isAccountClosed: isAccountClosed( state ),
 			sitesToBeDeleted: getAccountClosureSites( state ),
-			user,
 		};
 	},
 	{

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -732,7 +732,7 @@ class HelpContact extends Component {
 				{ this.props.shouldStartHappychatConnection && <HappychatConnection /> }
 				{ ! this.props.compact && <QuerySupportHistory email={ this.props.currentUser.email } /> }
 				<QueryTicketSupportConfiguration />
-				<QueryUserPurchases userId={ this.props.currentUser.ID } />
+				<QueryUserPurchases />
 				<QueryLanguageNames />
 			</Fragment>
 		);

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -38,7 +38,7 @@ class Courses extends Component {
 	}
 
 	render() {
-		const { courses, isBusinessPlanUser, isLoading, translate, userId } = this.props;
+		const { courses, isBusinessPlanUser, isLoading, translate } = this.props;
 
 		return (
 			<Main className="help-courses">
@@ -52,7 +52,7 @@ class Courses extends Component {
 					<CourseList courses={ courses } isBusinessPlanUser={ isBusinessPlanUser } />
 				) }
 
-				<QueryUserPurchases userId={ userId } />
+				<QueryUserPurchases />
 			</Main>
 		);
 	}
@@ -73,7 +73,6 @@ export function mapStateToProps( state ) {
 	return {
 		isLoading,
 		isBusinessPlanUser,
-		userId,
 		courses,
 	};
 }

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -300,7 +300,7 @@ class Help extends PureComponent {
 	};
 
 	render() {
-		const { isEmailVerified, userId, isLoading, translate } = this.props;
+		const { isEmailVerified, isLoading, translate } = this.props;
 
 		if ( isLoading ) {
 			return this.getPlaceholders();
@@ -335,7 +335,7 @@ class Help extends PureComponent {
 				) }
 				{ this.getContactUs() }
 				<QueryConciergeInitial />
-				<QueryUserPurchases userId={ userId } />
+				<QueryUserPurchases />
 			</Main>
 		);
 	}
@@ -357,7 +357,6 @@ export const mapStateToProps = ( state ) => {
 	const showCoursesTeaser = isBusinessPlanUser;
 
 	return {
-		userId,
 		isBusinessPlanUser,
 		showCoursesTeaser,
 		isLoading,

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -24,7 +24,6 @@ import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { isDataLoading } from 'calypso/me/purchases/utils';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
@@ -48,7 +47,6 @@ class CancelPurchase extends Component {
 		purchaseId: PropTypes.number.isRequired,
 		site: PropTypes.object,
 		siteSlug: PropTypes.string.isRequired,
-		userId: PropTypes.number,
 	};
 
 	state = {
@@ -147,7 +145,7 @@ class CancelPurchase extends Component {
 		if ( isDataLoading( this.props ) ) {
 			return (
 				<div>
-					<QueryUserPurchases userId={ this.props.userId } />
+					<QueryUserPurchases />
 					<CancelPurchaseLoadingPlaceholder
 						purchaseId={ this.props.purchaseId }
 						siteSlug={ this.props.siteSlug }
@@ -236,6 +234,5 @@ export default connect( ( state, props ) => {
 		purchase,
 		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
 		site: getSite( state, purchase ? purchase.siteId : null ),
-		userId: getCurrentUserId( state ),
 	};
 } )( localize( withLocalizedMoment( CancelPurchase ) ) );

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -21,7 +21,6 @@ import { cancelAndRefundPurchase } from 'calypso/lib/purchases/actions';
 import { cancelPurchase, purchasesRoot } from 'calypso/me/purchases/paths';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import {
@@ -52,7 +51,6 @@ class ConfirmCancelDomain extends Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		setAllSitesSelected: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string.isRequired,
-		userId: PropTypes.number,
 	};
 
 	state = {
@@ -257,7 +255,7 @@ class ConfirmCancelDomain extends Component {
 		if ( isDataLoading( this.props ) ) {
 			return (
 				<div>
-					<QueryUserPurchases userId={ this.props.userId } />
+					<QueryUserPurchases />
 					<ConfirmCancelDomainLoadingPlaceholder
 						purchaseId={ this.props.purchaseId }
 						selectedSite={ this.props.selectedSite }
@@ -331,7 +329,6 @@ export default connect(
 			isDomainOnlySite: isDomainOnly( state, selectedSite && selectedSite.ID ),
 			purchase: getByPurchaseId( state, props.purchaseId ),
 			selectedSite,
-			userId: getCurrentUserId( state ),
 		};
 	},
 	{

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -13,6 +13,7 @@ import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import {
 	getByPurchaseId,

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -13,7 +13,6 @@ import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
-import { getCurrentUserId, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import {
 	getByPurchaseId,
@@ -50,7 +49,6 @@ function ChangePaymentMethod( {
 		( state ) => getByPurchaseId( state, purchaseId )?.payment
 	);
 	const selectedSite = useSelector( getSelectedSite );
-	const userId = useSelector( getCurrentUserId );
 
 	const { isStripeLoading } = useStripe();
 
@@ -74,7 +72,7 @@ function ChangePaymentMethod( {
 		return (
 			<Fragment>
 				<QueryStoredCards />
-				{ userId && <QueryUserPurchases userId={ userId } /> }
+				<QueryUserPurchases />
 				<PaymentMethodLoader title={ changePaymentMethodTitle } />
 			</Fragment>
 		);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -132,7 +132,6 @@ class ManagePurchase extends Component {
 		site: PropTypes.object,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string.isRequired,
-		userId: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -827,7 +826,7 @@ class ManagePurchase extends Component {
 				{ this.props.siteId ? (
 					<QuerySitePurchases siteId={ this.props.siteId } />
 				) : (
-					<QueryUserPurchases userId={ this.props.userId } />
+					<QueryUserPurchases />
 				) }
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
@@ -920,7 +919,6 @@ export default connect( ( state, props ) => {
 		isPurchaseTheme,
 		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
 		isAtomicSite: isSiteAtomic( state, siteId ),
-		userId,
 		relatedMonthlyPlanSlug,
 		relatedMonthlyPlanPrice,
 		isJetpackTemporarySite: purchase && isJetpackTemporarySitePurchase( purchase.domain ),

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -106,7 +106,7 @@ class PurchasesList extends Component {
 	}
 
 	render() {
-		const { purchases, sites, translate, userId, subscriptions } = this.props;
+		const { purchases, sites, translate, subscriptions } = this.props;
 		let content;
 
 		if ( this.isDataLoading() ) {
@@ -171,7 +171,7 @@ class PurchasesList extends Component {
 
 		return (
 			<Main wideLayout className="purchases-list">
-				<QueryUserPurchases userId={ userId } />
+				<QueryUserPurchases />
 				<QueryMembershipsSubscriptions />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 				<MeSidebarNavigation />
@@ -204,7 +204,6 @@ PurchasesList.propTypes = {
 	purchases: PropTypes.oneOfType( [ PropTypes.array, PropTypes.bool ] ),
 	subscriptions: PropTypes.array,
 	sites: PropTypes.array.isRequired,
-	userId: PropTypes.number.isRequired,
 	name: PropTypes.string,
 };
 
@@ -220,7 +219,6 @@ export default connect(
 			sites: getSites( state ),
 			nextAppointment: getConciergeNextAppointment( state ),
 			scheduleId: getConciergeScheduleId( state ),
-			userId,
 			isUserBlocked: getConciergeUserBlocked( state ),
 		};
 	},

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -144,7 +144,7 @@ const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemTo
 
 	return (
 		<>
-			<QueryUserPurchases userId={ userId } />
+			<QueryUserPurchases />
 			{ shouldRender && (
 				<div className="cart__upsell-wrapper">
 					<UpcomingRenewalsDialog

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -53,7 +53,6 @@ class ListAll extends Component {
 		domainsList: PropTypes.array.isRequired,
 		filteredDomainsList: PropTypes.array.isRequired,
 		sites: PropTypes.object.isRequired,
-		user: PropTypes.object.isRequired,
 		addDomainClick: PropTypes.func.isRequired,
 		requestingSiteDomains: PropTypes.object,
 		isContactEmailEditContext: PropTypes.bool,

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -520,7 +520,7 @@ class ListAll extends Component {
 	}
 
 	renderContent() {
-		const { domainsList, translate, user } = this.props;
+		const { domainsList, translate } = this.props;
 
 		if (
 			this.props.isContactEmailEditContext &&
@@ -547,7 +547,7 @@ class ListAll extends Component {
 				<div className="list-all__form">{ this.renderActionForm() }</div>
 				<div className="list-all__container">
 					<QueryAllDomains />
-					<QueryUserPurchases userId={ user.ID } />
+					<QueryUserPurchases />
 					<Main wideLayout>
 						<SidebarNavigation />
 						<DocumentHead title={ translate( 'Domains', { context: 'A navigation label.' } ) } />
@@ -632,7 +632,6 @@ const getFilteredDomainsList = ( state, context ) => {
 export default connect(
 	( state, { context } ) => {
 		const sites = getSitesById( state );
-		const user = getCurrentUser( state );
 		const purchases = getPurchasesByCurrentUserId( state );
 		const action = parse( context.querystring )?.action;
 
@@ -649,7 +648,6 @@ export default connect(
 			requestingFlatDomains: isRequestingAllDomains( state ),
 			requestingSiteDomains: getAllRequestingSiteDomains( state ),
 			sites,
-			user,
 		};
 	},
 	{

--- a/client/my-sites/jetpack-search/placeholder.tsx
+++ b/client/my-sites/jetpack-search/placeholder.tsx
@@ -1,12 +1,10 @@
 import { ReactElement } from 'react';
-import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import JetpackSearchContent from './content';
 import JetpackSearchLogo from './logo';
 
@@ -18,10 +16,9 @@ interface Props {
 }
 
 export default function JetpackSearchPlaceholder( { siteId, isJetpack }: Props ): ReactElement {
-	const currentUserId = useSelector( getCurrentUserId );
 	return (
 		<Main className="jetpack-search__placeholder">
-			<QueryUserPurchases userId={ currentUserId } />
+			<QueryUserPurchases />
 			{ ! isJetpack && <QuerySiteSettings siteId={ siteId } /> }
 			{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -100,7 +100,7 @@ export const MarketingTools: FunctionComponent = () => {
 
 	return (
 		<Fragment>
-			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
+			<QueryUserPurchases />
 			{ ! sitePlan && <QuerySitePlans siteId={ siteId } /> }
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
 

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -47,7 +47,7 @@ export default function UltimateTrafficGuide() {
 
 	return (
 		<CompactCard className="ultimate-traffic-guide">
-			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
+			<QueryUserPurchases />
 			{ isLoading || ! purchases ? <Placeholder num={ 5 } /> : renderContent() }
 		</CompactCard>
 	);

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -670,7 +670,7 @@ class ThemeSheet extends Component {
 
 		const plansUrl = siteSlug ? `/plans/${ siteSlug }/?plan=value_bundle` : '/plans';
 
-		const { canonicalUrl, currentUserId, description, name: themeName } = this.props;
+		const { canonicalUrl, description, name: themeName } = this.props;
 		const title =
 			themeName &&
 			translate( '%(themeName)s Theme', {
@@ -757,7 +757,7 @@ class ThemeSheet extends Component {
 		return (
 			<Main className={ className }>
 				<QueryCanonicalTheme themeId={ this.props.id } siteId={ siteId } />
-				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
+				<QueryUserPurchases />
 				{
 					siteId && (
 						<QuerySitePurchases siteId={ siteId } />
@@ -859,7 +859,6 @@ export default connect(
 			siteId,
 			siteSlug,
 			backPath,
-			currentUserId,
 			isCurrentUserPaid,
 			isWpcomTheme,
 			isLoggedIn: !! currentUserId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryUserPurchases`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/me/purchases` and verify you see a request to `/me/purchases`
* Navigate away and go back, there shouldn't be another request (there may be other `/sites/<siteId>/purchases` requests though)

`QueryUserPurchases` is used in a bunch of other places, too, e.g. on `/home/<siteSlug>`. Behaviour should generally be the same as described above.
