### PR TITLE
Update step 1 on the manual activation flow for Jetpack user licenses

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
@@ -1,4 +1,4 @@
-import { Button, Card } from '@automattic/components';
+import { Button, Card, ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import footerCardBackground from 'calypso/assets/images/jetpack/jp-licensing-checkout-footer-bg.svg';
@@ -27,7 +27,14 @@ const LicensingThankYouAutoActivation: FC< Props > = ( { productSlug } ) => {
 			/>
 			<Card className="licensing-thank-you-manual-activation__card">
 				<div className="licensing-thank-you-manual-activation__card-main">
-					<JetpackLogo size={ 45 } />
+					<div className="licensing-thank-you-manual-activation__card-top">
+						<JetpackLogo size={ 45 } />
+						<ProgressBar
+							className="licensing-thank-you-manual-activation__progress-bar"
+							value={ 1 }
+							total={ 3 }
+						/>
+					</div>
 					<h1 className="licensing-thank-you-manual-activation__main-message">
 						{ translate( 'Thank you for your purchase!' ) }{ ' ' }
 						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
@@ -59,13 +59,6 @@ const LicensingThankYouAutoActivation: FC< Props > = ( { productSlug } ) => {
 					<div className="licensing-thank-you-manual-activation__card-footer-image">
 						<img src={ footerCardImg } alt="Checkout Thank you" />
 					</div>
-					<div className="licensing-thank-you-manual-activation__card-footer-text">
-						{ translate( 'Do you need help? {{a}}Contact us{{/a}}.', {
-							components: {
-								a: <a href={ supportContactLink } target="_blank" rel="noopener noreferrer" />,
-							},
-						} ) }
-					</div>
 				</div>
 			</Card>
 		</Main>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
@@ -14,8 +14,11 @@ interface Props {
 const LicensingThankYouAutoActivation: FC< Props > = ( { productSlug } ) => {
 	const translate = useTranslate();
 
-	const supportContactLink =
-		'https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/';
+	// This is the first step of three of the manual activation flow
+	const progressBarProperties = {
+		value: 1,
+		total: 3,
+	};
 
 	return (
 		<Main fullWidthLayout className="licensing-thank-you-manual-activation">
@@ -31,8 +34,7 @@ const LicensingThankYouAutoActivation: FC< Props > = ( { productSlug } ) => {
 						<JetpackLogo size={ 45 } />
 						<ProgressBar
 							className="licensing-thank-you-manual-activation__progress-bar"
-							value={ 1 }
-							total={ 3 }
+							{ ...progressBarProperties }
 						/>
 					</div>
 					<h1 className="licensing-thank-you-manual-activation__main-message">

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
@@ -1,40 +1,18 @@
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
 import footerCardBackground from 'calypso/assets/images/jetpack/jp-licensing-checkout-footer-bg.svg';
 import footerCardImg from 'calypso/assets/images/jetpack/licensing-card.png';
-import QueryProducts from 'calypso/components/data/query-products-list';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import {
-	isProductsListFetching as getIsProductListFetching,
-	getProductName,
-} from 'calypso/state/products-list/selectors';
 
 interface Props {
 	productSlug: string | 'no_product';
-	receiptId?: number;
-	source?: string;
-	jetpackTemporarySiteId?: number;
 }
 
-const LicensingThankYouAutoActivation: FC< Props > = ( {
-	productSlug,
-	receiptId = 0,
-	source = 'onboarding-calypso-ui',
-	jetpackTemporarySiteId = 0,
-} ) => {
+const LicensingThankYouAutoActivation: FC< Props > = ( { productSlug } ) => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-
-	const hasProductInfo = productSlug !== 'no_product';
-
-	const productName = useSelector( ( state ) =>
-		hasProductInfo ? getProductName( state, productSlug ) : null
-	);
 
 	const supportContactLink =
 		'https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/';
@@ -50,7 +28,6 @@ const LicensingThankYouAutoActivation: FC< Props > = ( {
 			<Card className="licensing-thank-you-manual-activation__card">
 				<div className="licensing-thank-you-manual-activation__card-main">
 					<JetpackLogo size={ 45 } />
-					{ hasProductInfo && <QueryProducts type="jetpack" /> }
 					<h1 className="licensing-thank-you-manual-activation__main-message">
 						{ translate( 'Thank you for your purchase!' ) }{ ' ' }
 						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -1037,6 +1037,26 @@
 	}
 }
 
+.licensing-thank-you-manual-activation__card-top {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	margin-bottom: 45px;
+}
+
+.licensing-thank-you-manual-activation .licensing-thank-you-manual-activation__card-top .jetpack-logo {
+	margin-bottom: 0;
+}
+
+.licensing-thank-you-manual-activation__progress-bar {
+	width: 60px;
+
+	.progress-bar__progress {
+		background-color: var( --studio-jetpack-green-40 );
+	}
+}
+
 .jetpack-checkout-siteless-thank-you {
 	.jetpack-checkout-siteless-thank-you__card {
 		@include break-medium {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the first step of the manual activation flow that was introduced in https://github.com/Automattic/wp-calypso/pull/57508. Note: the button CTA will remain disabled until the next step in the flow is implemented.

#### Testing instructions

* Download this PR.
* Start Calypso with `yarn start`.
* Visit `http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-manual-activate/jetpack_backup_daily`.
* Make sure the UI looks like in our Figma file (ceKxiVna5wfpmwFBsojrAx-fi-2219%3A25665).
* Make sure the UI looks well in different viewport sizes.

Related to 1201096622142517-as-1201096622142531

#### Demo
![image](https://user-images.githubusercontent.com/3418513/139941589-ecafd8ae-7980-46fc-9f94-1c7d886ee1c2.png)
