### PR TITLE
Update styles and add cart to domains breadcrumbs header

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -138,32 +138,54 @@
 
 .breadcrumbs__buttons,
 .breadcrumbs__buttons-mobile {
-	display: none;
+	align-items: center;
+
+	> * + * {
+		margin-left: 16px;
+	}
+
+	.popover-cart {
+		.header-button__text {
+			display: none;
+
+			@include break-mobile {
+				display: block;
+			}
+		}
+
+		button.button .gridicon.gridicons-cart {
+			fill: var( --color-neutral-80 );
+		}
+	}
+
+	& button,
+	& .select-dropdown {
+		height: 40px;
+
+		.select-dropdown__header {
+			height: 40px;
+		}
+	}
 
 	@include break-mobile {
-		display: flex;
-
-		& button,
-		& .select-dropdown {
-			margin-right: 16px;
-		}
-		& .button:last-child {
-			margin-right: 0;
+		.options-domain-button.ellipsis {
+			padding-right: 0;
 		}
 	}
 }
 
 .breadcrumbs__buttons-mobile {
-	display: block;
-
-	& .button {
-		margin-right: 16px;
-	}
-	& .button:last-child {
-		margin-right: 0;
-	}
+	display: flex;
 
 	@include break-mobile {
 		display: none;
+	}
+}
+
+.breadcrumbs__buttons {
+	display: none;
+
+	@include break-mobile {
+		display: flex;
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -224,11 +224,6 @@
 	@include break-mobile {
 		flex: 6 6 0;
 		margin: 0;
-
-		.ellipsis-menu {
-			position: relative;
-			right: 16px;
-		}
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -26,11 +26,13 @@ class AddDomainButton extends Component {
 		selectedSiteSlug: PropTypes.string,
 		specificSiteActions: PropTypes.bool,
 		ellipsisButton: PropTypes.bool,
+		borderless: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		specificSiteActions: false,
 		ellipsisButton: false,
+		borderless: false,
 	};
 
 	state = {
@@ -130,7 +132,7 @@ class AddDomainButton extends Component {
 	}
 
 	render() {
-		const { specificSiteActions, ellipsisButton } = this.props;
+		const { specificSiteActions, ellipsisButton, borderless } = this.props;
 		const classes = classNames( 'options-domain-button', ellipsisButton && 'ellipsis' );
 
 		return (
@@ -140,6 +142,7 @@ class AddDomainButton extends Component {
 					className={ classes }
 					onClick={ this.toggleAddMenu }
 					ref={ this.addDomainButtonRef }
+					borderless={ borderless }
 				>
 					{ this.renderLabel() }
 				</Button>

--- a/client/my-sites/domains/domain-management/list/options-domain-button.scss
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.scss
@@ -1,46 +1,45 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.options-domain-button {
-	padding: 8px;
+button {
+	&.options-domain-button {
+		padding: 8px;
 
-	&__popover {
-		margin-top: 5px;
-	}
-
-	@include break-mobile {
-		padding: 7px;
-		font-size: $font-body-extra-small;
-		line-height: 1;
-
-		.gridicon {
-			top: 5px;
-			margin-top: -8px;
+		&__popover {
+			margin-top: 5px;
 		}
 
-		& > .gridicon {
-			margin-left: 5px;
+		@include break-mobile {
+			padding: 7px 15px;
+			font-size: $font-body-small;
+			line-height: 1;
+
+			.gridicon {
+				top: 5px;
+				margin-top: -8px;
+			}
+
+			& > .gridicon {
+				margin-left: 5px;
+			}
 		}
 	}
-}
 
-.options-domain-button__desktop {
-	display: none;
+	.options-domain-button__desktop {
+		display: none;
 
-	@include break-mobile {
-		display: initial;
+		@include break-mobile {
+			display: initial;
+		}
 	}
-}
 
-.options-domain-button.ellipsis {
-	border: none;
+	.options-domain-button.ellipsis {
+		border: none;
 
-	@include break-mobile {
-		border: 1px solid var( --color-neutral-10 );
-
-		&:hover {
-			border-color: var( --color-neutral-20 );
-			color: var( --color-neutral-70 );
+		@include break-mobile {
+			&:hover {
+				color: var( --color-neutral-70 );
+			}
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -161,16 +161,6 @@ export class SiteDomains extends Component {
 			<>
 				{ ! hasProductsList && <QueryProductsList /> }
 
-				<div className="domains__header">
-					{ /* TODO: we need to decide where the HeaderCart will appear in the new design */ }
-					<div className="domains__header-buttons">
-						<HeaderCart
-							selectedSite={ this.props.selectedSite }
-							currentRoute={ this.props.currentRoute }
-						/>
-					</div>
-				</div>
-
 				{ ! this.isLoading() && nonWpcomDomains.length === 0 && ! selectedFilter && (
 					<EmptyDomainsListCard
 						selectedSite={ selectedSite }
@@ -291,14 +281,24 @@ export class SiteDomains extends Component {
 		};
 
 		const buttons = [
+			this.renderDomainTableFilterButton( false ),
 			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-			this.renderDomainTableFilterButton( true ),
-			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton />,
+			<HeaderCart
+				key="breadcrumb_button_cart"
+				selectedSite={ this.props.selectedSite }
+				currentRoute={ this.props.currentRoute }
+			/>,
+			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
 		];
 
 		const mobileButtons = [
 			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton />,
+			<HeaderCart
+				key="breadcrumb_button_cart"
+				selectedSite={ this.props.selectedSite }
+				currentRoute={ this.props.currentRoute }
+			/>,
+			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
 		];
 
 		return (

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -3,8 +3,9 @@
 @import '@wordpress/base-styles/mixins';
 
 .breadcrumbs {
-	svg.options-domain-button__add {
-		margin-left: 4px;
+	svg.options-domain-button__add.gridicon {
+		margin-left: 2px;
+		margin-right: 2px;
 
 		@include break-mobile {
 			margin-left: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the styles of the domains breadcrumbs buttons to match design updates.
* Add the shopping cart into the breadcrumbs buttons.

#### Testing instructions

- Load the Site Domains List page
- Make sure the header matches the new designs.

With empty shopping cart on desktop:

<img width="1410" alt="Screen Shot 2021-11-09 at 2 04 58 PM" src="https://user-images.githubusercontent.com/1379730/140989102-88378f64-0dfa-4e20-9f53-0113b0158654.png">

With shopping cart on desktop:

<img width="1408" alt="Screen Shot 2021-11-09 at 2 03 50 PM" src="https://user-images.githubusercontent.com/1379730/140989241-7c7c55d8-2a82-4d84-884c-61ed2c48c9f5.png">


With empty shopping cart on mobile:

<img width="378" alt="Screen Shot 2021-11-09 at 2 04 37 PM" src="https://user-images.githubusercontent.com/1379730/140989285-58b04383-84c8-488b-851c-19c9dd4e7fce.png">

With shopping cart on mobile:

<img width="378" alt="Screen Shot 2021-11-09 at 2 04 18 PM" src="https://user-images.githubusercontent.com/1379730/140989311-05b953d2-0c39-4bf8-ad01-7e9d793b3bc6.png">

