### PR TITLE
Remove Jetpack Pricing page "Most Popular" and tighten spacing

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -4,7 +4,7 @@
 	justify-content: space-between;
 	align-items: center;
 
-	margin-top: calc( 32px * 3 );
+	margin-top: 32px;
 	padding: 32px;
 
 	border-width: 1px 0;
@@ -15,7 +15,7 @@
 
 	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
-		margin-bottom: calc( 32px * 3 );
+		margin-bottom: 32px;
 
 		border-width: 1px;
 		border-radius: calc( 2px * 4 );

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -226,7 +226,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					onSelectProduct={ onSelectProduct }
 				/>
 			) }
-			<ProductGridSection title={ translate( 'Most Popular' ) }>
+			<ProductGridSection>
 				{ ! planRecommendation && filterBar }
 				<ul
 					className={ classNames( 'product-grid__plan-grid', {

--- a/client/my-sites/plans/jetpack-plans/product-grid/section.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/section.tsx
@@ -3,14 +3,14 @@ import { TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 
 type Props = {
-	title: TranslateResult;
+	title?: TranslateResult;
 	className?: string;
 	children: React.ReactNode;
 };
 
 const ProductGridSection: React.FC< Props > = ( { title, className, children } ) => (
 	<section className={ classNames( 'product-grid__section', className ) }>
-		<h2 className="product-grid__section-title">{ title }</h2>
+		{ title && <h2 className="product-grid__section-title">{ title }</h2> }
 		{ children }
 	</section>
 );

--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -18,6 +18,7 @@
 
 .jetpack-plans__pricing-header {
 	margin-top: 3rem;
+	margin-bottom: 3rem;
 	padding: 0 1rem;
 	max-width: none;
 
@@ -27,5 +28,6 @@
 
 	@include breakpoint-deprecated( '>660px' ) {
 		font-size: $font-headline-small;
+		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Jetpack Pricing page "Most Popular" sub-heading
* Tighten up spacing around introductory pricing banner


Before                                  |  After
:-------------------------:|:-------------------------:
![Screen Shot 2021-11-09 at 15 39 16](https://user-images.githubusercontent.com/2810519/141023201-8c582f33-4c00-424c-9156-052f07f17a02.png) | ![Screen Shot 2021-11-09 at 15 39 18](https://user-images.githubusercontent.com/2810519/141023200-fdfd1983-9552-4d6a-ab4b-4b28b76cf195.png)
![Screen Shot 2021-11-09 at 15 38 47](https://user-images.githubusercontent.com/2810519/141023205-67111076-c745-4d39-b9b9-e0cf12f8f9ba.png) | ![Screen Shot 2021-11-09 at 15 38 28](https://user-images.githubusercontent.com/2810519/141023208-51e797af-3f45-4bc0-bf6f-56e2c9b5616b.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/pricing` on branch, verify changes match the "after" screenshots above.
