### PR TITLE
Require the user password when generating backup codes.

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -200,8 +200,8 @@ TwoStepAuthorization.prototype.sendSMSCode = function ( callback ) {
 /*
  * Fetches a new set of backup codes by calling /me/two-step/backup-codes/new
  */
-TwoStepAuthorization.prototype.backupCodes = function ( callback ) {
-	wpcom.me().backupCodes( ( error, data ) => {
+TwoStepAuthorization.prototype.backupCodes = function ( userPassword, callback ) {
+	wpcom.me().backupCodes( userPassword, ( error, data ) => {
 		if ( error ) {
 			debug( 'Fetching Backup Codes failed: ' + JSON.stringify( error ) );
 		} else {

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -200,8 +200,12 @@ TwoStepAuthorization.prototype.sendSMSCode = function ( callback ) {
 /*
  * Fetches a new set of backup codes by calling /me/two-step/backup-codes/new
  */
-TwoStepAuthorization.prototype.backupCodes = function ( userPassword, callback ) {
-	wpcom.me().backupCodes( userPassword, ( error, data ) => {
+TwoStepAuthorization.prototype.backupCodes = function ( password, callback ) {
+	const args = {
+		path: '/me/two-step/backup-codes/new',
+		body: { password },
+	};
+	return wp.req.post( args, ( error, data ) => {
 		if ( error ) {
 			debug( 'Fetching Backup Codes failed: ' + JSON.stringify( error ) );
 		} else {

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -90,11 +90,11 @@ UndocumentedMe.prototype.setPeerReferralLinkEnable = function ( enable, callback
 	return this.wpcom.req.post( args, callback );
 };
 
-UndocumentedMe.prototype.backupCodes = function ( userPassword, callback ) {
+UndocumentedMe.prototype.backupCodes = function ( password, callback ) {
 	const args = {
 		apiVersion: '1.1',
 		path: '/me/two-step/backup-codes/new',
-		userPassword: userPassword,
+		password: password,
 	};
 
 	return this.wpcom.req.post( args, callback );

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -90,10 +90,11 @@ UndocumentedMe.prototype.setPeerReferralLinkEnable = function ( enable, callback
 	return this.wpcom.req.post( args, callback );
 };
 
-UndocumentedMe.prototype.backupCodes = function ( callback ) {
+UndocumentedMe.prototype.backupCodes = function ( userPassword, callback ) {
 	const args = {
 		apiVersion: '1.1',
 		path: '/me/two-step/backup-codes/new',
+		userPassword: userPassword,
 	};
 
 	return this.wpcom.req.post( args, callback );

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -90,16 +90,6 @@ UndocumentedMe.prototype.setPeerReferralLinkEnable = function ( enable, callback
 	return this.wpcom.req.post( args, callback );
 };
 
-UndocumentedMe.prototype.backupCodes = function ( password, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/two-step/backup-codes/new',
-		body: { password },
-	};
-
-	return this.wpcom.req.post( args, callback );
-};
-
 UndocumentedMe.prototype.sendVerificationEmail = function ( callback ) {
 	debug( '/me/send-verification-email' );
 

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -94,7 +94,7 @@ UndocumentedMe.prototype.backupCodes = function ( password, callback ) {
 	const args = {
 		apiVersion: '1.1',
 		path: '/me/two-step/backup-codes/new',
-		password: password,
+		body: { password },
 	};
 
 	return this.wpcom.req.post( args, callback );

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -34,7 +34,6 @@ class Security2faBackupCodes extends Component {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Generate New Backup Codes Button' );
 
 		this.setState( { addingPassword: true, showPrompt: false } );
-		return;
 	};
 
 	handleGenerateButton = ( userPassword ) => {
@@ -138,6 +137,7 @@ class Security2faBackupCodes extends Component {
 
 		return (
 			<Security2faBackupCodesPasswordPromt
+				isDisabled={ ! this.state.addingPassword }
 				onCancel={ this.toggleBackupCodePassword }
 				onSubmit={ this.handleGenerateButton }
 			/>

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -9,7 +9,7 @@ import Security2faBackupCodesList from 'calypso/me/security-2fa-backup-codes-lis
 import Security2faBackupCodesPrompt from 'calypso/me/security-2fa-backup-codes-prompt';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import Security2faBackupCodesPasswordPromt from './password-prompt';
+import Security2faBackupCodesPasswordPrompt from './password-prompt';
 
 import './style.scss';
 
@@ -55,6 +55,15 @@ class Security2faBackupCodes extends Component {
 		} );
 	};
 
+	onDismissClick = () => this.setState( { lastError: null } );
+
+	onNextStep = () => {
+		this.setState( {
+			backupCodes: [],
+			printed: true,
+		} );
+	};
+
 	onRequestComplete = ( error, data ) => {
 		if ( error ) {
 			this.setState( { lastError: error, generatingCodes: false } );
@@ -67,13 +76,6 @@ class Security2faBackupCodes extends Component {
 			lastError: null,
 			showPrompt: true,
 			addingPassword: false,
-		} );
-	};
-
-	onNextStep = () => {
-		this.setState( {
-			backupCodes: [],
-			printed: true,
 		} );
 	};
 
@@ -127,16 +129,12 @@ class Security2faBackupCodes extends Component {
 					  );
 
 			return (
-				<Notice
-					status="is-error"
-					text={ friendlyMessage }
-					onDismissClick={ () => this.setState( { lastError: null } ) }
-				/>
+				<Notice status="is-error" text={ friendlyMessage } onDismissClick={ this.onDismissClick } />
 			);
 		}
 
 		return (
-			<Security2faBackupCodesPasswordPromt
+			<Security2faBackupCodesPasswordPrompt
 				isDisabled={ ! this.state.addingPassword }
 				onCancel={ this.toggleBackupCodePassword }
 				onSubmit={ this.handleGenerateButton }

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -47,12 +47,12 @@ class Security2faBackupCodes extends Component {
 
 	toggleBackupCodePassword = ( event ) => {
 		event.preventDefault();
-		this.setState( {
-			addingPassword: ! this.state.addingPassword,
+		this.setState( ( prevState ) => ( {
+			addingPassword: ! prevState.addingPassword,
 			generatingCodes: false,
 			lastError: null,
 			showPrompt: true,
-		} );
+		} ) );
 	};
 
 	onDismissClick = () => this.setState( { lastError: null } );

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -45,8 +45,7 @@ class Security2faBackupCodes extends Component {
 		twoStepAuthorization.backupCodes( userPassword, this.onRequestComplete );
 	};
 
-	toggleBackupCodePassword = ( event ) => {
-		event.preventDefault();
+	toggleBackupCodePassword = () => {
 		this.setState( ( prevState ) => ( {
 			addingPassword: ! prevState.addingPassword,
 			generatingCodes: false,

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -45,7 +45,7 @@ class Security2faBackupCodesPasswordPromt extends React.Component {
 						type="password"
 						ref={ ( input ) => ( this.passwordInput = input ) }
 						value={ this.state.userPassword }
-						placeholder={ this.props.translate( 'Your WordPress.com password' ) }
+						placeholder={ this.props.translate( 'WordPress.com password' ) }
 						onChange={ this.handleChange }
 					/>
 					<FormSettingExplanation>

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -1,0 +1,67 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+class Security2faBackupCodesPasswordPromt extends React.Component {
+	static propTypes = {
+		onSubmit: PropTypes.func.isRequired,
+		onCancel: PropTypes.func.isRequired,
+	};
+
+	state = {
+		error: false,
+		userPassword: '',
+	};
+
+	componentDidMount = () => {
+		this.passwordInput.focus();
+	};
+
+	handleSubmit = ( e ) => {
+		e.preventDefault();
+		this.props.onSubmit( this.state.userPassword );
+	};
+
+	handleChange = ( e ) => {
+		const { value } = e.currentTarget;
+		this.setState( { userPassword: value } );
+	};
+
+	render() {
+		return (
+			<form onSubmit={ this.handleSubmit }>
+				<FormFieldset>
+					<FormLabel htmlFor="user_password">{ this.props.translate( 'Password' ) }</FormLabel>
+					<FormTextInput
+						autoComplete="off"
+						id="user_password"
+						name="user_password"
+						type="password"
+						ref={ ( input ) => ( this.passwordInput = input ) }
+						value={ this.state.userPassword }
+						placeholder={ this.props.translate( 'Your WordPress.com password' ) }
+						onChange={ this.handleChange }
+					/>
+					<FormSettingExplanation>
+						{ this.props.translate(
+							'Your WordPress.com password is required to generate new backup codes.'
+						) }
+					</FormSettingExplanation>
+				</FormFieldset>
+				<FormButton disabled={ 0 === this.state.userPassword.length }>
+					{ this.props.translate( 'Generate Backup Codes' ) }
+				</FormButton>
+				<FormButton onClick={ this.props.onCancel } isPrimary={ false }>
+					{ this.props.translate( 'Cancel' ) }
+				</FormButton>
+			</form>
+		);
+	}
+}
+
+export default localize( Security2faBackupCodesPasswordPromt );

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -54,7 +54,7 @@ class Security2faBackupCodesPasswordPromt extends React.Component {
 						) }
 					</FormSettingExplanation>
 				</FormFieldset>
-				<FormButton disabled={ 0 === this.state.userPassword.length }>
+				<FormButton disabled={ 0 === this.state.userPassword.length || this.props.isDisabled }>
 					{ this.props.translate( 'Generate Backup Codes' ) }
 				</FormButton>
 				<FormButton onClick={ this.props.onCancel } isPrimary={ false }>

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -25,6 +25,7 @@ class Security2faBackupCodesPasswordPromt extends React.Component {
 	handleSubmit = ( e ) => {
 		e.preventDefault();
 		this.props.onSubmit( this.state.userPassword );
+		this.setState( { userPassword: '' } );
 	};
 
 	handleChange = ( e ) => {

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -37,11 +37,11 @@ class Security2faBackupCodesPasswordPromt extends React.Component {
 		return (
 			<form onSubmit={ this.handleSubmit }>
 				<FormFieldset>
-					<FormLabel htmlFor="user_password">{ this.props.translate( 'Password' ) }</FormLabel>
+					<FormLabel htmlFor="password">{ this.props.translate( 'Password' ) }</FormLabel>
 					<FormTextInput
 						autoComplete="off"
-						id="user_password"
-						name="user_password"
+						id="password"
+						name="password"
 						type="password"
 						ref={ ( input ) => ( this.passwordInput = input ) }
 						value={ this.state.userPassword }

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -54,7 +54,7 @@ class Security2faBackupCodesPasswordPromt extends React.Component {
 						) }
 					</FormSettingExplanation>
 				</FormFieldset>
-				<FormButton disabled={ 0 === this.state.userPassword.length || this.props.isDisabled }>
+				<FormButton disabled={ ! this.state.userPassword.length || this.props.isDisabled }>
 					{ this.props.translate( 'Generate Backup Codes' ) }
 				</FormButton>
 				<FormButton onClick={ this.props.onCancel } isPrimary={ false }>

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -7,7 +7,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
-class Security2faBackupCodesPasswordPromt extends Component {
+class Security2faBackupCodesPasswordPrompt extends Component {
 	static propTypes = {
 		onCancel: PropTypes.func.isRequired,
 		onSubmit: PropTypes.func.isRequired,
@@ -62,4 +62,4 @@ class Security2faBackupCodesPasswordPromt extends Component {
 	}
 }
 
-export default localize( Security2faBackupCodesPasswordPromt );
+export default localize( Security2faBackupCodesPasswordPrompt );

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -54,7 +54,7 @@ class Security2faBackupCodesPasswordPrompt extends Component {
 				<FormButton disabled={ ! this.state.userPassword.length || this.props.isDisabled }>
 					{ this.props.translate( 'Generate Backup Codes' ) }
 				</FormButton>
-				<FormButton onClick={ this.props.onCancel } isPrimary={ false }>
+				<FormButton type="button" onClick={ this.props.onCancel } isPrimary={ false }>
 					{ this.props.translate( 'Cancel' ) }
 				</FormButton>
 			</form>

--- a/client/me/security-2fa-backup-codes/password-prompt.jsx
+++ b/client/me/security-2fa-backup-codes/password-prompt.jsx
@@ -1,25 +1,21 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
-class Security2faBackupCodesPasswordPromt extends React.Component {
+class Security2faBackupCodesPasswordPromt extends Component {
 	static propTypes = {
-		onSubmit: PropTypes.func.isRequired,
 		onCancel: PropTypes.func.isRequired,
+		onSubmit: PropTypes.func.isRequired,
 	};
 
 	state = {
 		error: false,
 		userPassword: '',
-	};
-
-	componentDidMount = () => {
-		this.passwordInput.focus();
 	};
 
 	handleSubmit = ( e ) => {
@@ -43,9 +39,10 @@ class Security2faBackupCodesPasswordPromt extends React.Component {
 						id="password"
 						name="password"
 						type="password"
-						ref={ ( input ) => ( this.passwordInput = input ) }
+						// eslint-disable-next-line jsx-a11y/no-autofocus
+						autoFocus
 						value={ this.state.userPassword }
-						placeholder={ this.props.translate( 'WordPress.com password' ) }
+						placeholder={ this.props.translate( 'WordPress.com Password' ) }
 						onChange={ this.handleChange }
 					/>
 					<FormSettingExplanation>

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -140,6 +140,7 @@ class Security2faEnable extends Component {
 		const args = {
 			code: this.state.verificationCode,
 			action: 'enable-two-step',
+			returnBackupCodes: true,
 		};
 
 		twoStepAuthorization.validateCode( args, this.onValidationResponseReceived );
@@ -147,7 +148,6 @@ class Security2faEnable extends Component {
 
 	onValidationResponseReceived = ( error, data ) => {
 		this.setState( { submittingCode: false } );
-
 		if ( error ) {
 			this.setState( {
 				lastError: this.props.translate( 'An unexpected error occurred. Please try again later.' ),
@@ -159,7 +159,7 @@ class Security2faEnable extends Component {
 				lastErrorType: 'is-error',
 			} );
 		} else {
-			this.props.onSuccess();
+			this.props.onSuccess( data.backup_codes );
 		}
 	};
 

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -140,7 +140,6 @@ class Security2faEnable extends Component {
 		const args = {
 			code: this.state.verificationCode,
 			action: 'enable-two-step',
-			returnBackupCodes: true,
 		};
 
 		twoStepAuthorization.validateCode( args, this.onValidationResponseReceived );

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -3,52 +3,26 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import Security2faBackupCodesList from 'calypso/me/security-2fa-backup-codes-list';
 import Security2faProgress from 'calypso/me/security-2fa-progress';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 class Security2faSetupBackupCodes extends Component {
-	state = {
-		backupCodes: [],
-		lastError: false,
-	};
-
 	static propTypes = {
 		onFinished: PropTypes.func.isRequired,
+		backupCodes: PropTypes.array.isRequired,
 	};
-
-	componentDidMount() {
-		twoStepAuthorization.backupCodes( this.onRequestComplete );
-	}
 
 	getClickHandler = ( action ) => {
 		return () => this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	};
-
-	onRequestComplete = ( error, data ) => {
-		if ( error ) {
-			this.setState( {
-				lastError: this.props.translate( 'Unable to obtain backup codes. Please try again later.' ),
-			} );
-			return;
-		}
-
-		this.setState( {
-			backupCodes: data.codes,
-		} );
 	};
 
 	onFinished = () => {
 		this.props.onFinished();
 	};
 
-	possiblyRenderError() {
-		if ( ! this.state.lastError ) {
-			return;
-		}
-
+	renderError() {
 		const errorMessage = this.props.translate(
 			'There was an error retrieving back up codes. Please {{supportLink}}contact support{{/supportLink}}',
 			{
@@ -67,13 +41,14 @@ class Security2faSetupBackupCodes extends Component {
 	}
 
 	renderList() {
-		if ( this.state.lastError ) {
-			return null;
+		const { backupCodes } = this.props;
+		if ( ! backupCodes || backupCodes.length === 0 ) {
+			return this.renderError();
 		}
 
 		return (
 			<Security2faBackupCodesList
-				backupCodes={ this.state.backupCodes }
+				backupCodes={ backupCodes }
 				onNextStep={ this.onFinished }
 				showList
 			/>
@@ -92,7 +67,6 @@ class Security2faSetupBackupCodes extends Component {
 					) }
 				</p>
 
-				{ this.possiblyRenderError() }
 				{ this.renderList() }
 			</div>
 		);

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -42,7 +42,7 @@ class Security2faSetupBackupCodes extends Component {
 
 	renderList() {
 		const { backupCodes } = this.props;
-		if ( ! backupCodes || backupCodes.length === 0 ) {
+		if ( ! backupCodes || ! backupCodes.length ) {
 			return this.renderError();
 		}
 

--- a/client/me/security-2fa-setup/index.jsx
+++ b/client/me/security-2fa-setup/index.jsx
@@ -17,6 +17,7 @@ class Security2faSetup extends Component {
 	state = {
 		step: 'initial-setup',
 		authMethod: 'app-based',
+		backupCodes: [],
 	};
 
 	onCancelSetup = ( event ) => {
@@ -28,8 +29,8 @@ class Security2faSetup extends Component {
 		this.setState( { step: authMethod, authMethod } );
 	};
 
-	onSetupSuccess = () => {
-		this.setState( { step: 'backup-codes' } );
+	onSetupSuccess = ( backupCodes ) => {
+		this.setState( { step: 'backup-codes', backupCodes } );
 	};
 
 	onFinished = () => {
@@ -83,7 +84,11 @@ class Security2faSetup extends Component {
 				) : null }
 
 				{ 'backup-codes' === this.state.step ? (
-					<Security2faSetupBackupCodes isSmsFlow={ isSmsFlow } onFinished={ this.onFinished } />
+					<Security2faSetupBackupCodes
+						backupCodes={ this.state.backupCodes }
+						isSmsFlow={ isSmsFlow }
+						onFinished={ this.onFinished }
+					/>
 				) : null }
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Requires the current user password when generating new backup codes.

#### Testing instructions

User with 2fa enabled:
* Navigate to `/me/security/two-step`
* Click on the `Generate new backup codes` button, you should notice a password prompt. <img width="1044" alt="Screenshot 2021-11-08 at 15 50 31" src="https://user-images.githubusercontent.com/1081870/140763743-0fb5590b-77e5-4ef0-beca-418f70f4c3fb.png">
* Backup codes are generated as always (this depends on the following backend change D69484)

User without 2fa enabled.
* Navigate to `/me/security/two-step`
* Enable 2fa with sms and/or with an app
* Backup codes are shown without the need to enter the user password.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
