### PR TITLE
Payments: Remove cardProcessorSupportsUpdates

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -394,21 +394,6 @@ function isCloseToExpiration( purchase ) {
 }
 
 /**
- * Checks if a purchase credit card number can be updated
- * Payments done via CC & Paygate can have their CC updated, but this
- * is not currently true for other providers such as EBANX.
- *
- * @param {object} purchase - the purchase with which we are concerned
- * @returns {boolean} if the purchase card can be updated
- */
-function cardProcessorSupportsUpdates( purchase ) {
-	return (
-		isPaidWithCreditCard( purchase ) &&
-		purchase.payment.creditCard.processor !== 'WPCOM_Billing_Ebanx'
-	);
-}
-
-/**
  * Checks if a purchase might be in the refund period, whether refundable or not.
  *
  * If you need to determine whether a purchase can be programmatically refunded
@@ -804,7 +789,6 @@ export {
 	needsToRenewSoon,
 	paymentLogoType,
 	purchaseType,
-	cardProcessorSupportsUpdates,
 	showCreditCardExpiringWarning,
 	subscribedWithinPastWeek,
 	shouldAddPaymentSourceInsteadOfRenewingNow,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -44,7 +44,6 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
-	cardProcessorSupportsUpdates,
 	getDomainRegistrationAgreementUrl,
 	getDisplayName,
 	getPartnerName,
@@ -57,10 +56,8 @@ import {
 	isCancelable,
 	isExpired,
 	isOneTimePurchase,
-	isPaidWithCreditCard,
 	isPartnerPurchase,
 	isRenewable,
-	isRenewing,
 	isSubscription,
 	isCloseToExpiration,
 	purchaseType,
@@ -348,15 +345,6 @@ class ManagePurchase extends Component {
 
 		if ( canEditPaymentDetails( purchase ) ) {
 			const path = getChangePaymentMethodUrlFor( siteSlug, purchase );
-			const renewing = isRenewing( purchase );
-
-			if (
-				renewing &&
-				isPaidWithCreditCard( purchase ) &&
-				! cardProcessorSupportsUpdates( purchase )
-			) {
-				return null;
-			}
 
 			return (
 				<CompactCard href={ path } onClick={ this.handleEditPaymentMethodNavItem }>

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -32,7 +32,6 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPaidWithCreditCard,
-	cardProcessorSupportsUpdates,
 	isRenewing,
 	isSubscription,
 	isCloseToExpiration,
@@ -299,12 +298,7 @@ function PurchaseMetaPaymentDetails( { purchase, getChangePaymentMethodUrlFor, s
 
 	const paymentDetails = <PaymentInfoBlock purchase={ purchase } />;
 
-	if (
-		! canEditPaymentDetails( purchase ) ||
-		! isPaidWithCreditCard( purchase ) ||
-		! cardProcessorSupportsUpdates( purchase ) ||
-		! site
-	) {
+	if ( ! canEditPaymentDetails( purchase ) || ! isPaidWithCreditCard( purchase ) || ! site ) {
 		return <li>{ paymentDetails }</li>;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the `cardProcessorSupportsUpdates()` guard function.

When we "update" a credit card, we are actually replacing the payment method on an ownership with a new one. There's therefore no reason to block doing that for purchases that were originally made with Ebanx, which is what the function mainly does.

While this function has an additional feature of returning false for non-credit card purchases, that guard already exists in the one place where it matters.

Fixes https://github.com/Automattic/wp-calypso/issues/57354

#### Testing instructions

- Use an account with the BRL currency.
- Go through checkout and buy something, and use a billing address in Brazil. Also see https://developer.ebanx.com/docs/resources/testCreditCards/ and https://developer.ebanx.com/docs/resources/testCustomerData/ for test cards and other test data, including CPF (a.k.a. Taxpayer Identification Number) to use.
- After purchasing, go to Manage Purchases and view the subscription.
- Verify that you see the "Change Payment Method" button.