### PR TITLE
E2E: use `waitForNavigation()` with URL wait wrapped in Promise.all for Signup: WPCC spec.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-signup__wpcc.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__wpcc.ts
@@ -68,7 +68,10 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function 
 			// Cursory check to ensure the newly registered account does not have a site.
 			// Waiting for `networkidle` is required so Calypso loading won't swallow up
 			// the click on navbar in the Close Account steps.
-			await page.goto( DataHelper.getCalypsoURL(), { waitUntil: 'networkidle' } );
+			await Promise.all( [
+				page.waitForNavigation( { url: '**/read', waitUntil: 'load' } ),
+				page.goto( DataHelper.getCalypsoURL() ),
+			] );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR switches the `Signup: WPCC` test to use the `Promise.all` construct combined with a `waitForNavigation()` with a URL specifier. 

This change is in response to https://github.com/Automattic/wp-calypso/issues/57847 in which the navigation by `page.goto` fails to resolve.



#### Testing instructions

- [x] pre-release

Closes #57847.
