### PR TITLE
Domains: fix sticky domain search bar and width

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -66,7 +66,6 @@ import { DropdownFilters, FilterResetNotice } from 'calypso/components/domains/s
 import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
 import EmptyContent from 'calypso/components/empty-content';
 import Notice from 'calypso/components/notice';
-import StickyPanel from 'calypso/components/sticky-panel';
 import { hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
 import {
 	checkDomainAvailability,
@@ -445,11 +444,11 @@ class RegisterDomainStep extends Component {
 		return (
 			<>
 				<div className={ containerDivClassName }>
-					<StickyPanel className={ searchBoxClassName }>
+					<div className={ searchBoxClassName }>
 						<CompactCard className="register-domain-step__search-card">
 							{ this.renderSearchBar() }
 						</CompactCard>
-					</StickyPanel>
+					</div>
 					{ ! isSignupStep && isQueryInvalid && (
 						<Notice
 							className="register-domain-step__notice"

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -91,7 +91,6 @@ body.is-section-signup.is-white-signup {
 
 		.domains__domain-side-content-container {
 			flex-direction: column;
-			width: 100vw;
 			margin-top: 40px;
 			display: none;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes https://github.com/Automattic/wp-calypso/issues/57856

Before:

<img width="400" src="https://user-images.githubusercontent.com/115071/141027207-f910e0ee-d9f9-4dce-9033-4284fec3c381.png" />

After:


<img width="400" src="https://user-images.githubusercontent.com/115071/141027217-08992d22-2876-45e3-bd22-aaa54eea6e96.png" />

<img width="400" src="https://user-images.githubusercontent.com/115071/141027275-82a92574-23eb-427d-8434-309c5c06bac8.png" />



#### Testing instructions
* Navigate to /start/domains. 
* Notice that when you resize the browser the search bar doesn't go to the top. 
* Notice that there is no side scroll bars.
* Notice that the filter works as expected (you should see a popup) 


