### PR TITLE
Try waiting for `networkidle` event to fire when viewing a user page.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -81,6 +81,8 @@ export class PeoplePage {
 	 * Delete the user from site.
 	 */
 	async deleteUser(): Promise< void > {
+		await this.page.waitForLoadState( 'networkidle' );
+
 		const elementHandle = await this.page.waitForSelector(
 			selectors.deletedUserContentAction( 'delete' )
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a wait for `networkidle` event to fire before proceeding to delete the user from the site.

Performance impact is negligible, adding approx. 770ms to the execution time (which I argue is necessary to avoid the radio button click from falling through):

```
  pw:api <= page.click succeeded +37ms
  pw:api => page.waitForLoadState started +1ms
  pw:api => page.waitForLoadState started +1ms
  pw:api <= page.waitForLoadState succeeded +1ms
  pw:api   "networkidle" event fired +770ms
  pw:api <= page.waitForLoadState succeeded +0ms
  pw:api => page.waitForSelector started +1ms
  pw:api   "networkidle" event fired +0ms
  pw:api waiting for selector "input[value="delete"]" to be visible +17ms
```

#### Testing instructions

- [ ] pre-release tests
- [ ] observe Pre-Release tests going forward

Fixes #57437.
