### PR TITLE
Playwright: use `locator` API for error-prone visitArticle button.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -172,6 +172,7 @@ export class SupportComponent {
 	async clickReadMore(): Promise< void > {
 		await Promise.all( [
 			this.page.waitForSelector( selectors.supportArticlePlaceholder, { state: 'hidden' } ),
+			this.page.waitForLoadState( 'networkidle' ),
 			this.page.click( selectors.readMoreButton ),
 		] );
 	}
@@ -182,9 +183,6 @@ export class SupportComponent {
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
-		const visitArticleHandle = await this.page.waitForSelector( selectors.visitArticleButton );
-		await visitArticleHandle.waitForElementState( 'stable' );
-
 		const browserContext = this.page.context();
 		// `Visit article` launches a new page.
 		const [ newPage ] = await Promise.all( [

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -183,11 +183,14 @@ export class SupportComponent {
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
+		const visitArticleLocator = this.page.locator( selectors.visitArticleButton );
+
 		const browserContext = this.page.context();
 		// `Visit article` launches a new page.
 		const [ newPage ] = await Promise.all( [
 			browserContext.waitForEvent( 'page' ),
-			this.page.click( selectors.visitArticleButton ),
+			visitArticleLocator.click(),
+			// this.page.click( selectors.visitArticleButton ),
 		] );
 		await newPage.waitForLoadState( 'domcontentloaded' );
 

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -172,7 +172,6 @@ export class SupportComponent {
 	async clickReadMore(): Promise< void > {
 		await Promise.all( [
 			this.page.waitForSelector( selectors.supportArticlePlaceholder, { state: 'hidden' } ),
-			this.page.waitForLoadState( 'networkidle' ),
 			this.page.click( selectors.readMoreButton ),
 		] );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR uses a new API introduced with Playwright 1.14 - `locator`, which encapsulates logic to retrieve a target element, allowing the caller to retrieve the up-to-date handler pointing to an element at any given moment.

Key changes:
- retrieve the `locator` handle for the `visitArticle` button, and call the `click` method.

Details:
`Locator` API, as briefly described in the opening sentence, differs from an `ElementHandle` in that contains all logic necessary to retrieve an up-to-date reference to an element.

This is useful in situations such as follows, in order:
- Playwright engine locates an element targetted by the selector.
- actionability checks are performed and it is determined to be actionable.
- target element shifts location due to rest of page loading or React component being re-rendered.
- Playwright proceeds to perform the `click` action.
- element has shifted and so the `click` action is unable to locate the target element.

A `locator` will always retrieve the up-to-date target of the selector. This in effect builds in additional resilience for the `click` process.

#### Testing instructions

- [x] stress
  - [x] mobile
  - [x] desktop
- [x] normal
  - [x] mobile
  - [x] desktop

Closes #57768.
