### PR TITLE
Ensure that G Suite hasDiscount() compares against UTC times

### DIFF
--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -24,8 +24,8 @@ export const hasDiscount = ( product ) => {
 	}
 
 	const currentTime = Date.now();
-	const startDate = new Date( product.sale_coupon.start_date );
-	const endDate = new Date( product.sale_coupon.expires );
+	const startDate = new Date( product.sale_coupon.start_date + ' GMT' );
+	const endDate = new Date( product.sale_coupon.expires + ' GMT' );
 
 	return currentTime >= startDate && currentTime <= endDate;
 };

--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -24,8 +24,8 @@ export const hasDiscount = ( product ) => {
 	}
 
 	const currentTime = Date.now();
-	const startDate = new Date( product.sale_coupon.start_date + ' GMT' );
-	const endDate = new Date( product.sale_coupon.expires + ' GMT' );
+	const startDate = new Date( product.sale_coupon.start_date.replace( ' ', 'T' ) + 'Z' );
+	const endDate = new Date( product.sale_coupon.expires.replace( ' ', 'T' ) + 'Z' );
 
 	return currentTime >= startDate && currentTime <= endDate;
 };

--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -24,6 +24,8 @@ export const hasDiscount = ( product ) => {
 	}
 
 	const currentTime = Date.now();
+	// Ensure that coupon start and end time are correctly converted to UTC times in the browser.
+	// Use ISO 8601 format to avoid cross-browser issues - convert '2021-12-12 12:34:56' to '2021-12-12T12:34:56Z'
 	const startDate = new Date( product.sale_coupon.start_date.replace( ' ', 'T' ) + 'Z' );
 	const endDate = new Date( product.sale_coupon.expires.replace( ' ', 'T' ) + 'Z' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes a small bug in the GSuite `hasDiscount()` function where the start and expiry times were not being specified in UTC.

#### Testing instructions

* Run this branch locally or via the live branch
* Ensure that you're running with Store Sandbox enabled
* Create a test sale coupon where the validity period in UTC differs from the validity period in your local time zone, preferably a situation where the coupon is currently valid in UTC, but not in your time zone
* Start the purchase flow for a new domain by navigating to Upgrades -> Domains, clicking on "Add a domain to this site" and then "Search for a domain"
* Select a domain
* On the email upsell page, verify that the sale price is displayed for Google Workspace