### PR TITLE
Playwright: add cookie directory to `.gitignore`.

### DIFF
--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -16,3 +16,6 @@ dist/
 
 # Playwright results
 results/
+
+# Cookie files
+cookies/


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a straightforward addition of the `test/e2e/cookies` directory to the `.gitignore` file.


#### Testing instructions

Closes #57842.
