### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` exports to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -953,60 +953,6 @@ Undocumented.prototype.uploadExportFile = function ( siteId, params ) {
 };
 
 /**
- * Get the available export configuration settings for a site
- *
- * @param {number}       siteId            The site ID
- * @param {Function}  fn                The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.getExportSettings = function ( siteId, fn ) {
-	return this.wpcom.req.get(
-		{
-			apiVersion: '1.1',
-			path: `/sites/${ siteId }/exports/settings`,
-		},
-		fn
-	);
-};
-
-/*
- * Start an export
- *
- * @param {number}       siteId            The site ID
- * @param {object}    advancedSettings  Advanced export configuration
- * @param {Function}  fn                The callback function
- * @returns {Promise}                   A promise that resolves when the export started
- */
-Undocumented.prototype.startExport = function ( siteId, advancedSettings, fn ) {
-	return this.wpcom.req.post(
-		{
-			apiVersion: '1.1',
-			path: `/sites/${ siteId }/exports/start`,
-		},
-		advancedSettings,
-		fn
-	);
-};
-
-/**
- * Check the status of an export
- *
- * @param {number|string} siteId - The site ID
- * @param {object} exportId - Export ID (for future use)
- * @param {Function} fn - The callback function
- * @returns {Promise}  promise
- */
-Undocumented.prototype.getExport = function ( siteId, exportId, fn ) {
-	return this.wpcom.req.get(
-		{
-			apiVersion: '1.1',
-			path: `/sites/${ siteId }/exports/${ exportId }`,
-		},
-		fn
-	);
-};
-
-/**
  * Check different info about WordPress and Jetpack status on a url
  *
  * @param  {string}  inputUrl The url of the site to check. Must use http or https protocol.

--- a/client/state/exporter/actions.js
+++ b/client/state/exporter/actions.js
@@ -68,9 +68,8 @@ export function advancedSettingsFetch( siteId ) {
 
 		const fetchFail = ( error ) => dispatch( advancedSettingsFail( siteId, error ) );
 
-		return wpcom
-			.undocumented()
-			.getExportSettings( siteId )
+		return wpcom.req
+			.get( `/sites/${ siteId }/exports/settings` )
 			.then( updateExportSettings )
 			.catch( fetchFail );
 	};
@@ -116,9 +115,8 @@ export function startExport( siteId, { exportAll = true } = {} ) {
 
 		const failure = ( error ) => dispatch( exportFailed( siteId, error ) );
 
-		return wpcom
-			.undocumented()
-			.startExport( siteId, advancedSettings )
+		return wpcom.req
+			.post( `/sites/${ siteId }/exports/start`, advancedSettings )
 			.then( success )
 			.catch( failure );
 	};
@@ -153,7 +151,7 @@ export function exportStatusFetch( siteId ) {
 			return failure( response );
 		};
 
-		return wpcom.undocumented().getExport( siteId, 0 ).then( success ).catch( failure );
+		return wpcom.req.get( `/sites/${ siteId }/exports/0` ).then( success ).catch( failure );
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates all the `wpcom.undocumented()` exports methods to `wpcom.req.get()` and `wpcom.req.post()`.  

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/export/:site` where `:site` is one of your WP.com simple sites.
* Verify that the request to `/sites/:siteId/export/settings` has been successful, and when you expand the "Export Content" accordion, you have some options loaded there (Posts and Pages at minimum).
* Click on "Export All" and verify that export is triggered correctly.
* Verify that we're successfully polling for the status of the export and you still receive an email and a success notice when it's finished.
* Verify the related tests still pass: `yarn run test-client client/state/exporter/test/actions.js`

