### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` monitor to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -45,32 +45,6 @@ Undocumented.prototype.me = function () {
 };
 
 /**
- * Fetches settings for the Monitor module.
- *
- * @param {number} [siteId] The site ID
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.fetchMonitorSettings = function ( siteId, fn ) {
-	debug( '/jetpack-blogs/:site_id: query' );
-	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId }, fn );
-};
-
-Undocumented.prototype.updateMonitorSettings = function (
-	siteId,
-	emailNotifications,
-	wpNoteNotifications,
-	fn
-) {
-	debug( '/jetpack-blogs/:site_id: query' );
-	return this.wpcom.req.post(
-		{ path: '/jetpack-blogs/' + siteId },
-		{},
-		{ email_notifications: emailNotifications, wp_note_notifications: wpNoteNotifications },
-		fn
-	);
-};
-
-/**
  * Disconnects a Jetpack site with id siteId from WP.com
  *
  * @param {number} [siteId] The site ID

--- a/client/state/sites/monitor/actions.js
+++ b/client/state/sites/monitor/actions.js
@@ -24,9 +24,8 @@ export const requestSiteMonitorSettings = ( siteId ) => {
 			siteId,
 		} );
 
-		return wp
-			.undocumented()
-			.fetchMonitorSettings( siteId )
+		return wp.req
+			.get( `/jetpack-blogs/${ siteId }` )
 			.then( ( response ) => {
 				dispatch( {
 					type: SITE_MONITOR_SETTINGS_RECEIVE,
@@ -66,9 +65,11 @@ export const updateSiteMonitorSettings = ( siteId, settings ) => {
 			settings,
 		} );
 
-		return wp
-			.undocumented()
-			.updateMonitorSettings( siteId, email_notifications, wp_note_notifications )
+		return wp.req
+			.post( `/jetpack-blogs/${ siteId }`, {
+				email_notifications,
+				wp_note_notifications,
+			} )
 			.then( () => {
 				dispatch( {
 					type: SITE_MONITOR_SETTINGS_UPDATE_SUCCESS,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` methods for Jetpack monitor to `wpcom.req.get()`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions
* Go to `/settings/security/:site` where `:site` is one of your Jetpack sites.
* Play with toggling on and off of the "Downtime monitoring" sub-settings and verify they save and are retrieved correctly.