### PR TITLE
Playwright: Skip signup specs as we redesign new flows

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-signup__free.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__free.ts
@@ -17,7 +17,8 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function () {
+// Skipping while new onboarding flows are in transition and we map the new tests
+describe.skip( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function () {
 	const inboxId = DataHelper.config.get( 'inviteInboxId' ) as string;
 	const username = `e2eflowtestingfree${ DataHelper.getTimestamp() }`;
 	const email = DataHelper.getTestEmailAddress( {

--- a/test/e2e/specs/specs-playwright/wp-signup__paid.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__paid.ts
@@ -22,7 +22,8 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Paid' ), function () {
+// Skipping while new onboarding flows are in transition and we map the new tests
+describe.skip( DataHelper.createSuiteTitle( 'Signup: WordPress.com Paid' ), function () {
 	const inboxId = DataHelper.config.get( 'inviteInboxId' ) as string;
 	const username = `e2eflowtestingpaid${ DataHelper.getTimestamp() }`;
 	const email = DataHelper.getTestEmailAddress( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the new blogger experience changes to onboarding, our signup flows no longer work and will need to be redesigned to not just stop failing, but also ensure we have the correct coverage for these new branching paths.

#### Testing instructions

The signup pre-release specs will not run. 

Related to #57550
