### PR TITLE
record step as 'loading' if the loading screen is visible

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -138,3 +138,20 @@ export function recordRegistration( { userData, flow, type } ) {
 	// FullStory
 	recordFullStoryEvent( 'calypso_user_registration_complete', { flow, type, device } );
 }
+
+/**
+ * Records loading of the processing screen
+ *
+ * @param {string} flow Signup flow name
+ * @param {string} previousStep The step before the processing screen
+ * @param {string} optionalProps Extra properties to record
+ */
+export function recordSignupProcessingScreen( flow, previousStep, optionalProps ) {
+	const device = resolveDeviceTypeByViewPort();
+	recordTracksEvent( 'calypso_signup_processing_screen', {
+		flow,
+		previous_step: previousStep,
+		device,
+		...optionalProps,
+	} );
+}

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -148,7 +148,7 @@ export function recordRegistration( { userData, flow, type } ) {
  */
 export function recordSignupProcessingScreen( flow, previousStep, optionalProps ) {
 	const device = resolveDeviceTypeByViewPort();
-	recordTracksEvent( 'calypso_signup_processing_screen', {
+	recordTracksEvent( 'calypso_signup_processing_screen_show', {
 		flow,
 		previous_step: previousStep,
 		device,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -31,6 +31,7 @@ import {
 	recordSignupComplete,
 	recordSignupStep,
 	recordSignupInvalidStep,
+	recordSignupProcessingScreen,
 } from 'calypso/lib/analytics/signup';
 import * as oauthToken from 'calypso/lib/oauth-token';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
@@ -241,15 +242,18 @@ class Signup extends Component {
 		debug( 'Signup component mounted' );
 		this.startTrackingForBusinessSite();
 		recordSignupStart( this.props.flowName, this.props.refParameter, this.getRecordProps() );
-		recordSignupStep( this.props.flowName, this.props.stepName, this.getRecordProps() );
+		if ( ! this.state.shouldShowLoadingScreen ) {
+			recordSignupStep( this.props.flowName, this.props.stepName, this.getRecordProps() );
+		}
 		this.preloadNextStep();
 		this.maybeShowSitePreview();
 	}
 
 	componentDidUpdate( prevProps ) {
 		if (
-			this.props.flowName !== prevProps.flowName ||
-			this.props.stepName !== prevProps.stepName
+			( this.props.flowName !== prevProps.flowName ||
+				this.props.stepName !== prevProps.stepName ) &&
+			! this.state.shouldShowLoadingScreen
 		) {
 			recordSignupStep( this.props.flowName, this.props.stepName, this.getRecordProps() );
 		}
@@ -366,6 +370,12 @@ class Signup extends Component {
 		}
 
 		if ( startLoadingScreen ) {
+			recordSignupProcessingScreen(
+				this.props.flowName,
+				this.props.stepName,
+				this.getRecordProps()
+			);
+
 			this.setState( { shouldShowLoadingScreen: true } );
 			/* Temporary change to add a 10 second delay to the processing screen.
 			 * This is done to allow the user 10 seconds to answer the bizx survey


### PR DESCRIPTION
#### Changes proposed in this Pull Request
In https://github.com/Automattic/wp-calypso/issues/57494 I noticed that on the final loading screen in the signup hero flow, a `calypso_signup_step_start` event is sent with `step=intent`. But that is the same event as is sent by the original intent screen. I think this could be confusing, and it also could be useful to have an event for the loading screen.
The issue also affects the loading screen in the existing `onboarding` flow which currently sends a`calypso_signup_step_start` event with `step=domains`.


#### Testing instruction
Complete the `/signup?flags=signup/hero-flow` flow. On the first loading screen, you should see a tracks event `calypso_signup_step_start,step=loading,flow=onboarding`. On the second loading screen you should see a tracks event `calypso_signup_step_start,step=loading,flow=setup-site`.

EDIT FROM AUTUMN:   I think the above testing should be for  'calypso_signup_processing_screen_show' 
