### PR TITLE
Onboarding: Fix BSOD because of missing site id

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -6,6 +6,7 @@ import store from 'store';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
+import flows from 'calypso/signup/config/flows';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
@@ -283,6 +284,7 @@ export default {
 		const stepName = getStepName( params );
 		const stepSectionName = getStepSectionName( params );
 		const signupDependencies = getSignupDependencyStore( getState() );
+		const { providesDependenciesInQuery } = flows.getFlow( flowName, userLoggedIn );
 
 		// wait for the step component module to load
 		const stepComponent = await getStepComponent( stepName );
@@ -294,7 +296,11 @@ export default {
 		dispatch( setLayoutFocus( 'content' ) );
 		dispatch( setCurrentFlowName( flowName ) );
 
-		if ( ! [ 'launch-site' ].includes( flowName ) ) {
+		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
+		if (
+			! providesDependenciesInQuery?.includes( 'siteId' ) &&
+			! providesDependenciesInQuery?.includes( 'siteSlug' )
+		) {
 			dispatch( setSelectedSiteId( null ) );
 		}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -61,6 +61,7 @@ import { submitSiteVertical } from 'calypso/state/signup/steps/site-vertical/act
 import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteId, isCurrentPlanPaid, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import flows from './config/flows';
 import { getStepComponent } from './config/step-components';
 import steps from './config/steps';
@@ -740,7 +741,13 @@ class Signup extends Component {
 export default connect(
 	( state, ownProps ) => {
 		const signupDependencies = getSignupDependencyStore( state );
-		const siteId = getSiteId( state, signupDependencies.siteSlug );
+
+		// Use selectedSiteId which was set by setSelectedSiteForSignup of controller
+		// If we don't have selectedSiteId, then fallback to use getSiteId by siteSlug
+		// Note that siteSlug might not be updated as the value was updated when the Signup component will mount
+		// and we initialized SignupFlowController
+		// See: https://github.com/Automattic/wp-calypso/pull/57386
+		const siteId = getSelectedSiteId( state ) || getSiteId( state, signupDependencies.siteSlug );
 		const siteDomains = getDomainsBySiteId( state, siteId );
 		const shouldStepShowSitePreview = get(
 			steps[ ownProps.stepName ],

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -740,7 +740,7 @@ class Signup extends Component {
 export default connect(
 	( state, ownProps ) => {
 		const signupDependencies = getSignupDependencyStore( state );
-		const siteId = getSiteId( state, signupDependencies.siteSlug );
+		const siteId = getSiteId( state, ownProps.siteIdOrSlug );
 		const siteDomains = getDomainsBySiteId( state, siteId );
 		const shouldStepShowSitePreview = get(
 			steps[ ownProps.stepName ],

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -740,7 +740,7 @@ class Signup extends Component {
 export default connect(
 	( state, ownProps ) => {
 		const signupDependencies = getSignupDependencyStore( state );
-		const siteId = getSiteId( state, ownProps.siteIdOrSlug );
+		const siteId = getSiteId( state, signupDependencies.siteSlug );
 		const siteDomains = getDomainsBySiteId( state, siteId );
 		const shouldStepShowSitePreview = get(
 			steps[ ownProps.stepName ],

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -114,7 +114,12 @@ export function fetchSiteDomains( siteId ) {
 		return wpcom.req
 			.get( `/sites/${ siteId }/domains`, { apiVersion: '1.2' } )
 			.then( ( data ) => {
-				const { domains = [] } = data;
+				const { domains = [], error, message } = data;
+
+				if ( error ) {
+					throw new Error( message );
+				}
+
 				dispatch( domainsRequestSuccessAction( siteId ) );
 				dispatch( domainsReceiveAction( siteId, domains ) );
 			} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the site domains are empty, we'll check it [here](https://github.com/Automattic/wp-calypso/blob/0d1b96bbc4ec8ba35fcaafeec3ff280bb18042a8/client/signup/main.jsx#L700) so that the main screen would render nothing and wait for querying domains. However, the `siteId` comes from [here](https://github.com/Automattic/wp-calypso/blob/0d1b96bbc4ec8ba35fcaafeec3ff280bb18042a8/client/signup/main.jsx#L743) and it depends on `siteSlug` of `signupDependencies`. However, we might not have `siteSlug` in this case so that the domain query fails. Note that it's weird as we would update `siteSlug` when we initialized the `SignupController` at `Signup` component mount. But it seems to not work well sometimes.
  https://github.com/Automattic/wp-calypso/blob/87bfd5c7f0116e0c605cee483d9807a60a955ea0/client/lib/signup/flow-controller.ts#L141
* I change to use `getSelectedSiteId` at first and fallback to `getSiteId` to fix the BSOD.
* One question is that why do we need to clear the selected site id except `launch-site`? It comes from https://github.com/Automattic/wp-calypso/pull/49680 and maybe we could also apply to `setup-site` flow?
  https://github.com/Automattic/wp-calypso/blob/0d1b96bbc4ec8ba35fcaafeec3ff280bb18042a8/client/signup/controller.js#L291

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `https://wordpress.com/start?flags=signup/hero-flow` (I don't know why I cannot reproduce this in local calypso)
* Select paid domain
* Select paid plan
* Complete checkout with credits
* Check the result after redirecting to Hero Flow

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57357
