### PR TITLE
Redux route state: store timestamp outside query

### DIFF
--- a/client/state/guided-tours/selectors/index.js
+++ b/client/state/guided-tours/selectors/index.js
@@ -72,7 +72,7 @@ const getTourFromQuery = createSelector(
 		const initial = getInitialQueryArguments( state );
 		const current = getCurrentQueryArguments( state );
 		const timestamp = getCurrentRouteTimestamp( state );
-		const tour = current && current.tour ? current.tour : initial.tour;
+		const tour = current.tour ?? initial.tour;
 
 		if ( tour && find( relevantFeatures, { tour } ) ) {
 			return { tour, timestamp };

--- a/client/state/guided-tours/selectors/index.js
+++ b/client/state/guided-tours/selectors/index.js
@@ -1,10 +1,11 @@
 import { createSelector } from '@automattic/state-utils';
 import debugFactory from 'debug';
-import { difference, find, findLast, flatMap, get, includes, map, startsWith, pick } from 'lodash';
+import { difference, find, findLast, flatMap, get, includes, map, startsWith } from 'lodash';
 import GuidedToursConfig from 'calypso/layout/guided-tours/config';
 import { GUIDED_TOUR_UPDATE, ROUTE_SET } from 'calypso/state/action-types';
 import { preferencesLastFetchedTimestamp } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getCurrentRouteTimestamp from 'calypso/state/selectors/get-current-route-timestamp';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { getActionLog } from 'calypso/state/ui/action-log/selectors';
 import { getSectionName, getSectionGroup } from 'calypso/state/ui/selectors';
@@ -70,12 +71,11 @@ const getTourFromQuery = createSelector(
 	( state ) => {
 		const initial = getInitialQueryArguments( state );
 		const current = getCurrentQueryArguments( state );
-		const tourProps = [ 'tour', '_timestamp' ];
-		const { tour, _timestamp } =
-			current && current.tour ? pick( current, tourProps ) : pick( initial, tourProps );
+		const timestamp = getCurrentRouteTimestamp( state );
+		const tour = current && current.tour ? current.tour : initial.tour;
 
 		if ( tour && find( relevantFeatures, { tour } ) ) {
-			return { tour, _timestamp };
+			return { tour, timestamp };
 		}
 	},
 	[ getInitialQueryArguments, getCurrentQueryArguments ]
@@ -85,9 +85,9 @@ const getTourFromQuery = createSelector(
  * Returns true if `tour` has been seen in the current Calypso session, false
  * otherwise.
  */
-const hasJustSeenTour = ( state, { tour, _timestamp } ) =>
+const hasJustSeenTour = ( state, { tour, timestamp } ) =>
 	getToursHistory( state ).some(
-		( entry ) => entry.tourName === tour && entry.timestamp > _timestamp
+		( entry ) => entry.tourName === tour && timestamp != null && entry.timestamp > timestamp
 	);
 
 /*

--- a/client/state/guided-tours/test/selectors.js
+++ b/client/state/guided-tours/test/selectors.js
@@ -55,6 +55,7 @@ describe( 'selectors', () => {
 			const tourState = getGuidedTourState( {
 				route: {
 					query: {
+						current: {},
 						initial: {},
 					},
 				},
@@ -84,6 +85,7 @@ describe( 'selectors', () => {
 		} ) => ( {
 			route: {
 				query: {
+					current: queryArguments,
 					initial: queryArguments,
 				},
 				timestamp,

--- a/client/state/guided-tours/test/selectors.js
+++ b/client/state/guided-tours/test/selectors.js
@@ -80,11 +80,13 @@ describe( 'selectors', () => {
 			toursHistory = [],
 			queryArguments = {},
 			userData = {},
+			timestamp = null,
 		} ) => ( {
 			route: {
 				query: {
 					initial: queryArguments,
 				},
+				timestamp,
 			},
 			ui: {
 				actionLog,
@@ -199,7 +201,8 @@ describe( 'selectors', () => {
 			const state = makeState( {
 				actionLog: [ navigateToThemes ],
 				toursHistory: [ themesTourSeen, mainTourJustSeen ],
-				queryArguments: { tour: 'main', _timestamp: 0 },
+				queryArguments: { tour: 'main' },
+				timestamp: 0,
 			} );
 			const tour = findEligibleTour( state );
 
@@ -227,7 +230,8 @@ describe( 'selectors', () => {
 			const state = makeState( {
 				actionLog: times( 50, () => navigateToTest ),
 				toursHistory: [ testTourSeen, themesTourSeen ],
-				queryArguments: { tour: 'themes', _timestamp: 0 },
+				queryArguments: { tour: 'themes' },
+				timestamp: 0,
 			} );
 			const tour = findEligibleTour( state );
 

--- a/client/state/route/path/reducer.js
+++ b/client/state/route/path/reducer.js
@@ -7,13 +7,12 @@ const initialState = {
 };
 
 export const pathReducer = ( state = initialState, action ) => {
-	const { path, type } = action;
-	switch ( type ) {
+	switch ( action.type ) {
 		case ROUTE_SET:
 			return {
-				initial: state.initial === '' ? path : state.initial,
-				current: path,
-				previous: state.current === '' ? '' : state.current,
+				initial: state.initial === '' ? action.path : state.initial,
+				current: action.path,
+				previous: state.current,
 			};
 	}
 	return state;

--- a/client/state/route/query/reducer.js
+++ b/client/state/route/query/reducer.js
@@ -1,16 +1,4 @@
-import { isEqual, omit } from 'lodash';
 import { ROUTE_SET } from 'calypso/state/action-types';
-
-const timestamped = ( query ) => ( {
-	...query,
-	_timestamp: Date.now(),
-} );
-
-const isEqualQuery = ( a, b ) => isEqual( omit( a, '_timestamp' ), omit( b, '_timestamp' ) );
-
-const initialReducer = ( state, query ) => ( state === false ? timestamped( query ) : state );
-const currentReducer = ( state, query ) =>
-	! isEqualQuery( state, query ) ? timestamped( query ) : state;
 
 const initialState = {
 	initial: false,
@@ -19,15 +7,15 @@ const initialState = {
 };
 
 export const queryReducer = ( state = initialState, action ) => {
-	const { query, type } = action;
-	switch ( type ) {
+	switch ( action.type ) {
 		case ROUTE_SET:
 			return {
-				initial: initialReducer( state.initial, query ),
-				current: currentReducer( state.current, query ),
-				previous: state.current === false ? false : state.current,
+				initial: state.initial === false ? action.query : state.initial,
+				current: action.query,
+				previous: state.current,
 			};
 	}
+
 	return state;
 };
 

--- a/client/state/route/reducer.js
+++ b/client/state/route/reducer.js
@@ -1,14 +1,25 @@
 import { withStorageKey } from '@automattic/state-utils';
+import { ROUTE_SET } from 'calypso/state/action-types';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import lastNonEditorRoute from './last-non-editor-route/reducer';
 import schema from './last-non-editor-route/schema';
 import path from './path/reducer';
 import query from './query/reducer';
 
+function timestamp( state = null, action ) {
+	switch ( action.type ) {
+		case ROUTE_SET:
+			return Date.now();
+		default:
+			return state;
+	}
+}
+
 const combinedReducer = combineReducers( {
 	lastNonEditorRoute: withSchemaValidation( schema, lastNonEditorRoute ),
 	path,
 	query,
+	timestamp,
 } );
 
 const routeReducer = withStorageKey( 'route', combinedReducer );

--- a/client/state/selectors/get-current-route-timestamp.js
+++ b/client/state/selectors/get-current-route-timestamp.js
@@ -1,0 +1,5 @@
+import 'calypso/state/route/init';
+
+export default function getCurrentRouteTimestamp( state ) {
+	return state.route.timestamp;
+}


### PR DESCRIPTION
The `state.route` Redux state stores the timestamp of the last `ROUTE_SET` navigation, and it's currently stored as a "special" query argument, in `state.route.query.current._timestamp`. That's a weird location. This PR moves to a standalone location, to `state.route.timestamp`.

The only usage is the `findRequestedQuery` selector in Guided Tours which compares the timestamp of the last seen query with the timestamp of last navigation. We need to update that code, too.

This PR should make typing the `state.route` state a bit easier. See also https://github.com/Automattic/wp-calypso/pull/55315#discussion_r692700303

**How to test:**
Verify that unit tests pass, and that the `_timestamp` query field is not being used anywhere else but Guided Tours.