### PR TITLE
CompactCard: forward ref to the child component

### DIFF
--- a/packages/components/src/card/compact.tsx
+++ b/packages/components/src/card/compact.tsx
@@ -1,8 +1,13 @@
+import { forwardRef } from 'react';
 import Card from '.';
 import type { Props, TagName } from '.';
+import type { Ref } from 'react';
 
-export default function CompactCard< T extends TagName = 'div' >(
-	props: Omit< Props< T >, 'compact' >
-): JSX.Element {
-	return <Card { ...( props as Props< T > ) } compact />;
-}
+const CompactCard = forwardRef(
+	< T extends TagName >( props: Omit< Props< T >, 'compact' >, ref: Ref< unknown > ) => (
+		<Card { ...( props as Props< T > ) } compact ref={ ref } />
+	)
+);
+CompactCard.displayName = 'CompactCard';
+
+export default CompactCard;


### PR DESCRIPTION
Fixes the `CompactCard` component so that it can receive refs and forward them to the subcomponent. In the current form, it doesn't accept refs because it's a functional component and triggers warnings like this:

<img width="902" alt="Screenshot 2021-11-10 at 11 21 53" src="https://user-images.githubusercontent.com/664258/141098292-a1f5ed51-0878-4c63-9e9c-bf4f3c3624a5.png">

**How to test:**
Go to the `/settings/taxonomies/category/:site` which renders a virtualized `TaxonomyManagerList` list which passes a `ref` to every item. When this list is in a "loading" state, it renders a `<CompactCard>` placeholder item which triggers the ref warning above. Verify that this warning disappears after applying this patch.