### PR TITLE
Fix calypso-build dependencies

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -33,7 +33,7 @@
 		"test:e2e": "jest -c test/e2e/config/jest.config.js"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^9.0.0",
+		"@automattic/calypso-build": "^10.0.0",
 		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"copy-webpack-plugin": "^6.2.1",
 		"electron": "12.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9290,7 +9290,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "WordPressDesktop@workspace:desktop"
   dependencies:
-    "@automattic/calypso-build": ^9.0.0
+    "@automattic/calypso-build": ^10.0.0
     "@automattic/calypso-eslint-overrides": ^1.0.0
     archiver: ^3.1.1
     copy-webpack-plugin: ^6.2.1


### PR DESCRIPTION
### Changes proposed in this Pull Request
After merging #57682, builds started failing. I believe they were failing because the desktop app was using an older version of calypso-build. Additionally, the yarn.lock was not up-to-date.

This PR resolves the problem, at least locally.

A future note: I should publish to npm _before_ merging the PR 