### PR TITLE
Use array syntax for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,5 +69,5 @@
 	"semanticCommitType": "chore",
 	"masterIssue": true,
 	"masterIssueTitle": "Renovate Dependency Updates",
-	"reviewers": "team:team-calypso-platform"
+	"reviewers": [ "team:team-calypso-platform" ]
 }


### PR DESCRIPTION
I introduced incorrect syntax in #57681 which is causing renovate to think our config is invalid. This fixes it.