### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` featured plugins to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1678,16 +1678,6 @@ Undocumented.prototype.oauth2ClientId = function ( clientId, fn ) {
 };
 
 /**
- * Fetch the curated list of featured plugins.
- *
- * @param {Function}   fn             The callback function
- * @returns {Promise}  A promise
- */
-Undocumented.prototype.getFeaturedPlugins = function ( fn ) {
-	return this.wpcom.req.get( '/plugins/featured', { apiNamespace: 'wpcom/v2' }, fn );
-};
-
-/**
  * Fetch a nonce to use in the `updateSiteAddress` call
  *
  * @param {number}   siteId  The ID of the site for which to get a nonce.

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -107,9 +107,8 @@ export function fetchPluginsList(
 
 		// The "Featured" category is managed by WP.com instead of WP.org
 		if ( 'featured' === category ) {
-			wpcom
-				.undocumented()
-				.getFeaturedPlugins()
+			wpcom.req
+				.get( '/plugins/featured', { apiNamespace: 'wpcom/v2' } )
 				.then( ( data ) => {
 					dispatch( receivePluginsList( category, page, searchTerm, data, null ) );
 				} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` method that fetches featured plugins to `wpcom.req.get()`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions
* Go to `/plugins/featured/:site` where `:site` is a Jetpack site.
* Verify the featured plugins still load well.
* Verify tests still pass: `yarn run test-client client/state/plugins/wporg/test/actions.js`