### PR TITLE
Video UI: pull data from endpoint

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -6,7 +6,7 @@ import './style.scss';
 const VideosUi = () => {
 	const translate = useTranslate();
 
-	const { data: course } = useCourseQuery( 'onboarding', { retry: false } );
+	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );
 
 	return (
 		<div className="videos-ui">

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -1,9 +1,12 @@
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import useCourseQuery from 'calypso/data/courses/use-course-query';
 import './style.scss';
 
 const VideosUi = () => {
 	const translate = useTranslate();
+
+	const { data: course } = useCourseQuery( 'onboarding', { retry: false } );
 
 	return (
 		<div className="videos-ui">
@@ -57,51 +60,22 @@ const VideosUi = () => {
 						<img src="https://placekitten.com/720/480" alt="placeholder" />
 					</div>
 					<div className="videos-ui__chapters">
-						<div className="videos-ui__chapter">
-							<span className="videos-ui__completed">
-								<Gridicon icon="checkmark" size={ 12 } />
-							</span>
-							1. { translate( 'Set up your blog in 5 steps' ) }{ ' ' }
-							<span className="videos-ui__duration">01:45</span>{ ' ' }
-						</div>
-						<div className="videos-ui__chapter">
-							<span className="videos-ui__completed">
-								<Gridicon icon="checkmark" size={ 12 } />
-							</span>
-							2. { translate( 'Write a blog post' ) }{ ' ' }
-							<span className="videos-ui__duration">02:55</span>{ ' ' }
-						</div>
-						<div className="videos-ui__chapter">
-							<span className="videos-ui__completed">
-								<Gridicon icon="checkmark" size={ 12 } />
-							</span>
-							3. { translate( 'How to edit in Wordpress' ) }{ ' ' }
-							<span className="videos-ui__duration">01:14</span>{ ' ' }
-						</div>
-						<div className="videos-ui__chapter">
-							<span className="videos-ui__completed">
-								<Gridicon icon="checkmark" size={ 12 } />
-							</span>
-							4. { translate( 'Social icons' ) } <span className="videos-ui__duration">03:18</span>{ ' ' }
-						</div>
-						<div className="videos-ui__chapter active">
-							<span className="videos-ui__completed">
-								<Gridicon icon="checkmark" size={ 12 } />
-							</span>
-							5. { translate( 'Add images to your posts' ) }{ ' ' }
-							<span className="videos-ui__duration">02:20</span>{ ' ' }
-							<div className="videos-ui__active-video-content">
-								<p>
-									{ translate(
-										"You're about to embark on the journey of starting a new blog. We'll run through five steps to make sure that you love the way your blog looks so you can feel proud to share it with others."
-									) }{ ' ' }
-								</p>
-								<button type="button" className="videos-ui__play-button">
-									<Gridicon icon="play" size={ 24 } />
-									{ translate( 'Play video' ) }
-								</button>
-							</div>
-						</div>
+						{ course &&
+							Object.entries( course.videos ).map( ( data, i ) => {
+								const video = data[ 1 ];
+								return (
+									<div key={ i } className="videos-ui__chapter">
+										<span className="videos-ui__completed">
+											<Gridicon icon="checkmark" size={ 12 } />
+										</span>
+										{ i + 1 }. { video.title }{ ' ' }
+										<span className="videos-ui__duration"> { video.duration } </span>{ ' ' }
+										<div className="videos-ui__active-video-content">
+											<p>{ video.description } </p>
+										</div>
+									</div>
+								);
+							} ) }
 					</div>
 				</div>
 			</div>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -53,7 +53,7 @@ const VideosUi = () => {
 			</div>
 			<div className="videos-ui__body">
 				<div className="videos-ui__body-title">
-					<h3>{ translate( 'Blogger Masterclass' ) }</h3>
+					<h3>{ course && course.title }</h3>
 				</div>
 				<div className="videos-ui__video-content">
 					<div className="videos-ui__video">

--- a/client/data/courses/use-course-query.js
+++ b/client/data/courses/use-course-query.js
@@ -1,0 +1,12 @@
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+const useCourseQuery = ( courseSlug, queryOptions = {} ) => {
+	return useQuery(
+		[ 'courses', courseSlug ],
+		() => wpcom.req.get( '/courses', { course_slug: courseSlug, apiNamespace: 'wpcom/v2' } ),
+		queryOptions
+	);
+};
+
+export default useCourseQuery;


### PR DESCRIPTION
This PR implements the pulling of data from the endpoint for the Video UI.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/139852232-a79d4402-674a-47b0-a8dc-3055574c5468.png) | ![image](https://user-images.githubusercontent.com/375980/139852059-53fbb4f9-1dd8-46e1-8700-be4d23d3c5de.png)  |

#### Testing instructions

1. If D69418-code is not merged you need to apply it on your sandbox.
2. This PR still does not load the UI anywhere (as it will be added as a modal in the work being done for #57326).
3. However, it can be tested by importing the VideosUi component anywhere in Calypso. (I have been testing it as a block on the home page for this initial development pass.).
4. Verify the video info is being loaded from the `https://public-api.wordpress.com/wpcom/v2/courses?course_slug=onboarding` endpoint.

Ref: https://github.com/Automattic/wp-calypso/issues/57448