### PR TITLE
Checkout: Remove undocumented.transactions function, take 2

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -830,26 +830,6 @@ Undocumented.prototype.updateConnection = function ( siteId, connectionId, data,
 };
 
 /**
- * POST create a payment transaction
- *
- * @param {object} [data] The REQUEST data
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- *
- * The post data format is: {
- *		payment_method: {string} The payment gateway,
- *		payment_key: {string} Either the cc token from the gateway, or the mp_ref from /me/stored_cards,
- *		payment: {object} Payment details, including payment_method and payment_key,
- *		cart: {object>shopping_cart} A Shopping cart object
- *		domain_details: {object>contact_information} Optional set of domain contact information
- *		locale: {string} Locale for translating strings in response data,
- * }
- */
-Undocumented.prototype.transactions = function ( data, fn ) {
-	return this.wpcom.req.post( '/me/transactions', mapKeysRecursively( data, snakeCase ), fn );
-};
-
-/**
  * GET paypal_express_url
  *
  * @param {object} [data] The GET data

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -1,3 +1,4 @@
+import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/wpcom-checkout';
 import wp from 'calypso/lib/wp';
 import { createAccount } from '../payment-method-helpers';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
@@ -34,9 +35,12 @@ export default async function submitWpcomTransaction(
 					cart_key: siteId || 'no-site',
 				},
 			};
-			return wp.undocumented().transactions( newPayload );
+			return wp.req.post(
+				'/me/transactions',
+				mapRecordKeysRecursively( newPayload, camelToSnakeCase )
+			);
 		} );
 	}
 
-	return wp.undocumented().transactions( payload );
+	return wp.req.post( '/me/transactions', mapRecordKeysRecursively( payload, camelToSnakeCase ) );
 }

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -4,6 +4,10 @@ import {
 	mockTransactionsEndpoint,
 	mockTransactionsSuccessResponse,
 	processorOptions,
+	basicExpectedDomainDetails,
+	countryCode,
+	postalCode,
+	contactDetailsForDomain,
 } from './util';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { Stripe } from '@stripe/stripe-js';
@@ -27,9 +31,6 @@ describe( 'existingCardProcessor', () => {
 		stripe,
 		responseCart: cart,
 	};
-
-	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
-	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
 
 	const basicExpectedStripeRequest = {
 		cart: {
@@ -73,27 +74,6 @@ describe( 'existingCardProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
-	};
-
-	const basicExpectedDomainDetails = {
-		address1: undefined,
-		address2: undefined,
-		alternate_email: undefined,
-		city: undefined,
-		country_code: 'US',
-		email: undefined,
-		extra: {
-			ca: null,
-			fr: null,
-			uk: null,
-		},
-		fax: undefined,
-		first_name: undefined,
-		last_name: undefined,
-		organization: undefined,
-		phone: undefined,
-		postal_code: '10001',
-		state: undefined,
 	};
 
 	it( 'throws an error if there is no storedDetailsId passed', async () => {
@@ -286,10 +266,7 @@ describe( 'existingCardProcessor', () => {
 				...options,
 				siteSlug: 'example.wordpress.com',
 				siteId: 1234567,
-				contactDetails: {
-					countryCode,
-					postalCode,
-				},
+				contactDetails: contactDetailsForDomain,
 				responseCart: { ...cart, products: [ domainProduct ] },
 				includeDomainDetails: true,
 			} )

--- a/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
@@ -4,6 +4,10 @@ import {
 	mockTransactionsEndpoint,
 	mockTransactionsSuccessResponse,
 	processorOptions,
+	basicExpectedDomainDetails,
+	countryCode,
+	postalCode,
+	contactDetailsForDomain,
 } from './util';
 
 describe( 'freePurchaseProcessor', () => {
@@ -18,9 +22,6 @@ describe( 'freePurchaseProcessor', () => {
 		...processorOptions,
 		responseCart: cart,
 	};
-
-	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
-	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
 
 	const basicExpectedStripeRequest = {
 		cart: {
@@ -64,27 +65,6 @@ describe( 'freePurchaseProcessor', () => {
 			tef_bank: undefined,
 			zip: '',
 		},
-	};
-
-	const basicExpectedDomainDetails = {
-		address1: undefined,
-		address2: undefined,
-		alternate_email: undefined,
-		city: undefined,
-		country_code: 'US',
-		email: undefined,
-		extra: {
-			ca: null,
-			fr: null,
-			uk: null,
-		},
-		fax: undefined,
-		first_name: undefined,
-		last_name: undefined,
-		organization: undefined,
-		phone: undefined,
-		postal_code: '10001',
-		state: undefined,
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {
@@ -192,10 +172,7 @@ describe( 'freePurchaseProcessor', () => {
 				...options,
 				siteSlug: 'example.wordpress.com',
 				siteId: 1234567,
-				contactDetails: {
-					countryCode,
-					postalCode,
-				},
+				contactDetails: contactDetailsForDomain,
 				responseCart: { ...cart, products: [ domainProduct ] },
 				includeDomainDetails: true,
 			} )

--- a/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
@@ -1,8 +1,5 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
-import wp from 'calypso/lib/wp';
 import fullCreditsProcessor from '../lib/full-credits-processor';
-
-jest.mock( 'calypso/lib/wp' );
 
 describe( 'fullCreditsProcessor', () => {
 	const stripeConfiguration = {

--- a/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
@@ -4,6 +4,10 @@ import {
 	mockTransactionsEndpoint,
 	mockTransactionsSuccessResponse,
 	processorOptions,
+	countryCode,
+	postalCode,
+	basicExpectedDomainDetails,
+	contactDetailsForDomain,
 } from './util';
 
 describe( 'fullCreditsProcessor', () => {
@@ -18,9 +22,6 @@ describe( 'fullCreditsProcessor', () => {
 		...processorOptions,
 		responseCart: cart,
 	};
-
-	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
-	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
 
 	const basicExpectedStripeRequest = {
 		cart: {
@@ -64,27 +65,6 @@ describe( 'fullCreditsProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
-	};
-
-	const basicExpectedDomainDetails = {
-		address1: undefined,
-		address2: undefined,
-		alternate_email: undefined,
-		city: undefined,
-		country_code: 'US',
-		email: undefined,
-		extra: {
-			ca: null,
-			fr: null,
-			uk: null,
-		},
-		fax: undefined,
-		first_name: undefined,
-		last_name: undefined,
-		organization: undefined,
-		phone: undefined,
-		postal_code: '10001',
-		state: undefined,
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {
@@ -193,10 +173,7 @@ describe( 'fullCreditsProcessor', () => {
 				...options,
 				siteSlug: 'example.wordpress.com',
 				siteId: 1234567,
-				contactDetails: {
-					countryCode,
-					postalCode,
-				},
+				contactDetails: contactDetailsForDomain,
 				responseCart: { ...cart, products: [ domainProduct ] },
 				includeDomainDetails: true,
 			} )

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -1,14 +1,9 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import nock from 'nock';
 import genericRedirectProcessor from '../lib/generic-redirect-processor';
+import { processorOptions } from './util';
 
 describe( 'genericRedirectProcessor', () => {
-	const stripeConfiguration = {
-		processor_id: 'IE',
-		js_url: 'https://stripe-js-url',
-		public_key: 'stripe-public-key',
-		setup_intent_id: null,
-	};
 	const product = getEmptyResponseCartProduct();
 	const domainProduct = {
 		...getEmptyResponseCartProduct(),
@@ -17,18 +12,8 @@ describe( 'genericRedirectProcessor', () => {
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
 	const options = {
-		includeDomainDetails: false,
-		includeGSuiteDetails: false,
-		createUserAndSiteBeforeTransaction: false,
-		stripeConfiguration,
-		recordEvent: () => null,
-		reduxDispatch: () => null,
+		...processorOptions,
 		responseCart: cart,
-		getThankYouUrl: () => '',
-		siteSlug: undefined,
-		siteId: undefined,
-		contactDetails: undefined,
-		stripe: undefined,
 	};
 
 	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -4,6 +4,10 @@ import {
 	mockTransactionsEndpoint,
 	mockTransactionsRedirectResponse,
 	processorOptions,
+	basicExpectedDomainDetails,
+	countryCode,
+	postalCode,
+	contactDetailsForDomain,
 } from './util';
 
 describe( 'genericRedirectProcessor', () => {
@@ -18,9 +22,6 @@ describe( 'genericRedirectProcessor', () => {
 		...processorOptions,
 		responseCart: cart,
 	};
-
-	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
-	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
 
 	const basicExpectedStripeRequest = {
 		cart: {
@@ -65,27 +66,6 @@ describe( 'genericRedirectProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
-	};
-
-	const basicExpectedDomainDetails = {
-		address1: undefined,
-		address2: undefined,
-		alternate_email: undefined,
-		city: undefined,
-		country_code: 'US',
-		email: undefined,
-		extra: {
-			ca: null,
-			fr: null,
-			uk: null,
-		},
-		fax: undefined,
-		first_name: undefined,
-		last_name: undefined,
-		organization: undefined,
-		phone: undefined,
-		postal_code: '10001',
-		state: undefined,
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {
@@ -324,10 +304,7 @@ describe( 'genericRedirectProcessor', () => {
 				...options,
 				siteSlug: 'example.wordpress.com',
 				siteId: 1234567,
-				contactDetails: {
-					countryCode,
-					postalCode,
-				},
+				contactDetails: contactDetailsForDomain,
 				responseCart: { ...cart, products: [ domainProduct ] },
 				includeDomainDetails: true,
 			} )

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -1,7 +1,11 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
-import wp from 'calypso/lib/wp';
 import multiPartnerCardProcessor from '../lib/multi-partner-card-processor';
+import {
+	mockTransactionsEndpoint,
+	mockTransactionsSuccessResponse,
+	processorOptions,
+} from './util';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
 	Stripe,
@@ -10,7 +14,6 @@ import type {
 	PaymentMethod,
 } from '@stripe/stripe-js';
 
-jest.mock( 'calypso/lib/wp' );
 jest.mock( 'calypso/lib/store-transactions', () => ( {
 	createEbanxToken: jest.fn(),
 } ) );
@@ -121,31 +124,31 @@ describe( 'multiPartnerCardProcessor', () => {
 			},
 			temporary: false,
 		},
-		domainDetails: undefined,
+		domain_details: undefined,
 		payment: {
 			address: undefined,
-			cancelUrl: undefined,
+			cancel_url: undefined,
 			city: undefined,
 			country: 'US',
-			countryCode: 'US',
-			deviceId: undefined,
+			country_code: 'US',
+			device_id: undefined,
 			document: undefined,
 			email: undefined,
 			gstin: undefined,
-			idealBank: undefined,
+			ideal_bank: undefined,
 			name: 'test name',
 			nik: undefined,
 			pan: undefined,
-			paymentKey: 'stripe-token',
-			paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
-			paymentPartner: 'IE',
-			phoneNumber: undefined,
-			postalCode: '10001',
+			payment_key: 'stripe-token',
+			payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+			payment_partner: 'IE',
+			phone_number: undefined,
+			postal_code: '10001',
 			state: undefined,
-			storedDetailsId: undefined,
-			streetNumber: undefined,
-			successUrl: undefined,
-			tefBank: undefined,
+			stored_details_id: undefined,
+			street_number: undefined,
+			success_url: undefined,
+			tef_bank: undefined,
 			zip: '10001',
 		},
 	};
@@ -154,28 +157,28 @@ describe( 'multiPartnerCardProcessor', () => {
 		...basicExpectedStripeRequest,
 		payment: {
 			address: '100 Main Street',
-			cancelUrl: undefined,
+			cancel_url: undefined,
 			city: 'New York',
 			country: 'US',
-			countryCode: 'US',
-			deviceId: 'mock-ebanx-device',
+			country_code: 'US',
+			device_id: 'mock-ebanx-device',
 			document: 'ebanx-document-code',
 			email: undefined,
 			gstin: undefined,
-			idealBank: undefined,
+			ideal_bank: undefined,
 			name: 'test name',
 			nik: undefined,
 			pan: undefined,
-			paymentKey: 'ebanx-token',
-			paymentMethod: 'WPCOM_Billing_Ebanx',
-			paymentPartner: undefined,
-			phoneNumber: '1111111111',
-			postalCode: '10001',
+			payment_key: 'ebanx-token',
+			payment_method: 'WPCOM_Billing_Ebanx',
+			payment_partner: undefined,
+			phone_number: '1111111111',
+			postal_code: '10001',
 			state: 'NY',
-			storedDetailsId: undefined,
-			streetNumber: '100',
-			successUrl: undefined,
-			tefBank: undefined,
+			stored_details_id: undefined,
+			street_number: '100',
+			success_url: undefined,
+			tef_bank: undefined,
 			zip: '10001',
 		},
 	};
@@ -183,9 +186,9 @@ describe( 'multiPartnerCardProcessor', () => {
 	const basicExpectedDomainDetails = {
 		address1: undefined,
 		address2: undefined,
-		alternateEmail: undefined,
+		alternate_email: undefined,
 		city: undefined,
-		countryCode: 'US',
+		country_code: 'US',
 		email: undefined,
 		extra: {
 			ca: null,
@@ -193,43 +196,24 @@ describe( 'multiPartnerCardProcessor', () => {
 			uk: null,
 		},
 		fax: undefined,
-		firstName: undefined,
-		lastName: undefined,
+		first_name: undefined,
+		last_name: undefined,
 		organization: undefined,
 		phone: undefined,
-		postalCode: '10001',
+		postal_code: '10001',
 		state: undefined,
 	};
-
-	const transactionsEndpoint = jest.fn();
-	const undocumentedFunctions = {
-		transactions: transactionsEndpoint,
-	};
-	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
 
 	const stripe = {
 		createPaymentMethod: createMockStripeToken,
 	} as Stripe;
 
 	const options: PaymentProcessorOptions = {
-		includeDomainDetails: false,
-		includeGSuiteDetails: false,
-		createUserAndSiteBeforeTransaction: false,
+		...processorOptions,
 		stripe,
 		stripeConfiguration,
-		recordEvent: () => null,
-		reduxDispatch: () => null,
 		responseCart: cart,
-		getThankYouUrl: () => '',
-		siteSlug: undefined,
-		siteId: undefined,
-		contactDetails: undefined,
 	};
-
-	beforeEach( () => {
-		transactionsEndpoint.mockClear();
-		transactionsEndpoint.mockReturnValue( Promise.resolve( 'test success' ) );
-	} );
 
 	it( 'throws an error if there is no paymentPartner', async () => {
 		const submitData = {};
@@ -328,6 +312,7 @@ describe( 'multiPartnerCardProcessor', () => {
 		} );
 
 		it( 'sends the correct data to the endpoint with no site and one product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 			const submitData = {
 				paymentPartner: 'stripe',
 				stripe,
@@ -335,7 +320,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				name: 'test name',
 				cardNumberElement: mockCardNumberElement,
 			};
-			const expected = { payload: 'test success', type: 'SUCCESS' };
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 			await expect(
 				multiPartnerCardProcessor( submitData, {
 					...options,
@@ -348,7 +333,14 @@ describe( 'multiPartnerCardProcessor', () => {
 			expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
 		} );
 
-		it( 'returns an explicit error response if the transaction fails', async () => {
+		it( 'returns an explicit error response if the transaction fails with a non-200 error', async () => {
+			mockTransactionsEndpoint( () => [
+				400,
+				{
+					error: 'test_error',
+					message: 'test error',
+				},
+			] );
 			const submitData = {
 				paymentPartner: 'stripe',
 				stripe,
@@ -356,7 +348,6 @@ describe( 'multiPartnerCardProcessor', () => {
 				name: 'test name',
 				cardNumberElement: mockCardNumberElement,
 			};
-			transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
 			const expected = { payload: 'test error', type: 'ERROR' };
 			await expect(
 				multiPartnerCardProcessor( submitData, {
@@ -370,6 +361,7 @@ describe( 'multiPartnerCardProcessor', () => {
 		} );
 
 		it( 'sends the correct data to the endpoint with a site and one product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 			const submitData = {
 				paymentPartner: 'stripe',
 				stripe,
@@ -377,7 +369,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				name: 'test name',
 				cardNumberElement: mockCardNumberElement,
 			};
-			const expected = { payload: 'test success', type: 'SUCCESS' };
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 			await expect(
 				multiPartnerCardProcessor( submitData, {
 					...options,
@@ -402,6 +394,7 @@ describe( 'multiPartnerCardProcessor', () => {
 		} );
 
 		it( 'sends the correct data to the endpoint with tax information', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 			const submitData = {
 				paymentPartner: 'stripe',
 				stripe,
@@ -409,7 +402,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				name: 'test name',
 				cardNumberElement: mockCardNumberElement,
 			};
-			const expected = { payload: 'test success', type: 'SUCCESS' };
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 			await expect(
 				multiPartnerCardProcessor( submitData, {
 					...options,
@@ -445,6 +438,7 @@ describe( 'multiPartnerCardProcessor', () => {
 		} );
 
 		it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 			const submitData = {
 				paymentPartner: 'stripe',
 				stripe,
@@ -452,7 +446,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				name: 'test name',
 				cardNumberElement: mockCardNumberElement,
 			};
-			const expected = { payload: 'test success', type: 'SUCCESS' };
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 			await expect(
 				multiPartnerCardProcessor( submitData, {
 					...options,
@@ -476,7 +470,7 @@ describe( 'multiPartnerCardProcessor', () => {
 					create_new_blog: false,
 					products: [ domainProduct ],
 				},
-				domainDetails: basicExpectedDomainDetails,
+				domain_details: basicExpectedDomainDetails,
 			} );
 		} );
 	} );
@@ -559,11 +553,12 @@ describe( 'multiPartnerCardProcessor', () => {
 		} );
 
 		it( 'sends the correct data to the endpoint with no site and one product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 			const submitData = {
 				paymentPartner: 'ebanx',
 				...ebanxCardTransactionRequest,
 			};
-			const expected = { payload: 'test success', type: 'SUCCESS' };
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
 				expected
 			);
@@ -571,11 +566,17 @@ describe( 'multiPartnerCardProcessor', () => {
 		} );
 
 		it( 'returns an explicit error response if the transaction fails', async () => {
+			mockTransactionsEndpoint( () => [
+				400,
+				{
+					error: 'test_error',
+					message: 'test error',
+				},
+			] );
 			const submitData = {
 				paymentPartner: 'ebanx',
 				...ebanxCardTransactionRequest,
 			};
-			transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
 			const expected = { payload: 'test error', type: 'ERROR' };
 			await expect( multiPartnerCardProcessor( submitData, options ) ).resolves.toStrictEqual(
 				expected
@@ -583,11 +584,12 @@ describe( 'multiPartnerCardProcessor', () => {
 		} );
 
 		it( 'sends the correct data to the endpoint with a site and one product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 			const submitData = {
 				paymentPartner: 'ebanx',
 				...ebanxCardTransactionRequest,
 			};
-			const expected = { payload: 'test success', type: 'SUCCESS' };
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 			await expect(
 				multiPartnerCardProcessor( submitData, {
 					...options,
@@ -613,11 +615,12 @@ describe( 'multiPartnerCardProcessor', () => {
 		} );
 
 		it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 			const submitData = {
 				paymentPartner: 'ebanx',
 				...ebanxCardTransactionRequest,
 			};
-			const expected = { payload: 'test success', type: 'SUCCESS' };
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 			await expect(
 				multiPartnerCardProcessor( submitData, {
 					...options,
@@ -641,7 +644,7 @@ describe( 'multiPartnerCardProcessor', () => {
 					create_new_blog: false,
 					products: [ domainProduct ],
 				},
-				domainDetails: basicExpectedDomainDetails,
+				domain_details: basicExpectedDomainDetails,
 			} );
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -5,6 +5,10 @@ import {
 	mockTransactionsEndpoint,
 	mockTransactionsSuccessResponse,
 	processorOptions,
+	basicExpectedDomainDetails,
+	countryCode,
+	postalCode,
+	contactDetailsForDomain,
 } from './util';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
@@ -106,9 +110,6 @@ describe( 'multiPartnerCardProcessor', () => {
 
 	const mockCardNumberElement = () => <div>mock card number</div>;
 
-	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
-	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
-
 	const basicExpectedStripeRequest = {
 		cart: {
 			blog_id: '0',
@@ -181,27 +182,6 @@ describe( 'multiPartnerCardProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
-	};
-
-	const basicExpectedDomainDetails = {
-		address1: undefined,
-		address2: undefined,
-		alternate_email: undefined,
-		city: undefined,
-		country_code: 'US',
-		email: undefined,
-		extra: {
-			ca: null,
-			fr: null,
-			uk: null,
-		},
-		fax: undefined,
-		first_name: undefined,
-		last_name: undefined,
-		organization: undefined,
-		phone: undefined,
-		postal_code: '10001',
-		state: undefined,
 	};
 
 	const stripe = {
@@ -452,10 +432,7 @@ describe( 'multiPartnerCardProcessor', () => {
 					...options,
 					siteSlug: 'example.wordpress.com',
 					siteId: 1234567,
-					contactDetails: {
-						countryCode,
-						postalCode,
-					},
+					contactDetails: contactDetailsForDomain,
 					responseCart: { ...cart, products: [ domainProduct ] },
 					includeDomainDetails: true,
 				} )
@@ -626,10 +603,7 @@ describe( 'multiPartnerCardProcessor', () => {
 					...options,
 					siteSlug: 'example.wordpress.com',
 					siteId: 1234567,
-					contactDetails: {
-						countryCode,
-						postalCode,
-					},
+					contactDetails: contactDetailsForDomain,
 					responseCart: { ...cart, products: [ domainProduct ] },
 					includeDomainDetails: true,
 				} )

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -5,17 +5,16 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import wp from 'calypso/lib/wp';
 import payPalExpressProcessor from '../lib/paypal-express-processor';
-import {
-	processorOptions,
-	countryCode,
-	postalCode,
-	basicExpectedDomainDetails,
-	contactDetailsForDomain,
-} from './util';
 
 jest.mock( 'calypso/lib/wp' );
 
 describe( 'payPalExpressProcessor', () => {
+	const stripeConfiguration = {
+		processor_id: 'IE',
+		js_url: 'https://stripe-js-url',
+		public_key: 'stripe-public-key',
+		setup_intent_id: null,
+	};
 	const product = getEmptyResponseCartProduct();
 	const domainProduct = {
 		...getEmptyResponseCartProduct(),
@@ -24,9 +23,21 @@ describe( 'payPalExpressProcessor', () => {
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
 	const options = {
-		...processorOptions,
+		includeDomainDetails: false,
+		includeGSuiteDetails: false,
+		createUserAndSiteBeforeTransaction: false,
+		stripeConfiguration,
+		recordEvent: () => null,
+		reduxDispatch: () => null,
 		responseCart: cart,
+		getThankYouUrl: () => '',
+		siteSlug: undefined,
+		siteId: undefined,
+		contactDetails: undefined,
 	};
+
+	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
+	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
 
 	const basicExpectedRequest = {
 		cancelUrl: 'https://example.com/',
@@ -48,6 +59,27 @@ describe( 'payPalExpressProcessor', () => {
 		domainDetails: null,
 		postalCode: '',
 		successUrl: 'https://example.com',
+	};
+
+	const basicExpectedDomainDetails = {
+		address1: undefined,
+		address2: undefined,
+		alternateEmail: undefined,
+		city: undefined,
+		countryCode: 'US',
+		email: undefined,
+		extra: {
+			ca: null,
+			fr: null,
+			uk: null,
+		},
+		fax: undefined,
+		firstName: undefined,
+		lastName: undefined,
+		organization: undefined,
+		phone: undefined,
+		postalCode: '10001',
+		state: undefined,
 	};
 
 	const transactionsEndpoint = jest.fn();
@@ -159,7 +191,10 @@ describe( 'payPalExpressProcessor', () => {
 				...options,
 				siteSlug: 'example.wordpress.com',
 				siteId: 1234567,
-				contactDetails: contactDetailsForDomain,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
 				responseCart: { ...cart, products: [ domainProduct ] },
 				includeDomainDetails: true,
 			} )

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -5,16 +5,17 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import wp from 'calypso/lib/wp';
 import payPalExpressProcessor from '../lib/paypal-express-processor';
+import {
+	processorOptions,
+	countryCode,
+	postalCode,
+	basicExpectedDomainDetails,
+	contactDetailsForDomain,
+} from './util';
 
 jest.mock( 'calypso/lib/wp' );
 
 describe( 'payPalExpressProcessor', () => {
-	const stripeConfiguration = {
-		processor_id: 'IE',
-		js_url: 'https://stripe-js-url',
-		public_key: 'stripe-public-key',
-		setup_intent_id: null,
-	};
 	const product = getEmptyResponseCartProduct();
 	const domainProduct = {
 		...getEmptyResponseCartProduct(),
@@ -23,21 +24,9 @@ describe( 'payPalExpressProcessor', () => {
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
 	const options = {
-		includeDomainDetails: false,
-		includeGSuiteDetails: false,
-		createUserAndSiteBeforeTransaction: false,
-		stripeConfiguration,
-		recordEvent: () => null,
-		reduxDispatch: () => null,
+		...processorOptions,
 		responseCart: cart,
-		getThankYouUrl: () => '',
-		siteSlug: undefined,
-		siteId: undefined,
-		contactDetails: undefined,
 	};
-
-	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
-	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
 
 	const basicExpectedRequest = {
 		cancelUrl: 'https://example.com/',
@@ -59,27 +48,6 @@ describe( 'payPalExpressProcessor', () => {
 		domainDetails: null,
 		postalCode: '',
 		successUrl: 'https://example.com',
-	};
-
-	const basicExpectedDomainDetails = {
-		address1: undefined,
-		address2: undefined,
-		alternateEmail: undefined,
-		city: undefined,
-		countryCode: 'US',
-		email: undefined,
-		extra: {
-			ca: null,
-			fr: null,
-			uk: null,
-		},
-		fax: undefined,
-		firstName: undefined,
-		lastName: undefined,
-		organization: undefined,
-		phone: undefined,
-		postalCode: '10001',
-		state: undefined,
 	};
 
 	const transactionsEndpoint = jest.fn();
@@ -191,10 +159,7 @@ describe( 'payPalExpressProcessor', () => {
 				...options,
 				siteSlug: 'example.wordpress.com',
 				siteId: 1234567,
-				contactDetails: {
-					countryCode,
-					postalCode,
-				},
+				contactDetails: contactDetailsForDomain,
 				responseCart: { ...cart, products: [ domainProduct ] },
 				includeDomainDetails: true,
 			} )

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -1,5 +1,28 @@
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
+
+export const stripeConfiguration = {
+	processor_id: 'IE',
+	js_url: 'https://stripe-js-url',
+	public_key: 'stripe-public-key',
+	setup_intent_id: null,
+};
+
+export const processorOptions = {
+	includeDomainDetails: false,
+	includeGSuiteDetails: false,
+	createUserAndSiteBeforeTransaction: false,
+	stripeConfiguration,
+	recordEvent: () => null,
+	reduxDispatch: () => null,
+	responseCart: getEmptyResponseCart(),
+	getThankYouUrl: () => '',
+	siteSlug: undefined,
+	siteId: undefined,
+	contactDetails: undefined,
+	stripe: undefined,
+};
 
 export const countryList = [
 	{

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -1,4 +1,5 @@
 import { getEmptyResponseCart } from '@automattic/shopping-cart';
+import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
@@ -697,3 +698,23 @@ export function createTestReduxStore() {
 		};
 	} );
 }
+
+export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
+	const transactionsEndpoint = jest.fn();
+	transactionsEndpoint.mockReturnValue( true );
+
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/me/transactions', ( body ) => {
+			return transactionsEndpoint( body );
+		} )
+		.reply( transactionsEndpointResponse );
+
+	return transactionsEndpoint;
+}
+
+export const mockTransactionsRedirectResponse = () => [
+	200,
+	{ redirect_url: 'https://test-redirect-url' },
+];
+
+export const mockTransactionsSuccessResponse = () => [ 200, { success: 'true' } ];

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -718,3 +718,52 @@ export const mockTransactionsRedirectResponse = () => [
 ];
 
 export const mockTransactionsSuccessResponse = () => [ 200, { success: 'true' } ];
+
+function getManagedValueFromString( value ) {
+	return { isTouched: true, value, errors: [], isRequired: true };
+}
+
+function getStringFromManagedValue( managedValue ) {
+	return managedValue.value;
+}
+
+export const countryCode = getManagedValueFromString( 'US' );
+export const postalCode = getManagedValueFromString( '10001' );
+export const address1 = getManagedValueFromString( '100 Main Street' );
+export const city = getManagedValueFromString( 'Rando city' );
+export const state = getManagedValueFromString( 'NY' );
+export const firstName = getManagedValueFromString( 'Human' );
+export const lastName = getManagedValueFromString( 'Person' );
+export const phone = getManagedValueFromString( '+1.5555555555' );
+
+export const contactDetailsForDomain = {
+	countryCode,
+	postalCode,
+	address1,
+	city,
+	state,
+	firstName,
+	lastName,
+	phone,
+};
+
+export const basicExpectedDomainDetails = {
+	address_1: getStringFromManagedValue( address1 ),
+	address_2: undefined,
+	alternate_email: undefined,
+	city: getStringFromManagedValue( city ),
+	country_code: getStringFromManagedValue( countryCode ),
+	email: undefined,
+	extra: {
+		ca: null,
+		fr: null,
+		uk: null,
+	},
+	fax: undefined,
+	first_name: getStringFromManagedValue( firstName ),
+	last_name: getStringFromManagedValue( lastName ),
+	organization: undefined,
+	phone: getStringFromManagedValue( phone ),
+	postal_code: getStringFromManagedValue( postalCode ),
+	state: getStringFromManagedValue( state ),
+};

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -8,6 +8,10 @@ import {
 	mockTransactionsEndpoint,
 	mockTransactionsRedirectResponse,
 	processorOptions,
+	basicExpectedDomainDetails,
+	countryCode,
+	postalCode,
+	contactDetailsForDomain,
 } from './util';
 
 describe( 'weChatProcessor', () => {
@@ -22,9 +26,6 @@ describe( 'weChatProcessor', () => {
 		...processorOptions,
 		responseCart: cart,
 	};
-
-	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
-	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
 
 	const basicExpectedStripeRequest = {
 		cart: {
@@ -69,27 +70,6 @@ describe( 'weChatProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
-	};
-
-	const basicExpectedDomainDetails = {
-		address1: undefined,
-		address2: undefined,
-		alternate_email: undefined,
-		city: undefined,
-		country_code: 'US',
-		email: undefined,
-		extra: {
-			ca: null,
-			fr: null,
-			uk: null,
-		},
-		fax: undefined,
-		first_name: undefined,
-		last_name: undefined,
-		organization: undefined,
-		phone: undefined,
-		postal_code: '10001',
-		state: undefined,
 	};
 
 	const redirect_url = 'https://test-redirect-url';
@@ -225,10 +205,7 @@ describe( 'weChatProcessor', () => {
 				...options,
 				siteSlug: 'example.wordpress.com',
 				siteId: 1234567,
-				contactDetails: {
-					countryCode,
-					postalCode,
-				},
+				contactDetails: contactDetailsForDomain,
 				responseCart: { ...cart, products: [ domainProduct ] },
 				includeDomainDetails: true,
 			} )

--- a/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
@@ -1,16 +1,13 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
-import wp from 'calypso/lib/wp';
 import webPayProcessor from '../lib/web-pay-processor';
-
-jest.mock( 'calypso/lib/wp' );
+import {
+	mockTransactionsEndpoint,
+	mockTransactionsSuccessResponse,
+	processorOptions,
+	stripeConfiguration,
+} from './util';
 
 describe( 'webPayProcessor', () => {
-	const stripeConfiguration = {
-		processor_id: 'IE',
-		js_url: 'https://stripe-js-url',
-		public_key: 'stripe-public-key',
-		setup_intent_id: null,
-	};
 	const product = getEmptyResponseCartProduct();
 	const domainProduct = {
 		...getEmptyResponseCartProduct(),
@@ -19,17 +16,8 @@ describe( 'webPayProcessor', () => {
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
 	const options = {
-		includeDomainDetails: false,
-		includeGSuiteDetails: false,
-		createUserAndSiteBeforeTransaction: false,
-		stripeConfiguration,
-		recordEvent: () => null,
-		reduxDispatch: () => null,
+		...processorOptions,
 		responseCart: cart,
-		getThankYouUrl: () => '',
-		siteSlug: undefined,
-		siteId: undefined,
-		contactDetails: undefined,
 	};
 
 	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
@@ -51,31 +39,31 @@ describe( 'webPayProcessor', () => {
 			},
 			temporary: false,
 		},
-		domainDetails: undefined,
+		domain_details: undefined,
 		payment: {
 			address: undefined,
 			cancelUrl: undefined,
 			city: undefined,
 			country: 'US',
-			countryCode: 'US',
-			deviceId: undefined,
+			country_code: 'US',
+			device_id: undefined,
 			document: undefined,
 			email: undefined,
 			gstin: undefined,
-			idealBank: undefined,
+			ideal_bank: undefined,
 			name: 'test name',
 			nik: undefined,
 			pan: undefined,
-			paymentKey: 'web-pay-token',
-			paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
-			paymentPartner: 'IE',
-			phoneNumber: undefined,
-			postalCode: '10001',
+			payment_key: 'web-pay-token',
+			payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+			payment_partner: 'IE',
+			phone_number: undefined,
+			postal_code: '10001',
 			state: undefined,
-			storedDetailsId: undefined,
-			streetNumber: undefined,
-			successUrl: undefined,
-			tefBank: undefined,
+			stored_details_id: undefined,
+			street_number: undefined,
+			success_url: undefined,
+			tef_bank: undefined,
 			zip: '10001',
 		},
 	};
@@ -83,9 +71,9 @@ describe( 'webPayProcessor', () => {
 	const basicExpectedDomainDetails = {
 		address1: undefined,
 		address2: undefined,
-		alternateEmail: undefined,
+		alternate_email: undefined,
 		city: undefined,
-		countryCode: 'US',
+		country_code: 'US',
 		email: undefined,
 		extra: {
 			ca: null,
@@ -93,24 +81,13 @@ describe( 'webPayProcessor', () => {
 			uk: null,
 		},
 		fax: undefined,
-		firstName: undefined,
-		lastName: undefined,
+		first_name: undefined,
+		last_name: undefined,
 		organization: undefined,
 		phone: undefined,
-		postalCode: '10001',
+		postal_code: '10001',
 		state: undefined,
 	};
-
-	const transactionsEndpoint = jest.fn();
-	const undocumentedFunctions = {
-		transactions: transactionsEndpoint,
-	};
-	wp.undocumented = jest.fn().mockReturnValue( undocumentedFunctions );
-
-	beforeEach( () => {
-		transactionsEndpoint.mockClear();
-		transactionsEndpoint.mockReturnValue( Promise.resolve( 'test success' ) );
-	} );
 
 	it( 'throws an error if there is no stripe object', async () => {
 		const submitData = { paymentPartner: 'stripe' };
@@ -127,13 +104,14 @@ describe( 'webPayProcessor', () => {
 	} );
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 		const submitData = {
 			stripe,
 			stripeConfiguration,
 			paymentMethodToken: 'web-pay-token',
 			name: 'test name',
 		};
-		const expected = { payload: 'test success', type: 'SUCCESS' };
+		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(
 			webPayProcessor( 'apple-pay', submitData, {
 				...options,
@@ -147,13 +125,19 @@ describe( 'webPayProcessor', () => {
 	} );
 
 	it( 'returns an explicit error response if the transaction fails', async () => {
+		mockTransactionsEndpoint( () => [
+			400,
+			{
+				error: 'test_error',
+				message: 'test error',
+			},
+		] );
 		const submitData = {
 			stripe,
 			stripeConfiguration,
 			paymentMethodToken: 'web-pay-token',
 			name: 'test name',
 		};
-		transactionsEndpoint.mockReturnValue( Promise.reject( new Error( 'test error' ) ) );
 		const expected = { payload: 'test error', type: 'ERROR' };
 		await expect(
 			webPayProcessor( 'apple-pay', submitData, {
@@ -167,13 +151,14 @@ describe( 'webPayProcessor', () => {
 	} );
 
 	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 		const submitData = {
 			stripe,
 			stripeConfiguration,
 			paymentMethodToken: 'web-pay-token',
 			name: 'test name',
 		};
-		const expected = { payload: 'test success', type: 'SUCCESS' };
+		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(
 			webPayProcessor( 'apple-pay', submitData, {
 				...options,
@@ -198,13 +183,14 @@ describe( 'webPayProcessor', () => {
 	} );
 
 	it( 'sends the correct data to the endpoint with tax information', async () => {
+		const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 		const submitData = {
 			stripe,
 			stripeConfiguration,
 			paymentMethodToken: 'web-pay-token',
 			name: 'test name',
 		};
-		const expected = { payload: 'test success', type: 'SUCCESS' };
+		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(
 			webPayProcessor( 'apple-pay', submitData, {
 				...options,
@@ -240,13 +226,14 @@ describe( 'webPayProcessor', () => {
 	} );
 
 	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
 		const submitData = {
 			stripe,
 			stripeConfiguration,
 			paymentMethodToken: 'web-pay-token',
 			name: 'test name',
 		};
-		const expected = { payload: 'test success', type: 'SUCCESS' };
+		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(
 			webPayProcessor( 'apple-pay', submitData, {
 				...options,
@@ -270,7 +257,7 @@ describe( 'webPayProcessor', () => {
 				create_new_blog: false,
 				products: [ domainProduct ],
 			},
-			domainDetails: basicExpectedDomainDetails,
+			domain_details: basicExpectedDomainDetails,
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
@@ -5,6 +5,10 @@ import {
 	mockTransactionsSuccessResponse,
 	processorOptions,
 	stripeConfiguration,
+	basicExpectedDomainDetails,
+	countryCode,
+	postalCode,
+	contactDetailsForDomain,
 } from './util';
 
 describe( 'webPayProcessor', () => {
@@ -20,8 +24,6 @@ describe( 'webPayProcessor', () => {
 		responseCart: cart,
 	};
 
-	const countryCode = { isTouched: true, value: 'US', errors: [], isRequired: true };
-	const postalCode = { isTouched: true, value: '10001', errors: [], isRequired: true };
 	const stripe = {};
 
 	const basicExpectedStripeRequest = {
@@ -66,27 +68,6 @@ describe( 'webPayProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
-	};
-
-	const basicExpectedDomainDetails = {
-		address1: undefined,
-		address2: undefined,
-		alternate_email: undefined,
-		city: undefined,
-		country_code: 'US',
-		email: undefined,
-		extra: {
-			ca: null,
-			fr: null,
-			uk: null,
-		},
-		fax: undefined,
-		first_name: undefined,
-		last_name: undefined,
-		organization: undefined,
-		phone: undefined,
-		postal_code: '10001',
-		state: undefined,
 	};
 
 	it( 'throws an error if there is no stripe object', async () => {
@@ -239,10 +220,7 @@ describe( 'webPayProcessor', () => {
 				...options,
 				siteSlug: 'example.wordpress.com',
 				siteId: 1234567,
-				contactDetails: {
-					countryCode,
-					postalCode,
-				},
+				contactDetails: contactDetailsForDomain,
 				responseCart: { ...cart, products: [ domainProduct ] },
 				includeDomainDetails: true,
 			} )

--- a/packages/wpcom-checkout/src/camel-to-snake-case.ts
+++ b/packages/wpcom-checkout/src/camel-to-snake-case.ts
@@ -1,0 +1,6 @@
+export function camelToSnakeCase( camelCaseString: string ): string {
+	return camelCaseString.replace(
+		/[A-Z]/g,
+		( letter: string ): string => `_${ letter.toLowerCase() }`
+	);
+}

--- a/packages/wpcom-checkout/src/camel-to-snake-case.ts
+++ b/packages/wpcom-checkout/src/camel-to-snake-case.ts
@@ -1,6 +1,29 @@
+/**
+ * Convert a camelCaseWord to a snake_case_word.
+ *
+ * This is designed to work nearly identically to the lodash `snakeCase`
+ * function. Notably:
+ *
+ * - Leading and trailing spaces are removed.
+ * - Leading and trailing underscores are removed.
+ * - Spaces are collapsed into a single underscore.
+ * - Numbers are considered to be capital letters of a different type.
+ * - Multiple adjacent captial letters of the same type are considered part of the same word.
+ */
 export function camelToSnakeCase( camelCaseString: string ): string {
-	return camelCaseString.replace(
-		/[A-Z]/g,
-		( letter: string ): string => `_${ letter.toLowerCase() }`
+	return (
+		camelCaseString
+			// collapse all spaces into an underscore
+			.replace( /\s+/g, '_' )
+			// wrap underscores around capitalized words
+			.replace( /[A-Z][a-z]+/g, ( letter: string ): string => `_${ letter.toLowerCase() }_` )
+			// wrap underscores around capital letter groups
+			.replace( /[A-Z]+/g, ( letter: string ): string => `_${ letter.toLowerCase() }_` )
+			// wrap underscores around number groups
+			.replace( /[0-9]+/g, ( letter: string ): string => `_${ letter }_` )
+			// remove duplicate underscores
+			.replace( /_+/g, '_' )
+			// strip leading/trailing underscores
+			.replace( /(^_)|(_$)/g, '' )
 	);
 }

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -26,3 +26,5 @@ export * from './get-introductory-offer-interval-display';
 export * from './join-classes';
 export * from './checkout-line-items';
 export * from './get-country-postal-code-support';
+export * from './map-record-keys-recursively';
+export * from './camel-to-snake-case';

--- a/packages/wpcom-checkout/src/map-record-keys-recursively.ts
+++ b/packages/wpcom-checkout/src/map-record-keys-recursively.ts
@@ -1,3 +1,14 @@
+/**
+ * Transform the keys of an record object recursively
+ *
+ * This transforms an object, modifying all of its keys using a tranform
+ * function. If any of the values of the object are also record objects, their
+ * keys will also be transformed, and so on.
+ *
+ * Note that even though Arrays are objects, this will not modify arrays that
+ * it finds, so any objects contained within arrays that are properties of the
+ * original object will be returned unchanged.
+ */
 export function mapRecordKeysRecursively(
 	record: Record< string, unknown >,
 	transform: ( original: string ) => string

--- a/packages/wpcom-checkout/src/map-record-keys-recursively.ts
+++ b/packages/wpcom-checkout/src/map-record-keys-recursively.ts
@@ -1,0 +1,20 @@
+export function mapRecordKeysRecursively(
+	record: Record< string, unknown >,
+	transform: ( original: string ) => string
+): Record< string, unknown > {
+	return Object.keys( record ).reduce( function ( mapped, key ) {
+		let value = record[ key ];
+		if ( isRecord( value ) ) {
+			value = mapRecordKeysRecursively( value, transform );
+		}
+		return {
+			...mapped,
+			[ transform( key ) ]: value,
+		};
+	}, {} );
+}
+
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	const valueAsObject = value as Record< string, unknown > | undefined;
+	return valueAsObject?.constructor === Object;
+}

--- a/packages/wpcom-checkout/test/camel-to-snake-case.ts
+++ b/packages/wpcom-checkout/test/camel-to-snake-case.ts
@@ -1,0 +1,55 @@
+import { camelToSnakeCase } from '../src/camel-to-snake-case';
+
+describe( 'camelToSnakeCase', () => {
+	it( 'transforms camelCase to snake_case for strings with two words', () => {
+		expect( camelToSnakeCase( 'camelCase' ) ).toBe( 'camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with four words', () => {
+		expect( camelToSnakeCase( 'thisIsCamelCase' ) ).toBe( 'this_is_camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with a number', () => {
+		expect( camelToSnakeCase( 'camelCase1' ) ).toBe( 'camel_case_1' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with multiple adjacent numbers', () => {
+		expect( camelToSnakeCase( 'hello1234Thing' ) ).toBe( 'hello_1234_thing' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with an existing underscore', () => {
+		expect( camelToSnakeCase( 'camelCase_word' ) ).toBe( 'camel_case_word' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with a capitalized first letter', () => {
+		expect( camelToSnakeCase( 'CamelCase' ) ).toBe( 'camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with a space', () => {
+		expect( camelToSnakeCase( 'camel case' ) ).toBe( 'camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings that start with a space', () => {
+		expect( camelToSnakeCase( ' camel case' ) ).toBe( 'camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings that start with an underscore', () => {
+		expect( camelToSnakeCase( '_camel_case' ) ).toBe( 'camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings that end with a space', () => {
+		expect( camelToSnakeCase( 'camel case ' ) ).toBe( 'camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings that end with an underscore', () => {
+		expect( camelToSnakeCase( 'camel_case_' ) ).toBe( 'camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with multiple adjacent spaces', () => {
+		expect( camelToSnakeCase( 'camel  case' ) ).toBe( 'camel_case' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with multiple adjacent capitals', () => {
+		expect( camelToSnakeCase( 'helloWORLDThing' ) ).toBe( 'hello_world_thing' );
+	} );
+} );

--- a/packages/wpcom-checkout/test/camel-to-snake-case.ts
+++ b/packages/wpcom-checkout/test/camel-to-snake-case.ts
@@ -13,6 +13,14 @@ describe( 'camelToSnakeCase', () => {
 		expect( camelToSnakeCase( 'camelCase1' ) ).toBe( 'camel_case_1' );
 	} );
 
+	it( 'transforms camelCase to snake_case for strings with a number_followed by a capital', () => {
+		expect( camelToSnakeCase( 'camelCase1Hi' ) ).toBe( 'camel_case_1_hi' );
+	} );
+
+	it( 'transforms camelCase to snake_case for strings with a number_followed by a lowercase', () => {
+		expect( camelToSnakeCase( 'camelCase1hi' ) ).toBe( 'camel_case_1_hi' );
+	} );
+
 	it( 'transforms camelCase to snake_case for strings with multiple adjacent numbers', () => {
 		expect( camelToSnakeCase( 'hello1234Thing' ) ).toBe( 'hello_1234_thing' );
 	} );

--- a/packages/wpcom-checkout/test/map-record-keys-recursively.ts
+++ b/packages/wpcom-checkout/test/map-record-keys-recursively.ts
@@ -1,0 +1,62 @@
+import { camelToSnakeCase } from '../src/camel-to-snake-case';
+import { mapRecordKeysRecursively } from '../src/map-record-keys-recursively';
+
+describe( 'mapRecordKeysRecursively', () => {
+	it( 'transforms the keys of a string/string record', () => {
+		const record = {
+			firstOne: 'helloThere',
+			secondOne: 'thank you',
+		};
+		const expected = {
+			first_one: 'helloThere',
+			second_one: 'thank you',
+		};
+		expect( mapRecordKeysRecursively( record, camelToSnakeCase ) ).toEqual( expected );
+	} );
+
+	it( 'transforms the keys of a three-level record', () => {
+		const record = {
+			firstOne: 'helloThere',
+			secondOne: 'thank you',
+			thirdOne: {
+				firstOne: 'helloThere',
+				secondOne: {
+					firstOne: 'helloThere',
+				},
+			},
+		};
+		const expected = {
+			first_one: 'helloThere',
+			second_one: 'thank you',
+			third_one: {
+				first_one: 'helloThere',
+				second_one: {
+					first_one: 'helloThere',
+				},
+			},
+		};
+		expect( mapRecordKeysRecursively( record, camelToSnakeCase ) ).toEqual( expected );
+	} );
+
+	it( 'does not transform objects within an array in the record', () => {
+		const record = {
+			firstOne: 'helloThere',
+			secondOne: 'thank you',
+			thirdOne: [
+				{
+					firstOne: 'helloThere',
+				},
+			],
+		};
+		const expected = {
+			first_one: 'helloThere',
+			second_one: 'thank you',
+			third_one: [
+				{
+					firstOne: 'helloThere',
+				},
+			],
+		};
+		expect( mapRecordKeysRecursively( record, camelToSnakeCase ) ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
This is a second attempt at https://github.com/Automattic/wp-calypso/pull/57280 which had to be reverted in https://github.com/Automattic/wp-calypso/pull/57504 due to an issue where the `address1` key in the contact details data was not being correctly converted to `address_1` before being sent to the endpoint. 

This PR greatly improves the `camelToSnakeCase` function to operate more like lodash's `snakeCase`. It includes unit tests for cases like the `address_1` issue above as well as many other cases that probably won't occur but cover other unusual rules used by `snakeCase`.

This PR also improves the unit tests for the payment processor functions so that they will also test for many of the expected contact details keys, including `address_1`.

Really, the contact details submission should be explicitly converted and typed as snake_case [like we do for contact validation](https://github.com/Automattic/wp-calypso/blob/cdce28a85cd69a0318e7d7d166b554487bfa8735/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx#L213), but this would be a much larger change due to the number of places that use the camelCase keys, so I think it's best to put that off until a later PR.

#### Changes proposed in this Pull Request

As part of the goal to remove the `wpcom.undocumented` module (see 429-gh-Automattic/payments-shilling), this PR modifies checkout to call the `/me/transactions` endpoint directly. This is the endpoint used to submit a purchase by all payment methods except for PayPal.

Since PayPal uses its own endpoint, it will need to be updated separately.

(This PR isn't as big as it looks. Mostly it's just updating the tests to mock the actual endpoint calls instead of being able to mock the `undocumented` function.)

#### Testing instructions

- Add a plan _and a domain_ to your cart and visit checkout.
- Complete the checkout form.
- Chose any payment method other than PayPal and submit the purchase.
- Verify that the purchase is successful.
