### PR TITLE
Fixing style variable usage in videos UI

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -1,3 +1,6 @@
+@import '@automattic/typography/styles/variables';
+@import '@automattic/onboarding/styles/mixins.scss';
+
 .videos-ui {
 	background: #101517;
 	color: #fff;
@@ -11,7 +14,7 @@
 			flex-direction: row;
 			align-items: center;
 			justify-content: space-between;
-			font-size: 0.875rem;
+			font-size: $font-body-small;
 			div,
 			a {
 				display: flex;
@@ -48,11 +51,11 @@
 			li {
 				list-style: none;
 				margin-bottom: 14px;
-				font-size: 0.875rem;
+				font-size: $font-body-small;
 			}
 			h2 {
-				font-family: 'Recoleta', 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
-				font-size: 2rem;
+				@include onboarding-font-recoleta;
+				font-size: $font-title-large;
 
 				&:first-child {
 					color: rgba( 255, 255, 255, 0.5 );
@@ -64,10 +67,9 @@
 	.videos-ui__body {
 
 		h3 {
-			font-size: 1.5rem;
+			font-size: $font-title-medium;
 			margin: 80px 80px 30px;
 		}
-
 
 		.videos-ui__video-content {
 			display: flex;
@@ -82,7 +84,7 @@
 
 		.videos-ui__chapters {
 			background: #1d262a;
-			font-size: 0.875rem;
+			font-size: $font-body-small;
 			flex-basis: auto;
 			width: 33%;
 			overflow: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Per comments in https://github.com/Automattic/wp-calypso/pull/57324, this PR updates styling in the new videos UI interface to make better use of existing font size and font family SCSS variables.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR still does not load the UI anywhere (as it will be added as a modal in the work being done for Videos UI: Add a new card to the My Home carousel for our MVP. #57326
* However, it can be tested by importing the VideosUi component anywhere in Calypso. (I have been testing it as a block on the home page for this initial development pass.)
* Visually, nothing should have changed between this PR and https://github.com/Automattic/wp-calypso/pull/57324

![image](https://user-images.githubusercontent.com/13437011/139296453-e84b6b81-3084-406d-826f-80682b957930.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57404
