### PR TITLE
Updating video UI stylesheet to use mobile-first structure

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -31,21 +31,11 @@
 
 		.videos-ui__header-content {
 			display: flex;
-			padding: 80px;
-			justify-content: space-between;
-
-			.videos-ui__titles {
-				flex-basis: auto;
-				width: 60%;
-			}
-
-			.videos-ui__summary {
-				flex-basis: auto;
-				width: 33%;
-			}
+			flex-direction: column;
+			padding: 20px;
 
 			ul {
-				margin: 0;
+				margin: 40px 0 0;
 			}
 
 			li {
@@ -68,25 +58,22 @@
 
 		h3 {
 			font-size: $font-title-medium;
-			margin: 80px 80px 30px;
+			margin: 20px;
 		}
 
 		.videos-ui__video-content {
 			display: flex;
-			padding: 0 80px 80px;
-			justify-content: space-between;
+			flex-direction: column;
+			padding: 0 20px 20px;
 		}
 
 		.videos-ui__video {
-			flex-basis: auto;
-			width: 60%;
+			margin-bottom: 30px;
 		}
 
 		.videos-ui__chapters {
 			background: #1d262a;
 			font-size: $font-body-small;
-			flex-basis: auto;
-			width: 33%;
 			overflow: auto;
 
 			.videos-ui__chapter {
@@ -124,6 +111,52 @@
 
 				button {
 					width: 100%;
+				}
+			}
+		}
+	}
+	@media screen and ( min-width: 660px ) {
+		.videos-ui__header {
+			.videos-ui__header-content {
+				flex-direction: row;
+				justify-content: space-between;
+				padding: 80px;
+
+				.videos-ui__titles {
+					flex-basis: auto;
+					width: 60%;
+				}
+
+				.videos-ui__summary {
+					flex-basis: auto;
+					width: 33%;
+				}
+
+				ul {
+					margin: 0;
+				}
+			}
+		}
+
+		.videos-ui__body {
+
+			h3 {
+				margin: 80px 80px 30px;
+			}
+
+			.videos-ui__video-content {
+				flex-direction: row;
+				justify-content: space-between;
+				padding: 0 80px 80px;
+
+				.videos-ui__video {
+					flex-basis: auto;
+					width: 60%;
+				}
+
+				.videos-ui__chapters {
+					flex-basis: auto;
+					width: 33%;
 				}
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the `VideosUi` component introduced in https://github.com/Automattic/wp-calypso/pull/57406 to use proper mobile-first styling.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR still does not load the UI anywhere (as it will be added as a modal in the work being done for Videos UI: Add a new card to the My Home carousel for our MVP. #57326
* However, it can be tested by importing the `VideosUi` component anywhere in Calypso (such as a block on the home page.)
* Verify that at screen widths below 660px, a mobile version of the component is displayed.
* Verify that above 660px, the desktop version is displayed.

Mobile version:

![image](https://user-images.githubusercontent.com/13437011/140092388-46c5212d-d542-4e55-a712-688aae6359f8.png)


Desktop version:

![image](https://user-images.githubusercontent.com/13437011/140092300-f36db581-f6e3-4df4-a37d-4bf1dec52817.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57446
