### PR TITLE
Interpolate components: set to public

### DIFF
--- a/packages/interpolate-components/package.json
+++ b/packages/interpolate-components/package.json
@@ -13,6 +13,9 @@
 	},
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",
+	"publishConfig": {
+		"access": "public"
+	},
 	"bugs": {
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Allow `interpolate-components` package to be published by adding `publishConfig`.

Follow-up to #57564

