### PR TITLE
`TaxonomyManagerList`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -66,7 +66,7 @@ export class TaxonomyManagerList extends Component {
 		}
 
 		return this.getTermChildren( item.ID ).reduce(
-			( memo, childItem ) => memo + this.getItemHeight( childItem, true ),
+			( totalHeight, childItem ) => totalHeight + this.getItemHeight( childItem, true ),
 			ITEM_HEIGHT
 		);
 	};

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -48,7 +48,7 @@ export class TaxonomyManagerList extends Component {
 
 	getTermChildren( termId ) {
 		const { terms } = this.props;
-		return terms.filter( ( term ) => term.parent === termId );
+		return terms?.filter( ( term ) => term.parent === termId ) ?? [];
 	}
 
 	getItemHeight = ( item, _recurse = false ) => {

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -2,7 +2,6 @@ import { CompactCard } from '@automattic/components';
 import { WindowScroller } from '@automattic/react-virtualized';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes, filter, map, reduce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -47,19 +46,9 @@ export class TaxonomyManagerList extends Component {
 		requestedPages: [ 1 ],
 	};
 
-	UNSAFE_componentWillMount() {
-		this.termIds = map( this.props.terms, 'ID' );
-	}
-
-	UNSAFE_componentWillReceiveProps( newProps ) {
-		if ( newProps.terms !== this.props.terms ) {
-			this.termIds = map( newProps.terms, 'ID' );
-		}
-	}
-
 	getTermChildren( termId ) {
 		const { terms } = this.props;
-		return filter( terms, { parent: termId } );
+		return terms.filter( ( term ) => term.parent === termId );
 	}
 
 	getItemHeight = ( item, _recurse = false ) => {
@@ -68,15 +57,12 @@ export class TaxonomyManagerList extends Component {
 		}
 
 		// if item has a parent, and parent is in payload, height is already part of parent
-		if ( item.parent && ! _recurse && includes( this.termIds, item.parent ) ) {
+		if ( item.parent && ! _recurse && this.props.termIds.includes( item.parent ) ) {
 			return 0;
 		}
 
-		return reduce(
-			this.getTermChildren( item.ID ),
-			( memo, childItem ) => {
-				return memo + this.getItemHeight( childItem, true );
-			},
+		return this.getTermChildren( item.ID ).reduce(
+			( memo, childItem ) => memo + this.getItemHeight( childItem, true ),
 			ITEM_HEIGHT
 		);
 	};
@@ -93,7 +79,7 @@ export class TaxonomyManagerList extends Component {
 
 	renderItem( item, _recurse = false ) {
 		// if item has a parent and it is in current props.terms, do not render
-		if ( item.parent && ! _recurse && includes( this.termIds, item.parent ) ) {
+		if ( item.parent && ! _recurse && this.props.termIds.includes( item.parent ) ) {
 			return;
 		}
 		const children = this.getTermChildren( item.ID );
@@ -176,15 +162,20 @@ export class TaxonomyManagerList extends Component {
 	}
 }
 
+const getTermIds = ( terms ) => ( Array.isArray( terms ) ? terms.map( ( term ) => term.ID ) : [] );
+
 export default connect( ( state, ownProps ) => {
 	const { taxonomy, query } = ownProps;
 	const siteId = getSelectedSiteId( state );
+	const terms = getTermsForQueryIgnoringPage( state, siteId, taxonomy, query );
+	const termIds = getTermIds( terms );
 
 	return {
 		loading: isRequestingTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
-		terms: getTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		lastPage: getTermsLastPageForQuery( state, siteId, taxonomy, query ),
-		siteId,
 		query,
+		siteId,
+		termIds,
+		terms,
 	};
 } )( localize( TaxonomyManagerList ) );

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -57,7 +57,11 @@ export class TaxonomyManagerList extends Component {
 		}
 
 		// if item has a parent, and parent is in payload, height is already part of parent
-		if ( item.parent && ! _recurse && this.props.termIds.includes( item.parent ) ) {
+		if (
+			item.parent &&
+			! _recurse &&
+			this.props.terms.some( ( term ) => term.ID === item.parent )
+		) {
 			return 0;
 		}
 
@@ -79,7 +83,11 @@ export class TaxonomyManagerList extends Component {
 
 	renderItem( item, _recurse = false ) {
 		// if item has a parent and it is in current props.terms, do not render
-		if ( item.parent && ! _recurse && this.props.termIds.includes( item.parent ) ) {
+		if (
+			item.parent &&
+			! _recurse &&
+			this.props.terms.some( ( term ) => term.ID === item.parent )
+		) {
 			return;
 		}
 		const children = this.getTermChildren( item.ID );
@@ -162,20 +170,15 @@ export class TaxonomyManagerList extends Component {
 	}
 }
 
-const getTermIds = ( terms ) => ( Array.isArray( terms ) ? terms.map( ( term ) => term.ID ) : [] );
-
 export default connect( ( state, ownProps ) => {
 	const { taxonomy, query } = ownProps;
 	const siteId = getSelectedSiteId( state );
-	const terms = getTermsForQueryIgnoringPage( state, siteId, taxonomy, query );
-	const termIds = getTermIds( terms );
 
 	return {
 		loading: isRequestingTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		lastPage: getTermsLastPageForQuery( state, siteId, taxonomy, query ),
 		query,
 		siteId,
-		termIds,
-		terms,
+		terms: getTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 	};
 } )( localize( TaxonomyManagerList ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `TaxonomyManagerList`: refactor away from `UNSAFE_*`
* also remove usages of lodash in this file

#### Testing instructions

* Go to `settings/taxonomies/category/<site>`, categories should appear as expected
* Switch to `Tags` and make sure everything looks normal there too
