### PR TITLE
Video UI: Fix for Play button regression and video width on mobile

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -13,13 +13,13 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ currentVideo, setCurrentVideo ] = useState( null );
 
-	const onVideoPlayClick = ( video ) => {
+	const onVideoPlayClick = ( videoSlug, videoInfo ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
 			course: course.slug,
-			video,
+			videoSlug,
 		} );
 
-		setCurrentVideo( video );
+		setCurrentVideo( videoInfo );
 	};
 
 	useEffect( () => {
@@ -129,7 +129,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 					<div className="videos-ui__chapters">
 						{ course &&
 							Object.entries( course.videos ).map( ( data, i ) => {
-								const video = data[ 1 ];
+								const videoInfo = data[ 1 ];
 								return (
 									<div
 										key={ i }
@@ -154,15 +154,15 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 													<Gridicon icon="chevron-down" size={ 18 } />
 												</span>
 											) }
-											{ i + 1 }. { video.title }{ ' ' }
-											<span className="videos-ui__duration"> { video.duration } </span>{ ' ' }
+											{ i + 1 }. { videoInfo.title }{ ' ' }
+											<span className="videos-ui__duration"> { videoInfo.duration } </span>{ ' ' }
 										</button>
 										<div className="videos-ui__active-video-content">
 											<div>
-												<p>{ video.description } </p>
+												<p>{ videoInfo.description } </p>
 												<Button
 													className="videos-ui__play-button"
-													onClick={ () => onVideoPlayClick( data[ 0 ] ) }
+													onClick={ () => onVideoPlayClick( data[ 0 ], videoInfo ) }
 												>
 													<Gridicon icon="play" />
 													<span>{ translate( 'Play video' ) }</span>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -16,7 +16,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 	const onVideoPlayClick = ( videoSlug, videoInfo ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
 			course: course.slug,
-			videoSlug,
+			video: videoSlug,
 		} );
 
 		setCurrentVideo( videoInfo );

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -70,7 +70,7 @@
 		.videos-ui__video {
 			margin-bottom: 30px;
 			flex-basis: auto;
-			width: 60%;
+			width: 100%;
 
 			video {
 				width: 100%;


### PR DESCRIPTION
There is a regression on Play behaviour. This PR fixes the play button.

It also fixes the video width on mobile.

#### Testing
1. This PR still does not load the UI anywhere (as it will be added as a modal in the work being done for #57326.
1. However, it can be tested by importing the VideosUi component anywhere in Calypso (such as a block on the home page.)
1. Verify that the play button works as expected.
2. Verify that tracks are triggering correctly.
3. Verify that the video width on mobile & desktop looks correct.