### PR TITLE
Playwright: use `waitForSelector` to wait for the Welcome Tour modal.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -30,6 +30,5 @@ export class NewPostFlow {
 		await navbarComponent.clickNewPost();
 		const gutenbergEditorPage = new GutenbergEditorPage( this.page );
 		await gutenbergEditorPage.waitUntilLoaded();
-		await gutenbergEditorPage.dismissWelcomeTourIfPresent();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -72,6 +72,8 @@ export class GutenbergEditorPage {
 	 */
 	async waitUntilLoaded(): Promise< Frame > {
 		await this.page.waitForLoadState( 'load' );
+		await this.dismissWelcomeTourIfPresent();
+
 		const frame = await this.getEditorFrame();
 		// Traditionally we try to avoid waits not related to the current flow. However, we need a stable way to identify loading being done.
 		// NetworkIdle takes too long here, so the most reliable alternative is the title being visible.

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -39,7 +39,7 @@ const selectors = {
 	closePublishPanel: 'button[aria-label="Close panel"]',
 
 	// Welcome tour
-	welcomeTourCloseButton: 'button:text("Skip")',
+	welcomeTourCloseButton: 'button[aria-label="Close Tour"]',
 
 	// Block editor sidebar
 	openSidebarButton: 'button[aria-label="Block editor sidebar"]',
@@ -101,7 +101,7 @@ export class GutenbergEditorPage {
 	 */
 	async getEditorFrame(): Promise< Frame > {
 		const elementHandle = await this.page.waitForSelector( selectors.editorFrame, {
-			timeout: 60 * 1000,
+			timeout: 105 * 1000,
 			state: 'attached',
 		} );
 		return ( await elementHandle.contentFrame() ) as Frame;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to make the Welcome tour dismissal more reliable.

Key changes:
- use the `Skip` button instead.
- alter the `dismissWelcomeTourIfPresent` method to use `waitForSelector` with a custom timeout of 5 seconds instead of `isVisible`.

Details:
Intermittently failures are observed due to this modal not being dismissed in the initial loading stages of the iframed editor. 

While testing this locally, I found that `isVisible` was evaluating to `false` and so the welcome tour was not dismissed despite the modal being present on screen. Timing wise, the modal renders last on the screen. When publishing, the modal ends up interfering with the on-screen elements in mobile view, preventing the normal publishing flow from executing.

The proposed solution is to use a `waitForSelector` with a short timeout of 5 seconds to better catch the modal as it loads. The call is wrapped around a `try/catch` block that suppresses the error if `waitForSelector` is not able to locate the modal (eg. if it has already been dismissed previously).

#### Testing instructions

- [ ] normal test
  - [ ] mobile
  - [ ] desktop


Closes #57460.
