### PR TITLE
Emails: Fix null pointer exception when accessing domain when it has not been loaded

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -735,7 +735,8 @@ export default connect(
 			selectedDomainName: ownProps.selectedDomainName,
 		} );
 
-		const domainName = ownProps.cartDomainName ?? domain.name;
+		const resolvedDomainName = domain ? domain.name : ownProps.selectedDomainName;
+		const domainName = ownProps.cartDomainName ?? resolvedDomainName;
 		const hasCartDomain = Boolean( ownProps.cartDomainName );
 
 		const isGSuiteSupported =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull requests address the issue #57490 where sometimes we are having a null pointer exception.
I think it's a simple fix and I am addressing it with the component properties: selectedDomainName as this property is mandatory and it will always have the selected domain name that we need to operate. I think we can even remove the domain retrieval as we only need the domain name from it. But would be good to discuss it here.

#### Testing instructions

Test instructions are described in Issue #57490 

But there is an easier way to replicate the issue, which is to go to a site with several domains (without email providers) and navigate to one of them through the button "Add email" then go back by clicking in the browsers button to do so, and go forward by clicking the proper button from the browser.


Related to 1200182182542585-as-1201301437729254
