### PR TITLE
Domains: Update email setup component

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
@@ -72,10 +72,6 @@ class EmailSetup extends Component {
 		};
 	}
 
-	isSelected = ( provider ) => {
-		return this.state.selectedTab === provider;
-	};
-
 	renderProviderTabs = () => {
 		return (
 			<SectionNav selectedText={ this.state.selectedTab }>
@@ -91,11 +87,19 @@ class EmailSetup extends Component {
 			<NavItem
 				key={ `email-provider-${ template.dnsTemplateProvider }` }
 				selected={ this.isSelected( template.name ) }
-				onClick={ () => this.setState( { selectedTab: template.name } ) }
+				onClick={ this.selectProvider( template.name ) }
 			>
 				{ template.name }
 			</NavItem>
 		);
+	};
+
+	isSelected = ( provider ) => {
+		return this.state.selectedTab === provider;
+	};
+
+	selectProvider = ( provider ) => () => {
+		this.setState( { selectedTab: provider } );
 	};
 
 	renderConfigurationForm = () => {

--- a/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
@@ -13,11 +13,7 @@ import './email-setup.scss';
 
 class EmailSetup extends Component {
 	static propTypes = {
-		// domains: PropTypes.array.isRequired,
-		// dns: PropTypes.object.isRequired,
-		// showPlaceholder: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
 
 	constructor( props ) {
@@ -80,17 +76,17 @@ class EmailSetup extends Component {
 		return this.state.selectedTab === provider;
 	};
 
-	renderProviders = () => {
+	renderProviderTabs = () => {
 		return (
 			<SectionNav selectedText={ this.state.selectedTab }>
 				<NavTabs label="Email providers">
-					{ this.state.templates.map( this.renderProvider ) }
+					{ this.state.templates.map( this.renderProviderTab ) }
 				</NavTabs>
 			</SectionNav>
 		);
 	};
 
-	renderProvider = ( template ) => {
+	renderProviderTab = ( template ) => {
 		return (
 			<NavItem
 				key={ `email-provider-${ template.dnsTemplateProvider }` }
@@ -102,11 +98,13 @@ class EmailSetup extends Component {
 		);
 	};
 
-	renderConfiguration = () => {
-		const template = this.state.templates.find( ( t ) => this.state.selectedTab === t.name );
-		if ( ! template ) return null;
+	renderConfigurationForm = () => {
+		const selectedTemplate = this.state.templates.find(
+			( template ) => this.state.selectedTab === template.name
+		);
+		if ( ! selectedTemplate ) return null;
 
-		return <EmailProvider template={ template } domain={ this.props.selectedDomainName } />;
+		return <EmailProvider template={ selectedTemplate } domain={ this.props.selectedDomainName } />;
 	};
 
 	render = () => {
@@ -119,8 +117,8 @@ class EmailSetup extends Component {
 		);
 		return (
 			<FoldableCard header={ header } clickableHeader className="email-setup">
-				{ this.renderProviders() }
-				{ this.renderConfiguration() }
+				{ this.renderProviderTabs() }
+				{ this.renderConfigurationForm() }
 			</FoldableCard>
 		);
 	};

--- a/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
@@ -82,7 +82,7 @@ class EmailSetup extends Component {
 
 	renderProviders = () => {
 		return (
-			<SectionNav>
+			<SectionNav selectedText={ this.state.selectedTab }>
 				<NavTabs label="Email providers">
 					{ this.state.templates.map( this.renderProvider ) }
 				</NavTabs>
@@ -93,6 +93,7 @@ class EmailSetup extends Component {
 	renderProvider = ( template ) => {
 		return (
 			<NavItem
+				key={ `email-provider-${ template.dnsTemplateProvider }` }
 				selected={ this.isSelected( template.name ) }
 				onClick={ () => this.setState( { selectedTab: template.name } ) }
 			>
@@ -105,13 +106,7 @@ class EmailSetup extends Component {
 		const template = this.state.templates.find( ( t ) => this.state.selectedTab === t.name );
 		if ( ! template ) return null;
 
-		return (
-			<EmailProvider
-				key={ `dns-templates-email-provider-${ template.dnsTemplate }` }
-				template={ template }
-				domain={ this.props.selectedDomainName }
-			/>
-		);
+		return <EmailProvider template={ template } domain={ this.props.selectedDomainName } />;
 	};
 
 	render = () => {

--- a/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
@@ -75,9 +75,7 @@ class EmailSetup extends Component {
 	renderProviderTabs = () => {
 		return (
 			<SectionNav selectedText={ this.state.selectedTab }>
-				<NavTabs label="Email providers">
-					{ this.state.templates.map( this.renderProviderTab ) }
-				</NavTabs>
+				<NavTabs>{ this.state.templates.map( this.renderProviderTab ) }</NavTabs>
 			</SectionNav>
 		);
 	};
@@ -112,11 +110,13 @@ class EmailSetup extends Component {
 	};
 
 	render = () => {
+		const { translate } = this.props;
+
 		const header = (
 			<span>
-				<strong>Email setup</strong>
+				<strong>{ translate( 'Email setup' ) }</strong>
 				<br />
-				<span>Set up an existing email service for this domain</span>
+				<span>{ translate( 'Set up an existing email service for this domain' ) }</span>
 			</span>
 		);
 		return (

--- a/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
@@ -1,0 +1,138 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import FoldableCard from 'calypso/components/foldable-card';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { dnsTemplates } from 'calypso/lib/domains/constants';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import EmailProvider from '../dns/email-provider';
+
+import './email-setup.scss';
+
+class EmailSetup extends Component {
+	static propTypes = {
+		// domains: PropTypes.array.isRequired,
+		// dns: PropTypes.object.isRequired,
+		// showPlaceholder: PropTypes.bool.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+		const { translate } = props;
+		const googleServiceName = getGoogleMailServiceFamily();
+
+		this.state = {
+			selectedTab: googleServiceName,
+			templates: [
+				{
+					name: googleServiceName,
+					label: translate(
+						'%(serviceName)s Verification Token - from the TXT record verification',
+						{
+							args: { serviceName: googleServiceName },
+							comment:
+								'%(serviceName)s will be replaced with the name of the service ' +
+								'that this token applies to, for example G Suite or Office 365',
+						}
+					),
+					placeholder: 'google-site-verification=...',
+					validationPattern: /^google-site-verification=[A-Za-z0-9_-]{43}$/,
+					dnsTemplateProvider: dnsTemplates.G_SUITE.PROVIDER,
+					dnsTemplateService: dnsTemplates.G_SUITE.SERVICE,
+				},
+				{
+					name: 'Office 365',
+					label: translate(
+						'%(serviceName)s Verification Token - from the TXT record verification',
+						{
+							args: { serviceName: 'Office 365' },
+							comment:
+								'%(serviceName)s will be replaced with the name of the service ' +
+								'that this token applies to, for example G Suite or Office 365',
+						}
+					),
+					placeholder: 'MS=ms...',
+					validationPattern: /^MS=ms\d{8}$/,
+					dnsTemplateProvider: dnsTemplates.MICROSOFT_OFFICE365.PROVIDER,
+					dnsTemplateService: dnsTemplates.MICROSOFT_OFFICE365.SERVICE,
+					modifyVariables: ( variables ) =>
+						Object.assign( {}, variables, {
+							mxdata: variables.domain.replace( '.', '-' ) + '.mail.protection.outlook.com',
+						} ),
+				},
+				{
+					name: 'Zoho Mail',
+					label: translate( 'Zoho Mail CNAME zb code' ),
+					placeholder: 'zb...',
+					validationPattern: /^zb\w{1,100}$/,
+					dnsTemplateProvider: dnsTemplates.ZOHO_MAIL.PROVIDER,
+					dnsTemplateService: dnsTemplates.ZOHO_MAIL.SERVICE,
+				},
+			],
+		};
+	}
+
+	isSelected = ( provider ) => {
+		return this.state.selectedTab === provider;
+	};
+
+	renderProviders = () => {
+		return (
+			<SectionNav>
+				<NavTabs label="Email providers">
+					{ this.state.templates.map( this.renderProvider ) }
+				</NavTabs>
+			</SectionNav>
+		);
+	};
+
+	renderProvider = ( template ) => {
+		return (
+			<NavItem
+				selected={ this.isSelected( template.name ) }
+				onClick={ () => this.setState( { selectedTab: template.name } ) }
+			>
+				{ template.name }
+			</NavItem>
+		);
+	};
+
+	renderConfiguration = () => {
+		const template = this.state.templates.find( ( t ) => this.state.selectedTab === t.name );
+		if ( ! template ) return null;
+
+		return (
+			<EmailProvider
+				key={ `dns-templates-email-provider-${ template.dnsTemplate }` }
+				template={ template }
+				domain={ this.props.selectedDomainName }
+			/>
+		);
+	};
+
+	renderMain = () => {
+		const header = (
+			<span>
+				<strong>Email setup</strong>
+				<br />
+				<span>Set up an existing email service for this domain</span>
+			</span>
+		);
+		return (
+			<FoldableCard header={ header } clickableHeader className="email-setup">
+				{ this.renderProviders() }
+				{ this.renderConfiguration() }
+			</FoldableCard>
+		);
+	};
+
+	render = () => {
+		return this.renderMain();
+	};
+}
+
+export default localize( EmailSetup );

--- a/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.jsx
@@ -114,7 +114,7 @@ class EmailSetup extends Component {
 		);
 	};
 
-	renderMain = () => {
+	render = () => {
 		const header = (
 			<span>
 				<strong>Email setup</strong>
@@ -128,10 +128,6 @@ class EmailSetup extends Component {
 				{ this.renderConfiguration() }
 			</FoldableCard>
 		);
-	};
-
-	render = () => {
-		return this.renderMain();
 	};
 }
 

--- a/client/my-sites/domains/domain-management/name-servers/email-setup.scss
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.scss
@@ -9,12 +9,13 @@
 	}
 }
 
-.dns__form {
-	border-top: 1px solid var( --color-neutral-0 );
-	overflow: visible;
-	padding-top: 20px;
+.email-setup.foldable-card {
+	.foldable-card__header {
+		padding: 24px;
+	}
 
-	.is-hidden {
-		display: none;
+	.foldable-card__content {
+		padding: 0 24px 24px;
+		border-top: none;
 	}
 }

--- a/client/my-sites/domains/domain-management/name-servers/email-setup.scss
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.scss
@@ -1,0 +1,20 @@
+.email-setup {
+	.section-nav {
+		box-shadow: none;
+		border-bottom: 1px solid var( --studio-gray-5 );
+	}
+
+	.form-label {
+		font-weight: 400;
+	}
+}
+
+.dns__form {
+	border-top: 1px solid var( --color-neutral-0 );
+	overflow: visible;
+	padding-top: 20px;
+
+	.is-hidden {
+		display: none;
+	}
+}

--- a/client/my-sites/domains/domain-management/name-servers/email-setup.scss
+++ b/client/my-sites/domains/domain-management/name-servers/email-setup.scss
@@ -7,6 +7,11 @@
 	.form-label {
 		font-weight: 400;
 	}
+
+	.dns__form {
+		padding-top: 4px;
+		border: none;
+	}
 }
 
 .email-setup.foldable-card {

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -34,6 +34,7 @@ import {
 	CLOUDFLARE_NAMESERVERS_REGEX,
 } from './constants';
 import CustomNameserversForm from './custom-nameservers-form';
+import DnsTemplates from './dns-templates';
 import EmailSetup from './email-setup';
 import FetchError from './fetch-error';
 import withDomainNameservers from './with-domain-nameservers';
@@ -161,9 +162,13 @@ class NameServers extends Component {
 				</VerticalNav>
 
 				<VerticalNav>
-					{ this.hasWpcomNameservers() && ! this.isPendingTransfer() && (
-						<EmailSetup selectedDomainName={ this.props.selectedDomainName } />
-					) }
+					{ this.hasWpcomNameservers() &&
+						! this.isPendingTransfer() &&
+						( config.isEnabled( 'domains/dns-records-redesign' ) ? (
+							<EmailSetup selectedDomainName={ this.props.selectedDomainName } />
+						) : (
+							<DnsTemplates selectedDomainName={ this.props.selectedDomainName } />
+						) ) }
 				</VerticalNav>
 			</Fragment>
 		);

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -34,7 +34,7 @@ import {
 	CLOUDFLARE_NAMESERVERS_REGEX,
 } from './constants';
 import CustomNameserversForm from './custom-nameservers-form';
-import DnsTemplates from './dns-templates';
+import EmailSetup from './email-setup';
 import FetchError from './fetch-error';
 import withDomainNameservers from './with-domain-nameservers';
 import WpcomNameserversToggle from './wpcom-nameservers-toggle';
@@ -162,7 +162,7 @@ class NameServers extends Component {
 
 				<VerticalNav>
 					{ this.hasWpcomNameservers() && ! this.isPendingTransfer() && (
-						<DnsTemplates selectedDomainName={ this.props.selectedDomainName } />
+						<EmailSetup selectedDomainName={ this.props.selectedDomainName } />
 					) }
 				</VerticalNav>
 			</Fragment>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the email provider setup component in the DNS settings section of the domain configuration pages. This is part of the domain pages redesign project detailed in pcYYhz-m2-p2.

**Note**: This new component is currently in the same place as the old one (Domains > domain > Change your name servers & DNS records) , but when #57604 is merged, it should be placed in the new `dns-records` page.

**Note 2**: We still need the intermediary DNS records page because of the "Use WordPress.com Name Servers" toggle - that toggle will be relocated to the redesigned domain settings page, which isn't done yet. So even after #57604 is merged, this component still shouldn't be moved.

This is the current component layout:

![Annotation on 2021-11-04 at 11-33-43](https://user-images.githubusercontent.com/5324818/140333911-00262156-4165-4742-adab-feec21f33312.png)

This is the redesigned component:

![Annotation on 2021-11-04 at 11-36-32](https://user-images.githubusercontent.com/5324818/140333935-2150d4ad-a0a8-442c-8c76-2f9af3ee836d.png)
<img width="570" alt="Screen Shot 2021-11-04 at 11 35 47" src="https://user-images.githubusercontent.com/5324818/140333967-f0cce26b-cde0-4b4a-8290-eca58d43ae30.png">

#### Testing instructions

Open the live Calypso link, navigate to the name servers editing page (Domains > domain > Change your name servers & DNS records), append the `?flags=domains/dns-records-redesign` query parameter to the URL and ensure the email setup component looks like the one in the screenshots and the design in the Figma project (hlVh2q24ad6MCwlwNnE9PQ-fi). Please also ensure the mobile view looks correct.

You can also check if the correct DNS records are added for the domain when one of the tokens is provided for one of the email services (Google, Office or Zoho). However, that code wasn't altered so that functionality shouldn't have changed.