### PR TITLE
Prevent next params in Jetpack Cloud oath flow that have a different host

### DIFF
--- a/client/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/jetpack-cloud/sections/auth/controller.tsx
@@ -45,5 +45,12 @@ export const tokenRedirect: PageJS.Callback = ( context, next ) => {
 		store.set( 'wpcom_token_expires_in', context.hash.expires_in );
 	}
 
-	document.location.replace( context.query.next || '/' );
+	if ( context.query?.next ) {
+		const nextUrl = new URL( context.query.next );
+		document.location.replace(
+			nextUrl.hostname === window.location.hostname ? nextUrl.toString() : '/'
+		);
+	} else {
+		document.location.replace( '/' );
+	}
 };

--- a/client/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/jetpack-cloud/sections/auth/controller.tsx
@@ -6,6 +6,8 @@ import Connect from './connect';
 const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
 const debug = debugFactory( 'calypso:jetpack-cloud-connect' );
 
+const DEFAULT_NEXT_LOCATION = '/';
+
 export const connect: PageJS.Callback = ( context, next ) => {
 	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
 		const redirectUri = new URL( '/connect/oauth/token', window.location.origin );
@@ -45,12 +47,16 @@ export const tokenRedirect: PageJS.Callback = ( context, next ) => {
 		store.set( 'wpcom_token_expires_in', context.hash.expires_in );
 	}
 
-	if ( context.query?.next ) {
-		const nextUrl = new URL( context.query.next );
-		document.location.replace(
-			nextUrl.hostname === window.location.hostname ? nextUrl.toString() : '/'
+	try {
+		const nextUrl = new URL(
+			context?.query.next ?? DEFAULT_NEXT_LOCATION,
+			new URL( window.location.origin )
 		);
-	} else {
-		document.location.replace( '/' );
+		document.location.replace(
+			nextUrl.host === window.location.host ? nextUrl.toString() : DEFAULT_NEXT_LOCATION
+		);
+	} catch ( error ) {
+		// if something is fundamentally wrong with context.query.next we just go to root.
+		document.location.replace( DEFAULT_NEXT_LOCATION );
 	}
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

for motivation see ( p3btAN-1A0-p2 )

* prevent next params on Jetpack Cloud OAuth flow that are invalid URLs or direct to other sites

#### Testing instructions

* Attempt to reproduce the attack in the **motivation** link above ( note the oauth client id for Jetpack Cloud Development is 68663, which will need to change along with the URL, and verify it no longer works
* Modify the url used above with a valid URL for redirect ( `/scan`, for example ) and verify next still works correctly