### PR TITLE
Fix firing of calypso_user_registration_complete on subsequent social logins via /start

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -560,6 +560,13 @@ export function createAccount(
 			return;
 		}
 
+		// Handling special case where users log in via social using signup form.
+		let newAccountCreated = true;
+
+		if ( signupType === SIGNUP_TYPE_SOCIAL && response && ! response.created_account ) {
+			newAccountCreated = false;
+		}
+
 		// we should either have an error with an error property, or we should have a response with a bearer_token
 		const bearerToken = {};
 		if ( response && response.bearer_token ) {
@@ -593,12 +600,14 @@ export function createAccount(
 
 		const plans_reorder_abtest_variation = response?.plans_reorder_abtest_variation ?? '';
 
-		// Fire after a new user registers.
-		recordRegistration( {
-			userData: registrationUserData,
-			flow: flowName,
-			type: signupType,
-		} );
+		// Fire tracking events, but only after a _new_ user registers.
+		if ( newAccountCreated ) {
+			recordRegistration( {
+				userData: registrationUserData,
+				flow: flowName,
+				type: signupType,
+			} );
+		}
 
 		const providedDependencies = {
 			username,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Adding a check for social login to see whether it's a new account, or a subsequent signup from an existing account via the social signup flow at /start/. 
* Ref: pau2Xa-3nI-p2 Users logging in via social login from /start/ will trigger a new `calypso_user_registration_complete` even if it's not their first login. Does not happen via the /log-in/ endpoint.

* Done by checking the `created_account` value received from https://public-api.wordpress.com/rest/v1.1/users/social/new
    * Defaults to `true` (to get same behavior as earlier incl. regular email signups)
    * Changes to `false` if it's a social account and `create_account` returned from the API is false. 


#### Testing instructions
* Sandbox WordPress.com
* Build and serve Calypso on wpcalypso.wordpress.com (ref: PCYsg-5YE-p2  )
* Go to http://wpcalypso.wordpress.com/start and open the "Network" tab in Chrome/Firefox
* Sign in with a new Google account
* Confirm Tracks event `calypso_user_registration_complete` fires
* Sign out
* Sign in again from http://wpcalypso.wordpress.com/start (using the Google signup button, not the "log in" one).
* Confirm `calypso_user_registration_complete` does not fire.
* Log out
* Go to http://wpcalypso.wordpress.com/start and sign up using email. 
* Confirm `calypso_user_registration_complete` fires.

Related to pau2Xa-3nI-p2
