### PR TITLE
Stats: Fix requests to have the http envelope

### DIFF
--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -66,7 +66,6 @@ export function requestSiteStats( siteId, statType, query ) {
 		let apiNamespace;
 		if ( wpcomV1Endpoints.hasOwnProperty( statType ) ) {
 			subpath = wpcomV1Endpoints[ statType ];
-			apiNamespace = 'rest/v1.1';
 		} else if ( wpcomV2Endpoints.hasOwnProperty( statType ) ) {
 			subpath = wpcomV2Endpoints[ statType ];
 			apiNamespace = 'wpcom/v2';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug we introduced in #57518 where we didn't specify requests to have the HTTP envelope.

Fixes #57775.

#### Testing instructions

* Go to `/stats/ads/year/:site` where `:site` has WordAds enabled.
* Verify stats appear properly now.