### PR TITLE
Videos UI: Add Tracks events for views and skipping.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -6,7 +6,6 @@ import './style.scss';
 
 const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 	const translate = useTranslate();
-
 	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );
 
 	const onVideoPlayClick = ( video ) => {
@@ -15,6 +14,15 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 			video,
 		} );
 	};
+
+	const skipClickHandler = () =>
+		recordTracksEvent( 'calypso_courses_skip_to_draft', {
+			course: course.slug,
+		} );
+
+	recordTracksEvent( 'calypso_courses_view', {
+		course: course.slug,
+	} );
 
 	return (
 		<div className="videos-ui">
@@ -31,7 +39,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 					</div>
 					<div>
 						{ shouldDisplayTopLinks && (
-							<a href="/" className="videos-ui__skip-link">
+							<a href="/" className="videos-ui__skip-link" onClick={ skipClickHandler }>
 								{ translate( 'Skip and draft first post' ) }
 							</a>
 						) }


### PR DESCRIPTION
This PR adds Tracks events for a view of the videos UI, and for clicking the "skip and go to draft" link. The CTA event will be handled in the PR that adds it.

**Testing Instructions**
* Switch to this PR.
* Enter `localStorage.setItem( 'debug', 'calypso:analytics*' )` in your console to see live Tracks events.
* Add the `<VideosUi />` component somewhere easy to test (like My Home).
* Verify the two Tracks events (the view one should fire automatically, the other when clicking on the link).

<img width="926" alt="Screen Shot 2021-11-02 at 3 10 07 PM" src="https://user-images.githubusercontent.com/349751/139959547-147de9ff-3ee9-47d1-b15f-2c285bd8c9bb.png">

<img width="913" alt="Screen Shot 2021-11-02 at 3 09 46 PM" src="https://user-images.githubusercontent.com/349751/139959503-30f43589-366f-4a0b-ab3f-2207748fed4e.png">


