### PR TITLE
E2E: Replace 'wooCommerceUser' with 'eCommerceUser'.

### DIFF
--- a/test/e2e/lib/jest/globalSetup.ts
+++ b/test/e2e/lib/jest/globalSetup.ts
@@ -30,7 +30,7 @@ export default async (): Promise< void > => {
 	// its presence when running each test file.
 	process.env.COOKIES_PATH = cookieBasePath;
 
-	const userList = [ 'gutenbergSimpleSiteUser', 'wooCommerceUser', 'defaultUser' ];
+	const userList = [ 'gutenbergSimpleSiteUser', 'eCommerceUser', 'defaultUser' ];
 
 	for await ( const user of userList ) {
 		const [ username, password ] = config.get( 'testAccounts' )[ user ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the user for which cookies will be pre-generated then stored prior to running the suite.


