### PR TITLE
Plugin Details: Fix back button in Safari

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -42,10 +42,6 @@ import { isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors'
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
 
-function goBack() {
-	window.history.back();
-}
-
 class SinglePlugin extends Component {
 	UNSAFE_componentWillMount() {
 		if ( ! this.isFetched() ) {
@@ -95,7 +91,7 @@ class SinglePlugin extends Component {
 		if ( prevPath ) {
 			return this.getPreviousListUrl();
 		}
-		return ! shouldUseHistoryBack ? '/plugins/manage/' + ( siteUrl || '' ) : null;
+		return ! shouldUseHistoryBack ? '/plugins/' + ( siteUrl || '' ) : null;
 	};
 
 	displayHeader() {
@@ -111,7 +107,6 @@ class SinglePlugin extends Component {
 				isCompact={ true }
 				backHref={ this.backHref( shouldUseHistoryBack ) }
 				onBackArrowClick={ recordEvent }
-				onClick={ shouldUseHistoryBack ? goBack : undefined }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
+import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -86,12 +87,13 @@ class SinglePlugin extends Component {
 		);
 	}
 
-	backHref = ( shouldUseHistoryBack ) => {
-		const { prevPath, siteUrl } = this.props;
+	goBack = () => {
+		const { prevPath, siteUrl, navigated } = this.props;
+		const shouldUseHistoryBack = window.history.length > 1 && navigated;
 		if ( prevPath ) {
-			return this.getPreviousListUrl();
+			return page( this.getPreviousListUrl() );
 		}
-		return ! shouldUseHistoryBack ? '/plugins/' + ( siteUrl || '' ) : null;
+		return ! shouldUseHistoryBack ? page( `/plugins/${ siteUrl || '' }` ) : window.history.back();
 	};
 
 	displayHeader() {
@@ -100,14 +102,9 @@ class SinglePlugin extends Component {
 		}
 
 		const recordEvent = this.recordEvent.bind( this, 'Clicked Header Plugin Back Arrow' );
-		const { navigated } = this.props;
-		const shouldUseHistoryBack = window.history.length > 1 && navigated;
+
 		return (
-			<HeaderCake
-				isCompact={ true }
-				backHref={ this.backHref( shouldUseHistoryBack ) }
-				onBackArrowClick={ recordEvent }
-			/>
+			<HeaderCake isCompact={ true } onBackArrowClick={ recordEvent } onClick={ this.goBack } />
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Following up on this comment (pdh6GB-80-p2#comment-298) which pointed that the back button doesn't work for the plugin details page in **safari** only. The element had both an `href` and a `onClick` callback for the last 3 years (#26762). _I am not sure if the experience was broken since then or why did chrome manage to work as we would like._

* Removed the `backHref` and consolidated it's functionality to the `onClick` callback

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/activity-log/` of an Atomic site
- Click a plugin from the log, you should get the plugin details page
- Click back, you should go back to the activity log
- Go to `/plugins/` of an Atomic site
- Click a plugin, you should get the plugin details page
- Click back, you should go back to the plugins screen


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh6GB-80-p2#comment-298