### PR TITLE
Update wording and price display for Google Workspace sales

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -350,21 +350,31 @@ class EmailProvidersComparison extends Component {
 			comment: '{{price/}} is the formatted price, e.g. $20',
 		} );
 
-		const discount = hasDiscount( gSuiteProduct )
-			? translate( 'First year %(discountedPrice)s', {
-					args: {
-						discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
-					},
-					comment: '%(discountedPrice)s is a formatted price, e.g. $75',
-			  } )
+		const productIsDiscounted = hasDiscount( gSuiteProduct );
+		const discount = productIsDiscounted
+			? translate(
+					'First year %(discountedPrice)s - %(monthlyPrice)s /user /month billed annually',
+					{
+						args: {
+							discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
+							monthlyPrice: getMonthlyPrice( gSuiteProduct.sale_cost, currencyCode ),
+						},
+						comment:
+							'%(discountedPrice)s is a formatted price, e.g. $72; %(monthlyPrice)s is also a formatted price, e.g. $6',
+					}
+			  )
 			: null;
 
-		const additionalPriceInformation = translate( '%(price)s billed annually', {
+		const annualPrice = getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode );
+		const annualPriceTranslateArgs = {
 			args: {
-				price: getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode ),
+				price: annualPrice,
 			},
 			comment: "Annual price formatted with the currency (e.g. '$99.99')",
-		} );
+		};
+		const additionalPriceInformation = productIsDiscounted
+			? translate( 'Renews annually at %(price)s', annualPriceTranslateArgs )
+			: translate( '%(price)s billed annually', annualPriceTranslateArgs );
 
 		// If we don't have any users, initialize the list to have 1 empty user
 		const googleUsers =

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -371,7 +371,7 @@ class EmailProvidersComparison extends Component {
 		const discount = productIsDiscounted ? (
 			<span className="email-providers-comparison__discount-with-renewal">
 				{ translate(
-					'%(discount)d% Off{{span}}, %(discountedPrice)s billed today, renews annually at %(standardPrice)s{{/span}}',
+					'%(discount)d% Off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
 					{
 						args: {
 							discount: gSuiteProduct.sale_coupon.discount,

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -343,38 +343,61 @@ class EmailProvidersComparison extends Component {
 			return null;
 		}
 
-		const formattedPrice = translate( '{{price/}} /user /month billed annually', {
-			components: {
-				price: <span>{ getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode ) }</span>,
-			},
-			comment: '{{price/}} is the formatted price, e.g. $20',
-		} );
-
 		const productIsDiscounted = hasDiscount( gSuiteProduct );
-		const discount = productIsDiscounted
-			? translate(
-					'First year %(discountedPrice)s - %(monthlyPrice)s /user /month billed annually',
+		const monthlyPrice = getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode );
+		const formattedPrice = productIsDiscounted
+			? translate( '{{fullPrice/}} {{discountedPrice/}} /user /month billed annually', {
+					components: {
+						fullPrice: <span>{ monthlyPrice }</span>,
+						discountedPrice: (
+							<span className="email-providers-comparison__discounted-price">
+								{ getMonthlyPrice( gSuiteProduct.sale_cost, currencyCode ) }
+							</span>
+						),
+					},
+					comment:
+						'{{fullPrice/}} is the formatted full price, e.g. $20; {{discountedPrice/}} is the discounted, formatted price, e.g. $10',
+			  } )
+			: translate( '{{price/}} /user /month billed annually', {
+					components: {
+						price: <span>{ monthlyPrice }</span>,
+					},
+					comment: '{{price/}} is the formatted price, e.g. $20',
+			  } );
+
+		const standardPrice = getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode );
+
+		// Note that when we have a discount, we include all renewal information in the discount content
+		const discount = productIsDiscounted ? (
+			<span className="email-providers-comparison__discount-with-renewal">
+				{ translate(
+					'%(discount)d% Off{{span}}, %(discountedPrice)s billed today, renews annually at %(standardPrice)s{{/span}}',
 					{
 						args: {
+							discount: gSuiteProduct.sale_coupon.discount,
 							discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
-							monthlyPrice: getMonthlyPrice( gSuiteProduct.sale_cost, currencyCode ),
+							standardPrice,
 						},
 						comment:
-							'%(discountedPrice)s is a formatted price, e.g. $72; %(monthlyPrice)s is also a formatted price, e.g. $6',
+							'%(discount)d is a numeric discount percentage, e.g. 40; ' +
+							'%(discountedPrice)s is a formatted, discounted price that the user will pay today, e.g. $3; ' +
+							'%(standardPrice)s is a formatted price, e.g. $5',
+						components: {
+							span: <span />,
+						},
 					}
-			  )
-			: null;
+				) }
+			</span>
+		) : null;
 
-		const annualPrice = getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode );
-		const annualPriceTranslateArgs = {
-			args: {
-				price: annualPrice,
-			},
-			comment: "Annual price formatted with the currency (e.g. '$99.99')",
-		};
 		const additionalPriceInformation = productIsDiscounted
-			? translate( 'Renews annually at %(price)s', annualPriceTranslateArgs )
-			: translate( '%(price)s billed annually', annualPriceTranslateArgs );
+			? null
+			: translate( '%(price)s billed annually', {
+					args: {
+						standardPrice,
+					},
+					comment: "Annual price formatted with the currency (e.g. '$99.99')",
+			  } );
 
 		// If we don't have any users, initialize the list to have 1 empty user
 		const googleUsers =

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -172,11 +172,22 @@
 			.price__discounted {
 				text-decoration: line-through;
 			}
+
+			&.price__discounted span.email-providers-comparison__discounted-price {
+				text-decoration: none;
+			}
 		}
 
 		.price__discount {
 			display: block;
+			font-weight: 600;
 			margin-left: 0;
+			margin-top: 0.25em;
+
+			.email-providers-comparison__discount-with-renewal span {
+				color: var( --color-text-subtle );
+				font-weight: 400;
+			}
 		}
 	}
 

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -173,8 +173,13 @@
 				text-decoration: line-through;
 			}
 
-			&.price__discounted span.email-providers-comparison__discounted-price {
-				text-decoration: none;
+			&.price__discounted span {
+				color: var( --color-text-subtle );
+
+				&.email-providers-comparison__discounted-price {
+					color: var( --studio-gray-100 );
+					text-decoration: none;
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the way we display the details for Google Workspace in the Email Comparison page when the product is on sale. The key items are listed below:
  - When a sale is present, we show "50% Off, $36 billed today, renews annually at $72", with "50% Off" highlighted in green, with that text the same size as the "/user /month billed annually" text
  - The standard, struck-out prices now use a grey font
* The PR also adds some vertical space above the discount text, and ensures that the primary discount text is bold

#### Screenshots

##### Google Workspace

###### Before

<img width="1053" alt="Screenshot 2021-11-01 at 22 33 16" src="https://user-images.githubusercontent.com/3376401/139738148-442899d7-6166-42a5-a723-66d250360a99.png">

###### After

<img width="1060" alt="Screenshot 2021-11-04 at 19 44 27" src="https://user-images.githubusercontent.com/3376401/140392683-747cc7cd-0447-4e28-9639-98bdc03b28bf.png">

##### Professional Email

###### Before

<img width="1060" alt="Screenshot 2021-11-04 at 19 51 18" src="https://user-images.githubusercontent.com/3376401/140393017-4f28513a-2e5c-4aaa-8e1c-da1016bd71e2.png">

###### After

<img width="1060" alt="Screenshot 2021-11-04 at 19 44 40" src="https://user-images.githubusercontent.com/3376401/140392703-46a2d8f3-c822-4e48-8520-988177de44ef.png">

#### Testing instructions

* Enable Store Sandbox mode for testing, and ensure that there is a sale configured for Google Workspace _in the sandbox mode_. (We don't want a sale for all users yet!)
  - It is easiest to handle this using D69393-code and the instructions there.
* Run this branch locally or via the live branch.
* Go to Upgrades -> Domains
* Click on the button to add a new domain. (The exact UX here depends on whether you're running locally or via the live branch, as this page is under development.)
* Search for and select a domain.
* Inspect the card for Google Workspace and verify that the wording and pricing details are as described above.
* Verify that the struck out prices for Professional Email and Google Workspace are in a grey font, and that the primary discount text is bolded green.
* Remove the sales coupon and re-run the test.
  - I had some issues with the coupon getting cached, so I wasn't fully able to bust this correctly - just removing the sale coupon takes some amount of time to be un-cached, so switching to non-Store sandbox mode is a quick way to check this.
* Verify that the standard text is shown.