### PR TITLE
Design Picker: Update blank canvas label

### DIFF
--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -42,7 +42,7 @@ describe( '<DesignPicker /> integration', () => {
 		render( <DesignPicker locale={ MOCK_LOCALE } onSelect={ jest.fn() } /> );
 
 		const firstDesignButton = screen.getAllByRole( 'button' )[ 0 ];
-		expect( firstDesignButton ).toHaveTextContent( /empty\spage/i );
+		expect( firstDesignButton ).toHaveTextContent( /blank\scanvas/i );
 	} );
 	( [ 'light', 'dark' ] as DesignPickerProps[ 'theme' ][] ).forEach( ( theme ) =>
 		it( `Should have design-picker--theme-${ theme } class when theme prop is set to ${ theme }`, () => {

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -61,7 +61,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const isBlankCanvas = isBlankCanvasDesign( design );
 
 	const defaultTitle = design.title;
-	const blankCanvasTitle = __( 'Start with an empty page', __i18n_text_domain__ );
+	const blankCanvasTitle = __( 'Blank Canvas', __i18n_text_domain__ );
 	const designTitle = isBlankCanvas ? blankCanvasTitle : defaultTitle;
 
 	return (
@@ -90,7 +90,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			>
 				{ isBlankCanvas ? (
 					<div className="design-picker__image-frame-blank-canvas__title">
-						{ __( 'Blank Canvas' ) }
+						{ __( 'Start from scratch', __i18n_text_domain__ ) }
 					</div>
 				) : (
 					<div className="design-picker__image-frame-inside">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the labels used for the Blank Canvas theme in the design picker to match the mockups.

EuqfSnWpfYx8fgiBlVmbuA-fi-2119%3A1107

The translation process for these strings is already complete (done here #56812)

- Updates the copy inside the design to "Start from scratch"
- Updates the label beneath the design to "Blank Canvas"
- Updates integration tests

<img width="1259" alt="Screenshot 2021-11-02 at 9 00 09 PM" src="https://user-images.githubusercontent.com/1500769/139808731-c93cf18b-c0bf-44a5-a2ae-f1a394032752.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the design picker in `/start` and see the copy has been updated
* Test the `/new` flow and see it's been updated there too

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
