### PR TITLE
Domains: Skip domain lock verification for inbound transfers when lock cannot be determined

### DIFF
--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -32,6 +32,10 @@ const TransferDomainStepUnlock = ( {
 	}, [ domain, setCheckInProgress ] );
 
 	const checkDomainLockStatus = async () => {
+		if ( initialDomainLockStatus === domainLockStatusType.UNKNOWN ) {
+			onNextStep();
+		}
+
 		try {
 			const isDomainUnlocked = await getDomainLockStatus();
 			if ( isDomainUnlocked ) onNextStep();
@@ -85,7 +89,9 @@ const TransferDomainStepUnlock = ( {
 			</p>
 			<div className={ className + '__actions' }>
 				<Button primary onClick={ checkDomainLockStatus } busy={ checkInProgress }>
-					{ __( "I've unlocked my domain" ) }
+					{ initialDomainLockStatus === domainLockStatusType.UNKNOWN
+						? __( 'Skip domain lock verificaiton' )
+						: __( "I've unlocked my domain" ) }
 				</Button>
 			</div>
 		</div>

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -90,7 +90,7 @@ const TransferDomainStepUnlock = ( {
 			</p>
 			<div className={ className + '__actions' }>
 				<Button primary onClick={ checkDomainLockStatus } busy={ checkInProgress }>
-					{ initialDomainLockStatus === domainLockStatusType.UNKNOWN
+					{ domainLockStatusType.UNKNOWN === initialDomainLockStatus
 						? __( 'Skip domain lock verificaiton' )
 						: __( "I've unlocked my domain" ) }
 				</Button>

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -38,8 +38,9 @@ const TransferDomainStepUnlock = ( {
 
 		try {
 			const isDomainUnlocked = await getDomainLockStatus();
-			if ( isDomainUnlocked ) onNextStep();
-			else {
+			if ( isDomainUnlocked || null === isDomainUnlocked ) {
+				onNextStep();
+			} else {
 				setDomainStatusError( 'Your domain is locked' );
 			}
 		} catch {

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -35,7 +35,11 @@ const TransferDomainStepUnlock = ( {
 	const checkDomainLockStatus = async () => {
 		try {
 			const isDomainUnlocked = await getDomainLockStatus();
-			if ( isDomainUnlocked || lockStatusUnknown ) {
+			if (
+				isDomainUnlocked ||
+				lockStatusUnknown ||
+				( domainLockStatusType.UNKNOWN === initialDomainLockStatus && null === isDomainUnlocked )
+			) {
 				onNextStep();
 			} else if ( isDomainUnlocked === null ) {
 				setDomainStatusError( 'Can’t get the domain’s lock status' );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the issue described in p2MSmN-8N0-p2, where a user wasn't able to initiate an inbound domain transfer because its lock couldn't be determined and came as `null` - this is not an uncommon situation, as there are a variety of reasons why a domain lock might not be determined.

This PR updates the transfer flow to allow skipping the lock verification in those cases, as shown in the screenshot:

![Annotation on 2021-11-04 at 16-56-11](https://user-images.githubusercontent.com/5324818/140410826-41486214-0c8b-4242-95a7-69a80d6d7ab2.png)

### Testing instructions

Try to find a pending domain transfer whose lock cannot be determined. Alternatively, sandbox `public-api` and hack the `/domains/<mygroovydomain.com>/inbound-transfer-status` endpoint to return the following data:

```
return [
	'admin_email' => null,
	'creation_date' => null,
	'in_redemption' => null,
	'privacy' => true,
	'registrar' => null,
	'registrar_iana_id' => null,
	'term_maximum_in_years' => 10,
	'transfer_eligible_date' => null,
	'transfer_restriction_status' => "not_restricted",
	'unlocked' => null,
];
```

Try to initiate a domain transfer in these conditions and ensure you're able to skip the domain lock verification step as shown in the screenshot.
