### PR TITLE
Video UI: Fix accordion item height when open

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -115,9 +115,9 @@
 
 				.videos-ui__active-video-content {
 					overflow: hidden;
-					height: 0;
+					max-height: 0;
 					transition:
-						height 0.2s ease-out;
+						max-height 0.2s ease-out;
 
 					div {
 						padding: 20px;
@@ -130,7 +130,7 @@
 				}
 
 				&.selected .videos-ui__active-video-content {
-					height: 250px;
+					max-height: 250px;
 				}
 			}
 		}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -79,10 +79,10 @@
 		}
 
 		.videos-ui__chapters {
-			background: #1d262a;
 			font-size: $font-body-small;
 
 			.videos-ui__chapter {
+				background: #1d262a;
 				border-bottom: 1px solid #343c3f;
 
 				&:last-child {


### PR DESCRIPTION
This PR adds relative height to each video item section in the accordion.

| Before  | After |
| ------------- | ------------- |
| ![2021-11-10 09 25 29](https://user-images.githubusercontent.com/375980/141112914-a0e90730-13aa-4702-9a75-3ac3f141f2a7.gif) |  ![2021-11-10 09 22 51](https://user-images.githubusercontent.com/375980/141112843-8ed16745-377a-4fb3-b92e-9b18b52aa353.gif) |

#### Testing


1. Apply this PR.
2. Add the VideosUi to the home screen.
3. Verify that accordion item height is correct when disclosed.


Related to #57671
