### PR TITLE
fix: Use automatic react runtime in storybooks

### DIFF
--- a/bin/storybook-default-config.js
+++ b/bin/storybook-default-config.js
@@ -23,7 +23,7 @@ module.exports = function storybookDefaultConfig( {
 		babel: {
 			presets: [
 				[ '@babel/preset-env', { targets: { browsers: 'last 2 versions' } } ],
-				[ '@babel/preset-react' ],
+				[ '@babel/preset-react', { runtime: 'automatic' } ],
 			],
 			plugins: [ [ '@babel/plugin-proposal-private-property-in-object', { loose: false } ] ],
 		},


### PR DESCRIPTION
## Background

Fixes #57733

Storybook have been broken for a while, likely since #56451. 

## Changes proposed in this Pull Request

Configures Storybook to use automatic JSX runtime

## Testing instructions

Run `yarn components:storybook:start` and verify it works
