### PR TITLE
Finalizing styles for video UI layout and chapter display

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -58,38 +58,38 @@ const VideosUi = () => {
 					</div>
 					<div className="videos-ui__chapters">
 						<div className="videos-ui__chapter">
+							<span className="videos-ui__completed">
+								<Gridicon icon="checkmark" size={ 12 } />
+							</span>
 							1. { translate( 'Set up your blog in 5 steps' ) }{ ' ' }
 							<span className="videos-ui__duration">01:45</span>{ ' ' }
+						</div>
+						<div className="videos-ui__chapter">
 							<span className="videos-ui__completed">
 								<Gridicon icon="checkmark" size={ 12 } />
 							</span>
-						</div>
-						<div className="videos-ui__chapter">
 							2. { translate( 'Write a blog post' ) }{ ' ' }
 							<span className="videos-ui__duration">02:55</span>{ ' ' }
+						</div>
+						<div className="videos-ui__chapter">
 							<span className="videos-ui__completed">
 								<Gridicon icon="checkmark" size={ 12 } />
 							</span>
-						</div>
-						<div className="videos-ui__chapter">
 							3. { translate( 'How to edit in Wordpress' ) }{ ' ' }
 							<span className="videos-ui__duration">01:14</span>{ ' ' }
+						</div>
+						<div className="videos-ui__chapter">
 							<span className="videos-ui__completed">
 								<Gridicon icon="checkmark" size={ 12 } />
 							</span>
-						</div>
-						<div className="videos-ui__chapter">
 							4. { translate( 'Social icons' ) } <span className="videos-ui__duration">03:18</span>{ ' ' }
+						</div>
+						<div className="videos-ui__chapter active">
 							<span className="videos-ui__completed">
 								<Gridicon icon="checkmark" size={ 12 } />
 							</span>
-						</div>
-						<div className="videos-ui__chapter">
 							5. { translate( 'Add images to your posts' ) }{ ' ' }
 							<span className="videos-ui__duration">02:20</span>{ ' ' }
-							<span className="videos-ui__completed">
-								<Gridicon icon="checkmark" size={ 12 } />
-							</span>
 							<div className="videos-ui__active-video-content">
 								<p>
 									{ translate(
@@ -97,7 +97,7 @@ const VideosUi = () => {
 									) }{ ' ' }
 								</p>
 								<button type="button" className="videos-ui__play-button">
-									<Gridicon icon="play" size={ 12 } />
+									<Gridicon icon="play" size={ 24 } />
 									{ translate( 'Play video' ) }
 								</button>
 							</div>

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -28,8 +28,23 @@
 
 		.videos-ui__header-content {
 			display: flex;
-			justify-content: space-around;
-			padding: 80px 30px;
+			padding: 80px;
+			justify-content: space-between;
+
+			.videos-ui__titles {
+				flex-basis: auto;
+				width: 60%;
+			}
+
+			.videos-ui__summary {
+				flex-basis: auto;
+				width: 33%;
+			}
+
+			ul {
+				margin: 0;
+			}
+
 			li {
 				list-style: none;
 				margin-bottom: 14px;
@@ -47,25 +62,87 @@
 	}
 
 	.videos-ui__body {
-		padding: 80px 140px;
 
 		h3 {
 			font-size: 1.5rem;
-			margin-bottom: 30px;
+			margin: 80px 80px 30px;
 		}
+
 
 		.videos-ui__video-content {
 			display: flex;
-			gap: 30px;
+			padding: 0 80px 80px;
+			justify-content: space-between;
 		}
+
 		.videos-ui__video {
-			flex: 2 1 66%;
+			flex-basis: auto;
+			width: 60%;
 		}
 
 		.videos-ui__chapters {
-			flex: 1 1 33%;
 			background: #1d262a;
 			font-size: 0.875rem;
+			flex-basis: auto;
+			width: 33%;
+			overflow: auto;
+
+			.videos-ui__chapter {
+				padding: 14px 20px;
+				border-bottom: 1px solid #343c3f;
+
+				&:last-child {
+					border-bottom: none;
+				}
+
+				&.active {
+					height: auto;
+				}
+
+				.videos-ui__duration {
+					color: rgba( 255, 255, 255, 0.5 );
+				}
+
+				.videos-ui__completed {
+					display: block;
+					width: 24px;
+					height: 24px;
+					/* stylelint-disable-next-line scales/radii */
+					border-radius: 24px;
+					float: right;
+					background: #00a32a;
+					text-align: center;
+					line-height: 24px;
+					margin-left: 10px;
+				}
+
+				.videos-ui__active-video-content {
+					margin-top: 26px;
+
+					.videos-ui__play-button {
+						display: block;
+						width: 100%;
+						background: #263135;
+						color: rgba( 255, 255, 255, 0.5 );
+						text-align: center;
+						height: 40px;
+						line-height: 40px;
+						/* stylelint-disable-next-line scales/radii */
+						border-radius: 4px;
+						cursor: pointer;
+
+						svg {
+							margin-right: 10px;
+							vertical-align: middle;
+						}
+
+						&:hover {
+							background: rgba( 255, 255, 255, 0.5 );
+							color: #263135;
+						}
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This diff further updates the work begun in https://github.com/Automattic/wp-calypso/pull/57324, finishing the initial markup styling for the video UI based on the Figma at EuqfSnWpfYx8fgiBlVmbuA-fi-2266%3A18557

![image](https://user-images.githubusercontent.com/13437011/139144670-dd7d7036-98f5-4564-af9f-9862cc155bb9.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR still does not load the UI anywhere (as it will be added as a modal in the work being done for https://github.com/Automattic/wp-calypso/issues/57326
* However, it can be tested by importing the `VideosUi` component anywhere in Calypso. (I have been testing it as a block on the home page for this initial development pass.)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56888