### PR TITLE
Fix the skipping the site options step

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -248,9 +248,14 @@ export default class SignupFlowController {
 
 	_assertFlowProvidedRequiredDependencies() {
 		const storedDependencies = keys( getSignupDependencyStore( this._reduxStore.getState() ) );
+		const signupProgress = getSignupProgress( this._reduxStore.getState() );
 
 		forEach( pick( steps, this._getFlowSteps() ), ( step ) => {
 			if ( ! step.providesDependencies ) {
+				return;
+			}
+
+			if ( signupProgress[ step.stepName ]?.wasSkipped ) {
 				return;
 			}
 
@@ -317,7 +322,10 @@ export default class SignupFlowController {
 			includes( currentSteps, step.stepName )
 		);
 		const pendingSteps = filter( signupProgress, { status: 'pending' } );
-		const completedSteps = filter( signupProgress, { status: 'completed' } );
+		const completedSteps = filter(
+			signupProgress,
+			( step ) => step.status === 'completed' || step.wasSkipped
+		);
 		const dependencies = getSignupDependencyStore( this._reduxStore.getState() );
 
 		if ( dependencies.bearer_token && ! wpcom.isTokenLoaded() ) {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -321,7 +321,10 @@ export default class SignupFlowController {
 		const signupProgress = filter( getSignupProgress( this._reduxStore.getState() ), ( step ) =>
 			includes( currentSteps, step.stepName )
 		);
-		const pendingSteps = filter( signupProgress, { status: 'pending' } );
+		const pendingNotSkippedSteps = filter(
+			signupProgress,
+			( step ) => step.status === 'pending' && ! step.wasSkipped
+		);
 		const completedOrSkippedSteps = filter(
 			signupProgress,
 			( step ) => step.status === 'completed' || step.wasSkipped
@@ -332,7 +335,7 @@ export default class SignupFlowController {
 			wpcom.loadToken( dependencies.bearer_token );
 		}
 
-		for ( const pendingStep of pendingSteps ) {
+		for ( const pendingStep of pendingNotSkippedSteps ) {
 			this._processStep( pendingStep );
 		}
 

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -322,7 +322,7 @@ export default class SignupFlowController {
 			includes( currentSteps, step.stepName )
 		);
 		const pendingSteps = filter( signupProgress, { status: 'pending' } );
-		const completedSteps = filter(
+		const completedOrSkippedSteps = filter(
 			signupProgress,
 			( step ) => step.status === 'completed' || step.wasSkipped
 		);
@@ -336,7 +336,10 @@ export default class SignupFlowController {
 			this._processStep( pendingStep );
 		}
 
-		if ( completedSteps.length === currentSteps.length && undefined !== this._onComplete ) {
+		if (
+			completedOrSkippedSteps.length === currentSteps.length &&
+			undefined !== this._onComplete
+		) {
 			this._assertFlowProvidedRequiredDependencies();
 			// deferred to ensure that the onComplete function is called after the stores have
 			// emitted their final change events.

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -325,7 +325,7 @@ export function generateSteps( {
 		},
 		'domain-only': {
 			stepName: 'domain-only',
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ],
+			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ], // note: siteId, siteSlug are not provided when used in domain flow
 			props: {
 				isDomainOnly: true,
 				forceHideFreeDomainExplainerAndStrikeoutUi: true,
@@ -334,7 +334,7 @@ export function generateSteps( {
 
 		'select-domain': {
 			stepName: 'select-domain',
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ],
+			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ], // note: siteId, siteSlug are not provided when used in add-domain flow
 			props: {
 				isAllDomains: true,
 				isDomainOnly: true,

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -36,18 +36,6 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] );
 
-	const skipStep = () => {
-		dispatch(
-			submitSignupStep(
-				{ stepName },
-				{
-					siteTitle: '',
-					tagline: '',
-				}
-			)
-		);
-		goToNextStep();
-	};
 	return (
 		<StepWrapper
 			headerText={ headerText }
@@ -66,8 +54,11 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 			skipButtonAlign={ 'top' }
 			skipLabelText={ translate( 'Skip this step' ) }
 			isHorizontalLayout={ true }
+			defaultDependencies={ {
+				siteTitle: '',
+				tagline: '',
+			} }
 			{ ...props }
-			goToNextStep={ skipStep }
 		/>
 	);
 }

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -36,16 +36,6 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] );
 
-	const skipStep = () => {
-		dispatch(
-			submitSignupStep( {
-				stepName,
-				wasSkipped: true,
-			} )
-		);
-		goToNextStep();
-	};
-
 	return (
 		<StepWrapper
 			headerText={ headerText }
@@ -65,7 +55,6 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 			skipLabelText={ translate( 'Skip this step' ) }
 			isHorizontalLayout={ true }
 			{ ...props }
-			goToNextStep={ skipStep }
 		/>
 	);
 }

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -36,6 +36,16 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] );
 
+	const skipStep = () => {
+		dispatch(
+			submitSignupStep( {
+				stepName,
+				wasSkipped: true,
+			} )
+		);
+		goToNextStep();
+	};
+
 	return (
 		<StepWrapper
 			headerText={ headerText }
@@ -55,6 +65,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 			skipLabelText={ translate( 'Skip this step' ) }
 			isHorizontalLayout={ true }
 			{ ...props }
+			goToNextStep={ skipStep }
 		/>
 	);
 }

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -36,6 +36,18 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] );
 
+	const skipStep = () => {
+		dispatch(
+			submitSignupStep(
+				{ stepName },
+				{
+					siteTitle: '',
+					tagline: '',
+				}
+			)
+		);
+		goToNextStep();
+	};
 	return (
 		<StepWrapper
 			headerText={ headerText }
@@ -55,6 +67,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 			skipLabelText={ translate( 'Skip this step' ) }
 			isHorizontalLayout={ true }
 			{ ...props }
+			goToNextStep={ skipStep }
 		/>
 	);
 }

--- a/client/state/signup/progress/schema.ts
+++ b/client/state/signup/progress/schema.ts
@@ -29,6 +29,7 @@ export interface StepState {
 	providedDependencies?: string[];
 	status: 'completed' | 'processing' | 'pending' | 'in-progress' | 'invalid';
 	stepName: string;
+	wasSkipped?: boolean;
 }
 
 export type ProgressState = Record< string, StepState >;

--- a/client/state/signup/progress/schema.ts
+++ b/client/state/signup/progress/schema.ts
@@ -29,7 +29,6 @@ export interface StepState {
 	providedDependencies?: string[];
 	status: 'completed' | 'processing' | 'pending' | 'in-progress' | 'invalid';
 	stepName: string;
-	wasSkipped?: boolean;
 }
 
 export type ProgressState = Record< string, StepState >;


### PR DESCRIPTION
Currently, if the site-options step is skipped, we are getting stuck on the loading screen. https://github.com/Automattic/wp-calypso/issues/57783

This is due to the site-options step being skipped and therefore the dependencies being unavailable, but the signup flow controller was still expecting them. This is because the signup flow controller hadn't been updated to handle skipped steps.

This PR allows the flow to be completed if all of the steps have either been _completed_ OR _skipped_. It extends the existing skipStep functionality for steps that have providesDependencies.

### Testing instructions.

Go to `/start/setup-site/intent?siteSlug=YOUR_TEST_SITE.wordpress.com&flags=signup/hero-flow` and select the `write` intent. Skip the site-options step. Choose the "Start Writing" starting point.

<img width="667" alt="Screen Shot 2021-11-09 at 9 47 56 pm" src="https://user-images.githubusercontent.com/22446385/140918834-39d9e4eb-582e-47fc-8385-008ae5920a8c.png">

Also test other flows as this PR modifies code in the flowController which is shared across other onboarding flows.

fixes https://github.com/Automattic/wp-calypso/issues/57783
