### PR TITLE
More Informative Scan: Update scanning flow

### DIFF
--- a/client/components/jetpack/security-icon/images/in-progress.svg
+++ b/client/components/jetpack/security-icon/images/in-progress.svg
@@ -1,1 +1,6 @@
-<svg width="123" height="150" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 68.182v-37.01L61.365 6.566l55.365 24.606v37.01c0 34.803-23.808 67.143-55.365 75.624C29.808 135.325 6 102.985 6 68.182z" fill="#D0E6B8" stroke="#069E08" stroke-width="12"/></svg>
+<svg width="40" height="48" viewBox="0 0 40 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M20 0L40 8.91914V22.2152C40 33.5494 32.5803 44.2809 22.1176 47.6664C20.7428 48.1112 19.2572 48.1112 17.8824 47.6664C7.41973 44.2809 0 33.5494 0 22.2152V8.91914L20 0Z" fill="#069E08"/>
+<rect x="9" y="21" width="6" height="6" rx="3" fill="white"/>
+<rect x="17" y="21" width="6" height="6" rx="3" fill="white"/>
+<rect x="25" y="21" width="6" height="6" rx="3" fill="white"/>
+</svg>

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -155,20 +155,28 @@ class ScanPage extends Component< Props > {
 			<>
 				<SecurityIcon icon="in-progress" />
 				{ this.renderHeader( heading ) }
+				<p className="scan__progress-bar-percent">{ scanProgress }%</p>
 				<ProgressBar value={ scanProgress } total={ 100 } color="#069E08" />
 				{ isInitialScan && (
 					<p>
 						{ translate(
-							'Welcome to Jetpack Scan, we are taking a first look at your site now ' +
-								'and the results will be with you soon.'
+							'Welcome to Jetpack Scan. We are starting your first scan now. ' +
+								'Scan results will be ready soon.'
 						) }
 					</p>
 				) }
 				<p>
 					{ translate(
-						'We will send you an email if security threats are found. In the meantime feel ' +
+						'{{strong}}Did you know{{/strong}} {{br/}}' +
+							'We will send you an email if security threats are found. In the meantime feel ' +
 							'free to continue to use your site as normal, you can check back on ' +
-							'progress at any time.'
+							'progress at any time.',
+						{
+							components: {
+								strong: <strong />,
+								br: <br />,
+							},
+						}
 					) }
 				</p>
 			</>

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -155,16 +155,16 @@ class ScanPage extends Component< Props > {
 			<>
 				<SecurityIcon icon="in-progress" />
 				{ this.renderHeader( heading ) }
-				<p className="scan__progress-bar-percent">{ scanProgress }%</p>
-				<ProgressBar value={ scanProgress } total={ 100 } color="#069E08" />
 				{ isInitialScan && (
-					<p>
+					<p className="scan__initial-scan-message">
 						{ translate(
 							'Welcome to Jetpack Scan. We are starting your first scan now. ' +
 								'Scan results will be ready soon.'
 						) }
 					</p>
 				) }
+				<p className="scan__progress-bar-percent">{ scanProgress }%</p>
+				<ProgressBar value={ scanProgress } total={ 100 } color="#069E08" />
 				<p>
 					{ translate(
 						'{{strong}}Did you know{{/strong}} {{br/}}' +

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -125,6 +125,13 @@
 	margin-top: 8px;
 }
 
+.scan__progress-bar-percent {
+	font-weight: 600;
+	line-height: 24px;
+	text-align: right;
+	color: #23282d;
+}
+
 /**
  * Jetpack.com specific styles
  */

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -17,6 +17,13 @@
 	}
 }
 
+.scan__content p.scan__initial-scan-message {
+	font-size: $font-title-medium;
+	line-height: 32px;
+	letter-spacing: 0.005em;
+	color: #2c3338;
+}
+
 .security-icon {
 	display: block;
 	margin: 0 auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the scanning flow for the More Informative Scan project(pbuNQi-1IT-p2).

Design reference (p6TEKc-5tS-p2)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a JP site with Scan and add a few threats (You can use the threat tester plugin to add a few innocuous threats for testing).
* Go to the scan section of both Calypso Blue and Calypso Green (To test Calypso Green you need to run yarn start start-jetpack-cloud and then go to http://jetpack.cloud.localhost:3000 on your browser) and run a scan.
* Verify that the layout matches the design specs linked above.

#### Screenshots

##### Before

<img width="769" alt="Screen Shot 2021-11-09 at 21 19 49" src="https://user-images.githubusercontent.com/12788275/141030587-1d0b623f-d297-4677-b6ae-7a045aab620b.png">

##### After
<img width="823" alt="Screen Shot 2021-11-09 at 21 17 39" src="https://user-images.githubusercontent.com/12788275/141030546-de01f32b-8e3f-4cdc-ad8d-eb23cceeb423.png">

