### PR TITLE
Fix CSS issues in the threat credentials form

### DIFF
--- a/client/components/jetpack/server-credentials-form/style.scss
+++ b/client/components/jetpack/server-credentials-form/style.scss
@@ -10,7 +10,8 @@
 		background: initial;
 	}
 
-	&__buttons {
+	// Making sure .dialog__action-buttons are overwritten
+	&__buttons.dialog__action-buttons {
 		background: var( --studio-gray-0 );
 		margin: 0 -24px;
 		padding: 16px 24px;

--- a/client/components/jetpack/server-credentials-wizard-dialog/style.scss
+++ b/client/components/jetpack/server-credentials-wizard-dialog/style.scss
@@ -1,4 +1,5 @@
-.dialog.server-credentials-wizard-dialog {
+// Making sure .dialog.card styles are overwritten
+.dialog.card.server-credentials-wizard-dialog {
 	width: 100%;
 
 	@include breakpoint-deprecated( '>660px' ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes some CSS issues in the form that allows a user to enter their site credentials, when fixing a threat.

Fixes 1164141197617539-as-1201087185388869

### Implementation notes

The `ServerCredentialsWizardDialog` component is built upon the more generic `Dialog` component. It overwrites the styles of the latter, however some CSS rules share the same specificity. The styles of `Dialog` are loaded asynchronously, and the order in which styles are applied is not something we can take for granted. In this diff, we update the specificity of some the credentials form styles, so that the visual outcome is consistent across browsers and sessions.

### Testing instructions

#### Prerequisites

- Make sure you have at your disposal a self-hosted Jetpack site, with Scan.
- Server credentials must not be set.
- Introduce a threat in your site.
- Scan your site and make sure the threat has been detected.

#### To reproduce the issue

_Note: the issue seems to appear consistently in Safari. It randomly occurs in Chrome._

- Open Safari.
- Visit `http://jetpack.cloud.localhost:3000/scan/<site>`.
- Click `Auto fix ` threat` to open the server credentials form.
- The footer of the form should look broken, and the modal should take almost the full width of the screen (see capture below).

#### To test the fix

- Repeat the steps above.
- The modal should be narrower and centered in the page. The footer should look like the capture below.

### Screenshots

#### Before

<img width="1274" alt="Screen Shot 2021-10-29 at 9 51 46 AM" src="https://user-images.githubusercontent.com/1620183/139450133-ec539c35-d5c4-4be9-b2f7-82cf793e37ed.png">
#### After

<img width="646" alt="Screen Shot 2021-10-29 at 9 51 56 AM" src="https://user-images.githubusercontent.com/1620183/139450147-694ff796-3225-4741-87f7-adabed1e67a8.png">

