### PR TITLE
Display the appropriate messages when introductory offers affect the renewal price.

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -33,6 +33,19 @@ function createPurchaseObject( purchase ) {
 					intervalCount: Number( purchase.introductory_offer.interval_count ),
 					intervalUnit: String( purchase.introductory_offer.interval_unit ),
 					isWithinPeriod: Boolean( purchase.introductory_offer.is_within_period ),
+					transitionAfterRenewalCount: Number(
+						purchase.introductory_offer.transition_after_renewal_count
+					),
+					isNextRenewalUsingOffer: Boolean(
+						purchase.introductory_offer.is_next_renewal_using_offer
+					),
+					remainingRenewalsUsingOffer: Number(
+						purchase.introductory_offer.remaining_renewals_using_offer
+					),
+					shouldProrateWhenOfferEnds: Boolean(
+						purchase.introductory_offer.should_prorate_when_offer_ends
+					),
+					isNextRenewalProrated: Boolean( purchase.introductory_offer.is_next_renewal_prorated ),
 			  }
 			: null,
 		isCancelable: Boolean( purchase.is_cancelable ),

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -76,6 +76,7 @@ function createPurchaseObject( purchase ) {
 		refundOptions: purchase.refund_options,
 		refundText: purchase.refund_text,
 		refundPeriodInDays: purchase.refund_period_in_days,
+		regularPriceText: purchase.regular_price_text,
 		renewDate: purchase.renew_date,
 		saleAmount: purchase.sale_amount,
 		siteId: Number( purchase.blog_id ),

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -276,7 +276,9 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase } ) {
 		translate,
 		purchase.introductoryOffer.intervalUnit,
 		purchase.introductoryOffer.intervalCount,
-		isIntroductoryOfferFreeTrial( purchase )
+		isIntroductoryOfferFreeTrial( purchase ),
+		'manage-purchases',
+		purchase.introductoryOffer.remainingRenewalsUsingOffer
 	);
 
 	return (

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -281,10 +281,37 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase } ) {
 		purchase.introductoryOffer.remainingRenewalsUsingOffer
 	);
 
+	let regularPriceText = null;
+	if ( purchase.introductoryOffer.isNextRenewalUsingOffer ) {
+		regularPriceText = translate(
+			'After the offer ends, the subscription price will be %(regularPrice)s',
+			{
+				args: {
+					regularPrice: purchase.regularPriceText,
+				},
+			}
+		);
+	} else if ( purchase.introductoryOffer.isNextRenewalProrated ) {
+		regularPriceText = translate(
+			'After the first renewal, the subscription price will be %(regularPrice)s',
+			{
+				args: {
+					regularPrice: purchase.regularPriceText,
+				},
+			}
+		);
+	}
+
 	return (
 		<>
 			<br />
 			<small> { text } </small>
+			{ regularPriceText && (
+				<>
+					{ ' ' }
+					<br /> <small> { regularPriceText } </small>{ ' ' }
+				</>
+			) }
 		</>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -74,6 +74,40 @@ function getMessageForTermsOfServiceRecord(
 				args.subscription_expiry_date &&
 				args.subscription_auto_renew_date
 			) {
+				if (
+					args.is_renewal_price_prorated &&
+					( locale === 'en' ||
+						i18nCalypso.hasTranslation(
+							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.'
+						) )
+				) {
+					return translate(
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+						{
+							args: {
+								startDate: moment( args.subscription_start_date ).format( 'll' ),
+								endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+								renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+								email: args.email,
+								renewalPrice: args.renewal_price,
+								regularPrice: args.regular_renewal_price,
+								numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+							},
+							components: {
+								updatePaymentMethodLink: (
+									<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
+								),
+								manageSubscriptionlink: (
+									<a
+										href={ `/purchases/subscriptions/${ siteSlug }` }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+					);
+				}
 				return translate(
 					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
 					{
@@ -136,6 +170,41 @@ function getMessageForTermsOfServiceRecord(
 				args.subscription_expiry_date &&
 				args.subscription_auto_renew_date
 			) {
+				if (
+					args.is_renewal_price_prorated &&
+					( locale === 'en' ||
+						i18nCalypso.hasTranslation(
+							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.'
+						) )
+				) {
+					return translate(
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+						{
+							args: {
+								startDate: moment( args.subscription_start_date ).format( 'll' ),
+								endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+								renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+								cardType: args.card_type,
+								cardLast4: args.card_last_4,
+								renewalPrice: args.renewal_price,
+								regularPrice: args.regular_renewal_price,
+								numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+							},
+							components: {
+								updatePaymentMethodLink: (
+									<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
+								),
+								manageSubscriptionlink: (
+									<a
+										href={ `/purchases/subscriptions/${ siteSlug }` }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+					);
+				}
 				return translate(
 					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
 					{

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -78,11 +78,11 @@ function getMessageForTermsOfServiceRecord(
 					args.is_renewal_price_prorated &&
 					( locale === 'en' ||
 						i18nCalypso.hasTranslation(
-							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.'
+							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.'
 						) )
 				) {
 					return translate(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.',
 						{
 							args: {
 								startDate: moment( args.subscription_start_date ).format( 'll' ),
@@ -174,11 +174,11 @@ function getMessageForTermsOfServiceRecord(
 					args.is_renewal_price_prorated &&
 					( locale === 'en' ||
 						i18nCalypso.hasTranslation(
-							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.'
+							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.'
 						) )
 				) {
 					return translate(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.',
 						{
 							args: {
 								startDate: moment( args.subscription_start_date ).format( 'll' ),

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -320,6 +320,8 @@ export interface IntroductoryOfferTerms {
 	interval_unit: string;
 	interval_count: number;
 	reason?: string;
+	transition_after_renewal_count: number;
+	should_prorate_when_offer_ends: boolean;
 }
 
 export interface CartLocation {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -79,30 +79,25 @@ export const LineItem = styled( WPLineItem )< {
 
 const LineItemMeta = styled.div< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
-	display: flex;
 	font-size: 14px;
-	justify-content: space-between;
 	width: 100%;
 `;
 
 const DiscountCallout = styled.div< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.success };
-	text-align: right;
-
-	.rtl & {
-		text-align: left;
-	}
+	display: block;
+	margin: 2px 0;
 `;
 
 const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`
 	flex: 1;
 	word-break: break-word;
-	font-size: ${ ( { isSummary } ) => ( isSummary ? '14px' : '16px' ) };
+	font-size: 16px;
 `;
 
 const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean } >`
 	margin-left: 12px;
-	font-size: ${ ( { isSummary } ) => ( isSummary ? '14px' : '16px' ) };
+	font-size: 16px;
 
 	.rtl & {
 		margin-right: 12px;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -617,7 +617,9 @@ function IntroductoryOfferCallout( {
 		translate,
 		product.introductory_offer_terms.interval_unit,
 		product.introductory_offer_terms.interval_count,
-		isFreeTrial
+		isFreeTrial,
+		'checkout',
+		product.introductory_offer_terms.transition_after_renewal_count
 	);
 	return <DiscountCallout>{ text }</DiscountCallout>;
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -579,6 +579,10 @@ function FirstTermDiscountCallout( {
 	const cost = product.product_cost_integer;
 	const isRenewal = product.is_renewal;
 
+	if ( product.introductory_offer_terms?.enabled ) {
+		return null;
+	}
+
 	if (
 		( ! isWpComPlan( planSlug ) && ! isJetpackProductSlug( planSlug ) ) ||
 		origCost <= cost ||

--- a/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
+++ b/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
@@ -65,26 +65,43 @@ export function getIntroductoryOfferIntervalDisplay(
 		}
 	}
 	if ( remainingRenewalsUsingOffer > 0 ) {
+		text += ' - ';
 		if ( context === 'checkout' ) {
-			text +=
-				' - ' +
-				String(
-					translate( 'The first %(remainingRenewals)d renewals are also discounted.', {
+			if ( remainingRenewalsUsingOffer === 1 ) {
+				text += String(
+					translate( 'The first renewal is also discounted.', {
 						args: {
 							remainingRenewals: remainingRenewalsUsingOffer,
 						},
 					} )
 				);
+			} else {
+				text += String(
+					translate(
+						'The first %(remainingRenewals)d renewal is also discounted.',
+						'The first %(remainingRenewals)d renewals are also discounted.',
+						{
+							count: remainingRenewalsUsingOffer,
+							args: {
+								remainingRenewals: remainingRenewalsUsingOffer,
+							},
+						}
+					)
+				);
+			}
 		} else {
-			text +=
-				' - ' +
-				String(
-					translate( '%(remainingRenewals)d discounted renewals remaining.', {
+			text += String(
+				translate(
+					'%(remainingRenewals)d discounted renewal remaining.',
+					'%(remainingRenewals)d discounted renewals remaining.',
+					{
+						count: remainingRenewalsUsingOffer,
 						args: {
 							remainingRenewals: remainingRenewalsUsingOffer,
 						},
-					} )
-				);
+					}
+				)
+			);
 		}
 	}
 	return text;

--- a/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
+++ b/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
@@ -4,7 +4,9 @@ export function getIntroductoryOfferIntervalDisplay(
 	translate: ReturnType< typeof useTranslate >,
 	intervalUnit: string,
 	intervalCount: number,
-	isFreeTrial: boolean
+	isFreeTrial: boolean,
+	context: string,
+	remainingRenewalsUsingOffer = 0
 ): string {
 	let text = String( translate( 'Discount for first period' ) );
 	if ( isFreeTrial ) {
@@ -60,6 +62,29 @@ export function getIntroductoryOfferIntervalDisplay(
 					} )
 				);
 			}
+		}
+	}
+	if ( remainingRenewalsUsingOffer > 0 ) {
+		if ( context === 'checkout' ) {
+			text +=
+				' - ' +
+				String(
+					translate( 'The first %(remainingRenewals)d renewals are also discounted.', {
+						args: {
+							remainingRenewals: remainingRenewalsUsingOffer,
+						},
+					} )
+				);
+		} else {
+			text +=
+				' - ' +
+				String(
+					translate( '%(remainingRenewals)d discounted renewals remaining.', {
+						args: {
+							remainingRenewals: remainingRenewalsUsingOffer,
+						},
+					} )
+				);
 		}
 	}
 	return text;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When an introductory offer affects the first renewal price, display the regular price in the terms of service message during checkout.

![Screen Shot 2021-11-03 at 15 30 07](https://user-images.githubusercontent.com/15204776/140224572-3a837ea1-b717-46a2-894f-12068271f2fe.png)

![Screen Shot 2021-11-03 at 15 31 10](https://user-images.githubusercontent.com/15204776/140224699-78e3c773-d0f4-44d7-b0c5-e780f49fb5b2.png)

* When an introductory offer is scheduled to be applied in the next X renewals, display a message to indicate how many will be/are left:

![image](https://user-images.githubusercontent.com/15204776/140226163-f69f81b2-bf5e-483a-9de5-1d9f654584cc.png)

![image](https://user-images.githubusercontent.com/15204776/140226961-7b7e2f88-08dc-400f-8430-9216b4e75398.png)

* In the manage purchases page, display a message to indicate the regular renewal price once the offer ends:

Renewal using offer price
![image](https://user-images.githubusercontent.com/15204776/140226163-f69f81b2-bf5e-483a-9de5-1d9f654584cc.png)

Prorated renewal
![Screen Shot 2021-11-03 at 16 27 32](https://user-images.githubusercontent.com/15204776/140227857-5b057a4f-0a8e-4909-854c-87c64a2e4aea.png)


#### Testing instructions

Depends on D69584-code

- Follow the instructions in D69584-code to enable the test billing plans.
- Use the monthly premium plan to validate renewals that use the introductory offer price.
- Use the yearly premium plan to validate the prorated renewals.
- Use the test instructions from D69240-code to simulate a prorated renewal for a Professional Email subscription. During the checkout process, validate that the Terms of Service message display the new content that mentions both the first renewal price and the regular price.
