### PR TITLE
Notifications: Add space for extra notification subject line

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -14,6 +14,7 @@
 	// Fixes font anti-aliasing in iframes: andrewmoreton.co.uk/typekit-iframes-safari-weird-antialiasing/
 	-webkit-font-smoothing: subpixel-antialiased;
 
+	/* stylelint-disable-next-line unit-allowed-list */
 	@media ( -webkit-min-device-pixel-ratio: 1.25 ), ( min-resolution: 120dpi ) {
 		body.font-smoothing-antialiased & {
 			text-rendering: optimizeLegibility;
@@ -203,7 +204,7 @@
 		background: var( --color-surface );
 		border: 1px solid var( --color-neutral-light );
 		border-right: none;
-		font-size: 13px;
+		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		height: 26px;
 		cursor: pointer;
 		user-select: none; // Makes text unselectable
@@ -222,14 +223,14 @@
 		}
 
 		&:first-of-type {
-			border-top-left-radius: 4px;
-			border-bottom-left-radius: 4px;
+			border-top-left-radius: 4px; /* stylelint-disable-line scales/radii */
+			border-bottom-left-radius: 4px; /* stylelint-disable-line scales/radii */
 		}
 
 		&:last-of-type {
 			border-right: 1px solid var( --color-neutral-light );
-			border-top-right-radius: 4px;
-			border-bottom-right-radius: 4px;
+			border-top-right-radius: 4px; /* stylelint-disable-line scales/radii */
+			border-bottom-right-radius: 4px; /* stylelint-disable-line scales/radii */
 
 			&.selected {
 				border-right-color: var( --color-primary );
@@ -292,7 +293,7 @@
 			border: {
 				width: 1px;
 				style: solid;
-				radius: 50%;
+				radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			}
 		}
 	}
@@ -317,12 +318,12 @@
 		transform: translateY( -50% );
 
 		h2 {
-			font: 400 21px/24px $sans;
+			font: 400 21px/24px $sans; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			margin-bottom: 4px;
 		}
 
 		p {
-			font: 400 16px/24px $sans;
+			font: 400 16px/24px $sans; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
 	}
 
@@ -378,7 +379,7 @@
 		}
 
 		.wpnc__note .wpnc__note-icon img {
-			border-radius: 50%;
+			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
 
 		.unread .wpnc__note-icon .wpnc__gridicon {
@@ -421,8 +422,8 @@
 			text-align: left;
 
 			.wpnc__subject {
-				max-height: 3em;
-				-webkit-line-clamp: 2;
+				max-height: 4em;
+				-webkit-line-clamp: 3;
 				@extend %ellipsy-box;
 				font-size: $wpnc__font-size;
 				line-height: $wpnc__line-height;
@@ -605,7 +606,7 @@
 		.wpnc__comment .wpnc__user p.wpnc__excerpt {
 			color: var( --color-secondary );
 			max-height: 1.5em;
-			font-size: 14px;
+			font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
 
 		.wpnc__reply {
@@ -638,7 +639,7 @@
 		}
 
 		.wpnc__note-icon .wpnc__gridicon {
-			font-size: 2em;
+			font-size: 2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			background-color: var( --color-neutral-10 );
 			border-color: var( --color-neutral-10 );
 		}
@@ -726,7 +727,7 @@
 			pre {
 				background: var( --color-neutral-0 );
 				border: 1px solid var( --color-neutral-10 );
-				border-radius: 3px;
+				border-radius: 3px; /* stylelint-disable-line scales/radii */
 				padding: 4px;
 
 				code {
@@ -737,11 +738,11 @@
 
 			code {
 				font-family: $code;
-				font-size: 90%;
+				font-size: 90%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 				color: var( --color-neutral-50 );
 				background: var( --color-neutral-0 );
 				border: 1px solid var( --color-neutral-10 );
-				border-radius: 3px;
+				border-radius: 3px; /* stylelint-disable-line scales/radii */
 				padding: 0 2px;
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The proposed change addresses https://github.com/Automattic/wp-calypso/issues/57398 by adding extra space for the notification subject line.

Please note that the PR also adds comments to ignore some of the linter warnings. Otherwise we would need to rewrite parts of the code unrelated to the issue we are fixing.

The actual fix is on lines 425 and 426 ([direct link to the lines](https://github.com/Automattic/wp-calypso/pull/57697/files#diff-020aead03581d73075c0f6f4a0330e72f54673caa87e64ec9e5acd4c326d4f86L424-R426)):

https://github.com/Automattic/wp-calypso/pull/57697/files#diff-020aead03581d73075c0f6f4a0330e72f54673caa87e64ec9e5acd4c326d4f86L424-R426

**Before:**
![Markup on 2021-11-05 at 13:28:50](https://user-images.githubusercontent.com/25105483/140510332-90acd029-0e6a-48c8-addd-87ffc4b266bb.png)

**After:** 
![Markup on 2021-11-05 at 13:29:20](https://user-images.githubusercontent.com/25105483/140510335-b3957d1e-7d43-4abf-9f6c-ee600b372098.png)

#### Testing instructions
1. Make sure your site title is long enough. You can use something like "This is a site with a very long name". The site title can be changed in Settings → General
2. Create a notification by following the site from another WPCOM account. For a Simple site you can use the Follow button on the bottom right-hand corner for example:
![Markup on 2021-11-05 at 13:32:13](https://user-images.githubusercontent.com/25105483/140510716-2bda522d-313b-4fdf-9f87-90932263e8ae.png)
3. The full notification text should display (as can be seen in the "After" screenshot above)

Related to https://github.com/Automattic/wp-calypso/issues/57398
