### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` site features to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -350,25 +350,6 @@ Undocumented.prototype.validateDomainContactInformation = function (
 };
 
 /**
- * Get a site specific details for WordPress.com featurs
- *
- * @param {Function} siteDomain The site slug
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.getSiteFeatures = function ( siteDomain, fn ) {
-	debug( '/sites/:site_domain:/features query' );
-
-	return this._sendRequest(
-		{
-			path: `/sites/${ encodeURIComponent( siteDomain ) }/features`,
-			method: 'get',
-			apiVersion: '1.1',
-		},
-		fn
-	);
-};
-
-/**
  * Return a list of third-party services that WordPress.com can integrate with for a specific site
  *
  * @param {number|string} siteId The site ID or domain

--- a/client/state/sites/features/actions.js
+++ b/client/state/sites/features/actions.js
@@ -37,29 +37,26 @@ export function fetchSiteFeatures( siteId ) {
 			siteId,
 		} );
 
-		return new Promise( ( resolve ) => {
-			wpcom.undocumented().getSiteFeatures( siteId, ( error, data ) => {
-				if ( error ) {
-					debug( 'Fetching site features failed: ', error );
+		return wpcom.req
+			.get( `/sites/${ siteId }/features` )
+			.then( ( data ) => {
+				dispatch( fetchSiteFeaturesCompleted( siteId, data ) );
+			} )
+			.catch( ( error ) => {
+				debug( 'Fetching site features failed: ', error );
 
-					const errorMessage =
-						error.message ||
-						i18n.translate(
-							'There was a problem fetching site features. Please try again later or contact support.'
-						);
+				const errorMessage =
+					error.message ||
+					i18n.translate(
+						'There was a problem fetching site features. Please try again later or contact support.'
+					);
 
-					dispatch( {
-						type: SITE_FEATURES_FETCH_FAILED,
-						siteId,
-						error: errorMessage,
-					} );
-				} else {
-					dispatch( fetchSiteFeaturesCompleted( siteId, data ) );
-				}
-
-				resolve();
+				dispatch( {
+					type: SITE_FEATURES_FETCH_FAILED,
+					siteId,
+					error: errorMessage,
+				} );
 			} );
-		} );
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` site features method to `wpcom.req.get()`. 

The PR also simplifies the code a little bit - we don't need to encode the site fragment, because anywhere in the code where we're making requests to this endpoint, we pass the numeric site ID. 

We're also removing an unnecessary wrapping `Promise` - `wpcom.req.get()` already returns a promise.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/marketing/traffic/:site` where `:site` is one of your sites.
* Verify that the request to `/sites/:site/features` is still successful.

