### PR TITLE
i18n: Remove `preventWidows` formatting from login terms text

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -17,7 +17,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import Notice from 'calypso/components/notice';
 import TextControl from 'calypso/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
-import { preventWidows } from 'calypso/lib/formatting';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
@@ -597,23 +596,20 @@ export class LoginForm extends Component {
 					</div>
 
 					<p className="login__form-terms">
-						{ preventWidows(
-							this.props.translate(
-								// To make any changes to this copy please speak to the legal team
-								'By continuing, ' + 'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
-								{
-									components: {
-										tosLink: (
-											<a
-												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
-								}
-							),
-							5
+						{ this.props.translate(
+							// To make any changes to this copy please speak to the legal team
+							'By continuing, ' + 'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+							{
+								components: {
+									tosLink: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
 						) }
 					</p>
 


### PR DESCRIPTION
Having hardcoded number of words in the `preventWidows` formatting for login screens terms text doesn't work verry well across different locales. Given "Terms of Service" is already styled to preserve its white spaces, the `preventWidows` formatting doesn't seem to be needed.

#### Changes proposed in this Pull Request

* Remove `preventWidows` formatting from `.login__form-terms` terms of service text.

**Before:**
![CleanShot 2021-11-01 at 14 30 29](https://user-images.githubusercontent.com/2722412/139671997-f5bd5f20-42d5-446f-8003-6ab4ad44d09f.png)

**After:**
![CleanShot 2021-11-01 at 14 30 45](https://user-images.githubusercontent.com/2722412/139671994-b9d0fad2-7f13-4006-bc83-0e597dc10e2d.png)

#### Testing instructions

* Go to `/log-in/new/{locale}` and `/log-in/{locale}` and confirm it renders as expected.

Related to 335-gh-Automattic/i18n-issues
