### PR TITLE
`QueryActiveTheme`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-active-theme/index.jsx
+++ b/client/components/data/query-active-theme/index.jsx
@@ -1,42 +1,27 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { isRequestingActiveTheme } from 'calypso/state/themes/selectors';
 
-class QueryActiveTheme extends Component {
-	static propTypes = {
-		siteId: PropTypes.number,
-		// Connected props
-		isRequesting: PropTypes.bool.isRequired,
-		requestActiveTheme: PropTypes.func.isRequired,
-	};
-
-	componentDidMount() {
-		this.request( this.props );
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( siteId && ! isRequestingActiveTheme( getState(), siteId ) ) {
+		dispatch( requestActiveTheme( siteId ) );
 	}
+};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId ) {
-			return;
-		}
-		this.request( nextProps );
-	}
+function QueryActiveTheme( { siteId } ) {
+	const dispatch = useDispatch();
 
-	request( props ) {
-		if ( props.siteId && ! props.isRequesting ) {
-			props.requestActiveTheme( props.siteId );
-		}
-	}
+	useEffect( () => {
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, { siteId } ) => ( {
-		isRequesting: isRequestingActiveTheme( state, siteId ),
-	} ),
-	{ requestActiveTheme }
-)( QueryActiveTheme );
+QueryActiveTheme.propTypes = {
+	siteId: PropTypes.number.isRequired,
+};
+
+export default QueryActiveTheme;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1168,11 +1168,6 @@ Undocumented.prototype.deleteThemeFromJetpack = function ( siteId, themeId, fn )
 	);
 };
 
-Undocumented.prototype.activeTheme = function ( siteId, fn ) {
-	debug( '/sites/:site_id/themes/mine' );
-	return this.wpcom.req.get( { path: '/sites/' + siteId + '/themes/mine' }, fn );
-};
-
 Undocumented.prototype.activateTheme = function ( themeId, siteId, dontChangeHomepage, fn ) {
 	debug( '/sites/:site_id/themes/mine' );
 	return this.wpcom.req.post(

--- a/client/state/themes/actions/request-active-theme.js
+++ b/client/state/themes/actions/request-active-theme.js
@@ -27,9 +27,8 @@ export function requestActiveTheme( siteId ) {
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.activeTheme( siteId )
+		return wpcom.req
+			.get( `/sites/${ siteId }/themes/mine` )
 			.then( ( theme ) => {
 				debug( 'Received current theme', theme );
 				// We want to store the theme object in the appropriate Redux subtree -- either 'wpcom'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryActiveTheme`: refactor away from `UNSAFE_*`
* on the side also remove undocumented `activeTheme` method

#### Testing instructions

* Go to `/themes` and make sure your currently active theme is shown at the top
* Change your currently active site and make sure the currently active theme is refetched accordingly
