### PR TITLE
Rename the `People` header to `Users`

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -59,7 +59,7 @@ function renderPeopleList( context, next ) {
 	const filter = context.params.filter;
 
 	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'People', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( i18n.translate( 'Users', { textOnly: true } ) ) );
 
 	context.primary = createElement( PeopleList, {
 		filter: filter,

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -59,7 +59,7 @@ function renderPeopleList( context, next ) {
 	const filter = context.params.filter;
 
 	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Users', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( i18n.translate( 'People', { textOnly: true } ) ) );
 
 	context.primary = createElement( PeopleList, {
 		filter: filter,

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -94,17 +94,17 @@ class People extends Component {
 
 		if ( isWPForTeamsSite ) {
 			if ( isP2HubSite ) {
-				return translate( 'People in %(sitename)s', {
+				return translate( 'Users in %(sitename)s', {
 					args: {
 						sitename: site.name,
-						context: 'People page for P2 hubs.',
+						context: 'Users page for P2 hubs.',
 					},
 				} );
 			}
-			return translate( 'People in this P2' );
+			return translate( 'Users in this P2' );
 		}
 
-		return translate( 'People' );
+		return translate( 'Users' );
 	}
 
 	render() {

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -77,13 +77,13 @@ class PeopleInvites extends PureComponent {
 
 		return (
 			<Main className="people-invites">
-				<PageViewTracker path="/people/invites/:site" title="People > Invites" />
+				<PageViewTracker path="/people/invites/:site" title="Users > Invites" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
 				<FormattedHeader
 					brandFont
 					className="people-invites__page-heading"
-					headerText={ translate( 'People' ) }
+					headerText={ translate( 'Users' ) }
 					subHeaderText={ translate( 'View and manage the invites to your site.' ) }
 					align="left"
 				/>

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -77,7 +77,7 @@ class PeopleInvites extends PureComponent {
 
 		return (
 			<Main className="people-invites">
-				<PageViewTracker path="/people/invites/:site" title="Users > Invites" />
+				<PageViewTracker path="/people/invites/:site" title="People > Invites" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
 				<FormattedHeader

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -110,7 +110,7 @@ class Sites extends Component {
 				path = translate( 'Sharing' );
 				break;
 			case 'people':
-				path = translate( 'People' );
+				path = translate( 'Users' );
 				break;
 			case 'domains':
 				path = translate( 'Domains' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename the People section to "Users"

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link and go to Users > All Users page
* Make sure that the header and the title of the page are now "Users"
* Make sure that the change is reflected on all sub-pages.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
![Screenshot 2021-11-09 at 17 29 02](https://user-images.githubusercontent.com/995955/140953784-0d010e54-a0bb-4aae-8d53-182ce8eff3b8.png)
![Screenshot 2021-11-09 at 17 29 35](https://user-images.githubusercontent.com/995955/140953797-5d1c65d3-2912-48b8-9e96-46c4b2ee711e.png)


Related to #51382
