### PR TITLE
Remove background color on Plan Comparison table

### DIFF
--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -40,7 +40,6 @@ $plan-features-sidebar-width: 272px;
 	display: flex;
 	align-items: flex-start;
 	padding: 12px 24px 12px 15px;
-	background-color: var( --color-surface );
 	justify-content: center;
 	font-weight: 400;
 	margin-top: 30px;
@@ -123,7 +122,6 @@ $plan-features-sidebar-width: 272px;
 		transition: opacity 0.05s;
 		border-right: solid 1px var( --color-neutral-5 );
 		border-left: solid 1px var( --color-neutral-5 );
-		background-color: var( --color-surface );
 		position: relative;
 
 		&.is-bold {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the #fff background color form the Plan Comparison table at https://wordpress.com/start/plans

#### Testing instructions

Visit https://wordpress.com/start/plans and verify there is no background color on table cells or headers

#### Before

<img width="1195" alt="Screen Shot 2021-11-03 at 7 59 45 pm" src="https://user-images.githubusercontent.com/1842363/140032843-cf38d949-d90d-461a-b71c-6f482080ea27.png">

#### After

<img width="1222" alt="Screen Shot 2021-11-03 at 7 59 56 pm" src="https://user-images.githubusercontent.com/1842363/140032871-2685c549-d0d7-4e6f-b5c7-5b8de1f2b10e.png">

