### PR TITLE
Playwright: wait for article to fully load and comment submission to finish.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -7,6 +7,8 @@ const selectors = {
 	actionButton: ( action: 'Share' | 'Comment' ) =>
 		`.reader-post-actions__item:has-text("${ action }")`,
 
+	// Post
+	placeholder: '.is-placeholder',
 	commentTextArea: '.comments__form textarea',
 	commentSubmitButton: '.comments__form button:text("Send")',
 	commentContentLocator: ( commentText: string ) =>
@@ -71,6 +73,7 @@ export class ReaderPage {
 		}
 
 		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selector ) ] );
+		await this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -87,9 +87,10 @@ export class ReaderPage {
 		);
 		await this.page.fill( selectors.commentTextArea, comment );
 		await Promise.all( [
-			this.page.waitForLoadState( 'networkidle' ),
+			this.page.waitForResponse(
+				( response ) => response.status() === 200 && response.url().includes( 'new?' )
+			),
 			this.page.click( selectors.commentSubmitButton ),
 		] );
-		await this.page.waitForSelector( selectors.comment( comment ) );
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -16,7 +16,7 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 	let page: Page;
 	let readerPage: ReaderPage;
 	let notificationsComponent: NotificationsComponent;
-	const comment = DataHelper.getRandomPhrase();
+	const comment = DataHelper.getRandomPhrase() + 'wp-reader__view-spec';
 
 	setupHooks( ( args: { page: Page } ) => {
 		page = args.page;

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -16,7 +16,7 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 	let page: Page;
 	let readerPage: ReaderPage;
 	let notificationsComponent: NotificationsComponent;
-	const comment = DataHelper.getRandomPhrase() + 'wp-reader__view-spec';
+	const comment = DataHelper.getRandomPhrase() + ' wp-reader__view-spec';
 
 	setupHooks( ( args: { page: Page } ) => {
 		page = args.page;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to slightly modify behavior of the `ReaderPage.comment` and `ReaderPage.visitArticle` methods.

Key changes:
- wait for `placeholder` elements to disappear when clicking on `Read More`.
- wait for `Visit Article` button element to be stable when clicking on `Read More`.
- use `waitForResponse` to wait for comment submission.

#### Testing instructions

- [ ] normal test
  - [x] mobile
  - [x] desktop
- [ ] stress test
  - [x] mobile 6932076
  - [x] desktop 6932084


Closes #57606.