### PR TITLE
Disabled Spellcheck for usernames during account closure

### DIFF
--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -154,7 +154,7 @@ class AccountCloseConfirmDialog extends Component {
 							value={ this.state.inputValue }
 							aria-required="true"
 							id="confirmAccountCloseInput"
-							spellcheck="false"
+							spellCheck={ false }
 						/>
 					</>
 				) }

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -154,6 +154,7 @@ class AccountCloseConfirmDialog extends Component {
 							value={ this.state.inputValue }
 							aria-required="true"
 							id="confirmAccountCloseInput"
+							spellcheck="false"
 						/>
 					</>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disable Spelling check on username when entered during the final step of Account closure in safari 14.1.2:

![](https://d.pr/i/5i2f0c+)
[Direct Link](https://d.pr/i/5i2f0c+)

#### Testing instructions

1. Goto [this page](https://wordpress.com/me/account/close) for closing account and in the final step enter the username for confirmation in safari 14.1.2
2. You will notice that safari autocorrects the username for spelling
3. I have disabled the spellcheck [like this](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck) for the `FormTextInput` component


Related to #55563
Request review from @tyxla 
