### PR TITLE
Backup: on storage display, offer storage upgrades to 1TB (not 2TB)

### DIFF
--- a/client/components/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/components/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -1,3 +1,7 @@
+import {
+	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
+	getJetpackStorageAmountDisplays,
+} from '@automattic/calypso-products';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -63,7 +67,19 @@ export const BackupStorageSpaceUpsell: React.FC< OwnProps > = ( {
 	}, [ dispatch, usageLevel, bytesUsed ] );
 
 	const statusText = preventWidows( useStatusText( usageLevel ) );
-	const actionText = preventWidows( translate( 'Upgrade your backup storage to 2TB' ) );
+
+	// For now, Backup and Security both have the same two tiers,
+	// so it's okay to statically reference one of them to retrieve
+	// our upgraded storage amount.
+	const upgradeStorageAmount = getJetpackStorageAmountDisplays()[
+		PRODUCT_JETPACK_BACKUP_T2_YEARLY
+	];
+	const actionText = preventWidows(
+		translate( 'Upgrade your backup storage to %(upgradeStorageAmount)s', {
+			args: { upgradeStorageAmount },
+			comment: 'upgradeStorageAmount is an abbreviated storage amount; e.g., 1TB',
+		} )
+	);
 
 	return (
 		<>


### PR DESCRIPTION
Resolves `1200412004370260-as-1201289204577521`, `p1HpG7-dpL-p2#comment-49980`.

#### Changes proposed in this Pull Request

* For sites nearing their storage limit, revise the backup display so that the storage upgrade prompt offers 1TB of space instead of 2.

#### Testing instructions

1. Select a Jetpack site that has a Backup or Security plan with 10GB of storage.
2. Visit the Backup page in any Calypso experience, or visit the My Plan tab in Calypso Blue.
3. If your site is nearing its storage limit (65% full or more), you should see an upsell in the backup storage display bar offering an upgrade to 1TB of storage.
4. (Optional) Visit the same page in a staging environment to see the incorrect "2TB" upgrade prompt.

**TIP:** If your site is not nearing its storage limit, you can simulate this state by dispatching the following action in Redux DevTools, substituting your site ID:

```js
{
  type: 'REWIND_SIZE_SET',
  siteId: <your_site_id>,
  size: {
    bytesUsed: 8589934592
  }
}
```

#### Reference screenshots (before / after)

<img width="375" alt="image" src="https://user-images.githubusercontent.com/670067/139715890-e7151147-cc88-484c-bb5c-3961ebb907ba.png"> <img width="375" alt="Screen Shot 2021-11-01 at 12 25 00" src="https://user-images.githubusercontent.com/670067/139715708-f958e32c-ad9a-40b8-a1d1-b72e75ba6b49.png">
