### PR TITLE
E2E: split Support Popover spec in two.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-support__popover-invalid.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-invalid.ts
@@ -11,60 +11,11 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
+describe( DataHelper.createSuiteTitle( 'Support: Popover/Invalid Keywords' ), function () {
 	let page: Page;
 
 	setupHooks( ( args: { page: Page } ) => {
 		page = args.page;
-	} );
-
-	describe.each( [
-		{ siteType: 'Simple', user: 'defaultUser' },
-		{ siteType: 'Atomic', user: 'eCommerceUser' },
-	] )( 'Search and view a support article ($siteType)', function ( { user } ) {
-		let supportComponent: SupportComponent;
-		let supportArticlePage: Page;
-
-		it( 'Log in', async function () {
-			const loginPage = new LoginPage( page );
-			await loginPage.login( { account: user } );
-		} );
-
-		it( 'Navigate to Tools > Marketing', async function () {
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Tools', 'Marketing' );
-		} );
-
-		it( 'Open support popover', async function () {
-			supportComponent = new SupportComponent( page );
-			await supportComponent.openPopover();
-		} );
-
-		it( 'Displays default entries', async function () {
-			await supportComponent.defaultStateShown();
-		} );
-
-		it( 'Enter search keyword', async function () {
-			const keyword = 'domain';
-			await supportComponent.search( keyword );
-		} );
-
-		it( 'Search results are shown', async function () {
-			const results = await supportComponent.getResults( 'article' );
-			expect( results.length ).toBeGreaterThan( 0 );
-		} );
-
-		it( 'Click and visit first support article', async function () {
-			await supportComponent.clickResult( 'article', 1 );
-			await supportComponent.clickReadMore();
-			// Obtain handle to the popup page.
-			supportArticlePage = await supportComponent.visitArticle();
-		} );
-
-		it( 'Close article page and preview', async function () {
-			await supportArticlePage.close();
-			await supportComponent.closeArticle();
-		} );
 	} );
 
 	describe.each( [

--- a/test/e2e/specs/specs-playwright/wp-support__popover-valid.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-valid.ts
@@ -1,0 +1,69 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	LoginPage,
+	SidebarComponent,
+	SupportComponent,
+	setupHooks,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
+	let page: Page;
+
+	setupHooks( ( args: { page: Page } ) => {
+		page = args.page;
+	} );
+
+	describe.each( [
+		{ siteType: 'Simple', user: 'defaultUser' },
+		{ siteType: 'Atomic', user: 'eCommerceUser' },
+	] )( 'Search and view a support article ($siteType)', function ( { user } ) {
+		let supportComponent: SupportComponent;
+		let supportArticlePage: Page;
+
+		it( 'Log in', async function () {
+			const loginPage = new LoginPage( page );
+			await loginPage.login( { account: user } );
+		} );
+
+		it( 'Navigate to Tools > Marketing', async function () {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Tools', 'Marketing' );
+		} );
+
+		it( 'Open support popover', async function () {
+			supportComponent = new SupportComponent( page );
+			await supportComponent.openPopover();
+		} );
+
+		it( 'Displays default entries', async function () {
+			await supportComponent.defaultStateShown();
+		} );
+
+		it( 'Enter search keyword', async function () {
+			const keyword = 'theme';
+			await supportComponent.search( keyword );
+		} );
+
+		it( 'Search results are shown', async function () {
+			const results = await supportComponent.getResults( 'article' );
+			expect( results.length ).toBeGreaterThan( 0 );
+		} );
+
+		it( 'Click and visit first support article', async function () {
+			await supportComponent.clickResult( 'article', 1 );
+			await supportComponent.clickReadMore();
+			// Obtain handle to the popup page.
+			supportArticlePage = await supportComponent.visitArticle();
+		} );
+
+		it( 'Close article page and preview', async function () {
+			await supportArticlePage.close();
+			await supportComponent.closeArticle();
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR splits the Support Popover component into two and uses a different search term.

Key changes:
- split the existing `Support: Popover` test into two.
- change the keyword used from `domain` to `theme`.

#### Testing instructions

- [x] stress test
  - [x] mobile
  - [x] desktop
- [x] normal
  - [x] mobile
  - [x] desktop

Closes https://github.com/Automattic/wp-calypso/issues/57851.
