### PR TITLE
New Plugin Details page

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -88,6 +88,7 @@ export function getAllowedPluginData( plugin ) {
 		'sections',
 		'slug',
 		'support_URL',
+		'tags',
 		'update',
 		'updating',
 		'version',

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -66,7 +66,7 @@ async function getRequest( url, query ) {
  */
 export function fetchPluginInformation( pluginSlug ) {
 	const query = {
-		fields: 'icons,banners,compatibility,ratings,-contributors',
+		fields: 'short_description,icons,banners,compatibility,ratings,-contributors',
 		locale: getWporgLocaleCode(),
 	};
 

--- a/client/my-sites/marketplace/controller.js
+++ b/client/my-sites/marketplace/controller.js
@@ -6,7 +6,7 @@ import { marketplaceDebugger } from 'calypso/my-sites/marketplace/constants';
 import { getDefaultProductInProductGroup } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 import MarketplaceDomainUpsell from 'calypso/my-sites/marketplace/pages/marketplace-domain-upsell';
 import MarketplacePluginSetup from 'calypso/my-sites/marketplace/pages/marketplace-plugin-setup-status';
-import MarketplacePluginUpload from 'calypso/my-sites/marketplace/pages/marketplace-plugin-upload-status';
+import MarketplacePluginInstall from 'calypso/my-sites/marketplace/pages/marketplace-plugin-upload-status';
 import MarketplacePluginDetails from 'calypso/my-sites/marketplace/pages/marketplace-product-details';
 import MarketplaceTest from 'calypso/my-sites/marketplace/pages/marketplace-test';
 
@@ -43,8 +43,9 @@ export function renderPluginsSetupStatusPage( context, next ) {
 	next();
 }
 
-export function renderPluginsUploadStatusPage( context, next ) {
-	context.primary = <MarketplacePluginUpload />;
+export function renderPluginsInstallPage( context, next ) {
+	const { productSlug } = context.params;
+	context.primary = <MarketplacePluginInstall productSlug={ productSlug } />;
 	next();
 }
 

--- a/client/my-sites/marketplace/index.js
+++ b/client/my-sites/marketplace/index.js
@@ -8,7 +8,7 @@ import {
 	renderMarketplaceTestPage,
 	renderMarketplaceThankYou,
 	renderPluginsSetupStatusPage,
-	renderPluginsUploadStatusPage,
+	renderPluginsInstallPage,
 	redirectToHome,
 } from './controller';
 
@@ -34,9 +34,9 @@ export default function () {
 			clientRender
 		);
 		page(
-			'/marketplace/product/install/:site',
+			'/marketplace/:productSlug?/install/:site?',
 			siteSelection,
-			renderPluginsUploadStatusPage,
+			renderPluginsInstallPage,
 			makeLayout,
 			clientRender
 		);

--- a/client/my-sites/marketplace/index.js
+++ b/client/my-sites/marketplace/index.js
@@ -34,6 +34,13 @@ export default function () {
 			clientRender
 		);
 		page(
+			'/marketplace/product/install/:site?',
+			siteSelection,
+			renderPluginsInstallPage,
+			makeLayout,
+			clientRender
+		);
+		page(
 			'/marketplace/:productSlug?/install/:site?',
 			siteSelection,
 			renderPluginsInstallPage,

--- a/client/my-sites/marketplace/index.js
+++ b/client/my-sites/marketplace/index.js
@@ -34,13 +34,6 @@ export default function () {
 			clientRender
 		);
 		page(
-			'/marketplace/product/install/:site?',
-			siteSelection,
-			renderPluginsInstallPage,
-			makeLayout,
-			clientRender
-		);
-		page(
 			'/marketplace/:productSlug?/install/:site?',
 			siteSelection,
 			renderPluginsInstallPage,

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -88,7 +88,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 	useEffect( () => {
 		if ( pluginActive ) {
 			waitFor( 1 ).then( () =>
-				page( `/marketplace/thank-you/${ installedPlugin?.slug }/${ selectedSiteSlug }` )
+				page.redirect( `/marketplace/thank-you/${ installedPlugin?.slug }/${ selectedSiteSlug }` )
 			);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -12,7 +12,7 @@ import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/prog
 import theme from 'calypso/my-sites/marketplace/theme';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
-import { installPluginSimple, activatePlugin } from 'calypso/state/plugins/installed/actions';
+import { installPlugin, activatePlugin } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite, getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
 import { getPlugin } from 'calypso/state/plugins/wporg/selectors';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
@@ -63,7 +63,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 	useEffect( () => {
 		if ( ! isUploadFlow && currentStep === 0 && wporgPlugin ) {
 			// initialize plugin installing
-			dispatch( installPluginSimple( siteId, wporgPlugin ) );
+			dispatch( installPlugin( siteId, wporgPlugin, false ) );
 			setCurrentStep( 1 );
 		}
 	}, [ isUploadFlow, currentStep, siteId, wporgPlugin, productSlug ] );

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -22,7 +22,11 @@ import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-com
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import './style.scss';
 
-const MarketplacePluginUpload = (): JSX.Element => {
+const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
+	console.log( productSlug );
+	// If `productSlug` is not provided then this should proceed as plugin upload flow
+	// If `productSlug` is provided, we need to install the plugin like is handled here
+	// https://github.com/Automattic/wp-calypso/blob/192bf6b66de62a84b8c70a622de70f218f516610/client/my-sites/plugins/plugin-install-button/index.jsx#L25-L55
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -104,4 +108,4 @@ const MarketplacePluginUpload = (): JSX.Element => {
 	);
 };
 
-export default MarketplacePluginUpload;
+export default MarketplacePluginInstall;

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -62,6 +62,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 		getStatusForPlugin( state, siteId, productSlug )
 	);
 
+	// Upload flow startup
 	useEffect( () => {
 		if ( 100 === pluginUploadProgress ) {
 			// For smaller uploads or fast networks give
@@ -71,6 +72,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 		}
 	}, [ pluginUploadProgress, setCurrentStep ] );
 
+	// Installing plugin flow startup
 	useEffect( () => {
 		if ( ! isUploadFlow && ! initializeInstallFlow && wporgPlugin && selectedSite ) {
 			// const upgradablePlan = isBusiness( selectedSite.plan ) || isEnterprise( selectedSite.plan ) || isEcommerce( selectedSite.plan );
@@ -89,6 +91,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 		}
 	}, [ isUploadFlow, siteId, wporgPlugin, productSlug ] );
 
+	// Validate completition of atomic transfer flow
 	useEffect( () => {
 		if (
 			moveToAtomicFlow &&
@@ -99,6 +102,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 		}
 	}, [ moveToAtomicFlow, automatedTransferStatus ] );
 
+	// Validate plugin is already installed and activate
 	useEffect( () => {
 		if (
 			installedPlugin &&
@@ -116,6 +120,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ pluginUploadComplete, installedPlugin, setCurrentStep ] );
 
+	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
 		if (
 			( installedPlugin && pluginActive ) ||

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -118,11 +118,13 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 
 	useEffect( () => {
 		if (
-			pluginActive ||
+			( installedPlugin && pluginActive ) ||
 			( moveToAtomicFlow && transferStates.COMPLETE === automatedTransferStatus )
 		) {
 			waitFor( 1 ).then( () =>
-				page.redirect( `/marketplace/thank-you/${ installedPlugin?.slug }/${ selectedSiteSlug }` )
+				page.redirect(
+					`/marketplace/thank-you/${ installedPlugin?.slug || productSlug }/${ selectedSiteSlug }`
+				)
 			);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/style.scss
@@ -1,16 +1,15 @@
-.is-section-plugins.has-no-sidebar {
+body.is-section-marketplace.theme-default.color-scheme {
+	--color-surface-backdrop: var( --studio-white );
+}
+
+.is-section-marketplace.has-no-sidebar {
 	.layout__content {
-		background-color: var( --studio-white );
 		height: 100vh;
 		@media ( max-width: 782px ) {
 			padding: 0;
-			background-color: var( --studio-white );
 			height: 100vh;
 			.layout__primary {
 				height: 100vh;
-				.marketplace-domain-upsell__root {
-					height: calc( 100vh - 50px );
-				}
 			}
 		}
 	}

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -31,13 +31,16 @@ function renderSinglePlugin( context, siteUrl ) {
 		prevPath = sectionify( context.prevPath );
 	}
 	// Render single plugin component
-	context.primary = createElement( config.isEnabled( 'marketplace' ) ? SinglePluginComponent : PluginComponent, {
-		path: context.path,
-		prevQuerystring: lastPluginsQuerystring,
-		prevPath,
-		pluginSlug,
-		siteUrl,
-	} );
+	context.primary = createElement(
+		config.isEnabled( 'marketplace' ) ? SinglePluginComponent : PluginComponent,
+		{
+			path: context.path,
+			prevQuerystring: lastPluginsQuerystring,
+			prevPath,
+			pluginSlug,
+			siteUrl,
+		}
+	);
 }
 
 function getPathWithoutSiteSlug( context, site ) {

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { includes, some } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';
@@ -12,7 +13,6 @@ import PluginEligibility from './plugin-eligibility';
 import PluginUpload from './plugin-upload';
 import PluginBrowser from './plugins-browser';
 import SinglePluginComponent from './single-plugin';
-import config from '@automattic/calypso-config';
 /**
  * Module variables
  */

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -7,10 +7,12 @@ import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-select
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
+import PluginComponent from './plugin';
 import PluginEligibility from './plugin-eligibility';
 import PluginUpload from './plugin-upload';
 import PluginBrowser from './plugins-browser';
 import SinglePluginComponent from './single-plugin';
+import config from '@automattic/calypso-config';
 /**
  * Module variables
  */
@@ -29,8 +31,7 @@ function renderSinglePlugin( context, siteUrl ) {
 		prevPath = sectionify( context.prevPath );
 	}
 	// Render single plugin component
-	context.primary = createElement( SinglePluginComponent, {
-		// TODO: add a feature flag check
+	context.primary = createElement( config.isEnabled( 'marketplace' ) ? SinglePluginComponent : PluginComponent, {
 		path: context.path,
 		prevQuerystring: lastPluginsQuerystring,
 		prevPath,

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -7,10 +7,10 @@ import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-select
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
-import PluginComponent from './plugin';
 import PluginEligibility from './plugin-eligibility';
 import PluginUpload from './plugin-upload';
 import PluginBrowser from './plugins-browser';
+import SinglePluginComponent from './single-plugin';
 /**
  * Module variables
  */
@@ -28,9 +28,9 @@ function renderSinglePlugin( context, siteUrl ) {
 	} else if ( context.prevPath ) {
 		prevPath = sectionify( context.prevPath );
 	}
-
 	// Render single plugin component
-	context.primary = createElement( PluginComponent, {
+	context.primary = createElement( SinglePluginComponent, {
+		// TODO: add a feature flag check
 		path: context.path,
 		prevQuerystring: lastPluginsQuerystring,
 		prevPath,

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -9,10 +9,10 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
 import PluginComponent from './plugin';
+import PluginDetails from './plugin-details';
 import PluginEligibility from './plugin-eligibility';
 import PluginUpload from './plugin-upload';
 import PluginBrowser from './plugins-browser';
-import PluginDetails from './single-plugin';
 /**
  * Module variables
  */

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -12,7 +12,7 @@ import PluginComponent from './plugin';
 import PluginEligibility from './plugin-eligibility';
 import PluginUpload from './plugin-upload';
 import PluginBrowser from './plugins-browser';
-import SinglePluginComponent from './single-plugin';
+import PluginDetails from './single-plugin';
 /**
  * Module variables
  */
@@ -32,7 +32,7 @@ function renderSinglePlugin( context, siteUrl ) {
 	}
 	// Render single plugin component
 	context.primary = createElement(
-		config.isEnabled( 'marketplace' ) ? SinglePluginComponent : PluginComponent,
+		config.isEnabled( 'marketplace' ) ? PluginDetails : PluginComponent,
 		{
 			path: context.path,
 			prevQuerystring: lastPluginsQuerystring,

--- a/client/my-sites/plugins/grid-mixins.scss
+++ b/client/my-sites/plugins/grid-mixins.scss
@@ -1,0 +1,20 @@
+@mixin display-grid {
+	display: -ms-grid;
+	display: grid;
+}
+@mixin grid-template-columns( $cols, $gap, $fr ) {
+	-ms-grid-columns: $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap
+		$fr $gap $fr $gap $fr;
+	grid-template-columns: repeat( $cols, [col-start] minmax( 0, $fr ) );
+	grid-column-gap: $gap;
+}
+@mixin grid-row( $row-start, $span ) {
+	-ms-grid-row: $row-start;
+	-ms-grid-row-span: $span;
+	grid-row: $row-start / span $span;
+}
+@mixin grid-column( $col-start, $span ) {
+	-ms-grid-column: $col-start * 2 - 1;
+	-ms-grid-column-span: $span + ( $span - 1 );
+	grid-column: $col-start / span $span;
+}

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -180,33 +180,30 @@ function PluginDetails( props ) {
 								{ fullPlugin.short_description || fullPlugin.description }
 							</div>
 							<div className="plugin-details__additional-info">
-								<table>
-									<thead>
-										<tr>
-											<th>{ translate( 'Developer' ) }</th>
-											<th>{ translate( 'Ratings' ) }</th>
-											<th>{ translate( 'Last updated' ) }</th>
-											<th>{ translate( 'Version' ) }</th>
-										</tr>
-									</thead>
-
-									<tbody>
-										<tr>
-											<td>
-												<a href={ fullPlugin.author_url }>{ fullPlugin.author_name }</a>
-											</td>
-											<td>
-												<Rating rating={ fullPlugin.rating } />
-											</td>
-											<td>
-												{ moment
-													.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' )
-													.format( 'YYYY-MM-DD' ) }
-											</td>
-											<td>{ fullPlugin.version }</td>
-										</tr>
-									</tbody>
-								</table>
+								<div className="plugin-details__info">
+									<div className="plugin-details__info-title">{ translate( 'Developer' ) }</div>
+									<div className="plugin-details__info-value">
+										<a href={ fullPlugin.author_url }>{ fullPlugin.author_name }</a>
+									</div>
+								</div>
+								<div className="plugin-details__info">
+									<div className="plugin-details__info-title">{ translate( 'Ratings' ) }</div>
+									<div className="plugin-details__info-value">
+										<Rating rating={ fullPlugin.rating } />
+									</div>
+								</div>
+								<div className="plugin-details__info">
+									<div className="plugin-details__info-title">{ translate( 'Last updated' ) }</div>
+									<div className="plugin-details__info-value">
+										{ moment
+											.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' )
+											.format( 'YYYY-MM-DD' ) }
+									</div>
+								</div>
+								<div className="plugin-details__info">
+									<div className="plugin-details__info-title">{ translate( 'Version' ) }</div>
+									<div className="plugin-details__info-value">{ fullPlugin.version }</div>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -86,6 +86,10 @@ function PluginDetails( props ) {
 		...wporgPlugin,
 	};
 
+	const tags = Object.values( fullPlugin?.tags || {} )
+		.slice( 0, 3 )
+		.join( ' · ' );
+
 	useEffect( () => {
 		if ( ! isFetched ) {
 			dispatch( wporgFetchPluginData( props.pluginSlug ) );
@@ -170,8 +174,11 @@ function PluginDetails( props ) {
 						) }
 					>
 						<div className="plugin-details__header">
+							<div className="plugin-details__tags">{ tags }</div>
 							<div className="plugin-details__name">{ fullPlugin.name }</div>
-							<div className="plugin-details__description">{ fullPlugin.description }</div>
+							<div className="plugin-details__description">
+								{ fullPlugin.short_description || fullPlugin.description }
+							</div>
 							<div className="plugin-details__additional-info">
 								<table>
 									<thead>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -236,13 +236,11 @@ function PluginDetails( props ) {
 					</div>
 				</div>
 
-				<div className="plugin-details__sites-list">
-					<SitesList
-						fullPlugin={ fullPlugin }
-						isPluginInstalledOnsite={ isPluginInstalledOnsite }
-						{ ...props }
-					/>
-				</div>
+				<SitesList
+					fullPlugin={ fullPlugin }
+					isPluginInstalledOnsite={ isPluginInstalledOnsite }
+					{ ...props }
+				/>
 
 				<div className="plugin-details__layout plugin-details__body">
 					<div className="plugin-details__layout-col plugin-details__layout-col-left">
@@ -372,23 +370,12 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 		return null;
 	}
 
-	if ( props.siteUrl && isPluginInstalledOnsite ) {
-		<PluginSiteList
-			className="plugin-details__installed-on"
-			title={ translate( 'Installed on', {
-				comment: 'header for list of sites a plugin is installed on',
-			} ) }
-			sites={ sites }
-			plugin={ plugin }
-		/>;
-	}
-
 	const notInstalledSites = sitesWithoutPlugin.map( ( siteId ) =>
 		sites.find( ( site ) => site.ID === siteId )
 	);
 
 	return (
-		<div>
+		<div className="plugin-details__sites-list">
 			<PluginSiteList
 				className="plugin-details__installed-on"
 				title={ translate( 'Installed on', {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -59,15 +59,13 @@ function PluginDetails( props ) {
 	const wporgPlugin = useSelector( ( state ) => getWporgPlugin( state, props.pluginSlug ) );
 	const isFetching = useSelector( ( state ) => isWporgPluginFetching( state, props.pluginSlug ) );
 	const isFetched = useSelector( ( state ) => isWporgPluginFetched( state, props.pluginSlug ) );
-	const isJetpackSite = useSelector(
-		( state ) => selectedSite?.ID && checkJetpackSite( state, selectedSite?.ID )
-	);
+	const isJetpackSite = useSelector( ( state ) => checkJetpackSite( state, selectedSite?.ID ) );
 	const isRequestingSites = useSelector( checkRequestingSites );
 	const requestingPluginsForSites = useSelector( ( state ) =>
 		isRequestingForSites( state, siteIds )
 	);
-	const sitePlugin = useSelector(
-		( state ) => selectedSite?.ID && getPluginOnSite( state, selectedSite?.ID, props.pluginSlug )
+	const sitePlugin = useSelector( ( state ) =>
+		getPluginOnSite( state, selectedSite?.ID, props.pluginSlug )
 	);
 	const userCanManagePlugins = useSelector( ( state ) =>
 		selectedSite?.ID

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -46,7 +46,7 @@ import {
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
 
-function SinglePlugin( props ) {
+function PluginDetails( props ) {
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
@@ -154,27 +154,32 @@ function SinglePlugin( props ) {
 			<FixedNavigationHeader navigationItems={ getNavigationItems() } />
 			<PluginNotices pluginId={ fullPlugin.id } sites={ sites } plugins={ [ fullPlugin ] } />
 
-			<div className="single-plugin__page">
-				<div className="single-plugin__layout single-plugin__top-section">
+			<div className="plugin-details__page">
+				<div className="plugin-details__layout plugin-details__top-section">
 					<div
-						className={ classNames( 'single-plugin__layout-col', 'single-plugin__layout-col-left', {
-							'no-cta ': ! shouldDisplayCTA(
-								selectedSite,
-								props.pluginSlug,
-								isPluginInstalledOnsite
-							),
-						} ) }
+						className={ classNames(
+							'plugin-details__layout-col',
+							'plugin-details__layout-col-left',
+							{
+								'no-cta ': ! shouldDisplayCTA(
+									selectedSite,
+									props.pluginSlug,
+									isPluginInstalledOnsite
+								),
+							}
+						) }
 					>
-						<div className="single-plugin__header">
-							<div className="single-plugin__name">{ fullPlugin.name }</div>
-							<div className="single-plugin__description">{ fullPlugin.description }</div>
-							<div className="single-plugin__additional-info">
+						<div className="plugin-details__header">
+							<div className="plugin-details__name">{ fullPlugin.name }</div>
+							<div className="plugin-details__description">{ fullPlugin.description }</div>
+							<div className="plugin-details__additional-info">
 								<table>
 									<thead>
 										<tr>
 											<th>{ translate( 'Developer' ) }</th>
 											<th>{ translate( 'Ratings' ) }</th>
 											<th>{ translate( 'Last updated' ) }</th>
+											<th>{ translate( 'Version' ) }</th>
 										</tr>
 									</thead>
 
@@ -191,6 +196,7 @@ function SinglePlugin( props ) {
 													.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' )
 													.format( 'YYYY-MM-DD' ) }
 											</td>
+											<td>{ fullPlugin.version }</td>
 										</tr>
 									</tbody>
 								</table>
@@ -199,8 +205,8 @@ function SinglePlugin( props ) {
 					</div>
 					<div
 						className={ classNames(
-							'single-plugin__layout-col',
-							'single-plugin__layout-col-right',
+							'plugin-details__layout-col',
+							'plugin-details__layout-col-right',
 							{
 								'no-cta': ! shouldDisplayCTA(
 									selectedSite,
@@ -210,15 +216,15 @@ function SinglePlugin( props ) {
 							}
 						) }
 					>
-						<div className="single-plugin__header">
-							<div className="single-plugin__price">{ translate( 'Free' ) }</div>
-							<div className="single-plugin__install">
+						<div className="plugin-details__header">
+							<div className="plugin-details__price">{ translate( 'Free' ) }</div>
+							<div className="plugin-details__install">
 								<CTA
 									slug={ props.pluginSlug }
 									isPluginInstalledOnsite={ isPluginInstalledOnsite }
 								/>
 							</div>
-							<div className="single-plugin__t-and-c">
+							<div className="plugin-details__t-and-c">
 								{ translate(
 									'By installing, you agree to WordPress.com’s Terms of Service and the Third-Party plug-in Terms.'
 								) }
@@ -227,7 +233,7 @@ function SinglePlugin( props ) {
 					</div>
 				</div>
 
-				<div className="single-plugin__sites-list">
+				<div className="plugin-details__sites-list">
 					<SitesList
 						fullPlugin={ fullPlugin }
 						isPluginInstalledOnsite={ isPluginInstalledOnsite }
@@ -235,11 +241,11 @@ function SinglePlugin( props ) {
 					/>
 				</div>
 
-				<div className="single-plugin__layout single-plugin__body">
-					<div className="single-plugin__layout-col single-plugin__layout-col-left">
+				<div className="plugin-details__layout plugin-details__body">
+					<div className="plugin-details__layout-col plugin-details__layout-col-left">
 						{ fullPlugin.wporg ? (
 							<PluginSections
-								className="single-plugin__plugins-sections"
+								className="plugin-details__plugins-sections"
 								plugin={ fullPlugin }
 								isWpcom={ isWpcom }
 								addBanner
@@ -249,28 +255,24 @@ function SinglePlugin( props ) {
 							<PluginSectionsCustom plugin={ fullPlugin } />
 						) }
 					</div>
-					<div className="single-plugin__layout-col single-plugin__layout-col-right">
-						<div className="single-plugin__plugin-details-title">
+					<div className="plugin-details__layout-col plugin-details__layout-col-right">
+						<div className="plugin-details__plugin-details-title">
 							{ translate( 'Plugin details' ) }
 						</div>
-						<div className="single-plugin__plugin-details-content">
-							<div className="single-plugin__downloads">
-								<div className="single-plugin__downloads-text title">
+						<div className="plugin-details__plugin-details-content">
+							<div className="plugin-details__downloads">
+								<div className="plugin-details__downloads-text title">
 									{ translate( 'Downloads' ) }
 								</div>
-								<div className="single-plugin__downloads-value value">
+								<div className="plugin-details__downloads-value value">
 									{ formatNumberCompact( fullPlugin.downloaded, 'en' ) }
 								</div>
 							</div>
-							<div className="single-plugin__version">
-								<div className="single-plugin__version-text title">{ translate( 'Version' ) }</div>
-								<div className="single-plugin__version-value value">{ fullPlugin.version }</div>
-							</div>
-							<div className="single-plugin__tested">
-								<div className="single-plugin__tested-text title">
+							<div className="plugin-details__tested">
+								<div className="plugin-details__tested-text title">
 									{ translate( 'Tested up to' ) }
 								</div>
-								<div className="single-plugin__tested-value value">{ fullPlugin.version }</div>
+								<div className="plugin-details__tested-value value">{ fullPlugin.version }</div>
 							</div>
 						</div>
 					</div>
@@ -306,7 +308,7 @@ function CTA( { slug, isPluginInstalledOnsite } ) {
 	);
 	return (
 		<Button
-			className="single-plugin__install-button"
+			className="plugin-details__install-button"
 			onClick={ () =>
 				onClickInstallPlugin( {
 					dispatch,
@@ -375,7 +377,7 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 
 	if ( props.siteUrl && isPluginInstalledOnsite ) {
 		<PluginSiteList
-			className="single-plugin__installed-on"
+			className="plugin-details__installed-on"
 			title={ translate( 'Installed on', {
 				comment: 'header for list of sites a plugin is installed on',
 			} ) }
@@ -391,7 +393,7 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 	return (
 		<div>
 			<PluginSiteList
-				className="single-plugin__installed-on"
+				className="plugin-details__installed-on"
 				title={ translate( 'Installed on', {
 					comment: 'header for list of sites a plugin is installed on',
 				} ) }
@@ -400,7 +402,7 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 			/>
 			{ plugin.wporg && (
 				<PluginSiteList
-					className="single-plugin__not-installed-on"
+					className="plugin-details__not-installed-on"
 					title={ translate( 'Available sites', {
 						comment: 'header for list of sites a plugin can be installed on',
 					} ) }
@@ -435,4 +437,4 @@ function PluginPlaceholder() {
 	return <MainComponent wideLayout>{ /* TODO: Create Placeholder */ }</MainComponent>;
 }
 
-export default SinglePlugin;
+export default PluginDetails;

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -60,18 +60,18 @@ function PluginDetails( props ) {
 	const isFetching = useSelector( ( state ) => isWporgPluginFetching( state, props.pluginSlug ) );
 	const isFetched = useSelector( ( state ) => isWporgPluginFetched( state, props.pluginSlug ) );
 	const isJetpackSite = useSelector(
-		( state ) => selectedSite.ID && checkJetpackSite( state, selectedSite.ID )
+		( state ) => selectedSite?.ID && checkJetpackSite( state, selectedSite?.ID )
 	);
 	const isRequestingSites = useSelector( checkRequestingSites );
 	const requestingPluginsForSites = useSelector( ( state ) =>
 		isRequestingForSites( state, siteIds )
 	);
 	const sitePlugin = useSelector(
-		( state ) => selectedSite.ID && getPluginOnSite( state, selectedSite.ID, props.pluginSlug )
+		( state ) => selectedSite?.ID && getPluginOnSite( state, selectedSite?.ID, props.pluginSlug )
 	);
 	const userCanManagePlugins = useSelector( ( state ) =>
-		selectedSite.ID
-			? canCurrentUser( state, selectedSite.ID, 'manage_options' )
+		selectedSite?.ID
+			? canCurrentUser( state, selectedSite?.ID, 'manage_options' )
 			: canCurrentUserManagePlugins( state )
 	);
 
@@ -298,7 +298,7 @@ function CTA( { slug, isPluginInstalledOnsite } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
-	const isJetpack = useSelector( ( state ) => checkJetpackSite( state, selectedSite.ID ) );
+	const isJetpack = useSelector( ( state ) => checkJetpackSite( state, selectedSite?.ID ) );
 
 	if ( ! shouldDisplayCTA( selectedSite, slug, isPluginInstalledOnsite ) ) {
 		return null;
@@ -333,7 +333,7 @@ function onClickInstallPlugin( { dispatch, selectedSite, slug, upgradeAndInstall
 	dispatch( recordGoogleEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', slug ) );
 	dispatch(
 		recordGoogleEvent( 'calypso_plugin_install_click_from_plugin_info', {
-			site: selectedSite.ID,
+			site: selectedSite?.ID,
 			plugin: slug,
 		} )
 	);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -93,7 +93,7 @@ function PluginDetails( props ) {
 		if ( ! isFetched ) {
 			dispatch( wporgFetchPluginData( props.pluginSlug ) );
 		}
-	}, [ isFetched ] );
+	}, [ isFetched, props.pluginSlug, dispatch ] );
 
 	const existingPlugin = useMemo( () => {
 		if ( isFetching || ! isFetched ) {

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -197,7 +197,7 @@ class PluginSections extends Component {
 	};
 
 	renderReadMore = () => {
-		if ( this.props.isWpcom || this.state.descriptionHeight < this._COLLAPSED_DESCRIPTION_HEIGHT ) {
+		if ( this.props.removeReadMore || this.props.isWpcom || this.state.descriptionHeight < this._COLLAPSED_DESCRIPTION_HEIGHT ) {
 			return null;
 		}
 		const button = (
@@ -219,11 +219,40 @@ class PluginSections extends Component {
 		);
 	};
 
-	render() {
+	renderSelectedSection() {
 		const contentClasses = classNames( 'plugin-sections__content', {
-			trimmed: ! this.props.isWpcom && ! this.state.readMore,
+			trimmed: !this.props.removeReadMore && (! this.props.isWpcom && ! this.state.readMore),
 		} );
 
+		if (!this.props.addBanner || this.getSelected() !== 'description') {
+			return <div
+				ref={ this.descriptionContent }
+				className={ contentClasses }
+				// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
+				dangerouslySetInnerHTML={ {
+					__html: this.props.plugin.sections[ this.getSelected() ],
+				} }
+			/>;
+		}
+
+		return <div ref={ this.descriptionContent } className={ contentClasses }>
+			<div className="plugin-sections__banner">
+				<img
+					className="plugin-sections__banner-image"
+					alt={ this.props.plugin.name }
+					src={ this.props.plugin.banners.high || this.props.plugin.banners.low }
+				/>
+			</div>
+			<div
+				// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
+				dangerouslySetInnerHTML={{
+					__html: this.props.plugin.sections[ this.getSelected() ],
+				}}
+			/>
+		</div>;
+	}
+
+	render() {
 		// Defensively check if this plugin has sections. If not, don't render anything.
 		if ( ! this.props.plugin || ! this.props.plugin.sections || ! this.getAvailableSections() ) {
 			return null;
@@ -231,7 +260,7 @@ class PluginSections extends Component {
 
 		/*eslint-disable react/no-danger*/
 		return (
-			<div className="plugin-sections">
+			<div className={ classNames( "plugin-sections", this.props.className )}>
 				<div className="plugin-sections__header">
 					<SectionNav selectedText={ this.getNavTitle( this.getSelected() ) }>
 						<NavTabs>
@@ -251,14 +280,7 @@ class PluginSections extends Component {
 				</div>
 				<Card>
 					{ 'faq' === this.getSelected() && this.props.isWpcom && this.getWpcomSupportContent() }
-					<div
-						ref={ this.descriptionContent }
-						className={ contentClasses }
-						// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
-						dangerouslySetInnerHTML={ {
-							__html: this.props.plugin.sections[ this.getSelected() ],
-						} }
-					/>
+					{ this.renderSelectedSection() }
 					{ this.renderReadMore() }
 				</Card>
 			</div>

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -197,7 +197,11 @@ class PluginSections extends Component {
 	};
 
 	renderReadMore = () => {
-		if ( this.props.removeReadMore || this.props.isWpcom || this.state.descriptionHeight < this._COLLAPSED_DESCRIPTION_HEIGHT ) {
+		if (
+			this.props.removeReadMore ||
+			this.props.isWpcom ||
+			this.state.descriptionHeight < this._COLLAPSED_DESCRIPTION_HEIGHT
+		) {
 			return null;
 		}
 		const button = (
@@ -221,35 +225,41 @@ class PluginSections extends Component {
 
 	renderSelectedSection() {
 		const contentClasses = classNames( 'plugin-sections__content', {
-			trimmed: !this.props.removeReadMore && (! this.props.isWpcom && ! this.state.readMore),
+			trimmed: ! this.props.removeReadMore && ! this.props.isWpcom && ! this.state.readMore,
 		} );
 
-		if (!this.props.addBanner || this.getSelected() !== 'description') {
-			return <div
-				ref={ this.descriptionContent }
-				className={ contentClasses }
-				// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
-				dangerouslySetInnerHTML={ {
-					__html: this.props.plugin.sections[ this.getSelected() ],
-				} }
-			/>;
+		/*eslint-disable react/no-danger*/
+		if ( ! this.props.addBanner || this.getSelected() !== 'description' ) {
+			return (
+				<div
+					ref={ this.descriptionContent }
+					className={ contentClasses }
+					// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
+					dangerouslySetInnerHTML={ {
+						__html: this.props.plugin.sections[ this.getSelected() ],
+					} }
+				/>
+			);
 		}
 
-		return <div ref={ this.descriptionContent } className={ contentClasses }>
-			<div className="plugin-sections__banner">
-				<img
-					className="plugin-sections__banner-image"
-					alt={ this.props.plugin.name }
-					src={ this.props.plugin.banners.high || this.props.plugin.banners.low }
+		return (
+			<div ref={ this.descriptionContent } className={ contentClasses }>
+				<div className="plugin-sections__banner">
+					<img
+						className="plugin-sections__banner-image"
+						alt={ this.props.plugin.name }
+						src={ this.props.plugin.banners.high || this.props.plugin.banners.low }
+					/>
+				</div>
+				<div
+					// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
+					dangerouslySetInnerHTML={ {
+						__html: this.props.plugin.sections[ this.getSelected() ],
+					} }
 				/>
 			</div>
-			<div
-				// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
-				dangerouslySetInnerHTML={{
-					__html: this.props.plugin.sections[ this.getSelected() ],
-				}}
-			/>
-		</div>;
+		);
+		/*eslint-enable react/no-danger*/
 	}
 
 	render() {
@@ -258,9 +268,8 @@ class PluginSections extends Component {
 			return null;
 		}
 
-		/*eslint-disable react/no-danger*/
 		return (
-			<div className={ classNames( "plugin-sections", this.props.className )}>
+			<div className={ classNames( 'plugin-sections', this.props.className ) }>
 				<div className="plugin-sections__header">
 					<SectionNav selectedText={ this.getNavTitle( this.getSelected() ) }>
 						<NavTabs>
@@ -285,7 +294,6 @@ class PluginSections extends Component {
 				</Card>
 			</div>
 		);
-		/*eslint-enable react/no-danger*/
 	}
 }
 

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -227,9 +227,10 @@ class PluginSections extends Component {
 		const contentClasses = classNames( 'plugin-sections__content', {
 			trimmed: ! this.props.removeReadMore && ! this.props.isWpcom && ! this.state.readMore,
 		} );
+		const banner = this.props.plugin.banners.high || this.props.plugin.banners.low;
 
 		/*eslint-disable react/no-danger*/
-		if ( ! this.props.addBanner || this.getSelected() !== 'description' ) {
+		if ( ! this.props.addBanner || ! banner || this.getSelected() !== 'description' ) {
 			return (
 				<div
 					ref={ this.descriptionContent }
@@ -248,7 +249,7 @@ class PluginSections extends Component {
 					<img
 						className="plugin-sections__banner-image"
 						alt={ this.props.plugin.name }
-						src={ this.props.plugin.banners.high || this.props.plugin.banners.low }
+						src={ banner }
 					/>
 				</div>
 				<div

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -125,3 +125,13 @@
 .plugin-sections__header > div {
 	margin-bottom: 0;
 }
+
+.single-plugin__plugins-sections {
+	.card {
+		padding-top: 44px;
+	}
+
+	.plugin-sections__banner {
+		padding-bottom: 50px;
+	}
+}

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -126,7 +126,7 @@
 	margin-bottom: 0;
 }
 
-.single-plugin__plugins-sections {
+.plugin-details__plugins-sections {
 	.card {
 		padding-top: 44px;
 	}

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -58,7 +58,7 @@ class PluginUpload extends Component {
 		}
 
 		if ( config.isEnabled( 'marketplace' ) && nextProps.inProgress ) {
-			page( `/marketplace/product/install/${ nextProps.siteSlug }` );
+			page( `/marketplace/install/${ nextProps.siteSlug }` );
 		}
 
 		const { COMPLETE } = transferStates;

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -189,6 +189,16 @@ function SinglePlugin( props ) {
 						</div>
 					</div>
 				</div>
+
+				<div className="single-plugin__layout single-plugin__body">
+					<div className="single-plugin__layout-col single-plugin__layout-col-left">
+						{ fullPlugin.wporg ? (
+							<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } />
+						) : (
+							<PluginSectionsCustom plugin={ fullPlugin } />
+						) }
+					</div>
+				</div>
 			</div>
 		</MainComponent>
 	);

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
 import { useEffect, useMemo } from 'react';
@@ -42,7 +42,6 @@ import { isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors'
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { Button } from '@automattic/components';
 
 function SinglePlugin( props ) {
 	const {
@@ -65,13 +64,10 @@ function SinglePlugin( props ) {
 		}
 	}, [ isFetched ] );
 
-	const fullPlugin = useMemo( () => {
-		// assign it .org details
-		return {
-			...plugin,
-			...wporgPlugin,
-		};
-	}, [ plugin, wporgPlugin ] );
+	const fullPlugin = {
+		...plugin,
+		...wporgPlugin,
+	};
 
 	const isPluginInstalledOnsite = useMemo( () => {
 		if ( requestingPluginsForSites ) {
@@ -145,7 +141,6 @@ function SinglePlugin( props ) {
 	const isWpcom = selectedSite && ! props.isJetpackSite;
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
 
-	console.log({ fullPlugin });
 	return (
 		<MainComponent wideLayout>
 			<DocumentHead title={ getPageTitle() } />

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -1,0 +1,331 @@
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { includes } from 'lodash';
+import { useEffect, useMemo } from 'react';
+import { connect } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+import EmptyContent from 'calypso/components/empty-content';
+import HeaderCake from 'calypso/components/header-cake';
+import MainComponent from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
+import PluginNotices from 'calypso/my-sites/plugins/notices';
+import PluginMeta from 'calypso/my-sites/plugins/plugin-meta';
+import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
+import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
+import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import getToursHistory from 'calypso/state/guided-tours/selectors/get-tours-history';
+import {
+	getPluginOnSite,
+	getPluginOnSites,
+	getSiteObjectsWithPlugin,
+	getSitesWithoutPlugin,
+	isPluginActionInProgress,
+	isRequestingForSites,
+} from 'calypso/state/plugins/installed/selectors';
+import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
+import {
+	isFetching as isWporgPluginFetching,
+	isFetched as isWporgPluginFetched,
+	getPlugin as getWporgPlugin,
+} from 'calypso/state/plugins/wporg/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
+import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
+import hasNavigated from 'calypso/state/selectors/has-navigated';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import NoPermissionsError from './no-permissions-error';
+
+function SinglePlugin( props ) {
+	const {
+		wporgFetched: isFetched,
+		wporgFetching: isFetching,
+		plugin,
+		wporgPlugin,
+		selectedSite,
+		siteIds,
+		sitesWithPlugin,
+		requestingPluginsForSites,
+	} = props;
+
+	useEffect( () => {
+		if ( ! isFetched ) {
+			props.wporgFetchPluginData( props.pluginSlug );
+		}
+	}, [ isFetched ] );
+
+	const fullPlugin = useMemo( () => {
+		// assign it .org details
+		return {
+			...plugin,
+			...wporgPlugin,
+		};
+	}, [ plugin, wporgPlugin ] );
+
+	const isPluginInstalledOnsite = useMemo( () => {
+		if ( requestingPluginsForSites ) {
+			return null;
+		}
+
+		return !! props.sitePlugin;
+	}, [ requestingPluginsForSites, props.sitePlugin ] );
+
+	const existingPlugin = useMemo( () => {
+		if ( isFetching || ! isFetched ) {
+			return 'unknown';
+		}
+		if ( fullPlugin && fullPlugin.fetched ) {
+			return true;
+		}
+
+		// If the plugin has at least one site then we know it exists
+		const pluginSites = Object.values( fullPlugin.sites );
+		if ( pluginSites && pluginSites[ 0 ] ) {
+			return true;
+		}
+
+		if ( requestingPluginsForSites ) {
+			return 'unknown';
+		}
+
+		return false;
+	}, [ isFetching, isFetched, fullPlugin, requestingPluginsForSites ] );
+
+	function getPageTitle() {
+		return props.translate( '%(pluginName)s Plugin', {
+			args: { pluginName: fullPlugin.name },
+			textOnly: true,
+			context: 'Page title: Plugin detail',
+		} );
+	}
+
+	function getAllowedPluginActions() {
+		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
+		const hiddenForAutomatedTransfer =
+			props.isAtomicSite && includes( autoManagedPlugins, fullPlugin.slug );
+
+		return {
+			autoupdate: ! hiddenForAutomatedTransfer,
+			activation: ! hiddenForAutomatedTransfer,
+			remove: ! hiddenForAutomatedTransfer,
+		};
+	}
+
+	if ( ! props.isRequestingSites && ! props.userCanManagePlugins ) {
+		return <NoPermissionsError title={ getPageTitle() } />;
+	}
+
+	const allowedPluginActions = getAllowedPluginActions( fullPlugin );
+
+	if ( existingPlugin === 'unknown' ) {
+		return (
+			<PluginPlaceholder
+				fullPlugin={ fullPlugin }
+				isPluginInstalledOnsite={ isPluginInstalledOnsite }
+				{ ...props }
+			/>
+		);
+	}
+
+	if ( existingPlugin === false ) {
+		return <PluginDoesNotExistView translate={ props.translate } selectedSite={ selectedSite } />;
+	}
+
+	const isWpcom = selectedSite && ! props.isJetpackSite;
+	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
+
+	return (
+		<MainComponent>
+			<DocumentHead title={ getPageTitle() } />
+			<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
+			<QueryJetpackPlugins siteIds={ siteIds } />
+			<SidebarNavigation />
+			<PluginNotices pluginId={ fullPlugin.id } sites={ props.sites } plugins={ [ fullPlugin ] } />
+
+			<div className="single-plugin__page">
+				<Header { ...props } />
+				<PluginMeta
+					plugin={ fullPlugin }
+					siteUrl={ props.siteUrl }
+					sites={ sitesWithPlugin }
+					selectedSite={ selectedSite }
+					isInstalledOnSite={ isPluginInstalledOnsite }
+					isInstalling={ props.isInstallingPlugin }
+					allowedActions={ allowedPluginActions }
+				/>
+				{ fullPlugin.wporg ? (
+					<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } />
+				) : (
+					<PluginSectionsCustom plugin={ fullPlugin } />
+				) }
+				<SitesList fullPlugin={ fullPlugin } isFetching={ isFetching } { ...props } />
+			</div>
+		</MainComponent>
+	);
+}
+
+function SitesList( { fullPlugin: plugin, ...props } ) {
+	if ( props.siteUrl || props.isFetching ) {
+		return null;
+	}
+
+	const { translate, sites, sitesWithPlugin, sitesWithoutPlugin } = props;
+	const notInstalledSites = sitesWithoutPlugin.map( ( siteId ) =>
+		sites.find( ( site ) => site.ID === siteId )
+	);
+
+	return (
+		<div>
+			<PluginSiteList
+				className="single-plugin__installed-on"
+				title={ translate( 'Installed on', {
+					comment: 'header for list of sites a plugin is installed on',
+				} ) }
+				sites={ sitesWithPlugin }
+				plugin={ plugin }
+			/>
+			{ plugin.wporg && (
+				<PluginSiteList
+					className="single-plugin__not-installed-on"
+					title={ translate( 'Available sites', {
+						comment: 'header for list of sites a plugin can be installed on',
+					} ) }
+					sites={ notInstalledSites }
+					plugin={ plugin }
+				/>
+			) }
+		</div>
+	);
+}
+
+function PluginDoesNotExistView( { selectedSite, translate } ) {
+	const actionUrl = '/plugins' + ( selectedSite ? '/' + selectedSite.slug : '' );
+	const action = translate( 'Browse all plugins' );
+
+	return (
+		<MainComponent>
+			<EmptyContent
+				title={ translate( "Oops! We can't find this plugin!" ) }
+				line={ translate( "The plugin you are looking for doesn't exist." ) }
+				actionURL={ actionUrl }
+				action={ action }
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+			/>
+		</MainComponent>
+	);
+}
+
+function PluginPlaceholder( props ) {
+	return (
+		<MainComponent>
+			<SidebarNavigation />
+			<div className="single-plugin__page">
+				<Header { ...props } />
+				<PluginMeta
+					isPlaceholder
+					isInstalledOnSite={ props.isPluginInstalledOnsite }
+					plugin={ props.fullPlugin }
+					siteUrl={ props.siteUrl }
+					sites={ props.sitesWithPlugin }
+					selectedSite={ props.selectedSite }
+					isAtomicSite={ props.isAtomicSite }
+				/>
+			</div>
+		</MainComponent>
+	);
+}
+
+function Header( props ) {
+	if ( ! props.selectedSite ) {
+		return <Card className="plugins__installed-header" />;
+	}
+
+	function getPreviousListUrl() {
+		const splitPluginUrl = props.prevPath.split( '/' + props.pluginSlug + '/' );
+		let previousPath = props.prevPath;
+
+		if ( splitPluginUrl[ 1 ] ) {
+			// Strip out the site url part.
+			previousPath = splitPluginUrl[ 0 ];
+		}
+		return (
+			previousPath +
+			'/' +
+			( props.siteUrl || '' ) +
+			( props.prevQuerystring ? '?' + props.prevQuerystring : '' )
+		);
+	}
+
+	const backHref = ( shouldUseHistoryBack ) => {
+		const { prevPath, siteUrl } = props;
+		if ( prevPath ) {
+			return getPreviousListUrl();
+		}
+		return ! shouldUseHistoryBack ? '/plugins/manage/' + ( siteUrl || '' ) : null;
+	};
+
+	const recordEvent = ( eventAction ) => {
+		props.recordGoogleEvent( 'Plugins', eventAction, 'Plugin Name', props.pluginSlug );
+	};
+
+	const recordBackArrowClickedEvent = recordEvent( 'Clicked Header Plugin Back Arrow' );
+	const shouldUseHistoryBack = window.history.length > 1 && props.navigated;
+	return (
+		<HeaderCake
+			isCompact={ true }
+			backHref={ backHref( shouldUseHistoryBack ) }
+			onBackArrowClick={ recordBackArrowClickedEvent }
+			onClick={ shouldUseHistoryBack ? goBack : undefined }
+		/>
+	);
+}
+
+function goBack() {
+	window.history.back();
+}
+
+export default connect(
+	( state, props ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const sites = getSelectedOrAllSitesWithPlugins( state );
+		const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
+
+		return {
+			plugin: getPluginOnSites( state, siteIds, props.pluginSlug ),
+			sitesWithPlugin: getSiteObjectsWithPlugin( state, siteIds, props.pluginSlug ),
+			sitePlugin: selectedSiteId && getPluginOnSite( state, selectedSiteId, props.pluginSlug ),
+			wporgPlugin: getWporgPlugin( state, props.pluginSlug ),
+			wporgFetching: isWporgPluginFetching( state, props.pluginSlug ),
+			wporgFetched: isWporgPluginFetched( state, props.pluginSlug ),
+			selectedSite: getSelectedSite( state ),
+			sitesWithoutPlugin: getSitesWithoutPlugin( state, siteIds, props.pluginSlug ),
+			isAtomicSite: isSiteAutomatedTransfer( state, selectedSiteId ),
+			isJetpackSite: selectedSiteId && isJetpackSite( state, selectedSiteId ),
+			isInstallingPlugin: isPluginActionInProgress(
+				state,
+				selectedSiteId,
+				props.pluginSlug,
+				INSTALL_PLUGIN
+			),
+			isRequestingSites: isRequestingSites( state ),
+			requestingPluginsForSites: isRequestingForSites( state, siteIds ),
+			userCanManagePlugins: selectedSiteId
+				? canCurrentUser( state, selectedSiteId, 'manage_options' )
+				: canCurrentUserManagePlugins( state ),
+			siteIds,
+			sites,
+			toursHistory: getToursHistory( state ),
+			navigated: hasNavigated( state ),
+		};
+	},
+	{
+		recordGoogleEvent,
+		wporgFetchPluginData,
+	}
+)( localize( SinglePlugin ) );

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -189,7 +189,13 @@ function SinglePlugin( props ) {
 				<div className="single-plugin__layout single-plugin__body">
 					<div className="single-plugin__layout-col single-plugin__layout-col-left">
 						{ fullPlugin.wporg ? (
-							<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } />
+							<PluginSections
+								className="single-plugin__plugins-sections"
+								plugin={ fullPlugin }
+								isWpcom={ isWpcom }
+								addBanner
+								removeReadMore
+							/>
 						) : (
 							<PluginSectionsCustom plugin={ fullPlugin } />
 						) }

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -9,6 +9,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import HeaderCake from 'calypso/components/header-cake';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import formatNumberCompact from 'calypso/lib/format-number-compact';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import PluginMeta from 'calypso/my-sites/plugins/plugin-meta';
@@ -192,6 +193,14 @@ function SinglePlugin( props ) {
 						) : (
 							<PluginSectionsCustom plugin={ fullPlugin } />
 						) }
+					</div>
+					<div className="single-plugin__layout-col single-plugin__layout-col-right">
+						<div className="single-plugin__downloads-text body-right-text">{ translate( 'Downloads' ) }</div>
+						<div className="single-plugin__downloads-value body-right-value">{ formatNumberCompact( fullPlugin.downloaded, 'en' ) }</div>
+						<div className="single-plugin__version-text body-right-text">{ translate( 'Version' ) }</div>
+						<div className="single-plugin__version-value body-right-value">{ fullPlugin.version }</div>
+						<div className="single-plugin__tested-text body-right-text">{ translate( 'Tested up to' ) }</div>
+						<div className="single-plugin__tested-value body-right-value">{ fullPlugin.version }</div>
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -41,6 +41,8 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { Button } from '@automattic/components';
 
 function SinglePlugin( props ) {
 	const {
@@ -50,9 +52,12 @@ function SinglePlugin( props ) {
 		wporgPlugin,
 		selectedSite,
 		siteIds,
+		translate,
 		sitesWithPlugin,
 		requestingPluginsForSites,
 	} = props;
+
+	const moment = useLocalizedMoment();
 
 	useEffect( () => {
 		if ( ! isFetched ) {
@@ -140,6 +145,7 @@ function SinglePlugin( props ) {
 	const isWpcom = selectedSite && ! props.isJetpackSite;
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
 
+	console.log({ fullPlugin });
 	return (
 		<MainComponent wideLayout>
 			<DocumentHead title={ getPageTitle() } />
@@ -149,30 +155,52 @@ function SinglePlugin( props ) {
 			<PluginNotices pluginId={ fullPlugin.id } sites={ props.sites } plugins={ [ fullPlugin ] } />
 
 			<div className="single-plugin__page">
-				<div className="single-plugin__layout">
+				<div className="single-plugin__layout single-plugin__top-section">
 					<div className="single-plugin__layout-col single-plugin__layout-col-left">
-						<Header { ...props } />
-						<PluginMeta
-							plugin={ fullPlugin }
-							siteUrl={ props.siteUrl }
-							sites={ sitesWithPlugin }
-							selectedSite={ selectedSite }
-							isInstalledOnSite={ isPluginInstalledOnsite }
-							isInstalling={ props.isInstallingPlugin }
-							allowedActions={ allowedPluginActions }
-						/>
-						{ fullPlugin.wporg ? (
-							<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } />
-						) : (
-							<PluginSectionsCustom plugin={ fullPlugin } />
-						) }
-						<SitesList fullPlugin={ fullPlugin } isFetching={ isFetching } { ...props } />
+						<div className="single-plugin__header">
+							<div className="single-plugin__name">{fullPlugin.name}</div>
+							<div className="single-plugin__description">{fullPlugin.description}</div>
+							<div className="single-plugin__additional-info">
+								<table>
+									<thead>
+										<tr>
+											<th>{ translate( 'Developer' ) }</th>
+											<th>{ translate( 'Ratings' ) }</th>
+											<th>{ translate( 'Last updated' ) }</th>
+										</tr>
+									</thead>
+
+									<tbody>
+										<tr>
+											<td><a href={fullPlugin.author_url}>{fullPlugin.author_name}</a></td>
+											<td><Rating rating={ fullPlugin.rating } /></td>
+											<td>{ moment.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' ).format( 'YYYY-MM-DD' ) }</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
 					</div>
-					<div className="single-plugin__layout-col single-plugin__layout-col-right"></div>
+					<div className="single-plugin__layout-col single-plugin__layout-col-right">
+						<div className="single-plugin__header">
+							<div className="single-plugin__price">{ translate( 'Free' ) }</div>
+							<div className="single-plugin__install"><Button className="single-plugin__install-button">{ translate( 'Install and activate' ) }</Button></div>
+							<div className="single-plugin__t-and-c">{ translate( 'By installing, you agree to WordPress.com’s Terms of Service and the Third-Party plug-in Terms.' ) }</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</MainComponent>
 	);
+}
+
+
+/* TODO: add the stars icons */
+function Rating ({ rating }) {
+	const inverseRating = 100 - Math.round( rating / 10 ) * 10;
+	const noFillOutlineCount = Math.floor( inverseRating / 20 ); // (5 - noFillOutlineCount) gives the number of stars to add
+
+	return rating/20;
 }
 
 function SitesList( { fullPlugin: plugin, ...props } ) {

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -1,12 +1,12 @@
 import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 import { useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
 import HeaderCake from 'calypso/components/header-cake';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import formatNumberCompact from 'calypso/lib/format-number-compact';
@@ -15,7 +15,7 @@ import PluginNotices from 'calypso/my-sites/plugins/notices';
 import PluginMeta from 'calypso/my-sites/plugins/plugin-meta';
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
-import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
+// import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -42,7 +42,6 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 function SinglePlugin( props ) {
 	const {
@@ -53,7 +52,6 @@ function SinglePlugin( props ) {
 		selectedSite,
 		siteIds,
 		translate,
-		sitesWithPlugin,
 		requestingPluginsForSites,
 	} = props;
 
@@ -107,23 +105,9 @@ function SinglePlugin( props ) {
 		} );
 	}
 
-	function getAllowedPluginActions() {
-		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
-		const hiddenForAutomatedTransfer =
-			props.isAtomicSite && includes( autoManagedPlugins, fullPlugin.slug );
-
-		return {
-			autoupdate: ! hiddenForAutomatedTransfer,
-			activation: ! hiddenForAutomatedTransfer,
-			remove: ! hiddenForAutomatedTransfer,
-		};
-	}
-
 	if ( ! props.isRequestingSites && ! props.userCanManagePlugins ) {
 		return <NoPermissionsError title={ getPageTitle() } />;
 	}
-
-	const allowedPluginActions = getAllowedPluginActions( fullPlugin );
 
 	if ( existingPlugin === 'unknown' ) {
 		return (
@@ -154,8 +138,8 @@ function SinglePlugin( props ) {
 				<div className="single-plugin__layout single-plugin__top-section">
 					<div className="single-plugin__layout-col single-plugin__layout-col-left">
 						<div className="single-plugin__header">
-							<div className="single-plugin__name">{fullPlugin.name}</div>
-							<div className="single-plugin__description">{fullPlugin.description}</div>
+							<div className="single-plugin__name">{ fullPlugin.name }</div>
+							<div className="single-plugin__description">{ fullPlugin.description }</div>
 							<div className="single-plugin__additional-info">
 								<table>
 									<thead>
@@ -168,9 +152,17 @@ function SinglePlugin( props ) {
 
 									<tbody>
 										<tr>
-											<td><a href={fullPlugin.author_url}>{fullPlugin.author_name}</a></td>
-											<td><Rating rating={ fullPlugin.rating } /></td>
-											<td>{ moment.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' ).format( 'YYYY-MM-DD' ) }</td>
+											<td>
+												<a href={ fullPlugin.author_url }>{ fullPlugin.author_name }</a>
+											</td>
+											<td>
+												<Rating rating={ fullPlugin.rating } />
+											</td>
+											<td>
+												{ moment
+													.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' )
+													.format( 'YYYY-MM-DD' ) }
+											</td>
 										</tr>
 									</tbody>
 								</table>
@@ -180,8 +172,16 @@ function SinglePlugin( props ) {
 					<div className="single-plugin__layout-col single-plugin__layout-col-right">
 						<div className="single-plugin__header">
 							<div className="single-plugin__price">{ translate( 'Free' ) }</div>
-							<div className="single-plugin__install"><Button className="single-plugin__install-button">{ translate( 'Install and activate' ) }</Button></div>
-							<div className="single-plugin__t-and-c">{ translate( 'By installing, you agree to WordPress.com’s Terms of Service and the Third-Party plug-in Terms.' ) }</div>
+							<div className="single-plugin__install">
+								<Button className="single-plugin__install-button">
+									{ translate( 'Install and activate' ) }
+								</Button>
+							</div>
+							<div className="single-plugin__t-and-c">
+								{ translate(
+									'By installing, you agree to WordPress.com’s Terms of Service and the Third-Party plug-in Terms.'
+								) }
+							</div>
 						</div>
 					</div>
 				</div>
@@ -201,12 +201,24 @@ function SinglePlugin( props ) {
 						) }
 					</div>
 					<div className="single-plugin__layout-col single-plugin__layout-col-right">
-						<div className="single-plugin__downloads-text body-right-text">{ translate( 'Downloads' ) }</div>
-						<div className="single-plugin__downloads-value body-right-value">{ formatNumberCompact( fullPlugin.downloaded, 'en' ) }</div>
-						<div className="single-plugin__version-text body-right-text">{ translate( 'Version' ) }</div>
-						<div className="single-plugin__version-value body-right-value">{ fullPlugin.version }</div>
-						<div className="single-plugin__tested-text body-right-text">{ translate( 'Tested up to' ) }</div>
-						<div className="single-plugin__tested-value body-right-value">{ fullPlugin.version }</div>
+						<div className="single-plugin__downloads-text body-right-text">
+							{ translate( 'Downloads' ) }
+						</div>
+						<div className="single-plugin__downloads-value body-right-value">
+							{ formatNumberCompact( fullPlugin.downloaded, 'en' ) }
+						</div>
+						<div className="single-plugin__version-text body-right-text">
+							{ translate( 'Version' ) }
+						</div>
+						<div className="single-plugin__version-value body-right-value">
+							{ fullPlugin.version }
+						</div>
+						<div className="single-plugin__tested-text body-right-text">
+							{ translate( 'Tested up to' ) }
+						</div>
+						<div className="single-plugin__tested-value body-right-value">
+							{ fullPlugin.version }
+						</div>
 					</div>
 				</div>
 			</div>
@@ -214,48 +226,47 @@ function SinglePlugin( props ) {
 	);
 }
 
-
 /* TODO: add the stars icons */
-function Rating ({ rating }) {
-	const inverseRating = 100 - Math.round( rating / 10 ) * 10;
-	const noFillOutlineCount = Math.floor( inverseRating / 20 ); // (5 - noFillOutlineCount) gives the number of stars to add
+function Rating( { rating } ) {
+	// const inverseRating = 100 - Math.round( rating / 10 ) * 10;
+	// const noFillOutlineCount = Math.floor( inverseRating / 20 ); // (5 - noFillOutlineCount) gives the number of stars to add
 
-	return rating/20;
+	return rating / 20;
 }
 
-function SitesList( { fullPlugin: plugin, ...props } ) {
-	if ( props.siteUrl || props.isFetching ) {
-		return null;
-	}
+// function SitesList( { fullPlugin: plugin, ...props } ) {
+// 	if ( props.siteUrl || props.isFetching ) {
+// 		return null;
+// 	}
 
-	const { translate, sites, sitesWithPlugin, sitesWithoutPlugin } = props;
-	const notInstalledSites = sitesWithoutPlugin.map( ( siteId ) =>
-		sites.find( ( site ) => site.ID === siteId )
-	);
+// 	const { translate, sites, sitesWithPlugin, sitesWithoutPlugin } = props;
+// 	const notInstalledSites = sitesWithoutPlugin.map( ( siteId ) =>
+// 		sites.find( ( site ) => site.ID === siteId )
+// 	);
 
-	return (
-		<div>
-			<PluginSiteList
-				className="single-plugin__installed-on"
-				title={ translate( 'Installed on', {
-					comment: 'header for list of sites a plugin is installed on',
-				} ) }
-				sites={ sitesWithPlugin }
-				plugin={ plugin }
-			/>
-			{ plugin.wporg && (
-				<PluginSiteList
-					className="single-plugin__not-installed-on"
-					title={ translate( 'Available sites', {
-						comment: 'header for list of sites a plugin can be installed on',
-					} ) }
-					sites={ notInstalledSites }
-					plugin={ plugin }
-				/>
-			) }
-		</div>
-	);
-}
+// 	return (
+// 		<div>
+// 			<PluginSiteList
+// 				className="single-plugin__installed-on"
+// 				title={ translate( 'Installed on', {
+// 					comment: 'header for list of sites a plugin is installed on',
+// 				} ) }
+// 				sites={ sitesWithPlugin }
+// 				plugin={ plugin }
+// 			/>
+// 			{ plugin.wporg && (
+// 				<PluginSiteList
+// 					className="single-plugin__not-installed-on"
+// 					title={ translate( 'Available sites', {
+// 						comment: 'header for list of sites a plugin can be installed on',
+// 					} ) }
+// 					sites={ notInstalledSites }
+// 					plugin={ plugin }
+// 				/>
+// 			) }
+// 		</div>
+// 	);
+// }
 
 function PluginDoesNotExistView( { selectedSite, translate } ) {
 	const actionUrl = '/plugins' + ( selectedSite ? '/' + selectedSite.slug : '' );

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -141,7 +141,7 @@ function SinglePlugin( props ) {
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
 
 	return (
-		<MainComponent>
+		<MainComponent wideLayout>
 			<DocumentHead title={ getPageTitle() } />
 			<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
 			<QueryJetpackPlugins siteIds={ siteIds } />
@@ -149,22 +149,27 @@ function SinglePlugin( props ) {
 			<PluginNotices pluginId={ fullPlugin.id } sites={ props.sites } plugins={ [ fullPlugin ] } />
 
 			<div className="single-plugin__page">
-				<Header { ...props } />
-				<PluginMeta
-					plugin={ fullPlugin }
-					siteUrl={ props.siteUrl }
-					sites={ sitesWithPlugin }
-					selectedSite={ selectedSite }
-					isInstalledOnSite={ isPluginInstalledOnsite }
-					isInstalling={ props.isInstallingPlugin }
-					allowedActions={ allowedPluginActions }
-				/>
-				{ fullPlugin.wporg ? (
-					<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } />
-				) : (
-					<PluginSectionsCustom plugin={ fullPlugin } />
-				) }
-				<SitesList fullPlugin={ fullPlugin } isFetching={ isFetching } { ...props } />
+				<div className="single-plugin__layout">
+					<div className="single-plugin__layout-col single-plugin__layout-col-left">
+						<Header { ...props } />
+						<PluginMeta
+							plugin={ fullPlugin }
+							siteUrl={ props.siteUrl }
+							sites={ sitesWithPlugin }
+							selectedSite={ selectedSite }
+							isInstalledOnSite={ isPluginInstalledOnsite }
+							isInstalling={ props.isInstallingPlugin }
+							allowedActions={ allowedPluginActions }
+						/>
+						{ fullPlugin.wporg ? (
+							<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } />
+						) : (
+							<PluginSectionsCustom plugin={ fullPlugin } />
+						) }
+						<SitesList fullPlugin={ fullPlugin } isFetching={ isFetching } { ...props } />
+					</div>
+					<div className="single-plugin__layout-col single-plugin__layout-col-right"></div>
+				</div>
 			</div>
 		</MainComponent>
 	);
@@ -209,7 +214,7 @@ function PluginDoesNotExistView( { selectedSite, translate } ) {
 	const action = translate( 'Browse all plugins' );
 
 	return (
-		<MainComponent>
+		<MainComponent wideLayout>
 			<EmptyContent
 				title={ translate( "Oops! We can't find this plugin!" ) }
 				line={ translate( "The plugin you are looking for doesn't exist." ) }
@@ -223,7 +228,7 @@ function PluginDoesNotExistView( { selectedSite, translate } ) {
 
 function PluginPlaceholder( props ) {
 	return (
-		<MainComponent>
+		<MainComponent wideLayout>
 			<SidebarNavigation />
 			<div className="single-plugin__page">
 				<Header { ...props } />

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -330,7 +330,10 @@ function CTA( { slug, isPluginInstalledOnsite, fullPlugin } ) {
 	}
 
 	return (
-		<Button className="single-plugin__install-button">
+		<Button
+			className="single-plugin__install-button"
+			href={ `/checkout/${ selectedSite.slug }/business?redirect_to=/marketplace/${ slug }/install/${ selectedSite.slug }#step2` }
+		>
 			{ translate( 'Upgrade and install' ) }
 		</Button>
 	);

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -7,6 +7,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -109,6 +110,18 @@ function SinglePlugin( props ) {
 		return false;
 	}, [ isFetching, isFetched, fullPlugin, requestingPluginsForSites ] );
 
+	const getNavigationItems = () => {
+		// ToDo:
+		// - add "Search Results" breadcrumb if prev page was search results
+		// - change the first breadcrumb if prev page wasn't plugins page (eg activity log)
+		const navigationItems = [
+			{ label: translate( 'Plugins' ), href: `/plugins/${ selectedSite.slug || '' }` },
+			{ label: fullPlugin.name },
+		];
+
+		return navigationItems;
+	};
+
 	const getPageTitle = () => {
 		return translate( '%(pluginName)s Plugin', {
 			args: { pluginName: fullPlugin.name },
@@ -135,6 +148,7 @@ function SinglePlugin( props ) {
 			<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
 			<QueryJetpackPlugins siteIds={ siteIds } />
 			<SidebarNavigation />
+			<FixedNavigationHeader navigationItems={ getNavigationItems() } />
 			<PluginNotices pluginId={ fullPlugin.id } sites={ sites } plugins={ [ fullPlugin ] } />
 
 			<div className="single-plugin__page">

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -20,8 +20,6 @@ import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custo
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { installPlugin } from 'calypso/state/plugins/installed/actions';
 import {
 	getPluginOnSite,
 	getPluginOnSites,
@@ -29,7 +27,6 @@ import {
 	getSitesWithoutPlugin,
 	isRequestingForSites,
 } from 'calypso/state/plugins/installed/selectors';
-import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import {
 	isFetching as isWporgPluginFetching,
@@ -216,7 +213,6 @@ function SinglePlugin( props ) {
 								<CTA
 									slug={ props.pluginSlug }
 									isPluginInstalledOnsite={ isPluginInstalledOnsite }
-									fullPlugin={ fullPlugin }
 								/>
 							</div>
 							<div className="single-plugin__t-and-c">
@@ -290,25 +286,9 @@ function shouldDisplayCTA( selectedSite, slug, isPluginInstalledOnsite ) {
 	);
 }
 
-function onClickInstallPlugin( { dispatch, selectedSiteId, fullPlugin, slug } ) {
-	dispatch( removePluginStatuses( 'completed', 'error' ) );
-	dispatch( installPlugin( selectedSiteId, fullPlugin ) );
-
-	dispatch( recordGoogleEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', slug ) );
-	dispatch(
-		recordGoogleEvent( 'calypso_plugin_install_click_from_plugin_info', {
-			site: selectedSiteId,
-			plugin: slug,
-		} )
-	);
-}
-
-function CTA( { slug, isPluginInstalledOnsite, fullPlugin } ) {
+function CTA( { slug, isPluginInstalledOnsite } ) {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
-
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const dispatch = useDispatch();
 
 	if ( ! shouldDisplayCTA( selectedSite, slug, isPluginInstalledOnsite ) ) {
 		return null;
@@ -322,7 +302,7 @@ function CTA( { slug, isPluginInstalledOnsite, fullPlugin } ) {
 		return (
 			<Button
 				className="single-plugin__install-button"
-				onClick={ () => onClickInstallPlugin( { dispatch, selectedSiteId, fullPlugin, slug } ) }
+				href={ `/marketplace/${ slug }/install/${ selectedSite.slug }` }
 			>
 				{ translate( 'Install and activate' ) }
 			</Button>

--- a/client/my-sites/plugins/single-plugin.jsx
+++ b/client/my-sites/plugins/single-plugin.jsx
@@ -115,7 +115,7 @@ function SinglePlugin( props ) {
 		// - add "Search Results" breadcrumb if prev page was search results
 		// - change the first breadcrumb if prev page wasn't plugins page (eg activity log)
 		const navigationItems = [
-			{ label: translate( 'Plugins' ), href: `/plugins/${ selectedSite.slug || '' }` },
+			{ label: translate( 'Plugins' ), href: `/plugins/${ selectedSite?.slug || '' }` },
 			{ label: fullPlugin.name },
 		];
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -194,3 +194,40 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		color: var( --studio-gray-50 );
 	}
 }
+
+.single-plugin__body {
+	.plugin-sections {
+		margin-top: 20px;
+
+		.section-nav {
+			box-shadow: none;
+		}
+
+		.card {
+			box-shadow: none;
+		}
+	}
+
+	.section-nav-tab {
+		&.is-selected,
+		&:hover:not(.is-selected) {
+			border-bottom-color: transparent;
+		}
+
+		.section-nav-tab__link {
+			font-size: $font-body-small;
+			color: var( --studio-gray-60 );
+
+			&:hover {
+				background-color: transparent;
+				color: var( --studio-black );
+			}
+		}
+
+		&.is-selected .section-nav-tab__link {
+			color: var( --studio-black );
+			font-weight: bold;
+			border-bottom: none;
+		}
+	}
+}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -117,6 +117,10 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 }
 
+.layout__content {
+	background: var( --studio-white );
+}
+
 .single-plugin__layout {
 	@include grid-row( 4, 1 );
 	@include breakpoint-deprecated( '>1040px' ) {
@@ -135,5 +139,58 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		@include breakpoint-deprecated( '>1040px' ) {
 			@include grid-column( 9, 4 );
 		}
+	}
+}
+
+.single-plugin__top-section {
+	border-bottom: 1px solid var( --studio-gray-5);
+}
+
+.single-plugin__header {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 400px;
+
+	.single-plugin__name, .single-plugin__price {
+		font-family: Recoleta;
+		font-size: $font-title-large;
+		color: var( --studio-gray-100 );
+		padding: 16px 0;
+	}
+
+	.single-plugin__description {
+		font-size: $font-title-small;
+		color: var( --studio-gray-70 );
+		padding-bottom: 30px;
+	}
+
+	.single-plugin__additional-info {
+		th {
+			font-size: $font-body-extra-small;
+			font-weight: 400;
+			color: var( --studio-gray-40 );
+		}
+
+		td {
+			font-size: $font-body;
+			color: var( --studio-gray-70 );
+		}
+	}
+
+	.single-plugin__install {
+		padding-bottom: 20px;
+
+		.single-plugin__install-button {
+			width: 100%;
+			padding: 12px 16px;
+			background-color: var( --studio-pink-50 );
+			color: var( --studio-white );
+		}
+	}
+	
+	.single-plugin__t-and-c {
+		font-size: $font-body-extra-small;
+		color: var( --studio-gray-50 );
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -230,4 +230,22 @@ body.is-section-plugins:not( .is-nav-unification ) {
 			border-bottom: none;
 		}
 	}
+
+	.single-plugin__layout-col-right {
+		margin-top: 100px;
+
+		.body-right-text {
+			color: var( --studio-gray-40 );
+			font-size: $font-body-extra-small;
+		}
+
+		.body-right-value {
+			color: var( --studio-gray-70 );
+			font-size: $font-body-small;
+
+			&.single-plugin__downloads-value {
+				font-size: $font-body;
+			}
+		}
+	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,9 +1,5 @@
 @import './grid-mixins.scss';
 
-.plugin__installed-on, .single-plugin__installed-on {
-	margin-bottom: 16px;
-}
-
 .is-section-plugins .main {
 	padding-top: 35px; // Compensate for the fixed header.
 
@@ -18,6 +14,10 @@
 
 body.is-section-plugins.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
+}
+
+.plugin__installed-on, .single-plugin__installed-on {
+	margin-bottom: 16px;
 }
 
 // Fix for Jetpack not having nav-unification styles yet.
@@ -117,10 +117,6 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 }
 
-.layout__content {
-	background: var( --studio-white );
-}
-
 .single-plugin__layout {
 	@include grid-row( 4, 1 );
 	@include breakpoint-deprecated( '>1040px' ) {
@@ -143,7 +139,7 @@ body.is-section-plugins:not( .is-nav-unification ) {
 }
 
 .single-plugin__top-section {
-	border-bottom: 1px solid var( --studio-gray-5);
+	border-bottom: 1px solid var( --studio-gray-5 );
 }
 
 .single-plugin__header {
@@ -210,7 +206,7 @@ body.is-section-plugins:not( .is-nav-unification ) {
 
 	.section-nav-tab {
 		&.is-selected,
-		&:hover:not(.is-selected) {
+		&:hover:not( .is-selected ) {
 			border-bottom-color: transparent;
 		}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -242,6 +242,7 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		.body-right-value {
 			color: var( --studio-gray-70 );
 			font-size: $font-body-small;
+			padding-bottom: 16px;
 
 			&.single-plugin__downloads-value {
 				font-size: $font-body;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,3 +1,7 @@
+.plugin__installed-on, .single-plugin__installed-on {
+	margin-bottom: 16px;
+}
+
 .is-section-plugins .main {
 	padding-top: 35px; // Compensate for the fixed header.
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,3 +1,5 @@
+@import './grid-mixins.scss';
+
 .plugin__installed-on, .single-plugin__installed-on {
 	margin-bottom: 16px;
 }
@@ -112,5 +114,26 @@ body.is-section-plugins:not( .is-nav-unification ) {
 
 	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0;
+	}
+}
+
+.single-plugin__layout {
+	@include grid-row( 4, 1 );
+	@include breakpoint-deprecated( '>1040px' ) {
+		@include display-grid;
+		@include grid-template-columns( 12, 24px, 1fr );
+		grid-gap: 24px;
+	}
+
+	.single-plugin__layout-col-left {
+		@include breakpoint-deprecated( '>1040px' ) {
+			@include grid-column( 1, 8 );
+		}
+	}
+
+	.single-plugin__layout-col-right {
+		@include breakpoint-deprecated( '>1040px' ) {
+			@include grid-column( 9, 4 );
+		}
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -140,6 +140,14 @@ body.is-section-plugins:not( .is-nav-unification ) {
 
 .single-plugin__top-section {
 	border-bottom: 1px solid var( --studio-gray-5 );
+
+	.single-plugin__layout-col-left.no-cta {
+		@include grid-column( 1, 12 );
+	}
+
+	.single-plugin__layout-col-right.no-cta {
+		display: none;
+	}
 }
 
 .single-plugin__header {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -196,10 +196,25 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	.single-plugin__t-and-c {
 		font-size: $font-body-extra-small;
 		color: var( --studio-gray-50 );
+
+		@media screen and ( max-width: 1040px ) {
+			padding-bottom: 40px;
+		}
+	}
+
+	@media screen and ( max-width: 1040px ) {
+		height: 100%;
 	}
 }
 
 .single-plugin__body {
+	.single-plugin__plugin-details-title {
+		padding: 15px 0;
+		display: none;
+		color: var( --studio-gray-100 );
+		font-size: $font-body-small;
+	}
+
 	.plugin-sections {
 		margin-top: 20px;
 
@@ -238,12 +253,12 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	.single-plugin__layout-col-right {
 		margin-top: 100px;
 
-		.body-right-text {
+		.title {
 			color: var( --studio-gray-40 );
 			font-size: $font-body-extra-small;
 		}
 
-		.body-right-value {
+		.value {
 			color: var( --studio-gray-70 );
 			font-size: $font-body-small;
 			padding-bottom: 16px;
@@ -251,6 +266,36 @@ body.is-section-plugins:not( .is-nav-unification ) {
 			&.single-plugin__downloads-value {
 				font-size: $font-body;
 			}
+		}
+	}
+
+	@media screen and ( max-width: 1040px ) {
+		display: flex;
+		flex-direction: column;
+
+		.single-plugin__plugin-details-content {
+			display: flex;
+		}
+
+		.single-plugin__plugin-details-title {
+			display: block;
+		}
+		
+		.single-plugin__layout-col-left {
+			order: 2;
+		}
+		
+		.single-plugin__layout-col-right {
+			order: 1;
+			margin-top: 0;
+			padding: 0 24px;
+			display: flex;
+			flex-direction: column;
+			border-bottom: 1px solid var( --studio-gray-5 );
+		}
+	
+		.single-plugin__version {
+			margin: auto;
 		}
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -141,12 +141,18 @@ body.is-section-plugins:not( .is-nav-unification ) {
 .plugin-details__top-section {
 	border-bottom: 1px solid var( --studio-gray-5 );
 
-	.plugin-details__layout-col-left.no-cta {
-		@include grid-column( 1, 12 );
-	}
-
 	.plugin-details__layout-col-right.no-cta {
-		display: none;
+		visibility: hidden;
+
+		@media screen and ( max-width: 1040px ) {
+			display: none;
+		}
+	}
+}
+
+.plugin-details__page {
+	@media screen and ( max-width: 1040px ) {
+		padding: 16px;
 	}
 }
 
@@ -156,8 +162,13 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	justify-content: center;
 	height: 400px;
 
+	.plugin-details__tags {
+		font-size: $font-body-extra-small;
+		color: var( --studio-gray-40 );
+	}
+
 	.plugin-details__name, .plugin-details__price {
-		font-family: Recoleta;
+		font-family: $brand-serif;
 		font-size: $font-title-large;
 		color: var( --studio-gray-100 );
 		padding: 16px 0;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -16,7 +16,7 @@ body.is-section-plugins.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
 }
 
-.plugin__installed-on, .single-plugin__installed-on {
+.plugin__installed-on, .plugin-details__installed-on {
 	margin-bottom: 16px;
 }
 
@@ -117,7 +117,7 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 }
 
-.single-plugin__layout {
+.plugin-details__layout {
 	@include grid-row( 4, 1 );
 	@include breakpoint-deprecated( '>1040px' ) {
 		@include display-grid;
@@ -125,51 +125,51 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		grid-gap: 24px;
 	}
 
-	.single-plugin__layout-col-left {
+	.plugin-details__layout-col-left {
 		@include breakpoint-deprecated( '>1040px' ) {
 			@include grid-column( 1, 8 );
 		}
 	}
 
-	.single-plugin__layout-col-right {
+	.plugin-details__layout-col-right {
 		@include breakpoint-deprecated( '>1040px' ) {
 			@include grid-column( 9, 4 );
 		}
 	}
 }
 
-.single-plugin__top-section {
+.plugin-details__top-section {
 	border-bottom: 1px solid var( --studio-gray-5 );
 
-	.single-plugin__layout-col-left.no-cta {
+	.plugin-details__layout-col-left.no-cta {
 		@include grid-column( 1, 12 );
 	}
 
-	.single-plugin__layout-col-right.no-cta {
+	.plugin-details__layout-col-right.no-cta {
 		display: none;
 	}
 }
 
-.single-plugin__header {
+.plugin-details__header {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	height: 400px;
 
-	.single-plugin__name, .single-plugin__price {
+	.plugin-details__name, .plugin-details__price {
 		font-family: Recoleta;
 		font-size: $font-title-large;
 		color: var( --studio-gray-100 );
 		padding: 16px 0;
 	}
 
-	.single-plugin__description {
+	.plugin-details__description {
 		font-size: $font-title-small;
 		color: var( --studio-gray-70 );
 		padding-bottom: 30px;
 	}
 
-	.single-plugin__additional-info {
+	.plugin-details__additional-info {
 		th {
 			font-size: $font-body-extra-small;
 			font-weight: 400;
@@ -182,10 +182,10 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		}
 	}
 
-	.single-plugin__install {
+	.plugin-details__install {
 		padding-bottom: 20px;
 
-		.single-plugin__install-button {
+		.plugin-details__install-button {
 			width: 100%;
 			padding: 12px 16px;
 			background-color: var( --studio-pink-50 );
@@ -193,7 +193,7 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		}
 	}
 	
-	.single-plugin__t-and-c {
+	.plugin-details__t-and-c {
 		font-size: $font-body-extra-small;
 		color: var( --studio-gray-50 );
 
@@ -207,8 +207,8 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 }
 
-.single-plugin__body {
-	.single-plugin__plugin-details-title {
+.plugin-details__body {
+	.plugin-details__plugin-details-title {
 		padding: 15px 0;
 		display: none;
 		color: var( --studio-gray-100 );
@@ -250,7 +250,7 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		}
 	}
 
-	.single-plugin__layout-col-right {
+	.plugin-details__layout-col-right {
 		margin-top: 100px;
 
 		.title {
@@ -263,7 +263,7 @@ body.is-section-plugins:not( .is-nav-unification ) {
 			font-size: $font-body-small;
 			padding-bottom: 16px;
 
-			&.single-plugin__downloads-value {
+			&.plugin-details__downloads-value {
 				font-size: $font-body;
 			}
 		}
@@ -273,29 +273,26 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		display: flex;
 		flex-direction: column;
 
-		.single-plugin__plugin-details-content {
+		.plugin-details__plugin-details-content {
 			display: flex;
+			justify-content: space-between;
 		}
 
-		.single-plugin__plugin-details-title {
+		.plugin-details__plugin-details-title {
 			display: block;
 		}
 		
-		.single-plugin__layout-col-left {
+		.plugin-details__layout-col-left {
 			order: 2;
 		}
 		
-		.single-plugin__layout-col-right {
+		.plugin-details__layout-col-right {
 			order: 1;
 			margin-top: 0;
 			padding: 0 24px;
 			display: flex;
 			flex-direction: column;
 			border-bottom: 1px solid var( --studio-gray-5 );
-		}
-	
-		.single-plugin__version {
-			margin: auto;
 		}
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -181,13 +181,24 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 
 	.plugin-details__additional-info {
-		th {
+		display: flex;
+		justify-content: space-between;
+		flex-wrap: wrap;
+
+		.plugin-details__info {
+			@media screen and ( max-width: 1040px ) {
+				width: 50%;
+				padding-bottom: 12px;
+			}
+		}
+
+		.plugin-details__info-title {
 			font-size: $font-body-extra-small;
 			font-weight: 400;
 			color: var( --studio-gray-40 );
 		}
 
-		td {
+		.plugin-details__info-value {
 			font-size: $font-body;
 			color: var( --studio-gray-70 );
 		}

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -351,7 +351,12 @@ function refreshNetworkSites( siteId ) {
 	};
 }
 
-function installPluginHelper( siteId, plugin, isMainNetworkSite = false ) {
+function installPluginHelper(
+	siteId,
+	plugin,
+	isMainNetworkSite = false,
+	simpleInstallation = false
+) {
 	return ( dispatch ) => {
 		const pluginId = plugin.id || plugin.slug;
 		const defaultAction = {
@@ -415,7 +420,7 @@ function installPluginHelper( siteId, plugin, isMainNetworkSite = false ) {
 			return Promise.reject( error );
 		};
 
-		if ( isMainNetworkSite ) {
+		if ( isMainNetworkSite || simpleInstallation ) {
 			return doInstall( plugin )
 				.then( doAutoupdates )
 				.then( successCallback )
@@ -436,6 +441,10 @@ export function installPlugin( siteId, plugin ) {
 
 export function installPluginOnMultisite( siteId, plugin ) {
 	return installPluginHelper( siteId, plugin, true );
+}
+
+export function installPluginSimple( siteId, plugin ) {
+	return installPluginHelper( siteId, plugin, false, true );
 }
 
 export function removePlugin( siteId, plugin ) {

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -355,7 +355,7 @@ function installPluginHelper(
 	siteId,
 	plugin,
 	isMainNetworkSite = false,
-	simpleInstallation = false
+	shouldActivatePlugin = true
 ) {
 	return ( dispatch ) => {
 		const pluginId = plugin.id || plugin.slug;
@@ -420,7 +420,7 @@ function installPluginHelper(
 			return Promise.reject( error );
 		};
 
-		if ( isMainNetworkSite || simpleInstallation ) {
+		if ( isMainNetworkSite || ! shouldActivatePlugin ) {
 			return doInstall( plugin )
 				.then( doAutoupdates )
 				.then( successCallback )
@@ -435,16 +435,12 @@ function installPluginHelper(
 	};
 }
 
-export function installPlugin( siteId, plugin ) {
-	return installPluginHelper( siteId, plugin );
+export function installPlugin( siteId, plugin, shouldActivatePlugin = true ) {
+	return installPluginHelper( siteId, plugin, false, shouldActivatePlugin );
 }
 
 export function installPluginOnMultisite( siteId, plugin ) {
 	return installPluginHelper( siteId, plugin, true );
-}
-
-export function installPluginSimple( siteId, plugin ) {
-	return installPluginHelper( siteId, plugin, false, true );
 }
 
 export function removePlugin( siteId, plugin ) {


### PR DESCRIPTION
### Summary 
Create a Plugin Details page with a new layout as oU6nEIeiKSg8CayhEtgR6b-fi-6559%3A49151
The implementation was made with a new component to be shown when the `marketplace` feature flag is enabled, this component is based on the old `plugin` component, but created as a functional React component.

### Testing instructions
1. Go to plugins page
2. Click in one of the plugins, this should redirect you to the plugin details page.
3. Once on the plugin details page, verify:
- The layout matches with oU6nEIeiKSg8CayhEtgR6b-fi-6559%3A49151
- The mobile version is working as expected
- The CTA actions redirect to a new page when installing and show a thank you page at the end.
- Check the CTA for the 3 possibilities:
  - Install when atomic
  - Upgrade to business and install
  - Install when not atomic

### Screenshots
|Before | After| After Mobile|
|-------|------|------|
|<img width="720" alt="Screen Shot 2021-11-07 at 11 41 09" src="https://user-images.githubusercontent.com/5039531/140652107-985f621d-194e-40ad-adb3-3b578ec8db77.png">|<img width="1188" alt="Screen Shot 2021-11-07 at 11 38 49" src="https://user-images.githubusercontent.com/5039531/140652115-cab3139a-ef5b-483b-9f18-49409743d467.png">|<img width="483" alt="Screen Shot 2021-11-07 at 11 39 42" src="https://user-images.githubusercontent.com/5039531/140652120-18968e17-d3c3-443f-9b1f-b661bf6e88cb.png">|


### Checklist

- [x] Turn a class component into a functional component
- [x] New Layout (wider, 2 columns)
- [x] Header with summary 
- [x] Description / FAQ's
- [x] Include cover image on the description
- [x] Remove the Read more action
- [x] Secondary Info
- [x] Add site list section
- [x] Fix the mobile version
- [x] CTA: Install when atomic
- [x] CTA: Upgrade to business and install
- [x] CTA: Install when not atomic

On separate / next PRs
- [ ] Add placeholder page
- [ ] Add site list styling
- [ ] Add star icons to rating
- [ ] Make sure that author link redirects to our plugin search results showing plugins of that author eg for yoast `https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=yoast`

---


Fixes #55577