### PR TITLE
Fixed Navigation Header: fixes buttons in manage plugins screen and styles in Jetpack sites

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -7,12 +7,18 @@ const Header = styled.header`
 	position: fixed;
 	z-index: 1;
 	top: var( --masterbar-height );
-	left: var( --sidebar-width-max );
-	width: calc( 100% - var( --sidebar-width-max ) );
+	left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
+	width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
 	padding: 0 32px;
 	box-sizing: border-box;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	background-color: var( --studio-white );
+
+	@media ( max-width: 960px ) {
+		// Account for jetpack sites with the old sidebar.
+		left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
+		width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
+	}
 
 	@media ( max-width: 782px ) {
 		width: 100%;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -1,4 +1,6 @@
 import { Button } from '@automattic/components';
+import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
+import { Icon, upload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { capitalize, find, flow, isEmpty } from 'lodash';
 import page from 'page';
@@ -43,6 +45,13 @@ import PluginsList from './plugins-list';
 import './style.scss';
 
 export class PluginsMain extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isMobile: isWithinBreakpoint( '<960px' ),
+		};
+	}
+
 	componentDidUpdate() {
 		const { currentPlugins } = this.props;
 
@@ -51,6 +60,13 @@ export class PluginsMain extends Component {
 			if ( ! pluginData ) {
 				this.props.wporgFetchPluginData( plugin.slug );
 			}
+		} );
+	}
+
+	componentDidMount() {
+		// Change the isMobile state when the size of the browser changes.
+		this.unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobile ) => {
+			this.setState( { isMobile } );
 		} );
 	}
 
@@ -358,7 +374,7 @@ export class PluginsMain extends Component {
 		this.props.recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' );
 	};
 
-	renderUploadPluginButton() {
+	renderUploadPluginButton( isMobile ) {
 		const { selectedSiteSlug, translate } = this.props;
 		const uploadUrl = '/plugins/upload' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
 
@@ -368,7 +384,8 @@ export class PluginsMain extends Component {
 				href={ uploadUrl }
 				onClick={ this.handleUploadPluginButtonClick }
 			>
-				<span className="plugins__button-text">{ translate( 'Install plugin' ) }</span>
+				<Icon className="plugins__button-icon" icon={ upload } width={ 18 } height={ 18 } />
+				{ ! isMobile && <span className="plugins__button-text">{ translate( 'Upload' ) }</span> }
 			</Button>
 		);
 	}
@@ -408,7 +425,7 @@ export class PluginsMain extends Component {
 				>
 					<div className="plugins__main-buttons">
 						{ this.renderAddPluginButton() }
-						{ this.renderUploadPluginButton() }
+						{ this.renderUploadPluginButton( this.state.isMobile ) }
 					</div>
 				</FixedNavigationHeader>
 				<div className="plugins__main">

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -30,17 +30,13 @@
 
 .plugins-browser__main-buttons {
 	display: flex;
+	align-items: center;
 	margin-right: 15px;
 
 	@media screen and ( max-width: 960px ) {
 		.plugins-browser__button {
 			border: none;
 		}
-	}
-
-	@include breakpoint-deprecated( '>480px' ) {
-		flex-direction: row;
-		align-items: flex-end;
 	}
 
 	.plugins-browser__button {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -10,8 +10,19 @@
 	}
 }
 
-.is-section-plugins.color-scheme.is-nav-unification {
+.is-section-plugins.theme-default.color-scheme {
 	--color-surface-backdrop: --studio-white;
+}
+
+// Fix for Jetpack not having nav-unification styles yet.
+body.is-section-plugins:not( .is-nav-unification ) {
+	.plugins-browser__header,
+	.plugins__page-heading {
+		@media ( min-width: 661px ) and ( max-width: 782px ) {
+			left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
+			width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
+		}
+	}
 }
 
 .upsell-nudge {
@@ -34,11 +45,11 @@
 	background: var( --color-surface );
 	flex-direction: column;
 	display: flex;
-	margin-bottom: 9px;
+	margin: 9px 0;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
-		margin-bottom: 17px;
+		margin: 17px 0;
 	}
 }
 
@@ -63,27 +74,26 @@
 
 .plugins__main-buttons {
 	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
-	align-items: stretch;
-	margin: auto;
-	margin-right: 15px;
+	align-items: center;
 
-	@include breakpoint-deprecated( '>480px' ) {
-		flex-direction: row;
-		align-items: flex-end;
-		margin-right: 0;
-		margin-bottom: 17px;
+	@media screen and ( max-width: 960px ) {
+		.plugins__button {
+			border: none;
+		}
 	}
 
 	.plugins__button {
 		white-space: nowrap;
+		display: flex;
+		align-items: center;
+		height: 32px;
+
+		.plugins__button-icon {
+			margin-right: 5px;
+		}
 
 		&:not( :last-child ) {
-			margin-bottom: 8px;
-
 			@include breakpoint-deprecated( '>480px' ) {
-				margin-bottom: 0;
 				margin-right: 10px;
 			}
 		}


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Fixes the following:

Jetpack Site `/plugins`
- wrong position for fixed header
- wrong bg color

|Before | After|
|-------|------|
|<img width="948" alt="SS 2021-11-02 at 18 38 30" src="https://user-images.githubusercontent.com/12430020/139907743-d324c898-ee95-4384-98bb-dbdb2b25d74a.png">|<img width="852" alt="SS 2021-11-02 at 18 39 03" src="https://user-images.githubusercontent.com/12430020/139907852-0f196118-41c3-462a-9186-95334042fc81.png">|

Manage Plugins screen `/plugins/manage`
- wrong buttons positioning 
- no mobile styles for buttons
- no padding in nav section

|Before | After|
|-------|------|
|<img width="696" alt="SS 2021-11-02 at 18 40 58" src="https://user-images.githubusercontent.com/12430020/139908105-d6a88d8c-e715-4e11-af91-f6a79f1d7ada.png">|<img width="496" alt="SS 2021-11-02 at 18 41 22" src="https://user-images.githubusercontent.com/12430020/139908157-0847f3d7-dfcb-4d2f-a171-9c379f739cb5.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the above scenarios and inspect the changes.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


