### PR TITLE
Initial GoogleSaleBanner implementation and domain type definition

### DIFF
--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -1,0 +1,117 @@
+import { gdprConsentStatus, transferStatus, type as domainType } from './constants';
+
+export type CannotAddEmailReason = {
+	code: string | number;
+	message: string;
+};
+
+export type DomainType = keyof typeof domainType;
+
+interface EmailSubscription {
+	ownedByUserId?: number;
+	status: string;
+}
+
+type EmailCost = {
+	amount: number;
+	currency: string;
+	text: string;
+};
+
+export type GDPRConsentStatus = keyof typeof gdprConsentStatus | null;
+
+export type GoogleEmailSubscription = EmailSubscription & {
+	pendingTosAcceptance?: boolean;
+	pendingUsers?: Array< string >;
+	productSlug?: string;
+	subscribedDate?: string;
+	subscriptionId?: string;
+	totalUserCount?: number;
+};
+
+export type TitanEmailSubscription = EmailSubscription & {
+	expiryDate?: string;
+	isEligibleForIntroductoryOffer?: boolean;
+	maximumMailboxCount?: number;
+	numberOfMailboxes?: number;
+	orderId?: number;
+	purchaseCostPerMailbox?: EmailCost | null;
+	renewalCostPerMailbox?: EmailCost | null;
+	subscriptionId?: number | null;
+};
+
+export type TransferStatus = keyof typeof transferStatus | null;
+
+export type ResponseDomain = {
+	adminEmail: string | null | undefined;
+	aRecordsRequiredForMapping?: Array< string >;
+	autoRenewalDate: string;
+	autoRenewing: boolean;
+	beginTransferUntilDate: string;
+	blogId: number;
+	bundledPlanSubscriptionId: string | number | null | undefined;
+	canSetAsPrimary: boolean;
+	connectionMode: string;
+	contactInfoDisclosed: boolean;
+	contactInfoDisclosureAvailable: boolean;
+	currentUserCanAddEmail: boolean;
+	currentUserCanCreateSiteFromDomainOnly: boolean;
+	currentUserCanManage: boolean;
+	currentUserCannotAddEmailReason: CannotAddEmailReason | null;
+	domain: string;
+	domainLockingAvailable: boolean;
+	domainRegistrationAgreementUrl: string | null;
+	emailForwardsCount: number;
+	expired: boolean;
+	expiry: string | null;
+	expirySoon: boolean;
+	gdprConsentStatus: GDPRConsentStatus;
+	googleAppsSubscription: GoogleEmailSubscription | null;
+	hasRegistration: boolean;
+	hasWpcomNameservers: boolean;
+	hasZone: boolean;
+	isAutoRenewing: boolean;
+	isEligibleForInboundTransfer: boolean;
+	isLocked: boolean;
+	isPendingIcannVerification: boolean;
+	isPendingRenewal: boolean;
+	isPendingWhoisUpdate: boolean;
+	isPremium: boolean;
+	isPrimary: boolean;
+	isRedeemable: boolean;
+	isRenewable: boolean;
+	isSubdomain: boolean;
+	isWPCOMDomain: boolean;
+	isWpcomStagingDomain: boolean;
+	manualTransferRequired: boolean;
+	mustRemovePrivacyBeforeContactUpdate: boolean;
+	name: string;
+	newRegistration: boolean;
+	owner: string;
+	partnerDomain: boolean;
+	pendingRegistration: boolean;
+	pendingRegistrationTime: string;
+	pendingTransfer?: boolean;
+	pointsToWpcom: boolean;
+	privacyAvailable: boolean;
+	privateDomain: boolean;
+	redeemableUntil: string;
+	registrar: string;
+	registrationDate: string;
+	renewableUntil: string;
+	sslStatus: string | null;
+	subscriptionId: string | null;
+	subdomainPart: string;
+	supportsDomainConnect: boolean;
+	supportsGdprConsentManagement: boolean;
+	supportsTransferApproval: boolean;
+	titanMailSubscription: TitanEmailSubscription | null;
+	tldMaintenanceEndTime?: number;
+	transferAwayEligibleAt: string | null;
+	transferEndDate: string | null;
+	transferLockOnWhoisUpdateOptional: boolean;
+	transferStartDate: string | null;
+	transferStatus: TransferStatus;
+	type: DomainType;
+	whoisUpdateUnmodifiableFields?: Array< string >;
+};

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -9,6 +9,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -22,6 +23,7 @@ import EmptyDomainsListCard from 'calypso/my-sites/domains/domain-management/lis
 import OptionsDomainButton from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
 import WpcomDomainItem from 'calypso/my-sites/domains/domain-management/list/wpcom-domain-item';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
+import GoogleSaleBanner from 'calypso/my-sites/email/google-sale-banner';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import {
 	composeAnalytics,
@@ -31,6 +33,7 @@ import {
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { getProductsList } from 'calypso/state/products-list/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -99,7 +102,14 @@ export class List extends Component {
 	}
 
 	renderNewDesign() {
-		const { selectedSite, domains, currentRoute, translate, isAtomicSite } = this.props;
+		const {
+			currentRoute,
+			domains,
+			hasProductsList,
+			isAtomicSite,
+			selectedSite,
+			translate,
+		} = this.props;
 		const { settingPrimaryDomain } = this.state;
 		const disabled = settingPrimaryDomain;
 
@@ -110,6 +120,8 @@ export class List extends Component {
 
 		return (
 			<>
+				{ ! hasProductsList && <QueryProductsList /> }
+
 				<div className="domains__header">
 					<FormattedHeader
 						brandFont
@@ -143,6 +155,8 @@ export class List extends Component {
 						hasNonWpcomDomains={ false }
 					/>
 				) }
+
+				{ ! this.isLoading() && <GoogleSaleBanner domains={ domains } /> }
 
 				<div className="domain-management-list__items">{ this.listNewItems() }</div>
 
@@ -423,6 +437,7 @@ export default connect(
 		return {
 			currentRoute: getCurrentRoute( state ),
 			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
+			hasProductsList: 0 < ( getProductsList( state )?.length ?? 0 ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
 			hasNonPrimaryDomainsFlag: getCurrentUser( state )

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -100,6 +100,7 @@ describe( 'index', () => {
 				currentUser: {
 					capabilities: {},
 				},
+				productsList: {},
 			},
 			( state ) => {
 				return state;

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -66,7 +66,11 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 		return null;
 	}
 
-	if ( ! hasDiscount( googleWorkspaceProduct ) ) {
+	// Verify that we have a percentage discount
+	if (
+		! hasDiscount( googleWorkspaceProduct ) ||
+		( ! googleWorkspaceProduct?.sale_coupon?.discount ?? null )
+	) {
 		return null;
 	}
 
@@ -99,7 +103,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 				'google-sale'
 			) }
 			title={ translate( 'Get %(discount)d% off Google Workspace for your domain!', {
-				args: { discount: googleWorkspaceProduct?.sale_coupon?.discount ?? 50 },
+				args: { discount: googleWorkspaceProduct?.sale_coupon?.discount },
 				comment: '%(discount)d is a percentage discount, e.g. 50',
 			} ) }
 		/>

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -11,6 +11,7 @@ import { getMonthlyPrice, hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -22,13 +23,10 @@ type GoogleSaleBannerProps = {
 	domains: Array< ResponseDomain >;
 };
 
-const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( {
-	domains,
-}: {
-	domains: Array< ResponseDomain >;
-} ) => {
+const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains } ) => {
 	const translate = useTranslate();
 
+	const canCurrentUserPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentRoute = useSelector( getCurrentRoute );
 	const googleWorkspaceProduct = useSelector( ( state ) =>
@@ -47,7 +45,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( {
 				return false;
 			}
 			if ( ! hasGSuiteSupportedDomain( [ domain ] ) ) {
-				//return false;
+				return false;
 			}
 
 			return true;
@@ -59,6 +57,10 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( {
 	const siteForSale = useSelector( ( state ) =>
 		domainForSale?.blogId ? getSite( state, domainForSale.blogId ) : getSelectedSite( state )
 	);
+
+	if ( ! canCurrentUserPurchaseGSuite ) {
+		return null;
+	}
 
 	if ( 0 === domainsEligibleForGoogleWorkspaceSale.length ) {
 		return null;

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -1,0 +1,107 @@
+import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
+import { Banner } from 'calypso/components/banner';
+import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
+import { hasPaidEmailWithUs } from 'calypso/lib/emails';
+import { getMonthlyPrice, hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
+import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+import './style.scss';
+
+type GoogleSaleBannerProps = {
+	domains: Array< ResponseDomain >;
+};
+
+const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( {
+	domains,
+}: {
+	domains: Array< ResponseDomain >;
+} ) => {
+	const translate = useTranslate();
+
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const currentRoute = useSelector( getCurrentRoute );
+	const googleWorkspaceProduct = useSelector( ( state ) =>
+		getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY )
+	);
+
+	const domainsEligibleForGoogleWorkspaceSale = domains
+		.filter( ( domain ) => {
+			if ( domain.expired || domain.isWpcomStagingDomain ) {
+				return false;
+			}
+			if ( ! canCurrentUserAddEmail( domain ) ) {
+				return false;
+			}
+			if ( hasPaidEmailWithUs( domain ) ) {
+				return false;
+			}
+			if ( ! hasGSuiteSupportedDomain( [ domain ] ) ) {
+				//return false;
+			}
+
+			return true;
+		} )
+		// Push the primary domain to be listed first
+		.sort( ( a, b ) => Number( b.isPrimary ?? false ) - Number( a.isPrimary ?? false ) );
+
+	const domainForSale = domainsEligibleForGoogleWorkspaceSale[ 0 ] ?? null;
+	const siteForSale = useSelector( ( state ) =>
+		domainForSale?.blogId ? getSite( state, domainForSale.blogId ) : getSelectedSite( state )
+	);
+
+	if ( 0 === domainsEligibleForGoogleWorkspaceSale.length ) {
+		return null;
+	}
+
+	if ( ! hasDiscount( googleWorkspaceProduct ) ) {
+		return null;
+	}
+
+	const monthlyPrice = getMonthlyPrice( googleWorkspaceProduct.sale_cost, currencyCode );
+
+	return (
+		<Banner
+			callToAction={ translate( 'Get Google Workspace' ) }
+			className="google-sale-banner"
+			description={ translate(
+				'Set up a custom email address @%(domainName)s for only {{strong}}%(price)s/mailbox/month{{/strong}} billed annually',
+				{
+					args: {
+						domainName: domainForSale.name,
+						price: monthlyPrice,
+					},
+					comment:
+						'%(domainName)s is a domain name, e.g. example.com; %(price)s is a formatted price, e.g. $3, £2.50',
+					components: {
+						strong: <strong />,
+					},
+				}
+			) }
+			disableCircle
+			iconPath={ googleWorkspaceIcon }
+			href={ emailManagementPurchaseNewEmailAccount(
+				siteForSale?.slug,
+				domainForSale.name,
+				currentRoute,
+				'google-sale'
+			) }
+			title={ translate( 'Get %(discount)d% off Google Workspace for your domain!', {
+				args: { discount: googleWorkspaceProduct?.sale_coupon?.discount ?? 50 },
+				comment: '%(discount)d is a percentage discount, e.g. 50',
+			} ) }
+		/>
+	);
+};
+
+export default GoogleSaleBanner;

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -7,9 +7,8 @@ import { Banner } from 'calypso/components/banner';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { hasPaidEmailWithUs } from 'calypso/lib/emails';
-import { getMonthlyPrice, hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
+import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
@@ -27,7 +26,6 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 	const translate = useTranslate();
 
 	const canCurrentUserPurchaseGSuite = useSelector( canUserPurchaseGSuite );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentRoute = useSelector( getCurrentRoute );
 	const googleWorkspaceProduct = useSelector( ( state ) =>
 		getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY )
@@ -74,23 +72,20 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 		return null;
 	}
 
-	const monthlyPrice = getMonthlyPrice( googleWorkspaceProduct.sale_cost, currencyCode );
-
 	return (
 		<Banner
 			callToAction={ translate( 'Get Google Workspace' ) }
 			className="google-sale-banner"
 			description={ translate(
-				'Set up a custom email address @%(domainName)s for only {{strong}}%(price)s/mailbox/month{{/strong}} billed annually',
+				'Set up your custom mailbox @%(domainName)s and enable all the productivity tools Google Workspace offers.',
 				{
 					args: {
 						domainName: domainForSale.name,
-						price: monthlyPrice,
 					},
 					comment:
 						'%(domainName)s is a domain name, e.g. example.com; %(price)s is a formatted price, e.g. $3, £2.50',
 					components: {
-						strong: <strong />,
+						em: <em />,
 					},
 				}
 			) }
@@ -102,7 +97,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 				currentRoute,
 				'google-sale'
 			) }
-			title={ translate( 'Get %(discount)d% off Google Workspace for your domain!', {
+			title={ translate( 'Get %(discount)d% off Google Workspace for a limited time!', {
 				args: { discount: googleWorkspaceProduct?.sale_coupon?.discount },
 				comment: '%(discount)d is a percentage discount, e.g. 50',
 			} ) }

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -82,8 +82,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 					args: {
 						domainName: domainForSale.name,
 					},
-					comment:
-						'%(domainName)s is a domain name, e.g. example.com; %(price)s is a formatted price, e.g. $3, £2.50',
+					comment: '%(domainName)s is a domain name, e.g. example.com',
 					components: {
 						em: <em />,
 					},
@@ -98,7 +97,9 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 				'google-sale'
 			) }
 			title={ translate( 'Get %(discount)d% off Google Workspace for a limited time!', {
-				args: { discount: googleWorkspaceProduct?.sale_coupon?.discount },
+				args: {
+					discount: googleWorkspaceProduct.sale_coupon.discount,
+				},
 				comment: '%(discount)d is a percentage discount, e.g. 50',
 			} ) }
 		/>

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -80,7 +80,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 
 	return (
 		<Banner
-			callToAction={ translate( 'Get Google Workspace' ) }
+			callToAction={ translate( 'Claim Now' ) }
 			className="google-sale-banner"
 			description={ translate(
 				'Set up your custom mailbox @%(domainName)s and enable all the productivity tools Google Workspace offers.',
@@ -95,7 +95,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 				}
 			) }
 			disableCircle
-			event="get-google-workspace"
+			event="claim-now"
 			iconPath={ googleWorkspaceIcon }
 			href={ emailManagementPurchaseNewEmailAccount(
 				siteForSale?.slug,

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -1,4 +1,5 @@
 import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
@@ -30,6 +31,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 	const googleWorkspaceProduct = useSelector( ( state ) =>
 		getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY )
 	);
+	const isMobile = useMobileBreakpoint();
 
 	const domainsEligibleForGoogleWorkspaceSale = domains
 		.filter( ( domain ) => {
@@ -55,6 +57,10 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 	const siteForSale = useSelector( ( state ) =>
 		domainForSale?.blogId ? getSite( state, domainForSale.blogId ) : getSelectedSite( state )
 	);
+
+	if ( isMobile ) {
+		return null;
+	}
 
 	if ( ! canCurrentUserPurchaseGSuite ) {
 		return null;
@@ -89,6 +95,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 				}
 			) }
 			disableCircle
+			event="get-google-workspace"
 			iconPath={ googleWorkspaceIcon }
 			href={ emailManagementPurchaseNewEmailAccount(
 				siteForSale?.slug,
@@ -102,6 +109,8 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 				},
 				comment: '%(discount)d is a percentage discount, e.g. 50',
 			} ) }
+			tracksClickName="calypso_email_google_workspace_sale_banner_cta_click"
+			tracksImpressionName="calypso_email_google_workspace_sale_banner_impression"
 		/>
 	);
 };

--- a/client/my-sites/email/google-sale-banner/style.scss
+++ b/client/my-sites/email/google-sale-banner/style.scss
@@ -1,4 +1,24 @@
-.google-sale-banner .banner__icon-no-circle {
-	height: 36px;
-	width: 36px;
+.google-sale-banner {
+
+	@include breakpoint-deprecated( '>480px' ) {
+		&.banner.card {
+			padding-right: 24px;
+		}
+	}
+
+	.banner__icons {
+		.banner__icon {
+			display: none;
+		}
+
+		.banner__icon-no-circle {
+			align-self: center;
+			height: 36px;
+			width: 36px;
+		}
+	}
+
+	.banner__action {
+		margin-right: 0;
+	}
 }

--- a/client/my-sites/email/google-sale-banner/style.scss
+++ b/client/my-sites/email/google-sale-banner/style.scss
@@ -1,0 +1,4 @@
+.google-sale-banner .banner__icon-no-circle {
+	height: 36px;
+	width: 36px;
+}

--- a/client/my-sites/email/google-sale-banner/style.scss
+++ b/client/my-sites/email/google-sale-banner/style.scss
@@ -20,5 +20,9 @@
 
 	.banner__action {
 		margin-right: 0;
+
+		.button.is-compact {
+			line-height: 1.25;
+		}
 	}
 }

--- a/client/my-sites/email/google-sale-banner/style.scss
+++ b/client/my-sites/email/google-sale-banner/style.scss
@@ -1,13 +1,8 @@
 .google-sale-banner {
 
-	&.banner.card {
-		display: none;
-	}
-
 	@include breakpoint-deprecated( '>480px' ) {
 		&.banner.card {
 			padding-right: 24px;
-			display: flex;
 		}
 	}
 

--- a/client/my-sites/email/google-sale-banner/style.scss
+++ b/client/my-sites/email/google-sale-banner/style.scss
@@ -1,8 +1,13 @@
 .google-sale-banner {
 
+	&.banner.card {
+		display: none;
+	}
+
 	@include breakpoint-deprecated( '>480px' ) {
 		&.banner.card {
 			padding-right: 24px;
+			display: flex;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR implements a new `GoogleSaleBanner` component that is intended for display in the domains listing page, but the banner should only be displayed when a number of conditions are all met:
  - The user's device is larger than a standard mobile device
  - We need to be running a sale for Google Workspace via a sale coupon
  - The user needs to be in a country that is supported by Google
  - The user needs to have at least one domain that doesn't have paid email service _and_ that domain supports  Google Workspace purchases (the most common requirement here is that the domain must use our nameservers)
* If _all_ of the above conditions are met and we have loaded the domain list, we show the banner on the domains listing page
* When the banner is displayed, we log a `calypso_email_google_workspace_sale_banner_impression` event to Tracks with a `cta_name` prop of `get-google-workspace`. (This implies we should not log this event for mobile devices.)
* When the user clicks on the banner, we log a `calypso_email_google_workspace_sale_banner_cta_click` event to Tracks.
* This PR also implements some new TS types for the domains package, with the most interesting being the `ResponseDomain` type, which I mostly defined using the code from `client/state/sites/domains/assembler.js`, which intentionally casts most of the values to specific types.
  - This piece can be split out into a separate PR if need be, but I think it will be well worth having these types available for documenting domain-related functions using the [JSDoc import syntax for types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types) -- we don't need to do this immediately, but we can start making updates as we touch files in various places
 * Note that I've implemented the banner in both the existing domain listing page and the new UI that's currently protected by the `domains/management-list-redesign` feature flag.
 * This PR also addresses what looks like a bug in the underlying `Banner` component for situations where we're on mobile and the user has specified `disableCircle` and `iconPath` - the icon component is duplicated. I'll tackle that underlying bug in a follow-up PR.

@Automattic/nomado, @poligilad-auto, and @saygunnyc, please share any feedback that you have on the banner.

##### Screenshots

_Note: the following screenshots were from testing with different discounts -- the discount is specified by the coupon configuration._

###### Desktop

<img width="1079" alt="Screenshot 2021-11-03 at 21 15 50" src="https://user-images.githubusercontent.com/3376401/140181312-370b78d1-82d8-4e31-b9d8-b01396e6f364.png">

###### Tablet

<img width="768" alt="Screenshot 2021-11-04 at 14 15 51" src="https://user-images.githubusercontent.com/3376401/140313368-032d4bcb-5137-40ce-9f71-515d757106d3.png">

###### Mobile

_As noted [here](https://github.com/Automattic/wp-calypso/pull/57530#issuecomment-960803138), we're not going to show the banner on mobile.

###### New design

<img width="1098" alt="Screenshot 2021-11-03 at 21 44 00" src="https://user-images.githubusercontent.com/3376401/140181808-f5be6e0d-19f1-4186-9550-b28e4534f99e.png">

#### Testing instructions

* Getting set up to test this requires access to a back end sandbox, as we need to tackle a few things:
  - You need to create a sales coupon for the test Store environment - see D69393-code for instructions
  - You need to enable the test Store environment
  - You need to modify one of the back end APIs to mock a test domain having WordPress.com nameservers - I have a sample in D69406-code
* Once you have all of those set up, load the UI via a local branch or the live branch
* Go to Upgrades -> Domains for a site that has at least one eligible domain - verify that you see the banner displayed with an eligible domain.
* Verify that the `calypso_email_google_workspace_sale_banner_impression` Tracks event is logged
* Load the domains listing page with `?flags=domains/management-list-redesign` and `?flags=-domains/management-list-redesign` set in the URL - this will load the new and old components, respectively.
* Click on "Get Google Workspace".
*  Verify that a `calypso_email_google_workspace_sale_banner_cta_click` event is logged to Tracks, and  you see the email comparison page, and that the `source` URL parameter has a value of `google-sale`.
  - For now, this page doesn't promote/auto-expand Google Workspace during sales - we will tackle that in a follow-up PR
  - Also note that #57516 addresses the details we display when Google Workspace is on sale
* Try the steps above for a site that doesn't have any domains eligible for the purchase - verify that you don't see the banner.
* Switch your back end APIs to the production API and ensure that you've disabled the Store sandbox/test mode.
* Work through the flow again and verify that you don't see the banner for the sites with and without eligible domains.

Related to #57516