### PR TITLE
Domains: Remove old code from "Use a domain I own" flow component

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -663,12 +663,6 @@ class DomainsStep extends Component {
 		return this.props.isDomainOnly ? 'domain-first' : 'signup';
 	}
 
-	resetState() {
-		if ( inputMode.domainInput === this.state?.step ) {
-			this.setState( {} );
-		}
-	}
-
 	renderContent() {
 		let content;
 		let sideContent;
@@ -678,7 +672,6 @@ class DomainsStep extends Component {
 		}
 
 		if ( ! this.props.stepSectionName || this.props.isDomainOnly ) {
-			this.resetState();
 			content = this.domainForm();
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Simple cleanup PR to remove unnecessary code introduced in #56366 on the "Use a domain I own" main component. 

#### Testing instructions
Make sure that the "Use a domain I own" flow/back button still works as expected - for both logged/unlogged contexts (`/new`, `/start/premium`, etc)