### PR TITLE
Template editing - unlock classic themes.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -205,8 +205,12 @@ function hide_fse_blocks( $editor_settings ) {
  * @return array Possibly modified editor settings.
  */
 function hide_template_editing( $editor_settings ) {
-	// this shouldn't even be hooked under this condition, but let's be sure.
-	if ( is_core_fse_active() ) {
+
+	if (
+		// This shouldn't even be hooked under this condition, but let's be sure.
+		is_core_fse_active() ||
+		// If this is not an FSE (or universal) theme, don't mess with the settings for template editing.
+		! is_fse_theme() ) {
 		return $editor_settings;
 	}
 	$editor_settings['supportsTemplateMode'] = false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After recent slack discussions - p1635345285013400-slack-C01DF571R5Y - it makes sense to unlock template editing for classic themes for  WP 5.9.


Some History:

Currently, we are hiding the template editing feature in the post editor unless the FSE beta environment is active.  This decisions was made because Universal themes on dotcom were the only themes that would enable the template editor, but they would be enabled in a broken state (unregistered FSE blocks) if the FSE beta was not active.  Thus it made sense to restrict template editing to the same conditions as the FSE beta.

However, it has come to our attention that classic themes can declare template editor support and make use of this feature (although no dotcom themes do at this time), and it does not make sense to hide this core feature for classic themes on dotcom.  While no dotcom themes are currently affected, we currently risk the possibility that a 3rd party classic theme that makes use of the template editor becomes unnecessarily restricted when running on dotcom or alongside the ETK plugin.

Here, we add 1 condition to our logic for disabling template editing - whether or not the theme is classic (non FSE/non universal).  If the theme is classic, the filter to disable template editing is bypassed.  Thus only FSE/Universal themes that are being used in 'classic' context (no FSE activated) will have template editing restricted.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify behavior does not change for universal themes.  If we toggle "Appearance->Site Editor" on/off, we should be able to load the template editor when ON and not able to when OFF.
* We have no classic themes on dotcom that declare support for the template editor, so this part of the change should not be noticeable at this time.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #