### PR TITLE
webpack-rtl-plugin: Handle assets with query strings (and misc cleanup)

### DIFF
--- a/packages/webpack-rtl-plugin/CHANGELOG.md
+++ b/packages/webpack-rtl-plugin/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - mini-css-extract-plugin to ^1.6.0
   - rtlcss to ^3.1.2
 - Removed unused dependency cssnano.
+- Update documentation to match code.
 
 ## 5.0.0 - 2021-03-26
 

--- a/packages/webpack-rtl-plugin/CHANGELOG.md
+++ b/packages/webpack-rtl-plugin/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - rtlcss to ^3.1.2
 - Removed unused dependency cssnano.
 - Update documentation to match code.
+- Allow for assets with query strings.
 
 ## 5.0.0 - 2021-03-26
 

--- a/packages/webpack-rtl-plugin/CHANGELOG.md
+++ b/packages/webpack-rtl-plugin/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unused dependency cssnano.
 - Update documentation to match code.
 - Allow for assets with query strings.
+- Drop unused dependency on `async`.
 
 ## 5.0.0 - 2021-03-26
 

--- a/packages/webpack-rtl-plugin/README.md
+++ b/packages/webpack-rtl-plugin/README.md
@@ -1,23 +1,19 @@
 # Webpack RTL Plugin
 
-Originally forked from <https://github.com/romainberger/webpack-rtl-plugin>, commit aca883ad70671a5d2a90c676fe8ea60d42c8759b (tag v2.0.0).
-
-This plugin contains Automattic changes to the original `webpack-rtl-plugin` and is released as `@automattic/webpack-rtl-plugin`.
-
-Following there is the original README file:
-
----
-
 Webpack plugin to use in addition to [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) to create a second css bundle, processed to be rtl.
 
 This uses [rtlcss](https://github.com/MohammadYounes/rtlcss) under the hood, please refer to its documentation for supported properties.
+
+Originally forked from <https://github.com/romainberger/webpack-rtl-plugin>, commit aca883ad70671a5d2a90c676fe8ea60d42c8759b (tag v2.0.0).
+
+This plugin contains Automattic changes to the original `webpack-rtl-plugin` and is released as `@automattic/webpack-rtl-plugin`.
 
 Check out the [webpack-rtl-example](https://github.com/romainberger/webpack-rtl-example) to see an example of an app using the rtl-css-loader and webpack-rtl-plugin.
 
 ## Installation
 
 ```shell
-$ npm install webpack-rtl-plugin
+$ npm install @automattic/webpack-rtl-plugin
 ```
 
 ## Usage
@@ -25,7 +21,7 @@ $ npm install webpack-rtl-plugin
 Add the plugin to your webpack configuration:
 
 ```js
-const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
+const WebpackRTLPlugin = require( '@automattic/webpack-rtl-plugin' );
 
 module.exports = {
 	entry: path.join( __dirname, 'src/index.js' ),
@@ -64,25 +60,13 @@ This will create the normal `style.css` and an additionnal `style.rtl.css`.
 
 ```
 new WebpackRTLPlugin({
-  filename: 'style.[contenthash].rtl.css',
   options: {},
   plugins: [],
   diffOnly: false,
-  minify: true,
 })
 ```
 
-- `test` a RegExp (object or string) that must match asset filename
-- `filename` the filename of the result file. May contain patterns in brackets. Default to `style.css`.
-  - `[contenthash]` a hash of the content of the extracted file
-  - `[id]` the module identifier
-  - `[name]` the module name
-  - `[file]` the extracted file filename
-  - `[filebase]` the extracted file basename
-  - `[ext]` the extracted file extension
-  - May be an array of replace function arguments like `[/(\.css)/i, '-rtl$1']`.
-    Replace applies to filename that specified in extract-text-webpack-plugin.
+- `test` a RegExp (object or string) that must match asset filename.
 - `options` Options given to `rtlcss`. See the [rtlcss documentation for available options](http://rtlcss.com/learn/usage-guide/options/).
 - `plugins` RTLCSS plugins given to `rtlcss`. See the [rtlcss documentation for writing plugins](http://rtlcss.com/learn/extending-rtlcss/writing-a-plugin/). Default to `[]`.
 - `diffOnly` If set to `true`, the stylesheet created will only contain the css that differs from the source stylesheet. Default to `false`.
-- `minify` will minify the css. You can also pass an object for the arguments passed to `cssnano`. Default to `true`.

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -35,7 +35,6 @@
 	},
 	"dependencies": {
 		"@romainberger/css-diff": "^1.0.3",
-		"async": "^2.0.0",
 		"rtlcss": "^3.1.2"
 	}
 }

--- a/packages/webpack-rtl-plugin/src/index.js
+++ b/packages/webpack-rtl-plugin/src/index.js
@@ -1,4 +1,3 @@
-const path = require( 'path' );
 const cssDiff = require( '@romainberger/css-diff' );
 const rtlcss = require( 'rtlcss' );
 const { ConcatSource } = require( 'webpack' ).sources;
@@ -20,13 +19,14 @@ class WebpackRTLPlugin {
 			compilation.hooks.processAssets.tapPromise(
 				{ name: pluginName, stage: compilation.PROCESS_ASSETS_STAGE_DERIVED },
 				async ( assets ) => {
+					const cssRe = /\.css(?:$|\?)/;
 					return Promise.all(
 						Array.from( compilation.chunks )
 							.flatMap( ( chunk ) =>
 								// Collect all files form all chunks, and generate an array of {chunk, file} objects
 								Array.from( chunk.files ).map( ( asset ) => ( { chunk, asset } ) )
 							)
-							.filter( ( { asset } ) => path.extname( asset ) === '.css' )
+							.filter( ( { asset } ) => cssRe.test( asset ) )
 							.map( async ( { chunk, asset } ) => {
 								if ( this.options.test ) {
 									const re = new RegExp( this.options.test );
@@ -36,8 +36,7 @@ class WebpackRTLPlugin {
 								}
 
 								// Compute the filename
-								const baseName = path.basename( asset, '.css' );
-								const filename = asset.replace( baseName, `${ baseName }.rtl` );
+								const filename = asset.replace( cssRe, '.rtl$&' );
 								const assetInstance = assets[ asset ];
 								chunk.files.add( filename );
 

--- a/packages/webpack-rtl-plugin/test/index.js
+++ b/packages/webpack-rtl-plugin/test/index.js
@@ -329,4 +329,66 @@ describe( 'Webpack RTL Plugin', () => {
 			expect( contentRrlCss ).toBe( expected );
 		} );
 	} );
+
+	describe( 'Asset with query string', () => {
+		const config = {
+			...baseConfig,
+			entry: path.join( __dirname, 'src/indirect.js' ),
+			output: {
+				path: path.resolve( __dirname, 'dist-querystring' ),
+				filename: '[name].js',
+				chunkFilename: '[name].js?ver=[contenthash]',
+			},
+			plugins: [
+				new MiniCssExtractPlugin( {
+					filename: '[name].css',
+					chunkFilename: '[name].css?ver=[contenthash]',
+				} ),
+				new WebpackRTLPlugin(),
+			],
+		};
+
+		const mainBundlePath = path.join( __dirname, 'dist-querystring/main.js' );
+		const ondemandBundlePath = path.join( __dirname, 'dist-querystring/ondemand.js' );
+		const cssMainBundlePath = path.join( __dirname, 'dist-querystring/main.css' );
+		const cssOndemandBundlePath = path.join( __dirname, 'dist-querystring/ondemand.css' );
+		const rtlCssMainBundlePath = path.join( __dirname, 'dist-querystring/main.rtl.css' );
+		const rtlCssOndemandBundlePath = path.join( __dirname, 'dist-querystring/ondemand.rtl.css' );
+
+		beforeAll(
+			() =>
+				new Promise( ( resolve, reject ) => {
+					webpack( config, ( err, stats ) => {
+						if ( err ) {
+							return reject( err );
+						}
+
+						if ( stats.hasErrors() ) {
+							return reject( new Error( stats.toString() ) );
+						}
+						resolve();
+					} );
+				} )
+		);
+
+		it( 'should create a second bundle', () => {
+			expect( fs.existsSync( mainBundlePath ) ).toBe( true );
+			expect( fs.existsSync( ondemandBundlePath ) ).toBe( true );
+			expect( fs.existsSync( cssMainBundlePath ) ).toBe( false );
+			expect( fs.existsSync( cssOndemandBundlePath ) ).toBe( true );
+			expect( fs.existsSync( rtlCssMainBundlePath ) ).toBe( false );
+			expect( fs.existsSync( rtlCssOndemandBundlePath ) ).toBe( true );
+		} );
+
+		it( 'should contain the correct content', () => {
+			const contentJs = fs.readFileSync( mainBundlePath, 'utf-8' );
+			const contentCss = fs.readFileSync( cssOndemandBundlePath, 'utf-8' );
+			const contentRtlCss = fs.readFileSync( rtlCssOndemandBundlePath, 'utf-8' );
+
+			expect( contentCss ).toContain( 'padding-left: 10px;' );
+			expect( contentRtlCss ).toContain( 'padding-right: 10px;' );
+			expect( contentJs ).toContain( '".js?ver="' );
+			expect( contentJs ).toContain( '".css?ver="' );
+		} );
+	} );
 } );

--- a/packages/webpack-rtl-plugin/test/src/indirect.js
+++ b/packages/webpack-rtl-plugin/test/src/indirect.js
@@ -1,0 +1,1 @@
+module.exports = import( /* webpackChunkName: "ondemand" */ './index.js' );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,7 +1122,6 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": ^1.0.0
     "@romainberger/css-diff": ^1.0.3
-    async: ^2.0.0
     css-loader: ^5.2.4
     mini-css-extract-plugin: ^1.6.0
     rtlcss: ^3.1.2
@@ -10045,7 +10044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^2.0.0, async@npm:^2.1.4, async@npm:^2.4.0, async@npm:^2.6.0, async@npm:^2.6.2":
+"async@npm:^2.1.4, async@npm:^2.4.0, async@npm:^2.6.0, async@npm:^2.6.2":
   version: 2.6.3
   resolution: "async@npm:2.6.3"
   dependencies:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The main thing here is that webpack-rtl-plugin should not fail to process CSS assets that have query parts to their name.
For example, for cache busting of on-demand modules while still having stable filenames you might have your CSS chunkFilename be like `[name].css?ver=[contenthash]`.

Also, the documentation describes options that do not exist since #51547, and there's a dependency that is not used since that PR either. May as well clean that up while I'm here.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests have been added. See that they pass.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/jetpack#21349
