### PR TITLE
Fix Site Editor close button for G v11.9

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/navigation-toggle/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/navigation-toggle/index.js
@@ -6,7 +6,13 @@ function injectNavigationToggleOnClickHandler() {
 		return;
 	}
 
-	const toggle = document.querySelector( '.edit-site-navigation-toggle' );
+	const toggle =
+		document.querySelector( '.edit-site-navigation-toggle' ) ||
+		// The navigation toggle is being removed with Gutenberg v11.9, so we must check the
+		// navigation link button to override the click behavior.  Once v12.0 lands, we should
+		// be able to use a slotfill and get rid of this entire file.
+		document.querySelector( '.edit-site-navigation-link__button' );
+
 	if ( ! toggle ) {
 		return;
 	}
@@ -35,7 +41,13 @@ domReady( () => {
 	}
 
 	const waitForNavigationToggleButton = setInterval( () => {
-		const toggleButton = document.querySelector( '.edit-site-navigation-toggle__button' );
+		const toggleButton =
+			document.querySelector( '.edit-site-navigation-toggle__button' ) ||
+			// The navigation toggle is being removed with Gutenberg v11.9, so we must check the
+			// navigation link button to override the click behavior.  Once v12.0 lands, we should
+			// be able to use a slotfill and get rid of this entire file.
+			document.querySelector( '.edit-site-navigation-link__button' );
+
 		if ( ! toggleButton ) {
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With Gutenberg v11.9, the navigation toggle was removed.  This caused our override to close the editor to no longer work, thus the editor in 11.9 now tries to close to wp-admin instead of calypso, which is not allowed and results in this gray screen:

![Screen Shot 2021-11-10 at 10 20 07 AM](https://user-images.githubusercontent.com/28742426/141140672-54f07598-e3e3-4ac3-8c9f-cb5d7dc5b4d1.png)

Here, we add the selector for the new close button to keep the same override functionality.  Once v12.0 is shipped to dotcom, we can get rid of this hacky goo altogether and go back to using the slot/fill for overriding the close button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this diff to your sandbox
* On a non-edge site, open the site editor and verify closing behavior is unchanged.
* Patch D69833-code to your sandbox to enable the new entry point.
* On an edge site, open the site editor and verify closing leads back to calypso.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #