### PR TITLE
signup flow: only remove background from comparison table if using reskinned flow

### DIFF
--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -40,6 +40,7 @@ $plan-features-sidebar-width: 272px;
 	display: flex;
 	align-items: flex-start;
 	padding: 12px 24px 12px 15px;
+	background-color: var( --color-surface );
 	justify-content: center;
 	font-weight: 400;
 	margin-top: 30px;
@@ -122,6 +123,7 @@ $plan-features-sidebar-width: 272px;
 		transition: opacity 0.05s;
 		border-right: solid 1px var( --color-neutral-5 );
 		border-left: solid 1px var( --color-neutral-5 );
+		background-color: var( --color-surface );
 		position: relative;
 
 		&.is-bold {
@@ -409,10 +411,15 @@ $plan-features-sidebar-width: 272px;
 body.is-section-signup.is-white-signup {
 	.plan-features-comparison__table-item {
 		border-left: none;
+		background-color: transparent;
 
 		&:last-of-type {
 			border-right: none;
 		}
+	}
+
+	.plan-features-comparison__header {
+		background-color: transparent;
 	}
 
 	.plan-features-comparison__row:last-of-type .plan-features-comparison__table-item {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Yesterday we made the change to [remove the background from the signup flow comparison table](https://github.com/Automattic/wp-calypso/pull/57588) to avoid a very subtle difference between the white table and the slightly off-white background. But this change didn't take into account the non-reskinned blue signup flow, removing the background for this flow breaks the text readability. Fortunately it appears that the non-reskinned AB tests have finished, but we should fix this flow.

#### Testing instructions
Go to the plans page with the `signup/reskin` flag disabled:`/start/plans?flags=-signup/reskin`
Observe that the plan table background is correct
Go to the reskinned plans page `/start/plans` 
Observer that there is still no very slight border around the table