### PR TITLE
Interpolate-components: Widen react peerDep to >=16.2

### DIFF
--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -38,7 +38,7 @@
 		"react-test-renderer": "^17.0.2"
 	},
 	"peerDependencies": {
-		"react": ">=16.2.0"
+		"react": "^17.0.2"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -38,7 +38,7 @@
 		"react-test-renderer": "^17.0.2"
 	},
 	"peerDependencies": {
-		"react": "^17.0.2"
+		"react": ">=16.2.0"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/interpolate-components/package.json
+++ b/packages/interpolate-components/package.json
@@ -22,7 +22,7 @@
 		"react-dom": "^17.0.2"
 	},
 	"peerDependencies": {
-		"react": "^17.0.2"
+		"react": ">=16.2.0"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20670,7 +20670,7 @@ fsevents@~2.1.2:
     tannin: ^1.1.1
     use-subscription: ^1.5.1
   peerDependencies:
-    react: ">=16.2.0"
+    react: ^17.0.2
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,7 +521,7 @@ __metadata:
     "@automattic/calypso-typescript-config": ^1.0.0
     react-dom: ^17.0.2
   peerDependencies:
-    react: ^17.0.2
+    react: ">=16.2.0"
   languageName: unknown
   linkType: soft
 
@@ -20670,7 +20670,7 @@ fsevents@~2.1.2:
     tannin: ^1.1.1
     use-subscription: ^1.5.1
   peerDependencies:
-    react: ^17.0.2
+    react: ">=16.2.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Interpolate components appears to require a minimum react version of 16.2.0 (based on requiring `React.Fragment`). Widen the declared peer dependency so that the package can be used by consumers on React 16.

#### Testing instructions

This is tricky to test, but you can install or link the built dependency into a react 16 project and confirm it's working as expected.

Related to #56933

