### PR TITLE
i18n: Fix Support links localization on Use My Domain screen

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -19,6 +20,7 @@ export default function OptionContent( {
 	titleText,
 	topText,
 } ) {
+	const localizeUrl = useLocalizeUrl();
 	const pricingTextClasses = classNames( 'option-content__pricing-text', {
 		[ 'is-free' ]: pricing?.isFree,
 	} );
@@ -54,7 +56,7 @@ export default function OptionContent( {
 				<a
 					className="option-content__learn-more"
 					target="_blank"
-					href={ learnMoreLink }
+					href={ localizeUrl( learnMoreLink ) }
 					rel="noopener noreferrer"
 				>
 					{ __( 'Learn more' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap "Learn more" links in Use My Domain Transfer or Connect Option Content component.

#### Testing instructions

* Change Calypso UI to Mag-16 language.
* Open calypso.live build and navigate to `/domains/add/use-my-domain/{site}`.
* Enter domain name and go to the next screen.
* Confirm Learn more links point to the localized Support Site URL:
 
![CleanShot 2021-11-09 at 14 31 02](https://user-images.githubusercontent.com/2722412/140925115-60375e3d-b61c-4397-a8a8-5f0c8a87e17e.png)

Related to 342-gh-Automattic/i18n-issues
