### PR TITLE
Home: Show the estimates before the click on mobile

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -265,6 +265,7 @@ const SiteSetupList = ( {
 									isCurrent={
 										useAccordionLayout ? isCurrent && showAccordionSelectedTask : isCurrent
 									}
+									timing={ enhancedTask.timing }
 									onClick={
 										useAccordionLayout && isCurrent && showAccordionSelectedTask
 											? () => {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -4,7 +4,15 @@ import { translate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useAccordionLayout } ) => {
+const NavItem = ( {
+	text,
+	taskId,
+	isCompleted,
+	isCurrent,
+	onClick,
+	useAccordionLayout,
+	timing,
+} ) => {
 	const dispatch = useDispatch();
 
 	const trackExpand = () =>
@@ -46,11 +54,22 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useAccordionL
 				<h6>{ text }</h6>
 			</div>
 			{ useAccordionLayout && (
-				<Gridicon
-					className="nav-item__chevron"
-					icon={ isCurrent ? 'chevron-up' : 'chevron-down' }
-					size={ 18 }
-				/>
+				<div className="nav-item__end">
+					{ ! isCompleted && (
+						<div className="nav-item__task-timing task__timing">
+							<Gridicon icon="time" size={ 18 } />
+							{ translate( '%d min', '%d mins', {
+								count: timing,
+								args: [ timing ],
+							} ) }
+						</div>
+					) }
+					<Gridicon
+						className="nav-item__chevron"
+						icon={ isCurrent ? 'chevron-up' : 'chevron-down' }
+						size={ 18 }
+					/>
+				</div>
 			) }
 		</button>
 	);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -187,8 +187,11 @@
 .nav-item__task-timing {
 	line-height: 12px;
 	position: relative;
-	padding-left: 24px;
+	padding-left: 26px;
 	padding-right: 8px;
+	min-width: 52px;
+	text-align: left;
+	font-weight: 400;
 
 	.gridicon {
 		top: -2px;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -185,7 +185,7 @@
 }
 
 .nav-item__task-timing {
-	line-height: 12px;
+	line-height: 18px;
 	position: relative;
 	padding-left: 26px;
 	padding-right: 8px;
@@ -194,7 +194,7 @@
 	font-weight: 400;
 
 	.gridicon {
-		top: -2px;
+		top: 0;
 		position: absolute;
 		width: 24px;
 		left: 0;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -143,8 +143,9 @@
 		line-height: 20px;
 	}
 
-	.nav-item__chevron {
+	.nav-item__end {
 		margin-left: auto;
+		display: flex;
 	}
 
 	.site-setup-list__nav-back {
@@ -181,4 +182,25 @@
 
 .customer-home__main .site-setup-list .card-heading {
 	margin-bottom: 0;
+}
+
+.nav-item__task-timing {
+	line-height: 12px;
+	position: relative;
+	padding-left: 24px;
+	padding-right: 8px;
+
+	.gridicon {
+		top: -2px;
+		position: absolute;
+		width: 24px;
+		left: 0;
+	}
+}
+
+.site-setup-list__task-timing {
+	display: none;
+	@include break-large {
+		display: block;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Move the duration of a task to the in the same line as the task name. So that we users can decide that to do better that are on smaller devices. 

Before: 
<img width="300" src="https://user-images.githubusercontent.com/115071/139356034-78d31836-ad68-4614-93f2-2e17bf426d74.png" />

<img width="300" src="https://user-images.githubusercontent.com/115071/139356040-ad484e93-ffd4-4918-8686-089910e00b5d.png" />
After:

<img width="300" src="https://user-images.githubusercontent.com/115071/139355860-4b03861d-e04c-472c-bd6f-f8a8ba4fabe2.png" />

<img width="300" src="https://user-images.githubusercontent.com/115071/139355851-35c92e9c-e141-4591-a6fd-b136df98bd5d.png" />

#### Testing instructions

Load this PR and visit the home dashboard. 
* Do you see the duration estimate as expected?
* The duration estimate should stay the same on larger screens. 

Related to https://github.com/Automattic/wp-calypso/issues/57463
