### PR TITLE
Fix renovate reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,5 +69,5 @@
 	"semanticCommitType": "chore",
 	"masterIssue": true,
 	"masterIssueTitle": "Renovate Dependency Updates",
-	"reviewers": [ "team:@Automattic/team-calypso-platform" ]
+	"reviewers": "team:team-calypso-platform"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
We currently intend for @Automattic/team-calypso-platform to get requested for review of any renovate PR. However, I've never been able to get this working. After searching around, I found [some prior art](https://github.com/Automattic/jetpack/pull/17842/files#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R36) in Jetpack which omits the "@Automattic/" portion of the team name in the syntax. I confirmed with the team that this [syntax does work](https://github.com/Automattic/jetpack/pull/17842#issuecomment-959556673)!

#### Testing instructions
None, I think this has to be shipped to test.
