### PR TITLE
Playwright: change artifact naming scheme.

### DIFF
--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -4,11 +4,11 @@ import { beforeAll, afterAll } from '@jest/globals';
 import { BrowserContext, chromium, Page, Video } from 'playwright';
 import { getDefaultLoggerConfiguration } from './browser-helper';
 import { closeBrowser, startBrowser, newBrowserContext, browser } from './browser-manager';
-import { getDateString } from './data-helper';
 
-// These are defined in our custom Jest environment (test/e2e/lib/jest/environment.js)
-declare const __CURRENT_TEST_FAILED__: boolean;
-declare const __CURRENT_TEST_NAME__: string;
+// Global values defined in our custom Jest environment (test/e2e/lib/jest/environment.js)
+declare const __STEP_FAILED__: boolean;
+declare const __FAILED_STEP_NAME__: string;
+declare const __FILE_NAME__: string;
 declare const artifactPath: string;
 
 /**
@@ -17,12 +17,10 @@ declare const artifactPath: string;
  * @param {string} testName The test name.
  * @returns The filename.
  */
-function getTestNameWithTime( testName: string ): string {
-	// Clean up the test name to be entirely lowercase and removing whitespace.
-	const currentTestName = testName.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-	// Obtain the ISO date string and replace non-supported filename chars with hyphens.
-	const dateTime = getDateString( 'ISO' )!.split( '.' )[ 0 ].replace( /:/g, '-' );
-	return `${ currentTestName }-${ dateTime }`;
+function getFileName( testName: string ): string {
+	// Clean up the test name to remove all non-alphanumeric characters.
+	const sanitizedTestStepName = testName.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
+	return `${ __FILE_NAME__ }-${ sanitizedTestStepName }`;
 }
 
 /**
@@ -61,14 +59,12 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 			throw new Error( 'No browser instance found.' );
 		}
 
-		const testName = __CURRENT_TEST_NAME__;
-
 		// Take screenshot for failed tests
-		if ( __CURRENT_TEST_FAILED__ ) {
+		if ( __STEP_FAILED__ ) {
 			const fileName = path.join(
 				artifactPath,
 				'screenshots',
-				`${ getTestNameWithTime( testName ) }.png`
+				`${ getFileName( __FAILED_STEP_NAME__ ) }.png`
 			);
 			await mkdir( path.dirname( fileName ), { recursive: true } );
 			await page.screenshot( { path: fileName } );
@@ -78,17 +74,20 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 		await page.close();
 
 		// Stop tracing and remove the trace output if the test did not fail.
-		const traceOutputPath = path.join( artifactPath, `${ getTestNameWithTime( testName ) }.zip` );
+		const traceOutputPath = path.join(
+			artifactPath,
+			`${ getFileName( __FAILED_STEP_NAME__ ) }.zip`
+		);
 		await context.tracing.stop( { path: traceOutputPath } );
-		if ( ! __CURRENT_TEST_FAILED__ ) {
+		if ( ! __STEP_FAILED__ ) {
 			await unlink( traceOutputPath );
 		}
 
-		if ( __CURRENT_TEST_FAILED__ ) {
+		if ( __STEP_FAILED__ ) {
 			const destination = path.join(
 				artifactPath,
 				'screenshots',
-				`${ getTestNameWithTime( testName ) }.webm`
+				`${ getFileName( __FAILED_STEP_NAME__ ) }.webm`
 			);
 			try {
 				// Save the failing test case with a specific name.

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -59,7 +59,7 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 			throw new Error( 'No browser instance found.' );
 		}
 
-		// Take screenshot for failed tests
+		// Take screenshot for failed test.
 		if ( __STEP_FAILED__ ) {
 			const fileName = path.join(
 				artifactPath,
@@ -73,7 +73,7 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 		// the video recording.
 		await page.close();
 
-		// Stop tracing and remove the trace output if the test did not fail.
+		// Save trace for failed test.
 		if ( __STEP_FAILED__ ) {
 			const traceOutputPath = path.join(
 				artifactPath,
@@ -82,6 +82,7 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 			await context.tracing.stop( { path: traceOutputPath } );
 		}
 
+		// Save video for failed test.
 		if ( __STEP_FAILED__ ) {
 			const destination = path.join(
 				artifactPath,

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -1,4 +1,4 @@
-import { mkdir, unlink } from 'fs/promises';
+import { mkdir } from 'fs/promises';
 import path from 'path';
 import { beforeAll, afterAll } from '@jest/globals';
 import { BrowserContext, chromium, Page, Video } from 'playwright';
@@ -74,13 +74,12 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 		await page.close();
 
 		// Stop tracing and remove the trace output if the test did not fail.
-		const traceOutputPath = path.join(
-			artifactPath,
-			`${ getFileName( __FAILED_STEP_NAME__ ) }.zip`
-		);
-		await context.tracing.stop( { path: traceOutputPath } );
-		if ( ! __STEP_FAILED__ ) {
-			await unlink( traceOutputPath );
+		if ( __STEP_FAILED__ ) {
+			const traceOutputPath = path.join(
+				artifactPath,
+				`${ getFileName( __FAILED_STEP_NAME__ ) }.zip`
+			);
+			await context.tracing.stop( { path: traceOutputPath } );
 		}
 
 		if ( __STEP_FAILED__ ) {

--- a/test/e2e/lib/jest/environment.js
+++ b/test/e2e/lib/jest/environment.js
@@ -48,6 +48,7 @@ class JestEnvironmentE2E extends JestEnvironmentNode {
 				/* If a hook has failed, mark all subsequent test
 				steps as failed.
 				Handling is different compared to test steps because
+				Jest treats failed hooks differently from tests.
 				*/
 				if ( this.hookFailed ) {
 					event.test.mode = 'fail';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves the artifact naming scheme.

Key changes:
- use the following schema: <test_file_name>-<test_step_name>
- rename some global variables to be more descriptive of its purpose

The new scheme should retain uniqueness of the file name (in case same step in multiple test files fail) but be much more legible and attributable to the step that failed).

Hook failure:
```
➜  ~/workspace/wp-calypso-second/test/e2e/results git:(pw/hooks-artifact-namne-57436) ✗ exa -R wp-media__upload-spec-KvgtBQ
playwright-1635452967352.log  screenshots  wp-media__upload-spec-beforeall.zip

wp-media__upload-spec-KvgtBQ/screenshots:
wp-media__upload-spec-beforeall.png  wp-media__upload-spec-beforeall.webm
```

Test failure:
```
➜  ~/workspace/wp-calypso-second/test/e2e/results git:(pw/hooks-artifact-namne-57436) ✗ exa -R
wp-invite__new-user-ISqSVh

./wp-invite__new-user-ISqSVh:
playwright-1635452872660.log  screenshots  wp-invite__new-user-log-in.zip

./wp-invite__new-user-ISqSVh/screenshots:
wp-invite__new-user-log-in.png  wp-invite__new-user-log-in.webm
```

Fixes #57436.
