### PR TITLE
Blogger Flow: Update copy on starting-point screen

### DIFF
--- a/client/signup/steps/starting-point/index.tsx
+++ b/client/signup/steps/starting-point/index.tsx
@@ -27,9 +27,7 @@ export default function StartingPointStep( props: Props ): React.ReactNode {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { goToNextStep, stepName } = props;
-	const headerText = translate( 'Nice job! Lastly,{{br}}{{/br}}pick a starting point', {
-		components: { br: <br /> },
-	} );
+	const headerText = translate( 'Nice job! Now it’s time to get creative.' );
 	const subHeaderText = translate( "Don't worry. You can come back to these steps!" );
 	const branchSteps = useBranchSteps( stepName );
 

--- a/client/signup/steps/starting-point/index.tsx
+++ b/client/signup/steps/starting-point/index.tsx
@@ -27,7 +27,9 @@ export default function StartingPointStep( props: Props ): React.ReactNode {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { goToNextStep, stepName } = props;
-	const headerText = translate( 'Nice job! Now it’s time to get creative.' );
+	const headerText = translate( 'Nice job! Now it’s{{br}}{{/br}} time to get creative.', {
+		components: { br: <br /> },
+	} );
 	const subHeaderText = translate( "Don't worry. You can come back to these steps!" );
 	const branchSteps = useBranchSteps( stepName );
 


### PR DESCRIPTION
Update copy in accordance with https://github.com/Automattic/wp-calypso/issues/57582

**Before:**
"Nice job! Lastly, pick a starting point."
**After:**
"Nice job! Now it’s time to get creative."
**Screenshots**
<img width="380" alt="Screen Shot 2021-11-03 at 9 29 31 am" src="https://user-images.githubusercontent.com/22446385/139965969-3719aaf4-a41f-4e8f-aa7b-f66b0a089d72.png">
<img width="576" alt="Screen Shot 2021-11-03 at 9 29 19 am" src="https://user-images.githubusercontent.com/22446385/139965979-9ca9a99e-7c68-46c4-80b0-1858328a1766.png">
<img width="1299" alt="Screen Shot 2021-11-03 at 9 29 04 am" src="https://user-images.githubusercontent.com/22446385/139965982-b4e6e1ca-e807-4191-ab7b-1a0c0da9000c.png">
