### PR TITLE
Playwright: add generic retry method `retryAction` that accepts a function as parameter.

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -77,8 +77,10 @@ export async function clickNavTab( page: Page, name: string ): Promise< void > {
 }
 
 /**
- * Retry any action up to three times or action passes without throwing an exception,
+ * Retry any function up to three times or action passes without throwing an exception,
  * whichever comes first.
+ *
+ * The function being passed in must throw an exception for this retry to work.
  *
  * This is useful for situations where the backend must process the results of a
  * previous action then inform the front end of the result of the process.
@@ -88,16 +90,20 @@ export async function clickNavTab( page: Page, name: string ): Promise< void > {
  *
  * @param {Page} page Page object.
  */
-export async function retryAction(
+export async function reloadAndRetry(
 	page: Page,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	func: ( page: Page, ...args: any[] ) => Promise< void >
+	func: ( page: Page ) => Promise< void >
 ): Promise< void > {
 	for ( let retries = 3; retries > 0; retries -= 1 ) {
 		try {
 			await func( page );
-		} catch {
-			await page.reload();
+		} catch ( err ) {
+			// Throw the error if final retry failed.
+			if ( retries === 1 ) {
+				throw err;
+			} else {
+				await page.reload();
+			}
 		}
 	}
 	return;

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -75,3 +75,30 @@ export async function clickNavTab( page: Page, name: string ): Promise< void > {
 	const elementHandle = await page.waitForSelector( selectors.navTab( name ) );
 	await Promise.all( [ page.waitForNavigation(), elementHandle.click() ] );
 }
+
+/**
+ * Retry any action up to three times or action passes without throwing an exception,
+ * whichever comes first.
+ *
+ * This is useful for situations where the backend must process the results of a
+ * previous action then inform the front end of the result of the process.
+ * An example of this is the user invitation system where the backend must receive,
+ * verify and send the invitation issued by a user. If the resulting checks were
+ * successful, the resulting invitation is shown as 'pending'.
+ *
+ * @param {Page} page Page object.
+ */
+export async function retryAction(
+	page: Page,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	func: ( page: Page, ...args: any[] ) => Promise< void >
+): Promise< void > {
+	for ( let retries = 3; retries > 0; retries -= 1 ) {
+		try {
+			await func( page );
+		} catch {
+			await page.reload();
+		}
+	}
+	return;
+}

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -1,5 +1,5 @@
 import { Page } from 'playwright';
-import { clickNavTab, retryAction } from '../../element-helper';
+import { clickNavTab, reloadAndRetry } from '../../element-helper';
 
 export type PeoplePageTabs = 'Team' | 'Followers' | 'Email Followers' | 'Invites';
 
@@ -136,9 +136,7 @@ export class PeoplePage {
 	 * @param {string} emailAddress Email address of the pending user.
 	 */
 	async selectInvitedUser( emailAddress: string ): Promise< void > {
-		// Retry three times, each time allowing 5 seconds for Playwright to locate the
-		// pending user invite.
-
+		emailAddress = emailAddress + 'lekwjrlwejr';
 		/**
 		 * Closure to wait for the invited user to be processed in the backend and then
 		 * appear on the frontend.
@@ -151,7 +149,7 @@ export class PeoplePage {
 			} );
 		}
 
-		await retryAction( this.page, waitForInviteToAppear );
+		await reloadAndRetry( this.page, waitForInviteToAppear );
 
 		await Promise.all( [
 			this.page.waitForNavigation(),

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -136,7 +136,6 @@ export class PeoplePage {
 	 * @param {string} emailAddress Email address of the pending user.
 	 */
 	async selectInvitedUser( emailAddress: string ): Promise< void > {
-		emailAddress = emailAddress + 'lekwjrlwejr';
 		/**
 		 * Closure to wait for the invited user to be processed in the backend and then
 		 * appear on the frontend.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements a generic method to retry actions that rely on some backend processing.

Key changes:
- migration of the retry mechanism out of `PeoplePage` to `ElementHelper`.
- accept a function as parameter to `retryAction` method.

Details:
As noted in https://github.com/Automattic/wp-calypso/issues/57771 and p1636391221268700-slack-CQD1HH4MA, in some areas of Calypso there are pages that rely on the backend processing or validating some data and updating the frontend with the result. The changes implemented in https://github.com/Automattic/wp-calypso/pull/57677 was for `PeoplePage` and it was successful in eliminating the race condition that arose from Playwright visiting the Pending Invites page prior to the backend having processed and verified the invite.

This genericized method retains the same behavior from the original implementation in `PeoplePage` but now accepts two parameters:
- Page object
- Method to execute

The method to execute should be asynchronous and written such that all required parameters are passed into the method. The revised example in `PeoplePage` is implemented using a closure, but it can be be a standalone class method.

All waits and actions should be contained in the method, as the `retryAction` method only contains logic for the retries and page reload.

#### Testing instructions

- [x] mobile
- [x] desktop

Closes #57771.