### PR TITLE
Videos UI: Refine breakpoint usage for styling.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -1,5 +1,7 @@
 @import '@automattic/typography/styles/variables';
 @import '@automattic/onboarding/styles/mixins.scss';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .videos-ui {
 	background: #101517;
@@ -33,6 +35,8 @@
 			display: flex;
 			flex-direction: column;
 			padding: 20px;
+			max-width: 1280px;
+			margin: auto;
 
 			ul {
 				margin: 40px 0 0;
@@ -55,6 +59,8 @@
 	}
 
 	.videos-ui__body {
+		max-width: 1280px;
+		margin: auto;
 
 		h3 {
 			font-size: $font-title-medium;
@@ -64,7 +70,6 @@
 		.videos-ui__video-content {
 			display: flex;
 			flex-direction: column;
-			padding: 0 20px 20px;
 		}
 
 		.videos-ui__video {
@@ -135,7 +140,8 @@
 			}
 		}
 	}
-	@media screen and ( min-width: 660px ) {
+
+	@include break-medium {
 		.videos-ui__header {
 			.videos-ui__header-content {
 				flex-direction: row;
@@ -157,17 +163,19 @@
 				}
 			}
 		}
+	}
 
+	@include break-xlarge {
 		.videos-ui__body {
 
+			padding: 0 80px 80px;
 			h3 {
-				margin: 80px 80px 30px;
+				margin: 80px 0 20px;
 			}
 
 			.videos-ui__video-content {
 				flex-direction: row;
 				justify-content: space-between;
-				padding: 0 80px 80px;
 
 				.videos-ui__video {
 					flex-basis: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the mobile styling changes added to the Videos UI in https://github.com/Automattic/wp-calypso/issues/57799, switching to standard Gutenberg breakpoints.
* It also restricts the UI to prevent expanding beyond a 1280px max-width which should be centered in its container.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Given the rather strange testing circumstances the Videos UI is currently in, getting it into a place where it can be accurately tested at various screen widths is a bit difficult. This is the way that I have found most convenient to test:

* Check out a copy of the modal branch (https://github.com/Automattic/wp-calypso/pull/57515), copy it into a temporary branch, and merge this branch into that temporary branch.
    * `git fetch`
    * `git checkout videos-ui-home-modal`
    * `git pull -f` (if necessary)
    * `git checkout -b videos-ui-home-modal-temp`
    * `git merge origin/update/videos-ui-breakpoint-refinement`
* Run this frankenbranch in Calypso local dev. 

You can now resize the window to various breakpoints and see an accurate representation of the full-screen UI.

* Verify that at sizes below 782px, all content is in a single column:

![image](https://user-images.githubusercontent.com/13437011/141006246-8d547b2d-2c41-43ff-9632-d5e4ebc03a8b.png)

* Verify that between 782px and 1080px, the header moves to two columns while the video content remains in one column:

![image](https://user-images.githubusercontent.com/13437011/141006421-4a364167-a50f-417e-9ee0-ef4721e11b37.png)

* Verify that above 1080px, both sections are in two columns:

![image](https://user-images.githubusercontent.com/13437011/141006510-a6db95da-11f5-44d9-9e41-a5b793eb2340.png)

* Verify that as the widow size moves above 1280px, the content remains capped at a max width of 1280px and stays centered in the overall container:

![image](https://user-images.githubusercontent.com/13437011/141006806-e99fd24c-9d6c-42c4-8c9c-900f9cc35285.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57799
