### PR TITLE
Clarify copy in backup restore form

### DIFF
--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -83,7 +83,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			<RewindConfigEditor currentConfig={ rewindConfig } onConfigChange={ setRewindConfig } />
 			<RewindFlowNotice
 				gridicon="notice"
-				title={ translate( 'This will override and remove all content after this point' ) }
+				title={ translate( 'Restoring will override and remove all content after this point.' ) }
 				type={ RewindFlowNoticeLevel.WARNING }
 			/>
 			<Button

--- a/client/my-sites/backup/rewind-flow/rewind-config-editor.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-config-editor.tsx
@@ -42,11 +42,17 @@ const BackupRewindConfigEditor: FunctionComponent< Props > = ( {
 		},
 		{
 			name: 'uploads',
-			label: translate( '{{strong}}Media Uploads{{/strong}}', {
-				components: {
-					strong: <strong />,
-				},
-			} ),
+			label: translate(
+				'{{strong}}Media Uploads{{/strong}} (check {{em}}Site database{{/em}} to ensure uploads are visible in the restored site)',
+				{
+					components: {
+						strong: <strong />,
+						em: <em />,
+					},
+					comment:
+						'"Site database" is another item of the list, at the same level as "Media Uploads"',
+				}
+			),
 		},
 		{
 			name: 'roots',
@@ -72,7 +78,7 @@ const BackupRewindConfigEditor: FunctionComponent< Props > = ( {
 		},
 		{
 			name: 'sqls',
-			label: translate( '{{strong}}Site database{{/strong}} (SQL)', {
+			label: translate( '{{strong}}Site database{{/strong}} (includes pages, and posts)', {
 				components: {
 					strong: <strong />,
 				},

--- a/client/my-sites/backup/rewind-flow/rewind-config-editor.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-config-editor.tsx
@@ -41,20 +41,6 @@ const BackupRewindConfigEditor: FunctionComponent< Props > = ( {
 			} ),
 		},
 		{
-			name: 'uploads',
-			label: translate(
-				'{{strong}}Media Uploads{{/strong}} (check {{em}}Site database{{/em}} to ensure uploads are visible in the restored site)',
-				{
-					components: {
-						strong: <strong />,
-						em: <em />,
-					},
-					comment:
-						'"Site database" is another item of the list, at the same level as "Media Uploads"',
-				}
-			),
-		},
-		{
 			name: 'roots',
 			label: translate(
 				'{{strong}}WordPress root{{/strong}} (includes wp-config php and any non WordPress files)',
@@ -83,6 +69,20 @@ const BackupRewindConfigEditor: FunctionComponent< Props > = ( {
 					strong: <strong />,
 				},
 			} ),
+		},
+		{
+			name: 'uploads',
+			label: translate(
+				'{{strong}}Media Uploads{{/strong}} (you must also select {{em}}Site database{{/em}} for restored media uploads to appear)',
+				{
+					components: {
+						strong: <strong />,
+						em: <em />,
+					},
+					comment:
+						'"Site database" is another item of the list, at the same level as "Media Uploads"',
+				}
+			),
 		},
 	];
 

--- a/client/my-sites/backup/rewind-flow/rewind-config-editor.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-config-editor.tsx
@@ -26,7 +26,7 @@ const BackupRewindConfigEditor: FunctionComponent< Props > = ( {
 	const checkboxes = [
 		{
 			name: 'themes',
-			label: translate( '{{strong}}WordPress Themes{{/strong}}', {
+			label: translate( '{{strong}}WordPress themes{{/strong}}', {
 				components: {
 					strong: <strong />,
 				},
@@ -34,7 +34,7 @@ const BackupRewindConfigEditor: FunctionComponent< Props > = ( {
 		},
 		{
 			name: 'plugins',
-			label: translate( '{{strong}}WordPress Plugins{{/strong}}', {
+			label: translate( '{{strong}}WordPress plugins{{/strong}}', {
 				components: {
 					strong: <strong />,
 				},
@@ -73,7 +73,7 @@ const BackupRewindConfigEditor: FunctionComponent< Props > = ( {
 		{
 			name: 'uploads',
 			label: translate(
-				'{{strong}}Media Uploads{{/strong}} (you must also select {{em}}Site database{{/em}} for restored media uploads to appear)',
+				'{{strong}}Media uploads{{/strong}} (you must also select {{em}}Site database{{/em}} for restored media uploads to appear)',
 				{
 					components: {
 						strong: <strong />,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy in the backup restore form, to bring some clarity about what will be restored.

It was reported in the ticket below that:
- it's not clear what _Site database_ is supposed to include.
- media won't be necessarily be visible in the restored site if _Site database_ is not restored as well.

Fixes 1164141197617539-as-1200871547379447

### Testing instructions

#### Prerequisites

- Make sure you have at your disposal a self-hosted Jetpack site.
- The site must have some backups.
- Server credentials must be entered.

#### Testing

- Run cloud or Calypso.
- Visit the _Backup_ section and select a past backup.
- Click _Restore to this point_.
- You should see the restore form with the updated copy and reorganized items, as shown in the capture below.

### Screenshots

#### Before
<img width="712" alt="Screen Shot 2021-10-29 at 10 39 59 AM" src="https://user-images.githubusercontent.com/1620183/139456932-754cacc7-e5bc-476b-b792-1cbf7d0ba4ca.png">

#### After
<img width="740" alt="Screen Shot 2021-11-15 at 2 53 59 PM" src="https://user-images.githubusercontent.com/1620183/141845350-99f42384-dfde-472a-b065-a3cdb7b0f923.png">

