### PR TITLE
Adding conditional logic for top links in videos UI

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 
-const VideosUi = () => {
+const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -11,15 +11,19 @@ const VideosUi = () => {
 				<div className="videos-ui__header-links">
 					<div>
 						<Gridicon icon="my-sites" size={ 24 } />
-						<a href="/" className="videos-ui__back-link">
-							<Gridicon icon="chevron-left" size={ 24 } />
-							<span>{ translate( 'Back' ) }</span>
-						</a>
+						{ shouldDisplayTopLinks && (
+							<a href="/" className="videos-ui__back-link">
+								<Gridicon icon="chevron-left" size={ 24 } />
+								<span>{ translate( 'Back' ) }</span>
+							</a>
+						) }
 					</div>
 					<div>
-						<a href="/" className="videos-ui__skip-link">
-							{ translate( 'Skip and draft first post' ) }
-						</a>
+						{ shouldDisplayTopLinks && (
+							<a href="/" className="videos-ui__skip-link">
+								{ translate( 'Skip and draft first post' ) }
+							</a>
+						) }
 					</div>
 				</div>
 				<div className="videos-ui__header-content">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a property to the `VideosUi` component introduced in https://github.com/Automattic/wp-calypso/pull/57324, allowing the top navigation links to be conditionally shown depending on a boolean prop. (This is because our initial usage of the component, in https://github.com/Automattic/wp-calypso/pull/57515, does not require those links to appear.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR still does not load the UI anywhere (as it will be added as a modal in the work being done for #57515
* However, it can be tested by importing the VideosUi component anywhere in Calypso (such as a block on the home page).
* Verify that when the component's `shouldDisplayTopLinks` property is set to `true` (`<VideosUi shouldDisplayTopLinks={true} />`), the top links are displayed as expected.
* Verify that when the property is set to false (`<VideosUi shouldDisplayTopLinks={false} />`) or omitted, the top links are hidden without changing other layout.

With property set to true:
![image](https://user-images.githubusercontent.com/13437011/139919981-7542e585-dd63-459c-ab3d-c79f56bf26e1.png)


Without property or set to false:

![image](https://user-images.githubusercontent.com/13437011/139919754-bfee5007-4b50-427f-8fe8-c83762997b80.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/57515#issuecomment-956924299
