### PR TITLE
Launch the design picker in production to English speaking users

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -105,7 +105,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
-		"signup/setup-site-after-checkout": false,
+		"signup/setup-site-after-checkout": true,
 		"signup/hero-flow": false,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,7 +106,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
-		"signup/setup-site-after-checkout": false,
+		"signup/setup-site-after-checkout": true,
 		"signup/hero-flow": false,
 		"site-indicator": true,
 		"support-user": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Launches the design picker to all English-speaking users

The code that ensures it is only shown to English-speaking users is here: https://github.com/Automattic/wp-calypso/blob/6522a1bef157c5073d89cd8e61f4a2f1f11f2912/client/signup/config/flows.js#L80

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This feature has already been tested, and this PR just enables it. This PR is mostly about a visual code review.

It's not truly testable until we land on staging because the feature is already enabled in all other environments. But you can get a sense of how it works by manually specifying the `signup/setup-site-after-checkout` flag i.e. https://wordpress.com/start?flags=signup/setup-site-after-checkout`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
