### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` Jetpack connection to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -40,17 +40,6 @@ Undocumented.prototype.me = function () {
 };
 
 /**
- * Disconnects a Jetpack site with id siteId from WP.com
- *
- * @param {number} [siteId] The site ID
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.disconnectJetpack = function ( siteId, fn ) {
-	debug( '/jetpack-blogs/:site_id:/mine/delete query' );
-	return this.wpcom.req.post( { path: '/jetpack-blogs/' + siteId + '/mine/delete' }, fn );
-};
-
-/**
  * Fetches plugin registration keys for WordPress.org sites with paid services
  *
  * @param {number} [siteId] The site ID
@@ -70,34 +59,6 @@ Undocumented.prototype.fetchJetpackKeys = function ( siteId, fn ) {
 Undocumented.prototype.testConnectionJetpack = function ( siteId, fn ) {
 	debug( '/jetpack-blogs/:site_id:/test-connection query' );
 	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/test-connection' }, fn );
-};
-
-/*
- * Retrieve current connection status of a Jetpack site.
- *
- * @param {number}      [siteId]
- * @param {Function} fn
- */
-Undocumented.prototype.getJetpackConnectionStatus = function ( siteId, fn ) {
-	return this.wpcom.req.get(
-		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/jetpack/v4/connection/' },
-		fn
-	);
-};
-
-/*
- * Retrieve current user's connection data for a Jetpack site.
- *
- * @param {number}      [siteId]
- * @param {Function} fn
- */
-Undocumented.prototype.getJetpackUserConnectionData = function ( siteId, fn ) {
-	return this.wpcom.req.get(
-		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/jetpack/v4/connection/data/' },
-		fn
-	);
 };
 
 Undocumented.prototype.jetpackLogin = function ( siteId, _wp_nonce, redirect_uri, scope, state ) {

--- a/client/state/jetpack/connection/actions.js
+++ b/client/state/jetpack/connection/actions.js
@@ -23,9 +23,8 @@ export const requestJetpackConnectionStatus = ( siteId ) => {
 			siteId,
 		} );
 
-		return wp
-			.undocumented()
-			.getJetpackConnectionStatus( siteId )
+		return wp.req
+			.get( `/jetpack-blogs/${ siteId }/rest-api/`, { path: '/jetpack/v4/connection/' } )
 			.then( ( response ) => {
 				dispatch( {
 					type: JETPACK_CONNECTION_STATUS_RECEIVE,
@@ -54,9 +53,8 @@ export const requestJetpackUserConnectionData = ( siteId ) => {
 			siteId,
 		} );
 
-		return wp
-			.undocumented()
-			.getJetpackUserConnectionData( siteId )
+		return wp.req
+			.get( `/jetpack-blogs/${ siteId }/rest-api/`, { path: '/jetpack/v4/connection/data/' } )
 			.then( ( response ) => {
 				dispatch( {
 					type: JETPACK_USER_CONNECTION_DATA_RECEIVE,
@@ -79,17 +77,14 @@ export const requestJetpackUserConnectionData = ( siteId ) => {
 };
 
 export const disconnect = ( siteId ) => ( dispatch ) =>
-	wp
-		.undocumented()
-		.disconnectJetpack( siteId )
-		.then( ( response ) => {
-			dispatch( {
-				type: JETPACK_DISCONNECT_RECEIVE,
-				siteId,
-				status: response,
-			} );
-			dispatch( fetchCurrentUser() );
+	wp.req.post( `/jetpack-blogs/${ siteId }/mine/delete` ).then( ( response ) => {
+		dispatch( {
+			type: JETPACK_DISCONNECT_RECEIVE,
+			siteId,
+			status: response,
 		} );
+		dispatch( fetchCurrentUser() );
+	} );
 
 /**
  * Change the jetpack connection owner.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates all the `wpcom.undocumented()` Jetpack connection methods to `wpcom.req.get()`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/settings/manage-connection/:site` where `:site` is one of your Jetpack sites.
* Verify that both network requests that include `jetpack%2Fv4%2Fconnection` in their query string load properly.
* Verify that the "Site owner" section loads correctly.
* Click on "Disconnect from WordPress.com" and verify disconnection works like it did before.