### PR TITLE
Plugin Details: Add eligibility checks 

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -34,6 +34,7 @@ const noop = () => {};
 interface ExternalProps {
 	backUrl: string;
 	onProceed: () => void;
+	standaloneProceed: boolean;
 	className?: string;
 	eligibilityData?: {
 		eligibilityHolds: string[];
@@ -53,6 +54,7 @@ export const EligibilityWarnings = ( {
 	isEligible,
 	isPlaceholder,
 	onProceed,
+	standaloneProceed,
 	recordUpgradeClick,
 	siteId,
 	siteSlug,
@@ -79,6 +81,10 @@ export const EligibilityWarnings = ( {
 	const makeCurrentSitePublic = () => makeSitePublic( siteId );
 
 	const logEventAndProceed = () => {
+		if ( standaloneProceed ) {
+			onProceed();
+			return;
+		}
 		if ( siteRequiresUpgrade( listHolds ) ) {
 			recordUpgradeClick( ctaName, feature );
 			page.redirect( `/checkout/${ siteSlug }/business` );

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,4 +1,8 @@
-import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
+import {
+	isWpComBusinessPlan,
+	isWpComEcommercePlan,
+	isEnterprise,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -308,9 +312,9 @@ function CTA( { slug, isPluginInstalledOnsite } ) {
 	}
 
 	const shouldUpgrade = ! (
-		isBusiness( selectedSite.plan ) ||
+		isWpComBusinessPlan( selectedSite.plan ) ||
 		isEnterprise( selectedSite.plan ) ||
-		isEcommerce( selectedSite.plan ) ||
+		isWpComEcommercePlan( selectedSite.plan ) ||
 		isJetpack ||
 		isVipSite
 	);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -382,7 +382,7 @@ function CTA( {
 		<>
 			<Dialog
 				isVisible={ showEligibility }
-				title="Eligibility"
+				title={ translate('Eligibility') }
 				onClose={ () => setShowEligibility( false ) }
 			>
 				<EligibilityWarnings

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -39,6 +39,7 @@ import {
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
+import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
 import {
 	isJetpackSite as checkJetpackSite,
 	isRequestingSites as checkRequestingSites,
@@ -300,6 +301,7 @@ function CTA( { slug, isPluginInstalledOnsite } ) {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => checkJetpackSite( state, selectedSite?.ID ) );
+	const isVipSite = useSelector( ( state ) => checkVipSite( state, selectedSite?.ID ) );
 
 	if ( ! shouldDisplayCTA( selectedSite, slug, isPluginInstalledOnsite ) ) {
 		return null;
@@ -309,7 +311,8 @@ function CTA( { slug, isPluginInstalledOnsite } ) {
 		isBusiness( selectedSite.plan ) ||
 		isEnterprise( selectedSite.plan ) ||
 		isEcommerce( selectedSite.plan ) ||
-		isJetpack
+		isJetpack ||
+		isVipSite
 	);
 	return (
 		<Button

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -382,7 +382,7 @@ function CTA( {
 		<>
 			<Dialog
 				isVisible={ showEligibility }
-				title={ translate('Eligibility') }
+				title={ translate( 'Eligibility' ) }
 				onClose={ () => setShowEligibility( false ) }
 			>
 				<EligibilityWarnings


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds a `standaloneProceed` mode in `EligibilityWarnings` so that we can override the behavior of the button action from the parent component
* exclude VIP sites from need to upgrade.
* uses wpcom specific plan selectors instead of generic ones eg `isWpComBusinessPlan` vs `isBusiness`
* handles incompatible plugins by not allowing installation in WordPress.com sites
* shows eligibilities (eg domain change, need to upgrade)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For all scenarios you will need a Simple Free site, Simple Business, Atomic, Jetpack

### Scenario 1 - Incompatible plugins

**Visit `/plugins/advanced-database-cleaner/[DOMAIN]**

- You should be able to install / proceed only in a Jetpack site. 
- The rest WordPress.com sites should display a warning.
<img width="1090" alt="SS 2021-11-15 at 19 37 17" src="https://user-images.githubusercontent.com/12430020/141828277-4d6a7046-0cd3-4e7d-a2e0-b7f5dc68742f.png">

### Scenario 2 - Eligibilities

**Visit `/plugins/wordpress-seo/[DOMAIN]**

- On Simple Free sites you should get a warning to upgrade and a domain change. 
- Clicking Upgrade & Continue should proceed with checkout of business plan & plugin installation
<img width="1023" alt="SS 2021-11-15 at 19 40 44" src="https://user-images.githubusercontent.com/12430020/141828734-8b1eacaf-ceb6-4901-a0df-f9808ed66a6b.png">

- On Simple Business sites, just the domain warning. 
- Clicking Continue should proceed with plugin installation
<img width="1049" alt="SS 2021-11-15 at 19 41 29" src="https://user-images.githubusercontent.com/12430020/141828856-323f4185-73ae-4053-8315-165ffa07e620.png">

- On Atomic & Jetpack sites, nothing should display, installation should be instant.

### Scenario 3 - Regressions

** Visit `/hosting-config/[DOMAIN]` of Simple Business site

- Clicking activate should display the domain warning
- Proceeding should transfer the site to Atomic 
<img width="819" alt="SS 2021-11-15 at 19 44 39" src="https://user-images.githubusercontent.com/12430020/141829330-3a62fa4c-f93c-4817-bfbc-9e3ec4ad311e.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57763
