### PR TITLE
App Banner: Disable for Jetpack and Atomic sites

### DIFF
--- a/client/data/block-editor/use-block-editor-nux-status-query.ts
+++ b/client/data/block-editor/use-block-editor-nux-status-query.ts
@@ -1,5 +1,8 @@
 import { useQuery, UseQueryResult } from 'react-query';
+import { useSelector } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
+import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 
 export type BlockEditorNuxStatus = {
 	show_welcome_guide: boolean;
@@ -9,6 +12,8 @@ export const useBlockEditorNuxStatusQuery = (
 	siteId: string
 ): UseQueryResult< BlockEditorNuxStatus > => {
 	const queryKey = [ 'blockEditorNuxStatus', siteId ];
+	const siteIsAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
 	return useQuery< BlockEditorNuxStatus >(
 		queryKey,
@@ -18,6 +23,6 @@ export const useBlockEditorNuxStatusQuery = (
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		{ enabled: !! siteId }
+		{ enabled: !! siteId && ! siteIsAtomic && ! siteIsJetpack }
 	);
 };

--- a/client/data/block-editor/use-block-editor-nux-status-query.ts
+++ b/client/data/block-editor/use-block-editor-nux-status-query.ts
@@ -1,7 +1,6 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
-import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 
 export type BlockEditorNuxStatus = {
@@ -12,7 +11,6 @@ export const useBlockEditorNuxStatusQuery = (
 	siteId: string
 ): UseQueryResult< BlockEditorNuxStatus > => {
 	const queryKey = [ 'blockEditorNuxStatus', siteId ];
-	const siteIsAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
 	return useQuery< BlockEditorNuxStatus >(
@@ -23,6 +21,6 @@ export const useBlockEditorNuxStatusQuery = (
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		{ enabled: !! siteId && ! siteIsAtomic && ! siteIsJetpack }
+		{ enabled: !! siteId && ! siteIsJetpack }
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After landing #57140, we're seeing this error for Jetpack and Atomic sites throughout Calypso:

![](https://cldup.com/O-XdyK2rOl.png)

To solve this, this PR disables the corresponding react query for Atomic and Jetpack sites.

#### Testing instructions

* Test with a Jetpack and an Atomic site and verify there are no requests to `/wpcom/v2/sites/:site/block-editor/nux`
* Test with a simple site and verify the request is still performed, and test instructions from #57140 still work.