### PR TITLE
Plans: Enable real-time Backup and Security products for all non-production envs

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,7 @@
 	"difm_typeform_id": "YMiXMYId",
 	"difm_signup_typeform_id": "m3s2pdgI",
 	"features": {
-		"activity-log/display-rules": false,
+		"activity-log/display-rules": true,
 		"ad-tracking": false,
 		"async-payments": false,
 		"automated-transfer": true,
@@ -92,7 +92,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,7 +15,7 @@
 	"difm_typeform_id": "YMiXMYId",
 	"difm_signup_typeform_id": "m3s2pdgI",
 	"features": {
-		"activity-log/display-rules": true,
+		"activity-log/display-rules": false,
 		"automated-transfer": true,
 		"async-payments": false,
 		"ad-tracking": false,
@@ -60,7 +60,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/user-licensing": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,6 +15,7 @@
 	"difm_typeform_id": "YMiXMYId",
 	"difm_signup_typeform_id": "m3s2pdgI",
 	"features": {
+		"activity-log/display-rules": true,
 		"automated-transfer": true,
 		"async-payments": false,
 		"ad-tracking": false,
@@ -59,6 +60,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
+		"jetpack/only-realtime-products": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/user-licensing": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -27,7 +27,7 @@
 	],
 	"oauth_client_id": 68663,
 	"features": {
-		"activity-log/display-rules": false,
+		"activity-log/display-rules": true,
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
@@ -39,7 +39,7 @@
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/backups-date-picker": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -24,6 +24,7 @@
 		}
 	],
 	"features": {
+		"activity-log/display-rules": true,
 		"activity-log/v2": true,
 		"always_use_logout_url": false,
 		"current-site/domain-warning": false,
@@ -32,6 +33,7 @@
 		"checkout/google-pay": true,
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
+		"jetpack/only-realtime-products": true,
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -24,7 +24,7 @@
 		}
 	],
 	"features": {
-		"activity-log/display-rules": true,
+		"activity-log/display-rules": false,
 		"activity-log/v2": true,
 		"always_use_logout_url": false,
 		"current-site/domain-warning": false,
@@ -33,7 +33,7 @@
 		"checkout/google-pay": true,
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
-		"jetpack/only-realtime-products": true,
+		"jetpack/only-realtime-products": false,
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -26,6 +26,7 @@
 	"oauth_client_id": 69041,
 	"features": {
 		"ad-tracking": true,
+		"activity-log/display-rules": false,
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -26,6 +26,7 @@
 	"oauth_client_id": 69040,
 	"features": {
 		"ad-tracking": false,
+		"activity-log/display-rules": true,
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
@@ -35,7 +36,7 @@
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/backups-date-picker": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -18,6 +18,7 @@
 	"difm_signup_typeform_id": "m3s2pdgI",
 	"features": {
 		"ad-tracking": true,
+		"activity-log/display-rules": false,
 		"async-payments": false,
 		"automated-transfer": true,
 		"bilmur-script": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,6 +16,7 @@
 	"difm_typeform_id": "YMiXMYId",
 	"difm_signup_typeform_id": "m3s2pdgI",
 	"features": {
+		"activity-log/display-rules": true,
 		"ad-tracking": false,
 		"async-payments": false,
 		"automated-transfer": true,
@@ -57,7 +58,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/test.json
+++ b/config/test.json
@@ -26,6 +26,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"features": {
 		"ad-tracking": false,
+		"activity-log/display-rules": true,
 		"async-payments": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
@@ -48,6 +49,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/happychat": true,
+		"jetpack/only-realtime-products": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,6 +16,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"features": {
 		"ad-tracking": false,
+		"activity-log/display-rules": true,
 		"async-payments": false,
 		"automated-transfer": true,
 		"calypsoify/plugins": true,
@@ -64,7 +65,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/user-licensing": false,


### PR DESCRIPTION
Resolves `1200412004370260-as-1201289204577501`.
Relates to `pbtFFM-XN-p2`.

#### Changes proposed in this Pull Request

* Enable the feature flag `activity-log/display-rules` by default in all non-production environments, signalling that the Activity Log will now track and limit visible events based on the selected site's subscription.
* Enable the feature flag `jetpack/only-realtime-products` by default in all non-production environments, signalling that "Daily" and "Real-time" offerings are no longer offered for purchase and have been replaced by Backup and Security products that always work in real time.

#### Testing instructions

* Inspect all environment configuration files. Verify the following flags are set to true in all web environments except `production` and `jetpack-cloud-production`:
  * `activity-log/display-rules`
  * `jetpack/only-realtime-products`
* Verify that in the `production` and `jetpack-cloud-production` environment configuration files, the abovementioned feature flags are explicitly set to `false`.
* In your testing environment:
  * Visit the pricing page in either Calypso Blue or Calypso Green. Verify the pricing page now reflects real-time Backup and Security products, and no longer shows "Daily" and "Real-time" product options (see reference screenshot).
  * Visit the Activity Log page. Verify it continues to work as in production, with no change to appearance or behavior unless you've selected a site that uses a new Backup or Security product subscription.

#### Reference screenshot (provisional)

<img width="342" alt="image" src="https://user-images.githubusercontent.com/670067/139311407-ef463e2c-2b50-40b4-91a5-1f261fddbebc.png">