### PR TITLE
Theming: fixes white bg color overrides.

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,7 +1,7 @@
 @import './grid-mixins.scss';
 
-body.is-section-home {
-	background: var( --studio-white );
+body.is-section-home.theme-default.color-scheme {
+	--color-surface-backdrop: var( --studio-white );
 }
 
 .customer-home__heading {
@@ -133,11 +133,6 @@ body.is-section-home {
 	}
 }
 
-.is-section-home.is-nav-unification .sidebar .sidebar__heading::after,
-.is-section-home.is-nav-unification .sidebar .sidebar__menu-link::after {
-	border-right-color: var( --studio-white );
-}
-
 .primary__customer-home-location-content {
 	display: flex;
 	flex-direction: column;
@@ -149,7 +144,8 @@ body.is-section-home {
 	// This lets us align the edges of the pager controls with text & images
 	// from the cards while also giving the checklist the freedom to reach the
 	// edges of the space with it's inner list.
-	.card, .task {
+	.card,
+	.task {
 		margin: 32px;
 	}
 
@@ -163,7 +159,6 @@ body.is-section-home {
 	@include breakpoint-deprecated( '>660px' ) {
 		box-shadow: 0 0 0 1px var( --color-border-subtle );
 	}
-
 }
 
 .primary__customer-home-location-content .dot-pager__controls {
@@ -174,7 +169,8 @@ body.is-section-home {
 .primary__customer-home-location-content .task {
 	box-shadow: none;
 
-	.task__text, .task__illustration {
+	.task__text,
+	.task__illustration {
 		padding-top: 0;
 		padding-bottom: 0;
 	}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -21,12 +21,8 @@
 	}
 }
 
-body.edit__body-white {
-	background: var( --studio-white );
-	&.is-nav-unification .sidebar .sidebar__heading::after,
-	&.is-nav-unification .sidebar .sidebar__menu-link::after {
-		border-right-color: var( --studio-white );
-	}
+body.edit__body-white.theme-default.color-scheme {
+	--color-surface-backdrop: var( --studio-white );
 }
 
 .domain-details-card {

--- a/client/my-sites/email/inbox/mailbox-selection-list/style.scss
+++ b/client/my-sites/email/inbox/mailbox-selection-list/style.scss
@@ -1,8 +1,8 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-body.is-section-inbox {
-	background-color: var( --studio-white );
+body.is-section-inbox.theme-default.color-scheme {
+	--color-surface-backdrop: var( --studio-white );
 }
 
 body.is-section-inbox .layout.is-section-inbox > .layout__content {
@@ -253,7 +253,8 @@ body.is-section-inbox .layout.is-section-inbox > .layout__content {
 				width: 100%;
 			}
 
-			> img, svg {
+			> img,
+			svg {
 				height: 36px;
 				margin-right: 16px;
 				min-height: 36px;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -10,8 +10,8 @@
 	}
 }
 
-.is-section-plugins.theme-default.color-scheme {
-	--color-surface-backdrop: --studio-white;
+body.is-section-plugins.theme-default.color-scheme {
+	--color-surface-backdrop: var( --studio-white );
 }
 
 // Fix for Jetpack not having nav-unification styles yet.

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -89,7 +89,7 @@ $font-size: rem( 14px );
 				height: 0;
 				margin-top: -8px;
 				border: solid 8px transparent;
-				border-right-color: #f1f1f1;
+				border-right-color: var( --color-surface-backdrop );
 				pointer-events: none;
 			}
 		}
@@ -102,7 +102,7 @@ $font-size: rem( 14px );
 				background-color: var( --color-sidebar-menu-hover-background );
 				color: var( --color-sidebar-menu-hover-text );
 				box-shadow: inset 4px 0 0 0 currentColor;
- 				transition: box-shadow 0.1s linear;
+				transition: box-shadow 0.1s linear;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Following pdh6GB-80-p2#comment-298 regarding inconsistencies in menu arrow color
![image](https://user-images.githubusercontent.com/12430020/140023718-9b700134-5d8c-4ba2-8d49-a7b3f0450150.png)
I decided to do a wider research and fix:

* use `--color-surface-backdrop` for the bg of the menu arrow
* set `--color-surface-backdrop` to `var( --studio-white );` in all instances _I found_ (domains, inbox, home, plugins). The rules has to use `body.is-section-[your-page].theme-default.color-scheme` so that it overrides correctly all color schemes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit domains, inbox, home, plugins with the default color scheme and repeat for any other color scheme
* Inspect that the background color of the primary section is white and that the menu arrow is also white

The changes in domains apply only for local environment since it relies on a feature flag.

|Before | After|
|-------|------|
|![SS 2021-11-03 at 09 46 09](https://user-images.githubusercontent.com/12430020/140024480-69a32d2c-f313-4770-be42-f6c13518936f.png)|![SS 2021-11-03 at 09 46 49](https://user-images.githubusercontent.com/12430020/140024532-fdfa714e-ad94-4780-860b-0ecb19a53033.png)|


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
