### PR TITLE
Stripe: Always use getStripeConfiguration in calypso

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -5,18 +5,13 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
-import wp from 'calypso/lib/wp';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
-import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-checkout/payment-method-helpers';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { RequestCart } from '@automattic/shopping-cart';
 
 import './style.scss';
-
-function fetchStripeConfigurationWpcom( args: Record< string, unknown > ) {
-	return fetchStripeConfiguration( args, wp );
-}
 
 function removeHashFromUrl(): void {
 	try {
@@ -75,7 +70,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 		>
 			<CalypsoShoppingCartProvider>
 				<StripeHookProvider
-					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
+					fetchStripeConfiguration={ getStripeConfiguration }
 					locale={ translate.locale }
 				>
 					<CompositeCheckout

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -5,13 +5,12 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { logToLogstash } from 'calypso/lib/logstash';
-import wp from 'calypso/lib/wp';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import Recaptcha from 'calypso/signup/recaptcha';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import PrePurchaseNotices from './composite-checkout/components/prepurchase-notices';
 import CompositeCheckout from './composite-checkout/composite-checkout';
-import { fetchStripeConfiguration } from './composite-checkout/payment-method-helpers';
 
 const logCheckoutError = ( error ) => {
 	logToLogstash( {
@@ -77,10 +76,7 @@ export default function CheckoutSystemDecider( {
 				onError={ logCheckoutError }
 			>
 				<CalypsoShoppingCartProvider>
-					<StripeHookProvider
-						fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
-						locale={ locale }
-					>
+					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
 						<CompositeCheckout
 							siteSlug={ siteSlug }
 							siteId={ selectedSite?.ID }
@@ -105,8 +101,4 @@ export default function CheckoutSystemDecider( {
 			{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
 		</>
 	);
-}
-
-function fetchStripeConfigurationWpcom( args ) {
-	return fetchStripeConfiguration( args, wp );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -6,10 +6,6 @@ import { stringifyBody } from 'calypso/state/login/utils';
 
 const { select } = defaultRegistry;
 
-export async function fetchStripeConfiguration( requestArgs, wpcom ) {
-	return wpcom.req.get( '/me/stripe-configuration', requestArgs );
-}
-
 async function createAccountCallback( response ) {
 	// Set siteId from response
 	const siteIdFromResponse = response?.blog_details?.blogid;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes a redundant function that fetches the stripe configuration for use by the `@automattic/calypso-stripe` package.

#### Testing instructions

Load checkout and verify that there are no fatal errors. Verify that you can see the credit card fields.