### PR TITLE
[PAUSED] Onboarding: Remove some of illustrations

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
@@ -3,7 +3,6 @@ import { useState } from '@wordpress/element';
 import { doAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import NuxModal from '../nux-modal';
-import draftPostImage from './images/draft-post.svg';
 import './style.scss';
 
 const DraftPostModal = () => {
@@ -20,7 +19,6 @@ const DraftPostModal = () => {
 				'It’s time to flex those writing muscles and start drafting your first post!',
 				'full-site-editing'
 			) }
-			imageSrc={ draftPostImage }
 			actionButtons={
 				<>
 					<Button isPrimary onClick={ closeModal }>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/index.tsx
@@ -8,7 +8,7 @@ interface Props {
 	className?: string;
 	title: string;
 	description: string;
-	imageSrc: string;
+	imageSrc?: string;
 	actionButtons: React.ReactElement;
 	onRequestClose: () => void;
 }
@@ -33,9 +33,11 @@ const NuxModal: React.FC< Props > = ( {
 			title=""
 			onRequestClose={ onRequestClose }
 		>
-			<div className="wpcom-block-editor-nux-modal__image-container">
-				<img src={ imageSrc } alt={ title } />
-			</div>
+			{ imageSrc && (
+				<div className="wpcom-block-editor-nux-modal__image-container">
+					<img src={ imageSrc } alt={ title } />
+				</div>
+			) }
 			<h1 className="wpcom-block-editor-nux-modal__title">{ title }</h1>
 			<p className="wpcom-block-editor-nux-modal__description">{ description }</p>
 			<div className="wpcom-block-editor-nux-modal__buttons">{ actionButtons }</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/style.scss
@@ -34,17 +34,18 @@
 	.wpcom-block-editor-nux-modal__image-container {
 		display: flex;
 		justify-content: center;
+		margin-bottom: 34px;
+
+		@include break-mobile {
+			margin-bottom: 24px;
+		}
 	}
 
 	.wpcom-block-editor-nux-modal__title {
-		margin: 34px 0 0;
+		margin: 0;
 		font-size: $font-headline-small;
 		font-weight: 500; // stylelint-disable-line scales/font-weights
 		line-height: 1.2;
-
-		@include break-mobile {
-			margin-top: 24px;
-		}
 	}
 
 	.wpcom-block-editor-nux-modal__description {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import NuxModal from '../nux-modal';
-import postPublishedImage from './images/post-published.svg';
 import './style.scss';
 
 /**
@@ -64,7 +63,6 @@ const PostPublishedModal: React.FC = () => {
 				'Congratulations! You did it. View your post to see how it will look on your site.',
 				'full-site-editing'
 			) }
-			imageSrc={ postPublishedImage }
 			actionButtons={
 				<Button isPrimary href={ link }>
 					{ __( 'View Post', 'full-site-editing' ) }

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -45,7 +44,6 @@ export default function IntentStep( props: Props ): React.ReactNode {
 		<StepWrapper
 			headerText={ headerText }
 			fallbackHeaderText={ headerText }
-			headerImageUrl={ intentImageUrl }
 			subHeaderText={ subHeaderText }
 			fallbackSubHeaderText={ subHeaderText }
 			stepContent={ <IntentScreen onSelect={ submitIntent } /> }

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import siteOptionsImage from 'calypso/assets/images/onboarding/site-options.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -42,7 +41,6 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 			fallbackHeaderText={ headerText }
 			subHeaderText={ '' }
 			fallbackSubHeaderText={ '' }
-			headerImageUrl={ siteOptionsImage }
 			stepContent={
 				<SiteOptions
 					defaultSiteTitle={ siteTitle }

--- a/client/signup/steps/starting-point/index.tsx
+++ b/client/signup/steps/starting-point/index.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import startingPointImageUrl from 'calypso/assets/images/onboarding/starting-point.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -50,7 +49,6 @@ export default function StartingPointStep( props: Props ): React.ReactNode {
 			{ ...props }
 			headerText={ headerText }
 			fallbackHeaderText={ headerText }
-			headerImageUrl={ startingPointImageUrl }
 			subHeaderText={ subHeaderText }
 			fallbackSubHeaderText={ subHeaderText }
 			stepContent={ <StartingPoint onSelect={ submitStartingPoint } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove illustrations temporarily according to the request

![image](https://user-images.githubusercontent.com/13596067/139397055-620ca0fd-e049-45da-b1d3-a4a09fa910ad.png)

![image](https://user-images.githubusercontent.com/13596067/139397088-8855e89e-d5ea-4a25-a1b4-484af65238e0.png)

![image](https://user-images.githubusercontent.com/13596067/139397120-d833e545-d50c-4268-ab1e-f7c8823894d5.png)

![image](https://user-images.githubusercontent.com/13596067/139396915-b75a5c0c-4897-44f9-a313-3150cb639d53.png)

![image](https://user-images.githubusercontent.com/13596067/139396989-8d59fbfd-08e4-4714-9c42-28db60e6556d.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open another terminal and run `cd apps/editing-toolkit && yarn dev --sync`
* Go to `/start?flags=signup/hero-flow`
* Complete signup flow
* Complete hero flow with the following options and check illustrations don't appear
  * Select write intent
  * Fill out site title and tagline
  * Select choose a design as starting point
* Land on the editor and check illustrations don't appear on the draft post modal
* Publish post and check illustrations don't appear on the first post published modal

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57458
