### PR TITLE
Onboarding: Update Jetpack logo image and text in magic signup onboar…

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -109,6 +109,7 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 							emailAddress,
 						},
 					} ),
+					'...',
 				] }
 			</h3>
 		</EmptyContent>

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -2,8 +2,8 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import JetpackConnected from 'calypso/assets/images/jetpack/connected.svg';
 import EmptyContent from 'calypso/components/empty-content';
+import JetpackLogo from 'calypso/components/jetpack-logo';
 import { login } from 'calypso/lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { rebootAfterLogin } from 'calypso/state/login/actions';
@@ -96,20 +96,22 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 	dispatch( recordTracksEvent( 'calypso_login_email_link_handle_click_view' ) );
 
 	return (
-		<EmptyContent
-			className="magic-login__handle-link jetpack"
-			illustration={ JetpackConnected }
-			illustrationWidth={ 150 }
-			title={ translate( 'Welcome back!' ) }
-			line={ [
-				translate( 'Logging in as %(emailAddress)s', {
-					args: {
-						emailAddress,
-					},
-				} ),
-				'...',
-			] }
-		/>
+		<EmptyContent className="magic-login__handle-link jetpack" title={ null } illustration={ null }>
+			<JetpackLogo size={ 74 } full />
+
+			<h2 className="magic-login__title empty-content__title">
+				{ translate( 'Email confirmed!' ) }
+			</h2>
+			<h3 className="magic-login__line empty-content__line">
+				{ [
+					translate( 'Logging in as %(emailAddress)s', {
+						args: {
+							emailAddress,
+						},
+					} ),
+				] }
+			</h3>
+		</EmptyContent>
 	);
 };
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -21,8 +21,8 @@
 }
 
 .magic-login__handle-link.jetpack {
-	img {
-		margin: 80px 0;
+	.jetpack-logo {
+		margin: 35px 0;
 	}
 }
 


### PR DESCRIPTION
### Changes 

- This PR will update the existing image and title in the onboarding screen of the magic link signup flow. The existing image doesn't bring any context for new customers, and the "Welcome back!" copy is not used correctly in this context since it's the first time user sees that specific flow.
- This update is addressed here: 1164141197617539-as-1201188735226273

### Testing Instructions

1. Checkout this PR
2. Run `yarn start`
3. Create a Jurassic Ninja website. 
4. Open an incognito window and continue with the next steps from there.
5. Login to your website and Initiate Jetpack's setup flow from there.
6. Enter an email address you have access to, but also this email must not be associated with any WP.com account. (_Hint: The `youremail+something@...` pattern would be good for this case._)
7. Open your inbox and find the "Create WordPress.com account" email you should have been received.
8. Copy the "Finish your Jetpack" button URL as otherwise you'll be redirected to WP.com.
9. Examine the URL and copy the value of the `&redirect_to` GET parameter.
10. Open DevTools of your browser and type: `copy(decodeURIComponent('THE_URL_YOU_JUST_COPIED'));`
11. In your clipboard, you'll have the correct URL for the flow, and now you can replace `wordpress.com` with `calypso.localhost`
12. As you'll be redirected to another page real quick, here's a quick and dirty way to prevent it, by adding `return;` [here](https://github.com/Automattic/wp-calypso/blob/update/magic-login-signup-welcome-screen/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx#L82), **but don't forget to remove it after your test!**
13. Verify that the full Jetpack logo is displayed with the "Email confirmed!" text.


### Implementation Details

- In this case, we cannot use the `illustration` property, because its value will be set as `src` to the image in the `EmptyContent` component. The `JetpackLogo` will return an actual SVG and that wouldn't work.
- In the current implementation, we're still using the `EmptyContent` mostly because of available CSS styles, as this flow should be visually consistent with similar ones.