### PR TITLE
Playwright: add ability to skip classes of test suites.

### DIFF
--- a/packages/calypso-e2e/src/environment.ts
+++ b/packages/calypso-e2e/src/environment.ts
@@ -1,1 +1,1 @@
-export const SKIP_DOMAIN_TESTS = process.env.SKIP_DOMAIN_TESTS ? false : true;
+export const SKIP_DOMAIN_TESTS = process.env.SKIP_DOMAIN_TESTS === 'true' ? true : false;

--- a/packages/calypso-e2e/src/environment.ts
+++ b/packages/calypso-e2e/src/environment.ts
@@ -1,0 +1,1 @@
+export const SKIP_DOMAIN_TESTS = process.env.SKIP_DOMAIN_TESTS ? true : false;

--- a/packages/calypso-e2e/src/environment.ts
+++ b/packages/calypso-e2e/src/environment.ts
@@ -1,1 +1,1 @@
-export const SKIP_DOMAIN_TESTS = process.env.SKIP_DOMAIN_TESTS ? true : false;
+export const SKIP_DOMAIN_TESTS = process.env.SKIP_DOMAIN_TESTS ? false : true;

--- a/packages/calypso-e2e/src/index.ts
+++ b/packages/calypso-e2e/src/index.ts
@@ -2,11 +2,12 @@ import * as BrowserHelper from './browser-helper';
 import * as BrowserManager from './browser-manager';
 import * as DataHelper from './data-helper';
 import * as ElementHelper from './element-helper';
+import * as TestEnvironment from './environment';
 import * as MediaHelper from './media-helper';
 export type { TestFile } from './media-helper';
 export type { PaymentDetails } from './data-helper';
 
-export { BrowserHelper, BrowserManager, MediaHelper, DataHelper, ElementHelper };
+export { BrowserHelper, BrowserManager, MediaHelper, DataHelper, ElementHelper, TestEnvironment };
 
 export * from './jest-conditionals';
 export * from './lib';

--- a/packages/calypso-e2e/src/jest-conditionals.ts
+++ b/packages/calypso-e2e/src/jest-conditionals.ts
@@ -2,7 +2,7 @@ import { it, describe } from '@jest/globals';
 
 // This allows a conditional skip based on the parameter input.
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const itSkipIf = ( conditional: boolean ) => ( conditional ? it : it.skip );
+export const itSkipIf = ( conditional: boolean ) => ( conditional ? it.skip : it );
 
 export const describeSkipIf = ( conditional: boolean ) =>
-	conditional ? describe : describe.skip;
+	conditional ? describe.skip : describe;

--- a/packages/calypso-e2e/src/jest-conditionals.ts
+++ b/packages/calypso-e2e/src/jest-conditionals.ts
@@ -1,5 +1,8 @@
-import { it } from '@jest/globals';
+import { it, describe } from '@jest/globals';
 
 // This allows a conditional skip based on the parameter input.
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const itif = ( conditional: boolean ) => ( conditional ? it : it.skip );
+export const itSkipIf = ( conditional: boolean ) => ( conditional ? it : it.skip );
+
+export const describeSkipIf = ( conditional: boolean ) =>
+	conditional ? describe : describe.skip;

--- a/test/e2e/specs/specs-playwright/wp-domains__add.ts
+++ b/test/e2e/specs/specs-playwright/wp-domains__add.ts
@@ -13,102 +13,107 @@ import {
 	CartCheckoutPage,
 	IndividualPurchasePage,
 	NavbarComponent,
+	describeSkipIf,
+	TestEnvironment,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
-	let page: Page;
+describeSkipIf( TestEnvironment.SKIP_DOMAIN_TESTS )(
+	DataHelper.createSuiteTitle( 'Domains: Add to current site' ),
+	function () {
+		let page: Page;
 
-	setupHooks( ( args ) => {
-		page = args.page;
-	} );
-
-	const blogName = DataHelper.getBlogName();
-
-	let sidebarComponent: SidebarComponent;
-	let domainSearchComponent: DomainSearchComponent;
-	let cartCheckoutPage: CartCheckoutPage;
-	let selectedDomain: string;
-	let domainsPage: DomainsPage;
-
-	it( 'Log in', async function () {
-		const loginPage = new LoginPage( page );
-		await loginPage.login( { account: 'calypsoPreReleaseUser' } );
-	} );
-
-	it( 'Set store cookie', async function () {
-		await BrowserManager.setStoreCookie( page );
-	} );
-
-	describe( 'Purchase domain', function () {
-		it( 'Navigate to Upgrades > Domains', async function () {
-			sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Upgrades', 'Domains' );
+		setupHooks( ( args ) => {
+			page = args.page;
 		} );
 
-		it( 'If required, clear the cart', async function () {
-			domainsPage = new DomainsPage( page );
-			const cartOpened = await domainsPage.openCart();
-			// The cart popover existing implies there are some items that need to be removed.
-			if ( cartOpened ) {
-				await domainsPage.emptyCart();
-			}
+		const blogName = DataHelper.getBlogName();
+
+		let sidebarComponent: SidebarComponent;
+		let domainSearchComponent: DomainSearchComponent;
+		let cartCheckoutPage: CartCheckoutPage;
+		let selectedDomain: string;
+		let domainsPage: DomainsPage;
+
+		it( 'Log in', async function () {
+			const loginPage = new LoginPage( page );
+			await loginPage.login( { account: 'calypsoPreReleaseUser' } );
 		} );
 
-		it( 'Add domain to site', async function () {
-			await domainsPage.addDomain();
+		it( 'Set store cookie', async function () {
+			await BrowserManager.setStoreCookie( page );
 		} );
 
-		it( 'Search for a domain name', async function () {
-			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName + '.live' );
+		describe( 'Purchase domain', function () {
+			it( 'Navigate to Upgrades > Domains', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Upgrades', 'Domains' );
+			} );
+
+			it( 'If required, clear the cart', async function () {
+				domainsPage = new DomainsPage( page );
+				const cartOpened = await domainsPage.openCart();
+				// The cart popover existing implies there are some items that need to be removed.
+				if ( cartOpened ) {
+					await domainsPage.emptyCart();
+				}
+			} );
+
+			it( 'Add domain to site', async function () {
+				await domainsPage.addDomain();
+			} );
+
+			it( 'Search for a domain name', async function () {
+				domainSearchComponent = new DomainSearchComponent( page );
+				await domainSearchComponent.search( blogName + '.live' );
+			} );
+
+			it( 'Choose the .live TLD', async function () {
+				selectedDomain = await domainSearchComponent.selectDomain( '.live' );
+			} );
+
+			it( 'Decline Titan Email upsell', async function () {
+				await domainSearchComponent.clickButton( 'Skip' );
+			} );
+
+			it( 'See secure payment', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				await cartCheckoutPage.validateCartItem( selectedDomain );
+			} );
+
+			it( 'Make purchase', async function () {
+				await Promise.all( [
+					page.waitForNavigation( {
+						url: '**/checkout/thank-you/**',
+						waitUntil: 'networkidle',
+						// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
+						timeout: 90 * 1000,
+					} ),
+					cartCheckoutPage.purchase(),
+				] );
+			} );
 		} );
 
-		it( 'Choose the .live TLD', async function () {
-			selectedDomain = await domainSearchComponent.selectDomain( '.live' );
-		} );
+		describe( 'Cancel domain', function () {
+			it( 'Return to Home dashboard', async function () {
+				const navbarComponent = new NavbarComponent( page );
+				await navbarComponent.clickMySites();
+			} );
 
-		it( 'Decline Titan Email upsell', async function () {
-			await domainSearchComponent.clickButton( 'Skip' );
-		} );
+			it( 'Navigate to Upgrades > Domains', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Upgrades', 'Domains' );
+			} );
 
-		it( 'See secure payment', async function () {
-			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( selectedDomain );
-		} );
+			it( 'Click on purchased domain', async function () {
+				const domainsPage = new DomainsPage( page );
+				await domainsPage.click( selectedDomain );
+			} );
 
-		it( 'Make purchase', async function () {
-			await Promise.all( [
-				page.waitForNavigation( {
-					url: '**/checkout/thank-you/**',
-					waitUntil: 'networkidle',
-					// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
-					timeout: 90 * 1000,
-				} ),
-				cartCheckoutPage.purchase( { timeout: 120 * 1000 } ),
-			] );
+			it( 'Cancel domain', async function () {
+				const individualPurchasePage = new IndividualPurchasePage( page );
+				await individualPurchasePage.deleteDomain();
+			} );
 		} );
-	} );
-
-	describe( 'Cancel domain', function () {
-		it( 'Return to Home dashboard', async function () {
-			const navbarComponent = new NavbarComponent( page );
-			await navbarComponent.clickMySites();
-		} );
-
-		it( 'Navigate to Upgrades > Domains', async function () {
-			sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Upgrades', 'Domains' );
-		} );
-
-		it( 'Click on purchased domain', async function () {
-			const domainsPage = new DomainsPage( page );
-			await domainsPage.click( selectedDomain );
-		} );
-
-		it( 'Cancel domain', async function () {
-			const individualPurchasePage = new IndividualPurchasePage( page );
-			await individualPurchasePage.deleteDomain();
-		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -13,7 +13,7 @@ import {
 	NewPostFlow,
 	setupHooks,
 	PublishedPostPage,
-	itif,
+	itSkipIf,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
@@ -89,7 +89,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		// On mobile web, preview button opens a new tab.
 
 		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
-		itif( targetDevice === 'mobile' )( 'Launch preview', async function () {
+		itSkipIf( targetDevice === 'mobile' )( 'Launch preview', async function () {
 			if ( BrowserHelper.getTargetDeviceName() === 'mobile' ) {
 				previewPage = await gutenbergEditorPage.openPreviewAsMobile();
 			} else {
@@ -98,7 +98,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 
 		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
-		itif( targetDevice === 'mobile' )( 'Close preview', async function () {
+		itSkipIf( targetDevice === 'mobile' )( 'Close preview', async function () {
 			// Mobile path.
 			if ( previewPage ) {
 				await previewPage.close();
@@ -109,7 +109,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 
 		// TODO: step skipped for mobile, since previewing naturally saves the post, rendering this step unnecessary.
-		itif( targetDevice !== 'mobile' )( 'Save draft', async function () {
+		itSkipIf( targetDevice !== 'mobile' )( 'Save draft', async function () {
 			await gutenbergEditorPage.saveDraft();
 		} );
 	} );

--- a/test/e2e/specs/specs-playwright/wp-signup__domain.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__domain.ts
@@ -12,128 +12,133 @@ import {
 	CartCheckoutPage,
 	NavbarComponent,
 	IndividualPurchasePage,
+	describeSkipIf,
+	TestEnvironment,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), function () {
-	const inboxId = DataHelper.config.get( 'signupInboxId' ) as string;
-	const username = `e2eflowtestingdomainonly${ DataHelper.getTimestamp() }`;
-	const email = DataHelper.getTestEmailAddress( {
-		inboxId: inboxId,
-		prefix: username,
-	} );
-	const signupPassword = DataHelper.config.get( 'passwordForNewTestSignUps' ) as string;
+describeSkipIf( TestEnvironment.SKIP_DOMAIN_TESTS )(
+	DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ),
+	function () {
+		const inboxId = DataHelper.config.get( 'signupInboxId' ) as string;
+		const username = `e2eflowtestingdomainonly${ DataHelper.getTimestamp() }`;
+		const email = DataHelper.getTestEmailAddress( {
+			inboxId: inboxId,
+			prefix: username,
+		} );
+		const signupPassword = DataHelper.config.get( 'passwordForNewTestSignUps' ) as string;
 
-	let page: Page;
-	let selectedDomain: string;
-	let domainSearchComponent: DomainSearchComponent;
-	let cartCheckoutPage: CartCheckoutPage;
+		let page: Page;
+		let selectedDomain: string;
+		let domainSearchComponent: DomainSearchComponent;
+		let cartCheckoutPage: CartCheckoutPage;
 
-	setupHooks( ( args ) => {
-		page = args.page;
-	} );
-
-	describe( 'Signup via /start/domain', function () {
-		it( 'Navigate to /start/domain', async function () {
-			await page.goto( DataHelper.getCalypsoURL( '/start/domain' ) );
+		setupHooks( ( args ) => {
+			page = args.page;
 		} );
 
-		it( 'Set store cookie', async function () {
-			await BrowserManager.setStoreCookie( page, { currency: 'JPY' } );
-		} );
+		describe( 'Signup via /start/domain', function () {
+			it( 'Navigate to /start/domain', async function () {
+				await page.goto( DataHelper.getCalypsoURL( '/start/domain' ) );
+			} );
 
-		it( 'Search for a domain', async function () {
-			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( username + '.live' );
-		} );
+			it( 'Set store cookie', async function () {
+				await BrowserManager.setStoreCookie( page, { currency: 'JPY' } );
+			} );
 
-		it( 'Select a .live domain', async function () {
-			selectedDomain = await domainSearchComponent.selectDomain( '.live' );
-		} );
+			it( 'Search for a domain', async function () {
+				domainSearchComponent = new DomainSearchComponent( page );
+				await domainSearchComponent.search( username + '.live' );
+			} );
 
-		it( 'Select to buy just the domain', async function () {
-			await page.click( 'button:text("Just buy a domain")' );
-		} );
+			it( 'Select a .live domain', async function () {
+				selectedDomain = await domainSearchComponent.selectDomain( '.live' );
+			} );
 
-		it( 'Sign up for a WordPress.com account', async function () {
-			const userSignupPage = new UserSignupPage( page );
-			await userSignupPage.signup( email, username, signupPassword );
-		} );
+			it( 'Select to buy just the domain', async function () {
+				await page.click( 'button:text("Just buy a domain")' );
+			} );
 
-		it( 'Land in checkout cart', async function () {
-			cartCheckoutPage = new CartCheckoutPage( page );
-			const totalAmount = await cartCheckoutPage.getCheckoutTotalAmount();
-			expect( totalAmount ).toBeGreaterThan( 0 );
-		} );
+			it( 'Sign up for a WordPress.com account', async function () {
+				const userSignupPage = new UserSignupPage( page );
+				await userSignupPage.signup( email, username, signupPassword );
+			} );
 
-		it( 'Enter registrar details', async function () {
-			await cartCheckoutPage.enterDomainRegistrarDetails(
-				DataHelper.getTestDomainRegistrarDetails( email )
-			);
-		} );
+			it( 'Land in checkout cart', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				const totalAmount = await cartCheckoutPage.getCheckoutTotalAmount();
+				expect( totalAmount ).toBeGreaterThan( 0 );
+			} );
 
-		it( 'Enter credit card details', async function () {
-			await cartCheckoutPage.enterPaymentDetails( DataHelper.getTestPaymentDetails() );
-		} );
+			it( 'Enter registrar details', async function () {
+				await cartCheckoutPage.enterDomainRegistrarDetails(
+					DataHelper.getTestDomainRegistrarDetails( email )
+				);
+			} );
 
-		// Skipping this test because of inconsistency in cookie working in this flow
-		// See GH Issue #56961 (https://github.com/Automattic/wp-calypso/issues/56961)
-		it.skip( 'Prices are shown in Japanese Yen', async function () {
-			const cartAmount = ( await cartCheckoutPage.getCheckoutTotalAmount( {
-				rawString: true,
-			} ) ) as string;
-			expect( cartAmount.startsWith( '¥' ) ).toBe( true );
-		} );
+			it( 'Enter credit card details', async function () {
+				await cartCheckoutPage.enterPaymentDetails( DataHelper.getTestPaymentDetails() );
+			} );
 
-		it( 'Check out', async function () {
-			// Purchasing a domain on a domain-only account results in multiple redirects
-			// to URLs such as `**/checkout/thank-you/no-site/**` and
-			// `**/checkout/thank-you/<selectedDomain>`, and this occurs multiple times.
-			// The following `waitForNavigation` is meant to catch those and ensure the page
-			// has loaded fully prior to next steps.
-			await Promise.all( [
-				page.waitForNavigation( {
+			// Skipping this test because of inconsistency in cookie working in this flow
+			// See GH Issue #56961 (https://github.com/Automattic/wp-calypso/issues/56961)
+			it.skip( 'Prices are shown in Japanese Yen', async function () {
+				const cartAmount = ( await cartCheckoutPage.getCheckoutTotalAmount( {
+					rawString: true,
+				} ) ) as string;
+				expect( cartAmount.startsWith( '¥' ) ).toBe( true );
+			} );
+
+			it( 'Check out', async function () {
+				// Purchasing a domain on a domain-only account results in multiple redirects
+				// to URLs such as `**/checkout/thank-you/no-site/**` and
+				// `**/checkout/thank-you/<selectedDomain>`, and this occurs multiple times.
+				// The following `waitForNavigation` is meant to catch those and ensure the page
+				// has loaded fully prior to next steps.
+				await Promise.all( [
+					page.waitForNavigation( {
+						url: `**/checkout/thank-you/${ selectedDomain }`,
+						timeout: 120 * 1000,
+					} ),
+					cartCheckoutPage.purchase(),
+				] );
+
+				await page.waitForNavigation( {
 					url: `**/checkout/thank-you/${ selectedDomain }`,
-					timeout: 120 * 1000,
-				} ),
-				cartCheckoutPage.purchase( { timeout: 120 * 1000 } ),
-			] );
-
-			await page.waitForNavigation( {
-				url: `**/checkout/thank-you/${ selectedDomain }`,
+				} );
 			} );
 		} );
-	} );
 
-	describe( 'Manage Domain', function () {
-		let individualPurchasePage: IndividualPurchasePage;
+		describe( 'Manage Domain', function () {
+			let individualPurchasePage: IndividualPurchasePage;
 
-		it( 'Click My Sites', async function () {
-			const navbarCompnent = new NavbarComponent( page );
-			await navbarCompnent.clickMySites();
+			it( 'Click My Sites', async function () {
+				const navbarCompnent = new NavbarComponent( page );
+				await navbarCompnent.clickMySites();
+			} );
+
+			it( 'Manage domain', async function () {
+				// This isn't MyHomePage, nor is it PurchasesPage.
+				// Instead of creating a POM for just one task, call the
+				// raw selector.
+				await page.click( 'a:text("Manage domain")' );
+			} );
+
+			it( 'Turn off auto-renew', async function () {
+				individualPurchasePage = new IndividualPurchasePage( page );
+				await individualPurchasePage.turnOffAutoRenew();
+			} );
+
+			it( 'Delete domain purchase', async function () {
+				await individualPurchasePage.deleteDomain();
+			} );
 		} );
 
-		it( 'Manage domain', async function () {
-			// This isn't MyHomePage, nor is it PurchasesPage.
-			// Instead of creating a POM for just one task, call the
-			// raw selector.
-			await page.click( 'a:text("Manage domain")' );
+		describe( 'Delete user account', function () {
+			it( 'Close account', async function () {
+				const closeAccountFlow = new CloseAccountFlow( page );
+				await closeAccountFlow.closeAccount();
+			} );
 		} );
-
-		it( 'Turn off auto-renew', async function () {
-			individualPurchasePage = new IndividualPurchasePage( page );
-			await individualPurchasePage.turnOffAutoRenew();
-		} );
-
-		it( 'Delete domain purchase', async function () {
-			await individualPurchasePage.deleteDomain();
-		} );
-	} );
-
-	describe( 'Delete user account', function () {
-		it( 'Close account', async function () {
-			const closeAccountFlow = new CloseAccountFlow( page );
-			await closeAccountFlow.closeAccount();
-		} );
-	} );
-} );
+	}
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds ability to skip an entire suite in addition to existing functionality to skip a test step.

Key changes:
- add new file `environment.ts` for test environment configuration.
- add `describeSkipIf`.

Details:
The domain query endpoint has been problematic recently with [multiple](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Pre_Release/6896638) [tests](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Pre_Release/6896482) [failing](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Pre_Release/6896418) [unexpectedly](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Pre_Release/6896409) in a short span of time.

When situations like this arise, it is useful to have the ability to continue running Pre-Release tests but without running the specs that interface with problematic third-party APIs that we do not control.

The file `environment.ts` will, going forward, hold values and methods that alter how Jest should run. The intention is to move most of methods in `BrowserHelper` that deal with configuration of the test environment to this file.

#### Testing instructions

- [x] SKIP_DOMAIN_TESTS
  - [x] set to true https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Pre_Release/6898319
  - [x] do not set https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Pre_Release/6898316


Closes #57401.
