### PR TITLE
[ETK/wpcom-block-editor] Remove fallback to `__experimentalInserterMenuExtension`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -379,13 +379,7 @@ module.exports = {
 		'wpcalypso/no-unsafe-wp-apis': [
 			'error',
 			{
-				'@wordpress/block-editor': [
-					'__experimentalBlock',
-					// InserterMenuExtension has been made unstable in this PR: https://github.com/WordPress/gutenberg/pull/31417 / Gutenberg v10.7.0-rc.1.
-					// We need to support both symbols until we're sure Gutenberg < v10.7.x is not used anymore in WPCOM.
-					'__unstableInserterMenuExtension',
-					'__experimentalInserterMenuExtension',
-				],
+				'@wordpress/block-editor': [ '__experimentalBlock', '__unstableInserterMenuExtension' ],
 				'@wordpress/date': [ '__experimentalGetSettings' ],
 				'@wordpress/edit-post': [ '__experimentalMainDashboardButton' ],
 				'@wordpress/components': [ '__experimentalNavigationBackButton' ],

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips.js
@@ -1,20 +1,10 @@
-import {
-	__unstableInserterMenuExtension,
-	__experimentalInserterMenuExtension,
-} from '@wordpress/block-editor';
+import { __unstableInserterMenuExtension as InserterMenuExtension } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { debounce } from 'lodash';
 import ContextualTip from './contextual-tips/contextual-tip';
 
 import './contextual-tips/style.scss';
-
-// InserterMenuExtension has been made unstable in this PR: https://github.com/WordPress/gutenberg/pull/31417 / Gutenberg v10.7.0-rc.1.
-// We need to support both symbols until we're sure Gutenberg < v10.7.x is not used anymore in WPCOM.
-const InserterMenuExtension =
-	typeof __unstableInserterMenuExtension !== 'undefined'
-		? __unstableInserterMenuExtension
-		: __experimentalInserterMenuExtension;
 
 const ContextualTips = function () {
 	const [ debouncedFilterValue, setFilterValue ] = useState( '' );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -1,18 +1,8 @@
-import {
-	__unstableInserterMenuExtension,
-	__experimentalInserterMenuExtension,
-} from '@wordpress/block-editor';
+import { __unstableInserterMenuExtension as InserterMenuExtension } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { debounce } from 'lodash';
 import tracksRecordEvent from './track-record-event';
-
-// InserterMenuExtension has been made unstable in this PR: https://github.com/WordPress/gutenberg/pull/31417 / Gutenberg v10.7.0-rc.1.
-// We need to support both symbols until we're sure Gutenberg < v10.7.x is not used anymore in WPCOM.
-const InserterMenuExtension =
-	typeof __unstableInserterMenuExtension !== 'undefined'
-		? __unstableInserterMenuExtension
-		: __experimentalInserterMenuExtension;
 
 const InserterMenuTrackingEvent = function () {
 	const [ searchTerm, setSearchTerm ] = useState( '' );


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/53131. 

Requires: D69127-code.

### Changes proposed in this Pull Request

* Remove the fallback logic for `__experimentalInserterMenuExtension` and any references to it. It was only needed while we were migrating away from Gutenberg < v10.7.x. It's not exported from `@wordpress/block-editor` anymore, either.

### Testing instructions

#### Simple sites

* Sync a custom ETK build based off this branch to your WPCOM sandbox;
* Apply D69127-code;
* Sync a dev version of `wpcom-block-editor` based on this branch to your WPCOM sandbox;
* Load the editor in your test non-edge simple site, then it should not crash with WSOD;
* Smoke-test the editor and make sure it works well, smoke test the main inserter menu.

#### AT

There's no easy way to test a custom block editor plugin on AT sites. For ETK, you can follow the instructions in [this PR](https://github.com/Automattic/wp-calypso/pull/53131). I'd say testing in simple sites is good enough for the purposes of this change.

Slack discussion: p1634102639414700-slack-C7YPUHBB2.