### PR TITLE
Plugins Browser: fix padding and typography.

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
@@ -93,7 +94,9 @@ class PluginsBrowserList extends Component {
 		return (
 			<div className="plugins-browser-list">
 				<div className="plugins-browser-list__header">
-					<div className="plugins-browser-list__title">{ this.props.title }</div>
+					<div className={ classnames( 'plugins-browser-list__title', this.props.listName ) }>
+						{ this.props.title }
+					</div>
 					<div className="plugins-browser-list__subtitle">{ this.props.subtitle }</div>
 				</div>
 				<Card className="plugins-browser-list__elements">{ this.renderViews() }</Card>

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -30,8 +30,13 @@
 
 .plugins-browser-list__header {
 	color: var( --color-gray-90 );
-	padding-top: 34px;
-	padding-bottom: 30px;
+	padding-top: 40px;
+	padding-bottom: 20px;
+
+	.plugins-browser-list__title {
+		font-size: $font-title-small;
+		font-weight: 500;
+	}
 
 	.plugins-browser-list__subtitle {
 		font-size: $font-body-small;

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -36,6 +36,10 @@
 	.plugins-browser-list__title {
 		font-size: $font-title-small;
 		font-weight: 500;
+
+		&[class*='search-'] {
+			font-weight: 400;
+		}
 	}
 
 	.plugins-browser-list__subtitle {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -233,7 +233,7 @@ export class PluginsBrowser extends Component {
 				<>
 					<PluginsBrowserList
 						plugins={ pluginsBySearchTerm }
-						listName={ searchTerm }
+						listName={ 'search-' + searchTerm }
 						title={ searchTitle }
 						subtitle={ subtitle }
 						site={ this.props.siteSlug }


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* fixes padding and typography in plugin browser list headings

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/plugins`
* Inspect padding and typography of section titles

|Before | After|
|-------|------|
|<img width="1068" alt="SS 2021-11-04 at 18 35 49" src="https://user-images.githubusercontent.com/12430020/140380757-3e177b0e-e735-44d7-8d08-e087a3bf75ef.png">|<img width="1066" alt="SS 2021-11-04 at 18 35 23" src="https://user-images.githubusercontent.com/12430020/140380720-a274b2ee-6cd6-481b-8013-5ff618c2498d.png">|

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

