### PR TITLE
Onboarding: Add new props to signup step start event

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -13,15 +13,15 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const signupDebug = debug( 'calypso:analytics:signup' );
 
-export function recordSignupStart( flow, ref ) {
+export function recordSignupStart( flow, ref, optionalProps ) {
 	// Tracks
-	recordTracksEvent( 'calypso_signup_start', { flow, ref } );
+	recordTracksEvent( 'calypso_signup_start', { flow, ref, ...optionalProps } );
 	// Google Analytics
 	gaRecordEvent( 'Signup', 'calypso_signup_start' );
 	// Marketing
 	adTrackSignupStart( flow );
 	// FullStory
-	recordFullStoryEvent( 'calypso_signup_start', { flow, ref } );
+	recordFullStoryEvent( 'calypso_signup_start', { flow, ref, ...optionalProps } );
 }
 
 export function recordSignupComplete(
@@ -90,15 +90,21 @@ export function recordSignupComplete(
 	} );
 }
 
-export function recordSignupStep( flow, step ) {
+export function recordSignupStep( flow, step, optionalProps ) {
 	const device = resolveDeviceTypeByViewPort();
+	const props = {
+		flow,
+		step,
+		device,
+		...optionalProps,
+	};
 
-	signupDebug( 'recordSignupStep:', { flow, step, device } );
+	signupDebug( 'recordSignupStep:', props );
 
 	// Tracks
-	recordTracksEvent( 'calypso_signup_step_start', { flow, step, device } );
+	recordTracksEvent( 'calypso_signup_step_start', props );
 	// FullStory
-	recordFullStoryEvent( 'calypso_signup_step_start', { flow, step, device } );
+	recordFullStoryEvent( 'calypso_signup_step_start', props );
 }
 
 export function recordSignupInvalidStep( flow, step ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -240,8 +240,8 @@ class Signup extends Component {
 	componentDidMount() {
 		debug( 'Signup component mounted' );
 		this.startTrackingForBusinessSite();
-		recordSignupStart( this.props.flowName, this.props.refParameter );
-		recordSignupStep( this.props.flowName, this.props.stepName );
+		recordSignupStart( this.props.flowName, this.props.refParameter, this.getRecordProps() );
+		recordSignupStep( this.props.flowName, this.props.stepName, this.getRecordProps() );
 		this.preloadNextStep();
 		this.maybeShowSitePreview();
 	}
@@ -251,7 +251,7 @@ class Signup extends Component {
 			this.props.flowName !== prevProps.flowName ||
 			this.props.stepName !== prevProps.stepName
 		) {
-			recordSignupStep( this.props.flowName, this.props.stepName );
+			recordSignupStep( this.props.flowName, this.props.stepName, this.getRecordProps() );
 		}
 
 		if (
@@ -267,6 +267,16 @@ class Signup extends Component {
 			// `scrollToTop` here handles cases where the viewport may fall slightly below the top of the page when the next step is rendered
 			this.scrollToTop();
 		}
+	}
+
+	getRecordProps() {
+		const { signupDependencies } = this.props;
+
+		return {
+			theme: get( signupDependencies, 'selectedDesign.theme' ),
+			intent: get( signupDependencies, 'intent' ),
+			starting_point: get( signupDependencies, 'startingPoint' ),
+		};
 	}
 
 	scrollToTop() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As 58MP46f44oGKl5Bin5bSp1-fi-3%3A132 mentioned, we should add new props to `calypso_signup_step_start` event to target the actual branch.

  | intent="write" and starting_point="design"  | intent="build" |
  | - | - |
  | ![image](https://user-images.githubusercontent.com/13596067/140878047-4ebe940d-fee0-45f5-97c8-8428190ccb5d.png) | ![image](https://user-images.githubusercontent.com/13596067/140878151-31f69c1a-09ee-4213-adc2-b44b3c6bf793.png) |

* One question is that should we remove the `starting_point` if the “intent” is `build` as we won't clear the value if the user goes back to the previous step?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?loading_ellipsis=1&flags=signup/hero-flow&siteSlug=<your_site>`
* Check following step to see you can differentiate the design picker showing at which branch
  * Select “write” intent > Fill out the site options > Pick "Choose the design” as starting point
  * Select “build” intent
* Checking the Devtool Network Tab to see `calypso_signup_step_start` has the `intent`, `starting_point` props after your selection.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 58MP46f44oGKl5Bin5bSp1-fi-3%3A132