### PR TITLE
Onboarding: Adjust tracks events

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -119,8 +119,6 @@ class StepWrapper extends Component {
 				borderless={ false }
 				primary
 				forwardIcon={ null }
-				// We don't need to record tracks event for next button
-				recordTracksEvent={ () => {} }
 			/>
 		);
 	}

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -119,6 +119,8 @@ class StepWrapper extends Component {
 				borderless={ false }
 				primary
 				forwardIcon={ null }
+				// We don't need to record tracks event for next button
+				recordTracksEvent={ () => {} }
 			/>
 		);
 	}

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -119,6 +119,11 @@ class DesignPickerStep extends Component {
 	};
 
 	previewDesign = ( selectedDesign ) => {
+		recordTracksEvent( 'calypso_signup_select_preview_design', {
+			theme: `pub/${ selectedDesign.theme }`,
+			template: selectedDesign.template,
+		} );
+
 		page( getStepUrl( this.props.flowName, this.props.stepName, selectedDesign.theme ) );
 	};
 

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -119,7 +119,7 @@ class DesignPickerStep extends Component {
 	};
 
 	previewDesign = ( selectedDesign ) => {
-		recordTracksEvent( 'calypso_signup_select_preview_design', {
+		recordTracksEvent( 'calypso_signup_design_preview_select', {
 			theme: `pub/${ selectedDesign.theme }`,
 			template: selectedDesign.template,
 		} );

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -31,7 +31,7 @@ export default function IntentStep( props: Props ): React.ReactNode {
 
 	const submitIntent = ( intent: IntentFlag ) => {
 		branchSteps( EXCLUDE_STEPS[ intent ] );
-		recordTracksEvent( 'calypso_signup_select_intent', { intent } );
+		recordTracksEvent( 'calypso_signup_intent_select', { intent } );
 		dispatch( submitSignupStep( { stepName }, { intent } ) );
 		goToNextStep();
 	};

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -23,7 +23,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 	const { stepName, signupDependencies, goToNextStep } = props;
 	const { siteTitle, tagline } = signupDependencies;
 	const submitSiteOptions = ( { siteTitle, tagline }: SiteOptionsFormValues ) => {
-		recordTracksEvent( 'calypso_signup_submit_site_options', {
+		recordTracksEvent( 'calypso_signup_site_options_submit', {
 			has_site_title: !! siteTitle,
 			has_tagline: !! tagline,
 		} );

--- a/client/signup/steps/starting-point/index.tsx
+++ b/client/signup/steps/starting-point/index.tsx
@@ -35,7 +35,7 @@ export default function StartingPointStep( props: Props ): React.ReactNode {
 
 	const submitStartingPoint = ( startingPoint: StartingPointFlag ) => {
 		branchSteps( EXCLUDE_STEPS[ startingPoint ] );
-		recordTracksEvent( 'calypso_signup_select_starting_point', { starting_point: startingPoint } );
+		recordTracksEvent( 'calypso_signup_starting_point_select', { starting_point: startingPoint } );
 		dispatch( submitSignupStep( { stepName }, { startingPoint } ) );
 		goToNextStep();
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* ~Don't send `calypso_signup_skip_step` event for the top-right button of the preview design step (ex. Start with Comfy)~ This is moved to https://github.com/Automattic/wp-calypso/issues/57494
* Send `calypso_signup_select_preview_design` when the user selects preview any design (ex. Preview Comfy)
* Rename tracks events to follow the naming convention `calypso_signup_<qualifier>_<action>`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?flags=signup/hero-flow&siteSlug=<your_site>`
* Select `Build` > Preview any design > Start with that design
* Check
  * `calypso_signup_design_preview_select ` fired when you previewed any design
  * ~`calypso_signup_skip_step` didn't fire when you started with that design in preview design step~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 58MP46f44oGKl5Bin5bSp1-fi-0%3A1