### PR TITLE
Sidebar: Set `return` param only on "Appearance > Customizer"

### DIFF
--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -23,10 +23,11 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 		url?.replace( /^https?:\/\//, '' )
 	);
 
-	if ( isSafeWpAdminUrl ) {
+	// Gives WP Admin Customizer a chance to return to where we started from.
+	if ( isSafeWpAdminUrl && url.includes( 'wp-admin/customize.php' ) ) {
 		url = addQueryArgs(
 			{
-				return: document.location.href, // Gives WP Admin a chance to return to where we started from.
+				return: document.location.href,
 			},
 			url
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/54204.

#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/50586 we added a `return` param to all the menu items that point to a WP Admin screen in order to allow users who access the Customizer to go back to Calypso after closing it.

We added the `return` param to all the menu items rather than specifically to the "Appearance > Customizer" menu item as a way of preemptively supporting the same behavior in other WP Admin pages. However, some WP Admin screens like `upload.php` present issues when an unexpected param is set in the URL.

To prevent these issues, this PR ensures that the `return` param is only set for the "Appearance > Customizer" menu item which is the only screen we know so far that supports the `return` param.

Note: To fully prevent the issues, we also need [this companion Jetpack PR](https://github.com/Automattic/jetpack/pull/21632).

#### Testing instructions

- Prepare the testing environment:
  - Simple sites: Apply D69415-code and D69520-code to your WP.com sandbox, and sandbox both the API and a Simple site.
  - Atomic sites: Install Jetpack Beta and switch to the `remove/nav-unification-preferred-view-param` branch
- Open the Calypso live link below.
- Make sure that "Appearance > Customizer" link still contains a `return` param.
- Make sure that other menu items linking to WP Admin pages (e.g. "Settings > Reading") don't include the `return` param.
- Go to "Media > Add new".
- Open the "Screen Options" tab and switch to the classic view.
- Make sure the `return` param is not present in the URL.
- Make sure you can successfully upload a new media item, and the loading bar shows up during the upload.


