### PR TITLE
`TermFormDialog`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -147,13 +147,14 @@ class TermFormDialog extends Component {
 		this.state = this.constructor.initialState;
 	}
 
-	init( props ) {
-		if ( ! props.term ) {
-			if ( props.searchTerm && props.searchTerm.trim().length ) {
+	init() {
+		const { term, searchTerm } = this.props;
+		if ( ! term ) {
+			if ( searchTerm && searchTerm.trim().length ) {
 				this.setState(
 					{
 						...this.constructor.initialState,
-						name: props.searchTerm,
+						name: searchTerm,
 					},
 					this.isValid
 				);
@@ -164,7 +165,7 @@ class TermFormDialog extends Component {
 			return;
 		}
 
-		const { name, description, parent = false } = props.term;
+		const { name, description, parent = false } = term;
 		this.setState( {
 			...this.constructor.initialState,
 			name,
@@ -177,12 +178,12 @@ class TermFormDialog extends Component {
 	componentDidUpdate( prevProps ) {
 		const { term, showDialog } = this.props;
 		if ( term !== prevProps.term || ( showDialog !== prevProps.showDialog && showDialog ) ) {
-			this.init( this.props );
+			this.init();
 		}
 	}
 
 	componentDidMount() {
-		this.init( this.props );
+		this.init();
 	}
 
 	getFormValues() {

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -247,7 +247,7 @@ class TermFormDialog extends Component {
 		if ( searchTerm && searchTerm.length ) {
 			query.search = searchTerm;
 		}
-		const hideTermAndChildren = term?.ID;
+		const hideTermAndChildren = !! term?.ID;
 		const isError = !! this.state.errors.parent;
 
 		// if there is only one term for the site, and we are editing that term

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -175,12 +175,10 @@ class TermFormDialog extends Component {
 		} );
 	}
 
-	UNSAFE_componentWillReceiveProps( newProps ) {
-		if (
-			this.props.term !== newProps.term ||
-			( this.props.showDialog !== newProps.showDialog && newProps.showDialog )
-		) {
-			this.init( newProps );
+	componentDidUpdate( prevProps ) {
+		const { term, showDialog } = this.props;
+		if ( term !== prevProps.term || ( showDialog !== prevProps.showDialog && showDialog ) ) {
+			this.init( this.props );
 		}
 	}
 

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -209,7 +209,7 @@ class TermFormDialog extends Component {
 			errors.name = this.props.translate( 'Name required', { textOnly: true } );
 		}
 		const lowerCasedTermName = values.name.toLowerCase();
-		const matchingTerm = this.props.terms.find(
+		const matchingTerm = this.props.terms?.find(
 			( term ) =>
 				term.name.toLowerCase() === lowerCasedTermName &&
 				( ! this.props.term || term.ID !== this.props.term.ID )

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -2,7 +2,6 @@ import { Dialog } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { get, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -209,12 +208,11 @@ class TermFormDialog extends Component {
 			errors.name = this.props.translate( 'Name required', { textOnly: true } );
 		}
 		const lowerCasedTermName = values.name.toLowerCase();
-		const matchingTerm = find( this.props.terms, ( term ) => {
-			return (
+		const matchingTerm = this.props.terms.find(
+			( term ) =>
 				term.name.toLowerCase() === lowerCasedTermName &&
 				( ! this.props.term || term.ID !== this.props.term.ID )
-			);
-		} );
+		);
 		if ( matchingTerm ) {
 			errors.name = this.props.translate( 'Name already exists', {
 				context: 'Terms: Add term error message - duplicate term name exists',
@@ -242,13 +240,13 @@ class TermFormDialog extends Component {
 	}
 
 	renderParentSelector() {
-		const { labels, siteId, taxonomy, translate, terms } = this.props;
+		const { labels, siteId, taxonomy, translate, terms, term } = this.props;
 		const { isTopLevel, searchTerm, selectedParent } = this.state;
 		const query = {};
 		if ( searchTerm && searchTerm.length ) {
 			query.search = searchTerm;
 		}
-		const hideTermAndChildren = get( this.props.term, 'ID' );
+		const hideTermAndChildren = term?.ID;
 		const isError = !! this.state.errors.parent;
 
 		// if there is only one term for the site, and we are editing that term
@@ -379,8 +377,8 @@ export default connect(
 		const { taxonomy, postType } = ownProps;
 		const siteId = getSelectedSiteId( state );
 		const taxonomyDetails = getPostTypeTaxonomy( state, siteId, postType, taxonomy );
-		const labels = get( taxonomyDetails, 'labels', {} );
-		const isHierarchical = get( taxonomyDetails, 'hierarchical', false );
+		const labels = taxonomyDetails?.labels ?? {};
+		const isHierarchical = taxonomyDetails?.hierarchical ?? false;
 
 		return {
 			terms: getTerms( state, siteId, taxonomy ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `TermFormDialog`: refactor away from `UNSAFE_*`
* also remove any lodash usage from that file

#### Testing instructions

* Go to `/settings/taxonomies/category/<site>` and hit `Add new Category`
* Enter a name which already exists and notice the error message
* Now choose a non-existent name and make it a child category, choose a parent and hit _Add_)
* Make sure all that works as expected
