### PR TITLE
Checkout: Remove undocumented.paypalExpressUrl function

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -671,27 +671,6 @@ Undocumented.prototype.updateConnection = function ( siteId, connectionId, data,
 	);
 };
 
-/**
- * GET paypal_express_url
- *
- * @param {object} [data] The GET data
- * @param {Function} fn The callback function
- * @returns {string} Url
- *
- * The data format is: {
- *		country: {string} The billing country,
- *		postal_code: {string} The billing postal code,
- *		cart: {Array} An JSON serialization of the cart,
- * }
- */
-Undocumented.prototype.paypalExpressUrl = function ( data, fn ) {
-	debug( '/me/paypal-express-url query' );
-
-	data = mapKeysRecursively( data, snakeCase );
-
-	return this.wpcom.req.post( '/me/paypal-express-url', data, fn );
-};
-
 function addReaderContentWidth( params ) {
 	if ( params.content_width ) {
 		return;

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -72,6 +72,9 @@ async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions
 ) {
+	const path = '/me/paypal-express-url';
+	const apiVersion = '1.2';
+
 	const isJetpackUserLessCheckout =
 		payload.cart.is_jetpack_checkout && payload.cart.cart_key === 'no-user';
 
@@ -96,17 +99,13 @@ async function wpcomPayPalExpress(
 				},
 			};
 
-			return wp.req.post(
-				'/me/paypal-express-url',
-				mapRecordKeysRecursively( newPayload, camelToSnakeCase )
-			);
+			const body = mapRecordKeysRecursively( newPayload, camelToSnakeCase );
+			return wp.req.post( { path }, { apiVersion }, body );
 		} );
 	}
 
-	return wp.req.post(
-		'/me/paypal-express-url',
-		mapRecordKeysRecursively( payload, camelToSnakeCase )
-	);
+	const body = mapRecordKeysRecursively( payload, camelToSnakeCase );
+	return wp.req.post( { path }, { apiVersion }, body );
 }
 
 function createPayPalExpressEndpointRequestPayloadFromLineItems( {
@@ -135,7 +134,5 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		country,
 		postalCode: postalCode ? tryToGuessPostalCodeFormat( postalCode.toUpperCase(), country ) : '',
 		domainDetails,
-		// Make the response JSON because it's easier for wpcom-xhr-request to parse; see https://github.com/Automattic/wp-calypso/pull/57575
-		as_json: true,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -1,5 +1,9 @@
 import { makeRedirectResponse, makeErrorResponse } from '@automattic/composite-checkout';
-import { tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
+import {
+	mapRecordKeysRecursively,
+	camelToSnakeCase,
+	tryToGuessPostalCodeFormat,
+} from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import wp from 'calypso/lib/wp';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
@@ -87,11 +91,17 @@ async function wpcomPayPalExpress(
 				},
 			};
 
-			return wp.undocumented().paypalExpressUrl( newPayload );
+			return wp.req.post(
+				'/me/paypal-express-url',
+				mapRecordKeysRecursively( newPayload, camelToSnakeCase )
+			);
 		} );
 	}
 
-	return wp.undocumented().paypalExpressUrl( payload );
+	return wp.req.post(
+		'/me/paypal-express-url',
+		mapRecordKeysRecursively( payload, camelToSnakeCase )
+	);
 }
 
 function createPayPalExpressEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -72,9 +72,6 @@ async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions
 ) {
-	// Make the response JSON because it's easier for wpcom-xhr-request to parse; see https://github.com/Automattic/wp-calypso/pull/57575
-	payload.as_json = true;
-
 	const isJetpackUserLessCheckout =
 		payload.cart.is_jetpack_checkout && payload.cart.cart_key === 'no-user';
 
@@ -138,5 +135,7 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		country,
 		postalCode: postalCode ? tryToGuessPostalCodeFormat( postalCode.toUpperCase(), country ) : '',
 		domainDetails,
+		// Make the response JSON because it's easier for wpcom-xhr-request to parse; see https://github.com/Automattic/wp-calypso/pull/57575
+		as_json: true,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -28,7 +28,7 @@ describe( 'payPalExpressProcessor', () => {
 	};
 
 	const basicExpectedRequest = {
-		cancelUrl: 'https://example.com/',
+		cancel_url: 'https://example.com/',
 		cart: {
 			blog_id: '0',
 			cart_key: 'no-site',
@@ -44,9 +44,9 @@ describe( 'payPalExpressProcessor', () => {
 			temporary: false,
 		},
 		country: '',
-		domainDetails: null,
-		postalCode: '',
-		successUrl: 'https://example.com',
+		domain_details: null,
+		postal_code: '',
+		success_url: 'https://example.com',
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -145,7 +145,7 @@ describe( 'payPalExpressProcessor', () => {
 				create_new_blog: false,
 				tax: { location: { postal_code: 'PR26 7RY', country_code: 'GB' } },
 			},
-			postalCode: 'PR26 7RY',
+			postal_code: 'PR26 7RY',
 			country: 'GB',
 		} );
 	} );
@@ -173,7 +173,7 @@ describe( 'payPalExpressProcessor', () => {
 				create_new_blog: false,
 				products: [ domainProduct ],
 			},
-			domainDetails: basicExpectedDomainDetails,
+			domain_details: basicExpectedDomainDetails,
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -28,7 +28,6 @@ describe( 'payPalExpressProcessor', () => {
 	};
 
 	const basicExpectedRequest = {
-		as_json: true,
 		cancel_url: 'https://example.com/',
 		cart: {
 			blog_id: '0',

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -28,6 +28,7 @@ describe( 'payPalExpressProcessor', () => {
 	};
 
 	const basicExpectedRequest = {
+		as_json: true,
 		cancel_url: 'https://example.com/',
 		cart: {
 			blog_id: '0',

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -699,6 +699,20 @@ export function createTestReduxStore() {
 	} );
 }
 
+export function mockPayPalEndpoint( endpointResponse ) {
+	const endpoint = jest.fn();
+	endpoint.mockReturnValue( true );
+
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/me/paypal-express-url', ( body ) => {
+			return endpoint( body );
+		} )
+		.reply( endpointResponse );
+	return endpoint;
+}
+
+export const mockPayPalRedirectResponse = () => [ 200, 'https://test-redirect-url' ];
+
 export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 	const transactionsEndpoint = jest.fn();
 	transactionsEndpoint.mockReturnValue( true );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -711,7 +711,10 @@ export function mockPayPalEndpoint( endpointResponse ) {
 	return endpoint;
 }
 
-export const mockPayPalRedirectResponse = () => [ 200, 'https://test-redirect-url' ];
+export const mockPayPalRedirectResponse = () => [
+	200,
+	{ redirect_url: 'https://test-redirect-url' },
+];
 
 export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 	const transactionsEndpoint = jest.fn();

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -704,7 +704,7 @@ export function mockPayPalEndpoint( endpointResponse ) {
 	endpoint.mockReturnValue( true );
 
 	nock( 'https://public-api.wordpress.com' )
-		.post( '/rest/v1.1/me/paypal-express-url', ( body ) => {
+		.post( '/rest/v1.2/me/paypal-express-url', ( body ) => {
 			return endpoint( body );
 		} )
 		.reply( endpointResponse );
@@ -721,7 +721,7 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 	transactionsEndpoint.mockReturnValue( true );
 
 	nock( 'https://public-api.wordpress.com' )
-		.post( '/rest/v1.1/me/transactions', ( body ) => {
+		.post( '/rest/v1.2/me/transactions', ( body ) => {
 			return transactionsEndpoint( body );
 		} )
 		.reply( transactionsEndpointResponse );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -721,7 +721,7 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 	transactionsEndpoint.mockReturnValue( true );
 
 	nock( 'https://public-api.wordpress.com' )
-		.post( '/rest/v1.2/me/transactions', ( body ) => {
+		.post( '/rest/v1.1/me/transactions', ( body ) => {
 			return transactionsEndpoint( body );
 		} )
 		.reply( transactionsEndpointResponse );

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -196,7 +196,6 @@ export type PayPalExpressEndpointRequestPayload = {
 	domainDetails: DomainContactDetails | null;
 	country: string;
 	postalCode: string;
-	as_json: true;
 };
 
 export type PayPalExpressEndpointResponse = unknown;

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -196,6 +196,7 @@ export type PayPalExpressEndpointRequestPayload = {
 	domainDetails: DomainContactDetails | null;
 	country: string;
 	postalCode: string;
+	as_json: true;
 };
 
 export type PayPalExpressEndpointResponse = unknown;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/57514, which removed the `wpcom.undocumented` function for the transactions endpoint. PayPal transactions use a different endpoint, `/me/paypal-express-url`, and therefore have a different `wpcom.undocumented` function. This PR removes that function as well.

Depends on D69619-code which adds an updated version of the endpoint that this PR then uses.

#### Testing instructions

- Add a plan _and a domain_ to your cart and visit checkout.
- Complete the checkout form.
- Chose PayPal as the payment method and submit the purchase.
- Verify that you are redirected to PayPal.
- Complete the purchase.
- Verify that the purchase completes successfully.