### PR TITLE
Calypso apps: Fix dev sync builds

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -17,7 +17,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
 		"build:wpcom-block-editor-no-minify": "NODE_ENV=development calypso-build",
-		"build:wpcom-block-editor": "calypso-build",
+		"build:wpcom-block-editor": "NODE_ENV=production calypso-build",
 		"clean": "npx rimraf dist",
 		"dev": "node ../../bin/build-calypso-app.mjs --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/wpcom-block-editor",
 		"build": "NODE_ENV=production yarn dev"

--- a/bin/build-calypso-app.mjs
+++ b/bin/build-calypso-app.mjs
@@ -90,7 +90,6 @@ async function runBuilder( args ) {
  * mode after a full sync. Is otherwise pending until the user kills the process.
  */
 function setupRemoteSync( localPath, remotePath, shouldWatch = false ) {
-	console.log( 'HERE' );
 	return new Promise( ( resolve, reject ) => {
 		let rsync = null;
 		const debouncedSync = debouncer( () => {
@@ -142,7 +141,6 @@ function setupRemoteSync( localPath, remotePath, shouldWatch = false ) {
 function debouncer( cb ) {
 	let timeout = null;
 	return () => {
-		console.log( 'debounce' );
 		// Each time the debounced function is called, cancel the current schedule
 		// and re-schedule it for +1s.
 		clearTimeout( timeout );

--- a/bin/build-calypso-app.mjs
+++ b/bin/build-calypso-app.mjs
@@ -39,7 +39,7 @@ const { argv } = yargs( hideBin( process.argv ) ).options( {
 	verbose: { type: 'boolean', default: false, alias: 'v' },
 	watch: { type: 'boolean', default: process.env.NODE_ENV === 'development', alias: 'w' },
 } );
-const VERBOSE = argv.versbose;
+const VERBOSE = argv.verbose;
 
 try {
 	await runBuilder( argv );
@@ -85,11 +85,12 @@ async function runBuilder( args ) {
 
 /**
  * Sets up remote syncing. In watch mode, schedules syncs to the remote after changes
- * have stoped happening and existing syncs have stopped. In non-watch mode, does
+ * have stopped happening and existing syncs have stopped. In non-watch mode, does
  * a single sync. Rejects if any errors happen during rsync. Resolves in non-watch
  * mode after a full sync. Is otherwise pending until the user kills the process.
  */
 function setupRemoteSync( localPath, remotePath, shouldWatch = false ) {
+	console.log( 'HERE' );
 	return new Promise( ( resolve, reject ) => {
 		let rsync = null;
 		const debouncedSync = debouncer( () => {
@@ -104,12 +105,13 @@ function setupRemoteSync( localPath, remotePath, shouldWatch = false ) {
 				`rsync -ahz --exclude=".*" ${ localPath } wpcom-sandbox:${ remotePath }`,
 				( err ) => {
 					rsync = null;
-					if ( err && err.signal !== 'SIGINT' ) {
-						// If there's an error other than sigint, reject and abort.
+					// err.signal is null on macOS, so use error code 20 in that case.
+					const wasRsyncCancelled = err && ( err.signal === 'SIGINT' || err.code === 20 );
+					if ( err && ! wasRsyncCancelled ) {
+						// If there's an error unrelated to cancellation, reject and abort.
 						reject( err );
 						return;
-					} else if ( err?.signal === 'SIGINT' ) {
-						// Sigint just means that we want to restart rsync.
+					} else if ( wasRsyncCancelled ) {
 						if ( VERBOSE ) {
 							console.log( 'Restarting sync.' );
 						}
@@ -140,6 +142,7 @@ function setupRemoteSync( localPath, remotePath, shouldWatch = false ) {
 function debouncer( cb ) {
 	let timeout = null;
 	return () => {
+		console.log( 'debounce' );
 		// Each time the debounced function is called, cancel the current schedule
 		// and re-schedule it for +1s.
 		clearTimeout( timeout );


### PR DESCRIPTION
### Changes proposed in this Pull Request
Over the past few days, there have been two issues reported with calypso app syncing. This PR fixes both (and should have no impact on production builds.)

#### Wpcom block editor sync task:
The `wpcom-block-editor` task would sync only non-minified dev files. However, your sandbox would enqueue the minified files. It is important to make sure that all builds, dev and prod, include both minified and non-minified variants, because your sandbox will enqueue one or the other based on the a WordPress debug constant.

Thanks for reporting, @Addison-Stavlo! Original thread: p1636133284095300-slack-C02DQP0FP

#### ETK Sync Task:

The ETK sync task would fail unexpectedly on macOS, saying that it was cancelled with SIGINT. This happens because my original testing was primarily on linux, where `error.signal` correctly includes `SIGINT`. On macOS, it appears that `error.signal` is null. So I can't rely on that to detect when we need to cancel an existing rsync without failing. Instead, I also use `error.code === 20`, which is what gets reported on mac for `proc.kill( 'SIGINT' )`.

Thanks for reporting, @escapemanuele and @chriskmnds! Original thread: p1636467717035500-slack-C029WSAQMT9
 
### Testing instructions
1. Run `yarn dev --sync` for ETK on macOS. It should not fail. Make some changes in `apps/editing-toolkit/editing-toolkit-plugin` and make sure that sync continues working.
2. Run `yarn dev --sync` for wpcom block editor. Looking on your sandbox, verify that both minified and non-minified files were synced. (For example, `calypso.editor.js` and `calypso.editor.min.js` should both be synced.)