### PR TITLE
Playwright: wrap calls in Promise.all construct and wait for element stability prior to clicking on Visit Article button.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -165,22 +165,17 @@ export class SupportComponent {
 	}
 
 	/**
-	 * Click on the `Read More` button shown on the support popover.
-	 *
-	 * The target button is shown only for Article type results.
-	 */
-	async clickReadMore(): Promise< void > {
-		await this.page.click( selectors.readMoreButton );
-	}
-
-	/**
 	 * Visit the support article from the inline support popover.
 	 *
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
-		// Wait for the placeholder to disappear from the Support article preview.
-		await this.page.waitForSelector( selectors.supportArticlePlaceholder, { state: 'hidden' } );
+		const visitArticleHandle = await this.page.waitForSelector( selectors.visitArticleButton );
+		await Promise.all( [
+			visitArticleHandle.waitForElementState( 'stable' ),
+			this.page.waitForSelector( selectors.supportArticlePlaceholder, { state: 'hidden' } ),
+			this.page.click( selectors.readMoreButton ),
+		] );
 
 		const browserContext = this.page.context();
 		// `Visit article` launches a new page.

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -170,12 +170,12 @@ export class SupportComponent {
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
-		const visitArticleHandle = await this.page.waitForSelector( selectors.visitArticleButton );
 		await Promise.all( [
-			visitArticleHandle.waitForElementState( 'stable' ),
 			this.page.waitForSelector( selectors.supportArticlePlaceholder, { state: 'hidden' } ),
 			this.page.click( selectors.readMoreButton ),
 		] );
+		const visitArticleHandle = await this.page.waitForSelector( selectors.visitArticleButton );
+		await visitArticleHandle.waitForElementState( 'stable' );
 
 		const browserContext = this.page.context();
 		// `Visit article` launches a new page.

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -165,15 +165,23 @@ export class SupportComponent {
 	}
 
 	/**
+	 * Click on the `Read More` button shown on the support popover.
+	 *
+	 * The target button is shown only for Article type results.
+	 */
+	async clickReadMore(): Promise< void > {
+		await Promise.all( [
+			this.page.waitForSelector( selectors.supportArticlePlaceholder, { state: 'hidden' } ),
+			this.page.click( selectors.readMoreButton ),
+		] );
+	}
+
+	/**
 	 * Visit the support article from the inline support popover.
 	 *
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
-		await Promise.all( [
-			this.page.waitForSelector( selectors.supportArticlePlaceholder, { state: 'hidden' } ),
-			this.page.click( selectors.readMoreButton ),
-		] );
 		const visitArticleHandle = await this.page.waitForSelector( selectors.visitArticleButton );
 		await visitArticleHandle.waitForElementState( 'stable' );
 

--- a/test/e2e/specs/specs-playwright/wp-support__popover-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-spec.ts
@@ -56,7 +56,6 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 
 		it( 'Click and visit first support article', async function () {
 			await supportComponent.clickResult( 'article', 1 );
-			await supportComponent.clickReadMore();
 			// Obtain handle to the popup page.
 			supportArticlePage = await supportComponent.visitArticle();
 		} );

--- a/test/e2e/specs/specs-playwright/wp-support__popover-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-spec.ts
@@ -56,6 +56,7 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 
 		it( 'Click and visit first support article', async function () {
 			await supportComponent.clickResult( 'article', 1 );
+			await supportComponent.clickReadMore();
 			// Obtain handle to the popup page.
 			supportArticlePage = await supportComponent.visitArticle();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes further changes to `SupportComponent` to stamp out some more flakiness.

Key changes:
- including the call to ensure `placeholder` elements are removed from DOM in the `clickReadMore` method.
- waiting for the `visitArticleButton` to be stable prior to clicking.

Details:
`SupportComponent` is quite reliable but due to some timing issues where Playwright executes too fast, there exists some more rare flakiness.

Firstly, the wait for `placeholder` elements is moved into the `clickReadMore` method, as this action is what triggers the placeholder elements to appear when the modal loads the preview of the article.

Secondly is the addition of `waitForElementState` to the `visitArticleButton` element. 
While the `click` action does wait for stability, it seems that Playwright determines the brief window where the modal loads _with_ the placeholder elements as being stable enough. This is obviously not the case, so adding an explicit wait for stability should resolve matters.

As an aside, Playwright 1.14 introduced an API called `locator`. This differs from an `ElementHandle` in that a `locator` always resolves to an up-to-date element before further actions are executed. This is handy for dealing with situations where React may render an entirely different component after some time.

I think using a `locator` would help address this issue here, but that will be in an upcoming patch (after upgrading Playwright to 1.16).

#### Testing instructions

- [x] stress
  - [x] desktop
  - [x] mobile
- [x] normal
  - [x] desktop
  - [x] mobile

Closes #57615
