### PR TITLE
Plugins Search: add tracks event when searching for a plugin.

### DIFF
--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -132,7 +132,7 @@ export function fetchPluginsList(
 				// Do not trigger a new tracks event for subsequent pages.
 				if ( searchTerm && info?.page === 1 ) {
 					dispatch(
-						recordTracksEvent( 'calypso_plugins_search', {
+						recordTracksEvent( 'calypso_plugins_search_results_show', {
 							search_term: searchTerm,
 							results_count: info?.results,
 						} )

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -130,11 +130,11 @@ export function fetchPluginsList(
 			.then( ( { info, plugins } ) => {
 				dispatch( receivePluginsList( category, page, searchTerm, plugins, null, info ) );
 				// Do not trigger a new tracks event for subsequent pages.
-				if ( searchTerm && info.page === 1 ) {
+				if ( searchTerm && info?.page === 1 ) {
 					dispatch(
 						recordTracksEvent( 'calypso_plugins_search', {
 							search_term: searchTerm,
-							results: info?.results,
+							results_count: info?.results,
 						} )
 					);
 				}

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { normalizePluginData, normalizePluginsList } from 'calypso/lib/plugins/utils';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -128,6 +129,15 @@ export function fetchPluginsList(
 		} )
 			.then( ( { info, plugins } ) => {
 				dispatch( receivePluginsList( category, page, searchTerm, plugins, null, info ) );
+				// Do not trigger a new tracks event for subsequent pages.
+				if ( searchTerm && info.page === 1 ) {
+					dispatch(
+						recordTracksEvent( 'calypso_plugins_search', {
+							search_term: searchTerm,
+							results: info?.results,
+						} )
+					);
+				}
 			} )
 			.catch( ( error ) => {
 				dispatch( receivePluginsList( category, page, searchTerm, [], error ) );

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { normalizePluginData, normalizePluginsList } from 'calypso/lib/plugins/utils';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -11,6 +10,7 @@ import {
 	PLUGINS_WPORG_PLUGIN_RECEIVE,
 	PLUGINS_WPORG_PLUGIN_REQUEST,
 } from 'calypso/state/action-types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import {
 	getNextPluginsListPage,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Adds a tracking event when a new search is initiated

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- load Calypso
- in the console enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
- reload the page
- go to `/plugins`
- search for a plugin
- make sure that the `calypso_plugins_search` event is logged and `search_term`, `results_count` are correct
- go to any other results page and make sure that the event isn't logged again
- change the term, make sure that the `calypso_plugins_search` event is logged and `search_term`, `results_count` are correct


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57381
