### PR TITLE
Tracks: update event name checker regex to allow digits

### DIFF
--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -173,12 +173,12 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 
 	if ( process.env.NODE_ENV !== 'production' && typeof console !== 'undefined' ) {
 		if (
-			! /^calypso(?:_[a-z]+){2,}$/.test( eventName ) &&
+			! /^calypso(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
 			! includes( EVENT_NAME_EXCEPTIONS, eventName )
 		) {
 			// eslint-disable-next-line no-console
 			console.error(
-				'Tracks: Event `%s` will be ignored because it does not match /^calypso(?:_[a-z]+){2,}$/ and is ' +
+				'Tracks: Event `%s` will be ignored because it does not match /^calypso(?:_[a-z0-9]+){2,}$/ and is ' +
 					'not a listed exception. Please use a compliant event name.',
 				eventName
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* There is a dev env-only regex checker for tracks event names which outputs a console error if the string does not match `/^calypso(?:_[a-z]+){2,}$/`. 

In this PR, we'd like to update this regex to also accept digits, i.e. `/^calypso(?:_[a-z0-9]+){2,}$/`, for the following reasons:
* PCYsg-4S2-p2 (Fieldguide) Tracks naming conventions state the format requirement as `^[a-z_][a-z0-9_]*$`
* We'd like to track events for a product named `p2` (has a digit), e.g. `calypso_p2_preapproved_domains_validation_fail`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the new regex `/^calypso(?:_[a-z0-9]+){2,}$/` accepts formats such as `calypso_edit_gravatar_click` and `calypso_p2_preapproved_domains_validation_fail`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->