### PR TITLE
Blogger Experience - add accordion behavior to videos UI

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -48,6 +48,14 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 		);
 	};
 
+	const onVideoSelected = ( idx ) => {
+		if ( selectedVideoIndex === idx ) {
+			setSelectedVideoIndex( null );
+		} else {
+			setSelectedVideoIndex( idx );
+		}
+	};
+
 	const skipClickHandler = () =>
 		recordTracksEvent( 'calypso_courses_skip_to_draft', {
 			course: course.slug,
@@ -125,30 +133,28 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 											selectedVideoIndex === i ? 'selected ' : ''
 										}videos-ui__chapter` }
 									>
-										<p>
-											<button
-												type="button"
-												className="videos-ui__chapter-accordion-toggle"
-												onClick={ () => setSelectedVideoIndex( i ) }
-											>
-												{ /* to be restored when completion functionality is implmented */ }
-												{ /* <span className="videos-ui__completed">
+										<button
+											type="button"
+											className="videos-ui__chapter-accordion-toggle"
+											onClick={ () => onVideoSelected( i ) }
+										>
+											{ /* to be restored when completion functionality is implmented */ }
+											{ /* <span className="videos-ui__completed">
 											<Gridicon icon="checkmark" size={ 12 } />
 										</span> */ }
-												{ i + 1 }. { video.title }{ ' ' }
-												<span className="videos-ui__duration"> { video.duration } </span>{ ' ' }
-											</button>
-										</p>
+											{ i + 1 }. { video.title }{ ' ' }
+											<span className="videos-ui__duration"> { video.duration } </span>{ ' ' }
+										</button>
 										<div className="videos-ui__active-video-content">
 											<p>{ video.description } </p>
+											<Button
+												className="videos-ui__play-button"
+												onClick={ () => onVideoPlayClick( data[ 0 ] ) }
+											>
+												<Gridicon icon="play" />
+												<span>{ translate( 'Play video' ) }</span>
+											</Button>
 										</div>
-										<Button
-											className="videos-ui__play-button"
-											onClick={ () => onVideoPlayClick( data[ 0 ] ) }
-										>
-											<Gridicon icon="play" />
-											<span>{ translate( 'Play video' ) }</span>
-										</Button>
 									</div>
 								);
 							} ) }

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -8,6 +8,7 @@ import './style.scss';
 const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 	const translate = useTranslate();
 	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );
+	const [ selectedVideoIndex, setSelectedVideoIndex ] = useState( null );
 
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ currentVideo, setCurrentVideo ] = useState( null );
@@ -118,16 +119,33 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 							Object.entries( course.videos ).map( ( data, i ) => {
 								const video = data[ 1 ];
 								return (
-									<div key={ i } className="videos-ui__chapter">
-										<span className="videos-ui__completed">
+									<div
+										key={ i }
+										className={ `${
+											selectedVideoIndex === i ? 'selected ' : ''
+										}videos-ui__chapter` }
+									>
+										<p>
+											<button
+												type="button"
+												className="videos-ui__chapter-accordion-toggle"
+												onClick={ () => setSelectedVideoIndex( i ) }
+											>
+												{ /* to be restored when completion functionality is implmented */ }
+												{ /* <span className="videos-ui__completed">
 											<Gridicon icon="checkmark" size={ 12 } />
-										</span>
-										{ i + 1 }. { video.title }{ ' ' }
-										<span className="videos-ui__duration"> { video.duration } </span>{ ' ' }
+										</span> */ }
+												{ i + 1 }. { video.title }{ ' ' }
+												<span className="videos-ui__duration"> { video.duration } </span>{ ' ' }
+											</button>
+										</p>
 										<div className="videos-ui__active-video-content">
 											<p>{ video.description } </p>
 										</div>
-										<Button onClick={ () => onVideoPlayClick( data[ 0 ] ) }>
+										<Button
+											className="videos-ui__play-button"
+											onClick={ () => onVideoPlayClick( data[ 0 ] ) }
+										>
 											<Gridicon icon="play" />
 											<span>{ translate( 'Play video' ) }</span>
 										</Button>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -48,8 +48,12 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 		);
 	};
 
+	const isVideoSelected = ( idx ) => {
+		return selectedVideoIndex === idx;
+	};
+
 	const onVideoSelected = ( idx ) => {
-		if ( selectedVideoIndex === idx ) {
+		if ( isVideoSelected( idx ) ) {
 			setSelectedVideoIndex( null );
 		} else {
 			setSelectedVideoIndex( idx );
@@ -129,9 +133,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 								return (
 									<div
 										key={ i }
-										className={ `${
-											selectedVideoIndex === i ? 'selected ' : ''
-										}videos-ui__chapter` }
+										className={ `${ isVideoSelected( i ) ? 'selected ' : '' }videos-ui__chapter` }
 									>
 										<button
 											type="button"
@@ -142,6 +144,16 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 											{ /* <span className="videos-ui__completed">
 											<Gridicon icon="checkmark" size={ 12 } />
 										</span> */ }
+											{ isVideoSelected( i ) && (
+												<span className="videos-ui__status-icon">
+													<Gridicon icon="chevron-up" size={ 24 } />
+												</span>
+											) }
+											{ ! isVideoSelected( i ) && (
+												<span className="videos-ui__status-icon">
+													<Gridicon icon="chevron-down" size={ 24 } />
+												</span>
+											) }
 											{ i + 1 }. { video.title }{ ' ' }
 											<span className="videos-ui__duration"> { video.duration } </span>{ ' ' }
 										</button>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -158,14 +158,16 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 											<span className="videos-ui__duration"> { video.duration } </span>{ ' ' }
 										</button>
 										<div className="videos-ui__active-video-content">
-											<p>{ video.description } </p>
-											<Button
-												className="videos-ui__play-button"
-												onClick={ () => onVideoPlayClick( data[ 0 ] ) }
-											>
-												<Gridicon icon="play" />
-												<span>{ translate( 'Play video' ) }</span>
-											</Button>
+											<div>
+												<p>{ video.description } </p>
+												<Button
+													className="videos-ui__play-button"
+													onClick={ () => onVideoPlayClick( data[ 0 ] ) }
+												>
+													<Gridicon icon="play" />
+													<span>{ translate( 'Play video' ) }</span>
+												</Button>
+											</div>
 										</div>
 									</div>
 								);

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -146,12 +146,12 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 										</span> */ }
 											{ isVideoSelected( i ) && (
 												<span className="videos-ui__status-icon">
-													<Gridicon icon="chevron-up" size={ 24 } />
+													<Gridicon icon="chevron-up" size={ 18 } />
 												</span>
 											) }
 											{ ! isVideoSelected( i ) && (
 												<span className="videos-ui__status-icon">
-													<Gridicon icon="chevron-down" size={ 24 } />
+													<Gridicon icon="chevron-down" size={ 18 } />
 												</span>
 											) }
 											{ i + 1 }. { video.title }{ ' ' }

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -94,10 +94,9 @@
 				}
 
 				.videos-ui__status-icon {
-					height: 48px;
+					height: 14px;
 					float: right;
 					text-align: center;
-					line-height: 48px;
 					margin-left: 10px;
 
 					svg {
@@ -111,9 +110,7 @@
 					display: block;
 					width: 100%;
 					text-align: left;
-					height: 48px;
-					line-height: 48px;
-					padding: 0 20px;
+					padding: 20px;
 				}
 
 				.videos-ui__active-video-content {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -84,7 +84,6 @@
 			overflow: auto;
 
 			.videos-ui__chapter {
-				padding: 14px 20px;
 				border-bottom: 1px solid #343c3f;
 
 				&:last-child {
@@ -118,14 +117,26 @@
 					display: block;
 					width: 100%;
 					text-align: left;
+					height: 48px;
+					line-height: 48px;
+					padding: 0 20px;
 				}
 
 				.videos-ui__active-video-content {
-					margin-top: 26px;
+					padding: 20px;
+					display: none;
 				}
 
 				.videos-ui__play-button {
 					width: 100%;
+				}
+
+				&.selected {
+					height: 250px;
+					overflow-y: auto;
+					.videos-ui__active-video-content {
+						display: block;
+					}
 				}
 			}
 		}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -112,11 +112,19 @@
 					margin-left: 10px;
 				}
 
+				.videos-ui__chapter-accordion-toggle {
+					color: #fff;
+					cursor: pointer;
+					display: block;
+					width: 100%;
+					text-align: left;
+				}
+
 				.videos-ui__active-video-content {
 					margin-top: 26px;
 				}
 
-				button {
+				.videos-ui__play-button {
 					width: 100%;
 				}
 			}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -81,17 +81,12 @@
 		.videos-ui__chapters {
 			background: #1d262a;
 			font-size: $font-body-small;
-			overflow: auto;
 
 			.videos-ui__chapter {
 				border-bottom: 1px solid #343c3f;
 
 				&:last-child {
 					border-bottom: none;
-				}
-
-				&.active {
-					height: auto;
 				}
 
 				.videos-ui__duration {
@@ -122,20 +117,23 @@
 				}
 
 				.videos-ui__active-video-content {
-					padding: 20px;
-					display: none;
+					overflow: hidden;
+					height: 0;
+					transition:
+						height 0.3s linear;
+
+					div {
+						padding: 20px;
+						overflow-y: auto;
+					}
 				}
 
 				.videos-ui__play-button {
 					width: 100%;
 				}
 
-				&.selected {
+				&.selected .videos-ui__active-video-content {
 					height: 250px;
-					overflow-y: auto;
-					.videos-ui__active-video-content {
-						display: block;
-					}
 				}
 			}
 		}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -98,17 +98,16 @@
 					color: rgba( 255, 255, 255, 0.5 );
 				}
 
-				.videos-ui__completed {
-					display: block;
-					width: 24px;
-					height: 24px;
-					/* stylelint-disable-next-line scales/radii */
-					border-radius: 24px;
+				.videos-ui__status-icon {
+					height: 48px;
 					float: right;
-					background: #00a32a;
 					text-align: center;
-					line-height: 24px;
+					line-height: 48px;
 					margin-left: 10px;
+
+					svg {
+						vertical-align: middle;
+					}
 				}
 
 				.videos-ui__chapter-accordion-toggle {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -117,7 +117,7 @@
 					overflow: hidden;
 					height: 0;
 					transition:
-						height 0.3s linear;
+						height 0.2s ease-out;
 
 					div {
 						padding: 20px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the chapter controls for the new course videos UI to display using an animated accordion styling.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR still does not load the UI anywhere (as it will be added as a modal in the work being done for Videos UI: Add a new card to the My Home carousel for our MVP. Videos UI: Add a new card to the My Home carousel for our MVP. #57326
* However, it can be tested by importing the VideosUi component anywhere in Calypso (such as a block on the home page.)
* Verify that in both mobile and desktop views, the course chapters are displayed in accordion mode and can be tabbed between with a sliding animation.

Desktop view:

![videos-ui-desktop-accordion](https://user-images.githubusercontent.com/13437011/140190246-ec85e987-c2b8-4281-9159-c22d7dfc7410.gif)

Mobile view:

![videos-ui-mobile-accordion](https://user-images.githubusercontent.com/13437011/140191242-28bef173-84c9-456c-adaf-43756b8cb8e0.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57447
