### PR TITLE
Connections: Add default grid icons for connection services

### DIFF
--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -46,6 +46,12 @@ class SharingConnection extends Component {
 		defaultServiceIcon: {
 			google_my_business: 'institution',
 			slack: 'link',
+			'instagram-basic-display': 'user',
+			linkedin: 'user',
+			twitter: 'user',
+			tumblr: 'user',
+			google_photos: 'user',
+			facebook: 'user',
 		},
 	};
 

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -272,6 +272,7 @@
 
 	.sharing-connection__account-avatar.is-fallback.#{ $name } {
 		background-color: $color;
+		color: var( --color-neutral-0 );
 	}
 }
 
@@ -842,7 +843,7 @@
 	padding: 1px 8px 0 5px;
 
 	&.style-icon {
-		border-radius: 50%;
+		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		border: 0;
 		box-shadow: none;
 		padding: 7px;


### PR DESCRIPTION
Third-party services (e.g. Facebook, LinkedIn, Twitter, ...) connected to a site (in Tools → Marketing → Connections) display linked profile picture (if it is available):

![Markup on 2021-11-10 at 12:55:43](https://user-images.githubusercontent.com/25105483/141108754-22df6db6-dd5c-41cf-af8b-2404b3a6733f.png)

When there is no profile picture available, empty box is displayed instead:

![Markup on 2021-11-10 at 12:58:51](https://user-images.githubusercontent.com/25105483/141109316-0cba27b9-26bc-45b3-bce8-c092cd93fa50.png)
![Markup on 2021-11-10 at 13:01:53](https://user-images.githubusercontent.com/25105483/141109607-f211e2dc-797a-4af0-bd2d-5e6c09c84e87.png)

The proposed change adds default [Grid icon](https://github.com/Automattic/gridicons) for each service and also addresses the Instagram case (https://github.com/Automattic/wp-calypso/issues/41326) where the profile picture isn't available due to [Instagram API](https://developers.facebook.com/docs/instagram-basic-display-api/reference/user) limitations.

The following screenshots illustrates the changes proposed by this PR:

![Markup on 2021-11-10 at 13:10:06](https://user-images.githubusercontent.com/25105483/141110711-6e875ed0-35f1-41cd-822a-fc01956afc7b.png)
![Markup on 2021-11-10 at 13:10:30](https://user-images.githubusercontent.com/25105483/141110714-59b69be4-feb4-47e5-aa05-57a0b9df1d90.png)


#### Changes proposed in this Pull Request

* Add default Grid icon for third-party services
* Make sure the styling is correct

#### Testing instructions
1. Navigate to Tools → Marketing → Connections
2. Decide which service you would like to test. The services easiest to test are Instagram and LinedIn.
3. If you are testing Instagram, simply connect your account to the site
4. If you are testing LinkedIn (or other third-party service), it is necessary to temporarily remove your profile picture from your third-party service account.
5. The default Grid icons (`user` - avatar) should be displayed - as can be see in the two screenshots above

Please note that some services won't let you remove your profile picture completely (e.g. Twitter). The PR adds default icon for them anyways - in case the service changes the way they handle profile pictures in the future.

Related to https://github.com/Automattic/wp-calypso/issues/41326.
