### PR TITLE
Experiment: Disabled Monthly Personal and Premium plans v2

### DIFF
--- a/client/components/plans/plan-pill/style.scss
+++ b/client/components/plans/plan-pill/style.scss
@@ -13,6 +13,8 @@
 	line-height: 1;
 	color: var( --color-text-inverted );
 	text-transform: uppercase;
+
+	white-space: nowrap;
 }
 
 .plan-pill.is-in-signup {

--- a/client/my-sites/plan-features-comparison/actions.jsx
+++ b/client/my-sites/plan-features-comparison/actions.jsx
@@ -103,6 +103,7 @@ PlanFeaturesComparisonActions.propTypes = {
 	className: PropTypes.string,
 	current: PropTypes.bool,
 	freePlan: PropTypes.bool,
+	isDisabled: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	isLaunchPage: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -183,7 +183,7 @@ PlanFeaturesComparisonHeader.propTypes = {
 	rawPrice: PropTypes.number,
 	title: PropTypes.string.isRequired,
 	translate: PropTypes.func,
-	disabledClasses: PropTypes.object,
+	disabledClasses: PropTypes.string,
 
 	// For Monthly Pricing test
 	annualPricePerMonth: PropTypes.number,

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -15,7 +15,16 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	renderPlansHeaderNoTabs() {
-		const { disabledClasses, planType, popular, selectedPlan, title, translate } = this.props;
+		const {
+			disabledClasses,
+			planType,
+			popular,
+			selectedPlan,
+			isMonthlyPlan,
+			monthlyDisabled,
+			title,
+			translate,
+		} = this.props;
 
 		const headerClasses = classNames(
 			'plan-features-comparison__header',
@@ -23,12 +32,13 @@ export class PlanFeaturesComparisonHeader extends Component {
 			disabledClasses
 		);
 
+		const popularLabel =
+			monthlyDisabled && isMonthlyPlan ? translate( 'Popular on monthly' ) : translate( 'Popular' );
+
 		return (
 			<span>
 				<div>
-					{ popular && ! selectedPlan && (
-						<PlanPill isInSignup={ true }>{ translate( 'Popular' ) }</PlanPill>
-					) }
+					{ popular && ! selectedPlan && <PlanPill isInSignup={ true }>{ popularLabel }</PlanPill> }
 				</div>
 				<header className={ headerClasses }>
 					<h4 className={ classNames( 'plan-features-comparison__header-title', disabledClasses ) }>
@@ -177,10 +187,13 @@ PlanFeaturesComparisonHeader.propTypes = {
 
 	// For Monthly Pricing test
 	annualPricePerMonth: PropTypes.number,
+
+	monthlyDisabled: PropTypes.bool,
 };
 
 PlanFeaturesComparisonHeader.defaultProps = {
 	popular: false,
+	monthlyDisabled: false,
 };
 
 export default localize( PlanFeaturesComparisonHeader );

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -374,9 +374,7 @@ export default connect(
 
 				let popular = false;
 				if ( monthlyDisabled && isMonthlyPlan ) {
-					if ( planObject?.product_name_short === 'Business' ) {
-						popular = plan;
-					}
+					popular = planObject?.product_name_short === 'Business';
 				} else {
 					popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
 				}

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -131,6 +131,7 @@ export class PlanFeaturesComparison extends Component {
 						title={ planConstantObj.getTitle() }
 						annualPricePerMonth={ annualPricePerMonth }
 						isMonthlyPlan={ isMonthlyPlan }
+						monthlyDisabled={ this.props.monthlyDisabled }
 					/>
 				</th>
 			);

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -364,17 +364,18 @@ export default connect(
 				const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
 				const planProductId = planConstantObj.getProductId();
 				const planObject = getPlan( state, planProductId );
-				const showMonthly = ! isMonthly( plan );
+				const isMonthlyPlan = isMonthly( plan );
+				const showMonthly = ! isMonthlyPlan;
 				const availableForPurchase = true;
 				const relatedMonthlyPlan = showMonthly
 					? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
 					: null;
 
-				let popular;
-				if ( monthlyDisabled && planObject?.product_name_short === 'Business' ) {
-					popular = true;
-				} else if ( monthlyDisabled ) {
-					popular = false;
+				let popular = false;
+				if ( monthlyDisabled && isMonthlyPlan ) {
+					if ( planObject?.product_name_short === 'Business' ) {
+						popular = plan;
+					}
 				} else {
 					popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
 				}
@@ -397,7 +398,6 @@ export default connect(
 				const discountPrice = getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
 
 				let annualPricePerMonth = rawPrice;
-				const isMonthlyPlan = isMonthly( plan );
 				if ( isMonthlyPlan ) {
 					// Get annual price per month for comparison
 					const yearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( plan ) );
@@ -447,7 +447,7 @@ export default connect(
 					planConstantObj,
 					planName: plan,
 					planObject: planObject,
-					popular: popular,
+					popular,
 					productSlug: get( planObject, 'product_slug' ),
 					hideMonthly: false,
 					primaryUpgrade: popular || plans.length === 1,

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -177,7 +177,7 @@ export class PlanFeaturesComparison extends Component {
 						className={ getPlanClass( planName ) }
 						current={ current }
 						freePlan={ isFreePlan( planName ) }
-						isDisabled={ disabledClasses }
+						isDisabled={ Boolean( disabledClasses ) }
 						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						isInSignup={ isInSignup }

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -75,6 +75,8 @@ export class PlanFeaturesHeader extends Component {
 			popular,
 			selectedPlan,
 			isInSignup,
+			isMonthlyPlan,
+			monthlyDisabled,
 			title,
 			translate,
 		} = this.props;
@@ -83,6 +85,8 @@ export class PlanFeaturesHeader extends Component {
 			'is-p2-plus': planType === PLAN_P2_PLUS,
 		} );
 		const isCurrent = this.isPlanCurrent();
+		const popularLabel =
+			monthlyDisabled && isMonthlyPlan ? translate( 'Popular on monthly' ) : translate( 'Popular' );
 
 		return (
 			<header className={ headerClasses }>
@@ -103,7 +107,7 @@ export class PlanFeaturesHeader extends Component {
 					<PlanPill isInSignup={ isInSignup }>{ translate( 'Suggested' ) }</PlanPill>
 				) }
 				{ popular && ! selectedPlan && ! isCurrent && (
-					<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
+					<PlanPill isInSignup={ isInSignup }>{ popularLabel }</PlanPill>
 				) }
 				{ newPlan && ! selectedPlan && ! isCurrent && (
 					<PlanPill isInSignup={ isInSignup }>{ translate( 'New' ) }</PlanPill>
@@ -123,6 +127,8 @@ export class PlanFeaturesHeader extends Component {
 			planType,
 			popular,
 			selectedPlan,
+			monthlyDisabled,
+			isMonthlyPlan,
 			title,
 			audience,
 			translate,
@@ -130,6 +136,8 @@ export class PlanFeaturesHeader extends Component {
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 		const isPillInCorner = this.resolveIsPillInCorner();
+		const popularLabel =
+			monthlyDisabled && isMonthlyPlan ? translate( 'Popular on monthly' ) : translate( 'Popular' );
 
 		return (
 			<span>
@@ -140,7 +148,7 @@ export class PlanFeaturesHeader extends Component {
 						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Suggested' ) }</PlanPill>
 					) }
 					{ popular && ! selectedPlan && (
-						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Popular' ) }</PlanPill>
+						<PlanPill isInSignup={ isPillInCorner }>{ popularLabel }</PlanPill>
 					) }
 					{ newPlan && ! selectedPlan && (
 						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'New' ) }</PlanPill>
@@ -522,6 +530,8 @@ PlanFeaturesHeader.propTypes = {
 	relatedYearlyPlan: PropTypes.object,
 
 	isLoggedInMonthlyPricing: PropTypes.bool,
+
+	monthlyDisabled: PropTypes.bool,
 };
 
 PlanFeaturesHeader.defaultProps = {
@@ -539,6 +549,7 @@ PlanFeaturesHeader.defaultProps = {
 	showPlanCreditsApplied: false,
 	siteSlug: '',
 	isLoggedInMonthlyPricing: false,
+	monthlyDisabled: false,
 };
 
 export default connect( ( state, { planType, relatedMonthlyPlan } ) => {

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -32,6 +32,8 @@ type Props = {
 	selectedFeature?: string;
 	isInSignup: boolean;
 	plans: string[];
+	eligibleForWpcomMonthlyPlans?: boolean;
+	disableMonthlyExperiment?: boolean;
 };
 
 interface PathArgs {
@@ -97,7 +99,11 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 
 type IntervalTypeProps = Pick<
 	Props,
-	'intervalType' | 'plans' | 'isInSignup' | 'eligibleForWpcomMonthlyPlans'
+	| 'intervalType'
+	| 'plans'
+	| 'isInSignup'
+	| 'eligibleForWpcomMonthlyPlans'
+	| 'disableMonthlyExperiment'
 >;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
@@ -108,7 +114,13 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		'is-signup': isInSignup,
 	} );
 	const popupIsVisible = intervalType === 'monthly' && isInSignup;
-	const maxDiscount = useMaxDiscount( props.plans );
+	const maxDiscount = useMaxDiscount(
+		props.plans.filter(
+			( plan ) =>
+				! props.disableMonthlyExperiment ||
+				! [ 'personal-bundle-monthly', 'value_bundle_monthly' ].includes( plan )
+		)
+	);
 
 	if ( ! eligibleForWpcomMonthlyPlans ) {
 		return null;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -32,7 +32,7 @@ export class PlansStep extends Component {
 	};
 
 	componentWillMount() {
-		loadExperimentAssignment( 'disabled_monthly_personal_premium' ).then( ( experimentName ) => {
+		loadExperimentAssignment( 'disabled_monthly_personal_premium_v2' ).then( ( experimentName ) => {
 			this.setState( { experiment: experimentName } );
 		} );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR runs a new version of the disabled monthly Personal and Premium experiment. This time we will highlight the yearly Premium plan instead of the yearly Business one. The monthly Business plan will remain highlighted.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_Note: Switching variations may take time. To make it effective immediately, you should delete `explat-experiment--disabled_monthly_personal_premium_v2` from local storage before getting yourself into a new assignment._

* Assign yourself to `treatment` of the `disabled-monthly-personal-premium-v2` experiment.
* On the plans steps, you should see highlighted Business and Premium plans in the monthly and the annually tab, respectively. Also, both monthly Personal and Premium plans should be disabled.
* The `popular` mark should be `Popular on monthly` for monthly plans.
* Max discount should be`24%` instead of `43%` because of disabled monthly plans.

**Desktop**
<img width="1048" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/141235131-965fa94f-c0a3-4943-b169-ec9d8d67f1e2.png">
<img width="1048" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/141235149-548c3362-9361-4e88-a087-54f8945fa359.png">

**Mobile**
<img width="360" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/141235540-6a111f4e-3572-47e2-bbaa-49625563645f.png">
<img width="360" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/141235553-2bb7e699-a6de-4062-af92-6c5251090666.png">

