### PR TITLE
Video UI: fullscreen support

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -19,7 +19,7 @@ const VideoPlayer = ( { videoUrl } ) => {
 	);
 };
 
-const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
+const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );
@@ -83,7 +83,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false } ) => {
 					<div>
 						<Gridicon icon="my-sites" size={ 24 } />
 						{ shouldDisplayTopLinks && (
-							<a href="/" className="videos-ui__back-link">
+							<a href="/" className="videos-ui__back-link" onClick={ onBackClick }>
 								<Gridicon icon="chevron-left" size={ 24 } />
 								<span>{ translate( 'Back' ) }</span>
 							</a>

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
@@ -1,0 +1,20 @@
+import { BlankCanvas } from 'calypso/components/blank-canvas';
+import VideosUi from 'calypso/components/videos-ui';
+
+import './style.scss';
+
+const BloggingQuickStartModal = ( props ) => {
+	const { isVisible = false, onClose = () => {} } = props;
+
+	return (
+		isVisible && (
+			<BlankCanvas className={ 'blogging-quick-start-modal' }>
+				<BlankCanvas.Content>
+					<VideosUi shouldDisplayTopLinks={ true } onBackClick={ onClose } />
+				</BlankCanvas.Content>
+			</BlankCanvas>
+		)
+	);
+};
+
+export default BloggingQuickStartModal;

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/style.scss
@@ -1,0 +1,5 @@
+.blogging-quick-start-modal {
+    .blank-canvas__content {
+        padding: 0;
+    }
+}


### PR DESCRIPTION
This PR implements fullscreen mode for the Video UI modal. The content of this PR does not change anything visible since it's meant to be merged to trunk. 

#### Before & After
| Before  | After |
| ------------- | ------------- |
| ![2021-11-09 14 16 21](https://user-images.githubusercontent.com/375980/140972688-e363d916-0282-45c7-b4f0-3247e17b0f47.gif) | ![2021-11-09 14 14 31](https://user-images.githubusercontent.com/375980/140972576-c8ac47a3-22bc-4779-95e5-8a8dca35f52e.gif) |

#### Testing instructions
1. Go to the modal branch: 
```sh
git checkout videos-ui-home-modal
```
2. Cherry pick changes from this PR: 
```sh
git cherry-pick 8ef51f060a7
```
3. In `client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx` remove the `BloggingQuickStartModal` component definition.
4. Add the following import: 
  ```js 
import BloggingQuickStartModal from './blogging-quick-start-modal';
```
5. Open the modal and verify it's full screen.
6. Click the `< Back` button and verify that it dismisses the modal.

Related to #57794
