### PR TITLE
preventWidows: call cloneElement to avoid key warning

### DIFF
--- a/client/lib/formatting/prevent-widows.js
+++ b/client/lib/formatting/prevent-widows.js
@@ -72,8 +72,10 @@ function preventWidowsInPart( part, spacesToSubstitute ) {
 	if ( isValidElement( part ) && part.props.children ) {
 		const result = preventWidowsInPart( part.props.children, spacesToSubstitute );
 		if ( result.substituted > 0 ) {
+			// pass children as spread arguments to prevent missing array key warnings
+			const partArray = Array.isArray( result.part ) ? result.part : [ result.part ];
 			return {
-				part: cloneElement( part, part.props, result.part ),
+				part: cloneElement( part, part.props, ...partArray ),
 				substituted: result.substituted,
 			};
 		}


### PR DESCRIPTION
Fixed a bug where `preventWidows` usage on the `/purchases/subscriptions/:site` page would lead to a React warning about missing keys:

<img width="1011" alt="Screenshot 2021-11-01 at 10 47 46" src="https://user-images.githubusercontent.com/664258/139656493-0597666c-f9a2-4697-9278-79907b4da24a.png">

This is triggered by this kind of code that doesn't really need keys:
```jsx
<p>{ preventWidows( <span><i>Hello</i><b>world</b></span> ) }</p> 
```

Why? React distinguishes between elements created with:
```jsx
createElement( 'span', null, <i>Hello</i>, <b>world</b> );
```
and
```jsx
createElement( 'span', null, [ <i>Hello</i>, <b>world</b> ] );
```
The resulting elements are completely identical, only in the first case, when children are passed as separate arguments, the children are considered "static" and keys are not validated. The `<span><i/><b/></span>` syntax is transpiled this way.

In the second case, the children are an array and keys are required. The `<span>{ [ <i/>, <b/> ] }</span>` syntax would be transpiled this way.

The `preventWidows` function calls `cloneElement`, and it turns out that `cloneElement` has the same two ways of passing children and that we need to call `cloneElement` carefully if we want to modify them. `cloneElement( el, props, children )` validates the keys if `children` is an array, `cloneElement( el, props, ...children )` doesn't validate.

`preventWidows` is (almost) always called with a static JSX (coming from `translate` and `interpolate-components` often), so the correct behavior is to spread the `children` when cloning.

**How to test:**
Select Upgrades > Purchases is a site sidebar, to navigate to `/purchases/subscriptions/:site`. Verify that there was a warning before this patch, and that this patch fixes it.