### PR TITLE
Show Design Picker Categories for DIFM

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -739,6 +739,9 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'selectedDesign' ],
 			optionalDependencies: [ 'selectedDesign' ],
+			props: {
+				showDesignPickerCategories: config.isEnabled( 'signup/design-picker-categories' ),
+			},
 		},
 		'difm-design-setup-site': {
 			stepName: 'difm-design-setup-site',
@@ -751,6 +754,7 @@ export function generateSteps( {
 				hideSkip: true,
 				hideExternalPreview: true,
 				useDIFMThemes: true,
+				showDesignPickerCategories: true,
 			},
 		},
 		'difm-design': {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, { isBlankCanvasDesign, getDesignUrl } from '@automattic/design-picker';
 import { shuffle } from '@automattic/js-utils';
 import { compose } from '@wordpress/compose';
@@ -159,7 +158,7 @@ class DesignPickerStep extends Component {
 				onSelect={ this.pickDesign }
 				onPreview={ this.previewDesign }
 				highResThumbnails
-				showCategoryFilter={ isEnabled( 'signup/design-picker-categories' ) }
+				showCategoryFilter={ this.props.showDesignPickerCategories }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Make design picker categories visibility a step prop
- FORCE `do-it-for-me` flow design picker step to show the categories
- leave `setup-site` design picker unchanged

#### Testing instructions
* On calypso live, go to flow `start/do-it-for-me` and make sure the DIFM categories are visible
* On calypso live, go to flow `start/setup-site?siteSlug=<some-site-slug>` and make categories are not visible


![image](https://user-images.githubusercontent.com/3422709/140308072-1a113693-b86d-4630-bf2a-0133eceefaed.png)

Related to #57185
