### PR TITLE
Introduce CalypsoDispatch type for thunk-enabled Calypso Redux store

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-partner/index.js
+++ b/client/components/data/query-jetpack-partner-portal-partner/index.js
@@ -9,7 +9,7 @@ export default function QueryJetpackPartnerPortalPartner() {
 
 	useEffect( () => {
 		if ( ! hasFetched ) {
-			dispatch( fetchPartner );
+			dispatch( fetchPartner() );
 		}
 	}, [ hasFetched, dispatch ] );
 

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
@@ -1,12 +1,12 @@
 import { createStripeSetupIntent } from '@automattic/calypso-stripe';
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
 import { saveCreditCard } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { StripeConfiguration, StripeSetupIntent } from '@automattic/calypso-stripe';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 interface Props {
 	useAsPrimaryPaymentMethod?: boolean;
@@ -14,14 +14,14 @@ interface Props {
 	stripe: Stripe | null;
 	stripeConfiguration: StripeConfiguration | null;
 	element: StripeCardNumberElement | undefined;
-	dispatch: ReturnType< typeof useDispatch >;
+	dispatch: CalypsoDispatch;
 }
 
 export async function assignNewCardProcessor(
 	{ useAsPrimaryPaymentMethod, translate, stripe, stripeConfiguration, dispatch, element }: Props,
 	submitData: unknown
 ): Promise< PaymentProcessorResponse > {
-	recordFormSubmitEvent( { dispatch } );
+	dispatch( recordFormSubmitEvent() );
 
 	try {
 		if ( ! isNewCardDataValid( submitData ) ) {
@@ -88,6 +88,6 @@ interface NewCardSubmitData {
 	name: string;
 }
 
-function recordFormSubmitEvent( { dispatch }: { dispatch: ReturnType< typeof useDispatch > } ) {
-	dispatch( recordTracksEvent( 'calypso_partner_portal_add_credit_card_form_submit' ) );
+function recordFormSubmitEvent() {
+	return recordTracksEvent( 'calypso_partner_portal_add_credit_card_form_submit' );
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -68,11 +68,7 @@ export async function assignNewCardProcessor(
 
 		const { name, countryCode, postalCode, useForAllSubscriptions } = submitData;
 
-		recordFormSubmitEvent( {
-			reduxDispatch,
-			purchase,
-			useForAllSubscriptions,
-		} );
+		reduxDispatch( recordFormSubmitEvent( { purchase, useForAllSubscriptions } ) );
 
 		const formFieldValues = {
 			country: countryCode,
@@ -161,7 +157,7 @@ export async function assignExistingCardProcessor(
 	reduxDispatch: CalypsoDispatch,
 	submitData: unknown
 ): Promise< PaymentProcessorResponse > {
-	recordFormSubmitEvent( { reduxDispatch, purchase } );
+	reduxDispatch( recordFormSubmitEvent( { purchase } ) );
 	try {
 		if ( ! isValidExistingCardData( submitData ) ) {
 			throw new Error( 'Credit card data is missing stored details id' );
@@ -194,7 +190,7 @@ export async function assignPayPalProcessor(
 	if ( ! purchase ) {
 		throw new Error( 'Cannot assign PayPal payment method without a purchase' );
 	}
-	recordFormSubmitEvent( { reduxDispatch, purchase } );
+	reduxDispatch( recordFormSubmitEvent( { purchase } ) );
 	return wpcomCreatePayPalAgreement(
 		String( purchase.id ),
 		addQueryArgs( window.location.href, { success: 'true' } ),
@@ -207,22 +203,18 @@ export async function assignPayPalProcessor(
 }
 
 function recordFormSubmitEvent( {
-	reduxDispatch,
 	purchase,
 	useForAllSubscriptions,
 }: {
-	reduxDispatch: CalypsoDispatch;
-	purchase?: Purchase | undefined;
+	purchase?: Purchase;
 	useForAllSubscriptions?: boolean;
 } ) {
-	reduxDispatch(
-		purchase?.productSlug
-			? recordTracksEvent( 'calypso_purchases_credit_card_form_submit', {
-					product_slug: purchase.productSlug,
-					use_for_all_subs: String( useForAllSubscriptions ),
-			  } )
-			: recordTracksEvent( 'calypso_add_credit_card_form_submit', {
-					use_for_all_subs: String( useForAllSubscriptions ),
-			  } )
-	);
+	return purchase?.productSlug
+		? recordTracksEvent( 'calypso_purchases_credit_card_form_submit', {
+				product_slug: purchase.productSlug,
+				use_for_all_subs: String( useForAllSubscriptions ),
+		  } )
+		: recordTracksEvent( 'calypso_add_credit_card_form_submit', {
+				use_for_all_subs: String( useForAllSubscriptions ),
+		  } );
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -6,7 +6,6 @@ import {
 } from '@automattic/composite-checkout';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
 import wp from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateCreditCard, saveCreditCard } from './stored-payment-method-api';
@@ -14,6 +13,7 @@ import type { StripeConfiguration, StripeSetupIntent } from '@automattic/calypso
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
 import type { Purchase } from 'calypso/lib/purchases/types';
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 const wpcomAssignPaymentMethod = (
 	subscriptionId: string,
@@ -50,7 +50,7 @@ export async function assignNewCardProcessor(
 		stripe: Stripe | null;
 		stripeConfiguration: StripeConfiguration | null;
 		cardNumberElement: StripeCardNumberElement | undefined;
-		reduxDispatch: ReturnType< typeof useDispatch >;
+		reduxDispatch: CalypsoDispatch;
 		eventSource?: string;
 	},
 	submitData: unknown
@@ -158,7 +158,7 @@ interface NewCardSubmitData {
 
 export async function assignExistingCardProcessor(
 	purchase: Purchase | undefined,
-	reduxDispatch: ReturnType< typeof useDispatch >,
+	reduxDispatch: CalypsoDispatch,
 	submitData: unknown
 ): Promise< PaymentProcessorResponse > {
 	recordFormSubmitEvent( { reduxDispatch, purchase } );
@@ -189,7 +189,7 @@ interface ExistingCardSubmitData {
 
 export async function assignPayPalProcessor(
 	purchase: Purchase | undefined,
-	reduxDispatch: ReturnType< typeof useDispatch >
+	reduxDispatch: CalypsoDispatch
 ): Promise< PaymentProcessorResponse > {
 	if ( ! purchase ) {
 		throw new Error( 'Cannot assign PayPal payment method without a purchase' );
@@ -211,7 +211,7 @@ function recordFormSubmitEvent( {
 	purchase,
 	useForAllSubscriptions,
 }: {
-	reduxDispatch: ReturnType< typeof useDispatch >;
+	reduxDispatch: CalypsoDispatch;
 	purchase?: Purchase | undefined;
 	useForAllSubscriptions?: boolean;
 } ) {

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -9,11 +9,11 @@ import {
 	PaymentMethod,
 } from 'calypso/lib/checkout/payment-methods';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { ReduxDispatch } from 'calypso/state/redux-store';
 import { deleteStoredCard } from 'calypso/state/stored-cards/actions';
 import { isDeletingStoredCard } from 'calypso/state/stored-cards/selectors';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
 import PaymentMethodDetails from './payment-method-details';
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 interface Props {
 	card: PaymentMethod;
@@ -24,7 +24,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const isDeleting = useSelector( ( state ) =>
 		isDeletingStoredCard( state, card.stored_details_id )
 	);
-	const reduxDispatch = useDispatch< ReduxDispatch >();
+	const reduxDispatch = useDispatch< CalypsoDispatch >();
 	const [ isDialogVisible, setIsDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );
 

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -8,6 +8,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { ResponseCartMessage } from '@automattic/shopping-cart';
+import type { CalypsoDispatch } from 'calypso/state/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 function CartMessage( { message }: { message: ResponseCartMessage } ): JSX.Element {
@@ -154,7 +155,7 @@ function getNoticeIdForMessage( message: ResponseCartMessage ): string {
 
 function showMessages(
 	messages: ResponseCartMessage[],
-	reduxDispatch: ReturnType< typeof useDispatch >,
+	reduxDispatch: CalypsoDispatch,
 	messageType: 'error' | 'success'
 ): void {
 	const messageActionCreator = messageType === 'error' ? errorNotice : successNotice;

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -18,7 +18,6 @@ import {
 	getRenewableSitePurchases,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import { ReduxDispatch } from 'calypso/state/redux-store';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { RequestCartProduct } from '@automattic/shopping-cart';
 import type { Purchase } from 'calypso/lib/purchases/types';
@@ -53,7 +52,7 @@ interface Props {
 }
 
 const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemToCart } ) => {
-	const reduxDispatch = useDispatch< ReduxDispatch >();
+	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) as SelectedSite );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -46,6 +46,7 @@ import type {
 } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { WPCOMTransactionEndpointResponse, Purchase } from '@automattic/wpcom-checkout';
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-on-payment-complete' );
 
@@ -282,7 +283,7 @@ function displayRenewalSuccessNotice(
 	purchases: Record< number, Purchase[] >,
 	translate: ReturnType< typeof useTranslate >,
 	moment: ReturnType< typeof useLocalizedMoment >,
-	reduxDispatch: ReturnType< typeof useDispatch >
+	reduxDispatch: CalypsoDispatch
 ): void {
 	const renewalItem = getRenewalItems( responseCart )[ 0 ];
 	// group all purchases into an array
@@ -355,7 +356,7 @@ function recordPaymentCompleteAnalytics( {
 	redirectUrl: string;
 	responseCart: ResponseCart;
 	checkoutFlow?: string;
-	reduxDispatch: ReturnType< typeof useDispatch >;
+	reduxDispatch: CalypsoDispatch;
 } ) {
 	const wpcomPaymentMethod = paymentMethodId
 		? translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId )

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -6,10 +6,7 @@ import {
 	isRedirectPaymentMethod,
 } from '../lib/translate-payment-method-names';
 import type { CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
-import type { AnyAction } from 'redux';
-import type { ThunkDispatch } from 'redux-thunk';
-
-type Dispatch = ThunkDispatch< unknown, void, AnyAction >;
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 export function logStashLoadErrorEvent(
 	errorType: string,
@@ -44,7 +41,7 @@ export const recordCompositeCheckoutErrorDuringAnalytics = ( {
 }: {
 	errorObject: unknown;
 	failureDescription: string;
-} ) => ( dispatch: Dispatch ): void => {
+} ) => ( dispatch: CalypsoDispatch ): void => {
 	// This is a fallback to catch any errors caused by the analytics code
 	// Anything in this block should remain very simple and extremely
 	// tolerant of any kind of data. It should make no assumptions about
@@ -64,7 +61,7 @@ export const recordTransactionBeginAnalytics = ( {
 	paymentMethodId,
 }: {
 	paymentMethodId: CheckoutPaymentMethodSlug;
-} ) => ( dispatch: Dispatch ): void => {
+} ) => ( dispatch: CalypsoDispatch ): void => {
 	try {
 		if ( isRedirectPaymentMethod( paymentMethodId ) ) {
 			dispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -8,7 +8,6 @@ import {
 import { useEvents } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -37,13 +36,14 @@ import type {
 	RawContactValidationResponseMessages,
 	ContactValidationResponseMessages,
 } from '@automattic/wpcom-checkout';
+import type { CalypsoDispatch } from 'calypso/state/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 const debug = debugFactory( 'calypso:composite-checkout:contact-validation' );
 
 const getEmailTakenLoginRedirectMessage = (
 	emailAddress: string,
-	reduxDispatch: ReturnType< typeof useDispatch >,
+	reduxDispatch: CalypsoDispatch,
 	translate: ReturnType< typeof useTranslate >
 ) => {
 	const { href, pathname } = window.location;
@@ -107,7 +107,7 @@ async function runContactValidationCheck(
 
 async function runLoggedOutEmailValidationCheck(
 	contactInfo: ManagedContactDetails,
-	reduxDispatch: ReturnType< typeof useDispatch >,
+	reduxDispatch: CalypsoDispatch,
 	translate: ReturnType< typeof useTranslate >
 ): Promise< unknown > {
 	const email = contactInfo.email?.value ?? '';
@@ -125,7 +125,7 @@ export async function validateContactDetails(
 	showErrorMessageBriefly: ( message: string ) => void,
 	applyDomainContactValidationResults: ( results: ManagedContactDetailsErrors ) => void,
 	clearDomainContactErrorMessages: () => void,
-	reduxDispatch: ReturnType< typeof useDispatch >,
+	reduxDispatch: CalypsoDispatch,
 	translate: ReturnType< typeof useTranslate >,
 	shouldDisplayErrors: boolean
 ): Promise< boolean > {

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -1,10 +1,10 @@
-import { useDispatch } from 'react-redux';
 import type { GetThankYouUrl } from '../hooks/use-get-thank-you-url';
 import type { ReactStandardAction } from '../types/analytics';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 import type { Stripe } from '@stripe/stripe-js';
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 export interface PaymentProcessorOptions {
 	includeDomainDetails: boolean;
@@ -13,7 +13,7 @@ export interface PaymentProcessorOptions {
 	stripe: Stripe | null;
 	stripeConfiguration: StripeConfiguration | null;
 	recordEvent: ( action: ReactStandardAction ) => void;
-	reduxDispatch: ReturnType< typeof useDispatch >;
+	reduxDispatch: CalypsoDispatch;
 	responseCart: ResponseCart;
 	getThankYouUrl: GetThankYouUrl;
 	siteSlug: string | undefined;

--- a/client/state/partner-portal/licenses/actions.ts
+++ b/client/state/partner-portal/licenses/actions.ts
@@ -18,7 +18,6 @@ import {
 	PaginatedItems,
 	PartnerPortalThunkAction,
 } from 'calypso/state/partner-portal/types';
-import { ReduxDispatch } from 'calypso/state/redux-store';
 
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
@@ -37,7 +36,7 @@ export function fetchLicenses(
 	sortDirection: LicenseSortDirection,
 	page: number
 ): PartnerPortalThunkAction {
-	return ( dispatch: ReduxDispatch ): void => {
+	return ( dispatch ) => {
 		dispatch(
 			createHttpAction( {
 				type: JETPACK_PARTNER_PORTAL_LICENSES_REQUEST,

--- a/client/state/partner-portal/partner/actions.ts
+++ b/client/state/partner-portal/partner/actions.ts
@@ -12,19 +12,13 @@ import {
 	getActivePartnerKeyId,
 	isFetchingPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
-import {
-	APIError,
-	Partner,
-	PartnerPortalStore,
-	PartnerPortalThunkAction,
-} from 'calypso/state/partner-portal/types';
-import { ReduxDispatch } from 'calypso/state/redux-store';
+import { APIError, Partner, PartnerPortalThunkAction } from 'calypso/state/partner-portal/types';
 
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
 
 export function setActivePartnerKey( partnerKeyId: number ): PartnerPortalThunkAction {
-	return ( dispatch: ReduxDispatch, getState: () => PartnerPortalStore ) => {
+	return ( dispatch, getState ) => {
 		if ( ! partnerKeyId || isFetchingPartner( getState() ) ) {
 			return;
 		}
@@ -36,16 +30,18 @@ export function setActivePartnerKey( partnerKeyId: number ): PartnerPortalThunkA
 	};
 }
 
-export function fetchPartner( dispatch: ReduxDispatch, getState: () => PartnerPortalStore ): void {
-	if ( isFetchingPartner( getState() ) ) {
-		return;
-	}
+export function fetchPartner(): PartnerPortalThunkAction {
+	return ( dispatch, getState ) => {
+		if ( isFetchingPartner( getState() ) ) {
+			return;
+		}
 
-	dispatch( { type: JETPACK_PARTNER_PORTAL_PARTNER_REQUEST } );
+		dispatch( { type: JETPACK_PARTNER_PORTAL_PARTNER_REQUEST } );
+	};
 }
 
 export function receivePartner( partner: Partner ): PartnerPortalThunkAction {
-	return ( dispatch: ReduxDispatch, getState: () => PartnerPortalStore ): void => {
+	return ( dispatch, getState ) => {
 		dispatch( {
 			type: JETPACK_PARTNER_PORTAL_PARTNER_RECEIVE,
 			partner,
@@ -72,7 +68,7 @@ export function receivePartner( partner: Partner ): PartnerPortalThunkAction {
 }
 
 export function receivePartnerError( error: APIError ): PartnerPortalThunkAction {
-	return ( dispatch: ReduxDispatch ): void => {
+	return ( dispatch ) => {
 		dispatch( {
 			type: JETPACK_PARTNER_PORTAL_PARTNER_RECEIVE_ERROR,
 			error: {

--- a/client/state/redux-store.ts
+++ b/client/state/redux-store.ts
@@ -1,9 +1,5 @@
-import { Reducer, Store, Action } from 'redux';
-import { ThunkDispatch } from 'redux-thunk';
+import { Reducer, Store } from 'redux';
 import { addReducerToStore, clear as clearReducers, WithAddReducer } from './add-reducer';
-import { getInitialState } from './initial-state';
-
-export type ReduxDispatch = ThunkDispatch< ReturnType< typeof getInitialState >, unknown, Action >;
 
 type QueueEntry = [ string[], Reducer ];
 

--- a/client/state/types.ts
+++ b/client/state/types.ts
@@ -1,11 +1,18 @@
-import { DefaultRootState } from 'react-redux';
-import { IMarketplaceState } from 'calypso/state/marketplace/types';
-import { IPluginsState } from 'calypso/state/plugins/reducer';
+import type { IMarketplaceState } from 'calypso/state/marketplace/types';
+import type { IPluginsState } from 'calypso/state/plugins/reducer';
+import type { DefaultRootState } from 'react-redux';
+import type { AnyAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
 
 /**
  * This global app state is currently incomplete and should be completed as each state slice becomes typed
- * */
+ */
 export interface IAppState extends DefaultRootState {
 	plugins: IPluginsState;
 	marketplace: IMarketplaceState;
 }
+
+/**
+ * Type of the Calypso Redux store `dispatch` function. Accepts both plain actions and thunks.
+ */
+export type CalypsoDispatch = ThunkDispatch< unknown, void, AnyAction >;

--- a/client/state/user-licensing/actions.ts
+++ b/client/state/user-licensing/actions.ts
@@ -17,8 +17,7 @@ import {
 } from 'calypso/state/action-types';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
-import { ReduxDispatch } from 'calypso/state/redux-store';
-import {
+import type {
 	LicenseCounts,
 	PaginatedItems,
 	License,
@@ -69,7 +68,7 @@ export const licensesRequestFailureAction = (
 ): UserLicensingThunkAction => ( dispatch ) => {
 	dispatch( {
 		type: USER_LICENSES_REQUEST_FAILURE,
-		error: error,
+		error,
 	} );
 	return dispatch(
 		errorNotice( translate( 'Failed to retrieve your licenses. Please try again later.' ) )
@@ -82,18 +81,16 @@ export const requestLicenses = (
 	sortField?: LicenseSortField,
 	sortDirection?: LicenseSortDirection,
 	page?: number
-): UserLicensingThunkAction => {
-	return ( dispatch: ReduxDispatch ) => {
-		dispatch( {
-			type: USER_LICENSES_REQUEST,
-			filter,
-			search,
-			sortField,
-			sortDirection,
-			page: page,
-			perPage: LICENSES_PER_PAGE,
-		} );
+): UserLicensingThunkAction => ( dispatch ) => {
+	dispatch( {
+		type: USER_LICENSES_REQUEST,
+		filter,
+		search,
+		sortField,
+		sortDirection,
+		page,
+		perPage: LICENSES_PER_PAGE,
+	} );
 
-		dispatch( requestLicensesCounts() );
-	};
+	dispatch( requestLicensesCounts() );
 };


### PR DESCRIPTION
In the most general case, it's unclear what is the TypeScript type of a Redux action, the `store.dispatch` function or of the `dispatch` function returned by `useDispatch`. It depends on the specific store, more precisely on its middlewares. A vanilla store accepts only objects with a `type` field, `redux-thunk` allows dispatching functions of a certain type...

At many places in Calypso we want to specify the type of the `dispatch`-like functions and until now we've done this inconsistently.

This PR introduces a `CalypsoDispatch` type, importable from the `calypso/state/types` module. It replaces the existing `ReduxDispatch` type exported from `client/state/redux-store.js`, and changes the `State` type param from `any` to `unknown`.

It also replaces existing usages of `ReturnType< typeof useDispatch >` that was often used to type dispatch-like parameter, but was unreliable because it didn't support thunks.

Using the `CalypsoDispatch` type is also needed to write type-safe code that dispatches thunks and uses the return values:
```ts
const fetchAction = () => async ( dispatch ) => {
  const data = await wpcom.req.get( '/stuff' );
  dispatch( { type: SET_STUFF, data } );
  return data;
}

const dispatch = useDispatch< CalypsoDispatch >();

dispatch( fetchAction() ).then( data => { /* ... */ } );
```
Without specifying the `CalypsoDispatch` type for `useDispatch`, TypeScript wouldn't let you call `.then` on the return value because it can't infer it from the return type of the `fetchAction` thunk.

**How to test:**
This changes only types, not any other code, except two functions:
- the `fetchPartner` function from `state/partner-portal` was converted to action creator -- one extra `()`.
- the `recordFormSubmitEvent` function in `assignment-processor-functions.ts` is now an action creator, not a function with a `{ dispatch }` params object.