### PR TITLE
`TimeSince`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/time-since/docs/example.jsx
+++ b/client/components/time-since/docs/example.jsx
@@ -5,7 +5,13 @@ const TimeSinceExample = () => {
 	return (
 		<div>
 			<div>
+				<TimeSince date={ moment().subtract( 30, 'seconds' ).toDate() } />
+			</div>
+			<div>
 				<TimeSince date={ moment().subtract( 5, 'minutes' ).toDate() } />
+			</div>
+			<div>
+				<TimeSince date={ moment().subtract( 3, 'days' ).toDate() } />
 			</div>
 			<div>
 				<TimeSince date={ moment().subtract( 5, 'months' ).toDate() } />

--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -1,40 +1,36 @@
 import moment from 'moment';
-import { PureComponent } from 'react';
-import humanDate from 'calypso/lib/human-date';
-import { Interval, EVERY_TEN_SECONDS } from 'calypso/lib/interval';
-import smartSetState from 'calypso/lib/react-smart-set-state';
+import { useState, useEffect } from 'react';
+import getHumanDate from 'calypso/lib/human-date';
+import { useInterval, EVERY_TEN_SECONDS } from 'calypso/lib/interval';
 
-export default class TimeSince extends PureComponent {
-	smartSetState = smartSetState;
+function TimeSince( { className, date, dateFormat } ) {
+	const [ humanDate, setHumanDate ] = useState( '' );
+	const [ fullDate, setFullDate ] = useState( '' );
 
-	UNSAFE_componentWillMount() {
-		this.update();
+	function update( newDate ) {
+		const newHumanDate = getHumanDate( newDate ?? date, dateFormat );
+		const newFullDate = moment( newDate ?? date ).format( 'llll' );
+
+		if ( newHumanDate !== humanDate ) {
+			setHumanDate( newHumanDate );
+		}
+
+		if ( newFullDate !== fullDate ) {
+			setFullDate( newFullDate );
+		}
 	}
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.update( nextProps.date );
-	}
+	useInterval( update, EVERY_TEN_SECONDS );
 
-	update = ( date ) => {
-		const { dateFormat } = this.props;
-		date = date || this.props.date;
+	useEffect( () => {
+		update( date );
+	}, [ update, date ] );
 
-		this.smartSetState( {
-			humanDate: humanDate( date, dateFormat ),
-			fullDate: moment( date ).format( 'llll' ),
-		} );
-	};
-
-	render() {
-		return (
-			<time
-				className={ this.props.className }
-				dateTime={ this.props.date }
-				title={ this.state.fullDate }
-			>
-				<Interval period={ EVERY_TEN_SECONDS } onTick={ this.update } />
-				{ this.state.humanDate }
-			</time>
-		);
-	}
+	return (
+		<time className={ className } dateTime={ date } title={ fullDate }>
+			{ humanDate }
+		</time>
+	);
 }
+
+export default TimeSince;

--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useHumanDate } from 'calypso/lib/human-date';
 
-function TimeSince( { className, date, dateFormat } ) {
+function TimeSince( { className, date, dateFormat = 'll' } ) {
 	const moment = useLocalizedMoment();
 	const fullDate = useMemo( () => moment( date ).format( 'llll' ), [ moment, date ] );
 	const humanDate = useHumanDate( date, dateFormat );

--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -1,26 +1,11 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import getHumanDate from 'calypso/lib/human-date';
-import { useInterval, EVERY_TEN_SECONDS } from 'calypso/lib/interval';
+import { useHumanDate } from 'calypso/lib/human-date';
 
 function TimeSince( { className, date, dateFormat } ) {
-	const [ humanDate, setHumanDate ] = useState( '' );
 	const moment = useLocalizedMoment();
 	const fullDate = useMemo( () => moment( date ).format( 'llll' ), [ moment, date ] );
-
-	function update() {
-		const newHumanDate = getHumanDate( date, dateFormat );
-
-		if ( newHumanDate !== humanDate ) {
-			setHumanDate( newHumanDate );
-		}
-	}
-
-	useInterval( update, EVERY_TEN_SECONDS );
-
-	useEffect( () => {
-		update();
-	}, [] );
+	const humanDate = useHumanDate( date, dateFormat );
 
 	return (
 		<time className={ className } dateTime={ date } title={ fullDate }>

--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -1,30 +1,26 @@
-import moment from 'moment';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import getHumanDate from 'calypso/lib/human-date';
 import { useInterval, EVERY_TEN_SECONDS } from 'calypso/lib/interval';
 
 function TimeSince( { className, date, dateFormat } ) {
 	const [ humanDate, setHumanDate ] = useState( '' );
-	const [ fullDate, setFullDate ] = useState( '' );
+	const moment = useLocalizedMoment();
+	const fullDate = useMemo( () => moment( date ).format( 'llll' ), [ moment, date ] );
 
-	function update( newDate ) {
-		const newHumanDate = getHumanDate( newDate ?? date, dateFormat );
-		const newFullDate = moment( newDate ?? date ).format( 'llll' );
+	function update() {
+		const newHumanDate = getHumanDate( date, dateFormat );
 
 		if ( newHumanDate !== humanDate ) {
 			setHumanDate( newHumanDate );
-		}
-
-		if ( newFullDate !== fullDate ) {
-			setFullDate( newFullDate );
 		}
 	}
 
 	useInterval( update, EVERY_TEN_SECONDS );
 
 	useEffect( () => {
-		update( date );
-	}, [ update, date ] );
+		update();
+	}, [] );
 
 	return (
 		<time className={ className } dateTime={ date } title={ fullDate }>

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -20,9 +20,7 @@ export function getHumanDateString( now, date, dateFormat, moment, translate ) {
 	if ( millisAgo < MILLIS_IN_MINUTE * 60 ) {
 		const minutes = Math.ceil( millisAgo / MILLIS_IN_MINUTE );
 		return translate( '%(minutes)dm ago', {
-			args: {
-				minutes: minutes,
-			},
+			args: { minutes },
 			comment: 'example for a resulting string: 2m ago',
 		} );
 	}
@@ -30,9 +28,7 @@ export function getHumanDateString( now, date, dateFormat, moment, translate ) {
 	if ( millisAgo < MILLIS_IN_MINUTE * 60 * 24 ) {
 		const hours = now.diff( date, 'hours' );
 		return translate( '%(hours)dh ago', {
-			args: {
-				hours: hours,
-			},
+			args: { hours },
 			comment: 'example for a resulting string: 5h ago',
 		} );
 	}
@@ -40,9 +36,7 @@ export function getHumanDateString( now, date, dateFormat, moment, translate ) {
 	if ( millisAgo < MILLIS_IN_MINUTE * 60 * 24 * 7 ) {
 		const days = now.diff( date, 'days' );
 		return translate( '%(days)dd ago', {
-			args: {
-				days: days,
-			},
+			args: { days },
 			comment: 'example for a resulting string: 4d ago',
 		} );
 	}

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useReducer, useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { EVERY_TEN_SECONDS, useInterval } from 'calypso/lib/interval';
 const MILLIS_IN_MINUTE = 60 * 1000;
@@ -53,23 +53,11 @@ function getHumanDateString( dateOrMoment, dateFormat, moment, translate ) {
 export function useHumanDate( dateOrMoment, dateFormat, interval = EVERY_TEN_SECONDS ) {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
-	const [ humanDate, setHumanDate ] = useState(
-		getHumanDateString( dateOrMoment, dateFormat, moment, translate )
-	);
+	const [ tick, doTick ] = useReducer( ( t ) => t + 1, 0 );
 
-	useInterval( () => {
-		const newHumanDateString = getHumanDateString( dateOrMoment, dateFormat, moment, translate );
-		if ( humanDate !== newHumanDateString ) {
-			setHumanDate( newHumanDateString );
-		}
-	}, interval );
+	useInterval( doTick, interval );
 
-	useEffect( () => {
-		const newHumanDateString = getHumanDateString( dateOrMoment, dateFormat, moment, translate );
-		if ( humanDate !== newHumanDateString ) {
-			setHumanDate( newHumanDateString );
-		}
-	}, [ setHumanDate, humanDate, dateOrMoment, dateFormat, moment, translate ] );
-
-	return humanDate;
+	return useMemo( () => {
+		return getHumanDateString( dateOrMoment, dateFormat, moment, translate );
+	}, [ tick, dateOrMoment, dateFormat, moment, translate ] );
 }

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -4,11 +4,11 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { EVERY_TEN_SECONDS, useInterval } from 'calypso/lib/interval';
 const MILLIS_IN_MINUTE = 60 * 1000;
 
-function getHumanDateString( dateOrMoment, dateFormat, moment, translate ) {
+function getHumanDateString( date, dateFormat, moment, translate ) {
 	const now = moment();
-	dateOrMoment = moment( dateOrMoment );
+	date = moment( date );
 
-	let millisAgo = now.diff( dateOrMoment );
+	let millisAgo = now.diff( date );
 	if ( millisAgo < 0 ) {
 		millisAgo = 0;
 	}
@@ -28,7 +28,7 @@ function getHumanDateString( dateOrMoment, dateFormat, moment, translate ) {
 	}
 
 	if ( millisAgo < MILLIS_IN_MINUTE * 60 * 24 ) {
-		const hours = now.diff( dateOrMoment, 'hours' );
+		const hours = now.diff( date, 'hours' );
 		return translate( '%(hours)dh ago', {
 			args: {
 				hours: hours,
@@ -38,7 +38,7 @@ function getHumanDateString( dateOrMoment, dateFormat, moment, translate ) {
 	}
 
 	if ( millisAgo < MILLIS_IN_MINUTE * 60 * 24 * 7 ) {
-		const days = now.diff( dateOrMoment, 'days' );
+		const days = now.diff( date, 'days' );
 		return translate( '%(days)dd ago', {
 			args: {
 				days: days,
@@ -47,10 +47,10 @@ function getHumanDateString( dateOrMoment, dateFormat, moment, translate ) {
 		} );
 	}
 
-	return dateOrMoment.format( dateFormat );
+	return date.format( dateFormat );
 }
 
-export function useHumanDate( dateOrMoment, dateFormat, interval = EVERY_TEN_SECONDS ) {
+export function useHumanDate( date, dateFormat, interval = EVERY_TEN_SECONDS ) {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 	const [ tick, doTick ] = useReducer( ( t ) => t + 1, 0 );
@@ -58,6 +58,6 @@ export function useHumanDate( dateOrMoment, dateFormat, interval = EVERY_TEN_SEC
 	useInterval( doTick, interval );
 
 	return useMemo( () => {
-		return getHumanDateString( dateOrMoment, dateFormat, moment, translate );
-	}, [ tick, dateOrMoment, dateFormat, moment, translate ] );
+		return getHumanDateString( date, dateFormat, moment, translate );
+	}, [ tick, date, dateFormat, moment, translate ] );
 }

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -6,6 +6,7 @@ const MILLIS_IN_MINUTE = 60 * 1000;
 
 function getHumanDateString( now, date, dateFormat, moment, translate ) {
 	date = moment( date );
+	now = moment( now );
 
 	let millisAgo = now.diff( date );
 	if ( millisAgo < 0 ) {
@@ -51,10 +52,10 @@ function getHumanDateString( now, date, dateFormat, moment, translate ) {
 
 export function useHumanDate( date, dateFormat, interval = EVERY_TEN_SECONDS ) {
 	const moment = useLocalizedMoment();
-	const [ now, setNow ] = useState( () => moment() );
+	const [ now, setNow ] = useState( () => new Date() );
 	const translate = useTranslate();
 
-	useInterval( () => setNow( moment() ), interval );
+	useInterval( () => setNow( new Date() ), interval );
 
 	return useMemo( () => {
 		return getHumanDateString( now, date, dateFormat, moment, translate );

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -4,7 +4,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { EVERY_TEN_SECONDS, useInterval } from 'calypso/lib/interval';
 const MILLIS_IN_MINUTE = 60 * 1000;
 
-function getHumanDateString( now, date, dateFormat, moment, translate ) {
+export function getHumanDateString( now, date, dateFormat, moment, translate ) {
 	date = moment( date );
 	now = moment( now );
 

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -1,11 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
-import { useReducer, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { EVERY_TEN_SECONDS, useInterval } from 'calypso/lib/interval';
 const MILLIS_IN_MINUTE = 60 * 1000;
 
-function getHumanDateString( date, dateFormat, moment, translate ) {
-	const now = moment();
+function getHumanDateString( now, date, dateFormat, moment, translate ) {
 	date = moment( date );
 
 	let millisAgo = now.diff( date );
@@ -52,12 +51,12 @@ function getHumanDateString( date, dateFormat, moment, translate ) {
 
 export function useHumanDate( date, dateFormat, interval = EVERY_TEN_SECONDS ) {
 	const moment = useLocalizedMoment();
+	const [ now, setNow ] = useState( () => moment() );
 	const translate = useTranslate();
-	const [ tick, doTick ] = useReducer( ( t ) => t + 1, 0 );
 
-	useInterval( doTick, interval );
+	useInterval( () => setNow( moment() ), interval );
 
 	return useMemo( () => {
-		return getHumanDateString( date, dateFormat, moment, translate );
-	}, [ tick, date, dateFormat, moment, translate ] );
+		return getHumanDateString( now, date, dateFormat, moment, translate );
+	}, [ now, date, dateFormat, moment, translate ] );
 }

--- a/client/lib/human-date/test/index.js
+++ b/client/lib/human-date/test/index.js
@@ -2,41 +2,54 @@
  * @jest-environment jsdom
  */
 
+import { translate } from 'i18n-calypso';
 import moment from 'moment';
-import humanDate from '..';
+import { getHumanDateString } from '..';
 
 describe( 'humanDate', () => {
-	it( 'should work without a provided format or locale', () => {
+	it( 'should work without a provided format', () => {
 		const now = new Date();
-		expect( humanDate( now ) ).not.toBeFalsy();
+		expect( getHumanDateString( now, now, null, moment, translate ) ).not.toBeFalsy();
 	} );
 
 	it( 'should work without a provided locale', () => {
 		const now = new Date();
-		expect( humanDate( now, 'll' ) ).not.toBeFalsy();
+		expect( getHumanDateString( now, now, 'll', moment, translate ) ).not.toBeFalsy();
 	} );
 
 	it( 'should return relative strings for recent dates', () => {
+		const now = new Date();
 		const aSecondAndHalfAgo = new Date( Date.now() - 1500 );
-		expect( humanDate( aSecondAndHalfAgo, 'll', 'en' ) ).toBe( 'just now' );
-		expect( humanDate( aSecondAndHalfAgo, 'l', 'en' ) ).toBe( 'just now' );
+		expect( getHumanDateString( now, aSecondAndHalfAgo, 'll', moment, translate ) ).toBe(
+			'just now'
+		);
+		expect( getHumanDateString( now, aSecondAndHalfAgo, 'l', moment, translate ) ).toBe(
+			'just now'
+		);
 
 		const aMinuteAndHalfAgo = new Date( Date.now() - 90 * 1000 );
-		expect( humanDate( aMinuteAndHalfAgo, 'll', 'en' ) ).toBe( '2m ago' );
-		expect( humanDate( aMinuteAndHalfAgo, 'l', 'en' ) ).toBe( '2m ago' );
+		expect( getHumanDateString( now, aMinuteAndHalfAgo, 'll', moment, translate ) ).toBe(
+			'2m ago'
+		);
+		expect( getHumanDateString( now, aMinuteAndHalfAgo, 'l', moment, translate ) ).toBe( '2m ago' );
 
 		const anHourAndHalfAgo = new Date( Date.now() - 90 * 60 * 1000 );
-		expect( humanDate( anHourAndHalfAgo, 'll', 'en' ) ).toBe( '1h ago' );
-		expect( humanDate( anHourAndHalfAgo, 'l', 'en' ) ).toBe( '1h ago' );
+		expect( getHumanDateString( now, anHourAndHalfAgo, 'll', moment, translate ) ).toBe( '1h ago' );
+		expect( getHumanDateString( now, anHourAndHalfAgo, 'l', moment, translate ) ).toBe( '1h ago' );
 
 		const aDayAndHalfAgo = new Date( Date.now() - 36 * 60 * 60 * 1000 );
-		expect( humanDate( aDayAndHalfAgo, 'll', 'en' ) ).toBe( '1d ago' );
-		expect( humanDate( aDayAndHalfAgo, 'l', 'en' ) ).toBe( '1d ago' );
+		expect( getHumanDateString( now, aDayAndHalfAgo, 'll', moment, translate ) ).toBe( '1d ago' );
+		expect( getHumanDateString( now, aDayAndHalfAgo, 'l', moment, translate ) ).toBe( '1d ago' );
 	} );
 
 	it( 'should return a formatted date for dates older than a week', () => {
-		const overThirtyDaysAgo = moment.utc( new Date( '2000-01-01' ) );
-		expect( humanDate( overThirtyDaysAgo, 'll', 'en' ) ).toBe( 'Jan 1, 2000' );
-		expect( humanDate( overThirtyDaysAgo, 'l', 'en' ) ).toBe( '1/1/2000' );
+		const now = new Date();
+		const overThirtyDaysAgo = new Date( '2000-01-01' );
+		expect( getHumanDateString( now, overThirtyDaysAgo, 'll', moment, translate ) ).toBe(
+			'Jan 1, 2000'
+		);
+		expect( getHumanDateString( now, overThirtyDaysAgo, 'l', moment, translate ) ).toBe(
+			'1/1/2000'
+		);
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `TimeSince`: refactor away from `UNSAFE_*`
* refactor `TimeSince` to a functional component

#### Testing instructions

* Go to `/devdocs/design/time-since`
* Make sure it looks as expected
* Wait some time to see the values update as time progresses

