### PR TITLE
Design Picker: Update skip button label when going to post editor

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -197,6 +197,17 @@ class DesignPickerStep extends Component {
 		return translate( 'Pick your favorite homepage layout. You can customize or change it later.' );
 	}
 
+	skipLabelText() {
+		const { signupDependencies, translate } = this.props;
+
+		if ( signupDependencies?.intent === 'write' ) {
+			return translate( 'Skip and draft first post' );
+		}
+
+		// Fall back to the default skip label used by <StepWrapper>
+		return undefined;
+	}
+
 	render() {
 		const { flowName, stepName, userLoggedIn, isReskinned, isMobile, translate } = this.props;
 		const { selectedDesign } = this.state;
@@ -241,6 +252,7 @@ class DesignPickerStep extends Component {
 				stepContent={ this.renderDesignPicker() }
 				align={ isReskinned ? 'left' : 'center' }
 				skipButtonAlign={ isReskinned ? 'top' : 'bottom' }
+				skipLabelText={ this.skipLabelText() }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change has been split out of #56812. That PR got the translation process started, but back then hero flow wasn't working yet it didn't know how to change the label based on intent.

* Update the skip button label to match mockup in Figma: EuqfSnWpfYx8fgiBlVmbuA-fi-2119%3A1107
* The mockup refers to "starting your first post", so only changing the label text when the user will be writing a post.



<img width="1262" alt="Screenshot 2021-11-02 at 9 09 34 PM" src="https://user-images.githubusercontent.com/1500769/139809103-34617f46-844b-4442-b6ba-ad8b93d8a5e0.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test signup flow without any flags, and verify that the design picker shows the old "Skip this step" label
* Test using the `signup/hero-flow` flag
	* Choose "write" intent and verify that the design picker label is updated
	* Go back to the intent screen and choose "build" and verify that the design picker isn't updated.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->