### PR TITLE
Videos UI: Add the "skip and draft first post" link.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -1,12 +1,15 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import './style.scss';
 
 const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
 	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );
 
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
@@ -71,7 +74,11 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 					</div>
 					<div>
 						{ shouldDisplayTopLinks && (
-							<a href="/" className="videos-ui__skip-link" onClick={ skipClickHandler }>
+							<a
+								href={ `/post/${ siteSlug }` }
+								className="videos-ui__skip-link"
+								onClick={ skipClickHandler }
+							>
 								{ translate( 'Skip and draft first post' ) }
 							</a>
 						) }


### PR DESCRIPTION
This PR sends the user to the post editor for a new post, upon clicking on the "skip and draft first post" link in the top right corner.

<img width="619" alt="Screen Shot 2021-11-03 at 2 22 38 PM" src="https://user-images.githubusercontent.com/349751/140194882-1530354b-b424-4a4d-8767-97245aa2dafd.png">

**Testing Instructions**
* Switch to this branch.
* Add the `<VideosUi />` component to My Home.
* Click on the "skip and draft first post" link in the top right corner, and verify you are taken to the editor for the correct site.