### PR TITLE
Jetpack Licensing: Rename "Partner Portal" to "Licensing"

### DIFF
--- a/client/components/jetpack/portal-nav/index.tsx
+++ b/client/components/jetpack/portal-nav/index.tsx
@@ -26,9 +26,7 @@ export default function PortalNav( { className = '' }: Props ): ReactElement | n
 	const partnerFetched = useSelector( hasFetchedPartner );
 	const partner = useSelector( getCurrentPartner );
 	const isManagingSites = ! useSelector( isPartnerPortal );
-	const selectedText = isManagingSites
-		? translate( 'Manage Sites' )
-		: translate( 'Partner Portal' );
+	const selectedText = isManagingSites ? translate( 'Manage Sites' ) : translate( 'Licensing' );
 	const show = partnerFetched && partner;
 
 	if ( ! isSectionNameEnabled( 'jetpack-cloud-partner-portal' ) ) {
@@ -63,9 +61,9 @@ export default function PortalNav( { className = '' }: Props ): ReactElement | n
 						<NavItem
 							path="/partner-portal"
 							selected={ ! isManagingSites }
-							onClick={ () => onNavItemClick( 'Partner Portal' ) }
+							onClick={ () => onNavItemClick( 'Licensing' ) }
 						>
-							{ translate( 'Partner Portal' ) }
+							{ translate( 'Licensing' ) }
 						</NavItem>
 					</NavTabs>
 				</SectionNav>

--- a/client/jetpack-cloud/sections/partner-portal/primary/partner-access/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/partner-access/index.tsx
@@ -37,7 +37,7 @@ export default function PartnerAccess(): ReactElement | null {
 		<Main className="partner-access">
 			<QueryJetpackPartnerPortalPartner />
 
-			<CardHeading size={ 36 }>{ translate( 'Partner Portal' ) }</CardHeading>
+			<CardHeading size={ 36 }>{ translate( 'Licensing' ) }</CardHeading>
 
 			{ isFetching && <Spinner /> }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
@@ -39,7 +39,7 @@ export default function SelectPartnerKey(): ReactElement | null {
 		<Main className="select-partner-key">
 			<QueryJetpackPartnerPortalPartner />
 
-			<CardHeading size={ 36 }>{ translate( 'Partner Portal' ) }</CardHeading>
+			<CardHeading size={ 36 }>{ translate( 'Licensing' ) }</CardHeading>
 
 			{ isFetching && <Spinner /> }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
@@ -64,7 +64,7 @@ export default function TermsOfServiceConsent(): ReactElement | null {
 		<Main className="terms-of-service-consent">
 			<QueryJetpackPartnerPortalPartner />
 
-			<CardHeading size={ 36 }>{ translate( 'Partner Portal' ) }</CardHeading>
+			<CardHeading size={ 36 }>{ translate( 'Licensing' ) }</CardHeading>
 
 			{ ! fetchedPartner && <Spinner /> }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR simply changes the text string from "Partner Portal" to "Licensing" in a few places.
* Ideally, we'd change the paths also, but we can do that in a separate PR if necessary, since it could be messy.

#### Testing instructions

* Make sure that Licensing is still accessible from all links, and that "Partner Portal" is not displayed anywhere.
