### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` push notification devices to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1455,41 +1455,6 @@ Undocumented.prototype.importReaderFeed = function ( file, fn ) {
 };
 
 /**
- * Creates a Push Notification registration for the device
- *
- * @param {string}     registration   The registration to be stored
- * @param {string}     deviceFamily   The device family
- * @param {string}     deviceName     The device name
- * @param {Function}   fn             The callback function
- * @returns {globalThis.XMLHttpRequest}          The XHR instance
- */
-Undocumented.prototype.registerDevice = function ( registration, deviceFamily, deviceName, fn ) {
-	debug( '/devices/new' );
-	return this.wpcom.req.post(
-		{ path: '/devices/new' },
-		{},
-		{
-			device_token: registration,
-			device_family: deviceFamily,
-			device_name: deviceName,
-		},
-		fn
-	);
-};
-
-/**
- * Removes a Push Notification registration for the device
- *
- * @param {number}        deviceId       The device ID for the registration to be removed
- * @param {Function}   fn             The callback function
- * @returns {globalThis.XMLHttpRequest}          The XHR instance
- */
-Undocumented.prototype.unregisterDevice = function ( deviceId, fn ) {
-	debug( '/devices/:device_id/delete' );
-	return this.wpcom.req.post( { path: `/devices/${ deviceId }/delete` }, fn );
-};
-
-/**
  * Requests streamlined approval to WordAds program
  *
  * @param {number}       siteId            The site ID

--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -218,9 +218,16 @@ export function sendSubscriptionToWPCOM( pushSubscription ) {
 		}
 
 		debug( 'Sending subscription to WPCOM', pushSubscription );
-		return wpcom
-			.undocumented()
-			.registerDevice( JSON.stringify( pushSubscription ), 'browser', 'Browser' )
+		return wpcom.req
+			.post(
+				{ path: '/devices/new' },
+				{},
+				{
+					device_token: JSON.stringify( pushSubscription ),
+					device_family: 'browser',
+					device_name: 'Browser',
+				}
+			)
 			.then( ( data, headers ) =>
 				dispatch( {
 					type: PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE,
@@ -263,9 +270,8 @@ export function unregisterDevice() {
 			dispatch( receiveUnregisterDevice() );
 			return;
 		}
-		return wpcom
-			.undocumented()
-			.unregisterDevice( deviceId )
+		return wpcom.req
+			.post( { path: `/devices/${ deviceId }/delete` } )
 			.then( ( data ) => {
 				debug( 'Successfully unregistered device', data );
 				dispatch( receiveUnregisterDevice( data ) );

--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -219,15 +219,11 @@ export function sendSubscriptionToWPCOM( pushSubscription ) {
 
 		debug( 'Sending subscription to WPCOM', pushSubscription );
 		return wpcom.req
-			.post(
-				{ path: '/devices/new' },
-				{},
-				{
-					device_token: JSON.stringify( pushSubscription ),
-					device_family: 'browser',
-					device_name: 'Browser',
-				}
-			)
+			.post( '/devices/new', {
+				device_token: JSON.stringify( pushSubscription ),
+				device_family: 'browser',
+				device_name: 'Browser',
+			} )
 			.then( ( data, headers ) =>
 				dispatch( {
 					type: PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE,
@@ -271,7 +267,7 @@ export function unregisterDevice() {
 			return;
 		}
 		return wpcom.req
-			.post( { path: `/devices/${ deviceId }/delete` } )
+			.post( `/devices/${ deviceId }/delete` )
 			.then( ( data ) => {
 				debug( 'Successfully unregistered device', data );
 				dispatch( receiveUnregisterDevice( data ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates all the usages of `wpcom.undocumented()` related to devices for push notifications to `wpcom.req.get()`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions
* Go to `/me/notifications`
* Play with enabling and disabling push notifications for the device and verify that still works well.
* Verify tests still pass: `yarn run test-client client/state/push-notifications/test/actions.js`