### PR TITLE
Fixed Header: add navigation items

### DIFF
--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -14,7 +14,7 @@ const navigationItems = [
 ];
 
 function render() {
-	return <Breadcrumb items={ navigationItems }/>;
+	return <Breadcrumb items={ navigationItems } />;
 }
 ```
 

--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -1,0 +1,23 @@
+# Bredcrumb (TSX)
+
+This component displays an array of items as a breadcrumb.
+Each item should have at least a label.
+
+## How to use
+
+```js
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+
+const navigationItems = [
+	{ label: 'Plugins', href: `/plugins` },
+	{ label: 'Search', href: `/plugins?s=woo` },
+];
+
+function render() {
+	return <Breadcrumb items={ navigationItems }/>;
+}
+```
+
+## Props
+
+- `items` (`{ label: string; href?: string }[]`) - The Navigations items to be shown

--- a/client/components/breadcrumb/docs/example.jsx
+++ b/client/components/breadcrumb/docs/example.jsx
@@ -1,0 +1,10 @@
+import Breadcrumb from 'calypso/components/breadcrumb';
+
+export default function BreadcrumbExample() {
+	const navigationItems = [
+		{ label: 'Plugins', href: `/plugins` },
+		{ label: 'Search', href: `/plugins?s=woo` },
+		{ label: 'Woocommerce' },
+	];
+	return <Breadcrumb items={ navigationItems } />;
+}

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -1,0 +1,60 @@
+import { Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
+import { Key } from 'react';
+
+const StyledUl = styled.ul`
+	display: flex;
+	align-items: center;
+	list-style-type: none;
+	margin: 0;
+`;
+
+const StyledLi = styled.li`
+	display: flex;
+	align-items: center;
+	font-size: 13px;
+	font-weight: 500;
+	--color-link: var( --studio-gray-100 );
+
+	&.first {
+		font-size: 16px;
+		font-weight: 600;
+		--color-link: var( --studio-gray-80 );
+	}
+
+	&.last {
+		--color-link: var( --studio-gray-50 );
+	}
+`;
+
+const StyledGridicon = styled( Gridicon )`
+	margin: 0 7px;
+	fill: var( --studio-gray-50 );
+`;
+
+interface Props {
+	items: { label: string; href?: string }[];
+}
+
+const Breadcrumb: React.FunctionComponent< Props > = ( { items } ) => {
+	return (
+		<StyledUl>
+			{ items.map( ( item: { href?: string; label: string }, index: Key, { length } ) => {
+				// eslint-disable-next-line no-nested-ternary
+				const className = index === 0 ? 'first' : index === length - 1 ? 'last' : '';
+				return (
+					<StyledLi key={ index } className={ className }>
+						{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 18 } /> }
+						{ item.href ? <a href={ item.href }>{ item.label }</a> : <span>{ item.label }</span> }
+					</StyledLi>
+				);
+			} ) }
+		</StyledUl>
+	);
+};
+
+Breadcrumb.defaultProps = {
+	items: [],
+};
+
+export default Breadcrumb;

--- a/client/components/fixed-navigation-header/README.md
+++ b/client/components/fixed-navigation-header/README.md
@@ -8,15 +8,23 @@ It can also include children items which will be positioned to the far right.
 ```js
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
+const navigationItems = [
+	{ text: this.props.translate( 'Plugins' ), path: `/plugins` },
+	{
+		text: this.props.translate( 'Search' ),
+		path: `/plugins?s=woo`,
+	},
+];
+
 function render() {
-	return <FixedNavigationHeader headerText="A main title">Children Item</FixedNavigationHeader>;
+	return <FixedNavigationHeader navigationItems={ navigationItems }>Children Item</FixedNavigationHeader>;
 }
 ```
 
 ## Props
 
-- `headerText` (`string`) - The main header text
-- `brandFont` (`bool`) - use the WP.com brand font for `headerText`
+- `navigationItems` (`{ text: string; path: string }[]`) - The Navigations items to be shown
+- `brandFont` (`bool`) - use the WP.com brand font for `navigationItems`
 - `id` (`string`) - ID for the header (optional)
 - `className` (`string`) - A class name for the wrapped component (optional)
 - `children` (`nodes`) – Any children elements which are being rendered to the far right (optional)

--- a/client/components/fixed-navigation-header/README.md
+++ b/client/components/fixed-navigation-header/README.md
@@ -1,6 +1,6 @@
-# FixedNavigationHeader (JSX)
+# FixedNavigationHeader (TSX)
 
-This component displays a header with navigation items. 
+This component displays a header with a breadcrumb. 
 It can also include children items which will be positioned to the far right.
 
 ## How to use
@@ -9,11 +9,8 @@ It can also include children items which will be positioned to the far right.
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
 const navigationItems = [
-	{ label: this.props.translate( 'Plugins' ), href: `/plugins` },
-	{
-		label: this.props.translate( 'Search' ),
-		href: `/plugins?s=woo`,
-	},
+	{ label: 'Plugins', href: `/plugins` },
+	{ label: 'Search', href: `/plugins?s=woo` },
 ];
 
 function render() {
@@ -24,7 +21,6 @@ function render() {
 ## Props
 
 - `navigationItems` (`{ label: string; href: string }[]`) - The Navigations items to be shown
-- `brandFont` (`bool`) - use the WP.com brand font for `navigationItems`
 - `id` (`string`) - ID for the header (optional)
 - `className` (`string`) - A class name for the wrapped component (optional)
 - `children` (`nodes`) – Any children elements which are being rendered to the far right (optional)

--- a/client/components/fixed-navigation-header/README.md
+++ b/client/components/fixed-navigation-header/README.md
@@ -9,10 +9,10 @@ It can also include children items which will be positioned to the far right.
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
 const navigationItems = [
-	{ text: this.props.translate( 'Plugins' ), path: `/plugins` },
+	{ label: this.props.translate( 'Plugins' ), href: `/plugins` },
 	{
-		text: this.props.translate( 'Search' ),
-		path: `/plugins?s=woo`,
+		label: this.props.translate( 'Search' ),
+		href: `/plugins?s=woo`,
 	},
 ];
 
@@ -23,7 +23,7 @@ function render() {
 
 ## Props
 
-- `navigationItems` (`{ text: string; path: string }[]`) - The Navigations items to be shown
+- `navigationItems` (`{ label: string; href: string }[]`) - The Navigations items to be shown
 - `brandFont` (`bool`) - use the WP.com brand font for `navigationItems`
 - `id` (`string`) - ID for the header (optional)
 - `className` (`string`) - A class name for the wrapped component (optional)

--- a/client/components/fixed-navigation-header/docs/example.jsx
+++ b/client/components/fixed-navigation-header/docs/example.jsx
@@ -3,10 +3,10 @@ import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
 export default function FixedNavigationHeaderExample() {
 	const navigationItems = [
-		{ text: this.props.translate( 'Plugins' ), path: `/plugins` },
+		{ label: this.props.translate( 'Plugins' ), href: `/plugins` },
 		{
-			text: this.props.translate( 'Search' ),
-			path: `/plugins?s=woo`,
+			label: this.props.translate( 'Search' ),
+			href: `/plugins?s=woo`,
 		},
 	];
 	return (

--- a/client/components/fixed-navigation-header/docs/example.jsx
+++ b/client/components/fixed-navigation-header/docs/example.jsx
@@ -1,18 +1,9 @@
-import { Fragment } from 'react';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
 export default function FixedNavigationHeaderExample() {
 	const navigationItems = [
-		{ label: this.props.translate( 'Plugins' ), href: `/plugins` },
-		{
-			label: this.props.translate( 'Search' ),
-			href: `/plugins?s=woo`,
-		},
+		{ label: 'Plugins', href: `/plugins` },
+		{ label: 'Search', href: `/plugins?s=woo` },
 	];
-	return (
-		<Fragment>
-			<FixedNavigationHeader navigationItems={ navigationItems } />
-			<FixedNavigationHeader navigationItems={ navigationItems } brandFont />
-		</Fragment>
-	);
+	return <FixedNavigationHeader navigationItems={ navigationItems } />;
 }

--- a/client/components/fixed-navigation-header/docs/example.jsx
+++ b/client/components/fixed-navigation-header/docs/example.jsx
@@ -2,10 +2,17 @@ import { Fragment } from 'react';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
 export default function FixedNavigationHeaderExample() {
+	const navigationItems = [
+		{ text: this.props.translate( 'Plugins' ), path: `/plugins` },
+		{
+			text: this.props.translate( 'Search' ),
+			path: `/plugins?s=woo`,
+		},
+	];
 	return (
 		<Fragment>
-			<FixedNavigationHeader headerText="This is the header." />
-			<FixedNavigationHeader headerText="This is the header with branded font" brandFont />
+			<FixedNavigationHeader navigationItems={ navigationItems } />
+			<FixedNavigationHeader navigationItems={ navigationItems } brandFont />
 		</Fragment>
 	);
 }

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -58,7 +58,7 @@ interface Props {
 	id?: string;
 	className?: string;
 	children?: ReactNode;
-	navigationItems: { text: string; path: string }[];
+	navigationItems: { label: string; href?: string }[];
 }
 
 const renderBreadcrumb = ( items ) => {
@@ -68,7 +68,7 @@ const renderBreadcrumb = ( items ) => {
 			{ items.map( ( item ) => (
 				<li>
 					<Gridicon icon="chevron-right" size={ 18 } />
-					<a href={ item.path }>{ item.text }</a>
+					{ item.href ? <a href={ item.href }>{ item.label }</a> : <span>{ item.label }</span> }
 				</li>
 			) ) }
 		</ul>

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { ReactNode } from 'react';
@@ -59,16 +60,29 @@ interface Props {
 	headerText: string | ReactNode;
 	className?: string;
 	children?: ReactNode;
+	navigationItems?: { text: string; path: string }[];
 }
 
+const renderBreadcrumb = ( items ) => {
+	return items.map( ( item ) => (
+		<span>
+			<Gridicon icon="chevron-right" size={ 18 } />
+			{ item.text }
+		</span>
+	) );
+};
+
 const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
-	const { brandFont, id, headerText, className, children } = props;
+	const { brandFont, id, headerText, className, children, navigationItems } = props;
 	const headerClasses = classNames( { 'wp-brand-font': brandFont } );
 
 	return (
 		<Header id={ id } className={ className }>
 			<Container>
-				<H1 className={ headerClasses }>{ preventWidows( headerText, 2 ) }</H1>
+				<H1 className={ headerClasses }>
+					{ preventWidows( headerText, 2 ) }
+					{ renderBreadcrumb( navigationItems ) }
+				</H1>
 				<ActionsContainer>{ children }</ActionsContainer>
 			</Container>
 		</Header>
@@ -79,6 +93,7 @@ FixedNavigationHeader.defaultProps = {
 	id: '',
 	className: '',
 	brandFont: false,
+	navigationItems: [],
 };
 
 export default FixedNavigationHeader;

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -2,7 +2,6 @@ import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { ReactNode } from 'react';
-import { preventWidows } from 'calypso/lib/formatting';
 
 const Header = styled.header`
 	position: fixed;
@@ -57,32 +56,33 @@ const ActionsContainer = styled.div`
 interface Props {
 	brandFont?: boolean;
 	id?: string;
-	headerText: string | ReactNode;
 	className?: string;
 	children?: ReactNode;
-	navigationItems?: { text: string; path: string }[];
+	navigationItems: { text: string; path: string }[];
 }
 
 const renderBreadcrumb = ( items ) => {
-	return items.map( ( item ) => (
-		<span>
-			<Gridicon icon="chevron-right" size={ 18 } />
-			{ item.text }
-		</span>
-	) );
+	return (
+		<ul>
+			{ ' ' }
+			{ items.map( ( item ) => (
+				<li>
+					<Gridicon icon="chevron-right" size={ 18 } />
+					<a href={ item.path }>{ item.text }</a>
+				</li>
+			) ) }
+		</ul>
+	);
 };
 
 const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
-	const { brandFont, id, headerText, className, children, navigationItems } = props;
+	const { brandFont, id, className, children, navigationItems } = props;
 	const headerClasses = classNames( { 'wp-brand-font': brandFont } );
 
 	return (
 		<Header id={ id } className={ className }>
 			<Container>
-				<H1 className={ headerClasses }>
-					{ preventWidows( headerText, 2 ) }
-					{ renderBreadcrumb( navigationItems ) }
-				</H1>
+				<H1 className={ headerClasses }>{ renderBreadcrumb( navigationItems ) }</H1>
 				<ActionsContainer>{ children }</ActionsContainer>
 			</Container>
 		</Header>

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -1,7 +1,6 @@
-import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
-import classNames from 'classnames';
-import { Key, ReactNode } from 'react';
+import { ReactNode } from 'react';
+import Breadcrumb from 'calypso/components/breadcrumb';
 
 const Header = styled.header`
 	position: fixed;
@@ -46,43 +45,25 @@ const Container = styled.div`
 	}
 `;
 
-const H1 = styled.h1``;
-
 const ActionsContainer = styled.div`
 	display: flex;
 	align-items: center;
 `;
 
 interface Props {
-	brandFont?: boolean;
 	id?: string;
 	className?: string;
 	children?: ReactNode;
 	navigationItems: { label: string; href?: string }[];
 }
 
-const renderBreadcrumb = ( items: any[] ) => {
-	return (
-		<ul>
-			{ ' ' }
-			{ items.map( ( item: { href?: string; label: string }, index: Key ) => (
-				<li key={ index }>
-					<Gridicon icon="chevron-right" size={ 18 } />
-					{ item.href ? <a href={ item.href }>{ item.label }</a> : <span>{ item.label }</span> }
-				</li>
-			) ) }
-		</ul>
-	);
-};
-
 const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
-	const { brandFont, id, className, children, navigationItems } = props;
-	const headerClasses = classNames( { 'wp-brand-font': brandFont } );
+	const { id, className, children, navigationItems } = props;
 
 	return (
 		<Header id={ id } className={ className }>
 			<Container>
-				<H1 className={ headerClasses }>{ renderBreadcrumb( navigationItems ) }</H1>
+				<Breadcrumb items={ navigationItems } />
 				<ActionsContainer>{ children }</ActionsContainer>
 			</Container>
 		</Header>
@@ -92,7 +73,6 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 FixedNavigationHeader.defaultProps = {
 	id: '',
 	className: '',
-	brandFont: false,
 	navigationItems: [],
 };
 

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import { ReactNode } from 'react';
+import { Key, ReactNode } from 'react';
 
 const Header = styled.header`
 	position: fixed;
@@ -61,12 +61,12 @@ interface Props {
 	navigationItems: { label: string; href?: string }[];
 }
 
-const renderBreadcrumb = ( items ) => {
+const renderBreadcrumb = ( items: any[] ) => {
 	return (
 		<ul>
 			{ ' ' }
-			{ items.map( ( item ) => (
-				<li>
+			{ items.map( ( item: { href?: string; label: string }, index: Key ) => (
+				<li key={ index }>
 					<Gridicon icon="chevron-right" size={ 18 } />
 					{ item.href ? <a href={ item.href }>{ item.label }</a> : <span>{ item.label }</span> }
 				</li>

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -390,6 +390,25 @@ export class PluginsMain extends Component {
 		);
 	}
 
+	getNavigationItems() {
+		const { search, selectedSiteSlug } = this.props;
+		const navigationItems = [
+			{ label: this.props.translate( 'Plugins' ), href: `/plugins/${ selectedSiteSlug || '' }` },
+			{
+				label: this.props.translate( 'Manage' ),
+				href: `/plugins/manage/${ selectedSiteSlug || '' }`,
+			},
+		];
+		if ( search ) {
+			navigationItems.push( {
+				label: this.props.translate( 'Search Results' ),
+				href: `/plugins/${ selectedSiteSlug || '' }?s=${ search }`,
+			} );
+		}
+
+		return navigationItems;
+	}
+
 	render() {
 		if ( ! this.props.isRequestingSites && ! this.props.userCanManagePlugins ) {
 			return <NoPermissionsError title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
@@ -419,9 +438,8 @@ export class PluginsMain extends Component {
 				{ this.renderPageViewTracking() }
 				<SidebarNavigation />
 				<FixedNavigationHeader
-					brandFont
 					className="plugins__page-heading"
-					headerText={ this.props.translate( 'Plugins' ) }
+					navigationItems={ this.getNavigationItems() }
 				>
 					<div className="plugins__main-buttons">
 						{ this.renderAddPluginButton() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -460,6 +460,11 @@ export class PluginsBrowser extends Component {
 
 	render() {
 		const { category, search } = this.props;
+		const headerText = this.props.translate( 'Plugins' );
+		const navigationItems = [];
+		if ( search ) {
+			navigationItems.push( { text: this.props.translate( 'Search Results' ), path: '' } );
+		}
 
 		if ( ! this.props.isRequestingSites && this.props.noPermissionsError ) {
 			return <NoPermissionsError title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
@@ -481,13 +486,14 @@ export class PluginsBrowser extends Component {
 					<QuerySiteRecommendedPlugins siteId={ this.props.selectedSiteId } />
 				) }
 				{ this.renderPageViewTracker() }
-				<DocumentHead title={ this.props.translate( 'Plugins', { textOnly: true } ) } />
+				<DocumentHead title={ headerText } />
 				<SidebarNavigation />
 				{ ! this.props.hideHeader && (
 					<FixedNavigationHeader
 						brandFont
 						className="plugins-browser__header"
-						headerText={ this.props.translate( 'Plugins' ) }
+						headerText={ headerText }
+						navigationItems={ navigationItems }
 					>
 						<div className="plugins-browser__main-buttons">
 							{ this.renderManageButton() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -458,13 +458,23 @@ export class PluginsBrowser extends Component {
 		return null;
 	}
 
+	getNavigationItems() {
+		const { search, siteSlug } = this.props;
+		const navigationItems = [
+			{ text: this.props.translate( 'Plugins' ), path: `/plugins/${ siteSlug }` },
+		];
+		if ( search ) {
+			navigationItems.push( {
+				text: this.props.translate( 'Search Results' ),
+				path: `/plugins/${ siteSlug }?s=${ search }`,
+			} );
+		}
+
+		return navigationItems;
+	}
+
 	render() {
 		const { category, search } = this.props;
-		const headerText = this.props.translate( 'Plugins' );
-		const navigationItems = [];
-		if ( search ) {
-			navigationItems.push( { text: this.props.translate( 'Search Results' ), path: '' } );
-		}
 
 		if ( ! this.props.isRequestingSites && this.props.noPermissionsError ) {
 			return <NoPermissionsError title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
@@ -486,14 +496,13 @@ export class PluginsBrowser extends Component {
 					<QuerySiteRecommendedPlugins siteId={ this.props.selectedSiteId } />
 				) }
 				{ this.renderPageViewTracker() }
-				<DocumentHead title={ headerText } />
+				<DocumentHead title={ this.props.translate( 'Plugins' ) } />
 				<SidebarNavigation />
 				{ ! this.props.hideHeader && (
 					<FixedNavigationHeader
 						brandFont
 						className="plugins-browser__header"
-						headerText={ headerText }
-						navigationItems={ navigationItems }
+						navigationItems={ this.getNavigationItems() }
 					>
 						<div className="plugins-browser__main-buttons">
 							{ this.renderManageButton() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -461,12 +461,12 @@ export class PluginsBrowser extends Component {
 	getNavigationItems() {
 		const { search, siteSlug } = this.props;
 		const navigationItems = [
-			{ label: this.props.translate( 'Plugins' ), href: `/plugins/${ siteSlug }` },
+			{ label: this.props.translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }` },
 		];
 		if ( search ) {
 			navigationItems.push( {
 				label: this.props.translate( 'Search Results' ),
-				href: `/plugins/${ siteSlug }?s=${ search }`,
+				href: `/plugins/${ siteSlug || '' }?s=${ search }`,
 			} );
 		}
 
@@ -500,7 +500,6 @@ export class PluginsBrowser extends Component {
 				<SidebarNavigation />
 				{ ! this.props.hideHeader && (
 					<FixedNavigationHeader
-						brandFont
 						className="plugins-browser__header"
 						navigationItems={ this.getNavigationItems() }
 					>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -461,12 +461,12 @@ export class PluginsBrowser extends Component {
 	getNavigationItems() {
 		const { search, siteSlug } = this.props;
 		const navigationItems = [
-			{ text: this.props.translate( 'Plugins' ), path: `/plugins/${ siteSlug }` },
+			{ label: this.props.translate( 'Plugins' ), href: `/plugins/${ siteSlug }` },
 		];
 		if ( search ) {
 			navigationItems.push( {
-				text: this.props.translate( 'Search Results' ),
-				path: `/plugins/${ siteSlug }?s=${ search }`,
+				label: this.props.translate( 'Search Results' ),
+				href: `/plugins/${ siteSlug }?s=${ search }`,
 			} );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Creates a new breadcrumb component
* Fixes examples and docs
* Adds the nav items in `/plugins`, `/plugins/manage`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/plugins`
* Search for `woo`, you should get a new breadcrumb `Plugins > Search Results`
* Click **Manage**, you should get a new breadcrumb `Plugins > Manage`
* On all cases, clicking "Plugins" should redirect you back to the plugins screen

![SS 2021-11-03 at 19 18 38](https://user-images.githubusercontent.com/12430020/140145618-eb845765-23d3-4ee1-958d-1d57e855b770.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57101
