### PR TITLE
Playwright: reload page if not able to locate newly created pending invite.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -139,7 +139,6 @@ export class PeoplePage {
 		// Retry three times, each time allowing 5 seconds for Playwright to locate the
 		// pending user invite.
 		for ( let retries = 3; retries > 0; retries -= 1 ) {
-			console.log( retries );
 			try {
 				await this.page.waitForSelector( selectors.invitedUser( emailAddress ), {
 					timeout: 5 * 1000,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is an iteration on previous works such as #57445, aimed at eliminating intermittent failures of the specs when the page object fails to locate the newly created invite for a given email address.

Key changes:
- add retry mechanism which waits for a selector for 5 seconds. If it fails to locate the selector, reload the page and try again.
- retry mechanism is capped at 3 retries.

#### Testing instructions

- [ ] stress
  - [x] mobile
  - [x] desktop
- [ ] normal
  - [x] mobile
  - [x] desktop

Closes #57673.
Related to #57445.
