### PR TITLE
Add step to show when the url is already on WordPress.com

### DIFF
--- a/client/signup/steps/import/capture/index.tsx
+++ b/client/signup/steps/import/capture/index.tsx
@@ -38,7 +38,11 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 	const runProcess = (): void => {
 		// Analyze the URL and when we receive the urlData, decide where to go next.
 		analyzeUrl( urlValue ).then( ( response: UrlData ) => {
-			const stepSectionName = response.platform === 'unknown' ? 'not' : 'preview';
+			let stepSectionName = response.platform === 'unknown' ? 'not' : 'preview';
+
+			if ( response.platform === 'wordpress' && response.platform_data?.is_wpcom ) {
+				stepSectionName = 'wpcom';
+			}
 			goToStep( 'ready', stepSectionName );
 		} );
 	};

--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
-import { getUrlData, isAnalyzing } from '../../../state/imports/url-analyzer/selectors';
+import { isAnalyzing, getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import CaptureStep from './capture';
 import ListStep from './list';
-import { ReadyPreviewStep, ReadyNotStep, ReadyStep } from './ready';
+import { ReadyPreviewStep, ReadyNotStep, ReadyStep, ReadyAlreadyOnWPCOMStep } from './ready';
 import { GoToNextStep, GoToStep, UrlData } from './types';
 import { getImporterUrl } from './util';
 import './style.scss';
@@ -82,6 +82,9 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 							goToImporterPage={ goToImporterPage }
 							siteSlug={ signupDependencies.siteSlug }
 						/>
+					) }
+					{ stepName === 'ready' && stepSectionName === 'wpcom' && (
+						<ReadyAlreadyOnWPCOMStep urlData={ urlData } />
 					) }
 				</div>
 			}

--- a/client/signup/steps/import/ready/index.tsx
+++ b/client/signup/steps/import/ready/index.tsx
@@ -17,17 +17,17 @@ interface ReadyPreviewProps {
 	goToImporterPage: ( platform: string ) => void;
 }
 
+const convertToFriendlyWebsiteName = ( website: string ): string => {
+	const { hostname, pathname } = new URL( website );
+	return ( hostname + ( pathname === '/' ? '' : pathname ) ).replace( 'www.', '' );
+};
+
 const ReadyPreviewStep: React.FunctionComponent< ReadyPreviewProps > = ( {
 	urlData,
 	goToImporterPage,
 } ) => {
 	const { __ } = useI18n();
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = React.useState( false );
-
-	const convertToFriendlyWebsiteName = ( website: string ): string => {
-		const { hostname, pathname } = new URL( website );
-		return ( hostname + ( pathname === '/' ? '' : pathname ) ).replace( 'www.', '' );
-	};
 
 	return (
 		<>
@@ -163,4 +163,43 @@ const ReadyStep: React.FunctionComponent< ReadyProps > = ( props ) => {
 	);
 };
 
-export { ReadyPreviewStep, ReadyNotStep, ReadyStep };
+interface ReadyWpComProps {
+	urlData: UrlData;
+}
+
+const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( { urlData } ) => {
+	const { __ } = useI18n();
+
+	return (
+		<div className="import-layout__center">
+			<div className="import__header">
+				<div className="import__heading  import__heading-center">
+					<Title>{ __( 'Your site is already on WordPress.com' ) }</Title>
+					<SubTitle>
+						{ createInterpolateElement(
+							sprintf(
+								/* translators: the website could be any domain (eg: "yourname.com") */
+								__(
+									'It looks like <strong>%(website)s</strong> is already on WordPress.com. Try a different address or start buidling a new site instead.'
+								),
+								{
+									website: convertToFriendlyWebsiteName( urlData.url ),
+								}
+							),
+							{ strong: createElement( 'strong' ) }
+						) }
+					</SubTitle>
+
+					<div className="import__buttons-group">
+						<NextButton>{ __( 'Start building' ) }</NextButton>
+						<div>
+							<BackButton>{ __( 'Back to start' ) }</BackButton>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export { ReadyPreviewStep, ReadyNotStep, ReadyStep, ReadyAlreadyOnWPCOMStep };

--- a/client/signup/steps/import/types.ts
+++ b/client/signup/steps/import/types.ts
@@ -3,6 +3,9 @@ export type GoToNextStep = () => void;
 export type UrlData = {
 	url: string;
 	platform: string;
+	platform_data?: {
+		is_wpcom: boolean;
+	};
 };
 
 export type FeatureName =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new screen to show when the URL provided in the `capture` step is already hosted on WordPress.com

#### Testing instructions

* Go to `/start/importers/capture`
* Enter a URL that is hosted on WordPress.com
* You should see a scene that tells you your site is already hosted on WordPress.com followed by the appropriate action buttons.

#### Screenshot
<img width="749" alt="Screenshot 2021-11-08 at 15 21 38" src="https://user-images.githubusercontent.com/1241413/140758673-552bcaa9-d257-4f8a-99f6-90b0595c2726.png">

You can repeat the step with a URL of a site using WordPress that is not hosted on WordPress.com to verify that it works as expected.

Related to #57131
