### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` Jetpack sync to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -174,30 +174,6 @@ Undocumented.prototype.jetpackIsUserConnected = function ( siteId ) {
 };
 
 /**
- * Gets the current status of a full sync for a Jetpack site.
- *
- * @param {number|string} siteId The site ID
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.getJetpackSyncStatus = function ( siteId, fn ) {
-	debug( '/sites/:site_id:/sync/status query' );
-	const endpointPath = '/sites/' + siteId + '/sync/status';
-	return this.wpcom.req.get( { path: endpointPath }, fn );
-};
-
-/**
- * Schedules a full sync for a Jetpack site.
- *
- * @param {number|string} siteId The site ID
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.scheduleJetpackFullysync = function ( siteId, fn ) {
-	debug( '/sites/:site_id:/sync query' );
-	const endpointPath = '/sites/' + siteId + '/sync';
-	return this.wpcom.req.post( { path: endpointPath }, {}, fn );
-};
-
-/**
  * GET/POST site settings
  *
  * @param {number|string} [siteId] The site ID

--- a/client/state/jetpack-sync/actions.js
+++ b/client/state/jetpack-sync/actions.js
@@ -26,7 +26,7 @@ export function getSyncStatus( siteId ) {
 		} );
 
 		return wpcom.req
-			.get( { path: `/sites/${ siteId }/sync/status` } )
+			.get( `/sites/${ siteId }/sync/status` )
 			.then( ( data ) => {
 				dispatch( {
 					type: JETPACK_SYNC_STATUS_SUCCESS,
@@ -53,7 +53,7 @@ export function scheduleJetpackFullysync( siteId ) {
 		} );
 
 		return wpcom.req
-			.post( { path: `/sites/${ siteId }/sync` }, {} )
+			.post( `/sites/${ siteId }/sync` )
 			.then( ( data ) => {
 				dispatch( {
 					type: JETPACK_SYNC_START_SUCCESS,

--- a/client/state/jetpack-sync/actions.js
+++ b/client/state/jetpack-sync/actions.js
@@ -25,9 +25,8 @@ export function getSyncStatus( siteId ) {
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.getJetpackSyncStatus( siteId )
+		return wpcom.req
+			.get( { path: `/sites/${ siteId }/sync/status` } )
 			.then( ( data ) => {
 				dispatch( {
 					type: JETPACK_SYNC_STATUS_SUCCESS,
@@ -53,9 +52,8 @@ export function scheduleJetpackFullysync( siteId ) {
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.scheduleJetpackFullysync( siteId )
+		return wpcom.req
+			.post( { path: `/sites/${ siteId }/sync` }, {} )
 			.then( ( data ) => {
 				dispatch( {
 					type: JETPACK_SYNC_START_SUCCESS,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates all the usages of `wpcom.undocumented()` related to Jetpack sync to `wpcom.req.get()`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions
* Make sure you're logged in with an a11n WP.com account.
* Go to `/settings/manage-connection/:site` where `:site` is one of your Jetpack sites.
* Trigger manual sync from the "initiate a sync manually" link.
* Verify it starts a manual sync correctly.
* Verify status is displayed correctly after a few seconds.
* Verify tests still pass: `yarn run test-client client/state/jetpack-sync/test/actions.js`