### PR TITLE
Config: Remove unused Jetpack personal plan flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -93,7 +93,6 @@
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/only-realtime-products": true,
-		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
-		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
 		"jetpack/only-realtime-products": false,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/production.json
+++ b/config/production.json
@@ -60,7 +60,6 @@
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/only-realtime-products": false,
-		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -59,7 +59,6 @@
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/only-realtime-products": true,
-		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the `jetpack/personal-plan` feature flag that has been unused since #52836 landed.

#### Testing instructions

Verify the removed feature flag is not in use anymore.