### PR TITLE
Disable track events for next button

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -110,7 +110,9 @@ export class NavigationLink extends Component {
 			this.props.goToNextStep();
 		}
 
-		this.recordClick();
+		if ( ! this.props.disabledTracks ) {
+			this.recordClick();
+		}
 	};
 
 	recordClick() {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -119,6 +119,7 @@ class StepWrapper extends Component {
 				borderless={ false }
 				primary
 				forwardIcon={ null }
+				disabledTracks
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding prop `disabledTracks` to `NavigationLink` and then set it to true for the next button. Thus, we won't send `calypso_signup_skip_step` event for the top-right button of the preview design step (ex. Start with Comfy) 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?flags=signup/hero-flow&siteSlug=<your_site>`
* Select Build > Preview any design > Start with that design
* Check `calypso_signup_skip_step` didn't fire when you started with that design in preview design step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57494
