### PR TITLE
Migrate undocumented().ImportsAnalyzeUrl() to wpcom.req

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1598,25 +1598,4 @@ Undocumented.prototype.getMatchingAnchorSite = function (
 	);
 };
 
-/**
- * Analyze a URL and return various pieces of information about it (platform, colors, meta).
- *
- * @param url {string} Example: www.example.com
- * @param fn {function} Callback function to run when the request completes.
- * @returns {Promise} A promise
- */
-Undocumented.prototype.ImportsAnalyzeUrl = function ( url, fn ) {
-	return this.wpcom.req.get(
-		{
-			path: '/imports/analyze-url',
-			method: 'GET',
-			apiNamespace: 'wpcom/v2',
-		},
-		{
-			site_url: url,
-		},
-		fn
-	);
-};
-
 export default Undocumented;

--- a/client/signup/steps/import/ready/index.tsx
+++ b/client/signup/steps/import/ready/index.tsx
@@ -37,9 +37,9 @@ const ReadyPreviewStep: React.FunctionComponent< ReadyPreviewProps > = ( {
 					<SubTitle>
 						{ createInterpolateElement(
 							sprintf(
-								/* translators: the website could be any domain (eg: "yourname.com") that is hosted by a platform (eg: Wix, Squarespace, Blogger, etc.) */
+								/* translators: the website could be any domain (eg: "yourname.com") that is built with a platform (eg: Wix, Squarespace, Blogger, etc.) */
 								__(
-									'It looks like <strong>%(website)s</strong> is hosted by %(platform)s. To move your existing content to your newly created WordPress.com site, try our %(platform)s importer.'
+									'It looks like <strong>%(website)s</strong> is built with %(platform)s. To move your existing content to your newly created WordPress.com site, try our %(platform)s importer.'
 								),
 								{
 									website: convertToFriendlyWebsiteName( urlData.url ),

--- a/client/state/imports/url-analyzer/actions.ts
+++ b/client/state/imports/url-analyzer/actions.ts
@@ -1,5 +1,5 @@
 import 'calypso/state/imports/init';
-import wpcom from 'calypso/lib/wp';
+import wp from 'calypso/lib/wp';
 import {
 	URL_ANALYZER_ANALYZE_DONE,
 	URL_ANALYZER_ANALYZE,
@@ -18,9 +18,8 @@ export const analyzeUrl = ( url: string ) => (
 		type: URL_ANALYZER_ANALYZE,
 	} );
 
-	return wpcom
-		.undocumented()
-		.ImportsAnalyzeUrl( url )
+	return wp.req
+		.get( { path: '/imports/analyze-url', apiNamespace: 'wpcom/v2' }, { site_url: url } )
 		.then( ( response: UrlData ) => {
 			// Update the state
 			dispatch( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate the `undocumented().importsAnalayzeUrl()` logic to the use `wp.req` directly in the action.

#### Testing instructions

* Go to `/start/importer/capture` and enter a URL
* Check that the URL is analyzed correctly by verifying the details on the next page.

Related to #57426
