### PR TITLE
Domains: Add domains management list breadcrumbs

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -2,6 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 
 .breadcrumbs {
+	position: relative;
 	margin: 0;
 
 	@include break-mobile {
@@ -107,6 +108,11 @@
 		& .breadcrumbs__item-label {
 			font-size: $font-body;
 		}
+	}
+	& span:first-child {
+		font-size: $font-body;
+		font-weight: 600;
+		color: var( --color-neutral-80 );
 	}
 
 	@include break-mobile {

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -4,6 +4,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { Icon, plus, search } from '@wordpress/icons';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -129,17 +130,16 @@ class AddDomainButton extends Component {
 	}
 
 	render() {
-		const { specificSiteActions } = this.props;
+		const { specificSiteActions, ellipsisButton } = this.props;
+		const classes = classNames( 'options-domain-button', ellipsisButton && 'ellipsis' );
 
 		return (
 			<Fragment>
 				<Button
 					primary={ specificSiteActions }
-					compact // only on not mobile
-					className="options-domain-button"
+					className={ classes }
 					onClick={ this.toggleAddMenu }
 					ref={ this.addDomainButtonRef }
-					// borderless={ ellipsisButton } mobile
 				>
 					{ this.renderLabel() }
 				</Button>

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -3,7 +3,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
-import { Icon, plus, search } from '@wordpress/icons';
+import { Icon, moreVertical, plus, search } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -104,7 +104,7 @@ class AddDomainButton extends Component {
 		const isRedesign = config.isEnabled( 'domains/management-list-redesign' );
 
 		if ( ellipsisButton ) {
-			return <Gridicon icon="ellipsis" className="options-domain-button__ellipsis" />;
+			return <Icon icon={ moreVertical } className="options-domain-button__ellipsis gridicon" />;
 		}
 
 		let label = translate( 'Other domain options' );
@@ -115,7 +115,7 @@ class AddDomainButton extends Component {
 		if ( isRedesign ) {
 			return (
 				<>
-					<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+					<Icon icon={ plus } className="options-domain-button__add gridicon" viewBox="2 2 20 20" />
 					<span className="options-domain-button__desktop">{ label }</span>
 				</>
 			);

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -98,53 +98,50 @@ class AddDomainButton extends Component {
 		);
 	};
 
-	getDesktopViewLabel() {
-		const { translate } = this.props;
+	renderLabel() {
+		const { ellipsisButton, specificSiteActions, translate } = this.props;
+		const isRedesign = config.isEnabled( 'domains/management-list-redesign' );
 
-		if ( this.props.ellipsisButton ) {
+		if ( ellipsisButton ) {
 			return <Gridicon icon="ellipsis" className="options-domain-button__ellipsis" />;
 		}
 
 		let label = translate( 'Other domain options' );
-		if ( this.props.specificSiteActions ) {
-			label = config.isEnabled( 'domains/management-list-redesign' )
-				? translate( 'Add a domain' )
-				: translate( 'Add a domain to this site' );
+		if ( specificSiteActions ) {
+			label = isRedesign ? translate( 'Add a domain' ) : translate( 'Add a domain to this site' );
 		}
+
+		if ( isRedesign ) {
+			return (
+				<>
+					<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+					<span className="options-domain-button__desktop">{ label }</span>
+				</>
+			);
+		}
+
 		return (
 			<>
-				<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 				{ label }
+				{ <Gridicon icon="chevron-down" /> }
 			</>
 		);
 	}
 
 	render() {
-		const { specificSiteActions, ellipsisButton } = this.props;
+		const { specificSiteActions } = this.props;
 
 		return (
 			<Fragment>
 				<Button
 					primary={ specificSiteActions }
-					compact
+					compact // only on not mobile
 					className="options-domain-button"
 					onClick={ this.toggleAddMenu }
 					ref={ this.addDomainButtonRef }
+					// borderless={ ellipsisButton } mobile
 				>
-					{ this.getDesktopViewLabel() }
-					{ ! ellipsisButton && <Gridicon icon="chevron-down" /> }
-				</Button>
-				<Button
-					primary={ specificSiteActions }
-					className="options-domain-button options-domain-button__mobile"
-					onClick={ this.toggleAddMenu }
-					ref={ this.addDomainButtonRef }
-					borderless={ ellipsisButton }
-				>
-					{ ! ellipsisButton && <Gridicon icon="plus" /> }
-					{ ellipsisButton && (
-						<Gridicon icon="ellipsis" className="options-domain-button__ellipsis" />
-					) }
+					{ this.renderLabel() }
 				</Button>
 				<PopoverMenu
 					className="options-domain-button__popover"

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -1,6 +1,9 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
+import { Icon, plus, search } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -64,7 +67,8 @@ class AddDomainButton extends Component {
 			const useYourDomainUrl = domainUseMyDomain( this.props.selectedSiteSlug );
 			return (
 				<Fragment>
-					<PopoverMenuItem icon="search" onClick={ this.clickAddDomain }>
+					<PopoverMenuItem onClick={ this.clickAddDomain }>
+						<Icon icon={ search } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 						{ translate( 'Search for a domain' ) }
 					</PopoverMenuItem>
 					<PopoverMenuItem icon="domains" href={ useYourDomainUrl } onClick={ this.trackMenuClick }>
@@ -101,13 +105,18 @@ class AddDomainButton extends Component {
 			return <Gridicon icon="ellipsis" className="options-domain-button__ellipsis" />;
 		}
 
+		let label = translate( 'Other domain options' );
 		if ( this.props.specificSiteActions ) {
-			if ( config.isEnabled( 'domains/management-list-redesign' ) ) {
-				return translate( 'Add a domain' );
-			}
-			return translate( 'Add a domain to this site' );
+			label = config.isEnabled( 'domains/management-list-redesign' )
+				? translate( 'Add a domain' )
+				: translate( 'Add a domain to this site' );
 		}
-		return translate( 'Other domain options' );
+		return (
+			<>
+				<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+				{ label }
+			</>
+		);
 	}
 
 	render() {

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -20,10 +21,12 @@ class AddDomainButton extends Component {
 	static propTypes = {
 		selectedSiteSlug: PropTypes.string,
 		specificSiteActions: PropTypes.bool,
+		ellipsisButton: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		specificSiteActions: false,
+		ellipsisButton: false,
 	};
 
 	state = {
@@ -61,10 +64,10 @@ class AddDomainButton extends Component {
 			const useYourDomainUrl = domainUseMyDomain( this.props.selectedSiteSlug );
 			return (
 				<Fragment>
-					<PopoverMenuItem onClick={ this.clickAddDomain }>
+					<PopoverMenuItem icon="search" onClick={ this.clickAddDomain }>
 						{ translate( 'Search for a domain' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem href={ useYourDomainUrl } onClick={ this.trackMenuClick }>
+					<PopoverMenuItem icon="domains" href={ useYourDomainUrl } onClick={ this.trackMenuClick }>
 						{ translate( 'Use a domain I own' ) }
 					</PopoverMenuItem>
 				</Fragment>
@@ -73,40 +76,66 @@ class AddDomainButton extends Component {
 
 		return (
 			<Fragment>
-				<PopoverMenuItem href={ domainManagementAllRoot() } onClick={ this.trackMenuClick }>
-					{ translate( 'Manage all domains' ) }
-				</PopoverMenuItem>
-				<PopoverMenuItem href="/new" onClick={ this.trackMenuClick }>
+				{ ! config.isEnabled( 'domains/management-list-redesign' ) && (
+					<PopoverMenuItem href={ domainManagementAllRoot() } onClick={ this.trackMenuClick }>
+						{ translate( 'Manage all domains' ) }
+					</PopoverMenuItem>
+				) }
+				<PopoverMenuItem icon="plus" href="/new" onClick={ this.trackMenuClick }>
 					{ translate( 'Add a domain to a new site' ) }
 				</PopoverMenuItem>
-				<PopoverMenuItem href="/domains/add" onClick={ this.trackMenuClick }>
+				<PopoverMenuItem icon="create" href="/domains/add" onClick={ this.trackMenuClick }>
 					{ translate( 'Add a domain to a different site' ) }
 				</PopoverMenuItem>
-				<PopoverMenuItem href="/start/domain" onClick={ this.trackMenuClick }>
+				<PopoverMenuItem icon="domains" href="/start/domain" onClick={ this.trackMenuClick }>
 					{ translate( 'Add a domain without a site' ) }
 				</PopoverMenuItem>
 			</Fragment>
 		);
 	};
 
-	render() {
+	getDesktopViewLabel() {
 		const { translate } = this.props;
 
-		const label = this.props.specificSiteActions
-			? translate( 'Add a domain to this site' )
-			: translate( 'Other domain options' );
+		if ( this.props.ellipsisButton ) {
+			return <Gridicon icon="ellipsis" className="options-domain-button__ellipsis" />;
+		}
+
+		if ( this.props.specificSiteActions ) {
+			if ( config.isEnabled( 'domains/management-list-redesign' ) ) {
+				return translate( 'Add a domain' );
+			}
+			return translate( 'Add a domain to this site' );
+		}
+		return translate( 'Other domain options' );
+	}
+
+	render() {
+		const { specificSiteActions, ellipsisButton } = this.props;
 
 		return (
 			<Fragment>
 				<Button
-					primary={ this.props.specificSiteActions }
+					primary={ specificSiteActions }
 					compact
 					className="options-domain-button"
 					onClick={ this.toggleAddMenu }
 					ref={ this.addDomainButtonRef }
 				>
-					{ label }
-					<Gridicon icon="chevron-down" />
+					{ this.getDesktopViewLabel() }
+					{ ! ellipsisButton && <Gridicon icon="chevron-down" /> }
+				</Button>
+				<Button
+					primary={ specificSiteActions }
+					className="options-domain-button options-domain-button__mobile"
+					onClick={ this.toggleAddMenu }
+					ref={ this.addDomainButtonRef }
+					borderless={ ellipsisButton }
+				>
+					{ ! ellipsisButton && <Gridicon icon="plus" /> }
+					{ ellipsisButton && (
+						<Gridicon icon="ellipsis" className="options-domain-button__ellipsis" />
+					) }
 				</Button>
 				<PopoverMenu
 					className="options-domain-button__popover"

--- a/client/my-sites/domains/domain-management/list/options-domain-button.scss
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.scss
@@ -1,26 +1,21 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.options-domain-button,
-.options-domain-button__mobile {
-	display: none;
-
+.options-domain-button {
 	&__popover {
 		margin-top: 5px;
 	}
 
 	@include break-mobile {
-		display: inline;
-
 		& > .gridicon {
 			margin-left: 5px;
 		}
 	}
 }
 
-.options-domain-button__mobile {
-	display: initial;
+.options-domain-button__desktop {
+	display: none;
 	@include break-mobile {
-		display: none;
+		display: initial;
 	}
 }

--- a/client/my-sites/domains/domain-management/list/options-domain-button.scss
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.scss
@@ -1,9 +1,26 @@
-.options-domain-button {
-	& > .gridicon {
-		margin-left: 5px;
-	}
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.options-domain-button,
+.options-domain-button__mobile {
+	display: none;
 
 	&__popover {
 		margin-top: 5px;
+	}
+
+	@include break-mobile {
+		display: inline;
+
+		& > .gridicon {
+			margin-left: 5px;
+		}
+	}
+}
+
+.options-domain-button__mobile {
+	display: initial;
+	@include break-mobile {
+		display: none;
 	}
 }

--- a/client/my-sites/domains/domain-management/list/options-domain-button.scss
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.scss
@@ -2,11 +2,22 @@
 @import '@wordpress/base-styles/mixins';
 
 .options-domain-button {
+	padding: 8px;
+
 	&__popover {
 		margin-top: 5px;
 	}
 
 	@include break-mobile {
+		padding: 7px;
+		font-size: $font-body-extra-small;
+		line-height: 1;
+
+		.gridicon {
+			top: 5px;
+			margin-top: -8px;
+		}
+
 		& > .gridicon {
 			margin-left: 5px;
 		}
@@ -15,7 +26,21 @@
 
 .options-domain-button__desktop {
 	display: none;
+
 	@include break-mobile {
 		display: initial;
+	}
+}
+
+.options-domain-button.ellipsis {
+	border: none;
+
+	@include break-mobile {
+		border: 1px solid var( --color-neutral-10 );
+
+		&:hover {
+			border-color: var( --color-neutral-20 );
+			color: var( --color-neutral-70 );
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import config from '@automattic/calypso-config';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -10,7 +9,6 @@ import { connect } from 'react-redux';
 import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -80,7 +78,7 @@ export class SiteDomains extends Component {
 	}
 
 	renderNewDesign() {
-		const { selectedSite, domains, currentRoute, translate, isAtomicSite } = this.props;
+		const { selectedSite, domains, currentRoute, isAtomicSite } = this.props;
 		const { primaryDomainIndex, settingPrimaryDomain } = this.state;
 		const disabled = settingPrimaryDomain;
 
@@ -132,27 +130,12 @@ export class SiteDomains extends Component {
 		return (
 			<>
 				<div className="domains__header">
-					{ /* TODO: remove this as it'll be handled by the new breadcrumbs component */ }
-					<FormattedHeader
-						brandFont
-						className="domain-management__page-heading"
-						headerText={ translate( 'Site Domains' ) }
-						subHeaderText={ translate(
-							'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
-								},
-							}
-						) }
-						align="left"
-					/>
+					{ /* TODO: we need to decide where the HeaderCart will appear in the new design */ }
 					<div className="domains__header-buttons">
 						<HeaderCart
 							selectedSite={ this.props.selectedSite }
 							currentRoute={ this.props.currentRoute }
 						/>
-						{ this.optionsDomainButton() }
 					</div>
 				</div>
 
@@ -307,14 +290,6 @@ export class SiteDomains extends Component {
 				.subtract( 30, 'minutes' )
 				.isBefore( this.props.moment( domain.registrationDate ) )
 		);
-	}
-
-	optionsDomainButton() {
-		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
-			return null;
-		}
-
-		return <OptionsDomainButton />;
 	}
 
 	setPrimaryDomain( domainName ) {

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -78,7 +78,7 @@ export class SiteDomains extends Component {
 	}
 
 	renderNewDesign() {
-		const { selectedSite, domains, currentRoute, isAtomicSite } = this.props;
+		const { selectedSite, domains, currentRoute, isAtomicSite, translate } = this.props;
 		const { primaryDomainIndex, settingPrimaryDomain } = this.state;
 		const disabled = settingPrimaryDomain;
 

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -18,6 +18,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { resolveDomainStatus } from 'calypso/lib/domains';
 import { type } from 'calypso/lib/domains/constants';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
+import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import EmptyDomainsListCard from 'calypso/my-sites/domains/domain-management/list/empty-domains-list-card';
 import FreeDomainItem from 'calypso/my-sites/domains/domain-management/list/free-domain-item';
 import OptionsDomainButton from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
@@ -206,6 +207,35 @@ export class SiteDomains extends Component {
 		);
 	}
 
+	renderBreadcrumbs() {
+		const { translate } = this.props;
+
+		const item = {
+			label: translate( 'Domains' ),
+			helpBubble: translate(
+				'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
+					},
+				}
+			),
+		};
+		const buttons = [
+			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
+			<OptionsDomainButton key="breadcrumb_button_2" ellipsisButton />,
+		];
+
+		return (
+			<Breadcrumbs
+				items={ [ item ] }
+				mobileItem={ item }
+				buttons={ buttons }
+				mobileButtons={ buttons }
+			/>
+		);
+	}
+
 	render() {
 		if ( ! this.props.userCanManageOptions ) {
 			if ( this.props.renderAllSites ) {
@@ -255,6 +285,7 @@ export class SiteDomains extends Component {
 		return (
 			<Main wideLayout>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+				{ this.renderBreadcrumbs() }
 				<DocumentHead title={ headerText } />
 				<SidebarNavigation />
 				{ this.renderNewDesign() }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -2,6 +2,12 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.breadcrumbs svg.options-domain-button__ellipsis {
+	transform: rotate( 90deg ) translateX( -2px );
+	height: 14px;
+	margin-left: 0;
+}
+
 .domain-management-list__notice {
 	margin-bottom: 0;
 }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -2,10 +2,33 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.breadcrumbs svg.options-domain-button__ellipsis {
-	transform: rotate( 90deg ) translateX( -2px );
-	height: 14px;
-	margin-left: 0;
+.breadcrumbs {
+	svg.options-domain-button__add {
+		margin-left: 4px;
+
+		@include break-mobile {
+			margin-left: 0;
+		}
+	}
+
+	button.options-domain-button.ellipsis {
+		padding: 4px 0;
+
+		@include break-mobile {
+			padding: 7px;
+		}
+	}
+
+	svg.options-domain-button__ellipsis {
+		width: 28px;
+		height: 28px;
+		margin-left: 0;
+
+		@include break-mobile {
+			width: 18px;
+			height: 18px;
+		}
+	}
 }
 
 .domain-management-list__notice {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds the breadcrumbs section for the new domain management list page. This is part of the domain management pages redesign described in pcYYhz-m2-p2.

Desktop view screenshot:

<img width="1146" alt="Screen Shot 2021-10-28 at 00 51 30" src="https://user-images.githubusercontent.com/5324818/139183671-0828c105-86b4-4094-976d-13dbb202e2d3.png">

Mobile view screenshot:

<img width="402" alt="Screen Shot 2021-10-28 at 00 51 42" src="https://user-images.githubusercontent.com/5324818/139183681-ff7d6641-b9d9-40f3-8c1e-79053caff450.png">

**Note**: This update was done initially in PR #57082 which had to be reverted because the popover for the "Add a domain" button was being shown incorrectly (see issue #57368). That happened because two different components (desktop and mobile buttons) were using the same reference. This was corrected now.

### Testing instructions

Access the live Calypso link, go to "Upgrades > Domains", and append this feature flag to your browser's URL: `?flags=domains/management-list-redesign`. Ensure the page contains the breadcrumbs as shown in the screenshot above and that all buttons work as expected. Please also check the page in mobile view.
