### PR TITLE
Sidebar: Add link to parent menu items

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -62,7 +62,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	// On which case we show a modal awaiting for user confirmation for opening that
 	// link on new tab in order to avoid Happy Chat session disconnection.
 	// We return a bool that shows if the logic should terminate here.
-	const continueInCalypso = ( url, event ) => {
+	const canNavigate = ( url, event ) => {
 		if ( isHappychatSessionActive && isExternal( url ) ) {
 			// Do not show warning modal on Jetpack sites, since all external links are
 			// always opened on new tabs for these sites.
@@ -118,7 +118,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 								sidebarCollapsed={ sidebarIsCollapsed }
 								isHappychatSessionActive={ isHappychatSessionActive }
 								isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-								continueInCalypso={ continueInCalypso }
+								canNavigate={ canNavigate }
 								{ ...item }
 							/>
 						);
@@ -130,7 +130,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 							selected={ isSelected }
 							isHappychatSessionActive={ isHappychatSessionActive }
 							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-							continueInCalypso={ continueInCalypso }
+							canNavigate={ canNavigate }
 							{ ...item }
 						/>
 					);

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -25,7 +25,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	url,
 	isHappychatSessionActive,
 	isJetpackNonAtomicSite,
-	continueInCalypso,
+	canNavigate,
 } ) => {
 	const reduxDispatch = useDispatch();
 
@@ -40,7 +40,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			count={ count }
 			label={ title }
 			link={ url }
-			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
+			onNavigate={ ( event ) => canNavigate( url, event ) && onNavigate() }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			forceInternalLink={ ! isHappychatSessionActive && ! isJetpackNonAtomicSite }
@@ -61,7 +61,7 @@ MySitesSidebarUnifiedItem.propTypes = {
 	url: PropTypes.string,
 	isHappychatSessionActive: PropTypes.bool.isRequired,
 	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
-	continueInCalypso: PropTypes.func.isRequired,
+	canNavigate: PropTypes.func.isRequired,
 };
 
 export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
-import { navigate } from 'calypso/lib/navigate';
 import { toggleMySitesSidebarSection as toggleSection } from 'calypso/state/my-sites/sidebar/actions';
 import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import MySitesSidebarUnifiedItem from './item';
@@ -28,7 +27,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	sidebarCollapsed,
 	isHappychatSessionActive,
 	isJetpackNonAtomicSite,
-	continueInCalypso,
+	canNavigate,
 	...props
 } ) => {
 	const reduxDispatch = useDispatch();
@@ -42,18 +41,11 @@ export const MySitesSidebarUnifiedMenu = ( {
 		( ! isWithinBreakpoint( '>782px' ) && ( childIsSelected || isExpanded ) ) || // For mobile breakpoints, we dont' care about the sidebar collapsed status.
 		( isWithinBreakpoint( '>782px' ) && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
 
+	// Avoid redirecting to the section if menu is full-width (i.e. mobile viewport) or if user
+	// is forced to keep the current page open (i.e. there is a Happychat session active).
+	const shouldRedirectToSection = isWithinBreakpoint( '>782px' ) && link && canNavigate( link );
+
 	const onClick = () => {
-		// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
-		if ( isWithinBreakpoint( '>782px' ) ) {
-			if ( link ) {
-				if ( ! continueInCalypso( link ) ) {
-					return;
-				}
-
-				navigate( link );
-			}
-		}
-
 		window.scrollTo( 0, 0 );
 		reduxDispatch( toggleSection( sectionId ) );
 	};
@@ -61,7 +53,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	return (
 		<li>
 			<ExpandableSidebarMenu
-				onClick={ () => onClick() }
+				onClick={ onClick }
 				expanded={ showAsExpanded }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
@@ -69,6 +61,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				count={ count }
 				hideExpandableIcon={ true }
 				inlineText={ props.inlineText }
+				href={ shouldRedirectToSection ? link : undefined }
 				{ ...props }
 			>
 				{ children.map( ( item ) => {
@@ -81,7 +74,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 							isSubItem={ true }
 							isHappychatSessionActive={ isHappychatSessionActive }
 							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-							continueInCalypso={ continueInCalypso }
+							canNavigate={ canNavigate }
 						/>
 					);
 				} ) }
@@ -101,7 +94,7 @@ MySitesSidebarUnifiedMenu.propTypes = {
 	sidebarCollapsed: PropTypes.bool,
 	isHappychatSessionActive: PropTypes.bool.isRequired,
 	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
-	continueInCalypso: PropTypes.func.isRequired,
+	canNavigate: PropTypes.func.isRequired,
 	/*
 	Example of children shape:
 	[


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/52291.

#### Changes proposed in this Pull Request

Adds a `href` attribute to the parent menu items of the sidebar so they can be opened on separated tabs if desired.

#### Testing instructions

- Use the Calypso live link below.
- ⌘+click on any parent menu item.
- Make sure it's opened on a separated tab.
- Make sure there are no regressions:
  - You shouldn't be able to open a parent menu item that links to WP Admin if there is a Happychat session active.
  - You shouldn't be able to open a parent menu item on mobile viewports, it should just toggle the section instead.
  - You should be able to open a parent menu item when the sidebar is collapsed.
