### PR TITLE
Onboarding: Change skip to skip-to-my-home for starting point

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -104,7 +104,7 @@ function getDestinationFromIntent( dependencies ) {
 	const { intent, startingPoint, siteSlug } = dependencies;
 
 	// If the user skips starting point, redirect them to My Home
-	if ( intent === 'write' && startingPoint !== 'skip' ) {
+	if ( intent === 'write' && startingPoint !== 'skip-to-my-home' ) {
 		if ( startingPoint !== 'write' ) {
 			window.sessionStorage.setItem( 'wpcom_signup_complete_show_draft_post_modal', '1' );
 		}

--- a/client/signup/steps/starting-point/index.tsx
+++ b/client/signup/steps/starting-point/index.tsx
@@ -20,7 +20,7 @@ interface Props {
 const EXCLUDE_STEPS: { [ key in StartingPointFlag ]: string[] } = {
 	write: [ 'design-setup-site' ],
 	design: [],
-	skip: [ 'design-setup-site' ],
+	'skip-to-my-home': [ 'design-setup-site' ],
 };
 
 export default function StartingPointStep( props: Props ): React.ReactNode {
@@ -58,7 +58,7 @@ export default function StartingPointStep( props: Props ): React.ReactNode {
 			skipButtonAlign={ 'top' }
 			skipLabelText={ translate( 'Skip to My Home' ) }
 			// We need to redirect user to My Home and apply the default theme if the user skips this step
-			goToNextStep={ () => submitStartingPoint( 'skip' ) }
+			goToNextStep={ () => submitStartingPoint( 'skip-to-my-home' ) }
 			isHorizontalLayout={ true }
 		/>
 	);

--- a/client/signup/steps/starting-point/types.ts
+++ b/client/signup/steps/starting-point/types.ts
@@ -1,1 +1,1 @@
-export type StartingPointFlag = 'write' | 'design' | 'skip';
+export type StartingPointFlag = 'write' | 'design' | 'skip-to-my-home';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* According to the comments 18 of 58MP46f44oGKl5Bin5bSp1-fi-0%3A1, rename the value of `skip` to `skip-to-my-home`

  ![image](https://user-images.githubusercontent.com/13596067/140876986-edc29820-a6d6-4be2-834b-3dc0df57030c.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?loading_ellipsis=1&flags=signup/hero-flow&siteSlug=<your_site>`
* Select write intent > Fill out site options
* When you land on staring point, select `Skip to My Home` 
* Check the Devtool Network Tab to see the `starting_point` of `calypso_signup_starting_point_select` is `skip-to-my-home`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 58MP46f44oGKl5Bin5bSp1-fi-0%3A1