### PR TITLE
Upgrade `react-query` to a version which includes the `meta` option

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -166,7 +166,7 @@
 		"react-live": "^2.3.0",
 		"react-modal": "^3.14.3",
 		"react-native": "^0.66.2",
-		"react-query": "^3.9.8",
+		"react-query": "^3.32.1",
 		"react-redux": "^7.2.6",
 		"react-router-dom": "^5.1.2",
 		"react-transition-group": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,7 +2942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.16.3
   resolution: "@babel/runtime@npm:7.16.3"
   dependencies:
@@ -11035,10 +11035,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"big-integer@npm:^1.6.44":
-  version: 1.6.48
-  resolution: "big-integer@npm:1.6.48"
-  checksum: 4012d69592f53ccd159acc0643f8594d341306485fed8b9a31b756a0d6fc8a889d8bc6023ef31b9aac78dba307b41d65e060dafcb8764f04238112b119b885e2
+"big-integer@npm:^1.6.16, big-integer@npm:^1.6.44":
+  version: 1.6.50
+  resolution: "big-integer@npm:1.6.50"
+  checksum: 03c8b0f4e7838b68fc89ae937e7f2aa307c26a7942378264eb8386381478482edc52cad66e8d6e4b4cd38ae8de556a74ef7e8ce533d674527c8b42e570b91f4e
   languageName: node
   linkType: hard
 
@@ -11308,6 +11308,22 @@ __metadata:
   version: 2.0.2
   resolution: "brcast@npm:2.0.2"
   checksum: a7d6bd5b8b5865e8ddee38804827690e56248ed3b6ae262655049d65a1ca888349ceed0a0f21a3bb2b14f4aeb5bd30b65fd8a8914ed003268bb2f2424758c1cd
+  languageName: node
+  linkType: hard
+
+"broadcast-channel@npm:^3.4.1":
+  version: 3.7.0
+  resolution: "broadcast-channel@npm:3.7.0"
+  dependencies:
+    "@babel/runtime": ^7.7.2
+    detect-node: ^2.1.0
+    js-sha3: 0.8.0
+    microseconds: 0.2.0
+    nano-time: 1.0.0
+    oblivious-set: 1.0.0
+    rimraf: 3.0.2
+    unload: 2.2.0
+  checksum: 95978446f24c685be666f5508a91350bcd4075c08feda929d26c0c678fb24bd421901f19fa8d36cb6f5ed480a334072f3bdce48fa177a8cb29793d88693911cc
   languageName: node
   linkType: hard
 
@@ -12029,7 +12045,7 @@ __metadata:
     react-live: ^2.3.0
     react-modal: ^3.14.3
     react-native: ^0.66.2
-    react-query: ^3.9.8
+    react-query: ^3.32.1
     react-redux: ^7.2.6
     react-router-dom: ^5.1.2
     react-test-renderer: ^17.0.2
@@ -15215,7 +15231,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-node@npm:^2.0.4":
+"detect-node@npm:^2.0.4, detect-node@npm:^2.1.0":
   version: 2.1.0
   resolution: "detect-node@npm:2.1.0"
   checksum: f039f601790f2e9d4654e499913259a798b1f5246ae24f86ab5e8bd4aaf3bce50484234c494f11fb00aecb0c6e2733aa7b1cf3f530865640b65fbbd65b2c4e09
@@ -23535,6 +23551,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"js-sha3@npm:0.8.0":
+  version: 0.8.0
+  resolution: "js-sha3@npm:0.8.0"
+  checksum: 43a21dc7967c871bd2c46cb1c2ae97441a97169f324e509f382d43330d8f75cf2c96dba7c806ab08a425765a9c847efdd4bffbac2d99c3a4f3de6c0218f40533
+  languageName: node
+  linkType: hard
+
 "js-string-escape@npm:^1.0.1":
   version: 1.0.1
   resolution: "js-string-escape@npm:1.0.1"
@@ -26111,6 +26134,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"microseconds@npm:0.2.0":
+  version: 0.2.0
+  resolution: "microseconds@npm:0.2.0"
+  checksum: 59dfae1c696c0bacd79603c4df7cd0dcc9e091b7c5556aaca9b0832017d3c0b40ad8f57ca25e0ee5709ef1973404448c4a2fea6c9c1fad7d9e197ff5c1c9c2d5
+  languageName: node
+  linkType: hard
+
 "miller-rabin@npm:^4.0.0":
   version: 4.0.1
   resolution: "miller-rabin@npm:4.0.1"
@@ -26731,6 +26761,15 @@ fsevents@~2.1.2:
   dependencies:
     node-gyp: latest
   checksum: a3ae7ce43d0aac223f58bf11952bd5ba5135df30506b55d46d0b983da83df4052631c41275fbfd5e3e749ed50c030d4561d12fb9b5bfba2083c0d66a75ee5ba1
+  languageName: node
+  linkType: hard
+
+"nano-time@npm:1.0.0":
+  version: 1.0.0
+  resolution: "nano-time@npm:1.0.0"
+  dependencies:
+    big-integer: ^1.6.16
+  checksum: 3bd12e0bcd30867178afdbe8053b3dde5fdd1c665ecd348bf879863049344fbaf05cbb1d7806a825b91efbca011ee115eee52e76fb38b7da9c97931cd9e61f15
   languageName: node
   linkType: hard
 
@@ -27713,6 +27752,13 @@ fsevents@~2.1.2:
   version: 1.0.4
   resolution: "objectorarray@npm:1.0.4"
   checksum: fb1a1c9ebadf21c3793a3c390d8675a049819c589585299de12239f9368758fbf08d34f15b2644942a4b3a8d6bb493560bf12faf099a2148a93f76427e200fa4
+  languageName: node
+  linkType: hard
+
+"oblivious-set@npm:1.0.0":
+  version: 1.0.0
+  resolution: "oblivious-set@npm:1.0.0"
+  checksum: ca8640474ea1e1feb3b5c98d42f5649f114ac4513ef84774e724f22fc7e529f1de3e7f26a0d9593097ab8942ca0bb8c241f7c1bd63c3e33047dd49de3aca9805
   languageName: node
   linkType: hard
 
@@ -31298,11 +31344,12 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-query@npm:^3.9.8":
-  version: 3.9.8
-  resolution: "react-query@npm:3.9.8"
+"react-query@npm:^3.32.1":
+  version: 3.32.1
+  resolution: "react-query@npm:3.32.1"
   dependencies:
     "@babel/runtime": ^7.5.5
+    broadcast-channel: ^3.4.1
     match-sorter: ^6.0.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -31311,7 +31358,7 @@ fsevents@~2.1.2:
       optional: true
     react-native:
       optional: true
-  checksum: 0e4b0f9a7237cc88bea20ee290cc485671828880cb0a57cfeb00a2337dc3194c7ce245cbcfb512ffa0d6be98973c75479a9cb96971e5a78e2d2edb3223c69f1b
+  checksum: fab3150f977f8450ee90132a63882f5163434299613542bc14c209928ce2c8665544bb2570b6fb75c597cdfa4ee32b57912035b8aa852dce8340076fbfbb3387
   languageName: node
   linkType: hard
 
@@ -37601,6 +37648,16 @@ testarmada-magellan@11.0.10:
   version: 2.0.0
   resolution: "universalify@npm:2.0.0"
   checksum: 07092b9f46df61b823d8ab5e57f0ee5120c178b39609a95e4a15a98c42f6b0b8e834e66fbb47ff92831786193be42f1fd36347169b88ce8639d0f9670af24a71
+  languageName: node
+  linkType: hard
+
+"unload@npm:2.2.0":
+  version: 2.2.0
+  resolution: "unload@npm:2.2.0"
+  dependencies:
+    "@babel/runtime": ^7.6.2
+    detect-node: ^2.0.4
+  checksum: 0a4f86b502e7aa35d39c27373ebeaad4f2b7da793fb3d6308e5337aab541885cfe7b339ea4a1963477bf73fddabd5d69f4f47023dad71224b4b4a25611ef7dd8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR precedes #57679, upgrading `react-query` to a version that allows query metadata customization.

The actual persistence opt-out is designed on #57679.

#### Testing instructions

Make sure queries still work inside Calypso (search for `useQuery` usages inside the app).

Related to #57679.