### PR TITLE
Correct some WP spelling.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -38,7 +38,7 @@ const VideosUi = () => {
 							</li>
 							<li>
 								<Gridicon icon="checkmark" size={ 12 } />{ ' ' }
-								{ translate( 'Familiarize yourself with Wordpress' ) }
+								{ translate( 'Familiarize yourself with WordPress' ) }
 							</li>
 							<li>
 								<Gridicon icon="checkmark" size={ 12 } /> { translate( 'Upskill and save hours' ) }

--- a/client/layout/masterbar/README.md
+++ b/client/layout/masterbar/README.md
@@ -14,7 +14,7 @@ logged-in.jsx respectively, which pass their items as children to this component
 
 ## logged-out.jsx
 
-Renders a logged-out masterbar with only a "Wordpress.com" link.
+Renders a logged-out masterbar with only a "WordPress.com" link.
 
 ## logged-in.jsx
 

--- a/client/signup/steps/import/ready/platform-details.tsx
+++ b/client/signup/steps/import/ready/platform-details.tsx
@@ -24,7 +24,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 			case 'Blogger':
 				return __( 'Importing content from Blogger' );
 			case 'Wordpress':
-				return __( 'Importing content from self-hosted WordPress to Wordpress.com' );
+				return __( 'Importing content from self-hosted WordPress to WordPress.com' );
 			case 'Medium':
 				return __( 'Importing content from Medium' );
 			default:


### PR DESCRIPTION
This PR corrects three user-facing instances of "Wordpress" to "WordPress". `#capitalpdangit`