### PR TITLE
Plans: Update styling for Jetpack CRM card to match other product cards

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/free.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/free.tsx
@@ -1,17 +1,17 @@
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 
 type OwnProps = {
-	showStartingAt?: boolean;
+	showAbovePriceText?: boolean;
 	hideSavingLabel?: boolean;
 	belowPriceText?: TranslateResult;
 };
 
-const Free: React.FC< OwnProps > = ( { showStartingAt, hideSavingLabel, belowPriceText } ) => {
+const Free: React.FC< OwnProps > = ( { showAbovePriceText, hideSavingLabel, belowPriceText } ) => {
 	const translate = useTranslate();
 
 	return (
 		<>
-			{ showStartingAt && (
+			{ showAbovePriceText && (
 				<span className="display-price__above-price-text">{ translate( 'Start for' ) }</span>
 			) }
 			<span className="display-price__price-free">{ translate( 'Free' ) }</span>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/free.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/free.tsx
@@ -10,6 +10,7 @@ const Free: React.FC< OwnProps > = ( { showStartingAt, hideSavingLabel, belowPri
 	const translate = useTranslate();
 
 	return (
+		<>
 			{ showStartingAt && (
 				<span className="display-price__above-price-text">{ translate( 'Start for' ) }</span>
 			) }
@@ -18,8 +19,9 @@ const Free: React.FC< OwnProps > = ( { showStartingAt, hideSavingLabel, belowPri
 				<span className="display-price__billing-time-frame">{ belowPriceText }</span>
 			) }
 			{ ! hideSavingLabel && (
-			<span className="display-price__get-started">{ translate( 'Get started for free' ) }</span>
+				<span className="display-price__get-started">{ translate( 'Get started for free' ) }</span>
 			) }
+		</>
 	);
 };
 

--- a/client/components/jetpack/card/jetpack-product-card/display-price/free.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/free.tsx
@@ -2,10 +2,11 @@ import { useTranslate, TranslateResult } from 'i18n-calypso';
 
 type OwnProps = {
 	showStartingAt?: boolean;
+	hideSavingLabel?: boolean;
 	belowPriceText?: TranslateResult;
 };
 
-const Free: React.FC< OwnProps > = ( { showStartingAt, belowPriceText } ) => {
+const Free: React.FC< OwnProps > = ( { showStartingAt, hideSavingLabel, belowPriceText } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -16,8 +17,9 @@ const Free: React.FC< OwnProps > = ( { showStartingAt, belowPriceText } ) => {
 			{ belowPriceText && (
 				<span className="display-price__billing-time-frame">{ belowPriceText }</span>
 			) }
+			{ ! hideSavingLabel && (
 			<span className="display-price__get-started">{ translate( 'Get started for free' ) }</span>
-		</div>
+			) }
 	);
 };
 

--- a/client/components/jetpack/card/jetpack-product-card/display-price/free.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/free.tsx
@@ -1,14 +1,17 @@
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 
 type OwnProps = {
+	showStartingAt?: boolean;
 	belowPriceText?: TranslateResult;
 };
 
-const Free: React.FC< OwnProps > = ( { belowPriceText } ) => {
+const Free: React.FC< OwnProps > = ( { showStartingAt, belowPriceText } ) => {
 	const translate = useTranslate();
 
 	return (
-		<div>
+			{ showStartingAt && (
+				<span className="display-price__above-price-text">{ translate( 'Start for' ) }</span>
+			) }
 			<span className="display-price__price-free">{ translate( 'Free' ) }</span>
 			{ belowPriceText && (
 				<span className="display-price__billing-time-frame">{ belowPriceText }</span>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -22,6 +22,7 @@ type OwnProps = {
 	isFree?: boolean;
 	isIncludedInPlan?: boolean;
 	isOwned?: boolean;
+	showStartingAt?: boolean;
 	originalPrice: number;
 	productName: TranslateResult;
 	tooltipText?: TranslateResult | ReactNode;
@@ -38,6 +39,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	isFree,
 	isIncludedInPlan,
 	isOwned,
+	showStartingAt,
 	hideSavingLabel,
 	originalPrice,
 	productName,
@@ -56,7 +58,12 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	}
 
 	if ( isFree ) {
-		return <Free belowPriceText={ belowPriceText } />;
+		return (
+			<Free
+				showStartingAt={ showStartingAt }
+				belowPriceText={ belowPriceText }
+			/>
+		);
 	}
 
 	return (

--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -22,7 +22,7 @@ type OwnProps = {
 	isFree?: boolean;
 	isIncludedInPlan?: boolean;
 	isOwned?: boolean;
-	showStartingAt?: boolean;
+	showAbovePriceText?: boolean;
 	originalPrice: number;
 	productName: TranslateResult;
 	tooltipText?: TranslateResult | ReactNode;
@@ -39,7 +39,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	isFree,
 	isIncludedInPlan,
 	isOwned,
-	showStartingAt,
+	showAbovePriceText,
 	hideSavingLabel,
 	originalPrice,
 	productName,
@@ -60,7 +60,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	if ( isFree ) {
 		return (
 			<Free
-				showStartingAt={ showStartingAt }
+				showAbovePriceText={ showAbovePriceText }
 				hideSavingLabel={ hideSavingLabel }
 				belowPriceText={ belowPriceText }
 			/>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -61,6 +61,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 		return (
 			<Free
 				showStartingAt={ showStartingAt }
+				hideSavingLabel={ hideSavingLabel }
 				belowPriceText={ belowPriceText }
 			/>
 		);

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -38,6 +38,7 @@ type OwnProps = {
 	aboveButtonText?: TranslateResult | ReactNode;
 	featuredLabel?: TranslateResult;
 	hideSavingLabel?: boolean;
+	showStartingAt?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 };
 
@@ -71,6 +72,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	tooltipText,
 	featuredLabel,
 	hideSavingLabel,
+	showStartingAt,
 	aboveButtonText = null,
 	scrollCardIntoView,
 } ) => {
@@ -125,6 +127,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 					currencyCode={ item.displayCurrency }
 					originalPrice={ originalPrice }
 					displayFrom={ displayFrom }
+					showStartingAt={ showStartingAt }
 					belowPriceText={ item.belowPriceText }
 					expiryDate={ expiryDate }
 					billingTerm={ item.displayTerm || item.term }

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -39,7 +39,7 @@ type OwnProps = {
 	aboveButtonText?: TranslateResult | ReactNode;
 	featuredLabel?: TranslateResult;
 	hideSavingLabel?: boolean;
-	showStartingAt?: boolean;
+	showAbovePriceText?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 };
 
@@ -74,7 +74,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	tooltipText,
 	featuredLabel,
 	hideSavingLabel,
-	showStartingAt,
+	showAbovePriceText,
 	aboveButtonText = null,
 	scrollCardIntoView,
 } ) => {
@@ -129,7 +129,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 					currencyCode={ item.displayCurrency }
 					originalPrice={ originalPrice }
 					displayFrom={ displayFrom }
-					showStartingAt={ showStartingAt }
+					showAbovePriceText={ showAbovePriceText }
 					belowPriceText={ item.belowPriceText }
 					expiryDate={ expiryDate }
 					billingTerm={ item.displayTerm || item.term }

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -15,6 +15,7 @@ import type { Moment } from 'moment';
 import './style.scss';
 
 type OwnProps = {
+	className?: string;
 	item: SelectorProduct;
 	// Disallow h6, so it can be used for a sub-header if needed
 	headerLevel: 1 | 2 | 3 | 4 | 5;
@@ -51,6 +52,7 @@ const Header: React.FC< HeaderProps > = ( { level, children, ...headerProps } ) 
 	createElement( `h${ level }`, headerProps, children );
 
 const JetpackProductCard: React.FC< OwnProps > = ( {
+	className,
 	item,
 	headerLevel,
 	description,
@@ -89,7 +91,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 
 	return (
 		<div
-			className={ classNames( 'jetpack-product-card', {
+			className={ classNames( 'jetpack-product-card', className, {
 				'is-disabled': isDisabled,
 				'is-owned': isOwned,
 				'is-deprecated': isDeprecated,

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -20,7 +20,7 @@ type OwnProps = {
 	// Disallow h6, so it can be used for a sub-header if needed
 	headerLevel: 1 | 2 | 3 | 4 | 5;
 	description?: ReactNode;
-	originalPrice: number;
+	originalPrice?: number;
 	discountedPrice?: number;
 	buttonLabel: TranslateResult;
 	buttonPrimary: boolean;

--- a/client/components/jetpack/card/product-without-price/default.tsx
+++ b/client/components/jetpack/card/product-without-price/default.tsx
@@ -1,0 +1,64 @@
+import { Button } from '@automattic/components';
+import classnames from 'classnames';
+import { useMemo } from 'react';
+import type { TranslateResult } from 'i18n-calypso';
+
+import './style.scss';
+
+export type DefaultProps = {
+	fullWidth?: boolean;
+	className?: string;
+	productSlug: string;
+	displayName: TranslateResult;
+	description: TranslateResult;
+	productFeatures?: TranslateResult[];
+	buttonHref?: string;
+	onButtonClick: React.MouseEventHandler;
+	buttonLabel: TranslateResult;
+};
+
+const ProductWithoutPrice: React.FC< DefaultProps > = ( {
+	fullWidth,
+	className,
+	productSlug,
+	displayName,
+	description,
+	productFeatures,
+	buttonHref,
+	onButtonClick,
+	buttonLabel,
+} ) => {
+	const featuresListItems = useMemo(
+		() =>
+			productFeatures?.map( ( text: TranslateResult, index: number ) => (
+				<li key={ index }>{ text }</li>
+			) ),
+		[ productFeatures ]
+	);
+
+	const ownClassName = fullWidth ? 'product-without-price--full-width' : 'product-without-price';
+
+	return (
+		<div
+			className={ classnames( ownClassName, 'jetpack-product-card', className ) }
+			data-e2e-product-slug={ productSlug }
+		>
+			<header className="product-without-price__header">
+				<h3 className="product-without-price__title">{ displayName }</h3>
+				<p className="product-without-price__subheadline">{ description }</p>
+				<Button
+					className="product-without-price__button"
+					href={ buttonHref }
+					onClick={ onButtonClick }
+				>
+					{ buttonLabel }
+				</Button>
+			</header>
+			{ productFeatures && (
+				<ul className="product-without-price__features-list">{ featuresListItems }</ul>
+			) }
+		</div>
+	);
+};
+
+export default ProductWithoutPrice;

--- a/client/components/jetpack/card/product-without-price/index.tsx
+++ b/client/components/jetpack/card/product-without-price/index.tsx
@@ -1,65 +1,15 @@
-import { Button } from '@automattic/components';
-import classnames from 'classnames';
-import { FC, useMemo } from 'react';
-import * as React from 'react';
-import type { TranslateResult } from 'i18n-calypso';
+import {
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
+import Default, { DefaultProps } from './default';
+import OnlyRealtimeProducts, { OnlyRealtimeProductsProps } from './only-realtime-products';
 
 import './style.scss';
 
-type OwnProps = {
-	fullWidth?: boolean;
-	className?: string;
-	productSlug: string;
-	displayName: TranslateResult;
-	description: TranslateResult;
-	productFeatures?: TranslateResult[];
-	buttonHref?: string;
-	onButtonClick: React.MouseEventHandler;
-	buttonLabel: TranslateResult;
-};
-
-const ProductWithoutPrice: FC< OwnProps > = ( {
-	fullWidth,
-	className,
-	productSlug,
-	displayName,
-	description,
-	productFeatures,
-	buttonHref,
-	onButtonClick,
-	buttonLabel,
-} ) => {
-	const featuresListItems = useMemo(
-		() =>
-			productFeatures?.map( ( text: TranslateResult, index: number ) => (
-				<li key={ index }>{ text }</li>
-			) ),
-		[ productFeatures ]
-	);
-
-	const ownClassName = fullWidth ? 'product-without-price--full-width' : 'product-without-price';
-
-	return (
-		<div
-			className={ classnames( ownClassName, 'jetpack-product-card', className ) }
-			data-e2e-product-slug={ productSlug }
-		>
-			<header className="product-without-price__header">
-				<h3 className="product-without-price__title">{ displayName }</h3>
-				<p className="product-without-price__subheadline">{ description }</p>
-				<Button
-					className="product-without-price__button"
-					href={ buttonHref }
-					onClick={ onButtonClick }
-				>
-					{ buttonLabel }
-				</Button>
-			</header>
-			{ productFeatures && (
-				<ul className="product-without-price__features-list">{ featuresListItems }</ul>
-			) }
-		</div>
-	);
-};
+const ProductWithoutPrice: React.FC< DefaultProps | OnlyRealtimeProductsProps > = ( props ) =>
+	getForCurrentCROIteration( {
+		[ Iterations.ONLY_REALTIME_PRODUCTS ]: <OnlyRealtimeProducts { ...props } />,
+	} ) ?? <Default { ...props } />;
 
 export default ProductWithoutPrice;

--- a/client/components/jetpack/card/product-without-price/only-realtime-products.tsx
+++ b/client/components/jetpack/card/product-without-price/only-realtime-products.tsx
@@ -1,0 +1,59 @@
+import { Button } from '@automattic/components';
+import classnames from 'classnames';
+import { useMemo } from 'react';
+import type { TranslateResult } from 'i18n-calypso';
+
+import './style.scss';
+
+export type OnlyRealtimeProductsProps = {
+	fullWidth?: boolean;
+	className?: string;
+	productSlug: string;
+	displayName: TranslateResult;
+	description: TranslateResult;
+	productFeatures?: TranslateResult[];
+	buttonHref?: string;
+	onButtonClick: React.MouseEventHandler;
+	buttonLabel: TranslateResult;
+};
+
+const ProductWithoutPrice: React.FC< OnlyRealtimeProductsProps > = ( {
+	className,
+	productSlug,
+	displayName,
+	description,
+	productFeatures,
+	buttonHref,
+	onButtonClick,
+	buttonLabel,
+} ) => {
+	const featuresListItems = useMemo(
+		() =>
+			productFeatures?.map( ( text: TranslateResult, index: number ) => (
+				<li key={ index }>{ text }</li>
+			) ),
+		[ productFeatures ]
+	);
+
+	return (
+		<div
+			className={ classnames( 'jetpack-product-card', 'product-without-price', className ) }
+			data-e2e-product-slug={ productSlug }
+		>
+			<h3 className="product-without-price__title">{ displayName }</h3>
+			<Button
+				className="product-without-price__button"
+				href={ buttonHref }
+				onClick={ onButtonClick }
+			>
+				{ buttonLabel }
+			</Button>
+			<p className="product-without-price__subheadline">{ description }</p>
+			{ productFeatures && (
+				<ul className="product-without-price__features-list">{ featuresListItems }</ul>
+			) }
+		</div>
+	);
+};
+
+export default ProductWithoutPrice;

--- a/client/components/jetpack/card/product-without-price/style.scss
+++ b/client/components/jetpack/card/product-without-price/style.scss
@@ -119,3 +119,35 @@
 		margin: 16px;
 	}
 }
+
+.jetpack-plans__iteration--only-realtime-products .product-without-price {
+	@include breakpoint-deprecated( '>660px' ) {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-column-gap: 32px;
+
+		.product-without-price__title {
+			grid-row: 1;
+			grid-column: 1 / span 2;
+			margin-block-end: initial;
+		}
+
+		.product-without-price__button {
+			grid-row: 3;
+			grid-column: 1;
+			margin: initial;
+			align-self: flex-end;
+		}
+
+		.product-without-price__subheadline {
+			grid-row: 2;
+			grid-column: 2;
+		}
+
+		.product-without-price__features-list {
+			grid-row: 3;
+			grid-column: 2;
+			margin: 0 0 0 16px;
+		}
+	}
+}

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/index.tsx
@@ -1,59 +1,18 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
-	PRODUCT_JETPACK_CRM_FREE,
-	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
-	TERM_MONTHLY,
-} from '@automattic/calypso-products';
-import { useCallback } from 'react';
-import * as React from 'react';
-import { useDispatch } from 'react-redux';
-import ProductCardWithoutPrice from 'calypso/components/jetpack/card/product-without-price';
-import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
-import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
-import type { Duration, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
+import CardWithPrice, { CardWithPriceProps } from './with-price';
+import CardWithoutPrice, { CardWithoutPriceProps } from './without-price';
 
-import './style.scss';
+const Wrapper: React.FC< CardWithPriceProps | CardWithoutPriceProps > = ( props ) => {
+	return getForCurrentCROIteration( ( iteration: Iterations ) => {
+		if ( iteration === Iterations.ONLY_REALTIME_PRODUCTS ) {
+			return <CardWithPrice { ...props } />;
+		}
 
-type OwnProps = {
-	fullWidth?: boolean;
-	duration: Duration;
-	siteId: number | null;
+		return <CardWithoutPrice { ...props } />;
+	} );
 };
 
-const JetpackCrmFreeCard: React.FC< OwnProps > = ( { fullWidth, duration, siteId } ) => {
-	const slug =
-		duration === TERM_MONTHLY ? PRODUCT_JETPACK_CRM_FREE_MONTHLY : PRODUCT_JETPACK_CRM_FREE;
-	const product = slugToSelectorProduct( slug ) as SelectorProduct;
-
-	const dispatch = useDispatch();
-	const trackCallback = useCallback(
-		() =>
-			dispatch(
-				recordTracksEvent( 'calypso_product_jpcrmfree_click', {
-					site_id: siteId ?? undefined,
-				} )
-			),
-		[ dispatch, siteId ]
-	);
-
-	const onButtonClick = useCallback( () => {
-		storePlan( slug );
-		trackCallback();
-	}, [ slug, trackCallback ] );
-
-	return (
-		<ProductCardWithoutPrice
-			fullWidth={ fullWidth }
-			className="jetpack-crm-free-card"
-			productSlug={ slug }
-			displayName={ product.displayName }
-			description={ product.description }
-			productFeatures={ product.features.items.map( ( i ) => i.text ) }
-			buttonLabel={ product.buttonLabel }
-			buttonHref={ product.externalUrl }
-			onButtonClick={ onButtonClick }
-		/>
-	);
-};
-
-export default JetpackCrmFreeCard;
+export default Wrapper;

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/style.scss
@@ -1,3 +1,17 @@
+.jetpack-crm-free-card.with-price {
+	.display-price__above-price-text {
+		display: block;
+		margin-inline-start: 2px;
+
+		font-size: 1rem;
+		font-weight: 700;
+
+		// Adjust leading margin so that different UI fonts
+		// still align to the price the same way
+		&.is-jetpack-cloud {
+			margin-inline-start: 4px;
+		}
+	}
 .jetpack-crm-free-card.product-without-price--full-width {
 	display: flex;
 	column-gap: 64px;

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/style.scss
@@ -1,7 +1,12 @@
 .jetpack-crm-free-card.with-price {
+	.display-price {
+		min-height: 133px;
+	}
+
 	.display-price__above-price-text {
 		display: block;
 		margin-inline-start: 2px;
+		margin-block-start: 38px;
 
 		font-size: 1rem;
 		font-weight: 700;
@@ -12,6 +17,13 @@
 			margin-inline-start: 4px;
 		}
 	}
+
+	.display-price__price-free {
+		line-height: $font-headline-medium;
+		letter-spacing: -2px;
+	}
+}
+
 .jetpack-crm-free-card.product-without-price--full-width {
 	display: flex;
 	column-gap: 64px;

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/with-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/with-price.tsx
@@ -1,0 +1,88 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	PRODUCT_JETPACK_CRM_FREE,
+	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
+	TERM_MONTHLY,
+} from '@automattic/calypso-products';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
+import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+import './style.scss';
+
+const CRM_FREE_URL =
+	'https://jetpackcrm.com/pricing?utm_source=jetpack&utm_medium=web&utm_campaign=pricing_i4&utm_content=pricing';
+
+const useCrmFreeItem = () => {
+	const translate = useTranslate();
+
+	return useMemo(
+		() => ( {
+			isFree: true,
+			displayName: translate( 'Jetpack CRM' ),
+			features: {
+				items: [
+					{ text: translate( 'Unlimited contacts' ) },
+					{ text: translate( 'Manage billing and create invoices' ) },
+					{ text: translate( 'CRM fully integrated with WordPress' ) },
+				],
+			},
+		} ),
+		[ translate ]
+	);
+};
+
+export type CardWithPriceProps = {
+	duration: Duration;
+	siteId: number | null;
+};
+
+const CardWithPrice: React.FC< CardWithPriceProps > = ( { duration, siteId } ) => {
+	const translate = useTranslate();
+	const crmFreeProduct = useCrmFreeItem();
+	const slug = useMemo(
+		() =>
+			duration === TERM_MONTHLY ? PRODUCT_JETPACK_CRM_FREE_MONTHLY : PRODUCT_JETPACK_CRM_FREE,
+		[ duration ]
+	);
+
+	const dispatch = useDispatch();
+	const trackCallback = useCallback(
+		() =>
+			dispatch(
+				recordTracksEvent( 'calypso_product_jpcrmfree_click', {
+					site_id: siteId ?? undefined,
+				} )
+			),
+		[ dispatch, siteId ]
+	);
+
+	const onButtonClick = useCallback( () => {
+		storePlan( slug );
+		trackCallback();
+	}, [ slug, trackCallback ] );
+
+	return (
+		<JetpackProductCard
+			className={ classNames( 'jetpack-crm-free-card', 'with-price', {
+				'is-jetpack-cloud': isJetpackCloud(),
+			} ) }
+			hideSavingLabel
+			showStartingAt
+			buttonPrimary
+			item={ crmFreeProduct }
+			headerLevel={ 3 }
+			description={ translate( 'Build better relationships with your customers and clients.' ) }
+			buttonLabel={ translate( 'Get CRM' ) }
+			buttonURL={ CRM_FREE_URL }
+			onButtonClick={ onButtonClick }
+		/>
+	);
+};
+
+export default CardWithPrice;

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/with-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/with-price.tsx
@@ -73,7 +73,7 @@ const CardWithPrice: React.FC< CardWithPriceProps > = ( { duration, siteId } ) =
 				'is-jetpack-cloud': isJetpackCloud(),
 			} ) }
 			hideSavingLabel
-			showStartingAt
+			showAbovePriceText
 			buttonPrimary
 			item={ crmFreeProduct }
 			headerLevel={ 3 }

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/without-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/without-price.tsx
@@ -1,0 +1,58 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	PRODUCT_JETPACK_CRM_FREE,
+	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
+	TERM_MONTHLY,
+} from '@automattic/calypso-products';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import ProductCardWithoutPrice from 'calypso/components/jetpack/card/product-without-price';
+import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
+import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
+import type { Duration, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+import './style.scss';
+
+export type CardWithoutPriceProps = {
+	fullWidth?: boolean;
+	duration: Duration;
+	siteId: number | null;
+};
+
+const CardWithoutPrice: React.FC< CardWithoutPriceProps > = ( { fullWidth, duration, siteId } ) => {
+	const slug =
+		duration === TERM_MONTHLY ? PRODUCT_JETPACK_CRM_FREE_MONTHLY : PRODUCT_JETPACK_CRM_FREE;
+	const product = slugToSelectorProduct( slug ) as SelectorProduct;
+
+	const dispatch = useDispatch();
+	const trackCallback = useCallback(
+		() =>
+			dispatch(
+				recordTracksEvent( 'calypso_product_jpcrmfree_click', {
+					site_id: siteId ?? undefined,
+				} )
+			),
+		[ dispatch, siteId ]
+	);
+
+	const onButtonClick = useCallback( () => {
+		storePlan( slug );
+		trackCallback();
+	}, [ slug, trackCallback ] );
+
+	return (
+		<ProductCardWithoutPrice
+			fullWidth={ fullWidth }
+			className="jetpack-crm-free-card"
+			productSlug={ slug }
+			displayName={ product.displayName }
+			description={ product.description }
+			productFeatures={ product.features.items.map( ( { text } ) => text ) }
+			buttonLabel={ product.buttonLabel }
+			buttonHref={ product.externalUrl }
+			onButtonClick={ onButtonClick }
+		/>
+	);
+};
+
+export default CardWithoutPrice;

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -184,14 +184,19 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 			return undefined;
 		}
 
+		const card = <JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />;
 		return (
-			<div
-				className={ classNames( 'product-grid__free', {
-					[ 'horizontal-layout' ]: ! shouldWrapOtherItems,
-				} ) }
-			>
-				<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
-			</div>
+			getForCurrentCROIteration( {
+				[ Iterations.ONLY_REALTIME_PRODUCTS ]: card,
+			} ) ?? (
+				<div
+					className={ classNames( 'product-grid__free', {
+						[ 'horizontal-layout' ]: ! shouldWrapOtherItems,
+					} ) }
+				>
+					{ card }
+				</div>
+			)
 		);
 	};
 

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -7,6 +7,7 @@ import {
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PRODUCT_JETPACK_CRM_FREE,
 } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -26,6 +27,7 @@ import PlanUpgradeSection from '../plan-upgrade';
 import PlansFilterBar from '../plans-filter-bar';
 import ProductCard from '../product-card';
 import { getProductPosition } from '../product-grid/products-order';
+import slugToSelectorProduct from '../slug-to-selector-product';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import ProductGridSection from './section';
 import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from './utils';
@@ -178,26 +180,12 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		],
 	} ) ?? [ PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_SECURITY_DAILY_MONTHLY ];
 
-	const getJetpackFreeCard = () => {
-		if ( ! showFreeCard ) {
-			return undefined;
-		}
-
-		return (
-			<div
-				className={ classNames( 'product-grid__free', {
-					[ 'horizontal-layout' ]: ! shouldWrapOtherItems,
-				} ) }
-			>
-				<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
-			</div>
-		);
-	};
-
 	const getOtherItemsProductCard = ( product: SelectorProduct ) => {
 		if ( PLAN_JETPACK_FREE === product.productSlug ) {
 			return showFreeCard ? (
-				<li key={ product.productSlug }>{ getJetpackFreeCard() }</li>
+				<li key={ product.productSlug }>
+					<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
+				</li>
 			) : undefined;
 		}
 
@@ -286,11 +274,20 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 							{ ! shouldWrapOtherItems && (
 								<>
 									<ul className="product-grid__product-grid second-grid">
-										{ otherItems.slice( 3, 5 ).map( getOtherItemsProductCard ) }
+										{ [ ...otherItems, slugToSelectorProduct( PRODUCT_JETPACK_CRM_FREE ) ]
+											.slice( 3, 5 )
+											.map( getOtherItemsProductCard ) }
 									</ul>
-									{ getJetpackFreeCard() }
 								</>
 							) }
+							<div className="product-grid__free">
+								{ shouldWrapOtherItems && (
+									<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
+								) }
+								{ showFreeCard && (
+									<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
+								) }
+							</div>
 						</>
 					),
 				} ) ?? (

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -11,7 +11,6 @@ import {
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef, useState, useEffect } from 'react';
-import * as React from 'react';
 import { useSelector } from 'react-redux';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -184,19 +183,14 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 			return undefined;
 		}
 
-		const card = <JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />;
 		return (
-			getForCurrentCROIteration( {
-				[ Iterations.ONLY_REALTIME_PRODUCTS ]: card,
-			} ) ?? (
-				<div
-					className={ classNames( 'product-grid__free', {
-						[ 'horizontal-layout' ]: ! shouldWrapOtherItems,
-					} ) }
-				>
-					{ card }
-				</div>
-			)
+			<div
+				className={ classNames( 'product-grid__free', {
+					[ 'horizontal-layout' ]: ! shouldWrapOtherItems,
+				} ) }
+			>
+				<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
+			</div>
 		);
 	};
 

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -68,7 +68,7 @@
 	}
 
 	&.second-grid {
-		margin-top: 16px;
+		margin: 16px 0;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -110,3 +110,14 @@
 .product-grid__more.is-detached {
 	margin-top: 48px;
 }
+
+.jetpack-plans__iteration--only-realtime-products {
+	.product-grid__free {
+		margin-top: 16px;
+		flex-direction: column;
+	}
+
+	.jetpack-product-card.jetpack-free-card {
+		margin: initial;
+	}
+}

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -82,6 +82,7 @@
 }
 
 .product-grid__free {
+	height: 100%;
 	display: flex;
 	gap: 16px;
 	flex-wrap: wrap;

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -95,29 +95,95 @@
 	&.add-top-margin {
 		margin-block-start: 16px;
 	}
-
-	&.horizontal-layout {
-		.jetpack-free-card {
-			display: grid;
-			grid-template-columns: 1fr 1fr;
-			grid-gap: 32px;
-			align-items: center;
-			margin-block-start: 16px;
-		}
-	}
 }
 
 .product-grid__more.is-detached {
 	margin-top: 48px;
 }
 
+// Show both CRM and Free as full-width on narrow or mid-width screens
 .jetpack-plans__iteration--only-realtime-products {
 	.product-grid__free {
 		margin-top: 16px;
 		flex-direction: column;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			.jetpack-free-card {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				grid-gap: 32px;
+				align-items: center;
+				margin-block-start: 16px;
+			}
+		}
 	}
 
 	.jetpack-product-card.jetpack-free-card {
 		margin: initial;
+	}
+
+	.product-grid__free .jetpack-crm-free-card .jetpack-product-card__body {
+		.display-price {
+			min-height: 133px;
+		}
+
+		@include breakpoint-deprecated( '>660px' ) {
+			display: grid;
+			grid-column-gap: 32px;
+			grid-template-columns: 1fr 1fr;
+
+			padding-block-end: 32px;
+
+			.jetpack-product-card__product-name {
+				grid-column: 1 / span 2;
+				grid-row: 1;
+			}
+
+			.display-price {
+				grid-column: 1;
+				grid-row: 2;
+
+				min-height: initial;
+			}
+
+			.display-price__above-price-text {
+				margin-block-start: initial;
+			}
+
+			.jetpack-product-card__button {
+				grid-column: 1;
+				grid-row: 3;
+				align-self: flex-end;
+				margin-block-end: initial;
+			}
+
+			.jetpack-product-card__description {
+				grid-column: 2;
+				grid-row: 2;
+				min-height: initial;
+			}
+
+			.jetpack-product-card__features {
+				margin-block-end: initial;
+			}
+
+			.jetpack-product-card__features-list {
+				grid-column: 2;
+				grid-row: 3;
+
+				margin-block-end: initial;
+				margin-inline-end: initial;
+			}
+
+			.jetpack-product-card__features-item {
+				&:first-child {
+					margin-block-start: initial;
+				}
+
+				&:last-child {
+					margin-block-end: initial;
+				}
+			}
+		}
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -106,16 +106,6 @@
 	.product-grid__free {
 		margin-top: 16px;
 		flex-direction: column;
-
-		@include breakpoint-deprecated( '>660px' ) {
-			.jetpack-free-card {
-				display: grid;
-				grid-template-columns: 1fr 1fr;
-				grid-gap: 32px;
-				align-items: center;
-				margin-block-start: 16px;
-			}
-		}
 	}
 
 	.jetpack-product-card.jetpack-free-card {

--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -1,6 +1,5 @@
 import {
 	JETPACK_RESET_PLANS,
-	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_SECURITY_T1_YEARLY,
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
@@ -56,13 +55,6 @@ export const getPlansToDisplay = ( {
 				// Don't include a plan the user already owns, regardless of the term
 				! currentPlanTerms.includes( product.productSlug )
 		);
-
-	// Add a placeholder for the free plan
-	doForCurrentCROIteration( ( key ) => {
-		if ( Iterations.ONLY_REALTIME_PRODUCTS === key ) {
-			plansToDisplay.push( { productSlug: PLAN_JETPACK_FREE } );
-		}
-	} );
 
 	if ( currentPlanSlug && JETPACK_RESET_PLANS.includes( currentPlanSlug ) ) {
 		const currentPlanSelectorProduct = slugToSelectorProduct( currentPlanSlug );

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -10,7 +10,6 @@ import {
 	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_SCAN_MONTHLY,
-	JETPACK_CRM_FREE_PRODUCTS,
 	JETPACK_SCAN_PRODUCTS,
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
@@ -125,13 +124,6 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 	) {
 		availableProducts = [ ...availableProducts, ...JETPACK_VIDEOPRESS_PRODUCTS ];
 	}
-
-	// Show Jetpack CRM free products
-	doForCurrentCROIteration( ( key ) => {
-		if ( Iterations.ONLY_REALTIME_PRODUCTS === key ) {
-			availableProducts = [ ...availableProducts, ...JETPACK_CRM_FREE_PRODUCTS ];
-		}
-	} );
 
 	return {
 		availableProducts: availableProducts.map( slugToSelectorProduct ) as SelectorProduct[],


### PR DESCRIPTION
Resolves `1200412004370260-as-1201272180272104`.
Relates to #57362.

#### Changes proposed in this Pull Request

* Split the `JetpackCrmFreeCard` component into two versions: one with, and one without, the price display.
* Add styling rules for the new displayed-price version of the CRM Free card to match other product cards.
* Add support for easier custom styling on the `JetpackProductCard` component.
* Add a property for `abovePriceText` on the `JetpackProductCard` component.
* Add support for the `hideSavingLabel` prop on free product price displays.

#### Testing instructions

***NOTE:** Please test this PR in both Calypso Blue and Calypso Green, for both wide and narrow screen layouts.*

1. Visit the pricing page in any non-production environment.
2. Verify the product grid still renders correctly and flows naturally as the screen resizes.
3. Verify the Jetpack CRM Free card still shows up to the right of the VideoPress product card, and that its styles match the other product cards.
4. Verify the Jetpack CRM Free card's price display and copy are aligned appropriately compared to other product cards.

#### Reference screenshots

<img height="250" alt="Screen Shot 2021-11-01 at 15 02 55" src="https://user-images.githubusercontent.com/670067/139875298-28084619-e210-403e-883c-7e10e480e5d7.png"> <img height="250" alt="Screen Shot 2021-11-01 at 15 03 12" src="https://user-images.githubusercontent.com/670067/139875300-3024acc7-7f5c-4b5d-9dc8-266895a2c6e3.png">

<img height="250" alt="Screen Shot 2021-11-01 at 15 10 43" src="https://user-images.githubusercontent.com/670067/139875307-fb441ba3-680e-4322-96f1-fcc3cb2840ac.png"> <img height="250" alt="Screen Shot 2021-11-01 at 15 03 31" src="https://user-images.githubusercontent.com/670067/139875303-f3d68ef8-4be6-4809-91bd-75643a3648b4.png">
