### PR TITLE
Playwright: Improve notifications test stability by using a new browser context

### DIFF
--- a/packages/calypso-e2e/src/lib/components/notifications-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notifications-component.ts
@@ -1,9 +1,9 @@
-import { ElementHandle, Page } from 'playwright';
+import { Page } from 'playwright';
 
 const selectors = {
 	// Notifications panel (including sub-panels)
-	comment: '.wpnc__comment',
-	singleViewPanel: '.wpnc__single-view',
+	activeSingleViewPanel: '.wpnc__single-view.wpnc__current',
+	notification: ( text: string ) => `.wpnc__comment:has-text("${ text }")`,
 
 	// Comment actions
 	commentAction: ( action: string ) => `button.wpnc__action-link:has-text("${ action }"):visible`,
@@ -25,27 +25,13 @@ export class NotificationsComponent {
 	}
 
 	/**
-	 * Locates and returns an ElementHandle to the notification.
-	 *
-	 * @param {string} text Text by which the notification should be located.
-	 * @returns {Promise<ElementHandle} Reference to the notification element.
-	 */
-	async getNotification( text: string ): Promise< ElementHandle > {
-		// Currently, only text selector is supported, but eventually it may make sense
-		// to implement a numerical selector as well.
-		const selector = `*css=${ selectors.comment } >> text=${ text }`;
-		return await this.page.waitForSelector( selector );
-	}
-
-	/**
 	 * Given a string of text, locate and click on the notification containing the text.
 	 *
 	 * @param {string} text Text contained in the notification.
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNotification( text: string ): Promise< void > {
-		const notification = await this.getNotification( text );
-		await notification.click();
+		await this.page.click( selectors.notification( text ) );
 	}
 
 	/**
@@ -57,7 +43,8 @@ export class NotificationsComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNotificationAction( action: 'Trash' ): Promise< void > {
-		const elementHandle = await this.page.waitForSelector( selectors.singleViewPanel );
+		// we need to make sure we're in a specific notification view before proceeding with the individual action
+		const elementHandle = await this.page.waitForSelector( selectors.activeSingleViewPanel );
 		await elementHandle.waitForElementState( 'stable' );
 		await this.page.click( selectors.commentAction( action ) );
 	}

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.ts
@@ -12,11 +12,12 @@ import {
 	NavbarComponent,
 	NotificationsComponent,
 } from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
 
 describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
-	let page;
-	let publishedPostsListPage;
-	let notificationsComponent;
+	let page: Page;
+	let publishedPostsListPage: PublishedPostsListPage;
+	let notificationsComponent: NotificationsComponent;
 
 	const commentingUser = 'commentingUser';
 	const notificationsUser = 'notificationsUser';
@@ -47,25 +48,35 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 			const commentsComponent = new CommentsComponent( page );
 			await commentsComponent.postComment( comment );
 		} );
-
-		it( 'Clear authentication state', async function () {
-			await BrowserManager.clearAuthenticationState( page );
-		} );
 	} );
 
 	describe( `Trash comment as ${ notificationsUser }`, function () {
+		let notificationsPage: Page;
+
+		afterAll( async function () {
+			if ( notificationsPage ) {
+				await BrowserManager.closePage( notificationsPage, { closeContext: true } );
+			}
+		} );
+
+		it( 'Launch new context', async function () {
+			notificationsPage = await BrowserManager.newPage( {
+				context: await BrowserManager.newBrowserContext(),
+			} );
+		} );
+
 		it( `Log in as ${ notificationsUser }`, async function () {
-			const loginPage = new LoginPage( page );
+			const loginPage = new LoginPage( notificationsPage );
 			await loginPage.login( { account: notificationsUser } );
 		} );
 
 		it( 'Open notification using keyboard shortcut', async function () {
-			const navbarComponent = new NavbarComponent( page );
+			const navbarComponent = new NavbarComponent( notificationsPage );
 			await navbarComponent.openNotificationsPanel( { useKeyboard: true } );
 		} );
 
 		it( `See notification for the comment left by ${ commentingUser }`, async function () {
-			notificationsComponent = new NotificationsComponent( page );
+			notificationsComponent = new NotificationsComponent( notificationsPage );
 			await notificationsComponent.clickNotification( comment );
 		} );
 

--- a/test/e2e/specs/specs-playwright/wp-user__notifications.ts
+++ b/test/e2e/specs/specs-playwright/wp-user__notifications.ts
@@ -75,7 +75,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 			await navbarComponent.openNotificationsPanel( { useKeyboard: true } );
 		} );
 
-		it( `See notification for the comment left by ${ commentingUser }`, async function () {
+		it( `See and click notification for the comment left by ${ commentingUser }`, async function () {
 			notificationsComponent = new NotificationsComponent( notificationsPage );
 			await notificationsComponent.clickNotification( comment );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `specs/specs-playwright/wp-notifications__trash-spec.js` spec has seen a little bit of flakiness recently.

This flakiness comes from the step where we clear the current logged-in authentication state. As part doing that, we always re-navigate back to the page where we were right before clearing auth state. In this case, that's a comment list of a blog site. 

However, completely reloading that page can be fickle and slow. If you look at the network traffic, there's a lot of calls to different media and ad services before the `load` event is actually called. If one of those happens to take a long time, we can hit a timeout.

To get around that, we switch from using the clearing authentication approach to just launching a new context, which is faster and safer.

**Note, it looks like you still have to explicitly close these new contexts - this might be worth enhancing/refactoring soon, but will do in another PR

#### Testing instructions

- [x] Ran a local stress test


Fixes #57395
