### PR TITLE
Emails: Expand Google Workspace card when we are coming from a Google sale banner

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -115,11 +115,7 @@ class EmailProvidersComparison extends Component {
 		this.state = {
 			googleUsers: [],
 			titanMailboxes: [ buildNewTitanMailbox( props.selectedDomainName, false ) ],
-			expanded: {
-				forwarding: false,
-				google: false,
-				titan: true,
-			},
+			expanded: this.expandedStateProvider( props.source ),
 			addingToCart: false,
 			validatedTitanMailboxUuids: [],
 		};
@@ -131,6 +127,21 @@ class EmailProvidersComparison extends Component {
 
 	componentWillUnmount() {
 		this.isMounted = false;
+	}
+
+	expandedStateProvider( source ) {
+		if ( source === 'google-sale' ) {
+			return {
+				forwarding: false,
+				google: true,
+				titan: false,
+			};
+		}
+		return {
+			forwarding: false,
+			google: false,
+			titan: true,
+		};
 	}
 
 	onExpandedStateChange = ( providerKey, isExpanded ) => {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -115,7 +115,7 @@ class EmailProvidersComparison extends Component {
 		this.state = {
 			googleUsers: [],
 			titanMailboxes: [ buildNewTitanMailbox( props.selectedDomainName, false ) ],
-			expanded: this.expandedStateProvider( props.source ),
+			expanded: this.getDefaultExpandedState( props.source ),
 			addingToCart: false,
 			validatedTitanMailboxUuids: [],
 		};
@@ -129,7 +129,7 @@ class EmailProvidersComparison extends Component {
 		this.isMounted = false;
 	}
 
-	expandedStateProvider( source ) {
+	getDefaultExpandedState( source ) {
 		if ( source === 'google-sale' ) {
 			return {
 				forwarding: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we are redirecting the user to buy an email subscription from a Google sale, we are pointing the user by our UI to buy Professional Email, because we don't have the Google Workspace expanded. This pull request expands the Google Workspace subscription rather than the Professional Email when we are coming from a CTA that sells Google Workspace.

#### Testing instructions

I've found a way easier method to test this change, originally we had to sandbox our machine, add some code at the backend plus create a Sale coupon. The test I propose is to navigate to a site that has no email subscription and is elegible to have a Google Workspace subscription.

**Default**
1. Navigate to your site by building this URL
2. `email/{site}/purchase/{domain}`
3. You should be presented with the Professional Email card expanded.
![image](https://user-images.githubusercontent.com/5689927/140925756-9a17de40-8d59-4ab3-99eb-902ae6350df0.png)

**Google Sale**
1. Now navigate to it by adding the next property to the URL:
2. `email/{site}/purchase/{domain}?source=google-sale`
3. You should be presented with the Google Workspace card expanded.
![image](https://user-images.githubusercontent.com/5689927/140925651-743315d1-43f7-414d-8e13-f9af766f90b2.png)


Related to 1200182182542585-as-1201334822297370
