### PR TITLE
My Plan: Hide headerChildren while the component loads

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -355,19 +355,22 @@ class PurchasesListing extends Component {
 				<Card compact>
 					<strong>{ translate( 'My Solutions' ) }</strong>
 				</Card>
-				{ productPurchases.map( ( purchase ) => (
-					<MyPlanCard
-						key={ purchase.id }
-						action={ this.getProductActionButtons( purchase ) }
-						details={ this.getExpirationInfoForPurchase( purchase ) }
-						isError={ this.isProductExpiring( purchase ) }
-						isPlaceholder={ this.isLoading() }
-						product={ purchase.productSlug }
-						tagline={ getJetpackProductTagline( purchase, true ) }
-						title={ this.getTitle( purchase ) }
-						headerChildren={ this.getHeaderChildren( purchase ) }
-					/>
-				) ) }
+				{ productPurchases.map( ( purchase ) =>
+					this.isLoading() ? (
+						<MyPlanCard isPlaceholder key={ purchase.id } />
+					) : (
+						<MyPlanCard
+							key={ purchase.id }
+							action={ this.getProductActionButtons( purchase ) }
+							details={ this.getExpirationInfoForPurchase( purchase ) }
+							isError={ this.isProductExpiring( purchase ) }
+							product={ purchase.productSlug }
+							tagline={ getJetpackProductTagline( purchase, true ) }
+							title={ this.getTitle( purchase ) }
+							headerChildren={ this.getHeaderChildren( purchase ) }
+						/>
+					)
+				) }
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
Resolves `1200412004370260-as-1201314177600170`, `p1HpG7-dpL-p2#comment-50028`.

#### Changes proposed in this Pull Request

* No longer pass extra arguments to `MyPlanCard` while it's rendering; only `isPlaceholder` and a `key`, if necessary.

#### Testing instructions

***Prerequisite:* You must select a site with a new Jetpack Backup plan, either with 10 GB or 1 TB of storage.*

1. In Calypso Blue, visit the **Upgrades > Plans > My Plan** page.
2. Closely watch the **My Products** section and verify the placeholder for Backup does not overflow the bottom of its parent container (see reference screenshot).

#### Reference screenshot: overflowing loading state

![image](https://user-images.githubusercontent.com/670067/140571168-321f64fd-e131-4e94-8f61-9a5e4dc84291.png)