### PR TITLE
Introduce data fetching persistence opt out

### DIFF
--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -4,6 +4,30 @@ import { persistQueryClient } from 'react-query/persistQueryClient-experimental'
 import { shouldPersist, MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/initial-state';
 import { getPersistedStateItem, storePersistedStateItem } from 'calypso/state/persisted-state';
 
+const SHOULD_PERSIST_QUERY_KEY = 'shouldPersistQuery';
+
+type PersistencePredicate< T > = ( data: T ) => boolean;
+
+type PersistenceMetaPartial< T > = {
+	[ SHOULD_PERSIST_QUERY_KEY ]: PersistencePredicate< T > | boolean;
+};
+
+const hasPersistenceSetting = ( value: unknown ): value is boolean => {
+	return typeof value === 'boolean';
+};
+
+const hasPersistenceCustomSetting = (
+	value: unknown
+): value is PersistencePredicate< unknown > => {
+	return typeof value === 'function';
+};
+
+export const shouldPersistQuery = < T >(
+	predicate: PersistencePredicate< T > | boolean
+): PersistenceMetaPartial< T > => ( {
+	[ SHOULD_PERSIST_QUERY_KEY ]: predicate,
+} );
+
 export async function createQueryClient( userId: number | undefined ): Promise< QueryClient > {
 	const queryClient = new QueryClient( {
 		defaultOptions: { queries: { cacheTime: MAX_AGE } },
@@ -26,6 +50,25 @@ export async function createQueryClient( userId: number | undefined ): Promise< 
 			queryClient,
 			persistor,
 			maxAge: MAX_AGE,
+			dehydrateOptions: {
+				shouldDehydrateQuery: ( query ) => {
+					if ( query.state.status !== 'success' ) {
+						return false;
+					}
+
+					const shouldPersist = query.meta?.[ SHOULD_PERSIST_QUERY_KEY ];
+
+					if ( hasPersistenceSetting( shouldPersist ) ) {
+						return shouldPersist;
+					}
+
+					if ( hasPersistenceCustomSetting( shouldPersist ) ) {
+						return shouldPersist( query.state.data );
+					}
+
+					return true;
+				},
+			},
 		} );
 	}
 	return queryClient;

--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -3,7 +3,7 @@ import { QueryClient } from 'react-query';
 import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
 import { shouldPersist, MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/initial-state';
 import { getPersistedStateItem, storePersistedStateItem } from 'calypso/state/persisted-state';
-import { shouldDehydrateQuery, shouldPersistQuery } from './should-dehydrate-query';
+import { shouldDehydrateQuery } from './should-dehydrate-query';
 
 export async function createQueryClient( userId: number | undefined ): Promise< QueryClient > {
 	const queryClient = new QueryClient( {
@@ -34,5 +34,3 @@ export async function createQueryClient( userId: number | undefined ): Promise< 
 	}
 	return queryClient;
 }
-
-export { shouldPersistQuery };

--- a/client/state/should-dehydrate-query.ts
+++ b/client/state/should-dehydrate-query.ts
@@ -1,0 +1,43 @@
+import { Query } from 'react-query';
+
+const SHOULD_PERSIST_QUERY_KEY = 'shouldPersistQuery';
+
+type PersistencePredicate< T > = ( data: T ) => boolean;
+
+type PersistenceMetaPartial< T > = {
+	[ SHOULD_PERSIST_QUERY_KEY ]: PersistencePredicate< T > | boolean;
+};
+
+const hasPersistenceSetting = ( value: unknown ): value is boolean => {
+	return typeof value === 'boolean';
+};
+
+const hasPersistenceCustomSetting = (
+	value: unknown
+): value is PersistencePredicate< unknown > => {
+	return typeof value === 'function';
+};
+
+export const shouldPersistQuery = < T >(
+	predicate: PersistencePredicate< T > | boolean
+): PersistenceMetaPartial< T > => ( {
+	[ SHOULD_PERSIST_QUERY_KEY ]: predicate,
+} );
+
+export const shouldDehydrateQuery = ( query: Query ): boolean => {
+	if ( query.state.status !== 'success' ) {
+		return false;
+	}
+
+	const shouldPersistQuery = query.meta?.[ SHOULD_PERSIST_QUERY_KEY ];
+
+	if ( hasPersistenceSetting( shouldPersistQuery ) ) {
+		return shouldPersistQuery;
+	}
+
+	if ( hasPersistenceCustomSetting( shouldPersistQuery ) ) {
+		return shouldPersistQuery( query.state.data );
+	}
+
+	return true;
+};

--- a/client/state/should-dehydrate-query.ts
+++ b/client/state/should-dehydrate-query.ts
@@ -1,12 +1,6 @@
 import { Query } from 'react-query';
 
-const SHOULD_PERSIST_QUERY_KEY = 'shouldPersistQuery';
-
 type PersistencePredicate< T > = ( data: T ) => boolean;
-
-type PersistenceMetaPartial< T > = {
-	[ SHOULD_PERSIST_QUERY_KEY ]: PersistencePredicate< T > | boolean;
-};
 
 const hasPersistenceSetting = ( value: unknown ): value is boolean => {
 	return typeof value === 'boolean';
@@ -18,25 +12,19 @@ const hasPersistenceCustomSetting = (
 	return typeof value === 'function';
 };
 
-export const shouldPersistQuery = < T >(
-	predicate: PersistencePredicate< T > | boolean
-): PersistenceMetaPartial< T > => ( {
-	[ SHOULD_PERSIST_QUERY_KEY ]: predicate,
-} );
-
 export const shouldDehydrateQuery = ( query: Query ): boolean => {
 	if ( query.state.status !== 'success' ) {
 		return false;
 	}
 
-	const shouldPersistQuery = query.meta?.[ SHOULD_PERSIST_QUERY_KEY ];
+	const shouldPersist = query.meta?.persist;
 
-	if ( hasPersistenceSetting( shouldPersistQuery ) ) {
-		return shouldPersistQuery;
+	if ( hasPersistenceSetting( shouldPersist ) ) {
+		return shouldPersist;
 	}
 
-	if ( hasPersistenceCustomSetting( shouldPersistQuery ) ) {
-		return shouldPersistQuery( query.state.data );
+	if ( hasPersistenceCustomSetting( shouldPersist ) ) {
+		return shouldPersist( query.state.data );
 	}
 
 	return true;

--- a/client/state/should-dehydrate-query.ts
+++ b/client/state/should-dehydrate-query.ts
@@ -2,13 +2,11 @@ import { Query } from 'react-query';
 
 type PersistencePredicate< T > = ( data: T ) => boolean;
 
-const hasPersistenceSetting = ( value: unknown ): value is boolean => {
+const hasSimplePersistence = ( value: unknown ): value is boolean => {
 	return typeof value === 'boolean';
 };
 
-const hasPersistenceCustomSetting = (
-	value: unknown
-): value is PersistencePredicate< unknown > => {
+const hasPersistencePredicate = ( value: unknown ): value is PersistencePredicate< unknown > => {
 	return typeof value === 'function';
 };
 
@@ -19,11 +17,11 @@ export const shouldDehydrateQuery = ( query: Query ): boolean => {
 
 	const shouldPersist = query.meta?.persist;
 
-	if ( hasPersistenceSetting( shouldPersist ) ) {
+	if ( hasSimplePersistence( shouldPersist ) ) {
 		return shouldPersist;
 	}
 
-	if ( hasPersistenceCustomSetting( shouldPersist ) ) {
+	if ( hasPersistencePredicate( shouldPersist ) ) {
 		return shouldPersist( query.state.data );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Now that `react-query` with the `meta` option was released, we can opt out of persistence in some cases.

This PR introduces the opt-out mechanism There are two types of persistence opt-out:

1. Dumb opt-out, where you pass a boolean to the `persist` meta property, like

```ts
useQuery( queryKey, fetchFn, {
	meta: {
		persist: false,
	},
} );
```

2. Smart opt-out, where you can pass a callback to decide whether or not to persist the query based on its data. Example:

```ts
useQuery( queryKey, fetchFn, {
	meta: {
		persist: ( data: Theme[] ) => data.length > 0,
	},
} );
```

It also disables persistence for queries that didn't succeed, regardless of the persistence predicate. That's the default for `shouldDehydrateQuery` when you don't pass a custom function.

I don't think we want to persist queries that failed, are idle, or are still loading, but let me know if I got the wrong thought process here.

#### Notes

- Where should I document this? I feel that the `client/state` README is pretty loaded and that the new section might be hard to find.

- It makes sense to persist query results by default because React Query is typically used to fetch and render server-side data. In Redux, on the other hand, we require folks to opt-in to persistence because Redux is often used for client-side UI state, which is typically not intended to be persisted. 

~- I found that returning an object and then passing this object to `meta` is a better option than making the `shouldPersistQuery` helper function itself return `{ meta: ... }`. The reason for that is people might want to put more data inside `meta`, something like:~

```ts
{
  meta: {
    ...shouldPersistQuery(),
    additionalData: true
  }
}
```

~And having such a shape, despite being a bit more verbose, allows for customization of the `meta` option as needed.~

#### Testing instructions

- `yarn install` at the root since an upgrade to the local dependencies is necessary;
- Use the `shouldPersistQuery` function in the `meta` option on any query as exemplified above;
- Select `calypso_store` inside IndexedDB or local storage;
- Check that the selected query is not persisted inside the `query-state` entry (path is `clientState.queries`).