### PR TITLE
Update disconnected Jetpack site error message for detached user license

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { isDomainTransfer, isConciergeSession } from '@automattic/calypso-products';
 import { CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -66,9 +67,11 @@ class PurchaseItem extends Component {
 
 		if ( isDisconnectedSite ) {
 			if ( isJetpackTemporarySite ) {
-				return (
-					<span className="purchase-item__is-error">{ translate( 'Awaiting site URL' ) }</span>
-				);
+				const isJetpackUserLicensingEnabled = isEnabled( 'jetpack/user-licensing' );
+				const errorMessage = isJetpackUserLicensingEnabled
+					? translate( 'Pending activation' )
+					: translate( 'Awaiting site URL' );
+				return <span className="purchase-item__is-error">{ errorMessage }</span>;
 			}
 
 			if ( isJetpack ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, when a subscription is attached to a Jetpack temporary site, we display a message that says `Awaiting site URL`. Once we launch end-user licenses, this message won't make sense anymore, so we are replacing it with `Pending activation`.

**Note**: I'm working under the assumption that all subscriptions will be backfilled with a user license, so there is no need to verify whether a subscription is linked to a license. If we know there is a subscription attached to a Jetpack temporary site, then we can assume the license has not been attached yet.

#### Testing instructions

Prerequisites
* Access to a WPCOM sandbox.
* Add `add_filter( 'jetpack_license_checkout_m2_enabled', '__return_true' );` to your `0-sandbox.php`.
* Sandbox `public-api.wordpress.com`.

Instructions
* Download this PR.
* Start Calypso blue with `yarn start`.
* Make a site-less Jetpack purchase.
* Go to `http://calypso.localhost:3000/me/purchases`.
* Verify that the new subscription shows the `Pending activation` message in red.
* Set `jetpack/user-licensing` to false in the `config/development.json` file.
* Restart the app.
* Go to `http://calypso.localhost:3000/me/purchases`.
* Verify that the new subscription shows the `Awaiting site URL` message in red.

Related to 1201096622142517-as-1201096624355395

#### Demo
![image](https://user-images.githubusercontent.com/3418513/139496762-26764725-edd4-4491-987c-b0390050a886.png)
