### PR TITLE
Removed atomic/automated-revert flag for self service atomic cancellations

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -86,7 +86,6 @@ import {
 	hasLoadedUserPurchasesFromServer,
 	hasLoadedSitePurchasesFromServer,
 	getRenewableSitePurchases,
-	shouldRevertAtomicSiteBeforeDeactivation,
 } from 'calypso/state/purchases/selectors';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
@@ -920,9 +919,5 @@ export default connect( ( state, props ) => {
 		relatedMonthlyPlanSlug,
 		relatedMonthlyPlanPrice,
 		isJetpackTemporarySite: purchase && isJetpackTemporarySitePurchase( purchase.domain ),
-		shouldRevertAtomicSiteBeforeCancel: shouldRevertAtomicSiteBeforeDeactivation(
-			state,
-			purchase?.id
-		),
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -69,7 +69,6 @@ import {
 } from 'calypso/lib/purchases';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { addQueryArgs } from 'calypso/lib/url';
-import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
@@ -432,7 +431,7 @@ class ManagePurchase extends Component {
 	}
 
 	renderCancelPurchaseNavItem() {
-		const { isAtomicSite, purchase, shouldRevertAtomicSiteBeforeCancel, translate } = this.props;
+		const { isAtomicSite, purchase, translate } = this.props;
 		const { id } = purchase;
 
 		if ( ! isCancelable( purchase ) ) {
@@ -440,12 +439,9 @@ class ManagePurchase extends Component {
 		}
 
 		let text;
-		let link = this.props.getCancelPurchaseUrlFor( this.props.siteSlug, id );
+		const link = this.props.getCancelPurchaseUrlFor( this.props.siteSlug, id );
 
-		if ( shouldRevertAtomicSiteBeforeCancel && ! config.isEnabled( 'atomic/automated-revert' ) ) {
-			text = translate( 'Contact Support to Cancel your Subscription' );
-			link = CALYPSO_CONTACT;
-		} else if ( hasAmountAvailableToRefund( purchase ) ) {
+		if ( hasAmountAvailableToRefund( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
 				text = translate( 'Cancel Domain and Refund' );
 			}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -9,14 +9,13 @@ import {
 	isPlan,
 	isTitanMail,
 } from '@automattic/calypso-products';
-import { Dialog, Button, CompactCard, Gridicon } from '@automattic/components';
+import { Button, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import CancelJetpackForm from 'calypso/components/marketing-survey/cancel-jetpack-form';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
 import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
@@ -328,44 +327,6 @@ class RemovePurchase extends Component {
 
 				{ isPlan( purchase ) && hasIncludedDomain( purchase ) && includedDomainText }
 			</div>
-		);
-	}
-
-	renderAtomicDialog( purchase ) {
-		const { translate } = this.props;
-		const supportButton = this.props.isChatAvailable
-			? this.getChatButton()
-			: this.getContactUsButton();
-
-		const buttons = [
-			supportButton,
-			{
-				action: 'cancel',
-				disabled: this.state.isRemoving,
-				isPrimary: true,
-				label: translate( "I'll Keep It" ),
-			},
-		];
-		const productName = getName( purchase );
-
-		return (
-			<Dialog
-				buttons={ buttons }
-				className="remove-purchase__dialog"
-				isVisible={ this.state.isDialogVisible }
-				onClose={ this.closeDialog }
-			>
-				<FormSectionHeading />
-				<p>
-					{ translate(
-						'To cancel your %(productName)s plan, please contact our support team' +
-							' — a Happiness Engineer will take care of it.',
-						{
-							args: { productName },
-						}
-					) }
-				</p>
-			</Dialog>
 		);
 	}
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -410,10 +410,6 @@ class RemovePurchase extends Component {
 			);
 		}
 
-		if ( this.props.shouldRevertAtomicSite && ! config.isEnabled( 'atomic/automated-revert' ) ) {
-			return this.renderAtomicDialog( purchase );
-		}
-
 		// Jetpack Plan or Product Cancellation
 		if ( this.props.isJetpack ) {
 			return this.renderJetpackDialog();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the atomic/automated-revert Calypso flag restriction.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D69088-code on your sandbox. 
* Get an Atomic site with a Business subscription
* Go to Upgrades > Purchases and click on the Business subscription
* Make sure that when you click on the remove subscription you'll be presented with the cancellation form.
* Fill-in the form and cancel your subscription
* Make sure that in Blog RC your site has started to revert (is not in the Completed status).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
