### PR TITLE
Plans: Fix Jetpack Free card so it doesn't overflow in Safari

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -106,6 +106,10 @@
 	.product-grid__free {
 		margin-top: 16px;
 		flex-direction: column;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			flex-direction: initial;
+		}
 	}
 
 	.jetpack-product-card.jetpack-free-card {


### PR DESCRIPTION
Resolves `1200412004370260-as-1201352774314328`, `p6TEKc-5yE-p2`.

#### Changes proposed in this Pull Request

* Restrict the `flex-direction: column;` rule for the Free card section so that it only takes effect on screens wider than 660px.

#### Testing instructions

**IMPORTANT:** This PR should be tested especially in Safari, but in other browsers as well.

1. Open the pricing page in either Calypso Blue or Calypso Green. _(NOTE: Please test both!)_
2. On wide-screen layouts, verify the Jetpack Free card does not overflow (see "before" screenshot).
3. Resize the viewport to make sure all product cards (esp. the Free and CRM cards) correctly resize themselves and re-flow correctly on the screen.

#### Reference screenshots (before / after)

![image](https://user-images.githubusercontent.com/670067/141123472-520f347b-1cc8-4605-bcd7-3014ba4fa34f.png)

<img width="1083" alt="Screen Shot 2021-11-10 at 07 32 51" src="https://user-images.githubusercontent.com/670067/141123511-80d746cc-853b-44ac-8777-8c3c1ee3fb0f.png">
