### PR TITLE
Modernize the VirtualList component: lifecycles, refs, lodash

### DIFF
--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -1,13 +1,24 @@
 import { AutoSizer, List } from '@automattic/react-virtualized';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-import { debounce, range } from 'lodash';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
-import { cloneElement, Component } from 'react';
+import { cloneElement, createRef, Component } from 'react';
 
 const noop = () => {};
 
-export class VirtualList extends Component {
+function range( start, end ) {
+	if ( end < start ) {
+		return range( end, start ).reverse();
+	}
+	const length = end - start + 1;
+	const result = Array( length );
+	for ( let i = 0; i < length; i++ ) {
+		result[ i ] = start + i;
+	}
+	return result;
+}
+
+export default class VirtualList extends Component {
 	static propTypes = {
 		items: PropTypes.array,
 		lastPage: PropTypes.number,
@@ -34,21 +45,17 @@ export class VirtualList extends Component {
 		query: {},
 	};
 
-	state = {};
+	rowHeights = {};
+	listRef = createRef();
 
-	UNSAFE_componentWillMount() {
-		this.rowHeights = {};
-		this.list = null;
-
-		this.queueRecomputeRowHeights = debounce( this.recomputeRowHeights );
-	}
+	queueRecomputeRowHeights = debounce( this.recomputeRowHeights );
 
 	componentDidUpdate( prevProps ) {
 		const forceUpdate =
 			( prevProps.loading && ! this.props.loading ) || ( ! prevProps.items && this.props.items );
 
 		if ( forceUpdate ) {
-			this.list.forceUpdateGrid();
+			this.listRef.current.forceUpdateGrid();
 		}
 
 		if ( this.props.items !== prevProps.items ) {
@@ -57,11 +64,7 @@ export class VirtualList extends Component {
 	}
 
 	recomputeRowHeights() {
-		if ( ! this.list ) {
-			return;
-		}
-
-		this.list.recomputeRowHeights();
+		this.listRef.current?.recomputeRowHeights();
 	}
 
 	getPageForIndex( index ) {
@@ -76,7 +79,7 @@ export class VirtualList extends Component {
 		const { loadOffset, onRequestPages } = this.props;
 		const pagesToRequest = range(
 			this.getPageForIndex( startIndex - loadOffset ),
-			this.getPageForIndex( stopIndex + loadOffset ) + 1
+			this.getPageForIndex( stopIndex + loadOffset )
 		);
 
 		if ( ! pagesToRequest.length ) {
@@ -114,10 +117,6 @@ export class VirtualList extends Component {
 		return count;
 	}
 
-	setListRef = ( ref ) => {
-		this.list = ref;
-	};
-
 	renderNoResults = () => {
 		if ( this.hasNoRows() ) {
 			return (
@@ -128,7 +127,7 @@ export class VirtualList extends Component {
 		}
 	};
 
-	setRowRef = ( index, rowRef ) => {
+	setRowRef = ( index ) => ( rowRef ) => {
 		if ( ! rowRef ) {
 			return;
 		}
@@ -151,8 +150,7 @@ export class VirtualList extends Component {
 		if ( ! element ) {
 			return element;
 		}
-		const setRowRef = ( ...args ) => this.setRowRef( props.index, ...args );
-		return cloneElement( element, { ref: setRowRef } );
+		return cloneElement( element, { ref: this.setRowRef( props.index ) } );
 	};
 
 	cellRendererWrapper = ( { key, style, ...rest } ) => {
@@ -175,7 +173,7 @@ export class VirtualList extends Component {
 				{ ( { width } ) => (
 					<div className={ classes }>
 						<List
-							ref={ this.setListRef }
+							ref={ this.listRef }
 							onRowsRendered={ this.setRequestedPages }
 							rowCount={ rowCount }
 							estimatedRowSize={ defaultRowHeight }
@@ -194,5 +192,3 @@ export class VirtualList extends Component {
 		);
 	}
 }
-
-export default localize( VirtualList );

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -11,11 +11,7 @@ function range( start, end ) {
 		return range( end, start ).reverse();
 	}
 	const length = end - start + 1;
-	const result = Array( length );
-	for ( let i = 0; i < length; i++ ) {
-		result[ i ] = start + i;
-	}
-	return result;
+	return Array.from( { length }, ( _, i ) => i + start );
 }
 
 export default class VirtualList extends Component {


### PR DESCRIPTION
Modernizes the `VirtualList` component:
- remove usages of `_.range` in favor of a local helper
- convert `list` ref to `createRef`
- remove unused `state`
- remove legacy `componentWillMount`, use instance field initializers instead
- remove the redundant `localize` HOC -- there's nothing localized here
- improve the ergonomics of the `setRowRef` method

Inspired by @flootr's #57819 which modified a related component, `TaxonomyManagerList`.