### PR TITLE
Onboarding: Add new props to signup complete event

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -25,7 +25,7 @@ export function recordSignupStart( flow, ref ) {
 }
 
 export function recordSignupComplete(
-	{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite },
+	{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite, theme, intent, startingPoint },
 	now
 ) {
 	const isNewSite = !! siteId;
@@ -35,7 +35,7 @@ export function recordSignupComplete(
 		return addToQueue(
 			'signup',
 			'recordSignupComplete',
-			{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite },
+			{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite, theme, intent, startingPoint },
 			true
 		);
 	}
@@ -50,6 +50,9 @@ export function recordSignupComplete(
 		is_new_user: isNewUser,
 		is_new_site: isNewSite,
 		has_cart_items: hasCartItems,
+		theme,
+		intent,
+		starting_point: startingPoint,
 	} );
 
 	// Google Analytics

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -417,6 +417,9 @@ class Signup extends Component {
 			( isNewishUser && dependencies && dependencies.siteSlug && existingSiteCount <= 1 )
 		);
 		const hasCartItems = dependenciesContainCartItem( dependencies );
+		const selectedDesign = get( dependencies, 'selectedDesign' );
+		const intent = get( dependencies, 'intent' );
+		const startingPoint = get( dependencies, 'startingPoint' );
 
 		const debugProps = {
 			isNewishUser,
@@ -426,6 +429,9 @@ class Signup extends Component {
 			isNew7DUserSite,
 			flow: this.props.flowName,
 			siteId,
+			theme: selectedDesign?.theme,
+			intent,
+			startingPoint,
 		};
 		debug( 'Tracking signup completion.', debugProps );
 
@@ -435,6 +441,10 @@ class Signup extends Component {
 			isNewUser,
 			hasCartItems,
 			isNew7DUserSite,
+			// Record the following values so that we can know the user completed which branch under the hero flow
+			theme: selectedDesign?.theme,
+			intent,
+			startingPoint,
 		} );
 
 		this.handleLogin( dependencies, destination );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding new props to the `calypso_signup_complete` event so that we can know that the user completed the hero flow under which branch.

| write and draft | write and design | build and design |
| - | - | - |
| ![Screen Shot 2021-11-02 at 5 02 33 PM](https://user-images.githubusercontent.com/13596067/139817183-5d61b4be-7a41-4664-9157-9eab658d1d4e.png) | ![Screen Shot 2021-11-02 at 4 57 47 PM](https://user-images.githubusercontent.com/13596067/139816448-6cfb436e-e153-4781-8157-0e59392ee22c.png) | ![Screen Shot 2021-11-02 at 5 04 52 PM](https://user-images.githubusercontent.com/13596067/139817501-898b187f-00d4-4cfe-bc81-a565f5009efd.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start?flags=flags=signup/hero-flow`
* After completing the Hero flow, make sure the `calypso_signup_complete` sent with `theme`, `intent` and `starting_point`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 58MP46f44oGKl5Bin5bSp1-fi-0%3A1