### PR TITLE
Domains: Add buttons to the DNS management breadcrumbs component

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -142,10 +142,10 @@
 	@include break-mobile {
 		display: block;
 
-		& button {
+		& .button {
 			margin-right: 16px;
 		}
-		& button:last-child {
+		& .button:last-child {
 			margin-right: 0;
 		}
 	}
@@ -154,10 +154,10 @@
 .breadcrumbs__buttons-mobile {
 	display: block;
 
-	& button {
+	& .button {
 		margin-right: 16px;
 	}
-	& button:last-child {
+	& .button:last-child {
 		margin-right: 0;
 	}
 

--- a/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
@@ -1,0 +1,14 @@
+import { Button } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import './dns-breadcrumb-button.scss';
+
+function DnsAddNewRecordButton(): JSX.Element {
+	const { __ } = useI18n();
+	return (
+		<Button primary href={ '#' } className={ 'dns__breadcrumb-button' }>
+			{ __( 'Add a new record' ) }
+		</Button>
+	);
+}
+
+export default DnsAddNewRecordButton;

--- a/client/my-sites/domains/domain-management/dns/dns-breadcrumb-button.scss
+++ b/client/my-sites/domains/domain-management/dns/dns-breadcrumb-button.scss
@@ -1,0 +1,34 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.dns__breadcrumb-button {
+	padding: 8px;
+
+	&.popover {
+		margin-top: 5px;
+	}
+
+	@include break-mobile {
+		padding: 7px;
+		font-size: $font-body-extra-small;
+		line-height: 1;
+
+		.gridicon {
+			top: 5px;
+			margin-top: -8px;
+		}
+	}
+}
+
+.dns__breadcrumb-button.ellipsis {
+	border: none;
+
+	@include break-mobile {
+		border: 1px solid var( --color-neutral-10 );
+
+		&:hover {
+			border-color: var( --color-neutral-20 );
+			color: var( --color-neutral-70 );
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Button } from '@automattic/components';
+import { Icon, moreVertical, redo } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useRef, useState } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import './dns-breadcrumb-button.scss';
+
+function DnsMenuOptionsButton(): JSX.Element {
+	const { __ } = useI18n();
+
+	const [ isMenuVisible, setMenuVisible ] = useState( false );
+	const optionsButtonRef = useRef( null );
+
+	const toggleMenu = useCallback( () => {
+		setMenuVisible( ! isMenuVisible );
+	}, [ isMenuVisible ] );
+
+	const closeMenu = useCallback( () => setMenuVisible( false ), [] );
+	return (
+		<>
+			<Button
+				className="dns__breadcrumb-button ellipsis"
+				onClick={ toggleMenu }
+				ref={ optionsButtonRef }
+			>
+				<Icon icon={ moreVertical } className="gridicon" />
+			</Button>
+			<PopoverMenu
+				className="dns__breadcrumb-button popover"
+				isVisible={ isMenuVisible }
+				onClose={ closeMenu }
+				context={ optionsButtonRef.current }
+				position="bottom"
+			>
+				<PopoverMenuItem onClick={ () => null }>
+					<Icon icon={ redo } size={ 14 } className="gridicon" viewBox="2 2 20 20" />
+					{ __( 'Restore default records' ) }
+				</PopoverMenuItem>
+			</PopoverMenu>
+		</>
+	);
+}
+
+export default DnsMenuOptionsButton;

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -85,7 +85,10 @@ class Dns extends Component {
 			showBackArrow: true,
 		};
 
-		const buttons = [ <DnsAddNewRecordButton />, <DnsMenuOptionsButton /> ];
+		const buttons = [
+			<DnsAddNewRecordButton />,
+			<DnsMenuOptionsButton domain={ selectedDomainName } />,
+		];
 
 		return (
 			<Breadcrumbs

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -26,8 +26,10 @@ import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import DnsTemplates from '../name-servers/dns-templates';
 import DnsAddNew from './dns-add-new';
+import DnsAddNewRecordButton from './dns-add-new-record-button';
 import DnsDetails from './dns-details';
 import DnsList from './dns-list';
+import DnsMenuOptionsButton from './dns-menu-options-button';
 import DomainConnectRecord from './domain-connect-record';
 
 import './style.scss';
@@ -83,7 +85,19 @@ class Dns extends Component {
 			showBackArrow: true,
 		};
 
-		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
+		const buttons = [
+			<DnsAddNewRecordButton label={ translate( 'Add a new record' ) } />,
+			<DnsMenuOptionsButton />,
+		];
+
+		return (
+			<Breadcrumbs
+				items={ items }
+				mobileItem={ mobileItem }
+				buttons={ buttons }
+				mobileButtons={ buttons }
+			/>
+		);
 	}
 
 	renderMain() {

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -85,10 +85,7 @@ class Dns extends Component {
 			showBackArrow: true,
 		};
 
-		const buttons = [
-			<DnsAddNewRecordButton label={ translate( 'Add a new record' ) } />,
-			<DnsMenuOptionsButton />,
-		];
+		const buttons = [ <DnsAddNewRecordButton />, <DnsMenuOptionsButton /> ];
 
 		return (
 			<Breadcrumbs

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -54,16 +54,13 @@ class Dns extends Component {
 	onRestoreSuccess() {
 		const { translate, selectedDomainName } = this.props;
 		this.props.fetchDns( selectedDomainName, true );
-		this.props.successNotice( translate( 'Default DNS records restored successfully.' ) );
+		this.props.successNotice(
+			translate( 'Yay, the name servers have been successfully updated!' )
+		);
 	}
 
-	onRestoreError() {
-		const { translate } = this.props;
-		this.props.errorNotice(
-			translate(
-				'There was an error trying to restore the default DNS records for your domain. Please try again later.'
-			)
-		);
+	onRestoreError( errorMessage ) {
+		this.props.errorNotice( errorMessage );
 	}
 
 	renderDnsTemplates() {

--- a/client/my-sites/domains/domain-management/dns/types.tsx
+++ b/client/my-sites/domains/domain-management/dns/types.tsx
@@ -1,0 +1,17 @@
+export type DnsRecord = {
+	id: string;
+	name: string;
+	type: string;
+	domain: string;
+	protected_field?: boolean;
+	active?: string;
+	data?: string;
+	ttl?: number;
+	rdata?: string;
+};
+
+export type DnsMenuOptionsButtonProps = {
+	domain: string;
+	onSuccess: ( records: DnsRecord[] ) => void;
+	onError: ( message: string ) => void;
+};

--- a/client/state/domains/dns/actions.js
+++ b/client/state/domains/dns/actions.js
@@ -15,10 +15,10 @@ import { getDomainDns } from './selectors';
 
 import 'calypso/state/domains/init';
 
-export const fetchDns = ( domainName ) => ( dispatch, getState ) => {
+export const fetchDns = ( domainName, forceReload = false ) => ( dispatch, getState ) => {
 	const dns = getDomainDns( getState(), domainName );
 
-	if ( dns.isFetching || dns.hasLoadedFromServer ) {
+	if ( ! forceReload && ( dns.isFetching || dns.hasLoadedFromServer ) ) {
 		return;
 	}
 

--- a/packages/wpcom.js/src/lib/domain.dns.js
+++ b/packages/wpcom.js/src/lib/domain.dns.js
@@ -46,6 +46,18 @@ class DomainDns {
 	delete( record, query, fn ) {
 		return this.wpcom.req.post( this._subpath + '/delete', query, record, fn );
 	}
+
+	/**
+	 * Restores the default A records also deleting any A and AAAA custom records.
+	 *
+	 * @param {object} [query] - query object parameter
+	 * @param {Function} [fn] - callback function
+	 * @returns {Function} request handler
+	 */
+	restoreDefaultRecords( query, fn ) {
+		query = query ?? { apiVersion: '1.3' };
+		return this.wpcom.req.post( this._subpath + '/restore-default-records', query, null, fn );
+	}
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Depends on D69587-code.
This PR adds the action buttons to the DNS records page breadcrumbs component. 
The "Add a new record" action will be added later - it shouldn't be a problem since this PR is behind the `domains/dns-records-redesign` feature flag.

![image](https://user-images.githubusercontent.com/18705930/140252192-15f1692e-caf3-4691-beb3-597294531ab7.png)

#### Testing instructions
Same as #57328. Additionally:

 - Confirm that both "Add a new record"/3 dot menu buttons are correctly displayed;
 - Check that clicking the 3 dot menu and choosing "restore default records" restores the default records and reloads the records list - _if any error occurs, a notice is displayed with a generic error message._
 - Make sure that only A and AAAA records are restored to their default values.