### PR TITLE
Site Address Changer: Improve error message when trying to rename wpcomstaging address

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -27,8 +27,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ConfirmationDialog from './dialog';
 
 import './style.scss';
-import { isAtomicSiteLogAccessEnabled } from '../../state/selectors/is-atomic-site-log-access-enabled';
-
 const SUBDOMAIN_LENGTH_MINIMUM = 4;
 const SUBDOMAIN_LENGTH_MAXIMUM = 50;
 const VALIDATION_DEBOUNCE_MS = 800;
@@ -216,16 +214,15 @@ export class SiteAddressChanger extends Component {
 	}
 
 	/**
-	 * Github Issue: #55306
 	 * This is an edge case scenario where user have the site address changer opened and the user transfers
 	 * the site to atomic on other tab/window, losing sync between client and server. Client will try to
 	 * check availability against wordpress.com and will receive 404s because site is transfered to wpcomstaging.com
 	 */
 	isUnsyncedAtomicSite() {
-		const { validationError, isAtomicSite } = this.props;
+		const { validationError } = this.props;
 		const serverValidationErrorStatus = get( validationError, 'errorStatus' );
 
-		return serverValidationErrorStatus === 404 && ! isAtomicSite;
+		return serverValidationErrorStatus === 404;
 	}
 
 	getValidationMessage() {

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -218,6 +218,8 @@ export class SiteAddressChanger extends Component {
 		const { isAvailable, validationError, translate } = this.props;
 		const { validationMessage } = this.state;
 		const serverValidationMessage = get( validationError, 'message' );
+		//const serverValidationErrorStatus = get( validationError, 'errorStatus' );
+		// if status is 404, return better error message
 
 		return isAvailable
 			? translate( 'Good news, that site address is available!' )

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -213,6 +213,18 @@ export class SiteAddressChanger extends Component {
 		return currentDomainName.replace( currentDomainSuffix, '' );
 	}
 
+	/**
+	 * This is an edge case scenario where user have the site address changer opened and the user transfers
+	 * the site to atomic on other tab/window, losing sync between client and server. Client will try to
+	 * check availability against wordpress.com and will receive 404s because site is transfered to wpcomstaging.com
+	 */
+	isUnsyncedAtomicSite() {
+		const { validationError } = this.props;
+		const serverValidationErrorStatus = get( validationError, 'errorStatus' );
+
+		return serverValidationErrorStatus === 404;
+	}
+
 	getValidationMessage() {
 		const { isAvailable, validationError, translate } = this.props;
 		const { validationMessage } = this.state;

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -213,24 +213,10 @@ export class SiteAddressChanger extends Component {
 		return currentDomainName.replace( currentDomainSuffix, '' );
 	}
 
-	/**
-	 * This is an edge case scenario where user have the site address changer opened and the user transfers
-	 * the site to atomic on other tab/window, losing sync between client and server. Client will try to
-	 * check availability against wordpress.com and will receive 404s because site is transfered to wpcomstaging.com
-	 */
-	isUnsyncedAtomicSite() {
-		const { validationError } = this.props;
-		const serverValidationErrorStatus = get( validationError, 'errorStatus' );
-
-		return serverValidationErrorStatus === 404;
-	}
-
 	getValidationMessage() {
 		const { isAvailable, validationError, translate } = this.props;
 		const { validationMessage } = this.state;
 		const serverValidationMessage = get( validationError, 'message' );
-		//const serverValidationErrorStatus = get( validationError, 'errorStatus' );
-		// if status is 404, return better error message
 
 		if ( this.isUnsyncedAtomicSite() ) {
 			return translate( 'wpcomstaging.com addresses cannot be changed.' );

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -229,6 +229,8 @@ export class SiteAddressChanger extends Component {
 		const { isAvailable, validationError, translate } = this.props;
 		const { validationMessage } = this.state;
 		const serverValidationMessage = get( validationError, 'message' );
+		//const serverValidationErrorStatus = get( validationError, 'errorStatus' );
+		// if status is 404, return better error message
 
 		if ( this.isUnsyncedAtomicSite() ) {
 			return translate( 'wpcomstaging.com addresses cannot be changed.' );

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -220,9 +220,8 @@ export class SiteAddressChanger extends Component {
 	 */
 	isUnsyncedAtomicSite() {
 		const { validationError } = this.props;
-		const serverValidationErrorStatus = get( validationError, 'errorStatus' );
 
-		return serverValidationErrorStatus === 404;
+		return 404 === validationError?.errorStatus;
 	}
 
 	getValidationMessage() {
@@ -231,7 +230,7 @@ export class SiteAddressChanger extends Component {
 		const serverValidationMessage = get( validationError, 'message' );
 
 		if ( this.isUnsyncedAtomicSite() ) {
-			return translate( 'wpcomstaging.com addresses cannot be changed.' );
+			return translate( "This site's address cannot be changed" );
 		}
 
 		return isAvailable

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -60,6 +60,7 @@ export const requestSiteAddressAvailability = (
 		.then( ( data ) => {
 			const errorType = get( data, 'error' );
 			const message = get( data, 'message' );
+			const errorStatus = get( data, 'status' );
 
 			if ( errorType ) {
 				dispatch( {
@@ -67,6 +68,7 @@ export const requestSiteAddressAvailability = (
 					siteId,
 					errorType,
 					message,
+					errorStatus,
 				} );
 
 				return;
@@ -81,12 +83,14 @@ export const requestSiteAddressAvailability = (
 		.catch( ( error ) => {
 			const errorType = get( error, 'error' );
 			const message = get( error, 'message' );
+			const errorStatus = get( error, 'status' );
 
 			dispatch( {
 				type: SITE_ADDRESS_AVAILABILITY_ERROR,
 				siteId,
 				errorType,
 				message,
+				errorStatus,
 			} );
 		} );
 };

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -58,9 +58,7 @@ export const requestSiteAddressAvailability = (
 		.undocumented()
 		.checkSiteAddressValidation( siteId, siteAddress, domain, siteType, testBool )
 		.then( ( data ) => {
-			const errorType = get( data, 'error' );
-			const message = get( data, 'message' );
-			const errorStatus = get( data, 'status' );
+			const { error: errorType, message, status: errorStatus } = data;
 
 			if ( errorType ) {
 				dispatch( {
@@ -81,9 +79,7 @@ export const requestSiteAddressAvailability = (
 			} );
 		} )
 		.catch( ( error ) => {
-			const errorType = get( error, 'error' );
-			const message = get( error, 'message' );
-			const errorStatus = get( error, 'status' );
+			const { error: errorType, message, status: errorStatus } = error;
 
 			dispatch( {
 				type: SITE_ADDRESS_AVAILABILITY_ERROR,

--- a/client/state/site-address-change/reducer.js
+++ b/client/state/site-address-change/reducer.js
@@ -124,7 +124,7 @@ export const validation = ( state = {}, action ) => {
 			};
 		}
 		case SITE_ADDRESS_AVAILABILITY_ERROR: {
-			const { siteId, errorType, message } = action;
+			const { siteId, errorType, message, errorStatus } = action;
 
 			return {
 				...state,
@@ -135,6 +135,7 @@ export const validation = ( state = {}, action ) => {
 					error: {
 						errorType,
 						message,
+						errorStatus,
 					},
 				},
 			};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `errorStatus` to get error status code (e.g. 404) from error data
* [x] Add new error message

<img width="749" alt="Screen Shot 2021-11-09 at 5 52 26 PM" src="https://user-images.githubusercontent.com/1689238/141018301-de23e2c1-096c-43e3-82d8-2bb2599f8cce.png">
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with a business plan.
* Go to Upgrades > Domains
* Click Manage > Change Site Address
* In a new tab, install a plugin to transfer the site to Atomic
* Once the site has transferred, go back to the first tab and start typing a new site address. 
* See our new and improved error message.
* Regression: Check that you can still see other errors when changing a Simple site address (e.g. about character length or the name being unavailable).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/55306
