### PR TITLE
Require tax location for existing cards

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -50,6 +50,7 @@ export default function useCreateAssignablePaymentMethods(
 		stripeLoadingError,
 		storedCards,
 		activePayButtonText: String( translate( 'Use this card' ) ),
+		allowEditingTaxInfo: true,
 	} );
 
 	const paymentMethods = useMemo(

--- a/client/me/purchases/payment-methods/components/payment-method-edit-button.tsx
+++ b/client/me/purchases/payment-methods/components/payment-method-edit-button.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@automattic/components';
+import type { FunctionComponent, ReactNode } from 'react';
+
+interface Props {
+	onClick: () => void;
+	buttonTextContent: string;
+	scary: boolean;
+	borderless: boolean;
+	icon?: ReactNode;
+}
+
+const PaymentMethodEditButton: FunctionComponent< Props > = ( {
+	onClick,
+	buttonTextContent,
+	scary,
+	borderless,
+	icon,
+} ) => {
+	return (
+		<Button
+			compact
+			borderless={ borderless }
+			scary={ scary }
+			className="payment-method-edit-button"
+			onClick={ onClick }
+		>
+			{ icon }
+			{ buttonTextContent }
+		</Button>
+	);
+};
+
+export default PaymentMethodEditButton;

--- a/client/me/purchases/payment-methods/components/payment-method-edit-button.tsx
+++ b/client/me/purchases/payment-methods/components/payment-method-edit-button.tsx
@@ -7,6 +7,7 @@ interface Props {
 	scary: boolean;
 	borderless: boolean;
 	icon?: ReactNode;
+	disabled?: boolean;
 }
 
 const PaymentMethodEditButton: FunctionComponent< Props > = ( {
@@ -15,6 +16,7 @@ const PaymentMethodEditButton: FunctionComponent< Props > = ( {
 	scary,
 	borderless,
 	icon,
+	disabled,
 } ) => {
 	return (
 		<Button
@@ -23,6 +25,7 @@ const PaymentMethodEditButton: FunctionComponent< Props > = ( {
 			scary={ scary }
 			className="payment-method-edit-button"
 			onClick={ onClick }
+			disabled={ disabled }
 		>
 			{ icon }
 			{ buttonTextContent }

--- a/client/me/purchases/payment-methods/components/payment-method-edit-dialog.tsx
+++ b/client/me/purchases/payment-methods/components/payment-method-edit-dialog.tsx
@@ -1,0 +1,57 @@
+import { Button, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import CardHeading from 'calypso/components/card-heading';
+import Notice from 'calypso/components/notice';
+import type { TranslateResult } from 'i18n-calypso';
+import type { FunctionComponent } from 'react';
+
+import 'calypso/me/purchases/payment-methods/style.scss';
+
+interface Props {
+	paymentMethodSummary: TranslateResult;
+	isVisible: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	form: JSX.Element;
+	error: string;
+}
+
+const PaymentMethodEditDialog: FunctionComponent< Props > = ( {
+	paymentMethodSummary,
+	isVisible,
+	onClose,
+	onConfirm,
+	form,
+	error,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<Dialog
+			isVisible={ isVisible }
+			additionalClassNames="payment-method-edit-dialog"
+			onClose={ onClose }
+			buttons={ [
+				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>,
+				<Button onClick={ onConfirm } primary>
+					{ translate( 'Save' ) }
+				</Button>,
+			] }
+		>
+			<CardHeading tagName="h2" size={ 24 }>
+				{ translate( 'Update Your Payment Method' ) }
+			</CardHeading>
+			<p>
+				{ translate( 'Please update the following information for {{paymentMethodSummary/}}', {
+					components: {
+						paymentMethodSummary: <strong>{ paymentMethodSummary }</strong>,
+					},
+				} ) }
+			</p>
+			{ error && <Notice status="is-error" isCompact={ true } text={ error } /> }
+			{ form }
+		</Dialog>
+	);
+};
+
+export default PaymentMethodEditDialog;

--- a/client/me/purchases/payment-methods/components/payment-method-edit-dialog.tsx
+++ b/client/me/purchases/payment-methods/components/payment-method-edit-dialog.tsx
@@ -39,15 +39,8 @@ const PaymentMethodEditDialog: FunctionComponent< Props > = ( {
 			] }
 		>
 			<CardHeading tagName="h2" size={ 24 }>
-				{ translate( 'Update Your Payment Method' ) }
+				<strong>{ paymentMethodSummary }</strong>
 			</CardHeading>
-			<p>
-				{ translate( 'Please update the following information for {{paymentMethodSummary/}}', {
-					components: {
-						paymentMethodSummary: <strong>{ paymentMethodSummary }</strong>,
-					},
-				} ) }
-			</p>
 			{ error && <Notice status="is-error" isCompact={ true } text={ error } /> }
 			{ form }
 		</Dialog>

--- a/client/me/purchases/payment-methods/components/payment-method-edit-form-fields.tsx
+++ b/client/me/purchases/payment-methods/components/payment-method-edit-form-fields.tsx
@@ -1,0 +1,89 @@
+import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import CountrySelectMenu from 'calypso/my-sites/checkout/composite-checkout/components/country-select-menu';
+import FormFieldAnnotation from 'calypso/my-sites/checkout/composite-checkout/components/form-field-annotation';
+import {
+	LeftColumn,
+	RightColumn,
+} from 'calypso/my-sites/checkout/composite-checkout/components/ie-fallback';
+import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
+
+const GridRow = styled.div`
+	display: -ms-grid;
+	display: grid;
+	width: 100%;
+	-ms-grid-columns: 48% 4% 48%;
+	grid-template-columns: 48% 48%;
+	grid-column-gap: 4%;
+	justify-items: stretch;
+`;
+
+const FieldRow = styled( GridRow )`
+	margin-top: 16px;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+const RenderEditFormFields = ( {
+	onChangePostalCode,
+	onChangeCountryCode,
+	postalCodeValue,
+	countryCodeValue,
+}: {
+	value?: string;
+	onChangePostalCode: unknown;
+	onChangeCountryCode: unknown;
+	postalCodeValue?: string;
+	countryCodeValue?: string;
+} ): JSX.Element => {
+	const countriesList = useCountryList( [] );
+	const translate = useTranslate();
+
+	const arePostalCodesSupported = getCountryPostalCodeSupport(
+		countriesList,
+		countryCodeValue ?? ''
+	);
+
+	return (
+		<>
+			<FieldRow>
+				<LeftColumn>
+					<CountrySelectMenu
+						translate={ translate }
+						onChange={ onChangeCountryCode }
+						isError={ false }
+						isDisabled={ false }
+						errorMessage={ '' }
+						currentValue={ countryCodeValue || '' }
+						countriesList={ countriesList }
+					/>
+				</LeftColumn>
+				{ arePostalCodesSupported && (
+					<RightColumn>
+						<FormFieldAnnotation
+							labelText={ translate( 'Postal code', { textOnly: true } ) }
+							formFieldId="tax_postal_code"
+							labelId="tax_postal_code_label"
+							descriptionId="tax_postal_code_label"
+							errorDescription=""
+						>
+							<FormTextInput
+								id="tax_postal_code"
+								name="tax_postal_code"
+								placeholder="Enter postal code"
+								value={ postalCodeValue || '' }
+								onChange={ onChangePostalCode }
+							/>
+						</FormFieldAnnotation>
+					</RightColumn>
+				) }
+			</FieldRow>
+		</>
+	);
+};
+
+export default RenderEditFormFields;

--- a/client/me/purchases/payment-methods/existing-credit-card.tsx
+++ b/client/me/purchases/payment-methods/existing-credit-card.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import {
 	Button,
 	FormStatus,
@@ -5,21 +6,63 @@ import {
 	useFormStatus,
 	PaymentLogo,
 } from '@automattic/composite-checkout';
+import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useDispatch } from 'react-redux';
+import { PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
+import wpcom from 'calypso/lib/wp';
 import {
 	SummaryLine,
 	SummaryDetails,
 } from 'calypso/my-sites/checkout/composite-checkout/components/summary-details';
+import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
+import { errorNotice } from 'calypso/state/notices/actions';
+import PaymentMethodEditButton from './components/payment-method-edit-button';
+import PaymentMethodEditDialog from './components/payment-method-edit-dialog';
+import RenderEditFormFields from './components/payment-method-edit-form-fields';
 import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'calypso:existing-card-payment-method' );
 
 // Disabling this to make migration easier
 /* eslint-disable @typescript-eslint/no-use-before-define */
+
+interface TaxInfo {
+	tax_postal_code: string;
+	tax_country_code: string;
+}
+
+interface TaxGetInfo extends TaxInfo {
+	is_tax_info_set: boolean;
+}
+
+async function fetchTaxInfo( storedDetailsId: string ): Promise< TaxGetInfo > {
+	return await wpcom.req.get( `/me/payment-methods/${ storedDetailsId }/tax-location` );
+}
+
+async function setTaxInfo(
+	storedDetailsId: string,
+	taxPostalCode: string,
+	taxCountryCode: string
+): Promise< TaxInfo > {
+	return await wpcom.req.post( {
+		path: `/me/payment-methods/${ storedDetailsId }/tax-location`,
+		body: {
+			tax_country_code: taxCountryCode,
+			tax_postal_code: taxPostalCode,
+		},
+	} );
+}
+
+function joinNonEmptyValues( joinString: string, ...values: ( string | undefined )[] ) {
+	return values.filter( ( value ) => value && value?.length > 0 ).join( joinString );
+}
 
 export function createExistingCardMethod( {
 	id,
@@ -55,9 +98,11 @@ export function createExistingCardMethod( {
 		label: (
 			<ExistingCardLabel
 				last4={ last4 }
+				storedDetailsId={ storedDetailsId }
 				cardExpiry={ cardExpiry }
 				cardholderName={ cardholderName }
 				brand={ brand }
+				paymentPartnerProcessorId={ paymentPartnerProcessorId }
 			/>
 		),
 		submitButton: (
@@ -91,21 +136,147 @@ function formatDate( cardExpiry: string ): string {
 	return formattedDate;
 }
 
+const CardDetails = styled.span`
+	display: inline-block;
+	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+`;
+
+const CardHolderName = styled.span`
+	display: block;
+`;
+
 function ExistingCardLabel( {
 	last4,
 	cardExpiry,
 	cardholderName,
 	brand,
+	storedDetailsId,
+	paymentPartnerProcessorId,
 }: {
 	last4: string;
 	cardExpiry: string;
 	cardholderName: string;
 	brand: string;
+	storedDetailsId: string;
+	paymentPartnerProcessorId: string;
 } ): JSX.Element {
 	const { __, _x } = useI18n();
 
+	const [ isDialogVisible, setIsDialogVisible ] = useState( false );
+	const [ inputValues, setInputValues ] = useState< TaxInfo >( {
+		tax_country_code: '',
+		tax_postal_code: '',
+	} );
+	const [ updateError, setUpdateError ] = useState( '' );
+	const closeDialog = useCallback( () => {
+		setUpdateError( '' );
+		setIsDialogVisible( false );
+	}, [] );
+	const queryClient = useQueryClient();
+
+	const queryKey = [ 'tax-info-is-set', storedDetailsId ];
+
+	const { data: taxInfoFromServer } = useQuery< TaxGetInfo, Error >(
+		queryKey,
+		() => fetchTaxInfo( storedDetailsId ),
+		{}
+	);
+
+	const mutation = useMutation(
+		( mutationInputValues: TaxInfo ) =>
+			setTaxInfo(
+				storedDetailsId,
+				mutationInputValues.tax_postal_code,
+				mutationInputValues.tax_country_code
+			),
+		{
+			onMutate: async ( onMutateInputValues: TaxInfo ) => {
+				// Stop any active fetches
+				await queryClient.cancelQueries( queryKey );
+				// Store previous fields so they can be restored if the data is invalid
+				const previousData = queryClient.getQueryData( queryKey );
+				// Optimistically update the fields
+				queryClient.setQueryData( queryKey, {
+					tax_postal_code: onMutateInputValues.tax_postal_code,
+					tax_country_code: onMutateInputValues.tax_country_code,
+					is_tax_info_set: true,
+				} );
+				return { previousData };
+			},
+			onError: ( error, _, context ) => {
+				// Restore previous fields
+				queryClient.setQueryData( queryKey, context?.previousData );
+				setUpdateError( ( error as Error ).message );
+			},
+			onSuccess: ( onSuccessInputValues: TaxInfo ) => {
+				queryClient.setQueryData( queryKey, {
+					tax_postal_code: onSuccessInputValues.tax_postal_code,
+					tax_country_code: onSuccessInputValues.tax_country_code,
+					is_tax_info_set: true,
+				} );
+				closeDialog();
+			},
+		}
+	);
+
+	const openDialog = useCallback( () => {
+		taxInfoFromServer && setInputValues( taxInfoFromServer );
+		setIsDialogVisible( true );
+	}, [ taxInfoFromServer ] );
+
+	useEffect( () => {
+		if ( ! taxInfoFromServer?.tax_country_code ) {
+			return;
+		}
+		setInputValues( {
+			tax_postal_code: taxInfoFromServer?.tax_postal_code ?? '',
+			tax_country_code: taxInfoFromServer?.tax_country_code ?? '',
+		} );
+	}, [ taxInfoFromServer?.tax_country_code, taxInfoFromServer?.tax_postal_code ] );
+
+	const countriesList = useCountryList( [] );
+	const updateTaxInfo = useCallback( () => {
+		mutation.mutate( inputValues );
+	}, [ mutation, inputValues ] );
+
+	const onChangeCountryCode = ( e: { target: { value: string } } ) => {
+		const arePostalCodesSupported = getCountryPostalCodeSupport( countriesList, e.target.value );
+		setInputValues( {
+			tax_country_code: e.target.value,
+			tax_postal_code: arePostalCodesSupported ? inputValues.tax_postal_code : '',
+		} );
+	};
+
+	const onChangePostalCode = ( e: { target: { value: string } } ) => {
+		setInputValues( { ...inputValues, tax_postal_code: e.target.value } );
+	};
+
+	const formRender = (
+		<form>
+			<div className="contact-fields payment-methods__tax-fields">
+				<RenderEditFormFields
+					postalCodeValue={ inputValues.tax_postal_code }
+					countryCodeValue={ inputValues.tax_country_code }
+					onChangePostalCode={ onChangePostalCode }
+					onChangeCountryCode={ onChangeCountryCode }
+				/>
+			</div>
+		</form>
+	);
+
 	/* translators: %s is the last 4 digits of the credit card number */
 	const maskedCardDetails = sprintf( _x( '**** %s', 'Masked credit card number' ), last4 );
+
+	const taxInfoDisplay = joinNonEmptyValues(
+		', ',
+		taxInfoFromServer?.tax_postal_code,
+		taxInfoFromServer?.tax_country_code
+	);
 
 	return (
 		<Fragment>
@@ -113,17 +284,41 @@ function ExistingCardLabel( {
 				<CardHolderName>{ cardholderName }</CardHolderName>
 				<CardDetails>{ maskedCardDetails }</CardDetails>
 				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
+				{ taxInfoDisplay ? (
+					<span className="existing-credit-card__tax-info-display">
+						<span className="existing-credit-card__tax-info-postal-country">
+							{ taxInfoDisplay }
+						</span>
+					</span>
+				) : (
+					<span className="existing-credit-card__tax-info-display tax-info-incomplete">
+						<PaymentMethodEditButton
+							onClick={ openDialog }
+							buttonTextContent={ __( 'Missing Billing Information' ) }
+							scary={ true }
+							borderless={ false }
+							icon={ <Gridicon icon="notice" /> }
+						/>
+					</span>
+				) }
 			</div>
 			<div className="existing-credit-card__logo payment-logos">
 				<PaymentLogo brand={ brand } isSummary={ true } />
+
+				<PaymentMethodEditDialog
+					paymentMethodSummary={
+						<PaymentMethodSummary type={ brand || paymentPartnerProcessorId } digits={ last4 } />
+					}
+					isVisible={ isDialogVisible }
+					onClose={ closeDialog }
+					onConfirm={ updateTaxInfo }
+					form={ formRender }
+					error={ updateError }
+				/>
 			</div>
 		</Fragment>
 	);
 }
-
-const CardHolderName = styled.span`
-	display: block;
-`;
 
 function ExistingCardPayButton( {
 	disabled,
@@ -144,6 +339,15 @@ function ExistingCardPayButton( {
 } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
+	const translate = useTranslate();
+
+	const { data: taxInfoFromServer } = useQuery<
+		{ tax_postal_code: string; tax_country_code: string; is_tax_info_set: boolean },
+		Error
+	>( [ 'tax-info-is-set', storedDetailsId ], () => fetchTaxInfo( storedDetailsId ), {} );
+
+	const isTaxInfoSet = taxInfoFromServer?.is_tax_info_set;
+	const dispatch = useDispatch();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -159,13 +363,21 @@ function ExistingCardPayButton( {
 			disabled={ disabled }
 			onClick={ () => {
 				debug( 'submitting existing card payment' );
-				onClick( 'existing-card', {
-					items,
-					name: cardholderName,
-					storedDetailsId,
-					paymentMethodToken,
-					paymentPartnerProcessorId,
-				} );
+				if ( ! isTaxInfoSet ) {
+					dispatch(
+						errorNotice( translate( 'Please update the missing billing information.' ), {
+							duration: 5000,
+						} )
+					);
+				} else {
+					onClick( 'existing-card', {
+						items,
+						name: cardholderName,
+						storedDetailsId,
+						paymentMethodToken,
+						paymentPartnerProcessorId,
+					} );
+				}
 			} }
 			buttonType="primary"
 			isBusy={ FormStatus.SUBMITTING === formStatus }
@@ -227,13 +439,3 @@ function ExistingCardSummary( {
 		</SummaryDetails>
 	);
 }
-
-const CardDetails = styled.span`
-	display: inline-block;
-	margin-right: 8px;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-`;

--- a/client/me/purchases/payment-methods/existing-credit-card.tsx
+++ b/client/me/purchases/payment-methods/existing-credit-card.tsx
@@ -272,35 +272,13 @@ function ExistingCardLabel( {
 	/* translators: %s is the last 4 digits of the credit card number */
 	const maskedCardDetails = sprintf( _x( '**** %s', 'Masked credit card number' ), last4 );
 
-	const taxInfoDisplay = joinNonEmptyValues(
-		', ',
-		taxInfoFromServer?.tax_postal_code,
-		taxInfoFromServer?.tax_country_code
-	);
-
 	return (
 		<Fragment>
 			<div>
 				<CardHolderName>{ cardholderName }</CardHolderName>
 				<CardDetails>{ maskedCardDetails }</CardDetails>
 				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
-				{ taxInfoDisplay ? (
-					<span className="existing-credit-card__tax-info-display">
-						<span className="existing-credit-card__tax-info-postal-country">
-							{ taxInfoDisplay }
-						</span>
-					</span>
-				) : (
-					<span className="existing-credit-card__tax-info-display tax-info-incomplete">
-						<PaymentMethodEditButton
-							onClick={ openDialog }
-							buttonTextContent={ __( 'Missing Billing Information' ) }
-							scary={ true }
-							borderless={ false }
-							icon={ <Gridicon icon="notice" /> }
-						/>
-					</span>
-				) }
+				<TaxInfoArea taxInfoFromServer={ taxInfoFromServer } openDialog={ openDialog } />
 			</div>
 			<div className="existing-credit-card__logo payment-logos">
 				<PaymentLogo brand={ brand } isSummary={ true } />
@@ -317,6 +295,40 @@ function ExistingCardLabel( {
 				/>
 			</div>
 		</Fragment>
+	);
+}
+
+function TaxInfoArea( {
+	taxInfoFromServer,
+	openDialog,
+}: {
+	taxInfoFromServer: TaxInfo | undefined;
+	openDialog: () => void;
+} ) {
+	const { __ } = useI18n();
+	const taxInfoDisplay = joinNonEmptyValues(
+		', ',
+		taxInfoFromServer?.tax_postal_code,
+		taxInfoFromServer?.tax_country_code
+	);
+
+	if ( taxInfoDisplay ) {
+		return (
+			<span className="existing-credit-card__tax-info-display">
+				<span className="existing-credit-card__tax-info-postal-country">{ taxInfoDisplay }</span>
+			</span>
+		);
+	}
+	return (
+		<span className="existing-credit-card__tax-info-display tax-info-incomplete">
+			<PaymentMethodEditButton
+				onClick={ openDialog }
+				buttonTextContent={ __( 'Missing Billing Information' ) }
+				scary={ true }
+				borderless={ false }
+				icon={ <Gridicon icon="notice" /> }
+			/>
+		</span>
 	);
 }
 

--- a/client/me/purchases/payment-methods/existing-credit-card.tsx
+++ b/client/me/purchases/payment-methods/existing-credit-card.tsx
@@ -181,7 +181,7 @@ function ExistingCardLabel( {
 
 	const queryKey = [ 'tax-info-is-set', storedDetailsId ];
 
-	const { data: taxInfoFromServer } = useQuery< TaxGetInfo, Error >(
+	const { data: taxInfoFromServer, isLoading: isLoadingTaxInfo } = useQuery< TaxGetInfo, Error >(
 		queryKey,
 		() => fetchTaxInfo( storedDetailsId ),
 		{}
@@ -278,7 +278,9 @@ function ExistingCardLabel( {
 				<CardHolderName>{ cardholderName }</CardHolderName>
 				<CardDetails>{ maskedCardDetails }</CardDetails>
 				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
-				<TaxInfoArea taxInfoFromServer={ taxInfoFromServer } openDialog={ openDialog } />
+				{ ! isLoadingTaxInfo && (
+					<TaxInfoArea taxInfoFromServer={ taxInfoFromServer } openDialog={ openDialog } />
+				) }
 			</div>
 			<div className="existing-credit-card__logo payment-logos">
 				<PaymentLogo brand={ brand } isSummary={ true } />

--- a/client/me/purchases/payment-methods/existing-credit-card.tsx
+++ b/client/me/purchases/payment-methods/existing-credit-card.tsx
@@ -74,6 +74,7 @@ export function createExistingCardMethod( {
 	paymentMethodToken,
 	paymentPartnerProcessorId,
 	activePayButtonText = undefined,
+	allowEditingTaxInfo,
 }: {
 	id: string;
 	cardholderName: string;
@@ -84,6 +85,7 @@ export function createExistingCardMethod( {
 	paymentMethodToken: string;
 	paymentPartnerProcessorId: string;
 	activePayButtonText: string | undefined;
+	allowEditingTaxInfo?: boolean;
 } ): PaymentMethod {
 	debug( 'creating a new existing credit card payment method', {
 		id,
@@ -103,6 +105,7 @@ export function createExistingCardMethod( {
 				cardholderName={ cardholderName }
 				brand={ brand }
 				paymentPartnerProcessorId={ paymentPartnerProcessorId }
+				allowEditingTaxInfo={ !! allowEditingTaxInfo }
 			/>
 		),
 		submitButton: (
@@ -157,6 +160,7 @@ function ExistingCardLabel( {
 	brand,
 	storedDetailsId,
 	paymentPartnerProcessorId,
+	allowEditingTaxInfo,
 }: {
 	last4: string;
 	cardExpiry: string;
@@ -164,6 +168,7 @@ function ExistingCardLabel( {
 	brand: string;
 	storedDetailsId: string;
 	paymentPartnerProcessorId: string;
+	allowEditingTaxInfo: boolean;
 } ): JSX.Element {
 	const { __, _x } = useI18n();
 
@@ -279,7 +284,11 @@ function ExistingCardLabel( {
 				<CardDetails>{ maskedCardDetails }</CardDetails>
 				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
 				{ ! isLoadingTaxInfo && (
-					<TaxInfoArea taxInfoFromServer={ taxInfoFromServer } openDialog={ openDialog } />
+					<TaxInfoArea
+						taxInfoFromServer={ taxInfoFromServer }
+						openDialog={ openDialog }
+						allowEditing={ allowEditingTaxInfo }
+					/>
 				) }
 			</div>
 			<div className="existing-credit-card__logo payment-logos">
@@ -303,9 +312,11 @@ function ExistingCardLabel( {
 function TaxInfoArea( {
 	taxInfoFromServer,
 	openDialog,
+	allowEditing,
 }: {
 	taxInfoFromServer: TaxInfo | undefined;
 	openDialog: () => void;
+	allowEditing: boolean;
 } ) {
 	const { __ } = useI18n();
 	const taxInfoDisplay = joinNonEmptyValues(
@@ -321,6 +332,9 @@ function TaxInfoArea( {
 				<span className="existing-credit-card__tax-info-postal-country">{ taxInfoDisplay }</span>
 			</span>
 		);
+	}
+	if ( ! allowEditing ) {
+		return null;
 	}
 	return (
 		<span className="existing-credit-card__tax-info-display tax-info-incomplete">

--- a/client/me/purchases/payment-methods/existing-credit-card.tsx
+++ b/client/me/purchases/payment-methods/existing-credit-card.tsx
@@ -313,6 +313,7 @@ function TaxInfoArea( {
 		taxInfoFromServer?.tax_postal_code,
 		taxInfoFromServer?.tax_country_code
 	);
+	const { formStatus } = useFormStatus();
 
 	if ( taxInfoDisplay ) {
 		return (
@@ -329,6 +330,7 @@ function TaxInfoArea( {
 				scary={ true }
 				borderless={ false }
 				icon={ <Gridicon icon="notice" /> }
+				disabled={ formStatus !== FormStatus.READY }
 			/>
 		</span>
 	);

--- a/client/me/purchases/payment-methods/existing-credit-card.tsx
+++ b/client/me/purchases/payment-methods/existing-credit-card.tsx
@@ -355,12 +355,11 @@ function ExistingCardPayButton( {
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
 
-	const { data: taxInfoFromServer } = useQuery<
-		{ tax_postal_code: string; tax_country_code: string; is_tax_info_set: boolean },
-		Error
-	>( [ 'tax-info-is-set', storedDetailsId ], () => fetchTaxInfo( storedDetailsId ), {} );
+	const { data: taxInfoFromServer } = useQuery< TaxGetInfo, Error >(
+		[ 'tax-info-is-set', storedDetailsId ],
+		() => fetchTaxInfo( storedDetailsId )
+	);
 
-	const isTaxInfoSet = taxInfoFromServer?.is_tax_info_set;
 	const dispatch = useDispatch();
 
 	// This must be typed as optional because it's injected by cloning the
@@ -377,11 +376,17 @@ function ExistingCardPayButton( {
 			disabled={ disabled }
 			onClick={ () => {
 				debug( 'submitting existing card payment' );
-				if ( ! isTaxInfoSet ) {
+				if ( ! taxInfoFromServer?.is_tax_info_set ) {
+					const description = ! taxInfoFromServer?.tax_country_code
+						? translate( 'Country', { textOnly: true } )
+						: translate( 'Postal code', { textOnly: true } );
 					dispatch(
-						errorNotice( translate( 'Please update the missing billing information.' ), {
-							duration: 5000,
-						} )
+						errorNotice(
+							translate( 'Missing required %(description)s field', { args: { description } } ),
+							{
+								duration: 5000,
+							}
+						)
 					);
 				} else {
 					onClick( 'existing-card', {

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -71,10 +71,34 @@
 	}
 }
 
-.payment-method-details__name {
+.existing-credit-card__tax-info-display {
+	display: block;
+}
+
+.payment-method-details__name, .payment-method-details__postal-code, .payment-method-details__country-code {
 	color: var( --color-neutral-50 );
 	display: block;
 	font-size: 0.875rem;
+}
+
+.existing-credit-card__tax-info-display {
+    display: table;
+}
+
+.existing-credit-card__tax-info-postal-country {
+    vertical-align: middle;
+	margin-right: 5px;
+}
+
+.existing-credit-card__tax-info-display button.payment-method-edit-button {
+    vertical-align: middle;
+	text-decoration: underline;
+}
+
+.existing-credit-card__tax-info-display.tax-info-incomplete button.payment-method-edit-button svg {
+	filter: grayscale( 0% );
+	color: var( --color-error );
+	margin-right: 3px;
 }
 
 .payment-method-delete-dialog {
@@ -85,6 +109,10 @@
 	.card-heading {
 		margin-top: 0;
 	}
+}
+
+.payment-method-edit-dialog .dialog__content .notice.is-error.is-compact {
+    margin-bottom: 10px;
 }
 
 .payment-method-backup-toggle {
@@ -105,4 +133,8 @@
 	.components-checkbox-control__input[type='checkbox']:checked {
 		background-color: var( --studio-jetpack-green-50 );
 	}
+}
+
+.payment-method-edit__button {
+	margin-right: 5px;
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -10,11 +10,13 @@ export default function useCreateExistingCards( {
 	stripeLoadingError,
 	storedCards,
 	activePayButtonText = undefined,
+	allowEditingTaxInfo,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	storedCards: StoredCard[];
 	activePayButtonText?: string;
+	allowEditingTaxInfo?: boolean;
 } ): PaymentMethod[] {
 	// The existing card payment methods do not require stripe, but the existing
 	// card processor does require it (for 3DS cards), so we wait to create the
@@ -43,10 +45,11 @@ export default function useCreateExistingCards( {
 					paymentMethodToken: storedDetails.mp_ref,
 					paymentPartnerProcessorId: storedDetails.payment_partner,
 					activePayButtonText,
+					allowEditingTaxInfo,
 				} )
 			) ?? []
 		);
-	}, [ memoizedStoredCards, activePayButtonText ] );
+	}, [ memoizedStoredCards, activePayButtonText, allowEditingTaxInfo ] );
 
 	return shouldLoad ? existingCardMethods : [];
 }

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -28,6 +28,7 @@ export const items = withSchemaValidation( storedCardsSchema, ( state = [], acti
 			const { item } = action;
 			return [ ...state, item ];
 		}
+
 		case STORED_CARDS_FETCH_COMPLETED: {
 			const { list } = action;
 			return list;
@@ -45,7 +46,7 @@ export const items = withSchemaValidation( storedCardsSchema, ( state = [], acti
 					return {
 						...item,
 						meta: [
-							...item.meta?.filter( ( meta ) => meta.meta_key !== 'is_backup' ),
+							...( item.meta?.filter( ( meta ) => meta.meta_key !== 'is_backup' ) ?? {} ),
 							{ meta_key: 'is_backup', meta_value: is_backup ? 'backup' : null },
 						],
 					};

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -84,4 +84,5 @@ export const hasLoadedStoredCardsFromServer = ( state ) =>
 
 export const isDeletingStoredCard = ( state, cardId ) =>
 	Boolean( state.storedCards?.isDeleting[ cardId ] );
+
 export const isFetchingStoredCards = ( state ) => Boolean( state.storedCards?.isFetching );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make sure that anytime we reassign an existing payment method to a WPcom or Jetpack subscription (outside of checkout, for now), that we have the tax location information. Possible use case: added via Akismet, Memberships, or Woo Shipping and then reassigned to WPcom subscription. 

## Testing instructions

### Saving Tax Info
1. Load this branch.
2. Using a WordPress.com Sandbox, patch D69656-code
3. Ensure that `public-api.wordpress.com` and `wordpress.com` are sandboxed.
4. Add a new card. 
5. Since `tax_postal_code` and `tax_country_code` will not yet be set (note they will not show in the card list), a "Missing Billing Information" button will appear on the card in the Purchases > Subscription > Change Payment Method screen, or alternatively, in the checkout payment selection screen.
6. Click the button, and enter in a zip code and country code.
7. Saving the location information should enable the payment type to be selected, as well as save the data to the payment method's meta fields, `tax_postal_code` and `tax_country_code`, in the database. The "Missing Billing Information" button should disappear as well.

### Using a card missing the tax information
1. Select a card with the "Missing Billing Information" button shown.
2. Click "Use this card" if updating an upgrade, or "Pay $XX.XX" if in checkout.
3. A notice should appear prompting the update the billing information, and should not proceed with selecting the card or processing the checkout.

### Using a card with the updated tax information
1. After updating the missing tax info, selecting a card for an upgrade and normal new purchase checkouts should proceed as normal.

### Card updated while in selection or checkout
Updating a card's tax information while in the selection screen or checkout should make it instantly available for use, as long as the Missing Tax Info button disappears.


Related to (544-gh-Automattic/payments-shilling)