### PR TITLE
Fix first post published modal on AT sites and only show if the intent is write

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller.
+ */
+class WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller extends \WP_REST_Controller {
+	/**
+	 * WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'block-editor/should-show-first-post-published-modal';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'should_show_first_post_published_modal' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return current_user_can( 'read' );
+	}
+
+	/**
+	 * Should we show the first post published modal
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function should_show_first_post_published_modal() {
+		// We don't sync this option to AT sites because we cannot update the value on the AT sites now
+		// Thus, the value on the AT sites is always false.
+		$has_never_published_post        = (bool) get_option( 'has_never_published_post', false );
+		$intent                          = get_option( 'site_intent', '' );
+		$show_first_post_published_modal = $has_never_published_post && 'write' === $intent;
+
+		return rest_ensure_response(
+			array(
+				'should_show_first_post_published_modal' => $show_first_post_published_modal,
+			)
+		);
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
@@ -53,7 +53,7 @@ class WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller extends \
 	public function should_show_first_post_published_modal() {
 		// As we has synced the `has_never_published_post` option to part of atomic sites but we cannot
 		// update the value now, always return false to avoid showing the modal at every publishing until
-		// we can update the value on atomic sites.
+		// we can update the value on atomic sites. See D69932-code.
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			return rest_ensure_response(
 				array(
@@ -62,13 +62,13 @@ class WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller extends \
 			);
 		}
 
-		$has_never_published_post        = (bool) get_option( 'has_never_published_post', false );
-		$intent                          = get_option( 'site_intent', '' );
-		$show_first_post_published_modal = $has_never_published_post && 'write' === $intent;
+		$has_never_published_post               = (bool) get_option( 'has_never_published_post', false );
+		$intent                                 = get_option( 'site_intent', '' );
+		$should_show_first_post_published_modal = $has_never_published_post && 'write' === $intent;
 
 		return rest_ensure_response(
 			array(
-				'should_show_first_post_published_modal' => $show_first_post_published_modal,
+				'should_show_first_post_published_modal' => $should_show_first_post_published_modal,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
@@ -51,8 +51,17 @@ class WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller extends \
 	 * @return WP_REST_Response
 	 */
 	public function should_show_first_post_published_modal() {
-		// We don't sync this option to AT sites because we cannot update the value on the AT sites now
-		// Thus, the value on the AT sites is always false.
+		// As we has synced the `has_never_published_post` option to part of atomic sites but we cannot
+		// update the value now, always return false to avoid showing the modal at every publishing until
+		// we can update the value on atomic sites.
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			return rest_ensure_response(
+				array(
+					'should_show_first_post_published_modal' => false,
+				)
+			);
+		}
+
 		$has_never_published_post        = (bool) get_option( 'has_never_published_post', false );
 		$intent                          = get_option( 'site_intent', '' );
 		$show_first_post_published_modal = $has_never_published_post && 'write' === $intent;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -83,6 +83,10 @@ class WPCOM_Block_Editor_NUX {
 		require_once __DIR__ . '/class-wp-rest-wpcom-block-editor-nux-status-controller.php';
 		$controller = new WP_REST_WPCOM_Block_Editor_NUX_Status_Controller();
 		$controller->register_rest_route();
+
+		require_once __DIR__ . '/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php';
+		$first_post_published_modal_controller = new WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller();
+		$first_post_published_modal_controller->register_rest_route();
 	}
 }
 add_action( 'init', array( __NAMESPACE__ . '\WPCOM_Block_Editor_NUX', 'init' ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -31,7 +31,7 @@ const PostPublishedModal: React.FC = () => {
 		fetchShouldShowFirstPostPublishedModal();
 	}, [ fetchShouldShowFirstPostPublishedModal ] );
 	useEffect( () => {
-		// If the user never published any post before and the current post status changed to publish,
+		// If the user is set to see the first post modal and current post status changes to publish,
 		// open the post publish modal
 		if (
 			shouldShowFirstPostPublishedModal &&

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -17,29 +17,30 @@ const PostPublishedModal: React.FC = () => {
 		select( 'core/editor' ).isCurrentPostPublished()
 	);
 	const previousIsCurrentPostPublished = useRef( isCurrentPostPublished );
-	const siteHasNeverPublishedPost = useSelect( ( select ) =>
-		select( 'automattic/wpcom-welcome-guide' ).getSiteHasNeverPublishedPost()
+	const shouldShowFirstPostPublishedModal = useSelect( ( select ) =>
+		select( 'automattic/wpcom-welcome-guide' ).getShouldShowFirstPostPublishedModal()
 	);
 	const [ isOpen, setIsOpen ] = useState( false );
 	const closeModal = () => setIsOpen( false );
-	const { fetchSiteHasNeverPublishedPost, setSiteHasNeverPublishedPost } = useDispatch(
-		'automattic/wpcom-welcome-guide'
-	);
+	const {
+		fetchShouldShowFirstPostPublishedModal,
+		setShouldShowFirstPostPublishedModal,
+	} = useDispatch( 'automattic/wpcom-welcome-guide' );
 
 	useEffect( () => {
-		fetchSiteHasNeverPublishedPost();
-	}, [ fetchSiteHasNeverPublishedPost ] );
+		fetchShouldShowFirstPostPublishedModal();
+	}, [ fetchShouldShowFirstPostPublishedModal ] );
 	useEffect( () => {
 		// If the user never published any post before and the current post status changed to publish,
 		// open the post publish modal
 		if (
-			siteHasNeverPublishedPost &&
+			shouldShowFirstPostPublishedModal &&
 			! previousIsCurrentPostPublished.current &&
 			isCurrentPostPublished &&
 			postType === 'post'
 		) {
 			previousIsCurrentPostPublished.current = isCurrentPostPublished;
-			setSiteHasNeverPublishedPost( false );
+			setShouldShowFirstPostPublishedModal( false );
 
 			// When the post published panel shows, it is focused automatically.
 			// Thus, we need to delay open the modal so that the modal would not be close immediately
@@ -50,9 +51,9 @@ const PostPublishedModal: React.FC = () => {
 		}
 	}, [
 		postType,
-		siteHasNeverPublishedPost,
+		shouldShowFirstPostPublishedModal,
 		isCurrentPostPublished,
-		setSiteHasNeverPublishedPost,
+		setShouldShowFirstPostPublishedModal,
 	] );
 
 	return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -61,10 +61,9 @@ const welcomeGuideVariantReducer = ( state = DEFAULT_VARIANT, action ) => {
 	}
 };
 
-const siteHasNeverPublishedPostReducer = ( state = false, action ) => {
+const shouldShowFirstPostPublishedModalReducer = ( state = false, action ) => {
 	switch ( action.type ) {
-		case 'WPCOM_SITE_HAS_NEVER_PUBLISHED_POST_FETCH_SUCCESS':
-		case 'WPCOM_SITE_HAS_NEVER_PUBLISHED_POST_SET':
+		case 'WPCOM_SET_SHOULD_SHOW_FIRST_POST_PUBLISHED_MODAL':
 			return action.value;
 		case 'WPCOM_WELCOME_GUIDE_RESET_STORE':
 			return false;
@@ -78,7 +77,7 @@ const reducer = combineReducers( {
 	showWelcomeGuide: showWelcomeGuideReducer,
 	tourRating: tourRatingReducer,
 	welcomeGuideVariant: welcomeGuideVariantReducer,
-	siteHasNeverPublishedPost: siteHasNeverPublishedPostReducer,
+	shouldShowFirstPostPublishedModal: shouldShowFirstPostPublishedModalReducer,
 } );
 
 const actions = {
@@ -90,12 +89,14 @@ const actions = {
 			response,
 		};
 	},
-	*fetchSiteHasNeverPublishedPost() {
-		const response = yield apiFetchControls( { path: '/wpcom/v2/site-has-never-published-post' } );
+	*fetchShouldShowFirstPostPublishedModal() {
+		const response = yield apiFetchControls( {
+			path: '/wpcom/v2/block-editor/should-show-first-post-published-modal',
+		} );
 
 		return {
-			type: 'WPCOM_SITE_HAS_NEVER_PUBLISHED_POST_FETCH_SUCCESS',
-			value: !! response,
+			type: 'WPCOM_SET_SHOULD_SHOW_FIRST_POST_PUBLISHED_MODAL',
+			value: response.show_first_post_published_modal,
 		};
 	},
 	setShowWelcomeGuide: ( show, { openedManually } = {} ) => {
@@ -117,8 +118,8 @@ const actions = {
 	setUsedPageOrPatternsModal: () => {
 		return { type: 'WPCOM_HAS_USED_PATTERNS_MODAL' };
 	},
-	setSiteHasNeverPublishedPost: ( value ) => {
-		return { type: 'WPCOM_SITE_HAS_NEVER_PUBLISHED_POST_SET', value };
+	setShouldShowFirstPostPublishedModal: ( value ) => {
+		return { type: 'WPCOM_SET_SHOULD_SHOW_FIRST_POST_PUBLISHED_MODAL', value };
 	},
 	// The `resetStore` action is only used for testing to reset the
 	// store inbetween tests.
@@ -135,7 +136,7 @@ const selectors = {
 	// the 'modal' variant previously used for mobile has been removed but its slug may still be persisted in local storage
 	getWelcomeGuideVariant: ( state ) =>
 		state.welcomeGuideVariant === 'modal' ? DEFAULT_VARIANT : state.welcomeGuideVariant,
-	getSiteHasNeverPublishedPost: ( state ) => state.siteHasNeverPublishedPost,
+	getShouldShowFirstPostPublishedModal: ( state ) => state.shouldShowFirstPostPublishedModal,
 };
 
 export function register() {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -96,7 +96,7 @@ const actions = {
 
 		return {
 			type: 'WPCOM_SET_SHOULD_SHOW_FIRST_POST_PUBLISHED_MODAL',
-			value: response.show_first_post_published_modal,
+			value: response.should_show_first_post_published_modal,
 		};
 	},
 	setShowWelcomeGuide: ( show, { openedManually } = {} ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As the original way to call `has-never-published-post` on AT sites would get the 404 error, we need another way to handle the first post published modal.

* Implement the endpoint in the ETK plugin so that we can call the API on AT sites
* Change the API to `should-show-first-post-published-modal` and check `has_never_published_post` and `site_intent` inside the API.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Basic

* Go to `/start`
* Complete the onboarding flow with an eCommerce plan
* Deactivate the ETK plugin and install the version built from this PR
* Create a new post
* Check the network request to see `/wpcom/v2/block-editor/should-show-first-post-published-modal` is successfully.

##### Don't show first post modal on the AT site now no matter the user intent.

* Go to `/start`
* Complete the onboarding flow with a free plan and hero flow.
* Upgrade to an eCommerce plan
* Deactivate the ETK plugin and install the version built from this PR
* Create a new post
* Check the first post published modal shows after publishing

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57855, p1635987439075900-slack-CRWCHQGUB