### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` billing history to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -23,14 +23,6 @@ function UndocumentedMe( wpcom ) {
  */
 inherits( UndocumentedMe, WPCOM.Me );
 
-UndocumentedMe.prototype.billingHistoryEmailReceipt = function ( receiptId, callback ) {
-	const args = {
-		path: '/me/billing-history/receipt/' + receiptId + '/email',
-	};
-
-	return this.wpcom.req.get( args, callback );
-};
-
 UndocumentedMe.prototype.getReceipt = function ( receiptId, queryOrCallback ) {
 	return this.wpcom.req.get(
 		{

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -412,22 +412,6 @@ Undocumented.prototype.getSiteProducts = function ( siteDomain, fn ) {
 };
 
 /**
- * Get the user's billing history
- *
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.billingHistory = function ( fn ) {
-	return this._sendRequest(
-		{
-			path: '/me/billing-history',
-			method: 'get',
-			apiVersion: '1.3',
-		},
-		fn
-	);
-};
-
-/**
  * Get a site specific details for WordPress.com plans
  *
  * @param {Function} siteDomain The site slug

--- a/client/state/billing-transactions/actions.js
+++ b/client/state/billing-transactions/actions.js
@@ -19,9 +19,8 @@ export const requestBillingTransactions = () => {
 			type: BILLING_TRANSACTIONS_REQUEST,
 		} );
 
-		return wp
-			.undocumented()
-			.billingHistory()
+		return wp.req
+			.get( '/me/billing-history', { apiVersion: '1.3' } )
 			.then( ( { billing_history, upcoming_charges } ) => {
 				dispatch( {
 					type: BILLING_TRANSACTIONS_RECEIVE,
@@ -48,10 +47,8 @@ export const sendBillingReceiptEmail = ( receiptId ) => {
 			receiptId,
 		} );
 
-		return wp
-			.undocumented()
-			.me()
-			.billingHistoryEmailReceipt( receiptId )
+		return wp.req
+			.get( `/me/billing-history/receipt/${ receiptId }/email` )
 			.then( () => {
 				dispatch( {
 					type: BILLING_RECEIPT_EMAIL_SEND_SUCCESS,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates all the `wpcom.undocumented()` Jetpack billing history methods to `wpcom.req.get()`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/me/purchases/billing`
* Verify all purchases are loading correctly.
* Click on the "Email receipt" link of a recept.
* Verify you see a success notice and you receive the email shortly.
* Verify tests still pass: `yarn run test-client client/state/billing-transactions/test/actions.js`
