### PR TITLE
Video UI: Prevent refresh on video HTML element

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -7,6 +7,18 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import './style.scss';
 
+const VideoPlayer = ( { videoUrl } ) => {
+	return (
+		<div key={ videoUrl } className="videos-ui__video">
+			<video controls>
+				<source src={ videoUrl } />{ ' ' }
+				{ /* @TODO: check if tracks are available, the linter demands one */ }
+				<track src="caption.vtt" kind="captions" srclang="en" label="english_captions" />
+			</video>
+		</div>
+	);
+};
+
 const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -38,18 +50,6 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 			setCurrentVideo( course.videos[ currentVideoKey ] );
 		}
 	}, [ currentVideoKey, course ] );
-
-	const VideoPlayer = ( { videoUrl } ) => {
-		return (
-			<div className="videos-ui__video">
-				<video controls>
-					<source src={ videoUrl } />{ ' ' }
-					{ /* @TODO: check if tracks are available, the linter demands one */ }
-					<track src="caption.vtt" kind="captions" srclang="en" label="english_captions" />
-				</video>
-			</div>
-		);
-	};
 
 	const isVideoSelected = ( idx ) => {
 		return selectedVideoIndex === idx;


### PR DESCRIPTION
This PR addresses the reloading that was being done on the video HTML element every time the component redraw itself.

| Before  | After |
| ------------- | ------------- |
| ![2021-11-05 08 57 06](https://user-images.githubusercontent.com/375980/140507173-4929f182-12e3-4d7f-b212-635ea9ea8475.gif)  | ![2021-11-05 08 56 22](https://user-images.githubusercontent.com/375980/140507138-9e6a42fb-1570-4327-8b89-bcb9c9a3f768.gif) |

#### Testing
1. Switch to this branch.
2. Add the <VideosUi /> component to My Home.
3. Verify that the video component only reloads when the play button is pressed.