### PR TITLE
Fixed Navigation Header

### DIFF
--- a/client/components/fixed-navigation-header/README.md
+++ b/client/components/fixed-navigation-header/README.md
@@ -1,0 +1,24 @@
+# FixedNavigationHeader (JSX)
+
+This component displays a header and optional sub-header.
+
+When the `compactOnMobile` flag is set, the header renders in a compact way on smaller screen sizes.
+
+## How to use
+
+```js
+import FixedNavigationHeader from 'calypso/components/formatted-header';
+
+function render() {
+	return <FixedNavigationHeader headerText="A main title" subHeaderText="A main title" />;
+}
+```
+
+## Props
+
+- `brandFont` (`bool`) - use the WP.com brand font for `headerText`
+- `id` (`string`) - ID for the header (optional)
+- `headerText` (`string`) - The main header text
+- `subHeaderText` (`node`) - Sub header text (optional)
+- `compactOnMobile` (`bool`) - Display a compact header on small screens (optional)
+- `isSecondary` (`bool`) - Use the H2 element instead of the H1 (optional)

--- a/client/components/fixed-navigation-header/README.md
+++ b/client/components/fixed-navigation-header/README.md
@@ -1,24 +1,22 @@
 # FixedNavigationHeader (JSX)
 
-This component displays a header and optional sub-header.
-
-When the `compactOnMobile` flag is set, the header renders in a compact way on smaller screen sizes.
+This component displays a header with navigation items. 
+It can also include children items which will be positioned to the far right.
 
 ## How to use
 
 ```js
-import FixedNavigationHeader from 'calypso/components/formatted-header';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
 function render() {
-	return <FixedNavigationHeader headerText="A main title" subHeaderText="A main title" />;
+	return <FixedNavigationHeader headerText="A main title">Children Item</FixedNavigationHeader>;
 }
 ```
 
 ## Props
 
+- `headerText` (`string`) - The main header text
 - `brandFont` (`bool`) - use the WP.com brand font for `headerText`
 - `id` (`string`) - ID for the header (optional)
-- `headerText` (`string`) - The main header text
-- `subHeaderText` (`node`) - Sub header text (optional)
-- `compactOnMobile` (`bool`) - Display a compact header on small screens (optional)
-- `isSecondary` (`bool`) - Use the H2 element instead of the H1 (optional)
+- `className` (`string`) - A class name for the wrapped component (optional)
+- `children` (`nodes`) – Any children elements which are being rendered to the far right (optional)

--- a/client/components/fixed-navigation-header/docs/example.jsx
+++ b/client/components/fixed-navigation-header/docs/example.jsx
@@ -1,15 +1,11 @@
-import { Fragment, PureComponent } from 'react';
+import { Fragment } from 'react';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
-export default class FixedNavigationHeaderExample extends PureComponent {
-	static displayName = 'FormattedHeaderExample';
-
-	render() {
-		return (
-			<Fragment>
-				<FixedNavigationHeader headerText="This is the header." />
-				<FixedNavigationHeader headerText="This is the header with branded font" brandFont />
-			</Fragment>
-		);
-	}
+export default function FixedNavigationHeaderExample() {
+	return (
+		<Fragment>
+			<FixedNavigationHeader headerText="This is the header." />
+			<FixedNavigationHeader headerText="This is the header with branded font" brandFont />
+		</Fragment>
+	);
 }

--- a/client/components/fixed-navigation-header/docs/example.jsx
+++ b/client/components/fixed-navigation-header/docs/example.jsx
@@ -1,0 +1,15 @@
+import { Fragment, PureComponent } from 'react';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+
+export default class FixedNavigationHeaderExample extends PureComponent {
+	static displayName = 'FormattedHeaderExample';
+
+	render() {
+		return (
+			<Fragment>
+				<FixedNavigationHeader headerText="This is the header." />
+				<FixedNavigationHeader headerText="This is the header with branded font" brandFont />
+			</Fragment>
+		);
+	}
+}

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -60,7 +60,7 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 	const headerClasses = classNames( { 'wp-brand-font': brandFont } );
 
 	return (
-		<Header id={ id } classNames={ className }>
+		<Header id={ id } className={ className }>
 			<Container>
 				<H1 className={ headerClasses }>{ preventWidows( headerText, 2 ) }</H1>
 				<ActionsContainer>{ children }</ActionsContainer>

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -12,11 +12,15 @@ const Header = styled.header`
 	padding: 0 32px;
 	box-sizing: border-box;
 	border-bottom: 1px solid var( --studio-gray-5 );
-	background-color: var( --color-surface-backdrop );
+	background-color: #fff;
 
 	@media ( max-width: 782px ) {
 		width: 100%;
 		left: 0;
+	}
+
+	@media ( max-width: 660px ) {
+		padding: 0 16px;
 	}
 `;
 
@@ -26,6 +30,10 @@ const Container = styled.div`
 	align-items: center;
 	min-height: 70px;
 
+	@media ( max-width: 660px ) {
+		min-height: 60px;
+	}
+
 	.main.is-wide-layout & {
 		max-width: 1040px;
 		margin: auto;
@@ -34,7 +42,10 @@ const Container = styled.div`
 
 const H1 = styled.h1``;
 
-const ActionsContainer = styled.div``;
+const ActionsContainer = styled.div`
+	display: flex;
+	align-items: center;
+`;
 
 interface Props {
 	brandFont?: boolean;

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import { preventWidows } from 'calypso/lib/formatting';
+
+const Header = styled.header`
+	position: fixed;
+	z-index: 1;
+	top: var( --masterbar-height );
+	left: var( --sidebar-width-max );
+	width: calc( 100% - var( --sidebar-width-max ) );
+	padding: 0 32px;
+	box-sizing: border-box;
+	border-bottom: 1px solid var( --studio-gray-5 );
+	background-color: var( --color-surface-backdrop );
+
+	@media ( max-width: 782px ) {
+		width: 100%;
+		left: 0;
+	}
+`;
+
+const Container = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	min-height: 70px;
+
+	.main.is-wide-layout & {
+		max-width: 1040px;
+		margin: auto;
+	}
+`;
+
+const H1 = styled.h1``;
+
+const ActionsContainer = styled.div``;
+
+interface Props {
+	brandFont?: boolean;
+	id?: string;
+	headerText: string | ReactNode;
+	className?: string;
+	children?: ReactNode;
+}
+
+const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
+	const { brandFont, id, headerText, className, children } = props;
+	const headerClasses = classNames( { 'wp-brand-font': brandFont } );
+
+	return (
+		<Header id={ id } classNames={ className }>
+			<Container>
+				<H1 className={ headerClasses }>{ preventWidows( headerText, 2 ) }</H1>
+				<ActionsContainer>{ children }</ActionsContainer>
+			</Container>
+		</Header>
+	);
+};
+
+FixedNavigationHeader.defaultProps = {
+	id: '',
+	className: '',
+	brandFont: false,
+};
+
+export default FixedNavigationHeader;

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -12,7 +12,7 @@ const Header = styled.header`
 	padding: 0 32px;
 	box-sizing: border-box;
 	border-bottom: 1px solid var( --studio-gray-5 );
-	background-color: #fff;
+	background-color: var( --studio-white );
 
 	@media ( max-width: 782px ) {
 		width: 100%;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -412,7 +412,6 @@ export class PluginsMain extends Component {
 					</div>
 				</FixedNavigationHeader>
 				<div className="plugins__main">
-					<div className="plugins__header"></div>
 					<div className="plugins__main-header">
 						<SectionNav selectedText={ this.getSelectedText() }>
 							<NavTabs>{ navItems }</NavTabs>

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -7,8 +7,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
-import InlineSupportLink from 'calypso/components/inline-support-link';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
@@ -402,29 +401,16 @@ export class PluginsMain extends Component {
 				<QueryJetpackPlugins siteIds={ this.props.siteIds } />
 				{ this.renderPageViewTracking() }
 				<SidebarNavigation />
+				<FixedNavigationHeader
+					brandFont
+					className="plugins__page-heading"
+					headerText={ this.props.translate( 'Plugins' ) }
+				>
+					{ this.renderAddPluginButton() }
+					{ this.renderUploadPluginButton() }
+				</FixedNavigationHeader>
 				<div className="plugins__main">
-					<div className="plugins__header">
-						<FormattedHeader
-							brandFont
-							className="plugins__page-heading"
-							headerText={ this.props.translate( 'Plugins' ) }
-							align="left"
-							subHeaderText={ this.props.translate(
-								'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="plugins" showIcon={ false } />
-										),
-									},
-								}
-							) }
-						/>
-						<div className="plugins__main-buttons">
-							{ this.renderAddPluginButton() }
-							{ this.renderUploadPluginButton() }
-						</div>
-					</div>
+					<div className="plugins__header"></div>
 					<div className="plugins__main-header">
 						<SectionNav selectedText={ this.getSelectedText() }>
 							<NavTabs>{ navItems }</NavTabs>

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -406,8 +406,10 @@ export class PluginsMain extends Component {
 					className="plugins__page-heading"
 					headerText={ this.props.translate( 'Plugins' ) }
 				>
-					{ this.renderAddPluginButton() }
-					{ this.renderUploadPluginButton() }
+					<div className="plugins__main-buttons">
+						{ this.renderAddPluginButton() }
+						{ this.renderUploadPluginButton() }
+					</div>
 				</FixedNavigationHeader>
 				<div className="plugins__main">
 					<div className="plugins__header"></div>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -484,7 +484,11 @@ export class PluginsBrowser extends Component {
 				<DocumentHead title={ this.props.translate( 'Plugins', { textOnly: true } ) } />
 				<SidebarNavigation />
 				{ ! this.props.hideHeader && (
-					<FixedNavigationHeader brandFont headerText={ this.props.translate( 'Plugins' ) }>
+					<FixedNavigationHeader
+						brandFont
+						className="plugins-browser__header"
+						headerText={ this.props.translate( 'Plugins' ) }
+					>
 						<div className="plugins-browser__main-buttons">
 							{ this.renderManageButton() }
 							{ this.renderUploadPluginButton() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -21,7 +21,7 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteRecommendedPlugins from 'calypso/components/data/query-site-recommended-plugins';
 import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
-import FormattedHeader from 'calypso/components/formatted-header';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import MainComponent from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
@@ -484,25 +484,16 @@ export class PluginsBrowser extends Component {
 				<DocumentHead title={ this.props.translate( 'Plugins', { textOnly: true } ) } />
 				<SidebarNavigation />
 				{ ! this.props.hideHeader && (
-					<div className="plugins-browser__header">
-						<FormattedHeader
-							brandFont
-							className="plugins-browser__page-heading"
-							headerText={ this.props.translate( 'Plugins' ) }
-							align="left"
-						/>
-
-						<div className="plugins-browser__main-buttons manage-plugins-button">
+					<FixedNavigationHeader brandFont headerText={ this.props.translate( 'Plugins' ) }>
+						<div className="plugins-browser__main-buttons">
 							{ this.renderManageButton() }
-						</div>
-						<div className="plugins-browser__main-buttons upload-plugin-button">
-							{ this.renderUploadPluginButton( this.state.isMobile ) }
+							{ this.renderUploadPluginButton() }
 						</div>
 
 						<div className="plugins-browser__searchbox">
 							{ this.getSearchBox( this.state.isMobile ) }
 						</div>
-					</div>
+					</FixedNavigationHeader>
 				) }
 				{ this.renderUpgradeNudge() }
 				{ this.getPluginBrowserContent() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -491,7 +491,7 @@ export class PluginsBrowser extends Component {
 					>
 						<div className="plugins-browser__main-buttons">
 							{ this.renderManageButton() }
-							{ this.renderUploadPluginButton() }
+							{ this.renderUploadPluginButton( this.state.isMobile ) }
 						</div>
 
 						<div className="plugins-browser__searchbox">

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,6 +1,9 @@
 .plugins-browser__searchbox {
 	width: 250px;
-	margin-bottom: 20px;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	align-items: stretch;
 
 	.search-component {
 		height: 30px;
@@ -38,11 +41,8 @@
 	}
 
 	@media screen and ( max-width: 660px ) {
-		margin-bottom: 0;
-
-		&.upload-plugin-button .plugins-browser__button {
+		.plugins-browser__button {
 			border: none;
-			margin-right: 0;
 		}
 	}
 

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,16 +1,3 @@
-.plugins-browser__header {
-	display: flex;
-	flex: 1 1 auto;
-	justify-content: flex-start;
-	align-items: center;
-	border-bottom: 1px solid var( --studio-gray-5 );
-	position: relative;
-
-	.plugins-browser__page-heading {
-		margin-bottom: 24px;
-	}
-}
-
 .plugins-browser__searchbox {
 	width: 250px;
 	margin-bottom: 20px;
@@ -19,11 +6,12 @@
 		height: 30px;
 		box-shadow: 0 0 0 1px var( --studio-gray-10 );
 
-		.search-component__open-icon, .search-component__close-icon {
+		.search-component__open-icon,
+		.search-component__close-icon {
 			color: var( --studio-black );
 		}
 
-		&.is-open input.search-component__input[type=search] {
+		&.is-open input.search-component__input[type='search'] {
 			font-size: $font-body-extra-small;
 		}
 	}
@@ -35,7 +23,6 @@
 			box-shadow: none;
 		}
 	}
-
 }
 
 .plugins-browser__main-buttons {
@@ -44,11 +31,6 @@
 	justify-content: flex-end;
 	align-items: stretch;
 	margin-right: 15px;
-	margin-bottom: 20px;
-
-	&.manage-plugins-button {
-		margin-left: auto;
-	}
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
@@ -75,10 +57,7 @@
 		}
 
 		&:not( :last-child ) {
-			margin-bottom: 8px;
-
 			@include breakpoint-deprecated( '>480px' ) {
-				margin-bottom: 0;
 				margin-right: 10px;
 			}
 		}

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -30,9 +30,6 @@
 
 .plugins-browser__main-buttons {
 	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
-	align-items: stretch;
 	margin-right: 15px;
 
 	@include breakpoint-deprecated( '>480px' ) {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -30,17 +30,6 @@
 	white-space: nowrap;
 }
 
-.plugins__header {
-	display: flex;
-	flex: 1 1 auto;
-	justify-content: flex-start;
-	align-items: center;
-
-	.plugins__page-heading {
-		width: 100%;
-	}
-}
-
 .plugins__main-header {
 	background: var( --color-surface );
 	flex-direction: column;
@@ -99,12 +88,6 @@
 			}
 		}
 	}
-}
-
-.plugins__header-navigation {
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
-		0 1px 2px var( --color-neutral-0 );
-	width: 100%;
 }
 
 .plugins__more-header {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,5 +1,13 @@
 .is-section-plugins .main {
-	padding-top: 70px; // Compensate for the fixed header.
+	padding-top: 35px; // Compensate for the fixed header.
+
+	@media ( max-width: 782px ) {
+		padding-top: 50px;
+	}
+
+	@media ( max-width: 660px ) {
+		padding-top: 70px;
+	}
 }
 
 .is-section-plugins.color-scheme.is-nav-unification {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,3 +1,7 @@
+.is-section-plugins .main {
+	padding-top: 70px; // Compensate for the fixed header.
+}
+
 .is-section-plugins.color-scheme.is-nav-unification {
 	--color-surface-backdrop: --studio-white;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* introduces a new Fixed Navigation Header component.
* uses it in plugin browser

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1073" alt="SS 2021-10-28 at 19 08 58" src="https://user-images.githubusercontent.com/12430020/139294268-58008f1e-7311-47e4-afa1-c4f306a9c231.png">|<img width="1073" alt="SS 2021-10-28 at 19 08 26" src="https://user-images.githubusercontent.com/12430020/139294187-78e0cdaf-b64d-431e-a780-8cc04f78860d.png">|

* Go to `/plugins`
* Inspect that the header:
-- is remaining sticky to the top
-- items are positioned as per designs

Out of scope:
- `font-family`, we need to discuss with the design team whether we are changing the font-family in all pages or only here
- navigation will be handled in https://github.com/Automattic/wp-calypso/pull/57442

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57101
