### PR TITLE
Plans: Remove stars from 1TB storage features in favor of bolding only

### DIFF
--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-storage-upgrade-product.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-storage-upgrade-product.ts
@@ -28,15 +28,12 @@ export const useGetTier1UpgradeProduct = (): StorageUpgradeGetter => {
 					items: [
 						{
 							text: translate( '%(storageAmount)s backup storage', { args: { storageAmount } } ),
-							isHighlighted: true,
 						},
 						{
 							text: translate( 'One-click restore from the last 30 days of backups' ),
-							isHighlighted: true,
 						},
 						{
 							text: translate( '30-day activity log' ),
-							isHighlighted: true,
 						},
 						{
 							text: translate( 'Real-time backups (as you edit)' ),
@@ -73,17 +70,14 @@ export const useGetTier2UpgradeProduct = (): StorageUpgradeGetter => {
 						{
 							text: translate( '%(storageAmount)s backup storage', { args: { storageAmount } } ),
 							isHighlighted: true,
-							isDifferentiator: true,
 						},
 						{
 							text: translate( 'One-click restore from the past year of backups' ),
 							isHighlighted: true,
-							isDifferentiator: true,
 						},
 						{
 							text: translate( 'One year activity log' ),
 							isHighlighted: true,
-							isDifferentiator: true,
 						},
 						{
 							text: translate( 'Real-time backups (as you edit)' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the storage upgrade pricing page, remove the `isDifferentiator` property from features that use it, so that "star" bullet points are no longer used.
* On the same page, remove `isHighlighted` from 10GB differentiating features, so that they're no longer bolded and 1TB features are still differentiated.

#### Testing instructions

1. Visit the storage pricing upgrade page in Calypso (`/pricing/storage/:site` or `/plans/storage/:site`).
2. Verify bullet points on the 1TB upgrade are no longer stars, but that some feature items are still bolded.
3. Verify feature items for the 10GB upgrade are no longer bolded.

#### Reference screenshots (before / after)

<img width="375" alt="Screen Shot 2021-11-09 at 10 02 10" src="https://user-images.githubusercontent.com/670067/140960201-1dfbd23a-fc16-41dd-b853-a9da56c11665.png"> <img width="375" alt="Screen Shot 2021-11-09 at 10 01 45" src="https://user-images.githubusercontent.com/670067/140960199-f007473c-da16-4960-87f4-29e667ba690c.png">