### PR TITLE
Payments: Remove requirement for postal code from add card form

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -57,7 +57,7 @@ export async function assignNewCardProcessor(
 ): Promise< PaymentProcessorResponse > {
 	try {
 		if ( ! isNewCardDataValid( submitData ) ) {
-			throw new Error( 'Credit Card data is missing name, country, or postal code' );
+			throw new Error( 'Credit Card data is missing country' );
 		}
 		if ( ! stripe || ! stripeConfiguration ) {
 			throw new Error( 'Cannot assign payment method if Stripe is not loaded' );
@@ -77,7 +77,7 @@ export async function assignNewCardProcessor(
 		const formFieldValues = {
 			country: countryCode,
 			postal_code: postalCode ?? '',
-			name,
+			name: name ?? '',
 		};
 		const tokenResponse = await createStripeSetupIntentAsync(
 			formFieldValues,
@@ -146,11 +146,11 @@ async function createStripeSetupIntentAsync(
 
 function isNewCardDataValid( data: unknown ): data is NewCardSubmitData {
 	const newCardData = data as NewCardSubmitData;
-	return !! ( newCardData.name && newCardData.countryCode );
+	return !! newCardData.countryCode;
 }
 
 interface NewCardSubmitData {
-	name: string;
+	name?: string;
 	countryCode: string;
 	postalCode?: string;
 	useForAllSubscriptions: boolean;

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -76,7 +76,7 @@ export async function assignNewCardProcessor(
 
 		const formFieldValues = {
 			country: countryCode,
-			postal_code: postalCode,
+			postal_code: postalCode ?? '',
 			name,
 		};
 		const tokenResponse = await createStripeSetupIntentAsync(
@@ -146,13 +146,13 @@ async function createStripeSetupIntentAsync(
 
 function isNewCardDataValid( data: unknown ): data is NewCardSubmitData {
 	const newCardData = data as NewCardSubmitData;
-	return !! ( newCardData.name && newCardData.countryCode && newCardData.postalCode );
+	return !! ( newCardData.name && newCardData.countryCode );
 }
 
 interface NewCardSubmitData {
 	name: string;
 	countryCode: string;
-	postalCode: string;
+	postalCode?: string;
 	useForAllSubscriptions: boolean;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/57041 we began hiding the postal code field in payment method management forms when there is no postal code for the selected country. However, there was one overlooked detail: the postal code was still being required by a hard-coded type guard in the assignment processor function. (Even worse, the error displayed was not meant to be hit and so is not localized.) 

**This means that it's currently impossible to add cards (using the "add card" form; checkout is unaffected) for countries without a postal code.**

This PR removes that requirement (and the requirement for a name). If the endpoint used by the form requires those fields, it should validate and return an appropriate error message itself.

Props to @sbathompson-he for finding this bug!

Before:

<img width="906" alt="Screen Shot 2021-11-02 at 7 37 24 PM" src="https://user-images.githubusercontent.com/2036909/139967034-35cb31d8-e0e9-47cd-89a9-0c23335b31f6.png">

After:

No screenshot needed. The card is added successfully.

#### Testing instructions

- Visit `/me/purchases/add-payment-method`.
- Enter new card details, but select `Curaçao` as the country.
- Submit the form.
- Verify that the new card is added successfully.