### PR TITLE
Bump calypso build to v10

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -48,7 +48,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/data-stores": "^2.0.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -44,7 +44,7 @@
 		"wpcom-xhr-request": "^1.2.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -23,7 +23,7 @@
 		"build": "NODE_ENV=production yarn dev"
 	},
 	"dependencies": {
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@wordpress/api-fetch": "^5.2.2",
 		"@wordpress/base-styles": "^4.0.0",
 		"@wordpress/block-editor": "^7.0.2",

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -51,7 +51,7 @@
 		"tinymce": "^4.9.6"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^3.2.1",
 		"enzyme": "^3.11.0",

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
 		"@automattic/accessible-focus": "^1.0.0-alpha.0",
 		"@automattic/browser-data-collector": "^3.0.0",
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^2.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -33,7 +33,7 @@
 		"test:e2e": "jest -c test/e2e/config/jest.config.js"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"copy-webpack-plugin": "^6.2.1",
 		"electron": "^12.0.12",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -33,7 +33,7 @@
 		"test:e2e": "jest -c test/e2e/config/jest.config.js"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^10.0.0",
+		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"copy-webpack-plugin": "^6.2.1",
 		"electron": "^12.0.12",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 	"dependencies": {
 		"@automattic/babel-plugin-i18n-calypso": "^1.2.0",
 		"@automattic/babel-plugin-transform-wpcalypso-async": "^1.0.1",
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-doctor": "^0.1.0",
 		"@automattic/color-studio": "2.5.0",

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## trunk
 
+## 10.0.0
+
 - Dropped `cache-loader`, as it is not compatible with Webpack 5.
 - Dropped `cacheDirectory` option in Sass loader
 - Updated dependencies:

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "9.0.0",
+	"version": "10.0.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -47,7 +47,7 @@
 		"redux": "^4.0.5"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0",
 		"@storybook/addon-actions": "^6.3.11",
 		"@storybook/preset-scss": "^1.0.3",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -23,7 +23,7 @@
 		"@automattic/calypso-typescript-config": "^1.0.0"
 	},
 	"dependencies": {
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/calypso-e2e": "^0.1.0",
 		"@automattic/mocha-debug-reporter": "^0.1.0",
 		"@automattic/testarmada-magellan-mocha-plugin": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,7 +83,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-build@^9.0.0, @automattic/calypso-build@workspace:packages/calypso-build":
+"@automattic/calypso-build@^10.0.0, @automattic/calypso-build@workspace:packages/calypso-build":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-build@workspace:packages/calypso-build"
   dependencies:
@@ -296,7 +296,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/composite-checkout@workspace:packages/composite-checkout"
   dependencies:
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
@@ -742,7 +742,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/notifications@workspace:apps/notifications"
   dependencies:
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-color-schemes": ^2.1.1
     "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-polyfills": ^2.0.0
@@ -774,7 +774,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/o2-blocks@workspace:apps/o2-blocks"
   dependencies:
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-eslint-overrides": ^1.0.0
     "@wordpress/api-fetch": ^5.2.2
     "@wordpress/base-styles": ^4.0.0
@@ -1184,7 +1184,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/wpcom-block-editor@workspace:apps/wpcom-block-editor"
   dependencies:
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-eslint-overrides": ^1.0.0
     "@wordpress/block-editor": ^7.0.2
     "@wordpress/blocks": ^11.1.0
@@ -1252,7 +1252,7 @@ __metadata:
   resolution: "@automattic/wpcom-editing-toolkit@workspace:apps/editing-toolkit"
   dependencies:
     "@automattic/calypso-analytics": ^1.0.0-alpha.1
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/composite-checkout": ^1.0.0
     "@automattic/data-stores": ^2.0.0
@@ -11431,7 +11431,7 @@ __metadata:
     "@automattic/accessible-focus": ^1.0.0-alpha.0
     "@automattic/browser-data-collector": ^3.0.0
     "@automattic/calypso-analytics": ^1.0.0-alpha.1
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-color-schemes": ^2.1.1
     "@automattic/calypso-config": ^1.0.0-alpha.0
     "@automattic/calypso-eslint-overrides": ^1.0.0
@@ -37245,7 +37245,7 @@ typescript@^4.4.3:
   dependencies:
     "@automattic/babel-plugin-i18n-calypso": ^1.2.0
     "@automattic/babel-plugin-transform-wpcalypso-async": ^1.0.1
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-color-schemes": ^2.1.1
     "@automattic/calypso-doctor": ^0.1.0
     "@automattic/calypso-eslint-overrides": ^1.0.0
@@ -37425,7 +37425,7 @@ typescript@^4.4.3:
   version: 0.0.0-use.local
   resolution: "wp-e2e-tests@workspace:test/e2e"
   dependencies:
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-e2e": ^0.1.0
     "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Prepare Calypso Build for a new npm release. I've bumped from v9 to v10.

#### Testing instructions
-  `yarn install` should work correctly locally
- `yarn build` for calypso apps should work
