### PR TITLE
QueryInlineHelpSupportTypes: remove redundant QueryLanguageNames call

### DIFF
--- a/client/blocks/inline-help/inline-help-query-support-types.jsx
+++ b/client/blocks/inline-help/inline-help-query-support-types.jsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Fragment, Component } from 'react';
 import { connect } from 'react-redux';
-import QueryLanguageNames from 'calypso/components/data/query-language-names';
 import QuerySupportHistory from 'calypso/components/data/query-support-history';
 import QueryTicketSupportConfiguration from 'calypso/components/data/query-ticket-support-configuration';
 import HappychatConnection from 'calypso/components/happychat/connection-connected';
@@ -55,7 +54,6 @@ class QueryInlineHelpSupportTypes extends Component {
 			<Fragment>
 				<QueryTicketSupportConfiguration />
 				<QuerySupportHistory email={ this.props.currentUserEmail } />
-				<QueryLanguageNames />
 				{ this.props.shouldStartHappychatConnection && <HappychatConnection /> }
 			</Fragment>
 		);

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -70,7 +70,7 @@ export class SupportComponent {
 			this.waitForQueryComplete(),
 			// Waits for one of the network request (triggered by the opening of the popover) to complete.
 			this.page.waitForResponse(
-				( response ) => response.status() === 200 && response.url().includes( 'language-names?' )
+				( response ) => response.status() === 200 && response.url().includes( 'kayako/mine?' )
 			),
 			this.page.click( selectors.supportPopoverButton ),
 		] );


### PR DESCRIPTION
Removes a `QueryLanguageNames` call that's not needed and only pulls in the `state/i18n` reducer and data layer into the bundle.

How to verify that we can remove this? Find all usages of the `getLocalizedLanguageNames` selector. There are three. Verify that these usages are always paired with a `<QueryLanguageNames />` call in the same module file. Therefore, the one `QueryInlineHelpSupportTypes` is redundant as it doesn't have a matching `getLocalizedLanguageNames` call.