### PR TITLE
Display Jetpack license key at the end of the manual activation flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
@@ -7,13 +7,15 @@ import licensingActivationPluginInstall from 'calypso/assets/images/jetpack/lice
 import ExternalLink from 'calypso/components/external-link';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
 	productSlug: string | 'no_product';
+	receiptId: number;
 }
 
-const LicensingActivationInstructions: FC< Props > = ( { productSlug } ) => {
+const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -24,9 +26,14 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug } ) => {
 			} )
 		);
 		return page(
-			`/checkout/jetpack/thank-you/licensing-manual-activate-license-key/${ productSlug }`
+			addQueryArgs(
+				{
+					receiptId,
+				},
+				`/checkout/jetpack/thank-you/licensing-manual-activate-license-key/${ productSlug }`
+			)
 		);
-	}, [ dispatch, productSlug ] );
+	}, [ dispatch, productSlug, receiptId ] );
 
 	return (
 		<>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation.tsx
@@ -6,13 +6,15 @@ import { useDispatch } from 'react-redux';
 import footerCardImg from 'calypso/assets/images/jetpack/licensing-card.png';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
 	productSlug: string | 'no_product';
+	receiptId: number;
 }
 
-const LicensingActivationThankYou: FC< Props > = ( { productSlug } ) => {
+const LicensingActivationThankYou: FC< Props > = ( { productSlug, receiptId } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -23,9 +25,14 @@ const LicensingActivationThankYou: FC< Props > = ( { productSlug } ) => {
 			} )
 		);
 		return page(
-			`/checkout/jetpack/thank-you/licensing-manual-activate-instructions/${ productSlug }`
+			addQueryArgs(
+				{
+					receiptId,
+				},
+				`/checkout/jetpack/thank-you/licensing-manual-activate-instructions/${ productSlug }`
+			)
 		);
-	}, [ dispatch, productSlug ] );
+	}, [ dispatch, productSlug, receiptId ] );
 
 	return (
 		<>

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -1082,6 +1082,10 @@
 
 		border: none;
 	}
+
+	.licensing-thank-you-manual-activation-license-key__input.form-text-input.is-loading {
+		@include placeholder( --color-neutral-20 );
+	}
 }
 
 .licensing-thank-you-manual-activation-license-key__button {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -7,6 +7,7 @@ import { setSectionMiddleware } from 'calypso/controller';
 import { CALYPSO_PLANS_PAGE } from 'calypso/jetpack-connect/constants';
 import { MARKETING_COUPONS_KEY } from 'calypso/lib/analytics/utils';
 import { TRUENAME_COUPONS } from 'calypso/lib/domains';
+import { addQueryArgs } from 'calypso/lib/url';
 import LicensingThankYouAutoActivation from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation';
 import LicensingThankYouManualActivation from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation';
 import LicensingThankYouManualActivationInstructions from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions';
@@ -323,24 +324,36 @@ export function redirectToSupportSession( context ) {
 
 export function licensingThankYouManualActivation( context, next ) {
 	const { product } = context.params;
+	const { receiptId } = context.query;
 
-	context.primary = <LicensingThankYouManualActivation productSlug={ product } />;
+	context.primary = (
+		<LicensingThankYouManualActivation productSlug={ product } receiptId={ receiptId } />
+	);
 
 	next();
 }
 
 export function licensingThankYouManualActivationInstructions( context, next ) {
 	const { product } = context.params;
+	const { receiptId } = context.query;
 
-	context.primary = <LicensingThankYouManualActivationInstructions productSlug={ product } />;
+	context.primary = (
+		<LicensingThankYouManualActivationInstructions
+			productSlug={ product }
+			receiptId={ receiptId }
+		/>
+	);
 
 	next();
 }
 
 export function licensingThankYouManualActivationLicenseKey( context, next ) {
 	const { product } = context.params;
+	const { receiptId } = context.query;
 
-	context.primary = <LicensingThankYouManualActivationLicenseKey productSlug={ product } />;
+	context.primary = (
+		<LicensingThankYouManualActivationLicenseKey productSlug={ product } receiptId={ receiptId } />
+	);
 
 	next();
 }
@@ -354,17 +367,23 @@ export function licensingThankYouAutoActivation( context, next ) {
 	const { receiptId, source, siteId } = context.query;
 
 	if ( ! userHasJetpackSites ) {
-		page.redirect( `/checkout/jetpack/thank-you/licensing-manual-activate/${ product }` );
+		page.redirect(
+			addQueryArgs(
+				{ receiptId },
+				`/checkout/jetpack/thank-you/licensing-manual-activate/${ product }`
+			)
+		);
+	} else {
+		context.primary = (
+			<LicensingThankYouAutoActivation
+				userHasJetpackSites={ userHasJetpackSites }
+				productSlug={ context.params.product }
+				receiptId={ receiptId }
+				source={ source }
+				jetpackTemporarySiteId={ siteId }
+			/>
+		);
 	}
-	context.primary = (
-		<LicensingThankYouAutoActivation
-			userHasJetpackSites={ userHasJetpackSites }
-			productSlug={ context.params.product }
-			receiptId={ receiptId }
-			source={ source }
-			jetpackTemporarySiteId={ siteId }
-		/>
-	);
 
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Carry over the receipt id throughout the manual activation UIs so that the license key can be fetched at the end of it.

#### Testing instructions

* Download PR.
* Start Calypso with `yarn start`.
* Visit `https://cloud.jetpack.com/pricing`.
* Select a paid product.
* Once you're on the checkout page, replace `wordpress.com` with `calypso.localhost:3000`.
* Submit the checkout form.
* Once you're on the page where a dropdown with your sites is displayed, select the last option to initiate the manual activation flow.
* Continue the flow until you reach the last step.
* Make sure you see a real license key.

Related to 1201096622142517-as-1201330575264885

#### Demo

##### Loading title and license key
![image](https://user-images.githubusercontent.com/3418513/140563811-32f2f808-91b1-4eec-9344-fcce0f497602.png)

##### Loading title
![image](https://user-images.githubusercontent.com/3418513/140563781-fba0427f-4a56-464c-a875-83f8edeed7e3.png)

##### Loading finished
![image](https://user-images.githubusercontent.com/3418513/140563711-1465572c-d329-458d-afb9-c0ed10222f0b.png)
