### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` site products to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -350,29 +350,6 @@ Undocumented.prototype.validateDomainContactInformation = function (
 };
 
 /**
- * Get site specific details for WordPress.com products
- *
- * @param {Function} siteDomain The site slug
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.getSiteProducts = function ( siteDomain, fn ) {
-	debug( '/sites/:site_domain:/products query' );
-
-	// the site domain could be for a jetpack site installed in
-	// a subdirectory.  encode any forward slash present before making
-	// the request
-	siteDomain = encodeURIComponent( siteDomain );
-
-	return this._sendRequest(
-		{
-			path: '/sites/' + siteDomain + '/products',
-			method: 'get',
-		},
-		fn
-	);
-};
-
-/**
  * Get a site specific details for WordPress.com plans
  *
  * @param {Function} siteDomain The site slug

--- a/client/state/sites/products/actions.js
+++ b/client/state/sites/products/actions.js
@@ -40,29 +40,26 @@ export function fetchSiteProducts( siteId ) {
 			siteId,
 		} );
 
-		return new Promise( ( resolve ) => {
-			wpcom.undocumented().getSiteProducts( siteId, ( error, data ) => {
-				if ( error ) {
-					debug( 'Fetching site products failed: ', error );
+		return wpcom.req
+			.get( `/sites/${ siteId }/products` )
+			.then( ( data ) => {
+				dispatch( fetchSiteProductsCompleted( siteId, data ) );
+			} )
+			.catch( ( error ) => {
+				debug( 'Fetching site products failed: ', error );
 
-					const errorMessage =
-						error.message ||
-						i18n.translate(
-							'There was a problem fetching site products. Please try again later or contact support.'
-						);
+				const errorMessage =
+					error.message ||
+					i18n.translate(
+						'There was a problem fetching site products. Please try again later or contact support.'
+					);
 
-					dispatch( {
-						type: SITE_PRODUCTS_FETCH_FAILED,
-						siteId,
-						error: errorMessage,
-					} );
-				} else {
-					dispatch( fetchSiteProductsCompleted( siteId, data ) );
-				}
-
-				resolve();
+				dispatch( {
+					type: SITE_PRODUCTS_FETCH_FAILED,
+					siteId,
+					error: errorMessage,
+				} );
 			} );
-		} );
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates all the `wpcom.undocumented()` site products method to `wpcom.req.get()`. 

The PR also simplifies the code a little bit - we don't need to encode the site fragment, because anywhere in the code where we're making requests to this endpoint, we pass the numeric site ID. I think there was no reason to have support for anything else than a numeric site ID in the first place TBH (see #40306 and cc @DavidRothstein just in case). We're also removing an unnecessary wrapping `Promise` - `wpcom.req.get()` already returns a promise.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/plans/:site` where `:site` is one of your Jetpack sites.
* Verify that the request to `/sites/:site/products` is still successful.

