### PR TITLE
CI: disable `nonZeroExitCode` failure condition for E2E tests.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -562,6 +562,15 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 			executionTimeoutMin = 20
 			// Do not fail on non-zero exit code to permit passing builds with muted tests.
 			nonZeroExitCode = false
+			failOnMetricChange {
+				metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+				threshold = 50
+				units = BuildFailureOnMetric.MetricUnit.PERCENTS
+				comparison = BuildFailureOnMetric.MetricComparison.LESS
+				compareTo = build {
+					buildRule = lastSuccessful()
+				}
+			}
 		}
 
 		dependencies {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -560,6 +560,8 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 
 		failureConditions {
 			executionTimeoutMin = 20
+			// Do not fail on non-zero exit code to permit passing builds with muted tests.
+			nonZeroExitCode = false
 		}
 
 		dependencies {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes TeamCity tests not fail if a non-zero exit code is returned by the test runner.

This change is to support active muting of flakey tests. 

Closes #57401.
