### PR TITLE
Add domains list filter button

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -135,12 +135,15 @@ class SelectDropdown extends Component {
 		if ( this.props.children ) {
 			// add refs and focus-on-click handlers to children
 			return Children.map( this.props.children, ( child ) => {
-				if ( ! child || child.type !== DropdownItem ) {
+				if (
+					! child ||
+					! [ DropdownItem, DropdownSeparator, DropdownLabel ].includes( child.type )
+				) {
 					return null;
 				}
 
 				return cloneElement( child, {
-					ref: this.setItemRef( refIndex++ ),
+					ref: child.type === DropdownItem ? this.setItemRef( refIndex++ ) : null,
 					onClick: ( event ) => {
 						this.dropdownContainerRef.current.focus();
 						if ( typeof child.props.onClick === 'function' ) {

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -4,6 +4,7 @@
 .breadcrumbs {
 	position: relative;
 	margin: 0;
+	z-index: 10;
 
 	@include break-mobile {
 		position: sticky;
@@ -62,14 +63,14 @@
 		font-size: 13px; /* stylelint-disable-line */
 		font-weight: 500; /* stylelint-disable-line */
 		color: var( --color-neutral-80 );
-		
+
 		& .breadcrumbs__item {
 			color: var( --color-neutral-80 );
-			
+
 			& .breadcrumbs__item-label {
 				color: var( --color-neutral-80 );
 			}
-			
+
 			&:first-child {
 				.breadcrumbs__item-label {
 					font-size: $font-body;
@@ -140,9 +141,10 @@
 	display: none;
 
 	@include break-mobile {
-		display: block;
+		display: flex;
 
-		& .button {
+		& button,
+		& .select-dropdown {
 			margin-right: 16px;
 		}
 		& .button:last-child {

--- a/client/my-sites/domains/domain-management/list/domains-table-filter-button.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-filter-button.jsx
@@ -1,0 +1,71 @@
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import SelectDropdown from 'calypso/components/select-dropdown';
+
+class DomainsTableFilterButton extends Component {
+	static propTypes = {
+		selectedFilter: PropTypes.string,
+		filterOptions: PropTypes.arrayOf(
+			PropTypes.shape( {
+				label: PropTypes.string.isRequired,
+				value: PropTypes.string.isRequired,
+				path: PropTypes.string,
+				count: PropTypes.number,
+			} )
+		),
+	};
+
+	getFilterOptions() {
+		return this.props.filterOptions;
+	}
+
+	getFilterItems() {
+		const { selectedFilter } = this.props;
+
+		return this.getFilterOptions().map( ( item, index ) => {
+			if ( ! item ) {
+				return <SelectDropdown.Separator key={ `key-separator-${ index }` } />;
+			}
+
+			return (
+				<SelectDropdown.Item
+					key={ `key-${ item.value }` }
+					selected={ item.value === selectedFilter }
+					value={ item.value }
+					path={ item.path }
+					count={ item.count }
+				>
+					{ item.label }
+				</SelectDropdown.Item>
+			);
+		} );
+	}
+
+	getSelectedItem() {
+		const { selectedFilter } = this.props;
+		return this.getFilterOptions().find( ( item ) => item && item.value === selectedFilter );
+	}
+
+	getSelectedText() {
+		return this.getSelectedItem().label;
+	}
+
+	getSelectedCount() {
+		return this.getSelectedItem().count;
+	}
+
+	render() {
+		return (
+			<SelectDropdown
+				compact
+				initialSelected="site-domains"
+				selectedText={ this.getSelectedText() }
+				selectedCount={ this.getSelectedCount() }
+			>
+				{ this.getFilterItems() }
+			</SelectDropdown>
+		);
+	}
+}
+
+export default DomainsTableFilterButton;

--- a/client/my-sites/domains/domain-management/list/domains-table-filter-button.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-filter-button.jsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
@@ -13,6 +14,7 @@ class DomainsTableFilterButton extends Component {
 				count: PropTypes.number,
 			} )
 		),
+		compact: PropTypes.bool.isRequired,
 	};
 
 	getFilterOptions() {
@@ -55,9 +57,13 @@ class DomainsTableFilterButton extends Component {
 	}
 
 	render() {
+		const { compact } = this.props;
 		return (
 			<SelectDropdown
-				compact
+				className={ classnames( 'domains-table-filter-button', {
+					'is-mobile-version': ! compact,
+				} ) }
+				compact={ compact }
 				initialSelected="site-domains"
 				selectedText={ this.getSelectedText() }
 				selectedCount={ this.getSelectedCount() }

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -7,6 +7,7 @@ import {
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
+import { stringify } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';
@@ -24,7 +25,7 @@ import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/b
 import EmptyDomainsListCard from 'calypso/my-sites/domains/domain-management/list/empty-domains-list-card';
 import FreeDomainItem from 'calypso/my-sites/domains/domain-management/list/free-domain-item';
 import OptionsDomainButton from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
-import { domainManagementList } from 'calypso/my-sites/domains/paths';
+import { domainManagementList, domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import GoogleSaleBanner from 'calypso/my-sites/email/google-sale-banner';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import {
@@ -48,6 +49,7 @@ import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import DomainOnly from './domain-only';
 import DomainsTable from './domains-table';
+import DomainsTableFilterButton from './domains-table-filter-button';
 import {
 	filterOutWpcomDomains,
 	getDomainManagementPath,
@@ -84,6 +86,17 @@ export class SiteDomains extends Component {
 		return this.props.isRequestingSiteDomains && this.props.domains.length === 0;
 	}
 
+	filterDomains( domains, filter ) {
+		return domains.filter( ( domain ) => {
+			if ( 'owned-by-me' === filter ) {
+				return domain.currentUserCanManage;
+			} else if ( 'owned-by-others' === filter ) {
+				return ! domain.currentUserCanManage;
+			}
+			return true;
+		} );
+	}
+
 	renderNewDesign() {
 		const {
 			currentRoute,
@@ -91,12 +104,15 @@ export class SiteDomains extends Component {
 			hasProductsList,
 			isAtomicSite,
 			selectedSite,
+			context,
 			translate,
 		} = this.props;
 		const { primaryDomainIndex, settingPrimaryDomain } = this.state;
 		const disabled = settingPrimaryDomain;
 
-		const nonWpcomDomains = filterOutWpcomDomains( domains );
+		const selectedFilter = context?.query?.filter;
+
+		const nonWpcomDomains = this.filterDomains( filterOutWpcomDomains( domains ), selectedFilter );
 		const wpcomDomain = domains.find(
 			( domain ) => domain.type === type.WPCOM || domain.isWpcomStagingDomain
 		);
@@ -155,7 +171,7 @@ export class SiteDomains extends Component {
 					</div>
 				</div>
 
-				{ ! this.isLoading() && nonWpcomDomains.length === 0 && (
+				{ ! this.isLoading() && nonWpcomDomains.length === 0 && ! selectedFilter && (
 					<EmptyDomainsListCard
 						selectedSite={ selectedSite }
 						hasDomainCredit={ this.props.hasDomainCredit }
@@ -169,7 +185,7 @@ export class SiteDomains extends Component {
 					<DomainsTable
 						isLoading={ this.isLoading() }
 						currentRoute={ currentRoute }
-						domains={ domains }
+						domains={ nonWpcomDomains }
 						domainsTableColumns={ domainsTableColumns }
 						selectedSite={ selectedSite }
 						primaryDomainIndex={ primaryDomainIndex }
@@ -181,7 +197,7 @@ export class SiteDomains extends Component {
 					/>
 				</div>
 
-				{ ! this.isLoading() && nonWpcomDomains.length > 0 && (
+				{ ! this.isLoading() && nonWpcomDomains.length > 0 && ! selectedFilter && (
 					<EmptyDomainsListCard
 						selectedSite={ selectedSite }
 						hasDomainCredit={ this.props.hasDomainCredit }
@@ -209,7 +225,8 @@ export class SiteDomains extends Component {
 	}
 
 	renderBreadcrumbs() {
-		const { translate } = this.props;
+		const { selectedSite, domains, context, translate } = this.props;
+		const selectedFilter = context?.query?.filter;
 
 		const item = {
 			label: translate( 'Domains' ),
@@ -222,9 +239,52 @@ export class SiteDomains extends Component {
 				}
 			),
 		};
+
+		const filterOptions = [
+			{
+				label: 'Site domains',
+				value: '',
+				path: domainManagementList( selectedSite?.slug ),
+				count: filterOutWpcomDomains( domains )?.length,
+			},
+			{
+				label: 'Owned by me',
+				value: 'owned-by-me',
+				path:
+					domainManagementList( selectedSite?.slug ) + '?' + stringify( { filter: 'owned-by-me' } ),
+				count: this.filterDomains( filterOutWpcomDomains( domains ), 'owned-by-me' )?.length,
+			},
+			{
+				label: 'Owned by others',
+				value: 'owned-by-others',
+				path:
+					domainManagementList( selectedSite?.slug ) +
+					'?' +
+					stringify( { filter: 'owned-by-others' } ),
+				count: this.filterDomains( filterOutWpcomDomains( domains ), 'owned-by-others' )?.length,
+			},
+			null,
+			{
+				label: 'All my domains',
+				value: 'all-my-domains',
+				path: domainManagementRoot(),
+				count: null,
+			},
+		];
+
 		const buttons = [
 			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-			<OptionsDomainButton key="breadcrumb_button_2" ellipsisButton />,
+			<DomainsTableFilterButton
+				key="breadcrumb_button_2"
+				selectedFilter={ selectedFilter || '' }
+				filterOptions={ filterOptions }
+			/>,
+			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton />,
+		];
+
+		const mobileButtons = [
+			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
+			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton />,
 		];
 
 		return (
@@ -232,7 +292,7 @@ export class SiteDomains extends Component {
 				items={ [ item ] }
 				mobileItem={ item }
 				buttons={ buttons }
-				mobileButtons={ buttons }
+				mobileButtons={ mobileButtons }
 			/>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -182,6 +182,9 @@ export class SiteDomains extends Component {
 				{ ! this.isLoading() && <GoogleSaleBanner domains={ domains } /> }
 
 				<div className="domain-management-list__items">
+					<div className="domain-management-list__filter">
+						{ this.renderDomainTableFilterButton( false ) }
+					</div>
 					<DomainsTable
 						isLoading={ this.isLoading() }
 						currentRoute={ currentRoute }
@@ -224,9 +227,56 @@ export class SiteDomains extends Component {
 		);
 	}
 
-	renderBreadcrumbs() {
-		const { selectedSite, domains, context, translate } = this.props;
+	renderDomainTableFilterButton( compact ) {
+		const { selectedSite, domains, context } = this.props;
+
 		const selectedFilter = context?.query?.filter;
+		const nonWpcomDomains = filterOutWpcomDomains( domains );
+
+		const filterOptions = [
+			{
+				label: 'Site domains',
+				value: '',
+				path: domainManagementList( selectedSite?.slug ),
+				count: nonWpcomDomains?.length,
+			},
+			{
+				label: 'Owned by me',
+				value: 'owned-by-me',
+				path:
+					domainManagementList( selectedSite?.slug ) + '?' + stringify( { filter: 'owned-by-me' } ),
+				count: this.filterDomains( nonWpcomDomains, 'owned-by-me' )?.length,
+			},
+			{
+				label: 'Owned by others',
+				value: 'owned-by-others',
+				path:
+					domainManagementList( selectedSite?.slug ) +
+					'?' +
+					stringify( { filter: 'owned-by-others' } ),
+				count: this.filterDomains( nonWpcomDomains, 'owned-by-others' )?.length,
+			},
+			null,
+			{
+				label: 'All my domains',
+				value: 'all-my-domains',
+				path: domainManagementRoot(),
+				count: null,
+			},
+		];
+
+		return (
+			<DomainsTableFilterButton
+				key="breadcrumb_button_2"
+				selectedFilter={ selectedFilter || '' }
+				filterOptions={ filterOptions }
+				compact={ compact }
+			/>
+		);
+	}
+
+	renderBreadcrumbs() {
+		const { translate } = this.props;
 
 		const item = {
 			label: translate( 'Domains' ),
@@ -240,45 +290,9 @@ export class SiteDomains extends Component {
 			),
 		};
 
-		const filterOptions = [
-			{
-				label: 'Site domains',
-				value: '',
-				path: domainManagementList( selectedSite?.slug ),
-				count: filterOutWpcomDomains( domains )?.length,
-			},
-			{
-				label: 'Owned by me',
-				value: 'owned-by-me',
-				path:
-					domainManagementList( selectedSite?.slug ) + '?' + stringify( { filter: 'owned-by-me' } ),
-				count: this.filterDomains( filterOutWpcomDomains( domains ), 'owned-by-me' )?.length,
-			},
-			{
-				label: 'Owned by others',
-				value: 'owned-by-others',
-				path:
-					domainManagementList( selectedSite?.slug ) +
-					'?' +
-					stringify( { filter: 'owned-by-others' } ),
-				count: this.filterDomains( filterOutWpcomDomains( domains ), 'owned-by-others' )?.length,
-			},
-			null,
-			{
-				label: 'All my domains',
-				value: 'all-my-domains',
-				path: domainManagementRoot(),
-				count: null,
-			},
-		];
-
 		const buttons = [
 			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-			<DomainsTableFilterButton
-				key="breadcrumb_button_2"
-				selectedFilter={ selectedFilter || '' }
-				filterOptions={ filterOptions }
-			/>,
+			this.renderDomainTableFilterButton( true ),
 			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton />,
 		];
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -305,6 +305,20 @@
 	margin-top: 24px;
 }
 
+.domain-management-list__filter {
+	padding: 0 16px;
+	> .domains-table-filter-button.is-mobile-version {
+		width: 100%;
+		.select-dropdown__container {
+			width: 100%;
+		}
+
+		@include break-mobile {
+			display: none;
+		}
+	}
+}
+
 .empty-domains-list-card__wrapper {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the new design we're having a filter button in the breadcrumbs on desktop or above the sort button on mobile

The filter button looks like this:

<img width="1094" alt="Screenshot 2021-11-04 at 18 22 55" src="https://user-images.githubusercontent.com/1355045/140378901-c6a3330e-d0bf-4535-b352-fe3ae6d50822.png">
<img width="1070" alt="Screenshot 2021-11-04 at 18 23 30" src="https://user-images.githubusercontent.com/1355045/140378908-e6606dcd-d72e-40e6-8028-82332dd87b01.png">

#### Testing instructions

* Spin up this branch or use `?flags=domains/management-list-redesign` on calypso.live version to verify that the filter button is in there and works as expected.
