### PR TITLE
Jetpack Backup: Do not offer 1TB storage upgrade to customers who already have 1TB

### DIFF
--- a/client/components/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/components/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -1,7 +1,4 @@
-import {
-	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
-	getJetpackStorageAmountDisplays,
-} from '@automattic/calypso-products';
+import { useJetpack1TbStorageAmountText } from '@automattic/calypso-products';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -23,7 +20,7 @@ const useStatusText = ( usageLevel: StorageUsageLevels ) => {
 			case StorageUsageLevels.Warning:
 				return translate( 'You will reach your storage limit soon.' );
 			case StorageUsageLevels.Critical:
-				return translate( 'You’re running out of storage space.' );
+				return translate( "You're running out of storage space." );
 			case StorageUsageLevels.Full:
 				return translate( 'You ran out of storage space.' );
 		}
@@ -68,12 +65,7 @@ export const BackupStorageSpaceUpsell: React.FC< OwnProps > = ( {
 
 	const statusText = preventWidows( useStatusText( usageLevel ) );
 
-	// For now, Backup and Security both have the same two tiers,
-	// so it's okay to statically reference one of them to retrieve
-	// our upgraded storage amount.
-	const upgradeStorageAmount = getJetpackStorageAmountDisplays()[
-		PRODUCT_JETPACK_BACKUP_T2_YEARLY
-	];
+	const upgradeStorageAmount = useJetpack1TbStorageAmountText();
 	const actionText = preventWidows(
 		translate( 'Upgrade your backup storage to %(upgradeStorageAmount)s', {
 			args: { upgradeStorageAmount },

--- a/client/components/backup-storage-space/index.tsx
+++ b/client/components/backup-storage-space/index.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryRewindPolicies } from 'calypso/components/data/query-rewind-policies';
 import { useQueryRewindSize } from 'calypso/components/data/query-rewind-size';
+import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
+import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import {
 	getRewindBytesAvailable,
 	getRewindBytesUsed,
@@ -20,6 +22,7 @@ const BackupStorageSpace: React.FC = () => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	useQueryRewindSize( siteId );
 	useQueryRewindPolicies( siteId );
+	useQuerySitePurchases( siteId );
 
 	const bytesUsed = useSelector( ( state ) => getRewindBytesUsed( state, siteId ) );
 	const bytesAvailable = useSelector( ( state ) => getRewindBytesAvailable( state, siteId ) );
@@ -27,12 +30,13 @@ const BackupStorageSpace: React.FC = () => {
 
 	const showWarning = usageLevel > StorageUsageLevels.Normal;
 
+	const requestingPurchases = useSelector( isFetchingSitePurchases );
 	const requestingPolicies = useSelector( ( state ) =>
 		isRequestingRewindPolicies( state, siteId )
 	);
 	const requestingSize = useSelector( ( state ) => isRequestingRewindSize( state, siteId ) );
 
-	if ( requestingPolicies ) {
+	if ( requestingPolicies || requestingPurchases ) {
 		return <Card className="backup-storage-space__loading" />;
 	}
 

--- a/client/components/backup-storage-space/index.tsx
+++ b/client/components/backup-storage-space/index.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryRewindPolicies } from 'calypso/components/data/query-rewind-policies';
 import { useQueryRewindSize } from 'calypso/components/data/query-rewind-size';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	getRewindBytesAvailable,
 	getRewindBytesUsed,
@@ -11,9 +10,9 @@ import {
 	isRequestingRewindSize,
 } from 'calypso/state/rewind/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { BackupStorageSpaceUpsell } from './backup-storage-space-upsell';
 import { getUsageLevel, StorageUsageLevels } from './storage-usage-levels';
 import UsageDisplay from './usage-display';
+import UsageWarning from './usage-warning';
 
 import './style.scss';
 
@@ -26,8 +25,8 @@ const BackupStorageSpace: React.FC = () => {
 	const bytesAvailable = useSelector( ( state ) => getRewindBytesAvailable( state, siteId ) );
 	const usageLevel = getUsageLevel( bytesUsed, bytesAvailable ) ?? StorageUsageLevels.Normal;
 
-	const showUpsell = usageLevel > StorageUsageLevels.Normal;
-	const siteSlug = useSelector( getSelectedSiteSlug );
+	const showWarning = usageLevel > StorageUsageLevels.Normal;
+	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 
 	const requestingPolicies = useSelector( ( state ) =>
 		isRequestingRewindPolicies( state, siteId )
@@ -47,13 +46,13 @@ const BackupStorageSpace: React.FC = () => {
 	return (
 		<Card className="backup-storage-space">
 			<UsageDisplay loading={ requestingSize } usageLevel={ usageLevel } />
-			{ showUpsell && (
+			{ showWarning && (
 				<>
 					<div className="backup-storage-space__divider"></div>
-					<BackupStorageSpaceUpsell
+					<UsageWarning
+						siteSlug={ siteSlug }
 						usageLevel={ usageLevel }
 						bytesUsed={ bytesUsed as number }
-						href={ isJetpackCloud() ? `/pricing/backup/${ siteSlug }` : `/plans/${ siteSlug }` }
 					/>
 				</>
 			) }

--- a/client/components/backup-storage-space/index.tsx
+++ b/client/components/backup-storage-space/index.tsx
@@ -9,7 +9,7 @@ import {
 	isRequestingRewindPolicies,
 	isRequestingRewindSize,
 } from 'calypso/state/rewind/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { getUsageLevel, StorageUsageLevels } from './storage-usage-levels';
 import UsageDisplay from './usage-display';
 import UsageWarning from './usage-warning';
@@ -26,7 +26,6 @@ const BackupStorageSpace: React.FC = () => {
 	const usageLevel = getUsageLevel( bytesUsed, bytesAvailable ) ?? StorageUsageLevels.Normal;
 
 	const showWarning = usageLevel > StorageUsageLevels.Normal;
-	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 
 	const requestingPolicies = useSelector( ( state ) =>
 		isRequestingRewindPolicies( state, siteId )
@@ -50,7 +49,7 @@ const BackupStorageSpace: React.FC = () => {
 				<>
 					<div className="backup-storage-space__divider"></div>
 					<UsageWarning
-						siteSlug={ siteSlug }
+						siteId={ siteId }
 						usageLevel={ usageLevel }
 						bytesUsed={ bytesUsed as number }
 					/>

--- a/client/components/backup-storage-space/usage-warning/action-button.tsx
+++ b/client/components/backup-storage-space/usage-warning/action-button.tsx
@@ -1,0 +1,43 @@
+import { Button } from '@wordpress/components';
+import classnames from 'classnames';
+import { StorageUsageLevels } from '../storage-usage-levels';
+import useStorageStatusText from './use-storage-status-text';
+import type { TranslateResult } from 'i18n-calypso';
+
+type OwnProps = {
+	className?: string;
+	usageLevel: StorageUsageLevels;
+	actionText: TranslateResult;
+	href?: string;
+	onClick?: React.MouseEventHandler;
+};
+
+const ActionButton: React.FC< OwnProps > = ( {
+	className,
+	usageLevel,
+	actionText,
+	href,
+	onClick,
+} ) => {
+	const storageStatusText = useStorageStatusText( usageLevel );
+
+	const hasClickableAction = Boolean( href || onClick );
+
+	return (
+		<Button
+			className={ classnames( className, 'usage-warning__action-button', {
+				'has-clickable-action': hasClickableAction,
+			} ) }
+			href={ href }
+			onClick={ onClick }
+		>
+			<div className="action-button__copy">
+				<div className="action-button__status">{ storageStatusText }</div>
+				<div className="action-button__action-text">{ actionText }</div>
+			</div>
+			{ hasClickableAction && <span className="action-button__arrow">&#8594;</span> }
+		</Button>
+	);
+};
+
+export default ActionButton;

--- a/client/components/backup-storage-space/usage-warning/index.tsx
+++ b/client/components/backup-storage-space/usage-warning/index.tsx
@@ -1,0 +1,21 @@
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { StorageUsageLevels } from '../storage-usage-levels';
+import Upsell from './upsell';
+
+type OwnProps = {
+	siteSlug: string;
+	usageLevel: StorageUsageLevels;
+	bytesUsed: number;
+};
+
+const UsageWarning: React.FC< OwnProps > = ( { usageLevel, bytesUsed, siteSlug } ) => {
+	return (
+		<Upsell
+			usageLevel={ usageLevel }
+			bytesUsed={ bytesUsed as number }
+			href={ isJetpackCloud() ? `/pricing/backup/${ siteSlug }` : `/plans/${ siteSlug }` }
+		/>
+	);
+};
+
+export default UsageWarning;

--- a/client/components/backup-storage-space/usage-warning/manage-storage.tsx
+++ b/client/components/backup-storage-space/usage-warning/manage-storage.tsx
@@ -1,0 +1,37 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { StorageUsageLevels } from '../storage-usage-levels';
+import ActionButton from './action-button';
+
+type OwnProps = {
+	usageLevel: StorageUsageLevels;
+	bytesUsed: number;
+};
+
+const ManageStorage: React.FC< OwnProps > = ( { usageLevel, bytesUsed } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	useEffect( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_storage_managestorage_display', {
+				type: StorageUsageLevels[ usageLevel ],
+				bytes_used: bytesUsed,
+			} )
+		);
+	}, [ dispatch, usageLevel, bytesUsed ] );
+
+	return (
+		<ActionButton
+			className="usage-warning__manage-storage"
+			usageLevel={ usageLevel }
+			actionText={ translate(
+				"We're working on adding more storage options. In the meantime, manage your storage to make some room."
+			) }
+		/>
+	);
+};
+
+export default ManageStorage;

--- a/client/components/backup-storage-space/usage-warning/site-can-upgrade-backup-storage.ts
+++ b/client/components/backup-storage-space/usage-warning/site-can-upgrade-backup-storage.ts
@@ -1,0 +1,29 @@
+import {
+	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+} from '@automattic/calypso-products';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import type { AppState } from 'calypso/types';
+
+const UPGRADEABLE_STORAGE_PRODUCT_SLUGS = [
+	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+];
+
+const siteCanUpgradeBackupStorage = ( state: AppState, siteId: number | null ): boolean | null => {
+	if ( siteId === null ) {
+		return null;
+	}
+
+	const sitePurchases = getSitePurchases( state, siteId ) ?? [];
+	return sitePurchases.some(
+		( { subscriptionStatus, productSlug } ) =>
+			subscriptionStatus === 'active' && UPGRADEABLE_STORAGE_PRODUCT_SLUGS.includes( productSlug )
+	);
+};
+
+export default siteCanUpgradeBackupStorage;

--- a/client/components/backup-storage-space/usage-warning/style.scss
+++ b/client/components/backup-storage-space/usage-warning/style.scss
@@ -1,10 +1,10 @@
-.usage-warning-upsell__title {
+.usage-warning__storage-full {
 	font-size: 1rem;
 	font-weight: bold;
 	margin-bottom: 16px;
 }
 
-.usage-warning-upsell__call-to-action.components-button {
+.usage-warning__action-button {
 	width: 100%;
 	height: 100%;
 
@@ -19,33 +19,43 @@
 	color: var( --color-text );
 	font-size: $font-body;
 
-	&:hover,
-	&:focus {
-		background: none;
+	&:visited {
+		color: var( --color-text );
+	}
 
-		.usage-warning-upsell__action-text {
+	&:focus,
+	&:hover {
+		cursor: initial;
+		background: none;
+	}
+
+	&.has-clickable-action:focus,
+	&.has-clickable-action:hover {
+		cursor: pointer;
+
+		.action-button__action-text {
 			text-decoration: underline;
 			text-decoration-thickness: 2px;
 		}
 
-		.usage-warning-upsell__arrow {
+		.action-button__arrow {
 			transform: translateX( 8px );
 		}
 	}
-}
 
-.usage-warning-upsell__status {
-	margin-bottom: 0.25rem;
-}
+	.action-button__status {
+		margin-bottom: 0.5rem;
+	}
 
-.usage-warning-upsell__action-text {
-	font-weight: bold;
-}
+	.action-button__action-text {
+		font-weight: bold;
+	}
 
-.usage-warning-upsell__arrow {
-	transition: transform 0.15s ease-out;
+	.action-button__arrow {
+		transition: transform 0.15s ease-out;
 
-	color: var( --studio-jetpack-green );
-	font-size: $font-title-medium;
-	font-weight: 600;
+		color: var( --studio-jetpack-green );
+		font-size: $font-title-medium;
+		font-weight: 600;
+	}
 }

--- a/client/components/backup-storage-space/usage-warning/style.scss
+++ b/client/components/backup-storage-space/usage-warning/style.scss
@@ -18,6 +18,7 @@
 
 	color: var( --color-text );
 	font-size: $font-body;
+	text-align: initial;
 
 	&:visited {
 		color: var( --color-text );

--- a/client/components/backup-storage-space/usage-warning/style.scss
+++ b/client/components/backup-storage-space/usage-warning/style.scss
@@ -1,10 +1,10 @@
-.backup-storage-space-upsell__title {
+.usage-warning-upsell__title {
 	font-size: 1rem;
 	font-weight: bold;
 	margin-bottom: 16px;
 }
 
-.backup-storage-space-upsell__call-to-action.components-button {
+.usage-warning-upsell__call-to-action.components-button {
 	width: 100%;
 	height: 100%;
 
@@ -23,26 +23,26 @@
 	&:focus {
 		background: none;
 
-		.backup-storage-space-upsell__action-text {
+		.usage-warning-upsell__action-text {
 			text-decoration: underline;
 			text-decoration-thickness: 2px;
 		}
 
-		.backup-storage-space-upsell__arrow {
+		.usage-warning-upsell__arrow {
 			transform: translateX( 8px );
 		}
 	}
 }
 
-.backup-storage-space-upsell__status {
+.usage-warning-upsell__status {
 	margin-bottom: 0.25rem;
 }
 
-.backup-storage-space-upsell__action-text {
+.usage-warning-upsell__action-text {
 	font-weight: bold;
 }
 
-.backup-storage-space-upsell__arrow {
+.usage-warning-upsell__arrow {
 	transition: transform 0.15s ease-out;
 
 	color: var( --studio-jetpack-green );

--- a/client/components/backup-storage-space/usage-warning/upsell.tsx
+++ b/client/components/backup-storage-space/usage-warning/upsell.tsx
@@ -2,7 +2,6 @@ import { useJetpack1TbStorageAmountText } from '@automattic/calypso-products';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo } from 'react';
-import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -35,11 +34,7 @@ type OwnProps = {
 	usageLevel: StorageUsageLevels;
 };
 
-export const BackupStorageSpaceUpsell: React.FC< OwnProps > = ( {
-	href,
-	bytesUsed,
-	usageLevel,
-} ) => {
+const UsageWarningUpsell: React.FC< OwnProps > = ( { href, bytesUsed, usageLevel } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -76,21 +71,23 @@ export const BackupStorageSpaceUpsell: React.FC< OwnProps > = ( {
 	return (
 		<>
 			{ usageLevel === StorageUsageLevels.Full && (
-				<div className="backup-storage-space-upsell__title">
+				<div className="usage-warning-upsell__title">
 					{ translate( 'Your Backup storage is full and new backups have been paused' ) }
 				</div>
 			) }
 			<Button
-				className="backup-storage-space-upsell__call-to-action"
+				className="usage-warning-upsell__call-to-action"
 				href={ href }
 				onClick={ onUpsellClick }
 			>
-				<div className="backup-storage-space-upsell__copy">
-					<div className="backup-storage-space-upsell__status">{ statusText }</div>
-					<div className="backup-storage-space-upsell__action-text">{ actionText }</div>
+				<div className="usage-warning-upsell__copy">
+					<div className="usage-warning-upsell__status">{ statusText }</div>
+					<div className="usage-warning-upsell__action-text">{ actionText }</div>
 				</div>
-				<span className="backup-storage-space-upsell__arrow">&#8594;</span>
+				<span className="usage-warning-upsell__arrow">&#8594;</span>
 			</Button>
 		</>
 	);
 };
+
+export default UsageWarningUpsell;

--- a/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
+++ b/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
@@ -1,0 +1,24 @@
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { StorageUsageLevels } from '../storage-usage-levels';
+
+const useStorageStatusText = ( usageLevel: StorageUsageLevels ): TranslateResult | null => {
+	const translate = useTranslate();
+
+	// TODO: For StorageUsageLevels.Warning, estimate how many days until
+	// all storage is used, and show that in the status text.
+	return useMemo( () => {
+		switch ( usageLevel ) {
+			case StorageUsageLevels.Warning:
+				return translate( 'You will reach your storage limit soon.' );
+			case StorageUsageLevels.Critical:
+				return translate( "You're running out of storage space." );
+			case StorageUsageLevels.Full:
+				return translate( 'You ran out of storage space.' );
+		}
+
+		return null;
+	}, [ translate, usageLevel ] );
+};
+
+export default useStorageStatusText;

--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -7,7 +7,7 @@ import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 
 const debug = debugFactory( 'calypso:query-site-purchases' );
 
-export default function QuerySitePurchases( { siteId } ) {
+export const useQuerySitePurchases = ( siteId ) => {
 	const isRequesting = useSelector( ( state ) => isFetchingSitePurchases( state ) );
 	const reduxDispatch = useDispatch();
 	const previousSiteId = useRef();
@@ -26,7 +26,10 @@ export default function QuerySitePurchases( { siteId } ) {
 
 		reduxDispatch( fetchSitePurchases( siteId ) );
 	}, [ siteId, reduxDispatch, isRequesting ] );
+};
 
+export default function QuerySitePurchases( { siteId } ) {
+	useQuerySitePurchases( siteId );
 	return null;
 }
 

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -187,7 +187,7 @@
 	}
 
 	.backup-storage-space__divider,
-	.usage-warning-upsell__title-text {
+	.usage-warning__storage-full {
 		display: none;
 	}
 

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -187,7 +187,7 @@
 	}
 
 	.backup-storage-space__divider,
-	.backup-storage-space-upsell__title-text {
+	.usage-warning-upsell__title-text {
 		display: none;
 	}
 

--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-storage-upgrade-product.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-storage-upgrade-product.ts
@@ -1,7 +1,6 @@
 import {
-	getJetpackStorageAmountDisplays,
-	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
-	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
+	useJetpack10GbStorageAmountText,
+	useJetpack1TbStorageAmountText,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -15,7 +14,7 @@ export const useGetTier1UpgradeProduct = (): StorageUpgradeGetter => {
 	const translate = useTranslate();
 
 	// Security and Backup share the same per-tier storage limits
-	const storageAmount = getJetpackStorageAmountDisplays()[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ];
+	const storageAmount = useJetpack10GbStorageAmountText();
 
 	return useCallback(
 		( slug: string ): SelectorProduct =>
@@ -56,7 +55,7 @@ export const useGetTier2UpgradeProduct = (): StorageUpgradeGetter => {
 	const translate = useTranslate();
 
 	// Security and Backup share the same per-tier storage limits
-	const storageAmount = getJetpackStorageAmountDisplays()[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ];
+	const storageAmount = useJetpack1TbStorageAmountText();
 
 	return useCallback(
 		( slug: string ): SelectorProduct =>

--- a/packages/calypso-products/src/translations.js
+++ b/packages/calypso-products/src/translations.js
@@ -1,5 +1,5 @@
-import { translate } from 'i18n-calypso';
-import { createElement } from 'react';
+import { translate, useTranslate } from 'i18n-calypso';
+import { createElement, useMemo } from 'react';
 import {
 	PRODUCT_JETPACK_ANTI_SPAM,
 	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
@@ -288,85 +288,53 @@ export const getJetpackProductsDescriptions = () => {
 	};
 };
 
-export const getJetpackStorageAmountDisplays = () => ( {
-	[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: translate(
-		'%(numberOfGigabytes)dGB',
-		'%(numberOfGigabytes)dGB',
-		{
-			comment:
-				'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
-			count: 10,
-			args: { numberOfGigabytes: 10 },
-		}
-	),
-	[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: translate(
-		'%(numberOfGigabytes)dGB',
-		'%(numberOfGigabytes)dGB',
-		{
-			comment:
-				'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
-			count: 10,
-			args: { numberOfGigabytes: 10 },
-		}
-	),
-	[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: translate(
-		'%(numberOfTerabytes)dTB',
-		'%(numberOfTerabytes)dTB',
-		{
-			comment:
-				'Displays an amount of terabytes. Plural string used in case TB needs to be pluralized.',
-			count: 1,
-			args: { numberOfTerabytes: 1 },
-		}
-	),
-	[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: translate(
-		'%(numberOfTerabytes)dTB',
-		'%(numberOfTerabytes)dTB',
-		{
-			comment:
-				'Displays an amount of terabytes. Plural string used in case TB needs to be pluralized.',
-			count: 1,
-			args: { numberOfTerabytes: 1 },
-		}
-	),
-	[ PLAN_JETPACK_SECURITY_T1_YEARLY ]: translate(
-		'%(numberOfGigabytes)dGB',
-		'%(numberOfGigabytes)dGB',
-		{
-			comment:
-				'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
-			count: 10,
-			args: { numberOfGigabytes: 10 },
-		}
-	),
-	[ PLAN_JETPACK_SECURITY_T1_MONTHLY ]: translate(
-		'%(numberOfGigabytes)dGB',
-		'%(numberOfGigabytes)dGB',
-		{
-			comment:
-				'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
-			count: 10,
-			args: { numberOfGigabytes: 10 },
-		}
-	),
-	[ PLAN_JETPACK_SECURITY_T2_YEARLY ]: translate(
-		'%(numberOfTerabytes)dTB',
-		'%(numberOfTerabytes)dTB',
-		{
-			comment:
-				'Displays an amount of terabytes. Plural string used in case TB needs to be pluralized.',
-			count: 1,
-			args: { numberOfTerabytes: 1 },
-		}
-	),
-	[ PLAN_JETPACK_SECURITY_T2_MONTHLY ]: translate(
-		'%(numberOfTerabytes)dTB',
-		'%(numberOfTerabytes)dTB',
-		{
-			comment:
-				'Displays an amount of terabytes. Plural string used in case TB needs to be pluralized.',
-			count: 1,
-			args: { numberOfTerabytes: 1 },
-		}
-	),
-} );
+export const useJetpack10GbStorageAmountText = () => {
+	const _translate = useTranslate();
+
+	return useMemo(
+		() =>
+			_translate( '%(numberOfGigabytes)dGB', '%(numberOfGigabytes)dGB', {
+				comment:
+					'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
+				count: 10,
+				args: { numberOfGigabytes: 10 },
+			} ),
+		[ _translate ]
+	);
+};
+
+export const useJetpack1TbStorageAmountText = () => {
+	const _translate = useTranslate();
+
+	return useMemo(
+		() =>
+			_translate( '%(numberOfTerabytes)dTB', '%(numberOfTerabytes)dTB', {
+				comment:
+					'Displays an amount of terabytes. Plural string used in case TB needs to be pluralized.',
+				count: 1,
+				args: { numberOfTerabytes: 1 },
+			} ),
+		[ _translate ]
+	);
+};
+
+export const useJetpackStorageAmountTextByProductSlug = ( productSlug ) => {
+	const TEN_GIGABYTES = useJetpack10GbStorageAmountText();
+	const ONE_TERABYTE = useJetpack1TbStorageAmountText();
+
+	return useMemo(
+		() =>
+			( {
+				[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: TEN_GIGABYTES,
+				[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: TEN_GIGABYTES,
+				[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: ONE_TERABYTE,
+				[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: ONE_TERABYTE,
+
+				[ PLAN_JETPACK_SECURITY_T1_MONTHLY ]: TEN_GIGABYTES,
+				[ PLAN_JETPACK_SECURITY_T1_YEARLY ]: TEN_GIGABYTES,
+				[ PLAN_JETPACK_SECURITY_T2_MONTHLY ]: ONE_TERABYTE,
+				[ PLAN_JETPACK_SECURITY_T2_YEARLY ]: ONE_TERABYTE,
+			}[ productSlug ] ),
+		[ TEN_GIGABYTES, ONE_TERABYTE, productSlug ]
+	);
+};

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -12,7 +12,6 @@ import type {
 	TYPES_LIST,
 	PERIOD_LIST,
 } from './constants';
-import type { getJetpackStorageAmountDisplays } from './translations';
 import type { TranslateResult } from 'i18n-calypso';
 
 const featureValues = Object.values( features );
@@ -49,7 +48,6 @@ export type JetpackPlanSlug =
 export type JetpackPurchasableItemSlug =
 	| JetpackProductSlug
 	| Exclude< JetpackPlanSlug, typeof PLAN_JETPACK_FREE >;
-export type JetpackSlugsWithStorage = keyof ReturnType< typeof getJetpackStorageAmountDisplays >;
 
 export interface JetpackPlan extends Plan {
 	getAnnualSlug?: () => JetpackPlanSlug;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor the backup storage upsell so that it can be used more generically, depending on the message we want to display.
* Create a new message that appears when customers with 1TB of storage are nearing their storage limit, prompting them to manage their storage.

#### Testing instructions

***Prerequisite:** You'll need access to a Jetpack site that has a Backup subscription with 1TB storage.*

1. Visit either the the **Backup** page, or the **Upgrades > Plans > My Plan** tab in Calypso Blue.
2. If your site is approaching its storage limit (≥ 65% used), verify you see a message like in the below screenshots: "We're working on adding more storage options. ..."
3. (Optional) Run the same test on a site that has 10GB of storage, ensuring the storage upgrade prompt still displays as before.

**TIP:** You can simulate different storage usages with Redux DevTools in your browser. Dispatch the following action, substituting `<your_site_id>` with your site's numeric ID and `<bytes>` with a number of bytes used:

(For reference: 1TB = `1099511627776`; 750GB = `805306368000`.)

```js
{
  type: 'REWIND_SIZE_SET',
  siteId: <your_site_id>,
  size: {
    bytesUsed: <bytes>
  }
}
```

#### Reference screenshots

##### My Plan page (10 GB / 1 TB)

<img width="375" alt="Screen Shot 2021-11-04 at 07 56 00" src="https://user-images.githubusercontent.com/670067/140317207-f010a934-a676-4b3c-94c1-3b3d28c7d0d1.png"> <img width="375" alt="Screen Shot 2021-11-04 at 07 59 35" src="https://user-images.githubusercontent.com/670067/140317674-a8395060-f32c-48c1-8372-7a24a9358523.png">

##### Backup page (10 GB / 1 TB)

<img width="375" alt="Screen Shot 2021-11-03 at 14 50 07" src="https://user-images.githubusercontent.com/670067/140317846-33db79cc-545b-46a7-8759-18743f6ed630.png"> <img width="375" alt="image" src="https://user-images.githubusercontent.com/670067/140318079-5e09b027-07c9-4f48-89a7-d2396dec3185.png">
