### PR TITLE
Signup: fix usage of getCompletedSteps

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -558,6 +558,7 @@ class Signup extends Component {
 		const completedSteps = getCompletedSteps(
 			this.props.flowName,
 			progress,
+			{},
 			this.props.isLoggedIn
 		);
 		return flowSteps.length === completedSteps.length;

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -96,9 +96,11 @@ const saveStep = ( state, { step } ) => {
 	return has( state, step.stepName )
 		? updateStep( state, {
 				...step,
-				// The pending status means this step needs to delay api request and the user goes back to this step
+				// The pending status means this step needs to delay api requests until the setup-site flow completes
+				// In case the user goes back to an earlier step and changes their intent
 				// So we can mark status as in-progress
-				status: status === 'pending' ? 'in-progress' : status,
+				status:
+					status === 'pending' && step.lastKnownFlow === 'setup-site' ? 'in-progress' : status,
 		  } )
 		: addStep( state, { ...step, status: 'in-progress' } );
 };


### PR DESCRIPTION
In this PR, we fix one usage of `getCompletedSteps`.

I think we introduced this small bug in https://github.com/Automattic/wp-calypso/pull/53491/files#diff-1ee63778838c31a9ed28f17a1a7139d6304a844cfba059c5ffcd128b175208d3R584 when we refactored `getCompletedSteps` passing in whether an user is logged in. The function has 4 parameters of which the third one is an optional object. However, we passed in `this.props.isLoggedIn` as the third argument thus making some of its usage invalid.

## Testing instructions

During signup, step over `isEveryStepSubmitted` with your debugger to see that we pass all the args to `getCompletedSteps` correctly now.

## Notes

Theoretically, this bug could be causing some signup issues. However, as I don't work on Calypso these days, I'm not sure of any. I stumbled upon it while debugging an issue with the P2 signup flow but it seems only slightly related and is not solved by fixing this.

## Update

Turns out it actually helps to fix our P2 signup issue. The thing is, if we don't correctly pass in `isUserLoggedIn`, it won't get into `getFilteredSteps`, thus not into `flows.getFlow` and so this line of code won't pass the condition: `if ( flowName === 'p2' && isUserLoggedIn ) {` thus making the array of `completedSteps` longer than it should be in `isEveryStepSubmitted`.