### PR TITLE
Emails: Remove ToS warning in domain management list

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -14,7 +14,6 @@ import {
 	transferStatus,
 	gdprConsentStatus,
 } from 'calypso/lib/domains/constants';
-import { hasPendingGSuiteUsers, isPendingGSuiteTOSAcceptance } from 'calypso/lib/gsuite';
 import {
 	CHANGE_NAME_SERVERS,
 	DOMAINS,
@@ -33,7 +32,6 @@ import {
 	domainManagementManageConsent,
 } from 'calypso/my-sites/domains/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import PendingGSuiteTosNotice from './pending-gsuite-tos-notice';
 
 import './style.scss';
 
@@ -67,7 +65,6 @@ export class DomainWarnings extends PureComponent {
 			'expiredDomainsCanManage',
 			'expiringDomainsCanManage',
 			'unverifiedDomainsCanManage',
-			'pendingGSuiteTosAcceptanceDomains',
 			'expiredDomainsCannotManage',
 			'expiringDomainsCannotManage',
 			'unverifiedDomainsCannotManage',
@@ -109,7 +106,6 @@ export class DomainWarnings extends PureComponent {
 			this.expiringDomainsCanManage,
 			this.unverifiedDomainsCanManage,
 			this.unverifiedDomainsCannotManage,
-			this.pendingGSuiteTosAcceptanceDomains,
 			this.expiredDomainsCannotManage,
 			this.expiringDomainsCannotManage,
 			this.wrongNSMappedDomains,
@@ -807,26 +803,6 @@ export class DomainWarnings extends PureComponent {
 			>
 				{ this.props.isCompact ? compactContent : fullContent }
 			</Notice>
-		);
-	};
-
-	pendingGSuiteTosAcceptanceDomains = () => {
-		const domains = this.getDomains().filter(
-			( domain ) => hasPendingGSuiteUsers( domain ) || isPendingGSuiteTOSAcceptance( domain )
-		);
-
-		if ( domains.length === 0 ) {
-			return null;
-		}
-
-		return (
-			<PendingGSuiteTosNotice
-				isCompact={ this.props.isCompact }
-				key="pending-gsuite-tos-notice"
-				siteSlug={ this.props.selectedSite && this.props.selectedSite.slug }
-				domains={ domains }
-				section="domain-management"
-			/>
 		);
 	};
 

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -811,8 +811,8 @@ export class DomainWarnings extends PureComponent {
 	};
 
 	pendingGSuiteTosAcceptanceDomains = () => {
-		const domains = this.getDomains().filter(
-			( domain ) => hasPendingGSuiteUsers( domain ) || isPendingGSuiteTOSAcceptance( domain )
+		const domains = this.getDomains().filter( ( domain ) =>
+			isPendingGSuiteTOSAcceptance( domain )
 		);
 
 		if ( domains.length === 0 ) {

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -14,6 +14,7 @@ import {
 	transferStatus,
 	gdprConsentStatus,
 } from 'calypso/lib/domains/constants';
+import { hasPendingGSuiteUsers, isPendingGSuiteTOSAcceptance } from 'calypso/lib/gsuite';
 import {
 	CHANGE_NAME_SERVERS,
 	DOMAINS,
@@ -32,6 +33,7 @@ import {
 	domainManagementManageConsent,
 } from 'calypso/my-sites/domains/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import PendingGSuiteTosNotice from './pending-gsuite-tos-notice';
 
 import './style.scss';
 
@@ -65,6 +67,7 @@ export class DomainWarnings extends PureComponent {
 			'expiredDomainsCanManage',
 			'expiringDomainsCanManage',
 			'unverifiedDomainsCanManage',
+			'pendingGSuiteTosAcceptanceDomains',
 			'expiredDomainsCannotManage',
 			'expiringDomainsCannotManage',
 			'unverifiedDomainsCannotManage',
@@ -106,6 +109,7 @@ export class DomainWarnings extends PureComponent {
 			this.expiringDomainsCanManage,
 			this.unverifiedDomainsCanManage,
 			this.unverifiedDomainsCannotManage,
+			this.pendingGSuiteTosAcceptanceDomains,
 			this.expiredDomainsCannotManage,
 			this.expiringDomainsCannotManage,
 			this.wrongNSMappedDomains,
@@ -803,6 +807,26 @@ export class DomainWarnings extends PureComponent {
 			>
 				{ this.props.isCompact ? compactContent : fullContent }
 			</Notice>
+		);
+	};
+
+	pendingGSuiteTosAcceptanceDomains = () => {
+		const domains = this.getDomains().filter(
+			( domain ) => hasPendingGSuiteUsers( domain ) || isPendingGSuiteTOSAcceptance( domain )
+		);
+
+		if ( domains.length === 0 || ! this.props.isCompact ) {
+			return null;
+		}
+
+		return (
+			<PendingGSuiteTosNotice
+				isCompact={ this.props.isCompact }
+				key="pending-gsuite-tos-notice"
+				siteSlug={ this.props.selectedSite && this.props.selectedSite.slug }
+				domains={ domains }
+				section="domain-management"
+			/>
 		);
 	};
 

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -14,7 +14,7 @@ import {
 	transferStatus,
 	gdprConsentStatus,
 } from 'calypso/lib/domains/constants';
-import { hasPendingGSuiteUsers, isPendingGSuiteTOSAcceptance } from 'calypso/lib/gsuite';
+import { isPendingGSuiteTOSAcceptance } from 'calypso/lib/gsuite';
 import {
 	CHANGE_NAME_SERVERS,
 	DOMAINS,

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -815,7 +815,7 @@ export class DomainWarnings extends PureComponent {
 			( domain ) => hasPendingGSuiteUsers( domain ) || isPendingGSuiteTOSAcceptance( domain )
 		);
 
-		if ( domains.length === 0 || ! this.props.isCompact ) {
+		if ( domains.length === 0 ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -90,7 +90,6 @@ export class List extends Component {
 					selectedSite={ this.props.selectedSite }
 					allowedRules={ [
 						'unverifiedDomainsCanManage',
-						'pendingGSuiteTosAcceptanceDomains',
 						'unverifiedDomainsCannotManage',
 						'transferStatus',
 						'newTransfersWrongNS',

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -90,6 +90,7 @@ export class List extends Component {
 					selectedSite={ this.props.selectedSite }
 					allowedRules={ [
 						'unverifiedDomainsCanManage',
+						'pendingGSuiteTosAcceptanceDomains',
 						'unverifiedDomainsCannotManage',
 						'transferStatus',
 						'newTransfersWrongNS',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It removes the pending ToS warning in the domains management screen

#### Testing instructions

Have a site with Google Workspace subscription where you have not accepted the ToS (buy, log in, don't click on accept ToS)

You should not see any warning above the domain lists:
![image](https://user-images.githubusercontent.com/5689927/140780191-f05d03bf-bd2c-4203-9c79-3e618efd745a.png)

For reference:
![image](https://user-images.githubusercontent.com/5689927/140780560-4a1a2b7d-0ba1-4acb-9e19-eed5a7d21427.png)

Extra test:
If you have several domains at the same time with not accepted ToS you should not see either any message.

Related to 1200182182542585-as-1201257638729675
