### PR TITLE
Blogger Experience - Fix video UI course loading and Tracks errors

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -15,7 +15,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 	const onVideoPlayClick = ( video ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
 			course: course.slug,
-			video: video.title,
+			video,
 		} );
 
 		setCurrentVideo( video );
@@ -127,7 +127,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 										<div className="videos-ui__active-video-content">
 											<p>{ video.description } </p>
 										</div>
-										<Button onClick={ () => onVideoPlayClick( video ) }>
+										<Button onClick={ () => onVideoPlayClick( data[ 0 ] ) }>
 											<Gridicon icon="play" />
 											<span>{ translate( 'Play video' ) }</span>
 										</Button>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -14,8 +14,8 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 
 	const onVideoPlayClick = ( video ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
-			course: course.slug,
-			video,
+			course: course.title,
+			video: video.title,
 		} );
 
 		setCurrentVideo( video );
@@ -49,12 +49,16 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 
 	const skipClickHandler = () =>
 		recordTracksEvent( 'calypso_courses_skip_to_draft', {
-			course: course.slug,
+			course: course.title,
 		} );
 
-	recordTracksEvent( 'calypso_courses_view', {
-		course: course.slug,
-	} );
+	useEffect( () => {
+		if ( course ) {
+			recordTracksEvent( 'calypso_courses_view', {
+				course: course.title,
+			} );
+		}
+	}, [ course ] );
 
 	return (
 		<div className="videos-ui">

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -14,7 +14,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 
 	const onVideoPlayClick = ( video ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
-			course: course.title,
+			course: course.slug,
 			video: video.title,
 		} );
 
@@ -49,13 +49,13 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 
 	const skipClickHandler = () =>
 		recordTracksEvent( 'calypso_courses_skip_to_draft', {
-			course: course.title,
+			course: course.slug,
 		} );
 
 	useEffect( () => {
 		if ( course ) {
 			recordTracksEvent( 'calypso_courses_view', {
-				course: course.title,
+				course: course.slug,
 			} );
 		}
 	}, [ course ] );


### PR DESCRIPTION
This PR addresses multiple `calypso_courses_view` Tracks events firing on a single load.

It also addresses an error which was preventing tracks events for the videos UI play button to run correctly:

![image](https://user-images.githubusercontent.com/13437011/140199178-976a860c-1431-4949-94c0-b1a57c60eb7d.png)

Fixes #57622.

#### Testing instructions
* Verify that the component loads correctly, that clicking on "Play" buttons does not log a console error, and that Tracks events are properly catalogued 
* Enter `localStorage.setItem( 'debug', 'calypso:analytics*' )` in your console to see live Tracks events.

