### PR TITLE
i18n: Update getLanguageFileUrl to string type revision

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -60,10 +60,14 @@ export function getLanguageFileUrl( localeSlug, fileType = 'json', languageRevis
 		fileType = 'json';
 	}
 
-	const revision = languageRevisions[ localeSlug ];
 	const fileUrl = `${ getLanguageFilePathUrl() }${ localeSlug }-v1.1.${ fileType }`;
+	let revision = languageRevisions[ localeSlug ];
 
-	return typeof revision === 'number' ? fileUrl + `?v=${ revision }` : fileUrl;
+	if ( typeof revision === 'number' ) {
+		revision = revision.toString();
+	}
+
+	return typeof revision === 'string' ? fileUrl + `?v=${ revision }` : fileUrl;
 }
 
 function getHtmlLangAttribute() {

--- a/client/lib/i18n-utils/test/switch-locale.js
+++ b/client/lib/i18n-utils/test/switch-locale.js
@@ -42,9 +42,15 @@ describe( 'getLanguageFileUrl()', () => {
 	} );
 
 	test( 'should append a revision cache buster.', () => {
-		const expected = getLanguageFilePathUrl() + 'zh-v1.1.js?v=123';
+		const expectedWithNumberRevision = getLanguageFilePathUrl() + 'zh-v1.1.js?v=123';
 
-		expect( getLanguageFileUrl( 'zh', 'js', { zh: 123 } ) ).toEqual( expected );
+		expect( getLanguageFileUrl( 'zh', 'js', { zh: 123 } ) ).toEqual( expectedWithNumberRevision );
+
+		const expectedWithStringRevision = getLanguageFilePathUrl() + 'de-v1.1.js?v=abc123';
+
+		expect( getLanguageFileUrl( 'de', 'js', { de: 'abc123' } ) ).toEqual(
+			expectedWithStringRevision
+		);
 	} );
 
 	test( 'should not append a revision cache buster for an unknown locale.', () => {
@@ -53,10 +59,10 @@ describe( 'getLanguageFileUrl()', () => {
 		expect( getLanguageFileUrl( 'kr', 'js', { xd: 222 } ) ).toEqual( expected );
 	} );
 
-	test( 'should not use a non-number revision', () => {
+	test( 'should not use a non-number-or-string revision', () => {
 		const expected = getLanguageFilePathUrl() + 'zh-v1.1.js';
 
-		expect( getLanguageFileUrl( 'zh', 'js', { zh: 'what-is-this?' } ) ).toEqual( expected );
+		expect( getLanguageFileUrl( 'zh', 'js', { zh: true } ) ).toEqual( expected );
 	} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow using revision with type string in `getLanguageFileUrl`.

#### Testing instructions

* Confirm unit tests pass with `yarn test-client client/lib/i18n-utils/test/switch-locale.js`.
* Boot Calypso locally with `ENABLE_FEATURES=wpcom-user-bootstrap yarn start`.
* Change the UI to non-English language.
* Inspect the page source and confirm the language file script url has the revision param appended.

Related to D58346-code
