### PR TITLE
Gutenboarding importer flow: additional UI tweaks

### DIFF
--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -53,6 +53,11 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 			: page.redirect( importerUrl );
 	};
 
+	const getBackUrl = ( stepName: string, stepSectionName: string ) => {
+		if ( stepName === 'capture' ) return getStepUrl( 'setup-site', 'intent' );
+		else if ( stepName === 'ready' && ! stepSectionName ) return getStepUrl( 'importer', 'list' );
+	};
+
 	return (
 		<StepWrapper
 			flowName={ 'importer' }
@@ -61,7 +66,7 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 			hideNext={ shouldHideNextBtn( stepName ) }
 			nextLabelText={ __( "I don't have a site address" ) }
 			allowBackFirstStep={ true }
-			backUrl={ stepName === 'capture' ? getStepUrl( 'setup-site', 'intent' ) : undefined }
+			backUrl={ getBackUrl( stepName, stepSectionName ) }
 			goToNextStep={ goToNextStep }
 			hideFormattedHeader={ true }
 			stepName={ stepName }

--- a/client/signup/steps/import/style.scss
+++ b/client/signup/steps/import/style.scss
@@ -75,12 +75,12 @@
 			margin-bottom: 20px;
 		}
 
-		.action-buttons__back {
-			color: var( --studio-gray-100 ) !important;
+		.components-button.action-buttons__back {
+			color: var( --studio-gray-100 );
 			font-weight: 500; /* stylelint-disable-line */
 
 			&:hover {
-				text-decoration: none;
+				color: var( --color-neutral-70 );
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Improved a way of generating the Back URL
* Improved styling of the secondary button on hover action

#### Testing instructions

- Go to `/start/importer?siteSlug={YOUR_SITE}`
- Click on "I don't have a site address"
- Click on any platform from the list
- Header Back button should revert you to the previous page

#### Screenshot

<img width="1278" alt="Screenshot 2021-11-09 at 14 42 49" src="https://user-images.githubusercontent.com/1241413/140934954-1709347f-91cc-43ff-b1bc-8aeb565af068.png">
Related to #57131
