### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` whois to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1183,39 +1183,6 @@ Undocumented.prototype.transferToSite = function ( siteId, domainName, targetSit
 	);
 };
 
-/*
- * Retrieves WHOIS data for given domain.
- *
- * @param {string} [domainName]
- * @param {Function} [fn]
- */
-Undocumented.prototype.fetchWhois = function ( domainName, fn ) {
-	debug( '/domains/:domainName/whois query' );
-	return this.wpcom.req.get( `/domains/${ domainName }/whois`, fn );
-};
-
-/*
- * Updates WHOIS data for given domain.
- *
- * @param {string} [domainName]
- * @param {object} [whois]
- * @param {Function} [fn]
- */
-Undocumented.prototype.updateWhois = function ( domainName, whois, transferLock, fn ) {
-	debug( '/domains/:domainName/whois' );
-	return this.wpcom.req.post(
-		{
-			path: `/domains/${ domainName }/whois`,
-			apiVersion: '1.1',
-			body: {
-				whois,
-				transfer_lock: transferLock,
-			},
-		},
-		fn
-	);
-};
-
 /**
  * Add domain mapping for eligible clients.
  *

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -436,13 +436,9 @@ class ListAll extends Component {
 		const saveWhoisPromises = selectedDomainNamesList.map( ( domainName ) => {
 			const updatedContactInfo = this.getUpdatedContactInfo( domainName, contactInfo );
 			return wpcom.req
-				.post( {
-					path: `/domains/${ domainName }/whois`,
-					apiVersion: '1.1',
-					body: {
-						whois: updatedContactInfo,
-						transfer_lock: this.state.transferLockOptOut,
-					},
+				.post( `/domains/${ domainName }/whois`, {
+					whois: updatedContactInfo,
+					transfer_lock: this.state.transferLockOptOut,
 				} )
 				.then( () => {
 					this.setState( ( { contactInfoSaveResults } ) => {

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -120,9 +120,8 @@ class ListAll extends Component {
 	};
 
 	fetchWhoisData = ( domain ) => {
-		wpcom
-			.undocumented()
-			.fetchWhois( domain )
+		wpcom.req
+			.get( `/domains/${ domain }/whois` )
 			.then( ( whoisData ) => this.setWhoisData( domain, whoisData[ 0 ] ?? null ) )
 			.catch( () => this.setWhoisData( domain, null ) );
 	};
@@ -436,9 +435,15 @@ class ListAll extends Component {
 
 		const saveWhoisPromises = selectedDomainNamesList.map( ( domainName ) => {
 			const updatedContactInfo = this.getUpdatedContactInfo( domainName, contactInfo );
-			return wpcom
-				.undocumented()
-				.updateWhois( domainName, updatedContactInfo, this.state.transferLockOptOut )
+			return wpcom.req
+				.post( {
+					path: `/domains/${ domainName }/whois`,
+					apiVersion: '1.1',
+					body: {
+						whois: updatedContactInfo,
+						transfer_lock: this.state.transferLockOptOut,
+					},
+				} )
 				.then( () => {
 					this.setState( ( { contactInfoSaveResults } ) => {
 						return {

--- a/client/state/domains/management/actions.js
+++ b/client/state/domains/management/actions.js
@@ -96,9 +96,8 @@ export function requestWhois( domain ) {
 			domain,
 		} );
 
-		return wpcom
-			.undocumented()
-			.fetchWhois( domain )
+		return wpcom.req
+			.get( `/domains/${ domain }/whois` )
 			.then( ( whoisData ) => {
 				dispatch( receiveWhois( domain, whoisData ) );
 				dispatch( {
@@ -132,9 +131,15 @@ export function saveWhois( domain, whoisData, transferLock ) {
 			domain,
 		} );
 
-		return wpcom
-			.undocumented()
-			.updateWhois( domain, whoisData, transferLock )
+		return wpcom.req
+			.post( {
+				path: `/domains/${ domain }/whois`,
+				apiVersion: '1.1',
+				body: {
+					whois: whoisData,
+					transfer_lock: transferLock,
+				},
+			} )
 			.then( ( data ) => {
 				dispatch( updateWhois( domain, whoisData ) );
 				dispatch( {

--- a/client/state/domains/management/actions.js
+++ b/client/state/domains/management/actions.js
@@ -132,13 +132,9 @@ export function saveWhois( domain, whoisData, transferLock ) {
 		} );
 
 		return wpcom.req
-			.post( {
-				path: `/domains/${ domain }/whois`,
-				apiVersion: '1.1',
-				body: {
-					whois: whoisData,
-					transfer_lock: transferLock,
-				},
+			.post( `/domains/${ domain }/whois`, {
+				whois: whoisData,
+				transfer_lock: transferLock,
 			} )
 			.then( ( data ) => {
 				dispatch( updateWhois( domain, whoisData ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` methods for domains whois to `wpcom.req.get()`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions
* Go to `/domains/manage/:domain/edit-contact-info/:site` where `:domain` and `:site` correspond to one of your sites with custom domains.
* Verify the current contact information is retrieved correctly.
* Change some data and save the form, then verify the new contact information is stored correctly.