### PR TITLE
Breadcrumb: simplify first, last logic.

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -16,13 +16,13 @@ const StyledLi = styled.li`
 	font-weight: 500;
 	--color-link: var( --studio-gray-100 );
 
-	&.first {
+	:first-child {
 		font-size: 16px;
 		font-weight: 600;
 		--color-link: var( --studio-gray-80 );
 	}
 
-	&.last {
+	:last-child {
 		--color-link: var( --studio-gray-50 );
 	}
 `;
@@ -39,11 +39,9 @@ interface Props {
 const Breadcrumb: React.FunctionComponent< Props > = ( { items } ) => {
 	return (
 		<StyledUl>
-			{ items.map( ( item: { href?: string; label: string }, index: Key, { length } ) => {
-				// eslint-disable-next-line no-nested-ternary
-				const className = index === 0 ? 'first' : index === length - 1 ? 'last' : '';
+			{ items.map( ( item: { href?: string; label: string }, index: Key ) => {
 				return (
-					<StyledLi key={ index } className={ className }>
+					<StyledLi key={ index }>
 						{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 18 } /> }
 						{ item.href ? <a href={ item.href }>{ item.label }</a> : <span>{ item.label }</span> }
 					</StyledLi>


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Simplifies breadcrumb first, last logic by using only CSS selectors

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/plugins?s=woo`
* Make sure that the first element has different styling from the second

![SS 2021-11-04 at 10 27 25](https://user-images.githubusercontent.com/12430020/140281513-79be8b05-2bc4-48e3-be3a-252a33b1d3ff.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/57442
