### PR TITLE
Site Editor e2e - update `selectSiteEditor` sidebar method for new entry point.

### DIFF
--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -70,10 +70,16 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectSiteEditor() {
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.menu-link-text[data-e2e-sidebar*="Site Editor"]' )
-		);
+		// This menu location is being removed with 11.9.  Once the new menu location under
+		// 'Appearance' is stable, we can remove this old menu handling.
+		const oldMenuSelector = By.css( '.menu-link-text[data-e2e-sidebar*="Site Editor"]' );
+		const isOldMenuPresent = await driverHelper.isElementLocated( this.driver, oldMenuSelector );
+		if ( isOldMenuPresent ) {
+			return await driverHelper.clickWhenClickable( this.driver, oldMenuSelector );
+		}
+
+		await this.expandDrawerItem( 'Appearance' );
+		return await this._scrollToAndClickMenuItem( 'Editor' );
 	}
 
 	async selectWPAdmin() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The entry point to the site editor has changed with Gutenberg v11.9.  Here, we update the `selectSiteEditor` method to handle this new location appropriately.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ran e2e test `wp-site-editor-spec.js` on both non-edge and edge and verified the site editor opens in the beginning as expected.
* NOTE - edge tests are expected to fail until https://github.com/Automattic/jetpack/pull/21691 is deployed to dotcom, but the site editor should load before that point either way.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
