### PR TITLE
Checkout: Remove site ID and slug from wordpress/data store

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { RequestCart } from '@automattic/shopping-cart';
 
 import './style.scss';
@@ -36,6 +36,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 	const translate = useTranslate();
 
 	const site = useSelector( getSelectedSite );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	useEffect( () => {
 		return () => {
@@ -77,7 +78,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 						redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
 						isInEditor
 						isFocusedLaunch={ isFocusedLaunch }
-						siteId={ site?.ID }
+						siteId={ selectedSiteId ?? undefined }
 						siteSlug={ site?.slug }
 						productAliasFromUrl={ commaSeparatedProductSlugs }
 						onAfterPaymentComplete={ handleAfterPaymentComplete }

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -8,6 +8,7 @@ import { logToLogstash } from 'calypso/lib/logstash';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import Recaptcha from 'calypso/signup/recaptcha';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import PrePurchaseNotices from './composite-checkout/components/prepurchase-notices';
 import CompositeCheckout from './composite-checkout/composite-checkout';
@@ -43,6 +44,7 @@ export default function CheckoutSystemDecider( {
 } ) {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	const prepurchaseNotices = <PrePurchaseNotices />;
 
@@ -79,7 +81,7 @@ export default function CheckoutSystemDecider( {
 					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
 						<CompositeCheckout
 							siteSlug={ siteSlug }
-							siteId={ selectedSite?.ID }
+							siteId={ selectedSiteId }
 							productAliasFromUrl={ productAliasFromUrl }
 							purchaseId={ purchaseId }
 							couponCode={ couponCode }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -22,7 +22,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
@@ -160,7 +160,6 @@ export default function WPCheckout( {
 		sel( 'wpcom' ).getContactInfo()
 	);
 	const {
-		setSiteId,
 		touchContactFields,
 		applyDomainContactValidationResults,
 		clearDomainContactErrorMessages,
@@ -198,11 +197,6 @@ export default function WPCheckout( {
 	} );
 
 	const { formStatus } = useFormStatus();
-
-	// Copy siteId to the store so it can be more easily accessed during payment submission
-	useEffect( () => {
-		setSiteId( siteId );
-	}, [ siteId, setSiteId ] );
 
 	const arePostalCodesSupported = getCountryPostalCodeSupport(
 		countriesList,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -104,7 +104,7 @@ export default function CompositeCheckout( {
 	isInEditor,
 	onAfterPaymentComplete,
 	isFocusedLaunch,
-	isJetpackCheckout,
+	isJetpackCheckout = false,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
@@ -125,7 +125,7 @@ export default function CompositeCheckout( {
 	infoMessage?: JSX.Element;
 	onAfterPaymentComplete?: () => void;
 	isFocusedLaunch?: boolean;
-	isJetpackCheckout: boolean;
+	isJetpackCheckout?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -311,15 +311,10 @@ export default function CompositeCheckout( {
 	const areThereErrors =
 		[ ...errors, cartLoadingError, cartProductPrepError ].filter( isValueTruthy ).length > 0;
 
-	const siteSlugLoggedOutCart: string | undefined = select( 'wpcom' )?.getSiteSlug();
 	const {
 		isRemovingProductFromCart,
 		removeProductFromCartAndMaybeRedirect,
-	} = useRemoveFromCartAndRedirect(
-		updatedSiteSlug,
-		siteSlugLoggedOutCart,
-		createUserAndSiteBeforeTransaction
-	);
+	} = useRemoveFromCartAndRedirect( updatedSiteSlug, createUserAndSiteBeforeTransaction );
 
 	const { storedCards, isLoading: isLoadingStoredCards, error: storedCardsError } = useStoredCards(
 		wpcomGetStoredCards,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -206,6 +206,8 @@ export default function CompositeCheckout( {
 		addProductsToCart,
 	} = useShoppingCart( cartKey );
 
+	const updatedSiteId = isJetpackCheckout ? parseInt( String( responseCart.blog_id ), 10 ) : siteId;
+
 	const maybeJetpackIntroCouponCode = useMaybeJetpackIntroCouponCode(
 		productsForCart,
 		couponStatus === 'applied'
@@ -426,7 +428,7 @@ export default function CompositeCheckout( {
 			recordEvent,
 			reduxDispatch,
 			responseCart,
-			siteId,
+			siteId: updatedSiteId,
 			siteSlug: updatedSiteSlug,
 			stripeConfiguration,
 			stripe,
@@ -441,7 +443,7 @@ export default function CompositeCheckout( {
 			recordEvent,
 			reduxDispatch,
 			responseCart,
-			siteId,
+			updatedSiteId,
 			stripe,
 			stripeConfiguration,
 			updatedSiteSlug,
@@ -626,8 +628,6 @@ export default function CompositeCheckout( {
 			</Fragment>
 		);
 	}
-
-	const updatedSiteId = isJetpackCheckout ? parseInt( String( responseCart.blog_id ), 10 ) : siteId;
 
 	return (
 		<Fragment>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -369,6 +369,7 @@ export default function CompositeCheckout( {
 		( allowedPaymentMethods.includes( 'web-pay' ) && isWebPayLoading );
 
 	const contactDetails: ManagedContactDetails | undefined = select( 'wpcom' )?.getContactInfo();
+	const recaptchaClientId: number | undefined = select( 'wpcom' )?.getRecaptchaClientId();
 	const countryCode: string = contactDetails?.countryCode?.value ?? '';
 
 	const paymentMethods = arePaymentMethodsLoading
@@ -434,6 +435,7 @@ export default function CompositeCheckout( {
 			siteSlug: updatedSiteSlug,
 			stripeConfiguration,
 			stripe,
+			recaptchaClientId,
 		} ),
 		[
 			contactDetails,
@@ -448,6 +450,7 @@ export default function CompositeCheckout( {
 			stripe,
 			stripeConfiguration,
 			updatedSiteSlug,
+			recaptchaClientId,
 		]
 	);
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -11,7 +11,6 @@ const debug = debugFactory( 'calypso:composite-checkout:use-redirect-if-cart-emp
 
 export default function useRemoveFromCartAndRedirect(
 	siteSlug: string | undefined,
-	siteSlugLoggedOutCart: string | undefined,
 	createUserAndSiteBeforeTransaction: boolean
 ): {
 	isRemovingProductFromCart: boolean;
@@ -21,14 +20,14 @@ export default function useRemoveFromCartAndRedirect(
 	const { removeProductFromCart } = useShoppingCart( cartKey );
 
 	// In some cases, the cloud.jetpack.com/pricing page sends a `checkoutBackUrl` url query param to checkout.
-	const checkoutBackUrl = useValidCheckoutBackUrl( siteSlug || siteSlugLoggedOutCart );
+	const checkoutBackUrl = useValidCheckoutBackUrl( siteSlug );
 
 	const redirectDueToEmptyCart = useCallback( () => {
 		debug( 'cart is empty; redirecting...' );
 		let cartEmptyRedirectUrl = `/plans/${ siteSlug || '' }`;
 
 		if ( createUserAndSiteBeforeTransaction ) {
-			cartEmptyRedirectUrl = siteSlugLoggedOutCart ? `/plans/${ siteSlugLoggedOutCart }` : '/start';
+			cartEmptyRedirectUrl = siteSlug ? `/plans/${ siteSlug }` : '/start';
 		}
 
 		debug( 'Before redirect, first clear redirect url cookie' );
@@ -51,7 +50,7 @@ export default function useRemoveFromCartAndRedirect(
 		} else {
 			page.redirect( cartEmptyRedirectUrl );
 		}
-	}, [ createUserAndSiteBeforeTransaction, siteSlug, siteSlugLoggedOutCart, checkoutBackUrl ] );
+	}, [ createUserAndSiteBeforeTransaction, siteSlug, checkoutBackUrl ] );
 
 	const isMounted = useRef( true );
 	useEffect( () => {

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -19,8 +19,6 @@ type WpcomStoreAction =
 			payload: ManagedContactDetailsErrors;
 	  }
 	| { type: 'UPDATE_DOMAIN_CONTACT_FIELDS'; payload: DomainContactDetails }
-	| { type: 'SET_SITE_ID'; payload: string }
-	| { type: 'SET_SITE_SLUG'; payload: string }
 	| { type: 'SET_RECAPTCHA_CLIENT_ID'; payload: number }
 	| { type: 'UPDATE_VAT_ID'; payload: string }
 	| { type: 'UPDATE_EMAIL'; payload: string }
@@ -87,24 +85,6 @@ export function useWpcomStore(
 		}
 	}
 
-	function siteIdReducer( state: string, action: WpcomStoreAction ): string {
-		switch ( action.type ) {
-			case 'SET_SITE_ID':
-				return action.payload;
-			default:
-				return state;
-		}
-	}
-
-	function siteSlugReducer( state: string, action: WpcomStoreAction ): string {
-		switch ( action.type ) {
-			case 'SET_SITE_SLUG':
-				return action.payload;
-			default:
-				return state;
-		}
-	}
-
 	function recaptchaClientIdReducer( state: number, action: WpcomStoreAction ): number {
 		switch ( action.type ) {
 			case 'SET_RECAPTCHA_CLIENT_ID':
@@ -120,8 +100,6 @@ export function useWpcomStore(
 				state === undefined ? getInitialWpcomStoreState( managedContactDetails ) : state;
 			return {
 				contactDetails: contactReducer( checkedState.contactDetails, action ),
-				siteId: siteIdReducer( checkedState.siteId, action ),
-				siteSlug: siteSlugReducer( checkedState.siteSlug, action ),
 				recaptchaClientId: recaptchaClientIdReducer( checkedState.recaptchaClientId, action ),
 			};
 		},
@@ -135,14 +113,6 @@ export function useWpcomStore(
 
 			clearDomainContactErrorMessages(): WpcomStoreAction {
 				return { type: 'CLEAR_DOMAIN_CONTACT_ERROR_MESSAGES' };
-			},
-
-			setSiteId( payload: string ): WpcomStoreAction {
-				return { type: 'SET_SITE_ID', payload };
-			},
-
-			setSiteSlug( payload: string ): WpcomStoreAction {
-				return { type: 'SET_SITE_SLUG', payload };
 			},
 
 			setRecaptchaClientId( payload: number ): WpcomStoreAction {
@@ -197,14 +167,6 @@ export function useWpcomStore(
 		},
 
 		selectors: {
-			getSiteId( state: WpcomStoreState ): string {
-				return state.siteId;
-			},
-
-			getSiteSlug( state: WpcomStoreState ): string {
-				return state.siteSlug;
-			},
-
 			getContactInfo( state: WpcomStoreState ): ManagedContactDetails {
 				return state.contactDetails;
 			},

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -79,11 +79,14 @@ async function wpcomPayPalExpress(
 		payload.cart.is_jetpack_checkout && payload.cart.cart_key === 'no-user';
 
 	if ( transactionOptions.createUserAndSiteBeforeTransaction || isJetpackUserLessCheckout ) {
-		const createAccountOptions = isJetpackUserLessCheckout
-			? { signupFlowName: 'jetpack-userless-checkout' }
-			: { signupFlowName: 'onboarding-registrationless' };
-
-		return createAccount( createAccountOptions ).then( ( response ) => {
+		return createAccount( {
+			signupFlowName: isJetpackUserLessCheckout
+				? 'jetpack-userless-checkout'
+				: 'onboarding-registrationless',
+			email: transactionOptions.contactDetails?.email?.value,
+			siteId: transactionOptions.siteId,
+			recaptchaClientId: transactionOptions.recaptchaClientId,
+		} ).then( ( response ) => {
 			const siteIdFromResponse = response?.blog_details?.blogid;
 
 			// If the account is already created(as happens when we are reprocessing after a transaction error), then

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -110,6 +110,7 @@ async function wpcomPayPalExpress(
 					...payload.cart,
 					blog_id: siteId || '0',
 					cart_key: siteId || 'no-site',
+					create_new_blog: siteId ? false : true,
 				},
 			};
 

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -17,11 +17,14 @@ export default async function submitWpcomTransaction(
 	if ( transactionOptions.createUserAndSiteBeforeTransaction || isJetpackUserLessCheckout ) {
 		const isJetpackUserLessCheckout = payload.cart.is_jetpack_checkout;
 
-		const createAccountOptions = isJetpackUserLessCheckout
-			? { signupFlowName: 'jetpack-userless-checkout' }
-			: { signupFlowName: 'onboarding-registrationless' };
-
-		return createAccount( createAccountOptions ).then( ( response ) => {
+		return createAccount( {
+			signupFlowName: isJetpackUserLessCheckout
+				? 'jetpack-userless-checkout'
+				: 'onboarding-registrationless',
+			email: transactionOptions.contactDetails?.email?.value,
+			siteId: transactionOptions.siteId,
+			recaptchaClientId: transactionOptions.recaptchaClientId,
+		} ).then( ( response ) => {
 			const siteIdFromResponse = response?.blog_details?.blogid;
 
 			// If the account is already created(as happens when we are reprocessing after a transaction error), then

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -47,6 +47,7 @@ export default async function submitWpcomTransaction(
 					...payload.cart,
 					blog_id: siteId || '0',
 					cart_key: siteId || 'no-site',
+					create_new_blog: siteId ? false : true,
 				},
 			};
 			return wp.req.post(

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -7,13 +7,6 @@ import { stringifyBody } from 'calypso/state/login/utils';
 const { select } = defaultRegistry;
 
 async function createAccountCallback( response ) {
-	// Set siteId from response
-	const siteIdFromResponse = response?.blog_details?.blogid;
-	const siteSlugFromResponse = response?.blog_details?.site_slug;
-	const { dispatch } = defaultRegistry;
-	siteIdFromResponse && dispatch( 'wpcom' ).setSiteId( siteIdFromResponse );
-	siteSlugFromResponse && dispatch( 'wpcom' ).setSiteSlug( siteSlugFromResponse );
-
 	if ( ! response.bearer_token ) {
 		return;
 	}

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -1,10 +1,7 @@
-import { defaultRegistry } from '@automattic/composite-checkout';
 import i18n from 'i18n-calypso';
 import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import wp from 'calypso/lib/wp';
 import { stringifyBody } from 'calypso/state/login/utils';
-
-const { select } = defaultRegistry;
 
 async function createAccountCallback( response ) {
 	if ( ! response.bearer_token ) {
@@ -28,7 +25,7 @@ async function createAccountCallback( response ) {
 	} );
 }
 
-export async function createAccount( { signupFlowName } ) {
+export async function createAccount( { signupFlowName, email, siteId, recaptchaClientId } ) {
 	let newSiteParams = null;
 	try {
 		newSiteParams = JSON.parse( window.localStorage.getItem( 'siteParams' ) || '{}' );
@@ -36,10 +33,6 @@ export async function createAccount( { signupFlowName } ) {
 		newSiteParams = {};
 	}
 
-	const { email } = select( 'wpcom' )?.getContactInfo() ?? {};
-	const siteId = select( 'wpcom' )?.getSiteId();
-	const emailValue = email.value;
-	const recaptchaClientId = select( 'wpcom' )?.getRecaptchaClientId();
 	const isRecaptchaLoaded = typeof recaptchaClientId === 'number';
 
 	let recaptchaToken = undefined;
@@ -63,7 +56,7 @@ export async function createAccount( { signupFlowName } ) {
 	try {
 		const response = await wp.undocumented().createUserAndSite(
 			{
-				email: emailValue,
+				email,
 				'g-recaptcha-error': recaptchaError,
 				'g-recaptcha-response': recaptchaToken || undefined,
 				is_passwordless: true,

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.ts
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.ts
@@ -4,6 +4,7 @@ import wp from 'calypso/lib/wp';
 import { stringifyBody } from 'calypso/state/login/utils';
 
 interface CreateAccountResponse {
+	success: boolean;
 	bearer_token?: string;
 	username?: string;
 	blog_details?: {
@@ -79,23 +80,20 @@ export async function createAccount( {
 	const blogName = newSiteParams?.blog_name;
 
 	try {
-		const response = await wp.undocumented().createUserAndSite(
-			{
-				email,
-				'g-recaptcha-error': recaptchaError,
-				'g-recaptcha-response': recaptchaToken || undefined,
-				is_passwordless: true,
-				extra: { username_hint: blogName },
-				signup_flow_name: signupFlowName,
-				validate: false,
-				new_site_params: newSiteParams,
-				should_create_site: ! siteId,
-			},
-			null
-		);
+		const response = await wp.undocumented().createUserAndSite( {
+			email,
+			'g-recaptcha-error': recaptchaError,
+			'g-recaptcha-response': recaptchaToken || undefined,
+			is_passwordless: true,
+			extra: { username_hint: blogName },
+			signup_flow_name: signupFlowName,
+			validate: false,
+			new_site_params: newSiteParams,
+			should_create_site: ! siteId,
+		} );
 
-		if ( ! isCreateAccountResponse( response ) ) {
-			return {};
+		if ( ! isCreateAccountResponse( response ) || ! response.success ) {
+			throw new Error( 'Failed to create account' );
 		}
 
 		createAccountCallback( response );

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -350,7 +350,7 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: 1234567,
 					cart_key: 1234567,
 					coupon: '',
-					create_new_blog: true,
+					create_new_blog: true, // NOTE: I wonder if this is incorrect behavior since the site has already been created at this point
 				},
 			} );
 		} );

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -350,7 +350,7 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: 1234567,
 					cart_key: 1234567,
 					coupon: '',
-					create_new_blog: true, // NOTE: I wonder if this is incorrect behavior since the site has already been created at this point
+					create_new_blog: false,
 				},
 			} );
 		} );

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -6,9 +6,14 @@ import {
 	mockTransactionsSuccessResponse,
 	processorOptions,
 	basicExpectedDomainDetails,
+	mockCreateAccountEndpoint,
+	expectedCreateAccountRequest,
 	countryCode,
 	postalCode,
+	email,
 	contactDetailsForDomain,
+	mockCreateAccountSiteCreatedResponse,
+	mockCreateAccountSiteNotCreatedResponse,
 } from './util';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
@@ -311,6 +316,112 @@ describe( 'multiPartnerCardProcessor', () => {
 				} )
 			).resolves.toStrictEqual( expected );
 			expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+		} );
+
+		it( 'creates an account and site before sending the correct data to the endpoint with no user, no site, and one product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
+			const createAccountEndpoint = mockCreateAccountEndpoint(
+				mockCreateAccountSiteCreatedResponse
+			);
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+				cardNumberElement: mockCardNumberElement,
+			};
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					createUserAndSiteBeforeTransaction: true,
+					contactDetails: {
+						email,
+						countryCode,
+						postalCode,
+					},
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( createAccountEndpoint ).toHaveBeenCalledWith( expectedCreateAccountRequest );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+				...basicExpectedStripeRequest,
+				cart: {
+					...basicExpectedStripeRequest.cart,
+					blog_id: 1234567,
+					cart_key: 1234567,
+					coupon: '',
+					create_new_blog: true,
+				},
+			} );
+		} );
+
+		it( 'creates an account before sending the correct data with a site creation request to the endpoint with no user, no site, and one product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
+			const createAccountEndpoint = mockCreateAccountEndpoint(
+				mockCreateAccountSiteNotCreatedResponse
+			);
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+				cardNumberElement: mockCardNumberElement,
+			};
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					createUserAndSiteBeforeTransaction: true,
+					contactDetails: {
+						email,
+						countryCode,
+						postalCode,
+					},
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( createAccountEndpoint ).toHaveBeenCalledWith( expectedCreateAccountRequest );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+		} );
+
+		it( 'creates an account and no site before sending the correct data to the endpoint with no user, a site, and one product', async () => {
+			const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsSuccessResponse );
+			const createAccountEndpoint = mockCreateAccountEndpoint(
+				mockCreateAccountSiteNotCreatedResponse
+			);
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+				cardNumberElement: mockCardNumberElement,
+			};
+			const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
+			await expect(
+				multiPartnerCardProcessor( submitData, {
+					...options,
+					siteId: 1234567,
+					createUserAndSiteBeforeTransaction: true,
+					contactDetails: {
+						email,
+						countryCode,
+						postalCode,
+					},
+				} )
+			).resolves.toStrictEqual( expected );
+			expect( createAccountEndpoint ).toHaveBeenCalledWith( {
+				...expectedCreateAccountRequest,
+				should_create_site: false,
+			} );
+			expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+				...basicExpectedStripeRequest,
+				cart: {
+					...basicExpectedStripeRequest.cart,
+					blog_id: 1234567,
+					cart_key: 1234567,
+					coupon: '',
+					create_new_blog: false,
+				},
+			} );
 		} );
 
 		it( 'returns an explicit error response if the transaction fails with a non-200 error', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -206,7 +206,7 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: 1234567,
 				cart_key: 1234567,
 				coupon: '',
-				create_new_blog: true,
+				create_new_blog: true, // NOTE: I wonder if this is incorrect behavior since the site has been created at this point
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -206,7 +206,7 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: 1234567,
 				cart_key: 1234567,
 				coupon: '',
-				create_new_blog: true, // NOTE: I wonder if this is incorrect behavior since the site has been created at this point
+				create_new_blog: false,
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -9,9 +9,14 @@ import {
 	mockPayPalRedirectResponse,
 	processorOptions,
 	basicExpectedDomainDetails,
+	email,
 	countryCode,
 	postalCode,
 	contactDetailsForDomain,
+	mockCreateAccountEndpoint,
+	expectedCreateAccountRequest,
+	mockCreateAccountSiteCreatedResponse,
+	mockCreateAccountSiteNotCreatedResponse,
 } from './util';
 
 describe( 'payPalExpressProcessor', () => {
@@ -173,6 +178,103 @@ describe( 'payPalExpressProcessor', () => {
 				products: [ domainProduct ],
 			},
 			domain_details: basicExpectedDomainDetails,
+		} );
+	} );
+
+	it( 'creates an account and site before sending the correct data to the endpoint with no user, no site, and one product', async () => {
+		const transactionsEndpoint = mockPayPalEndpoint( mockPayPalRedirectResponse );
+		const createAccountEndpoint = mockCreateAccountEndpoint( mockCreateAccountSiteCreatedResponse );
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+					email,
+				},
+				createUserAndSiteBeforeTransaction: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( createAccountEndpoint ).toHaveBeenCalledWith( expectedCreateAccountRequest );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedRequest,
+			site_id: 1234567,
+			cancel_url: 'https://example.com/?cart=no-user',
+			cart: {
+				...basicExpectedRequest.cart,
+				blog_id: 1234567,
+				cart_key: 1234567,
+				coupon: '',
+				create_new_blog: true,
+			},
+		} );
+	} );
+
+	it( 'creates an account before sending the correct data with a site creation request to the endpoint with no user, no site, and one product', async () => {
+		const transactionsEndpoint = mockPayPalEndpoint( mockPayPalRedirectResponse );
+		const createAccountEndpoint = mockCreateAccountEndpoint(
+			mockCreateAccountSiteNotCreatedResponse
+		);
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+					email,
+				},
+				createUserAndSiteBeforeTransaction: true,
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( createAccountEndpoint ).toHaveBeenCalledWith( expectedCreateAccountRequest );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedRequest,
+			cancel_url: 'https://example.com/?cart=no-user',
+			cart: {
+				...basicExpectedRequest.cart,
+				blog_id: '0',
+				cart_key: 'no-site',
+				coupon: '',
+				create_new_blog: true,
+			},
+		} );
+	} );
+
+	it( 'creates an account and no site before sending the correct data to the endpoint with no user, a site, and one product', async () => {
+		const transactionsEndpoint = mockPayPalEndpoint( mockPayPalRedirectResponse );
+		const createAccountEndpoint = mockCreateAccountEndpoint(
+			mockCreateAccountSiteNotCreatedResponse
+		);
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				siteId: 1234567,
+				createUserAndSiteBeforeTransaction: true,
+				contactDetails: {
+					countryCode,
+					postalCode,
+					email,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( createAccountEndpoint ).toHaveBeenCalledWith( {
+			...expectedCreateAccountRequest,
+			should_create_site: false,
+		} );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedRequest,
+			cancel_url: 'https://example.com/?cart=no-user',
+			site_id: 1234567,
+			cart: {
+				...basicExpectedRequest.cart,
+				blog_id: 1234567,
+				cart_key: 1234567,
+				coupon: '',
+				create_new_blog: false,
+			},
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { getEmptyResponseCart } from '@automattic/shopping-cart';
 import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
@@ -716,6 +717,18 @@ export const mockPayPalRedirectResponse = () => [
 	{ redirect_url: 'https://test-redirect-url' },
 ];
 
+export function mockCreateAccountEndpoint( endpointResponse ) {
+	const endpoint = jest.fn();
+	endpoint.mockReturnValue( true );
+
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/users/new', ( body ) => {
+			return endpoint( body );
+		} )
+		.reply( endpointResponse );
+	return endpoint;
+}
+
 export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 	const transactionsEndpoint = jest.fn();
 	transactionsEndpoint.mockReturnValue( true );
@@ -728,6 +741,17 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 
 	return transactionsEndpoint;
 }
+
+export const mockCreateAccountSiteNotCreatedResponse = () => [ 200, {} ];
+
+export const mockCreateAccountSiteCreatedResponse = () => [
+	200,
+	{
+		blog_details: {
+			blogid: 1234567,
+		},
+	},
+];
 
 export const mockTransactionsRedirectResponse = () => [
 	200,
@@ -752,6 +776,7 @@ export const state = getManagedValueFromString( 'NY' );
 export const firstName = getManagedValueFromString( 'Human' );
 export const lastName = getManagedValueFromString( 'Person' );
 export const phone = getManagedValueFromString( '+1.5555555555' );
+export const email = getManagedValueFromString( 'test@example.com' );
 
 export const contactDetailsForDomain = {
 	countryCode,
@@ -783,4 +808,19 @@ export const basicExpectedDomainDetails = {
 	phone: getStringFromManagedValue( phone ),
 	postal_code: getStringFromManagedValue( postalCode ),
 	state: getStringFromManagedValue( state ),
+};
+
+export const expectedCreateAccountRequest = {
+	email: getStringFromManagedValue( email ),
+	'g-recaptcha-error': 'recaptcha_didnt_load',
+	'g-recaptcha-response': undefined,
+	is_passwordless: true,
+	extra: {},
+	signup_flow_name: 'onboarding-registrationless',
+	validate: false,
+	new_site_params: {},
+	should_create_site: true,
+	locale: 'en',
+	client_id: config( 'wpcom_signup_id' ),
+	client_secret: config( 'wpcom_signup_key' ),
 };

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -742,11 +742,12 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 	return transactionsEndpoint;
 }
 
-export const mockCreateAccountSiteNotCreatedResponse = () => [ 200, {} ];
+export const mockCreateAccountSiteNotCreatedResponse = () => [ 200, { success: true } ];
 
 export const mockCreateAccountSiteCreatedResponse = () => [
 	200,
 	{
+		success: true,
 		blog_details: {
 			blogid: 1234567,
 		},

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -19,4 +19,5 @@ export interface PaymentProcessorOptions {
 	siteSlug: string | undefined;
 	siteId: number | undefined;
 	contactDetails: ManagedContactDetails | undefined;
+	recaptchaClientId?: number;
 }

--- a/client/state/ui/actions/set-sites.js
+++ b/client/state/ui/actions/set-sites.js
@@ -7,7 +7,7 @@ import 'calypso/state/ui/init';
  * as selected.
  *
  * @param {number} siteId Site ID
- * @returns {object} Action object
+ * @returns {{type: string, siteId: number}} Action object
  */
 export function setSelectedSiteId( siteId ) {
 	return {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -326,8 +326,6 @@ export interface ManagedValue {
 }
 
 export type WpcomStoreState = {
-	siteId: string;
-	siteSlug: string;
 	recaptchaClientId: number;
 	transactionResult?: WPCOMTransactionEndpointResponse | undefined;
 	contactDetails: ManagedContactDetails;


### PR DESCRIPTION
#### Background

When using wpcom checkout without a wpcom account, we [set a variable](https://github.com/Automattic/wp-calypso/blob/f1afce3400780cf5fdc0e7c90da8d910d9d0098b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx#L142-L143) that tells the payment processors to [create an account](https://github.com/Automattic/wp-calypso/blob/f1afce3400780cf5fdc0e7c90da8d910d9d0098b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts#L24) before submitting the transaction.

When that account has been created, we [save the site ID and slug](https://github.com/Automattic/wp-calypso/blob/f1afce3400780cf5fdc0e7c90da8d910d9d0098b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js#L14-L19) to a `@wordpress/data` store for later use. 

The saved site ID is actually never used after checkout, so that code normally has no effect. The site ID in the store is used for checkout [_before_ site creation](https://github.com/Automattic/wp-calypso/blob/f1afce3400780cf5fdc0e7c90da8d910d9d0098b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js#L51), which is typically just being [copied there](https://github.com/Automattic/wp-calypso/blob/f1afce3400780cf5fdc0e7c90da8d910d9d0098b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx#L203-L205) from [the shopping cart](https://github.com/Automattic/wp-calypso/blob/f1afce3400780cf5fdc0e7c90da8d910d9d0098b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx#L632). However, that could be affected by the site creation if the site creation was completed but the transaction failed.

The saved site slug [is used](https://github.com/Automattic/wp-calypso/blob/f1afce3400780cf5fdc0e7c90da8d910d9d0098b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx#L314) only [when creating a redirect url](https://github.com/Automattic/wp-calypso/blob/f1afce3400780cf5fdc0e7c90da8d910d9d0098b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts#L31) for when a user removes the last product in their cart. Since this would only occur if an account was created during checkout and the subsequent transaction failed, this is an edge case which could be handled differently (and anyway is not the only way that a user can leave checkout).

As part of [creating](https://github.com/Automattic/wp-calypso/pull/52890) a mini-cart to use in wp-admin, we're [removing](https://github.com/Automattic/wp-calypso/pull/57628) `@wordpress/data` from the `composite-checkout` package, and to do that we need to clean up extraneous uses of the default registry, like the one mentioned above that stores the site ID and slug after site creation.

#### Changes proposed in this Pull Request

This PR therefore removes the code that saves the site ID and slug after site creation and also removes the (now unused) site ID and slug from the checkout `@wordpress/data` store.

To prevent bugs caused by this change, this PR passes the site ID used by Jetpack checkout into the payment processors in lieu of the plain site ID, which will allow it to be used by site creation directly instead of the round-about method of using the `@wordpress/data` store to get it there (hopefully this does not also cause any unintended side effects).

To make sure that we don't accidentally create more than one site if a transaction fails after creating an account, this PR also saves all newly created site IDs during checkout to Redux in `state.ui.selectedSiteId`.

#### Testing instructions

First, we must verify that there are no remaining instances of `setSiteId`/`getSiteId` or `setSiteSlug`/`getSiteSlug` in calypso which are attached to the `'wpcom'` `@wordpress/data` store (there are similarly named functions for the Redux data store, but those are fine).

Second, we need to verify that user account creation in checkout still works correctly. This means making sure that all uses of `createAccount` have had their call-sites updated correctly, and that a new account is created for userless checkout and Jetpack checkout as expected. [This PR](https://github.com/Automattic/wp-calypso/pull/44234) has some instructions for wpcom userless checkout and [this PR](https://github.com/Automattic/wp-calypso/pull/54253) has instructions for Jetpack userless checkout.

Third, we need to verify that the redirect after removing the last product from the cart during userless checkout works as expected. [This PR](https://github.com/Automattic/wp-calypso/pull/44206) may have the necessary instructions for that. Specifically, we need to test what happens if the account creation succeeds, but the transaction fails, and then the cart is emptied.