### PR TITLE
Playwright: wait until networkidle when loading the list of invited users.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -55,9 +55,7 @@ export class PeoplePage {
 		// For Invites tab, wait for the full request to be completed.
 		if ( name === 'Invites' ) {
 			await Promise.all( [
-				this.page.waitForResponse(
-					( response ) => response.url().includes( 'invites?' ) && response.status() === 200
-				),
+				this.page.waitForNavigation( { url: '**/people/invites/**', waitUntil: 'networkidle' } ),
 				clickNavTab( this.page, name ),
 			] );
 			return;

--- a/test/e2e/specs/specs-playwright/wp-invite__revoke.ts
+++ b/test/e2e/specs/specs-playwright/wp-invite__revoke.ts
@@ -78,7 +78,8 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 	} );
 
 	it( `Ensure invite link is no longer valid`, async function () {
-		const testPage = await BrowserManager.newPage( { newContext: true } );
+		const testContext = await BrowserManager.newBrowserContext();
+		const testPage = await BrowserManager.newPage( { context: testContext } );
 		await testPage.goto( adjustedInviteLink );
 
 		await testPage.waitForSelector( `:text("Oops, that invite is not valid")` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the behavior when the `PeoplePage.clickTab` method is called to navigate to the Invites page.

Key changes:
- replace `waitForResponse` with a `waitForNavigation` to the Invites page.
- wait until `networkidle` is fired.

Details:
It appears the `invites?` request does not necessarily fire last, and completion of its loading does not necessarily signify that the Invites page is fully loaded.

Instead, wait until `networkidle` is fired. This is used after careful consideration and does not add an unreasonable amount of time. See the following:

```
  pw:api attempting click action +4ms
  pw:api   waiting for element to be visible, enabled and stable +1ms
  pw:api   element is visible, enabled and stable +64ms
  pw:api   scrolling into view if needed +0ms
  pw:api   done scrolling +0ms
  pw:api   checking that element receives pointer events at (737.28,179.79) +1ms
  pw:api   element does receive pointer events +22ms
  pw:api   performing click action +18ms
  pw:api   click action done +109ms
  pw:api   waiting for scheduled navigations to finish +0ms
  pw:api   navigated to "https://wordpress.com/people/invites/e2eflowtesting4.wordpress.com" +0ms
  pw:api <= page.waitForNavigation succeeded +2ms
  pw:api   navigated to "https://wordpress.com/people/invites/e2eflowtesting4.wordpress.com" +1ms
  pw:api   navigated to "https://wordpress.com/people/invites/e2eflowtesting4.wordpress.com" +0ms
  pw:api   navigations have finished +6ms
  pw:api <= elementHandle.click succeeded +5ms
  pw:api   "networkidle" event fired +944ms
```

`networkidle` event is fired after approx. 1 second.

#### Testing instructions

- [ ] stress test
  - [ ] mobile
  - [x] desktop 6903256
- [ ] normal test
  - [ ] mobile
  - [ ] desktop

Fixes #57438.