### PR TITLE
Remove most Lodash usages from Guided Tours

### DIFF
--- a/client/layout/guided-tours/config-elements/tour.js
+++ b/client/layout/guided-tours/config-elements/tour.js
@@ -1,4 +1,3 @@
-import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { contextTypes } from '../context-types';
@@ -17,7 +16,7 @@ export default class Tour extends Component {
 		const { children } = this.props;
 		const { step } = this.context;
 		const nextStep = Array.isArray( children )
-			? find( children, ( stepComponent ) => stepComponent.props.name === step )
+			? children.find( ( stepComponent ) => stepComponent.props.name === step )
 			: children;
 
 		return nextStep || null;

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -10,7 +10,7 @@ import jetpackVideoHosting from 'calypso/layout/guided-tours/tours/jetpack-video
 import marketingConnectionsTour from 'calypso/layout/guided-tours/tours/marketing-connections-tour/meta';
 import mediaBasicsTour from 'calypso/layout/guided-tours/tours/media-basics-tour/meta';
 
-export default {
+export default [
 	checklistSiteTitle,
 	jetpackChecklist,
 	jetpackLazyImages,
@@ -22,4 +22,4 @@ export default {
 	jetpackVideoHosting,
 	marketingConnectionsTour,
 	mediaBasicsTour,
-};
+];

--- a/client/layout/guided-tours/positioning.ts
+++ b/client/layout/guided-tours/positioning.ts
@@ -1,5 +1,4 @@
 import { isMobile } from '@automattic/viewport';
-import { find, startsWith } from 'lodash';
 import { CSSProperties } from 'react';
 import scrollTo from 'calypso/lib/scroll-to';
 import { Coordinate, DialogPosition, ArrowPosition } from './types';
@@ -101,7 +100,7 @@ export function targetForSlug( targetSlug?: string ) {
 		: `[data-tip-target="${ targetSlug }"]`;
 
 	const targetEls = query( cssSelector );
-	return find( targetEls, hasNonEmptyClientRect ) || null;
+	return targetEls.find( hasNonEmptyClientRect ) || null;
 }
 
 export function getValidatedArrowPosition( {
@@ -130,7 +129,8 @@ export function getValidatedArrowPosition( {
 	}
 
 	if (
-		( startsWith( arrow, 'left' ) || startsWith( arrow, 'right' ) ) &&
+		arrow &&
+		( arrow.startsWith( 'left' ) || arrow.startsWith( 'right' ) ) &&
 		DIALOG_WIDTH > 0.98 * document.documentElement.clientWidth
 	) {
 		// window not wide enough for adding an arrow

--- a/client/layout/guided-tours/tour-branching.js
+++ b/client/layout/guided-tours/tour-branching.js
@@ -1,4 +1,3 @@
-import { flatMap } from 'lodash';
 import { Children } from 'react';
 
 /*
@@ -61,7 +60,7 @@ const branching = ( element ) => {
 		return [ [ typeName.toLowerCase(), element.props.step ] ];
 	}
 
-	return flatMap( childrenToArray( element.props.children ), branching );
+	return childrenToArray( element.props.children ).flatMap( branching );
 };
 
 /*

--- a/client/state/guided-tours/reducer.js
+++ b/client/state/guided-tours/reducer.js
@@ -1,5 +1,4 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { omit } from 'lodash';
 import {
 	GUIDED_TOUR_UPDATE,
 	GUIDED_TOUR_PAUSE,
@@ -10,8 +9,10 @@ export function guidedTours( state = {}, action ) {
 	switch ( action.type ) {
 		case GUIDED_TOUR_UPDATE:
 		case GUIDED_TOUR_PAUSE:
-		case GUIDED_TOUR_RESUME:
-			return Object.assign( {}, state, omit( action, 'type' ) );
+		case GUIDED_TOUR_RESUME: {
+			const { type, ...update } = action;
+			return { ...state, ...update };
+		}
 	}
 	return state;
 }

--- a/client/state/guided-tours/selectors/find-ongoing-tour.js
+++ b/client/state/guided-tours/selectors/find-ongoing-tour.js
@@ -1,4 +1,3 @@
-import { findLast } from 'lodash';
 import { GUIDED_TOUR_UPDATE } from 'calypso/state/action-types';
 import { getActionLog } from 'calypso/state/ui/action-log/selectors';
 
@@ -9,6 +8,8 @@ import 'calypso/state/guided-tours/init';
  * yet finished or dimissed according to the action log.
  */
 export default ( state ) => {
-	const last = findLast( getActionLog( state ), { type: GUIDED_TOUR_UPDATE } );
+	const last = getActionLog( state )
+		.reverse()
+		.find( ( action ) => action.type === GUIDED_TOUR_UPDATE );
 	return last && last.shouldShow === undefined && last.tour;
 };

--- a/client/state/guided-tours/selectors/index.js
+++ b/client/state/guided-tours/selectors/index.js
@@ -1,6 +1,6 @@
 import { createSelector } from '@automattic/state-utils';
 import debugFactory from 'debug';
-import GuidedToursConfig from 'calypso/layout/guided-tours/config';
+import guidedToursConfig from 'calypso/layout/guided-tours/config';
 import { GUIDED_TOUR_UPDATE, ROUTE_SET } from 'calypso/state/action-types';
 import { preferencesLastFetchedTimestamp } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -45,12 +45,11 @@ const getToursFromFeaturesReached = createSelector(
 			.filter( ( { type } ) => type === ROUTE_SET )
 			.reverse();
 		// find tours that match by route path
-		const tourEntries = Object.entries( GuidedToursConfig );
 		const matchingTours = navigationActions.flatMap( ( action ) =>
-			tourEntries.filter( ( [ , meta ] ) => tourMatchesPath( meta, action.path ) )
+			guidedToursConfig.filter( ( tour ) => tourMatchesPath( tour, action.path ) )
 		);
 		// return array of tour names
-		return matchingTours.map( ( [ tour ] ) => tour );
+		return matchingTours.map( ( tour ) => tour.name );
 	},
 	[ getActionLog ]
 );
@@ -75,7 +74,7 @@ const getTourFromQuery = createSelector(
 		const timestamp = getCurrentRouteTimestamp( state );
 		const tour = current.tour ?? initial.tour;
 
-		if ( tour && GuidedToursConfig[ tour ] ) {
+		if ( tour && guidedToursConfig.some( ( { name } ) => name === tour ) ) {
 			return { tour, timestamp };
 		}
 	},
@@ -117,7 +116,7 @@ const findTriggeredTour = ( state ) => {
 	const toursToDismiss = getToursSeen( state );
 	const newTours = toursFromTriggers.filter( ( tour ) => ! toursToDismiss.includes( tour ) );
 	return newTours.find( ( tour ) => {
-		const { when = () => true } = GuidedToursConfig[ tour ];
+		const { when = () => true } = guidedToursConfig.find( ( { name } ) => name === tour );
 		return when( state );
 	} );
 };

--- a/client/state/guided-tours/test/fixtures/config.js
+++ b/client/state/guided-tours/test/fixtures/config.js
@@ -2,36 +2,28 @@ import { isNewUser } from 'calypso/state/guided-tours/contexts';
 
 const stubTrue = () => true;
 
-export const MainTourMeta = {
-	name: 'main',
-	version: 'test',
-	path: '/',
-	when: isNewUser,
-};
-
-export const ThemesTourMeta = {
-	name: 'themes',
-	version: 'test',
-	path: '/themes',
-	when: stubTrue,
-};
-
-export const StatsTourMeta = {
-	name: 'stats',
-	version: 'test',
-	path: '/stats',
-};
-
-export const TestTourMeta = {
-	name: 'test',
-	version: 'test',
-	path: [ '/test', '/foo' ],
-	when: stubTrue,
-};
-
-export default {
-	main: MainTourMeta,
-	themes: ThemesTourMeta,
-	stats: StatsTourMeta,
-	test: TestTourMeta,
-};
+export default [
+	{
+		name: 'main',
+		version: 'test',
+		path: '/',
+		when: isNewUser,
+	},
+	{
+		name: 'themes',
+		version: 'test',
+		path: '/themes',
+		when: stubTrue,
+	},
+	{
+		name: 'stats',
+		version: 'test',
+		path: '/stats',
+	},
+	{
+		name: 'test',
+		version: 'test',
+		path: [ '/test', '/foo' ],
+		when: stubTrue,
+	},
+];

--- a/client/state/guided-tours/test/selectors.js
+++ b/client/state/guided-tours/test/selectors.js
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { expect } from 'chai';
-import { times } from 'lodash';
 import { findEligibleTour, getGuidedTourState, hasTourJustBeenVisible } from '../selectors';
 
 jest.mock( 'calypso/layout/guided-tours/config', () => {
@@ -14,7 +12,7 @@ describe( 'selectors', () => {
 	describe( '#hasTourJustBeenVisible', () => {
 		test( 'should return false when no tour has been seen', () => {
 			const state = { ui: { actionLog: [] } };
-			expect( hasTourJustBeenVisible( state ) ).to.be.undefined;
+			expect( hasTourJustBeenVisible( state ) ).toBeUndefined();
 		} );
 
 		test( 'should return true when a tour has just been seen', () => {
@@ -30,7 +28,7 @@ describe( 'selectors', () => {
 					],
 				},
 			};
-			expect( hasTourJustBeenVisible( state, now ) ).to.be.true;
+			expect( hasTourJustBeenVisible( state, now ) ).toBe( true );
 		} );
 
 		test( 'should return false when a tour has been seen longer ago', () => {
@@ -46,7 +44,7 @@ describe( 'selectors', () => {
 					],
 				},
 			};
-			expect( hasTourJustBeenVisible( state, now ) ).to.not.be.ok;
+			expect( hasTourJustBeenVisible( state, now ) ).toBe( false );
 		} );
 	} );
 
@@ -72,7 +70,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( tourState ).to.deep.equal( { shouldShow: false } );
+			expect( tourState ).toEqual( { shouldShow: false } );
 		} );
 	} );
 	describe( '#findEligibleTour()', () => {
@@ -155,13 +153,13 @@ describe( 'selectors', () => {
 			const state = makeState( { actionLog: [ { type: 'IRRELEVANT' } ] } );
 			const tour = findEligibleTour( state );
 
-			expect( tour ).to.equal( undefined );
+			expect( tour ).toBeUndefined();
 		} );
 		test( 'should find `themes` when applicable', () => {
 			const state = makeState( { actionLog: [ navigateToThemes ] } );
 			const tour = findEligibleTour( state );
 
-			expect( tour ).to.equal( 'themes' );
+			expect( tour ).toBe( 'themes' );
 		} );
 		test( 'should not find `themes` if previously seen', () => {
 			const state = makeState( {
@@ -171,7 +169,7 @@ describe( 'selectors', () => {
 
 			const tour = findEligibleTour( state );
 
-			expect( tour ).to.equal( undefined );
+			expect( tour ).toBeUndefined();
 		} );
 		test( 'should see to it that an ongoing tour is selected', () => {
 			const havingStartedTour = makeState( {
@@ -181,8 +179,8 @@ describe( 'selectors', () => {
 				actionLog: [ mainTourStarted, mainTourAborted, navigateToThemes ],
 			} );
 
-			expect( findEligibleTour( havingStartedTour ) ).to.equal( 'main' );
-			expect( findEligibleTour( havingQuitTour ) ).to.equal( 'themes' );
+			expect( findEligibleTour( havingStartedTour ) ).toBe( 'main' );
+			expect( findEligibleTour( havingQuitTour ) ).toBe( 'themes' );
 		} );
 		test( 'should favor a tour launched via query arguments', () => {
 			const state = makeState( {
@@ -192,7 +190,7 @@ describe( 'selectors', () => {
 			} );
 			const tour = findEligibleTour( state );
 
-			expect( tour ).to.equal( 'main' );
+			expect( tour ).toBe( 'main' );
 		} );
 		test( 'should dismiss a requested tour at the end', () => {
 			const mainTourJustSeen = {
@@ -208,7 +206,7 @@ describe( 'selectors', () => {
 			} );
 			const tour = findEligibleTour( state );
 
-			expect( tour ).to.equal( undefined );
+			expect( tour ).toBeUndefined();
 		} );
 		test( 'should respect tour "when" conditions', () => {
 			const state = makeState( {
@@ -221,7 +219,7 @@ describe( 'selectors', () => {
 			// to `/`, and `state` satisfies `main`'s "when" condition that the user
 			// should be a new user. In our config, `main` is declared before
 			// `themes`, so the selector should prefer the former.
-			expect( tour ).to.equal( 'main' );
+			expect( tour ).toBe( 'main' );
 		} );
 		test( "shouldn't show a requested tour twice", () => {
 			/*
@@ -230,14 +228,14 @@ describe( 'selectors', () => {
 			 * anymore.
 			 */
 			const state = makeState( {
-				actionLog: times( 50, () => navigateToTest ),
+				actionLog: Array.from( { length: 50 }, () => navigateToTest ),
 				toursHistory: [ testTourSeen, themesTourSeen ],
 				queryArguments: { tour: 'themes' },
 				timestamp: 0,
 			} );
 			const tour = findEligibleTour( state );
 
-			expect( tour ).to.equal( undefined );
+			expect( tour ).toBeUndefined();
 		} );
 		test( 'should bail if user preferences are stale', () => {
 			const state = makeState( {
@@ -247,7 +245,7 @@ describe( 'selectors', () => {
 			delete state.preferences.lastFetchedTimestamp;
 			const tour = findEligibleTour( state );
 
-			expect( tour ).to.equal( undefined );
+			expect( tour ).toBeUndefined();
 		} );
 		describe( 'picking a tour based on the most recent actions', () => {
 			test( 'should pick `themes`', () => {
@@ -256,7 +254,7 @@ describe( 'selectors', () => {
 				} );
 				const tour = findEligibleTour( state );
 
-				expect( tour ).to.equal( 'test' );
+				expect( tour ).toBe( 'test' );
 			} );
 			test( 'should pick `test`', () => {
 				const state = makeState( {
@@ -264,7 +262,7 @@ describe( 'selectors', () => {
 				} );
 				const tour = findEligibleTour( state );
 
-				expect( tour ).to.equal( 'themes' );
+				expect( tour ).toBe( 'themes' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Removes most Lodash usages from `client/state/guided-tours` and `client/layout/guided-tours`.

The most complex replacement is removal of the `relevantFeatures` variable in `selectors`. It transforms `GuidedToursConfig` data structure to another form: from object with keys:
```js
{
  tourFoo: { path: [ 'a', 'b' ], when: check }
}
```
to an array where every `path` element is expanded into a duplicate item:
```js
[
  { tour: 'tourFoo', path: 'a', when: check },
  { tour: 'tourFoo', path: 'b', when: check },
]
```
I'm rewriting all code that used `relevantFeatures` to work on the `GuidedToursConfig` object directly.

**How to test:**
Verify that unit tests pass, and that guided tours can be started and walked through.