### PR TITLE
Playwright: Support gutenberg and coblocks edge in e2e specs

### DIFF
--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -98,6 +98,15 @@ export function targetGutenbergEdge(): boolean {
 }
 
 /**
+ * Returns boolean indicating whether this test run should target a CoBlocks Edge user and site.
+ *
+ * @returns {boolean} True if should target Coblocks edge. False otherwise.
+ */
+export function targetCoBlocksEdge(): boolean {
+	return !! process.env.COBLOCKS_EDGE;
+}
+
+/**
  * Returns the default Logger configuration.
  *
  * The default Logger configuration has the following:

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks-gutter-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks-gutter-spec.ts
@@ -9,6 +9,7 @@ import {
 	NewPostFlow,
 	GutenbergEditorPage,
 	PricingTableBlock,
+	BrowserHelper,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
@@ -17,13 +18,22 @@ describe( DataHelper.createSuiteTitle( 'WPCOM-specific gutter controls' ), () =>
 	let pricingTableBlock: PricingTableBlock;
 	let page: Page;
 
+	let user: string;
+	if ( BrowserHelper.targetCoBlocksEdge() ) {
+		user = 'coBlocksSimpleSiteEdgeUser';
+	} else if ( BrowserHelper.targetGutenbergEdge() ) {
+		user = 'gutenbergSimpleSiteEdgeUser';
+	} else {
+		user = 'gutenbergSimpleSiteUser';
+	}
+
 	setupHooks( ( args ) => {
 		page = args.page;
 	} );
 
 	it( 'Log in', async function () {
 		const loginPage = new LoginPage( page );
-		await loginPage.login( { account: 'gutenbergSimpleSiteUser' } );
+		await loginPage.login( { account: user } );
 	} );
 
 	it( 'Start new post', async function () {

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
@@ -15,6 +15,7 @@ import {
 	ClicktoTweetBlock,
 	LogosBlock,
 	TestFile,
+	BrowserHelper,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
@@ -24,6 +25,15 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), function () {
 	let pricingTableBlock: PricingTableBlock;
 	let page: Page;
 	let logoImage: TestFile;
+
+	let user: string;
+	if ( BrowserHelper.targetCoBlocksEdge() ) {
+		user = 'coBlocksSimpleSiteEdgeUser';
+	} else if ( BrowserHelper.targetGutenbergEdge() ) {
+		user = 'gutenbergSimpleSiteEdgeUser';
+	} else {
+		user = 'gutenbergSimpleSiteUser';
+	}
 
 	// Test data
 	const pricingTableBlockPrice = 888;
@@ -41,7 +51,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), function () {
 
 	it( 'Log in', async function () {
 		const loginPage = new LoginPage( page );
-		await loginPage.login( { account: 'gutenbergSimpleSiteUser' } );
+		await loginPage.login( { account: user } );
 	} );
 
 	it( 'Start new post', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, the coblocks specs didn't support the GUTENBERG_EDGE and COBLOCKS_EDGE env variables. 

Now they do, using the correct blog/users when they are set!

#### Testing instructions

- [ ] `GUTENBERG_EDGE=true yarn jest specs/specs-playwrights/wp-blocks__coblocks.ts`
- [ ] `COBLOCKS_EDGE=true yarn jest specs/specs-playwrights/wp-blocks__coblocks.ts`
- [ ] `GUTENBERG_EDGE=true yarn jest specs/specs-playwrights/wp-blocks__coblocks-gutter-spec.ts`
- [ ] `COBLOCKS_EDGE=true yarn jest specs/specs-playwrights/wp-blocks__coblocks-gutter-spec.ts`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #55837
