### PR TITLE
i18n: Add an hreflang block to the login page

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -9,12 +9,7 @@ import { ssrSetupLocaleMiddleware } from './ssr-setup-locale.js';
 /**
  * Re-export
  */
-export {
-	setSectionMiddleware,
-	setLocaleMiddleware,
-	setLocalizedCanonicalUrl,
-	setHrefLangLinks,
-} from './shared.js';
+export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
 
 /**
  * Server side rendering (SSR) is used exclusively for logged out users. Normally, for

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -1,21 +1,20 @@
-import config from '@automattic/calypso-config';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { getLocaleSlug } from 'i18n-calypso';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { RouteProvider } from 'calypso/components/route';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
-import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
 import { makeLayoutMiddleware } from './shared.js';
 import { ssrSetupLocaleMiddleware } from './ssr-setup-locale.js';
 
 /**
  * Re-export
  */
-export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
+export {
+	setSectionMiddleware,
+	setLocaleMiddleware,
+	setLocalizedCanonicalUrl,
+	setHrefLangLinks,
+} from './shared.js';
 
 /**
  * Server side rendering (SSR) is used exclusively for logged out users. Normally, for
@@ -73,64 +72,6 @@ const ProviderWrappedLoggedOutLayout = ( {
 export const makeLayout = makeLayoutMiddleware( ProviderWrappedLoggedOutLayout );
 
 export const ssrSetupLocale = ssrSetupLocaleMiddleware();
-
-const getLocalizedCanonicalUrl = ( path, locale ) => {
-	const baseUrl = `https://wordpress.com${ path }`;
-	const baseUrlWithoutLang = baseUrl.replace(
-		new RegExp( `\\/(${ getLanguageSlugs().join( '|' ) })(\\/|\\?|$)` ),
-		'$2'
-	);
-	let localizedUrl = localizeUrl( baseUrlWithoutLang, locale, false );
-
-	// Remove the trailing slash if `path` doesn't have one either.
-	if ( path.slice( -1 ) !== '/' && localizedUrl.slice( -1 ) === '/' ) {
-		localizedUrl = localizedUrl.slice( 0, -1 );
-	}
-
-	return localizedUrl;
-};
-
-export const setHrefLangLinks = ( context, next ) => {
-	if ( isUserLoggedIn( context.store.getState() ) ) {
-		next();
-		return;
-	}
-
-	const langCodes = [ 'x-default', 'en', ...config( 'magnificent_non_en_locales' ) ];
-	const hrefLangBlock = langCodes.map( ( hrefLang ) => {
-		let localeSlug = hrefLang;
-
-		if ( localeSlug === 'x-default' ) {
-			localeSlug = config( 'i18n_default_locale_slug' );
-		}
-
-		const href = getLocalizedCanonicalUrl( context.res.req.originalUrl, localeSlug );
-		return {
-			rel: 'alternate',
-			hrefLang,
-			href,
-		};
-	} );
-
-	context.store.dispatch( setDocumentHeadLink( hrefLangBlock ) );
-	next();
-};
-
-export const setLocalizedCanonicalUrl = ( context, next ) => {
-	if ( isUserLoggedIn( context.store.getState() ) ) {
-		next();
-		return;
-	}
-
-	const href = getLocalizedCanonicalUrl( context.res.req.originalUrl, getLocaleSlug() );
-	const link = {
-		rel: 'canonical',
-		href,
-	};
-
-	context.store.dispatch( setDocumentHeadLink( link ) );
-	next();
-};
 
 /**
  * These functions are not used by Node. It is here to provide an APi compatible with `./index.web.js`

--- a/client/controller/localized-links.js
+++ b/client/controller/localized-links.js
@@ -1,0 +1,64 @@
+import config from '@automattic/calypso-config';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { getLocaleSlug } from 'i18n-calypso';
+import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
+
+const getLocalizedCanonicalUrl = ( path, locale ) => {
+	const baseUrl = `https://wordpress.com${ path }`;
+	const baseUrlWithoutLang = baseUrl.replace(
+		new RegExp( `\\/(${ getLanguageSlugs().join( '|' ) })(\\/|\\?|$)` ),
+		'$2'
+	);
+	let localizedUrl = localizeUrl( baseUrlWithoutLang, locale, false );
+
+	// Remove the trailing slash if `path` doesn't have one either.
+	if ( ! path.endsWith( '/' ) && localizedUrl.endsWith( '/' ) ) {
+		localizedUrl = localizedUrl.slice( 0, -1 );
+	}
+
+	return localizedUrl;
+};
+
+export const setLocalizedCanonicalUrl = ( context, next ) => {
+	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
+		next();
+		return;
+	}
+
+	const href = getLocalizedCanonicalUrl( context.originalUrl, getLocaleSlug() );
+	const link = {
+		rel: 'canonical',
+		href,
+	};
+
+	context.store.dispatch( setDocumentHeadLink( link ) );
+	next();
+};
+
+export const setHrefLangLinks = ( context, next ) => {
+	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
+		next();
+		return;
+	}
+
+	const langCodes = [ 'x-default', 'en', ...config( 'magnificent_non_en_locales' ) ];
+	const hrefLangBlock = langCodes.map( ( hrefLang ) => {
+		let localeSlug = hrefLang;
+
+		if ( localeSlug === 'x-default' ) {
+			localeSlug = config( 'i18n_default_locale_slug' );
+		}
+
+		const href = getLocalizedCanonicalUrl( context.originalUrl, localeSlug );
+		return {
+			rel: 'alternate',
+			hrefLang,
+			href,
+		};
+	} );
+
+	context.store.dispatch( setDocumentHeadLink( hrefLangBlock ) );
+	next();
+};

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -1,10 +1,6 @@
 import config from '@automattic/calypso-config';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { getLocaleSlug } from 'i18n-calypso';
-import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
 import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
 import { setSection } from 'calypso/state/ui/actions';
 import { setLocale } from 'calypso/state/ui/language/actions';
 
@@ -83,61 +79,3 @@ export function composeHandlers( ...handlers ) {
 		handleNext();
 	};
 }
-
-const getLocalizedCanonicalUrl = ( path, locale ) => {
-	const baseUrl = `https://wordpress.com${ path }`;
-	const baseUrlWithoutLang = baseUrl.replace(
-		new RegExp( `\\/(${ getLanguageSlugs().join( '|' ) })(\\/|\\?|$)` ),
-		'$2'
-	);
-	let localizedUrl = localizeUrl( baseUrlWithoutLang, locale, false );
-
-	// Remove the trailing slash if `path` doesn't have one either.
-	if ( path.slice( -1 ) !== '/' && localizedUrl.slice( -1 ) === '/' ) {
-		localizedUrl = localizedUrl.slice( 0, -1 );
-	}
-
-	return localizedUrl;
-};
-
-export const setLocalizedCanonicalUrl = ( context, next ) => {
-	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
-		next();
-		return;
-	}
-
-	const href = getLocalizedCanonicalUrl( context.originalUrl, getLocaleSlug() );
-	const link = {
-		rel: 'canonical',
-		href,
-	};
-
-	context.store.dispatch( setDocumentHeadLink( link ) );
-	next();
-};
-
-export const setHrefLangLinks = ( context, next ) => {
-	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
-		next();
-		return;
-	}
-
-	const langCodes = [ 'x-default', 'en', ...config( 'magnificent_non_en_locales' ) ];
-	const hrefLangBlock = langCodes.map( ( hrefLang ) => {
-		let localeSlug = hrefLang;
-
-		if ( localeSlug === 'x-default' ) {
-			localeSlug = config( 'i18n_default_locale_slug' );
-		}
-
-		const href = getLocalizedCanonicalUrl( context.originalUrl, localeSlug );
-		return {
-			rel: 'alternate',
-			hrefLang,
-			href,
-		};
-	} );
-
-	context.store.dispatch( setDocumentHeadLink( hrefLangBlock ) );
-	next();
-};

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -1,10 +1,8 @@
 import config from '@automattic/calypso-config';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { getLocaleSlug } from 'i18n-calypso';
-import {
-	isTranslatedIncompletely,
-	getLanguageSlugs,
-	localizeUrl,
-} from 'calypso/lib/i18n-utils/utils';
+import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
+import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
 import { setSection } from 'calypso/state/ui/actions';

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -101,7 +101,7 @@ const getLocalizedCanonicalUrl = ( path, locale ) => {
 };
 
 export const setLocalizedCanonicalUrl = ( context, next ) => {
-	if ( isUserLoggedIn( context.store.getState() ) ) {
+	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
 		next();
 		return;
 	}

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -5,6 +5,7 @@ import {
 	setLocaleMiddleware,
 	setSectionMiddleware,
 	makeLayoutMiddleware,
+	setHrefLangLinks,
 } from 'calypso/controller/shared';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
@@ -87,6 +88,7 @@ export default ( router ) => {
 		redirectJetpack,
 		redirectDefaultLocale,
 		setLocaleMiddleware,
+		setHrefLangLinks,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		login,
 		setShouldServerSideRenderLogin,

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -1,11 +1,11 @@
 import config from '@automattic/calypso-config';
 import { Provider as ReduxProvider } from 'react-redux';
 import { RouteProvider } from 'calypso/components/route';
+import { setHrefLangLinks } from 'calypso/controller/localized-links';
 import {
 	setLocaleMiddleware,
 	setSectionMiddleware,
 	makeLayoutMiddleware,
-	setHrefLangLinks,
 } from 'calypso/controller/shared';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';

--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -1,9 +1,5 @@
-import {
-	makeLayout,
-	ssrSetupLocale,
-	setHrefLangLinks,
-	setLocalizedCanonicalUrl,
-} from 'calypso/controller';
+import { makeLayout, ssrSetupLocale } from 'calypso/controller';
+import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import { details, fetchThemeDetailsData, notFoundError } from './controller';
 

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -1,9 +1,5 @@
-import {
-	makeLayout,
-	ssrSetupLocale,
-	setHrefLangLinks,
-	setLocalizedCanonicalUrl,
-} from 'calypso/controller';
+import { makeLayout, ssrSetupLocale } from 'calypso/controller';
+import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import {
 	fetchThemeData,

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -49,9 +49,10 @@ const setLocalizedWpComPath = (
 	return url;
 };
 
-const prefixLocalizedUrlPath = (
+const prefixOrSuffixLocalizedUrlPath = (
 	validLocales: Locale[] = [],
-	limitPathMatch: RegExp | null = null
+	limitPathMatch: RegExp | null = null,
+	prefixOrSuffix: string
 ) => ( url: URL, localeSlug: Locale ): URL => {
 	if ( typeof limitPathMatch === 'object' && limitPathMatch instanceof RegExp ) {
 		if ( ! limitPathMatch.test( url.pathname ) ) {
@@ -60,9 +61,35 @@ const prefixLocalizedUrlPath = (
 	}
 
 	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
-		url.pathname = localeSlug + url.pathname;
+		if ( prefixOrSuffix === 'prefix' ) {
+			url.pathname = localeSlug + url.pathname;
+		} else if ( prefixOrSuffix === 'suffix' ) {
+			url.pathname = url.pathname + localeSlug;
+		}
 	}
 	return url;
+};
+
+const prefixLocalizedUrlPath = (
+	validLocales: Locale[] = [],
+	limitPathMatch: RegExp | null = null
+) => ( url: URL, localeSlug: Locale ): URL => {
+	return prefixOrSuffixLocalizedUrlPath(
+		validLocales,
+		limitPathMatch,
+		'prefix'
+	)( url, localeSlug );
+};
+
+const suffixLocalizedUrlPath = (
+	validLocales: Locale[] = [],
+	limitPathMatch: RegExp | null = null
+) => ( url: URL, localeSlug: Locale ): URL => {
+	return prefixOrSuffixLocalizedUrlPath(
+		validLocales,
+		limitPathMatch,
+		'suffix'
+	)( url, localeSlug );
 };
 
 type LinkLocalizer = ( url: URL, localeSlug: string, isLoggedIn: boolean ) => URL;
@@ -107,6 +134,9 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 	},
 	'wordpress.com/themes/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+	},
+	'wordpress.com/log-in/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
+		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},
 };
 

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -49,10 +49,12 @@ const setLocalizedWpComPath = (
 	return url;
 };
 
+type PrefixOrSuffix = 'prefix' | 'suffix';
+
 const prefixOrSuffixLocalizedUrlPath = (
 	validLocales: Locale[] = [],
 	limitPathMatch: RegExp | null = null,
-	prefixOrSuffix: string
+	prefixOrSuffix: PrefixOrSuffix
 ) => ( url: URL, localeSlug: Locale ): URL => {
 	if ( typeof limitPathMatch === 'object' && limitPathMatch instanceof RegExp ) {
 		if ( ! limitPathMatch.test( url.pathname ) ) {

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -62,11 +62,19 @@ const prefixOrSuffixLocalizedUrlPath = (
 		}
 	}
 
-	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
-		if ( prefixOrSuffix === 'prefix' ) {
-			url.pathname = localeSlug + url.pathname;
-		} else if ( prefixOrSuffix === 'suffix' ) {
-			url.pathname = url.pathname + localeSlug;
+	if ( ! validLocales.includes( localeSlug ) || localeSlug === 'en' ) {
+		return url;
+	}
+
+	if ( prefixOrSuffix === 'prefix' ) {
+		url.pathname = localeSlug + url.pathname;
+	} else if ( prefixOrSuffix === 'suffix' ) {
+		// Make sure there's a slash between the path and the locale. Plus, if
+		// the path has a trailing slash, add one after the suffix too.
+		if ( url.pathname.endsWith( '/' ) ) {
+			url.pathname += localeSlug + '/';
+		} else {
+			url.pathname += '/' + localeSlug;
 		}
 	}
 	return url;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
I've added an hreflang block to the login page using the existing `setHrefLangLinks` middleware function.

Implementation notes:
* I've moved the `getLocalizedCanonicalUrl`, `setLocalizedCanonicalUrl`, and `setHrefLangLinks` functions from `controller/index.node.js` to a new `controller/localized-links.js` module, so that:
  * They can easily be used in both `index.node.js` (as we already did on /themes and theme details pages) and `index.web.js` (as proposed here for the login page).
  * They're only bundled in the sections that need them.
* I’ve added `wordpress.com/log-in/` as a separate case to `urlLocalizationMapping` because on /log-in, the locale is _appended_ to the path instead of _prepended_ (e.g. http://calypso.localhost:3000/log-in/es). 
  * I've made a `suffixLocalizedUrlPath` function (similar to `prefixLocalizedUrlPath`) in case other routes would want to do the same thing later on. It takes trailing slashes into account.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Browse to http://calypso.localhost:3000/log-in while logged out, and verify that there are 18 hreflang links: the Mag-16, ‘en’ and ‘x-default’.
2. Browse to the login page for other locales on calypso.localhost (e.g. http://calypso.localhost:3000/log-in/es) and verify that the same hreflang block is displayed.
3. Verify that logging in still works.
4. Repeat steps 1 and 2 for the theme showcase (http://calypso.localhost:3000/themes) and for a theme details page (e.g. http://calypso.localhost:3000/theme/quadrat), to check for regression issues caused by moving the middleware functions to `controller/localized-links.js`.
5. Though the above steps already check that both prefixing (in themes) and suffixing works (in login), check some more localized links for regression issues in `localizeUrl` now that the `prefixLocalizedUrlPath` function has been refactored.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to 347-gh-Automattic/i18n-issues