### PR TITLE
Spoiler block: Add keywords for discoverability

### DIFF
--- a/apps/o2-blocks/src/spoiler/editor.jsx
+++ b/apps/o2-blocks/src/spoiler/editor.jsx
@@ -86,7 +86,7 @@ registerBlockType( 'a8c/spoiler', {
 	icon: 'warning',
 	category: 'a8c',
 	description: __( 'Hide content until the reader wants to see it.' ),
-	keywords: [ __( 'spoiler' ) ],
+	keywords: [ __( 'spoiler' ), __( 'accordion' ), __( 'dropdown' ) ],
 	attributes: blockAttributes,
 	edit,
 	save,

--- a/apps/o2-blocks/src/spoiler/editor.jsx
+++ b/apps/o2-blocks/src/spoiler/editor.jsx
@@ -86,7 +86,7 @@ registerBlockType( 'a8c/spoiler', {
 	icon: 'warning',
 	category: 'a8c',
 	description: __( 'Hide content until the reader wants to see it.' ),
-	keywords: [ __( 'spoiler' ), __( 'accordion' ), __( 'dropdown' ) ],
+	keywords: [ __( 'spoiler' ), __( 'accordion' ), __( 'Dropdown' ) ],
 	attributes: blockAttributes,
 	edit,
 	save,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds `accordion` and `dropdown` to the discoverable keywords.

This block basically functions as an accordion. Let's improve the discoverability for people looking for such functionality. 

Internal discussion: pb6Nl-e8L-p2#comment-96199

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Sandbox a p2 of your choice 
- Run `install-plugin.sh o2-blocks update/spoiler-block-keywords` in your sandbox
- Edit a post 
- Search for `accordion` and `dropdown` 
- Spoiler block should show up 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->