### PR TITLE
Onboarding: Update the 'Learn more' CTA label in Activity Log for Free plans

### DIFF
--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -21,7 +21,7 @@ class UpgradeBanner extends Component {
 			<div className="activity-log-banner__upgrade">
 				{ isJetpack && ! isAtomic ? (
 					<UpsellNudge
-						callToAction={ translate( 'Learn more' ) }
+						callToAction={ translate( 'Upgrade now' ) }
 						event="activity_log_upgrade_click_jetpack"
 						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
 						href={ `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ACTIVITY_LOG ] }` }
@@ -40,7 +40,7 @@ class UpgradeBanner extends Component {
 				) : (
 					<UpsellNudge
 						forceDisplay={ true }
-						callToAction={ translate( 'Learn more' ) }
+						callToAction={ translate( 'Upgrade now' ) }
 						event="activity_log_upgrade_click_wpcom"
 						feature={ FEATURE_JETPACK_ESSENTIAL }
 						plan={ PLAN_PERSONAL }


### PR DESCRIPTION
### Changes

- This PR will replace the CTA label (to "Upgrade now") in the Activity Log of our free plans, as we have a banner there that suggests an upgrade and redirects the user to checkout, however, the CTA label is "Learn more".
- This PR is addressed here: 1164141197617539-as-1200934905125514

### Testing Instructions

1. Checkout this PR.
2. Run `yarn start`
3. Visit http://calypso.localhost:3000/
4. Switch to a website that **uses the Free Jetpack plan** (you can create a Jurassic Ninja website if you don't have one).
5. Go to Jetpack > Activity log.
6. Verify that the CTA label of "Unlock more activities now" is now "Upgrade now" and not "Learn more".
