### PR TITLE
Playwright: use a combination of `click` and `waitForSelector` instead of `check` when removing a user.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -98,9 +98,9 @@ export class PeoplePage {
 		// Native `page.check` sometimes fails here. Instead, click on the radio and wait for the
 		// Delete user button to become enabled.
 		await this.page.click( selectors.deletedUserContentAction( 'delete' ) );
-		await this.page.waitForSelector( `${ selectors.deleteUserButton }[disabled=""]`, {
-			state: 'detached',
-		} );
+		await this.page.waitForSelector(
+			`${ selectors.deletedUserContentAction( 'delete' ) }:checked`
+		);
 
 		await Promise.all( [
 			this.page.waitForNavigation(),

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -95,7 +95,13 @@ export class PeoplePage {
 			elementHandle
 		);
 
-		await this.page.check( selectors.deletedUserContentAction( 'delete' ) );
+		// Native `page.check` sometimes fails here. Instead, click on the radio and wait for the
+		// Delete user button to become enabled.
+		await this.page.click( selectors.deletedUserContentAction( 'delete' ) );
+		await this.page.waitForSelector( `${ selectors.deleteUserButton }[disabled=""]`, {
+			state: 'detached',
+		} );
+
 		await Promise.all( [
 			this.page.waitForNavigation(),
 			this.page.click( selectors.deleteUserButton ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the interaction for `PeoplePage.deleteUser`.

Key changes:
- instead of single `page.check`, use `page.click` followed by `page.waitForSelector`.

Details:
Slack: p1635441879120200-slack-CQD1HH4MA

Rarely, Playwright fails to verify that `page.check` performed its actions when attempting to remove a user from the site. The radio button in question present on `/people/edit` is a React component and so the 'checked' behavior is not coming from a native form.

#### Testing instructions

- [x] pre-release test

Stress test is skipped due to the sheer load it would cause on the signup page, in addition to locking up Pre-Release task for 20 minutes (as execution is limited to 1 instance across all branches).

Fixes #57437.