### PR TITLE
Domains: Fix pending transfers unable to start

### DIFF
--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -14,6 +14,7 @@ import {
 } from 'calypso/components/domains/use-my-domain/utilities';
 import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
+import { domainAvailability } from 'calypso/lib/domains/constants';
 import { MAP_EXISTING_DOMAIN } from 'calypso/lib/url/support';
 import wpcom from 'calypso/lib/wp';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -60,18 +61,22 @@ function TransferDomainStepStart( {
 			}
 
 			try {
-				const availabilityData = await wpcom
-					.domain( domain )
-					.isAvailable( { apiVersion: '1.3', is_cart_pre_check: false } );
-
-				const availabilityErrorMessage = getAvailabilityErrorMessage( {
-					availabilityData,
-					domainName: domain,
-					selectedSite,
+				const availabilityData = await wpcom.domain( domain ).isAvailable( {
+					apiVersion: '1.3',
+					is_cart_pre_check: false,
+					blog_id: selectedSite?.ID,
 				} );
 
-				if ( availabilityErrorMessage ) {
-					setInboundTransferStatusInfo( null );
+				if ( domainAvailability.TRANSFER_PENDING_SAME_SITE !== availabilityData.status ) {
+					const availabilityErrorMessage = getAvailabilityErrorMessage( {
+						availabilityData,
+						domainName: domain,
+						selectedSite,
+					} );
+
+					if ( availabilityErrorMessage ) {
+						setInboundTransferStatusInfo( null );
+					}
 				}
 			} catch {
 				setInboundTransferStatusInfo( {} );

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -68,7 +68,6 @@ function TransferDomainStepStart( {
 				const availabilityData = await wpcom.domain( domain ).isAvailable( {
 					apiVersion: '1.3',
 					is_cart_pre_check: false,
-					blog_id: selectedSite?.ID,
 				} );
 
 				if ( domainAvailability.TRANSFER_PENDING_SAME_USER !== availabilityData.status ) {

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -48,9 +48,11 @@ function TransferDomainStepStart( {
 	useEffect( () => {
 		( async () => {
 			if ( initialValidation.current ) return;
-			setIsFetching( true );
+			if ( isFetching ) return;
 
 			if ( ! inboundTransferStatusInfo ) {
+				setIsFetching( true );
+
 				try {
 					const inboundTransferStatusResult = await getDomainInboundTransferStatusInfo( domain );
 
@@ -61,13 +63,15 @@ function TransferDomainStepStart( {
 			}
 
 			try {
+				setIsFetching( true );
+
 				const availabilityData = await wpcom.domain( domain ).isAvailable( {
 					apiVersion: '1.3',
 					is_cart_pre_check: false,
 					blog_id: selectedSite?.ID,
 				} );
 
-				if ( domainAvailability.TRANSFER_PENDING_SAME_SITE !== availabilityData.status ) {
+				if ( domainAvailability.TRANSFER_PENDING_SAME_USER !== availabilityData.status ) {
 					const availabilityErrorMessage = getAvailabilityErrorMessage( {
 						availabilityData,
 						domainName: domain,
@@ -85,7 +89,7 @@ function TransferDomainStepStart( {
 				setIsFetching( false );
 			}
 		} )();
-	} );
+	}, [ domain, inboundTransferStatusInfo, selectedSite, isFetching ] );
 
 	const stepContent = (
 		<>

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -31,9 +31,11 @@ export function getAvailabilityErrorMessage( { availabilityData, domainName, sel
 		return null;
 	}
 
-	const availabilityStatus = [ domainAvailability.MAPPABLE, domainAvailability.MAPPED ].includes(
-		mappable
-	)
+	const availabilityStatus = [
+		domainAvailability.MAPPABLE,
+		domainAvailability.MAPPED,
+		domainAvailability.TRANSFER_PENDING,
+	].includes( mappable )
 		? status
 		: mappable;
 	const maintenanceEndTime = maintenance_end_time ?? null;

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -57,7 +57,6 @@ export const domainAvailability = {
 	TLD_NOT_SUPPORTED_TEMPORARILY: 'tld_not_supported_temporarily',
 	TRANSFER_PENDING: 'transfer_pending',
 	TRANSFER_PENDING_SAME_USER: 'transfer_pending_same_user',
-	TRANSFER_PENDING_SAME_SITE: 'transfer_pending_same_site',
 	TRANSFERRABLE: 'transferrable',
 	TRANSFERRABLE_PREMIUM: 'transferrable_premium',
 	UNKNOWN: 'unknown',

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -57,6 +57,7 @@ export const domainAvailability = {
 	TLD_NOT_SUPPORTED_TEMPORARILY: 'tld_not_supported_temporarily',
 	TRANSFER_PENDING: 'transfer_pending',
 	TRANSFER_PENDING_SAME_USER: 'transfer_pending_same_user',
+	TRANSFER_PENDING_SAME_SITE: 'transfer_pending_same_site',
 	TRANSFERRABLE: 'transferrable',
 	TRANSFERRABLE_PREMIUM: 'transferrable_premium',
 	UNKNOWN: 'unknown',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For the "Use a domain I own" flow, to check whether a domain is considered mappable/transferrable, we currently rely on both availability checks and `getAvailabilityErrorMessage` module.

While that's a correct solution for the `domain-input` state, it shouldn't be used for the `transfer-domain` state, as some more validations need to happen. 

This PR does the additional validations and re-enables users to start the pending transfers.

#### Testing instructions
- With a pending transfer for a domain `X` / site `Y`:

  - Check that it's possible to start the pending transfer;
  - Check that passing `X` to the "Use a domain I own" initial input returns an error message;
