### PR TITLE
Welcome Tour Next: Add spotlight effect v.1

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/components/spotlight/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/components/spotlight/index.tsx
@@ -1,0 +1,73 @@
+/**
+ * External Dependencies
+ */
+import { useRef, useMemo } from '@wordpress/element';
+import classnames from 'classnames';
+import { usePopper } from 'react-popper';
+import type { Rect, Placement } from '@popperjs/core';
+
+interface Props {
+	referenceElementSelector: string;
+}
+
+const Spotlight: React.FunctionComponent< Props > = ( { referenceElementSelector } ) => {
+	const popperElementRef = useRef( null );
+	const referenceElement = document.querySelector( referenceElementSelector );
+	const { styles: popperStyles, attributes: popperAttributes } = usePopper(
+		referenceElement,
+		popperElementRef?.current,
+		{
+			strategy: 'fixed',
+			modifiers: [
+				useMemo(
+					() => ( {
+						name: 'offset',
+						options: {
+							offset: ( {
+								placement,
+								reference,
+								popper,
+							}: {
+								placement: Placement;
+								reference: Rect;
+								popper: Rect;
+							} ): [ number, number ] => {
+								if ( placement === 'bottom' ) {
+									return [ 0, -( reference.height + ( popper.height - reference.height ) / 2 ) ];
+								}
+								return [ 0, 0 ];
+							},
+						},
+					} ),
+					[]
+				),
+			],
+		}
+	);
+
+	const clipRepositionProps = referenceElement
+		? {
+				style: popperStyles?.popper,
+				...popperAttributes?.popper,
+		  }
+		: null;
+
+	return (
+		<>
+			<div
+				className={ classnames( 'wpcom-editor-welcome-tour__spotlight-overlay', {
+					'--visible': ! clipRepositionProps,
+				} ) }
+			/>
+			<div
+				className={ classnames( 'wpcom-editor-welcome-tour__spotlight-clip', {
+					'--visible': clipRepositionProps,
+				} ) }
+				ref={ popperElementRef }
+				{ ...clipRepositionProps }
+			/>
+		</>
+	);
+};
+
+export default Spotlight;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -18,14 +18,31 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	cursor: default;
 }
 
-.wpcom-editor-welcome-tour__screen-overlay {
+.wpcom-editor-welcome-tour__spotlight-overlay {
 	position: fixed;
-	left: 0;
-	right: 0;
-	bottom: 0;
+	width: 100vw;
+	height: 100vh;
 	top: 0;
-	background-color: black;
-	opacity: 0.5;
+	left: 0;
+	background:rgba( 0, 0, 0 );
+	opacity: 0;
+
+	&.--visible {
+		opacity: 0.5;
+	}
+}
+
+.wpcom-editor-welcome-tour__spotlight-clip {
+	&.--visible {
+		position: fixed;
+		width: 50px;
+		height: 50px;
+		overflow: hidden;
+		// box-shadow: 0 0 0 9999px rgba(0, 0, 255, 0.2);
+		outline: 99999px solid rgba( 0, 0, 0, 0.5 );
+		border-radius: 2px;
+		z-index: 1;
+	}
 }
 
 .welcome-tour-card__heading {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As of #56867 the Welcome Tour applies step repositioning to move the steps near reference elements on the page (or fallback to the default position - bottom left). It also adds a semi-transparent overlay to block interaction with the editor.

This PR adds a spotlight effect on the reference elements (variation 1 / #57059).

#### Media/Demo

little square holes | stick around
-- | --
![Kapture 2021-11-03 at 18 18 21](https://user-images.githubusercontent.com/1705499/140514946-37a83fac-1ed0-4ccd-8aeb-70a80abd896d.gif) | ![Kapture 2021-11-03 at 18 25 25](https://user-images.githubusercontent.com/1705499/140515663-995978a5-f554-4a60-bc55-52cec44e505e.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Sandbox a site, checkout branch, and `yarn dev --sync` from `apps/editing-toolkit` to sync sandbox.
- Go to the editor, open the sidebar, and from there click on "Welcome Guide".
- Tour should be focused and keyboard navigation enabled.
- Focus should be on the "Try it out!" button.
- Stepping through the steps should move them closer to the element they refer to (as in the [Figma mocks](https://github.com/Automattic/wp-calypso/pull/Mh2ZK4ZkifXClvLEG5imNc-fi-596%3A15786)).
- Reference elements should be enclosed/visible via a transparent box.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### TODO

[ ] picking mobile/desktop references needs addressing #57223

Related to #56867
Fixes #57057
