### PR TITLE
New sites use default headstart annotation, not theme annotation

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -145,6 +145,10 @@ function getNewSiteParams( {
 		get( signupDependencies, 'themeSlugWithRepo', false ) ||
 		siteTypeTheme;
 
+	// We will use the default annotation instead of theme annotation as fallback,
+	// when segment and vertical values are not sent. Check pbAok1-p2#comment-834.
+	const shouldUseDefaultAnnotationAsFallback = true;
+
 	const newSiteParams = {
 		blog_title: siteTitle,
 		public: Visibility.PublicNotIndexed,
@@ -152,6 +156,7 @@ function getNewSiteParams( {
 			designType: designType || undefined,
 			theme,
 			use_theme_annotation: get( signupDependencies, 'useThemeHeadstart', false ),
+			default_annotation_as_primary_fallback: shouldUseDefaultAnnotationAsFallback,
 			siteGoals: siteGoals || undefined,
 			site_style: siteStyle || undefined,
 			site_segment: siteSegment || undefined,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Zoologist annotation had been trimmed down so that it was appropriate for default content. However, the Zoologist annotation is now being made to match the demo site again D69769-code. We want new sites to continue to use the trimmed down annotations so D69776-code changes the default headstart annotations to be the trimmed down content, and this PR asks the endpoint to use those default annotations. Which is how everything used to work before #57134.

* Reinstates the `default_annotation_as_primary_fallback` flag which was first put in place by #39795, and removed by #57134.

Reference p1636407007167400-slack-C029SB8JT8S

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D69776-code
* Create a new site using `/start`
* Confirm that `/sites/new` endpoint is called with the `default_annotation_as_primary_fallback` flag and that the newly created site has just one page and one post with no media
* If you want apply D69769-code too
* Select Zoologist from the Design Picker during the hero flow and confirm that a trimmed down version of the Zoologist demo site has been applied (no menu and no pages, but multiple posts)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->