### PR TITLE
Use notice for unsupported browser redirect

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -201,9 +201,10 @@ class Document extends Component {
 								
 								closeButton.style = "\
 									position: absolute;\
-									right: 6px\
+									right: 6px;\
 									margin: 10px;\
 									height: 30px;\
+									color: white;\
 								"
 
 								closeButton.onclick = function () {

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -85,6 +85,7 @@ class Document extends Component {
 
 		const LoadingLogo = chooseLoadingLogo( this.props );
 
+		const unsupportedBrowser = true;
 		return (
 			<html
 				lang={ lang }
@@ -155,6 +156,74 @@ class Document extends Component {
 						</EnvironmentBadge>
 					) }
 
+					{ unsupportedBrowser && (
+						<script
+							nonce={ inlineScriptNonce }
+							dangerouslySetInnerHTML={ {
+								__html: `
+							(function() {
+								/* Main Banner Element */
+								var banner = document.createElement( 'div' )
+								banner.appendChild( document.createTextNode( 'This browser is unsupported.' ) );
+
+								banner.style = " \
+									position: absolute; \
+									top: 0; \
+									left: 0;\
+									height: 50px;\
+									background-color: red;\
+									width: 100%;\
+									z-index: 999;\
+									transform: translateY(-50px);\
+									line-height: 50px;\
+									font-size: 30px;\
+									color: white;\
+									padding-left: 10px;\
+								"
+
+								/* More Info Link */
+								var info = document.createElement( 'a' )
+								info.appendChild( document.createTextNode( 'More information' ) )
+									info.style = "\
+									font-size: 15px;\
+									color: blue; \
+									margin-left: 10px; \
+								"
+								info.href='https://browsehappy.com'
+								banner.appendChild( info )
+
+								/* The Close Button */
+								var closeButton = document.createElement( 'button' )
+
+								closeButton.appendChild( document.createTextNode( 'Close' ) )
+								
+								closeButton.style = "\
+									position: absolute;\
+									right: 0;\
+									margin: 10px;\
+									height: 30px;\
+								"
+
+								closeButton.onclick = function () {
+									document.querySelector( 'body' ).style.transform = null
+									// We will still have a reference to this element.
+									if ( banner ) {
+										// .remove() is unsupported in IE
+										banner.parentNode.removeChild( banner )
+									}
+								}
+								banner.appendChild( closeButton )
+
+								document.querySelector( 'body' ).insertAdjacentElement( 'afterbegin', banner )
+								document.querySelector( 'body' ).style.transform = 'translateY(50px)'
+								
+								// Move focus to the "modal". Perhaps a different element?
+								closeButton.focus()
+							})();
+							`,
+							} }
+						/>
+					) }
 					<script
 						type="text/javascript"
 						nonce={ inlineScriptNonce }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -170,15 +170,15 @@ class Document extends Component {
 									position: absolute; \
 									top: 0; \
 									left: 0;\
+									right: 0;\
 									height: 50px;\
-									background-color: red;\
-									width: 100%;\
+									background-color: #d63638;\
 									z-index: 999;\
 									transform: translateY(-50px);\
 									line-height: 50px;\
 									font-size: 30px;\
 									color: white;\
-									padding-left: 10px;\
+									padding: 0 16px;\
 								"
 
 								/* More Info Link */
@@ -186,8 +186,10 @@ class Document extends Component {
 								info.appendChild( document.createTextNode( 'More information' ) )
 									info.style = "\
 									font-size: 15px;\
-									color: blue; \
+									color: white; \
 									margin-left: 10px; \
+									font-weight: bold;\
+									font-size; 15px;\
 								"
 								info.href='https://browsehappy.com'
 								banner.appendChild( info )
@@ -199,7 +201,7 @@ class Document extends Component {
 								
 								closeButton.style = "\
 									position: absolute;\
-									right: 0;\
+									right: 6px\
 									margin: 10px;\
 									height: 30px;\
 								"
@@ -218,7 +220,7 @@ class Document extends Component {
 								document.querySelector( 'body' ).style.transform = 'translateY(50px)'
 								
 								// Move focus to the "modal". Perhaps a different element?
-								closeButton.focus()
+								info.focus()
 							})();
 							`,
 							} }


### PR DESCRIPTION
### Changes proposed in this Pull Request
So far, this just demonstrates what a notice could look like for the unsupported browser behavior in Calypso. Currently, we have a redirect, but are discussing its removal. p9oQ9f-MJ-p2 One option is to show a modal using very plain JS if the server thinks the browser agent should be unsupported.

This demonstrates that behavior. **Obviously very ugly and needs a design pass!** But this should help us decide for sure if we want to take this approach.

### Demo:

https://user-images.githubusercontent.com/6265975/140441426-c097e238-0a49-4ec7-bf58-cd06945a92a5.mov

### Things we should do before merging:
- [ ] Organize the code better, maybe a separate script instead of putting it all in a string.
- [ ] Get a proper design.
- [ ] Make sure this works for accessibility concerns. Things like this are hard without helpers, and we can't use components here.
- [ ] Verify copy and any links.
- [ ] See if this text would impact search indexes. If so, prevent the notice from showing for bots.
- [ ] Create a list of browsers we support. Show the notice otherwise. Alternatively, create a list of browsers we specifically don't support, and only show the notice to them. 
- [ ] See if we can keep the cookie approach to not show the notice for 24 hours
- [ ] mobile browser support

### Testing instructions
1. Spin up calypso.live
2. The notice should display for any pages. (it always displays in this PR)
