### PR TITLE
Announcement Modal: add tracks event for dismiss.

### DIFF
--- a/client/blocks/announcement-modal/index.jsx
+++ b/client/blocks/announcement-modal/index.jsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { Title } from '@automattic/onboarding';
 import { Guide } from '@wordpress/components';
 import { useSelector, useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
@@ -38,7 +39,7 @@ const Modal = ( { announcementId, pages, finishButtonText } ) => {
 	const dispatch = useDispatch();
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const hasPreferences = useSelector( hasReceivedRemotePreferences );
-	const dismissPreference = `announcement-modal-${ userId }-${ announcementId }`;
+	const dismissPreference = `announcement-modal-${ announcementId }-${ userId }`;
 	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
 	const singlePage = pages.length === 1;
 
@@ -48,6 +49,11 @@ const Modal = ( { announcementId, pages, finishButtonText } ) => {
 
 	const handleDismiss = () => {
 		dispatch( savePreference( dismissPreference, 1 ) );
+		dispatch(
+			recordTracksEvent( 'calypso_announcement_modal_dismiss', {
+				announcement_id: announcementId,
+			} )
+		);
 	};
 
 	return (


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Adds a `calypso_announcement_modal_dismiss` track event with an `announcementId` parameter
* moves the UserId param to the end of the `dismissPreference`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- load Calypso
- in the console enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
- reload the page
- go to `/plugins`
- dismiss the modal (if you have already dismissed it, remove it from the debug menu -> preferences)
- make sure that the `calypso_announcement_modal_dismiss` event is logged and `announcementId` parameter matches `plugins-page-revamp`

![SS 2021-11-05 at 12 15 23](https://user-images.githubusercontent.com/12430020/140495396-2fa39dd3-2c0c-4651-83ac-0cd54c1061a3.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57692
