### PR TITLE
build: Fix mac and windows builds for WP Desktop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,7 @@ jobs:
     environment:
       CONFIG_ENV: release
       CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     steps:
       - checkout
       - attach_workspace:
@@ -297,6 +298,7 @@ jobs:
     environment:
       CONFIG_ENV: release
       CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,9 @@ jobs:
       - attach_workspace:
           at: /Users/distiller/wp-calypso
       - run: *update-node
+      - restore_cache: *restore-yarn-cache
       - run: *yarn-install
+      - save_cache: *save-yarn-cache
       - run:
           name: Build Desktop Mac
           no_output_timeout: 45m
@@ -244,7 +246,7 @@ jobs:
 
             # Build all artifacts only when project config changes.
             # Otherwise only build application executable required for end-to-end testing.
-            ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|desktop/yarn.lock' && ELECTRON_BUILDER_ARGS='-c.mac.target=dir'
+            ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && ELECTRON_BUILDER_ARGS='-c.mac.target=dir'
 
             # Override SDKROOT and MACOSX_DEPLOYMENT_TARGET to ensure correct SDK configuration:
             # https://github.com/Homebrew/homebrew-core/pull/19296#issuecomment-352867571
@@ -309,7 +311,9 @@ jobs:
           command: |
             sudo apt update
             sudo apt-get install -y libsecret-1-dev
+      - restore_cache: *restore-yarn-cache
       - run: *yarn-install
+      - save_cache: *save-yarn-cache
       - run:
           name: Build Desktop Linux
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ jobs:
     working_directory: /Users/distiller/wp-calypso
     environment:
       CONFIG_ENV: release
+      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
     steps:
       - checkout
       - attach_workspace:
@@ -295,6 +296,7 @@ jobs:
     shell: /bin/bash --login
     environment:
       CONFIG_ENV: release
+      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,6 +366,8 @@ jobs:
     working_directory: C:\Users\circleci\wp-calypso
     environment:
       CONFIG_ENV: release
+      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ references:
   restore-yarn-cache: &restore-yarn-cache
     name: 'Restore yarn cache'
     keys:
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-yarn-cache-{{ checksum ".yarnrc.yml" }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-yarn-cache
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-yarn-cache-{{ arch }}-{{ checksum ".yarnrc.yml" }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-yarn-cache-{{ arch }}
 
   yarn-install: &yarn-install
     name: Install dependencies
@@ -103,7 +103,7 @@ references:
 
   save-yarn-cache: &save-yarn-cache
     name: 'Save yarn cache'
-    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-yarn-cache-{{ checksum ".yarnrc.yml" }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-yarn-cache-{{ arch }}-{{ checksum ".yarnrc.yml" }}
     paths:
       # This is the default path when using enableGlobalCache:true
       - ~/.yarn/berry/cache

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,7 +46,7 @@ package: PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "consol
 package:
 	$(info Packaging app...)
 
-	@cd $(DESKTOP_DIR) && npx electron-builder ${ELECTRON_BUILDER_ARGS} -c.electronVersion=$(PACKAGE_ELECTRON_VERSION) build --publish never
+	@cd $(DESKTOP_DIR) && yarn electron-builder ${ELECTRON_BUILDER_ARGS} -c.electronVersion=$(PACKAGE_ELECTRON_VERSION) build --publish never
 
 e2e:
 	$(info Running end-to-end tests...)

--- a/package.json
+++ b/package.json
@@ -316,7 +316,8 @@
 	"resolutions": {
 		"@automattic/newspack-blocks/swiper@4.5.1": "patch:swiper@4.5.1#.patches/swiper@4.5.1.diff",
 		"@automattic/newspack-blocks/prettier": "npm:wp-prettier@2.2.1-beta-1",
-		"@types/react": "^17.0.33"
+		"@types/react": "^17.0.33",
+		"keytar@npm:7.7.0/node-addon-api": "3.1.0"
 	},
 	"packageManager": "yarn@3.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26916,6 +26916,15 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:3.1.0":
+  version: 3.1.0
+  resolution: "node-addon-api@npm:3.1.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 991b65f3bac4934f0fe8aa72b3fd4df4be5cc1483fe7d5c4b80c7091a3e4bcf50756444363c33723ec449ced349d6d677daab4ea63cfd91c198c24a0208a0960
+  languageName: node
+  linkType: hard
+
 "node-addon-api@npm:^1.6.0, node-addon-api@npm:^1.6.3":
   version: 1.7.2
   resolution: "node-addon-api@npm:1.7.2"
@@ -26925,7 +26934,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^3.0.0, node-addon-api@npm:^3.2.0":
+"node-addon-api@npm:^3.2.0":
   version: 3.2.1
   resolution: "node-addon-api@npm:3.2.1"
   dependencies:


### PR DESCRIPTION
## Background

`wp-desktop-mac` and `wp-desktop-win` CircleCI builds are failing in `trunk`. This started to happen after #57633 was merged.

The build seems to fail with 

```
➤ YN0000: │ chromedriver@npm:89.0.0 STDERR 40:47: execution error: Can’t get application "Google Chrome". (-1728)
➤ YN0000: │ chromedriver@npm:89.0.0 STDOUT Your Chrome version is null
➤ YN0000: │ chromedriver@npm:89.0.0 STDERR ChromeDriver installation failed TypeError: Cannot read properties of null (reading '1')
➤ YN0000: │ chromedriver@npm:89.0.0 STDERR     at install (/Users/distiller/wp-calypso/node_modules/chromedriver/install.js:43:75)
➤ YN0000: │ chromedriver@npm:89.0.0 STDERR     at processTicksAndRejections (node:internal/process/task_queues:96:5)
➤ YN0009: │ chromedriver@npm:89.0.0 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/6y/gy9gggt14379c_k39vwb50lc0000gn/T/xfs-676b11aa/build.log)
```

## Changes proposed in this Pull Request

Disables chromedriver download in Mac and Windows builds for Desktop.  After all, we don't use it for tests.

## Testing

Verify `wp-desktop-mac` and `wp-desktop-win` pass in this PR.
