### PR TITLE
Support: Re-enable open tickets banner

### DIFF
--- a/client/data/help/use-active-support-tickets-query.js
+++ b/client/data/help/use-active-support-tickets-query.js
@@ -3,16 +3,12 @@ import wpcom from 'calypso/lib/wp';
 
 const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
 
-// Support History data needs to be disabled temporarily to avoid rate-limiting with our Zendesk API.
-// It is only used for non-essential read-only operations right now.
-const ENABLE_SUPPORT_HISTORY = false;
-
 export const useActiveSupportTicketsQuery = ( email, queryOptions = {} ) =>
 	useQuery(
 		[ 'activeSupportTickets', email ],
 		() => wpcom.req.get( '/support-history', { email, apiNamespace: 'wpcom/v2' } ),
 		{
-			enabled: !! email && ENABLE_SUPPORT_HISTORY,
+			enabled: !! email,
 			select: ( { data } ) =>
 				data.filter(
 					( item ) => item.type === 'Zendesk_History' && ACTIVE_STATUSES.includes( item.status )


### PR DESCRIPTION
Calypso's contact page makes a call to the Zendesk API to check if the user has open tickets, and let them know. We disabled this in https://github.com/Automattic/wp-calypso/pull/55733 to mitigate rate limiting we were experiencing with Zendesk.
This has been since fixed and we should be OK re-enabling it.

### Testing

Open the contact form. You should see a Redux action `SUPPORT_HISTORY_REQUEST` _and_ a corresponding API call matching `support-history`.