### PR TITLE
feat: trim country from VAT number if country matches the selected one (issue #56032)

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,6 +1,6 @@
 import { CompactCard, Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -81,24 +81,6 @@ function VatForm(): JSX.Element {
 
 	const isVatAlreadySet = !! vatDetails.id;
 
-	const setCurrentVatDetailsByValue = useCallback(
-		( value: string ) => {
-			if ( value?.length > 1 ) {
-				const first2UppercasedChars = value.substr( 0, 2 ).toUpperCase();
-
-				if (
-					isNaN( Number( first2UppercasedChars ) ) &&
-					first2UppercasedChars === currentVatDetails.country
-				) {
-					return setCurrentVatDetails( { ...currentVatDetails, id: value.substr( 2 ) } );
-				}
-			}
-
-			return setCurrentVatDetails( { ...currentVatDetails, id: value } );
-		},
-		[ currentVatDetails.id, currentVatDetails.country ]
-	);
-
 	return (
 		<>
 			<FormFieldset className="vat-info__country-field">
@@ -119,7 +101,7 @@ function VatForm(): JSX.Element {
 					disabled={ isUpdating || isVatAlreadySet }
 					value={ currentVatDetails.id ?? vatDetails.id ?? '' }
 					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-						setCurrentVatDetailsByValue( event.target.value )
+						setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
 					}
 				/>
 				{ isVatAlreadySet && (

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,6 +1,6 @@
 import { CompactCard, Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -81,6 +81,24 @@ function VatForm(): JSX.Element {
 
 	const isVatAlreadySet = !! vatDetails.id;
 
+	const setCurrentVatDetailsByValue = useCallback(
+		( value: string ) => {
+			if ( value?.length > 1 ) {
+				const first2UppercasedChars = value.substr( 0, 2 ).toUpperCase();
+
+				if (
+					isNaN( Number( first2UppercasedChars ) ) &&
+					first2UppercasedChars === currentVatDetails.country
+				) {
+					return setCurrentVatDetails( { ...currentVatDetails, id: value.substr( 2 ) } );
+				}
+			}
+
+			return setCurrentVatDetails( { ...currentVatDetails, id: value } );
+		},
+		[ currentVatDetails.id, currentVatDetails.country ]
+	);
+
 	return (
 		<>
 			<FormFieldset className="vat-info__country-field">
@@ -101,7 +119,7 @@ function VatForm(): JSX.Element {
 					disabled={ isUpdating || isVatAlreadySet }
 					value={ currentVatDetails.id ?? vatDetails.id ?? '' }
 					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-						setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
+						setCurrentVatDetailsByValue( event.target.value )
 					}
 				/>
 				{ isVatAlreadySet && (

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -47,9 +47,22 @@ export default function useVatDetails(): VatDetailsManager {
 			queryClient.setQueryData( 'vat-details', data );
 		},
 	} );
+	const formatVatDetails = useCallback( ( data: VatDetails ) => {
+		const { country, id } = data;
+
+		if ( !! id && id?.length > 1 ) {
+			const first2UppercasedChars = id.substr( 0, 2 ).toUpperCase();
+
+			if ( isNaN( Number( first2UppercasedChars ) ) && first2UppercasedChars === country ) {
+				return { ...data, id: id.substr( 2 ) };
+			}
+		}
+
+		return data;
+	}, [] );
 	const setDetails = useCallback(
 		( vatDetails: VatDetails ) => {
-			mutation.mutate( vatDetails );
+			mutation.mutate( formatVatDetails( vatDetails ) );
 		},
 		[ mutation ]
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Leading country to be trimmed from VAT number if it matches the selected one.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/me/purchases/vat-details`
1. Complete the form and prepend the country code to the VAT number
2. Submit the form
3. Check the request payload

![vat_details](https://user-images.githubusercontent.com/57601672/140614098-46dace3f-d0e9-4547-ab93-4f6f2a0f9ac2.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56032
