### PR TITLE
ci: WP Desktop tests use ci-e2e image

### DIFF
--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -20,7 +20,7 @@ object DesktopApp : Project({
 	buildType(E2ETests)
 
 	params {
-		text("docker_image_desktop", "registry.a8c.com/calypso/ci-desktop:latest", label = "Docker image", description = "Docker image to use for the run", allowEmpty = true)
+		text("docker_image_desktop", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker image", description = "Docker image to use for the run", allowEmpty = true)
 		password("CALYPSO_SECRETS_ENCRYPTION_KEY", "credentialsJSON:ff451a7d-df79-4635-b6e8-cbd6ec18ddd8", description = "password for encrypting/decrypting certificates and general secrets for the wp-desktop and simplenote-electron repo", display = ParameterDisplay.HIDDEN)
 		password("E2EGUTENBERGUSER", "credentialsJSON:27ca9d7b-c6b5-4e84-94d5-ea43879d8184", display = ParameterDisplay.HIDDEN)
 		password("E2EPASSWORD", "credentialsJSON:2c4425c4-07d2-414c-9f18-b64da307bdf2", display = ParameterDisplay.HIDDEN)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -111,20 +111,6 @@ object BuildBaseImages : BuildType({
 			param("dockerImage.platform", "linux")
 		}
 		dockerCommand {
-			name = "Build CI Desktop image"
-			commandType = build {
-				source = file {
-					path = "Dockerfile.base"
-				}
-				namesAndTags = """
-					registry.a8c.com/calypso/ci-desktop:%image_tag%
-					registry.a8c.com/calypso/ci-desktop:%build.number%
-				""".trimIndent()
-				commandArgs = "--target ci-desktop"
-			}
-			param("dockerImage.platform", "linux")
-		}
-		dockerCommand {
 			name = "Build CI e2e image"
 			commandType = build {
 				source = file {
@@ -158,8 +144,6 @@ object BuildBaseImages : BuildType({
 				namesAndTags = """
 					registry.a8c.com/calypso/base:%image_tag%
 					registry.a8c.com/calypso/base:%build.number%
-					registry.a8c.com/calypso/ci-desktop:%image_tag%
-					registry.a8c.com/calypso/ci-desktop:%build.number%
 					registry.a8c.com/calypso/ci-e2e:%image_tag%
 					registry.a8c.com/calypso/ci-e2e:%build.number%
 					registry.a8c.com/calypso/ci-wpcom:%image_tag%

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -73,17 +73,14 @@ COPY --from=cache --chown=$UID /calypso/.yarn /calypso/.yarn
 
 ENTRYPOINT [ "/bin/bash" ]
 
-#### ci-desktop image
-#### This image is used to run desktop tests.
-FROM base as ci-desktop
+#### ci-e2e image
+#### This image is used to run E2E tests.
+FROM base as ci-e2e
 
-ENV ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
-ENV USE_HARD_LINKS=false
 ENV CHROMEDRIVER_SKIP_DOWNLOAD=false
 ENV PUPPETEER_SKIP_DOWNLOAD=false
 ENV PLAYWRIGHT_SKIP_DOWNLOAD=false
-# This chrome image is the latest version supported by wp-desktop's chromedriver, declared in desktop/package.json.
-ENV CHROME_VERSION="80.0.3987.163-1"
+ENV DETECT_CHROMEDRIVER_VERSION=true
 ENV DISPLAY=:99
 
 RUN apt update \
@@ -113,25 +110,11 @@ RUN apt update \
 		xfonts-scalable \
 		xvfb
 
-RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
-	&& apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb \
-	&& rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
-
-ENTRYPOINT [ "/bin/bash" ]
-
-#### ci-e2e image
-#### This image is used to run e2e tests. The only difference with ci-desktop is the Chrome version.
-FROM ci-desktop as ci-e2e
-
-# test/e2e/test/mocha.env.js will install a compatible chromedriver.
-ENV DETECT_CHROMEDRIVER_VERSION=true
-
 RUN wget --no-verbose https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
 	&& apt-get install -y ./google-chrome-stable_current_amd64.deb \
 	&& rm ./google-chrome-stable_current_amd64.deb
 
 ENTRYPOINT [ "/bin/bash" ]
-
 
 #### ci-wpcom image
 #### This image is used to test and build WPCOM plugins in Calypso repo.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Drop docker image `ci-desktop`. From now on, WP Desktop tests will use the image `ci-e2e`, as it doesn't need a specific Chrome version.

#### Testing instructions

Verify Desktop tests are passing
