### PR TITLE
Fix how the domains table header sorting works

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -18,8 +18,8 @@ export function resolveDomainStatus(
 		isJetpackSite = null,
 		isSiteAutomatedTransfer = null,
 		isDomainOnlySite = false,
-		hasMappingError = false,
 		siteSlug = null,
+		getMappingErrors = false,
 	} = {}
 ) {
 	const transferOptions = {
@@ -58,6 +58,7 @@ export function resolveDomainStatus(
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
+						listStatusWeight: 1000,
 					};
 				}
 
@@ -67,43 +68,54 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
+					listStatusWeight: 800,
 				};
 			}
 
-			if ( hasMappingError ) {
-				const setupStep =
-					domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update';
-				const options = {
-					components: {
-						strong: <strong />,
-						a: (
-							<a
-								href={ domainMappingSetup( siteSlug, domain.domain, setupStep ) }
-								onClick={ ( e ) => e.stopPropagation() }
-							/>
-						),
-					},
-				};
+			if ( getMappingErrors ) {
+				const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
 
-				let status;
-				if ( domain?.connectionMode === 'advanced' ) {
-					status = translate(
-						'{{strong}}Connection error:{{/strong}} The A records are incorrect. Please {{a}}try this step{{/a}} again.',
-						options
-					);
-				} else {
-					status = translate(
-						'{{strong}}Connection error:{{/strong}} The name servers are incorrect. Please {{a}}try this step{{/a}} again.',
-						options
-					);
+				const hasMappingError =
+					domain.type === domainTypes.MAPPED &&
+					! domain.pointsToWpcom &&
+					moment.utc().isAfter( registrationDatePlus3Days );
+
+				if ( hasMappingError ) {
+					const setupStep =
+						domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update';
+					const options = {
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									href={ domainMappingSetup( siteSlug, domain.domain, setupStep ) }
+									onClick={ ( e ) => e.stopPropagation() }
+								/>
+							),
+						},
+					};
+
+					let status;
+					if ( domain?.connectionMode === 'advanced' ) {
+						status = translate(
+							'{{strong}}Connection error:{{/strong}} The A records are incorrect. Please {{a}}try this step{{/a}} again.',
+							options
+						);
+					} else {
+						status = translate(
+							'{{strong}}Connection error:{{/strong}} The name servers are incorrect. Please {{a}}try this step{{/a}} again.',
+							options
+						);
+					}
+					return {
+						statusText: translate( 'Connection error' ),
+						statusClass: 'status-alert',
+						icon: 'info',
+						listStatusText: status,
+						listStatusClass: 'alert',
+						listStatusWeight: 1000,
+					};
 				}
-				return {
-					statusText: translate( 'Connection error' ),
-					statusClass: 'status-alert',
-					icon: 'info',
-					listStatusText: status,
-					listStatusClass: 'alert',
-				};
 			}
 
 			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom ) {
@@ -121,6 +133,7 @@ export function resolveDomainStatus(
 					icon: 'verifying',
 					listStatusText: status,
 					listStatusClass: 'verifying',
+					listStatusWeight: 200,
 				};
 			}
 
@@ -147,6 +160,7 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusText: pendingRenewalMessage,
 					listStatusClass: 'warning',
+					listStatusWeight: 800,
 				};
 			}
 
@@ -187,6 +201,7 @@ export function resolveDomainStatus(
 							'timeSinceExpiry is of the form "[number] [time-period] ago" e.g. "3 days ago"',
 					} ),
 					listStatusClass: 'alert',
+					listStatusWeight: 1000,
 				};
 			}
 
@@ -202,6 +217,7 @@ export function resolveDomainStatus(
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
+						listStatusWeight: 1000,
 					};
 				}
 
@@ -211,6 +227,7 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
+					listStatusWeight: 800,
 				};
 			}
 
@@ -221,6 +238,7 @@ export function resolveDomainStatus(
 					icon: 'cloud_upload',
 					listStatusText: translate( 'Activating' ),
 					listStatusClass: 'info',
+					listStatusWeight: 400,
 				};
 			}
 
@@ -269,6 +287,7 @@ export function resolveDomainStatus(
 						}
 					),
 					listStatusClass: 'transfer-warning',
+					listStatusWeight: 600,
 				};
 			}
 
@@ -326,6 +345,7 @@ export function resolveDomainStatus(
 						}
 					),
 					listStatusClass: 'transfer-warning',
+					listStatusWeight: 600,
 				};
 			} else if ( domain.transferStatus === transferStatus.CANCELLED ) {
 				return {
@@ -337,6 +357,7 @@ export function resolveDomainStatus(
 						transferOptions
 					),
 					listStatusClass: 'alert',
+					listStatusWeight: 1000,
 				};
 			} else if ( domain.transferStatus === transferStatus.PENDING_REGISTRY ) {
 				if ( domain.transferEndDate ) {
@@ -349,6 +370,7 @@ export function resolveDomainStatus(
 							transferOptions
 						),
 						listStatusClass: 'verifying',
+						listStatusWeight: 200,
 					};
 				}
 				return {
@@ -360,6 +382,7 @@ export function resolveDomainStatus(
 						transferOptions
 					),
 					listStatusClass: 'verifying',
+					listStatusWeight: 200,
 				};
 			}
 
@@ -372,6 +395,7 @@ export function resolveDomainStatus(
 					transferOptions
 				),
 				listStatusClass: 'verifying',
+				listStatusWeight: 200,
 			};
 
 		default:

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -1,7 +1,6 @@
 import { Button, CompactCard } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import moment from 'moment';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Fragment, PureComponent } from 'react';
@@ -417,15 +416,6 @@ class DomainItem extends PureComponent {
 		);
 	}
 
-	hasMappingError( domain ) {
-		const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
-		return (
-			domain.type === domainTypes.MAPPED &&
-			! domain.pointsToWpcom &&
-			moment.utc().isAfter( registrationDatePlus3Days )
-		);
-	}
-
 	render() {
 		const {
 			domain,
@@ -440,7 +430,7 @@ class DomainItem extends PureComponent {
 		const { listStatusText, listStatusClass } = resolveDomainStatus(
 			domainDetails || domain,
 			null,
-			{ siteSlug: site?.slug, hasMappingError: this.hasMappingError( domain ) }
+			{ siteSlug: site?.slug, getMappingErrors: true }
 		);
 
 		const rowClasses = classNames( 'domain-item', `domain-item__status-${ listStatusClass }` );

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -84,18 +84,20 @@ class DomainsTable extends PureComponent {
 
 		const domainItems = filterOutWpcomDomains( domains );
 
+		const selectedColumnDefinition = domainsTableColumns.find(
+			( column ) => column.name === sortKey
+		);
+
 		if ( sortKey && sortOrder ) {
 			domainItems.sort( ( first, second ) => {
-				const firstValue = first?.[ sortKey ];
-				const secondValue = second?.[ sortKey ];
-
-				if ( firstValue > secondValue ) {
-					return sortOrder;
+				let result = 0;
+				for ( const sortFunction of selectedColumnDefinition.sortFunctions ) {
+					result = sortFunction( first, second, sortOrder );
+					if ( 0 !== result ) {
+						break;
+					}
 				}
-				if ( firstValue < secondValue ) {
-					return -1 * sortOrder;
-				}
-				return 0;
+				return result;
 			} );
 		}
 

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -15,6 +15,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { resolveDomainStatus } from 'calypso/lib/domains';
 import { type } from 'calypso/lib/domains/constants';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
@@ -46,6 +47,7 @@ import {
 	getDomainManagementPath,
 	showUpdatePrimaryDomainSuccessNotice,
 	showUpdatePrimaryDomainErrorNotice,
+	getSimpleSortFunctionBy,
 } from './utils';
 
 import './style.scss';
@@ -114,14 +116,33 @@ export class SiteDomains extends Component {
 				isSortable: true,
 				initialSortOrder: 1,
 				supportsOrderSwitching: true,
+				sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
 			},
-			{ name: 'status', label: translate( 'Status' ), isSortable: true, initialSortOrder: -1 },
+			{
+				name: 'status',
+				label: translate( 'Status' ),
+				isSortable: true,
+				initialSortOrder: -1,
+				sortFunctions: [
+					( first, second, sortOrder ) => {
+						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus( first, null, {
+							getMappingErrors: true,
+						} );
+						const { listStatusWeight: secondStatusWeight } = resolveDomainStatus( second, null, {
+							getMappingErrors: true,
+						} );
+						return ( ( firstStatusWeight ?? 0 ) - ( secondStatusWeight ?? 0 ) ) * sortOrder;
+					},
+					getSimpleSortFunctionBy( 'domain' ),
+				],
+			},
 			{
 				name: 'registered-until',
 				label: translate( 'Registered until' ),
 				isSortable: true,
 				initialSortOrder: 1,
 				supportsOrderSwitching: true,
+				sortFunctions: [ getSimpleSortFunctionBy( 'expiry' ), getSimpleSortFunctionBy( 'domain' ) ],
 			},
 			{ name: 'auto-renew', label: translate( 'Auto-renew' ) },
 			{ name: 'email', label: translate( 'Email' ) },

--- a/client/my-sites/domains/domain-management/list/utils.js
+++ b/client/my-sites/domains/domain-management/list/utils.js
@@ -51,3 +51,19 @@ export const showUpdatePrimaryDomainErrorNotice = ( errorMessage ) => {
 export const filterOutWpcomDomains = ( domains ) => {
 	return domains.filter( ( domain ) => domain.type !== type.WPCOM );
 };
+
+export const getSimpleSortFunctionBy = ( column ) => ( first, second, sortOrder ) => {
+	if ( ! first.hasOwnProperty( column ) || ! second.hasOwnProperty( column ) ) {
+		return -1;
+	}
+	if ( first?.[ column ] === null || second?.[ column ] === null ) {
+		return -1;
+	}
+	if ( first?.[ column ] > second?.[ column ] ) {
+		return 1 * sortOrder;
+	}
+	if ( first?.[ column ] < second?.[ column ] ) {
+		return -1 * sortOrder;
+	}
+	return 0;
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix how the sorting of the domains table works (chained sorting functions defined at column level)
* Add `listStatusWeight` in the `resolveDomainStatus` function so we can use it for sorting
* Refactored the `resolveDomainStatus` to have `getMappingErrors` boolean value instead of `hasMappingErrors` so that we can reuse the code (@leonardost this might need to land in the domain item PR too)

NOTE: This applies on top of add/domains-table-header-sorting branch - not sure how we'll merge those

#### Testing instructions

* Spin up the branch and verify that sorting by Domain, Status and Registered until works as expected. You can also test this with the domain list mocks from D68679-code