### PR TITLE
Revert "Sidebar: Add link to parent menu items"

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -62,7 +62,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	// On which case we show a modal awaiting for user confirmation for opening that
 	// link on new tab in order to avoid Happy Chat session disconnection.
 	// We return a bool that shows if the logic should terminate here.
-	const canNavigate = ( url, event ) => {
+	const continueInCalypso = ( url, event ) => {
 		if ( isHappychatSessionActive && isExternal( url ) ) {
 			// Do not show warning modal on Jetpack sites, since all external links are
 			// always opened on new tabs for these sites.
@@ -118,7 +118,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 								sidebarCollapsed={ sidebarIsCollapsed }
 								isHappychatSessionActive={ isHappychatSessionActive }
 								isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-								canNavigate={ canNavigate }
+								continueInCalypso={ continueInCalypso }
 								{ ...item }
 							/>
 						);
@@ -130,7 +130,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 							selected={ isSelected }
 							isHappychatSessionActive={ isHappychatSessionActive }
 							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-							canNavigate={ canNavigate }
+							continueInCalypso={ continueInCalypso }
 							{ ...item }
 						/>
 					);

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -25,7 +25,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	url,
 	isHappychatSessionActive,
 	isJetpackNonAtomicSite,
-	canNavigate,
+	continueInCalypso,
 } ) => {
 	const reduxDispatch = useDispatch();
 
@@ -40,7 +40,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			count={ count }
 			label={ title }
 			link={ url }
-			onNavigate={ ( event ) => canNavigate( url, event ) && onNavigate() }
+			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			forceInternalLink={ ! isHappychatSessionActive && ! isJetpackNonAtomicSite }
@@ -61,7 +61,7 @@ MySitesSidebarUnifiedItem.propTypes = {
 	url: PropTypes.string,
 	isHappychatSessionActive: PropTypes.bool.isRequired,
 	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
-	canNavigate: PropTypes.func.isRequired,
+	continueInCalypso: PropTypes.func.isRequired,
 };
 
 export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
+import { navigate } from 'calypso/lib/navigate';
 import { toggleMySitesSidebarSection as toggleSection } from 'calypso/state/my-sites/sidebar/actions';
 import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import MySitesSidebarUnifiedItem from './item';
@@ -27,7 +28,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	sidebarCollapsed,
 	isHappychatSessionActive,
 	isJetpackNonAtomicSite,
-	canNavigate,
+	continueInCalypso,
 	...props
 } ) => {
 	const reduxDispatch = useDispatch();
@@ -41,11 +42,18 @@ export const MySitesSidebarUnifiedMenu = ( {
 		( ! isWithinBreakpoint( '>782px' ) && ( childIsSelected || isExpanded ) ) || // For mobile breakpoints, we dont' care about the sidebar collapsed status.
 		( isWithinBreakpoint( '>782px' ) && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
 
-	// Avoid redirecting to the section if menu is full-width (i.e. mobile viewport) or if user
-	// is forced to keep the current page open (i.e. there is a Happychat session active).
-	const shouldRedirectToSection = isWithinBreakpoint( '>782px' ) && link && canNavigate( link );
-
 	const onClick = () => {
+		// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
+		if ( isWithinBreakpoint( '>782px' ) ) {
+			if ( link ) {
+				if ( ! continueInCalypso( link ) ) {
+					return;
+				}
+
+				navigate( link );
+			}
+		}
+
 		window.scrollTo( 0, 0 );
 		reduxDispatch( toggleSection( sectionId ) );
 	};
@@ -53,7 +61,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	return (
 		<li>
 			<ExpandableSidebarMenu
-				onClick={ onClick }
+				onClick={ () => onClick() }
 				expanded={ showAsExpanded }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
@@ -61,7 +69,6 @@ export const MySitesSidebarUnifiedMenu = ( {
 				count={ count }
 				hideExpandableIcon={ true }
 				inlineText={ props.inlineText }
-				href={ shouldRedirectToSection ? link : undefined }
 				{ ...props }
 			>
 				{ children.map( ( item ) => {
@@ -74,7 +81,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 							isSubItem={ true }
 							isHappychatSessionActive={ isHappychatSessionActive }
 							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-							canNavigate={ canNavigate }
+							continueInCalypso={ continueInCalypso }
 						/>
 					);
 				} ) }
@@ -94,7 +101,7 @@ MySitesSidebarUnifiedMenu.propTypes = {
 	sidebarCollapsed: PropTypes.bool,
 	isHappychatSessionActive: PropTypes.bool.isRequired,
 	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
-	canNavigate: PropTypes.func.isRequired,
+	continueInCalypso: PropTypes.func.isRequired,
 	/*
 	Example of children shape:
 	[


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/57780.

Reverts Automattic/wp-calypso#57642 since it caused a regression (reported in https://github.com/Automattic/wp-calypso/issues/57780).

#### Testing instructions
- Go to any Calypso page using the live link below.
- Initiate a support chat (you need to log as agent in the Staging HUD).
- Make sure the "A support chat session is currently in progress. Click continue to open this link in a new tab." message doesn't show up.