### PR TITLE
SettingsSectionHeader: fix proptypes to prevent warning

### DIFF
--- a/client/my-sites/site-settings/settings-section-header.jsx
+++ b/client/my-sites/site-settings/settings-section-header.jsx
@@ -34,10 +34,7 @@ SettingsSectionHeader.propTypes = {
 	isSaving: PropTypes.bool,
 	onButtonClick: PropTypes.func,
 	showButton: PropTypes.bool,
-	title: PropTypes.string.isRequired,
-
-	// from localize() HoC
-	translate: PropTypes.func,
+	title: PropTypes.node.isRequired,
 };
 
 export default SettingsSectionHeader;


### PR DESCRIPTION
Fixes proptypes of the `SettingsSectionHeader` component to accept `PropTypes.node`, i.e., a generic JSX markup, instead of just a `PropTypes.string` as the `title` prop. Fixes this warning:

<img width="840" alt="Screenshot 2021-11-10 at 11 49 01" src="https://user-images.githubusercontent.com/664258/141101077-89750dd8-de1a-4184-ae5a-65b32e04bf27.png">

issued when rendering a `Fragment` (title with an icon) in `/settings/general/:site`:

<img width="731" alt="Screenshot 2021-11-10 at 11 49 25" src="https://user-images.githubusercontent.com/664258/141101238-0dcb4e63-7892-4fbe-b7ea-807e09ed1148.png">

I'm also removing the proptype for `translate` because that's now handled by the `useTranslate` hook, not by a HOC that would inject the prop.

**How to test**
Go to `/settings/general/:site` and verify the warning is no longer there.