### PR TITLE
`QueryReaderRecommendedSites`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-reader-recommended-sites/index.jsx
+++ b/client/components/data/query-reader-recommended-sites/index.jsx
@@ -1,30 +1,15 @@
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestRecommendedSites } from 'calypso/state/reader/recommended-sites/actions';
 
-class QueryReaderRecommendedSites extends Component {
-	static propTypes = {
-		seed: PropTypes.number,
-		offset: PropTypes.number,
-	};
+function QueryReaderRecommendedSites( { seed = 0, offset = 0 } ) {
+	const dispatch = useDispatch();
 
-	static defaultProps = {
-		seed: 0,
-		offset: 0,
-	};
+	useEffect( () => {
+		dispatch( requestRecommendedSites( { seed, offset } ) );
+	}, [ dispatch, seed, offset ] );
 
-	UNSAFE_componentWillMount() {
-		this.props.requestRecommendedSites( { seed: this.props.seed, offset: this.props.offset } );
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.props.requestRecommendedSites( { seed: nextProps.seed, offset: nextProps.offset } );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect( null, { requestRecommendedSites } )( QueryReaderRecommendedSites );
+export default QueryReaderRecommendedSites;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryReaderRecommendedSites`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/following/manage` or hit _Reader_ and click on _Manage_ right below the search input
* Make sure recommendations are shown (you should see a network request)
* Hit _X_ on a few items and make sure you see subsequent requests (`offset` should change)