### PR TITLE
Video UI: Trigger a new video to play when clicking a "Play" button

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -69,6 +69,13 @@
 
 		.videos-ui__video {
 			margin-bottom: 30px;
+			flex-basis: auto;
+			width: 60%;
+
+			video {
+				width: 100%;
+				height: auto;
+			}
 		}
 
 		.videos-ui__chapters {


### PR DESCRIPTION
This PR implements the 'Play' functionality.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/140165974-8728a9d0-08d3-467b-8084-d15a087b1dfd.png) | ![2021-11-03 14 56 35](https://user-images.githubusercontent.com/375980/140166085-9f24b490-bf36-45a5-b06b-50bec4f56143.gif) |

#### Testing
1. This PR still does not load the UI anywhere (as it will be added as a modal in the work being done for #57326).
1. However, it can be tested by importing the VideosUi component anywhere in Calypso. (I have been testing it as a block on the home page for this initial development pass.).
1. Verify the play button loads the correct video.

ref: https://github.com/Automattic/wp-calypso/issues/57574