### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` Jetpack modules to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -44,59 +44,6 @@ Undocumented.prototype.me = function () {
 	return new Me( this.wpcom );
 };
 
-/*
- * Retrieve Jetpack modules data for a site with id siteid.
- * Uses the REST API of the Jetpack site.
- *
- * @param {number}      [siteId]
- * @param {Function} fn
- */
-Undocumented.prototype.getJetpackModules = function ( siteId, fn ) {
-	return this.wpcom.req.get(
-		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/jetpack/v4/module/all/' },
-		fn
-	);
-};
-
-/*
- * Activate a Jetpack module with slug moduleSlug for a site with id siteid.
- * Uses the REST API of the Jetpack site.
- *
- * @param {number} [siteId]
- * @param {string} [moduleSlug]
- * @param {Function} fn
- */
-Undocumented.prototype.jetpackModuleActivate = function ( siteId, moduleSlug, fn ) {
-	return this.wpcom.req.post(
-		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{
-			path: '/jetpack/v4/module/' + moduleSlug + '/active/',
-			body: JSON.stringify( { active: true } ),
-		},
-		fn
-	);
-};
-
-/*
- * Deactivate a Jetpack module with slug moduleSlug for a site with id siteid.
- * Uses the REST API of the Jetpack site.
- *
- * @param {number} [siteId]
- * @param {string} [moduleSlug]
- * @param {Function} fn
- */
-Undocumented.prototype.jetpackModuleDeactivate = function ( siteId, moduleSlug, fn ) {
-	return this.wpcom.req.post(
-		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{
-			path: '/jetpack/v4/module/' + moduleSlug + '/active/',
-			body: JSON.stringify( { active: false } ),
-		},
-		fn
-	);
-};
-
 /**
  * Fetches settings for the Monitor module.
  *

--- a/client/state/jetpack/modules/actions.js
+++ b/client/state/jetpack/modules/actions.js
@@ -1,6 +1,6 @@
 import { translate } from 'i18n-calypso';
 import { omit, mapValues } from 'lodash';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import {
 	JETPACK_MODULE_ACTIVATE,
 	JETPACK_MODULE_ACTIVATE_FAILURE,
@@ -54,9 +54,14 @@ export const activateModule = ( siteId, moduleSlug, silent = false ) => {
 			silent,
 		} );
 
-		return wp
-			.undocumented()
-			.jetpackModuleActivate( siteId, moduleSlug )
+		return wpcom.req
+			.post(
+				{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
+				{
+					path: '/jetpack/v4/module/' + moduleSlug + '/active/',
+					body: JSON.stringify( { active: true } ),
+				}
+			)
 			.then( () => {
 				dispatch( {
 					type: JETPACK_MODULE_ACTIVATE_SUCCESS,
@@ -88,9 +93,14 @@ export const deactivateModule = ( siteId, moduleSlug, silent = false ) => {
 			silent,
 		} );
 
-		return wp
-			.undocumented()
-			.jetpackModuleDeactivate( siteId, moduleSlug )
+		return wpcom.req
+			.post(
+				{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
+				{
+					path: '/jetpack/v4/module/' + moduleSlug + '/active/',
+					body: JSON.stringify( { active: false } ),
+				}
+			)
 			.then( () => {
 				dispatch( {
 					type: JETPACK_MODULE_DEACTIVATE_SUCCESS,
@@ -136,9 +146,11 @@ export const fetchModuleList = ( siteId ) => {
 			siteId,
 		} );
 
-		return wp
-			.undocumented()
-			.getJetpackModules( siteId )
+		return wpcom.req
+			.get(
+				{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
+				{ path: '/jetpack/v4/module/all/' }
+			)
 			.then( ( { data } ) => {
 				const modules = mapValues( data, ( module ) => ( {
 					active: module.activated,

--- a/client/state/jetpack/modules/actions.js
+++ b/client/state/jetpack/modules/actions.js
@@ -55,13 +55,10 @@ export const activateModule = ( siteId, moduleSlug, silent = false ) => {
 		} );
 
 		return wpcom.req
-			.post(
-				{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-				{
-					path: '/jetpack/v4/module/' + moduleSlug + '/active/',
-					body: JSON.stringify( { active: true } ),
-				}
-			)
+			.post( `/jetpack-blogs/${ siteId }/rest-api/`, {
+				path: `/jetpack/v4/module/${ moduleSlug }/active/`,
+				body: JSON.stringify( { active: true } ),
+			} )
 			.then( () => {
 				dispatch( {
 					type: JETPACK_MODULE_ACTIVATE_SUCCESS,
@@ -94,13 +91,10 @@ export const deactivateModule = ( siteId, moduleSlug, silent = false ) => {
 		} );
 
 		return wpcom.req
-			.post(
-				{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-				{
-					path: '/jetpack/v4/module/' + moduleSlug + '/active/',
-					body: JSON.stringify( { active: false } ),
-				}
-			)
+			.post( `/jetpack-blogs/${ siteId }/rest-api/`, {
+				path: `/jetpack/v4/module/${ moduleSlug }/active/`,
+				body: JSON.stringify( { active: false } ),
+			} )
 			.then( () => {
 				dispatch( {
 					type: JETPACK_MODULE_DEACTIVATE_SUCCESS,
@@ -147,10 +141,9 @@ export const fetchModuleList = ( siteId ) => {
 		} );
 
 		return wpcom.req
-			.get(
-				{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-				{ path: '/jetpack/v4/module/all/' }
-			)
+			.get( `/jetpack-blogs/${ siteId }/rest-api/`, {
+				path: '/jetpack/v4/module/all/',
+			} )
 			.then( ( { data } ) => {
 				const modules = mapValues( data, ( module ) => ( {
 					active: module.activated,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates all the usages of `wpcom.undocumented()` related to general Jetpack modules to `wpcom.req.get()`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions
* Go to `/settings/performance/:site` where `:site` is the slug of a Jetpack site. 
* Verify the retrieval of the current state of Jetpack modules still works.
* Enable and disable some modules and verify it still works well and saves the data properly.
* Feel free to test on any other settings page that manages Jetpack modules.
* Verify tests still pass: `yarn run test-client client/state/jetpack/modules/test/actions.js`