### PR TITLE
Editor Tracking - Track saving from the multi-entity save panel.

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -639,7 +639,41 @@ const trackSaveEditedEntityRecord = ( kind, type, id ) => {
 			entityContent,
 			'wpcom_block_editor_global_styles_save'
 		);
+	} else {
+		const savedEntity = select( 'core' ).getEntityRecord( kind, type, id );
+
+		const savePanel = document.querySelector( '.entities-saved-states__panel' );
+		const source = savePanel ? 'multi-entity-save-panel' : 'unknown';
+
+		const variationSlug =
+			type === 'wp_template_part' && savedEntity?.area !== 'uncategorized'
+				? savedEntity?.area
+				: undefined;
+
+		tracksRecordEvent( 'test-event', {
+			entity_kind: kind,
+			entity_type: type,
+			entity_id: id,
+			saving_source: source,
+			// TODO - consider the save changing the variation.
+			variation_slug: variationSlug,
+		} );
 	}
+};
+
+const trackSaveSpecifiedEntityEdits = ( kind, type, id, itemsToSave ) => {
+	const savePanel = document.querySelector( '.entities-saved-states__panel' );
+	const source = savePanel ? 'multi-entity-save-panel' : 'unknown';
+
+	itemsToSave.forEach( ( item ) =>
+		tracksRecordEvent( 'test-event', {
+			entity_kind: kind,
+			entity_type: type,
+			entity_id: id,
+			saving_source: source,
+			items_saved: item,
+		} )
+	);
 };
 
 /**
@@ -667,6 +701,7 @@ const REDUX_TRACKING = {
 		saveEntityRecord: trackSaveEntityRecord,
 		editEntityRecord: trackEditEntityRecord,
 		saveEditedEntityRecord: trackSaveEditedEntityRecord,
+		__experimentalSaveSpecifiedEntityEdits: trackSaveSpecifiedEntityEdits,
 	},
 	'core/block-editor': {
 		moveBlocksUp: getBlocksTracker( 'wpcom_block_moved_up' ),

--- a/apps/wpcom-block-editor/src/wpcom/features/utils.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/utils.js
@@ -65,7 +65,6 @@ const buildPropsFromContextBlock = ( block ) => {
  * block action.
  *
  * @param {string} rootClientId The rootClientId of the block event.
- *
  * @returns {object} The block event's context properties.
  */
 export const getBlockEventContextProperties = ( rootClientId ) => {
@@ -109,7 +108,6 @@ export const getBlockEventContextProperties = ( rootClientId ) => {
  * @param {object|Array} newObject The object that has had an update.
  * @param {object|Array} oldObject The original object to reference.
  * @param {Array}  		 keyMap    Used in recursion.  A list of keys mapping to the changed item.
- *
  * @returns {Array[object]} Array of objects containing a keyMap array and value for the changed items.
  */
 const compareObjects = ( newObject, oldObject, keyMap = [] ) => {
@@ -147,7 +145,6 @@ const compareObjects = ( newObject, oldObject, keyMap = [] ) => {
  *
  * @param {object} newContent The object that has had an update.
  * @param {object} oldContent The original object to reference.
- *
  * @returns {Array[object]} Array of objects containing a keyMap array and value for the changed items.
  */
 const findUpdates = ( newContent, oldContent ) => {
@@ -178,7 +175,6 @@ const findUpdates = ( newContent, oldContent ) => {
  *
  * @param {Array[string]} keyMap A list of keys mapping to the changed item in the global styles content object.
  * @param {*} 			  value  New value of the updated item.
- *
  * @returns {object} An object containing the event properties for a global styles change.
  */
 const buildGlobalStylesEventProps = ( keyMap, value ) => {
@@ -256,4 +252,16 @@ export const getFlattenedBlockNames = ( block ) => {
 	}
 
 	return blockNames;
+};
+
+/**
+ * Checks the editor for open saving interfaces and returns the result.
+ *
+ * @returns {string} Name of saving interface found.
+ */
+export const findSavingSource = () => {
+	const savePanel = document.querySelector( '.entities-saved-states__panel' );
+	// Currently we only expect these save actions to trigger from the save panel.
+	// However, we fall back to 'unknown' in case some new saving mechanism is added.
+	return savePanel ? 'multi-entity-save-panel' : 'unknown';
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds redux tracking for the two save actions utilized by the multi-entity save panel, `saveEditedEntityRecord` and `__experimentalSaveSpecifiedEntityEdits`.  The former is used for saving standard posts via the panel, while the latter is used to save individual site items (title, logo, description, etc.).  This will allow us to have a better understand of what users have accomplished inside the Site Editor, but extends to the post editor using this multi-entity panel as well.

New event: `wpcom_block_editor_edited_entity_save`
Event specific properties:
* `entity_kind` - the kind of entity, such as "postType" or "root"
* `entity_type` - the type of entity, such as "page" or "site"
* `saving_source` - expected value of `'multi-entity-save-panel'` and fallback value of `'unknown'` as a safety measure for if/when these actions are utilized with other saving interfaces.
* `entity_id` (conditional) - This is conditional as it DNE for the root site entity, but has value for template parts since it can convey whether or not the template part originated from a theme file.
* `template_part_area` (conditional) - The 'area' classification (header, footer, etc.) if the item being saved is a template part.
* `new_template_part_area` (conditional) - To be present when the 'area' classification is changed by this save action (changing a header to a footer, etc.)
* `item_saved` (conditional) - Present when called from the `__experimentalSaveSpecifiedEntityEdits` action, denotes the edit that was saved.  Ex - for the root site entity this may be "title", "site_logo", or "description".

Note that standard block editor tracking event properties are also inherited, such as `editor_type` used to distinguish between post and site editors.

TODO - Follow up with some e2e test coverage once this is deployed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow steps to enable tracking debugging at PCYsg-nrf-p2
* Load the site editor, edit and save some items, verify the new event fires with properties as expected above.
* Load the post editor, edit a separate entity (such as the site title) to trigger the multi-entity save panel.  Save and verify the expected event is tracked.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
