### PR TITLE
WPCOM: Remove unused undocumented `externalMediaList` method

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1635,20 +1635,6 @@ Undocumented.prototype.initiateTransfer = function ( siteId, plugin, theme, onPr
 };
 
 /**
- * Returns a list of media from an external media service. Similar to Site.mediaList in use, but
- * with a more restricted set of query params.
- *
- * @param {object} query - Media query, supports 'path', 'search', 'max', 'page_handle', and 'source'
- * @param {Function} fn - The callback function
- * @returns {Promise} promise for handling result
- */
-Undocumented.prototype.externalMediaList = function ( query, fn ) {
-	debug( `/meta/external-media/${ query.source }` );
-
-	return this.wpcom.req.get( `/meta/external-media/${ query.source }`, query, fn );
-};
-
-/**
  * Fetch the status of an Automated Transfer.
  *
  * @param {number} siteId -- the ID of the site being transferred


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes an unused `wpcom.undocumented()` method - `externalMediaList`. It's no longer in use since #44023.

#### Testing instructions

Verify the removed method is not in use.