### PR TITLE
Gutenboarding importer flow: additional UI tweaks

### DIFF
--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -84,7 +84,7 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 						/>
 					) }
 					{ stepName === 'ready' && stepSectionName === 'wpcom' && (
-						<ReadyAlreadyOnWPCOMStep urlData={ urlData } />
+						<ReadyAlreadyOnWPCOMStep urlData={ urlData } goToStep={ goToStep } />
 					) }
 				</div>
 			}

--- a/client/signup/steps/import/ready/index.tsx
+++ b/client/signup/steps/import/ready/index.tsx
@@ -102,7 +102,7 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( { goToStep } ) 
 						</NextButton>
 						<div>
 							<BackButton onClick={ () => goToStep( 'capture' ) }>
-								{ __( 'Back to the start' ) }
+								{ __( 'Back to start' ) }
 							</BackButton>
 						</div>
 					</div>
@@ -165,9 +165,13 @@ const ReadyStep: React.FunctionComponent< ReadyProps > = ( props ) => {
 
 interface ReadyWpComProps {
 	urlData: UrlData;
+	goToStep: GoToStep;
 }
 
-const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( { urlData } ) => {
+const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
+	urlData,
+	goToStep,
+} ) => {
 	const { __ } = useI18n();
 
 	return (
@@ -191,9 +195,13 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( { 
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton>{ __( 'Start building' ) }</NextButton>
+						<NextButton onClick={ () => goToStep( 'design-setup-site', '', 'setup-site' ) }>
+							{ __( 'Start building' ) }
+						</NextButton>
 						<div>
-							<BackButton>{ __( 'Back to start' ) }</BackButton>
+							<BackButton onClick={ () => goToStep( 'capture' ) }>
+								{ __( 'Back to start' ) }
+							</BackButton>
 						</div>
 					</div>
 				</div>

--- a/client/signup/steps/import/ready/index.tsx
+++ b/client/signup/steps/import/ready/index.tsx
@@ -4,7 +4,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
 import { UrlData, GoToStep } from '../types';
-import { convertPlatformName } from '../util';
+import { convertPlatformName, convertToFriendlyWebsiteName } from '../util';
 import ImportPlatformDetails, { coveredPlatforms } from './platform-details';
 import ImportPreview from './preview';
 import './style.scss';
@@ -16,11 +16,6 @@ interface ReadyPreviewProps {
 	siteSlug: string;
 	goToImporterPage: ( platform: string ) => void;
 }
-
-const convertToFriendlyWebsiteName = ( website: string ): string => {
-	const { hostname, pathname } = new URL( website );
-	return ( hostname + ( pathname === '/' ? '' : pathname ) ).replace( 'www.', '' );
-};
 
 const ReadyPreviewStep: React.FunctionComponent< ReadyPreviewProps > = ( {
 	urlData,

--- a/client/signup/steps/import/ready/preview.tsx
+++ b/client/signup/steps/import/ready/preview.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { MShotParams } from '../types';
+import useWindowDimensions from '../windowDimensions.effect';
 import type { FunctionComponent } from 'react';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -12,6 +14,11 @@ const protocolRgx = /(?<protocol>https?:\/\/)?(?<address>.*)/i;
 
 const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
 	const [ mShotUrl, setMShotUrl ] = useState( '' );
+	const { width } = useWindowDimensions();
+	const mShotParams: MShotParams = {
+		scale: 2,
+		vpw: width <= 640 ? 640 : undefined,
+	};
 	const websiteMatch = website.match( protocolRgx );
 
 	const checkScreenshot = ( screenShotUrl: string ) => {
@@ -33,7 +40,12 @@ const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
 		http.send();
 	};
 
-	checkScreenshot( `https://s0.wp.com/mshots/v1/${ website }?scale=2` );
+	checkScreenshot(
+		`https://s0.wp.com/mshots/v1/${ website }?${ Object.keys( mShotParams )
+			.filter( ( key ) => !! mShotParams[ key as keyof MShotParams ] )
+			.map( ( key ) => key + '=' + mShotParams[ key as keyof MShotParams ] )
+			.join( '&' ) }`
+	);
 
 	const Screenshot = () => {
 		if ( mShotUrl !== '' ) {

--- a/client/signup/steps/import/ready/preview.tsx
+++ b/client/signup/steps/import/ready/preview.tsx
@@ -41,9 +41,9 @@ const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
 	};
 
 	checkScreenshot(
-		`https://s0.wp.com/mshots/v1/${ website }?${ Object.keys( mShotParams )
-			.filter( ( key ) => !! mShotParams[ key as keyof MShotParams ] )
-			.map( ( key ) => key + '=' + mShotParams[ key as keyof MShotParams ] )
+		`https://s0.wp.com/mshots/v1/${ website }?${ Object.entries( mShotParams )
+			.filter( ( entry ) => !! entry[ 1 ] )
+			.map( ( [ key, val ] ) => key + '=' + val )
 			.join( '&' ) }`
 	);
 

--- a/client/signup/steps/import/ready/style.scss
+++ b/client/signup/steps/import/ready/style.scss
@@ -103,7 +103,11 @@
 		}
 
 		.import__screenshot-loading {
-			margin-top: 150px;
+			margin-top: 25px;
+
+			@include break-small {
+				margin-top: 150px;
+			}
 
 			.wpcom__loading-ellipsis {
 				display: block;

--- a/client/signup/steps/import/types.ts
+++ b/client/signup/steps/import/types.ts
@@ -7,6 +7,10 @@ export type UrlData = {
 		is_wpcom: boolean;
 	};
 };
+export type MShotParams = {
+	vpw?: number;
+	scale?: number;
+};
 
 export type FeatureName =
 	| 'tags'

--- a/client/signup/steps/import/util.ts
+++ b/client/signup/steps/import/util.ts
@@ -29,6 +29,9 @@ export const orgImporters: string[] = [
 	'blogroll',
 ];
 
+/**
+ * Platform name helpers
+ */
 export function getPlatformImporterName( platform: string ): string {
 	return platformImporterNameMap[ platform ] ? platformImporterNameMap[ platform ] : platform;
 }
@@ -37,6 +40,14 @@ export function convertPlatformName( platform: string ): string {
 	return platformMap[ platform ] !== undefined ? platformMap[ platform ] : 'Unknown';
 }
 
+export function convertToFriendlyWebsiteName( website: string ): string {
+	const { hostname, pathname } = new URL( website );
+	return ( hostname + ( pathname === '/' ? '' : pathname ) ).replace( 'www.', '' );
+}
+
+/**
+ * Importer URL helpers
+ */
 export function getWpComMigrateUrl( siteSlug: string ): string {
 	return '/migrate/{siteSlug}'.replace( '{siteSlug}', siteSlug );
 }

--- a/client/signup/steps/import/util.ts
+++ b/client/signup/steps/import/util.ts
@@ -37,6 +37,10 @@ export function convertPlatformName( platform: string ): string {
 	return platformMap[ platform ] !== undefined ? platformMap[ platform ] : 'Unknown';
 }
 
+export function getWpComMigrateUrl( siteSlug: string ): string {
+	return '/migrate/{siteSlug}'.replace( '{siteSlug}', siteSlug );
+}
+
 export function getWpComImporterUrl( siteSlug: string, platform: string ): string {
 	const wpComBase = '/import/{siteSlug}?engine={importer}';
 
@@ -54,7 +58,11 @@ export function getWpOrgImporterUrl( siteSlug: string, platform: string ): strin
 }
 
 export function getImporterUrl( siteSlug: string, platform: string ): string {
-	return orgImporters.includes( platform )
-		? getWpOrgImporterUrl( siteSlug, platform )
-		: getWpComImporterUrl( siteSlug, platform );
+	if ( platform === 'wordpress' ) {
+		return getWpComMigrateUrl( siteSlug );
+	} else if ( orgImporters.includes( platform ) ) {
+		return getWpOrgImporterUrl( siteSlug, platform );
+	}
+
+	return getWpComImporterUrl( siteSlug, platform );
 }

--- a/client/signup/steps/import/windowDimensions.effect.ts
+++ b/client/signup/steps/import/windowDimensions.effect.ts
@@ -1,0 +1,29 @@
+import { debounce } from 'lodash';
+import { useState, useEffect } from 'react';
+
+const DEBOUNCE_TIME = 300;
+
+function getWindowDimensions() {
+	const { innerWidth: width, innerHeight: height } = window;
+	return {
+		width,
+		height,
+	};
+}
+
+export default function useWindowDimensions() {
+	const [ windowDimensions, setWindowDimensions ] = useState( getWindowDimensions() );
+
+	useEffect( () => {
+		function handleResize() {
+			setWindowDimensions( getWindowDimensions() );
+		}
+
+		const throttledHandleResize = debounce( handleResize, DEBOUNCE_TIME );
+
+		window.addEventListener( 'resize', throttledHandleResize );
+		return () => window.removeEventListener( 'resize', throttledHandleResize );
+	}, [] );
+
+	return windowDimensions;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Improved internal routing on the "Your site is already on WordPress.com" screen
* Updated wordpress importer link from `/import` to `/migrate`
* Optimized screenshot (mShot) preview for mobile devices

#### Testing instructions
* Go to `/start/importer?siteSlug={YOUR_SITE}`
* Enter website URL hosted on wordpress.com
* Click on available actions (buttons)

--

* Go to `/start/importer?siteSlug={YOUR_SITE}`
* Enter website URL
* Resize the screen to lower than 640px width
* Check if the screenshot is optimized for the mobile device

#### Screenshot
<img width="414" alt="Screenshot 2021-11-08 at 17 53 31" src="https://user-images.githubusercontent.com/1241413/140784535-805653d8-880d-4429-9409-7d494374cacf.png">

Related to #57131
