### PR TITLE
P2 Signup: fix flow

### DIFF
--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -98,7 +98,7 @@ const saveStep = ( state, { step } ) => {
 				...step,
 				// The pending status means this step needs to delay api request and the user goes back to this step
 				// So we can mark status as in-progress
-				status: status === 'pending' ? 'in-progress' : status,
+				status: status === 'pending' && step.stepName !== 'p2-site' ? 'in-progress' : status,
 		  } )
 		: addStep( state, { ...step, status: 'in-progress' } );
 };

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -96,9 +96,11 @@ const saveStep = ( state, { step } ) => {
 	return has( state, step.stepName )
 		? updateStep( state, {
 				...step,
-				// The pending status means this step needs to delay api request and the user goes back to this step
+				// The pending status means this step needs to delay api requests until the setup-site flow completes
+				// In case the user goes back to an earlier step and changes their intent
 				// So we can mark status as in-progress
-				status: status === 'pending' && step.stepName !== 'p2-site' ? 'in-progress' : status,
+				status:
+					status === 'pending' && step.lastKnownFlow === 'setup-site' ? 'in-progress' : status,
 		  } )
 		: addStep( state, { ...step, status: 'in-progress' } );
 };


### PR DESCRIPTION
Built on top of #57666.

In this PR, we fix an issue with the P2 signup flow in which the first step (`p2-site`) is marked as `in-progress` from `pending` after submitting the step which causes flow failures in some cases (like logging in during the process).

## Testing instructions

Apply the code and build Calypso. Navigate to http://calypso.localhost:3000/start/p2 in an incognito window and try to finish the multiple flows: creating a new account, logging in during the flow and finally logging in before the flow and then going through the flow.

## Notes

The bug seems to be caused by #56725. @arthur791004 and/or @roo2, could you please provide more context for this change: `status: status === 'pending' ? 'in-progress' : status,`? I haven't worked on Calypso signup in more than a year so I might be missing stuff. However, this change looks to be quite general, applying to all steps and flows as it's in `saveStep`. Do we want to update `pending` to `in-progress` for all those cases? I'm not sure if this might be causing some issues for other signup flows but we should probably recheck and retest.