### PR TITLE
change site address changer header now uses get() to access name attribute of domain

### DIFF
--- a/client/my-sites/domains/domain-management/change-site-address/index.jsx
+++ b/client/my-sites/domains/domain-management/change-site-address/index.jsx
@@ -41,7 +41,7 @@ class ChangeSiteAddress extends Component {
 
 		return (
 			<Main className="change-site-address">
-				<Header onClick={ this.goBack } selectedDomainName={ domain.name }>
+				<Header onClick={ this.goBack } selectedDomainName={ get( domain, 'name', '' ) }>
 					{ translate( 'Change Site Address' ) }
 				</Header>
 

--- a/client/my-sites/domains/domain-management/change-site-address/index.jsx
+++ b/client/my-sites/domains/domain-management/change-site-address/index.jsx
@@ -1,5 +1,4 @@
 import { localize, translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';

--- a/client/my-sites/domains/domain-management/change-site-address/index.jsx
+++ b/client/my-sites/domains/domain-management/change-site-address/index.jsx
@@ -36,12 +36,13 @@ class ChangeSiteAddress extends Component {
 
 	render() {
 		const domain = getSelectedDomain( this.props );
-		const dotblogSubdomain = get( domain, 'name', '' ).match( /\.\w+\.blog$/ );
+		const domainName = domain?.name ?? '';
+		const dotblogSubdomain = domainName.match( /\.\w+\.blog$/ );
 		const domainSuffix = dotblogSubdomain ? dotblogSubdomain[ 0 ] : '.wordpress.com';
 
 		return (
 			<Main className="change-site-address">
-				<Header onClick={ this.goBack } selectedDomainName={ get( domain, 'name', '' ) }>
+				<Header onClick={ this.goBack } selectedDomainName={ domainName }>
 					{ translate( 'Change Site Address' ) }
 				</Header>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Site address changer now uses `get()` to access the name attribute of a domain.

#### Testing instructions
1. Open a simple site without a domain
2. Navigate to Upgrades > Domains.
3. Click on Manage > Change site address.
4. Clearing the Indexed DB and Hard Refresh (CMD + SHIFT + R) the site multiple times and you don't get the error described in #57461 anymore.

Related to #57461
