### PR TITLE
E2E: add test to check admin bar presence in mobile.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { resolve } from 'path/posix';
 import { Page, Frame, ElementHandle } from 'playwright';
 import { getTargetDeviceName } from '../../browser-helper';
 import { NavbarComponent } from '../components';
@@ -382,15 +383,18 @@ export class GutenbergEditorPage {
 	 */
 	async returnToHomeDashboard(): Promise< void > {
 		const frame = await this.getEditorFrame();
+		const navbarComponent = new NavbarComponent( this.page );
+		const actions: unknown[] = [
+			this.page.waitForNavigation( { url: '**/home/**', waitUntil: 'load' } ),
+		];
+
 		if ( getTargetDeviceName() === 'desktop' ) {
-			await Promise.all( [
-				this.page.waitForNavigation(),
-				frame.click( selectors.desktopDashboardLink ),
-			] );
+			actions.push( frame.click( selectors.desktopDashboardLink ) );
 		} else {
-			const navbarComponent = new NavbarComponent( this.page );
-			await Promise.all( [ this.page.waitForNavigation(), navbarComponent.clickMySites() ] );
+			actions.push( navbarComponent.clickMySites() );
 		}
+
+		await Promise.all( actions );
 	}
 
 	/* Previews */

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import { resolve } from 'path/posix';
 import { Page, Frame, ElementHandle } from 'playwright';
 import { getTargetDeviceName } from '../../browser-helper';
 import { NavbarComponent } from '../components';

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -382,12 +382,22 @@ export class GutenbergEditorPage {
 	 */
 	async returnToHomeDashboard(): Promise< void > {
 		const frame = await this.getEditorFrame();
+		const targetDevice = getTargetDeviceName();
+
+		if (
+			targetDevice !== 'mobile' &&
+			( await frame.getAttribute( selectors.desktopEditorSidebarButton, 'aria-expanded' ) ) ===
+				'false'
+		) {
+			await this.openNavSidebar();
+		}
+
 		const navbarComponent = new NavbarComponent( this.page );
-		const actions: unknown[] = [
+		const actions: Promise< unknown >[] = [
 			this.page.waitForNavigation( { url: '**/home/**', waitUntil: 'load' } ),
 		];
 
-		if ( getTargetDeviceName() === 'desktop' ) {
+		if ( getTargetDeviceName() !== 'mobile' ) {
 			actions.push( frame.click( selectors.desktopDashboardLink ) );
 		} else {
 			actions.push( navbarComponent.clickMySites() );

--- a/test/e2e/specs/specs-playwright/wp-editor__navbar.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__navbar.ts
@@ -1,0 +1,37 @@
+/**
+ * @group gutenberg
+ */
+
+import {
+	DataHelper,
+	LoginPage,
+	NewPostFlow,
+	GutenbergEditorPage,
+	setupHooks,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
+	let page: Page;
+	const mainUser = 'gutenbergSimpleSiteUser';
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log in', async function () {
+		const loginPage = new LoginPage( page );
+		await loginPage.login( { account: mainUser } );
+	} );
+
+	it( 'Start new post', async function () {
+		const newPostFlow = new NewPostFlow( page );
+		await newPostFlow.newPostFromNavbar();
+	} );
+
+	it( 'Return to Home dashboard', async function () {
+		const gutenbergEditorPage = new GutenbergEditorPage( page );
+		await gutenbergEditorPage.openNavSidebar();
+		await gutenbergEditorPage.returnToHomeDashboard();
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-editor__navbar.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__navbar.ts
@@ -1,5 +1,6 @@
 /**
  * @group gutenberg
+ * @group calypso-pr
  */
 
 import {
@@ -31,7 +32,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 
 	it( 'Return to Home dashboard', async function () {
 		const gutenbergEditorPage = new GutenbergEditorPage( page );
-		await gutenbergEditorPage.openNavSidebar();
 		await gutenbergEditorPage.returnToHomeDashboard();
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -49,86 +49,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		it( 'Enter post title', async function () {
 			gutenbergEditorPage = new GutenbergEditorPage( page );
-			await gutenbergEditorPage.enterTitle( title );
-		} );
-
-		it( 'Enter post text', async function () {
-			await gutenbergEditorPage.enterText( quote );
-		} );
-
-		it( 'Open editor settings sidebar for post', async function () {
-			await gutenbergEditorPage.openSettings();
-			const frame = await gutenbergEditorPage.getEditorFrame();
-			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
-			await editorSettingsSidebarComponent.clickTab( 'Post' );
-		} );
-
-		it( 'Add post category', async function () {
-			await editorSettingsSidebarComponent.expandSectionIfCollapsed( 'Categories' );
-			await editorSettingsSidebarComponent.clickCategory( category );
-		} );
-
-		it( 'Add post tag', async function () {
-			await editorSettingsSidebarComponent.expandSectionIfCollapsed( 'Tags' );
-			await editorSettingsSidebarComponent.enterTag( tag );
-		} );
-	} );
-
-	describe( 'Preview post', function () {
-		const targetDevice = BrowserHelper.getTargetDeviceName();
-		let previewPage: Page;
-
-		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
-		it( 'Close settings sidebar', async function () {
-			await editorSettingsSidebarComponent.closeSidebar();
-		} );
-
-		// The following two steps have conditiionals inside them, as how the
-		// Editor Preview behaves depends on the device type.
-		// On desktop and tablet, preview applies CSS attributes to modify the preview in-editor.
-		// On mobile web, preview button opens a new tab.
-
-		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
-		itif( targetDevice === 'mobile' )( 'Launch preview', async function () {
-			if ( BrowserHelper.getTargetDeviceName() === 'mobile' ) {
-				previewPage = await gutenbergEditorPage.openPreviewAsMobile();
-			} else {
-				await gutenbergEditorPage.openPreviewAsDesktop( 'Mobile' );
-			}
-		} );
-
-		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
-		itif( targetDevice === 'mobile' )( 'Close preview', async function () {
-			// Mobile path.
-			if ( previewPage ) {
-				await previewPage.close();
-				// Desktop path.
-			} else {
-				await gutenbergEditorPage.closePreview();
-			}
-		} );
-
-		// TODO: step skipped for mobile, since previewing naturally saves the post, rendering this step unnecessary.
-		itif( targetDevice !== 'mobile' )( 'Save draft', async function () {
-			await gutenbergEditorPage.saveDraft();
-		} );
-	} );
-
-	describe( 'Publish post', function () {
-		it( 'Publish and visit post', async function () {
-			const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
-			expect( publishedURL ).toBe( page.url() );
-		} );
-
-		it( 'Post content is found in published post', async function () {
-			publishedPostPage = new PublishedPostPage( page );
-			await publishedPostPage.validateTextInPost( title );
-			await publishedPostPage.validateTextInPost( quote );
-		} );
-
-		it( 'Post metadata is found in published post', async function () {
-			await publishedPostPage.validateTextInPost( category );
-			await publishedPostPage.validateTextInPost( tag );
+			await gutenbergEditorPage.openNavSidebar();
+			await gutenbergEditorPage.returnToHomeDashboard();
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -49,8 +49,86 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		it( 'Enter post title', async function () {
 			gutenbergEditorPage = new GutenbergEditorPage( page );
-			await gutenbergEditorPage.openNavSidebar();
-			await gutenbergEditorPage.returnToHomeDashboard();
+			await gutenbergEditorPage.enterTitle( title );
+		} );
+
+		it( 'Enter post text', async function () {
+			await gutenbergEditorPage.enterText( quote );
+		} );
+
+		it( 'Open editor settings sidebar for post', async function () {
+			await gutenbergEditorPage.openSettings();
+			const frame = await gutenbergEditorPage.getEditorFrame();
+			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
+			await editorSettingsSidebarComponent.clickTab( 'Post' );
+		} );
+
+		it( 'Add post category', async function () {
+			await editorSettingsSidebarComponent.expandSectionIfCollapsed( 'Categories' );
+			await editorSettingsSidebarComponent.clickCategory( category );
+		} );
+
+		it( 'Add post tag', async function () {
+			await editorSettingsSidebarComponent.expandSectionIfCollapsed( 'Tags' );
+			await editorSettingsSidebarComponent.enterTag( tag );
+		} );
+	} );
+
+	describe( 'Preview post', function () {
+		const targetDevice = BrowserHelper.getTargetDeviceName();
+		let previewPage: Page;
+
+		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
+		it( 'Close settings sidebar', async function () {
+			await editorSettingsSidebarComponent.closeSidebar();
+		} );
+
+		// The following two steps have conditiionals inside them, as how the
+		// Editor Preview behaves depends on the device type.
+		// On desktop and tablet, preview applies CSS attributes to modify the preview in-editor.
+		// On mobile web, preview button opens a new tab.
+
+		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
+		itif( targetDevice === 'mobile' )( 'Launch preview', async function () {
+			if ( BrowserHelper.getTargetDeviceName() === 'mobile' ) {
+				previewPage = await gutenbergEditorPage.openPreviewAsMobile();
+			} else {
+				await gutenbergEditorPage.openPreviewAsDesktop( 'Mobile' );
+			}
+		} );
+
+		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
+		itif( targetDevice === 'mobile' )( 'Close preview', async function () {
+			// Mobile path.
+			if ( previewPage ) {
+				await previewPage.close();
+				// Desktop path.
+			} else {
+				await gutenbergEditorPage.closePreview();
+			}
+		} );
+
+		// TODO: step skipped for mobile, since previewing naturally saves the post, rendering this step unnecessary.
+		itif( targetDevice !== 'mobile' )( 'Save draft', async function () {
+			await gutenbergEditorPage.saveDraft();
+		} );
+	} );
+
+	describe( 'Publish post', function () {
+		it( 'Publish and visit post', async function () {
+			const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
+			expect( publishedURL ).toBe( page.url() );
+		} );
+
+		it( 'Post content is found in published post', async function () {
+			publishedPostPage = new PublishedPostPage( page );
+			await publishedPostPage.validateTextInPost( title );
+			await publishedPostPage.validateTextInPost( quote );
+		} );
+
+		it( 'Post metadata is found in published post', async function () {
+			await publishedPostPage.validateTextInPost( category );
+			await publishedPostPage.validateTextInPost( tag );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-signup__free.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__free.ts
@@ -11,7 +11,6 @@ import {
 	setupHooks,
 	UserSignupPage,
 	SignupPickPlanPage,
-	BrowserHelper,
 	CloseAccountFlow,
 	GutenboardingFlow,
 } from '@automattic/calypso-e2e';

--- a/test/e2e/specs/specs-playwright/wp-signup__free.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__free.ts
@@ -73,13 +73,9 @@ describe.skip( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), func
 		it( 'Return to Home dashboard', async function () {
 			// Temporary workaround due to https://github.com/Automattic/wp-calypso/issues/51162.
 			// Conditional can be removed once fixed.
-			if ( BrowserHelper.getTargetDeviceName() === 'mobile' ) {
-				await page.goBack();
-			} else {
-				gutenbergEditorPage = new GutenbergEditorPage( page );
-				await gutenbergEditorPage.openNavSidebar();
-				await gutenbergEditorPage.returnToDashboard();
-			}
+			gutenbergEditorPage = new GutenbergEditorPage( page );
+			await gutenbergEditorPage.openNavSidebar();
+			await gutenbergEditorPage.returnToHomeDashboard();
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a test as per #57190 to check the presence and basic functionality of the admin bar (also called navbar).

Key changes:
- change name of some existing selectors.
- specify `:visible` pseudo-CSS.
- add handling for different mobile/desktop behavior for exiting the editor.

Details:
Changes in this PR arose from the parent issue #57190 and #51162 where on the mobile web editor no methods were provided for the user to exit the editor back to WordPress.com. 

The changes in #57234 were to persistently show the navbar in the editor view, so the user can click on `My Sites` to return to WordPress.com.

However, this means that experience of exiting the editor differs depending on the viewport size used:
- desktop: click on the site icon, then click on 'Dashboard'.
- mobile: click on My Sites.

The method `openNavSidebar` has been restructured so that it only performs its action on desktop.
Similarly, `returnToHomeDashboard` has been restructured to handle both scenarios.

#### Testing instructions

- [ ] stress test
  - [x] mobile 6924664
  - [x] desktop 6924674
- [ ] normal test
  - [x] mobile
  - [x] desktop

Closes #57190.
