### PR TITLE
Playwright: add ability to specify custom timeout to `CartCheckoutPage.purchase`.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -236,7 +236,7 @@ export class CartCheckoutPage {
 	/**
 	 * Complete the purchase by clicking on the 'Pay' button.
 	 */
-	async purchase( { timeout = 30000 }: { timeout?: number } = {} ): Promise< void > {
+	async purchase( { timeout }: { timeout?: number } = {} ): Promise< void > {
 		await Promise.all( [
 			this.page.waitForNavigation( { timeout: timeout } ),
 			this.page.click( selectors.purchaseButton ),

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -236,9 +236,9 @@ export class CartCheckoutPage {
 	/**
 	 * Complete the purchase by clicking on the 'Pay' button.
 	 */
-	async purchase(): Promise< void > {
+	async purchase( { timeout = 30000 }: { timeout?: number } = {} ): Promise< void > {
 		await Promise.all( [
-			this.page.waitForNavigation(),
+			this.page.waitForNavigation( { timeout: timeout } ),
 			this.page.click( selectors.purchaseButton ),
 		] );
 	}

--- a/test/e2e/specs/specs-playwright/wp-domains__add.ts
+++ b/test/e2e/specs/specs-playwright/wp-domains__add.ts
@@ -85,7 +85,7 @@ describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), functio
 					// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
 					timeout: 90 * 1000,
 				} ),
-				cartCheckoutPage.purchase(),
+				cartCheckoutPage.purchase( { timeout: 120 * 1000 } ),
 			] );
 		} );
 	} );

--- a/test/e2e/specs/specs-playwright/wp-signup__domain.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__domain.ts
@@ -96,7 +96,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 					url: `**/checkout/thank-you/${ selectedDomain }`,
 					timeout: 120 * 1000,
 				} ),
-				cartCheckoutPage.purchase(),
+				cartCheckoutPage.purchase( { timeout: 120 * 1000 } ),
 			] );
 
 			await page.waitForNavigation( {

--- a/test/e2e/specs/specs-playwright/wp-signup__paid.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__paid.ts
@@ -114,7 +114,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Paid' ), function 
 		} );
 
 		it( 'Make purchase', async function () {
-			await cartCheckoutPage.purchase( { timeout: 60 * 1000 } );
+			await cartCheckoutPage.purchase();
 		} );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-signup__paid.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__paid.ts
@@ -114,7 +114,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Paid' ), function 
 		} );
 
 		it( 'Make purchase', async function () {
-			await cartCheckoutPage.purchase();
+			await cartCheckoutPage.purchase( { timeout: 60 * 1000 } );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to add the ability to specify a custom timeout for the `purchase` method.

Key changes:
- add optional timeout for `purchase` method to pass through a provided value to the `waitForNavigation` method.
- update tests to use optional timeout.

#### Testing instructions

- [ ] normal test
  - [ ] mobile
  - [ ] desktop

Related to #
