### PR TITLE
Onboarding: Add intent hero flow related events

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -87,6 +87,9 @@ export function recordSignupComplete(
 		is_new_user: isNewUser,
 		is_new_site: isNewSite,
 		has_cart_items: hasCartItems,
+		theme,
+		intent,
+		starting_point: startingPoint,
 	} );
 }
 

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -387,9 +387,12 @@ export default class SignupFlowController {
 				if ( errors ) {
 					this._reduxStore.dispatch( invalidateStep( step, errors ) );
 				} else {
+					const { intent } = getSignupDependencyStore( this._reduxStore.getState() );
+
 					recordTracksEvent( 'calypso_signup_actions_complete_step', {
 						step: step.stepName,
 						flow: this._flowName,
+						intent,
 					} );
 					this._reduxStore.dispatch( completeSignupStep( step, providedDependencies ) );
 				}

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -136,6 +136,7 @@ class DesignPickerStep extends Component {
 			theme: `pub/${ selectedDesign.theme }`,
 			template: selectedDesign.template,
 			flow: this.props.flowName,
+			intent: this.props.signupDependencies.intent,
 		} );
 
 		page( getStepUrl( this.props.flowName, this.props.stepName, selectedDesign.theme, locale ) );
@@ -146,6 +147,7 @@ class DesignPickerStep extends Component {
 			theme: `pub/${ selectedDesign?.theme }`,
 			template: selectedDesign?.template,
 			flow: this.props.flowName,
+			intent: this.props.signupDependencies.intent,
 		} );
 
 		this.props.goToNextStep();

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -36,7 +36,7 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	const branchSteps = useBranchSteps( stepName );
 
 	const submitIntent = ( intent: IntentFlag ) => {
-		recordTracksEvent( 'calypso_signup_select_intent', { intent } );
+		recordTracksEvent( 'calypso_signup_intent_select', { intent } );
 
 		if ( EXTERNAL_FLOW[ intent ] ) {
 			page( getStepUrl( EXTERNAL_FLOW[ intent ] ) );

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -11,6 +11,7 @@ import {
 	SIGNUP_PROGRESS_ADD_STEP,
 } from 'calypso/state/action-types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 
 import 'calypso/state/signup/init';
@@ -23,7 +24,7 @@ function addProvidedDependencies( step, providedDependencies ) {
 	return { ...step, providedDependencies };
 }
 
-function recordSubmitStep( stepName, providedDependencies ) {
+function recordSubmitStep( stepName, providedDependencies, optionalProps ) {
 	// Transform the keys since tracks events only accept snaked prop names.
 	// And anonymize personally identifiable information.
 	const inputs = reduce(
@@ -70,6 +71,7 @@ function recordSubmitStep( stepName, providedDependencies ) {
 	return recordTracksEvent( 'calypso_signup_actions_submit_step', {
 		device,
 		step: stepName,
+		...optionalProps,
 		...inputs,
 	} );
 }
@@ -91,8 +93,9 @@ export function submitSignupStep( step, providedDependencies ) {
 	return ( dispatch, getState ) => {
 		const lastKnownFlow = getCurrentFlowName( getState() );
 		const lastUpdated = Date.now();
+		const { intent } = getSignupDependencyStore( getState() );
 
-		dispatch( recordSubmitStep( step.stepName, providedDependencies ) );
+		dispatch( recordSubmitStep( step.stepName, providedDependencies, { intent } ) );
 
 		dispatch( {
 			type: SIGNUP_PROGRESS_SUBMIT_STEP,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add intent to the following events
  * calypso_signup_select_design
  * calypso_signup_design_preview_select
  * calypso_signup_actions_submit_step
* Also, fix the naming of `calypso_signup_intent_select` as it changed back to the wrong one in https://github.com/Automattic/wp-calypso/pull/57393

| calypso_signup_select_design | calypso_signup_design_preview_select |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/141060946-cb0245bc-1b83-415c-afe1-f89da33fac0b.png) | ![image](https://user-images.githubusercontent.com/13596067/141060741-d4f3ea6a-732c-4ee9-9e48-f61319340e2e.png) |

| calypso_signup_actions_submit_step | calypso_signup_actions_complete_step |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/141060872-b7d9bd92-0f63-483d-a3f8-120786ba6ef3.png) | ![image](https://user-images.githubusercontent.com/13596067/141230605-11048862-1834-4fe5-8aa6-bd0fcdd2a2d4.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?loading_ellipsis=1&flags=signup/hero-flow&siteSlug=<your_site>`
* Selec build intent
* Select `Preview <theme>`
* Seelect `Start with <theme>`
* Check every events mentioned above have the `intent`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57779#issuecomment-964598062
