### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` GDPR consent to `wpcom.req`

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -30,7 +30,6 @@ export {
 	isMappedDomainWithWpcomNameservers,
 } from './mapped-domains';
 export { getRegisteredDomains, isRegisteredDomain } from './registered-domains';
-export { requestGdprConsentManagementLink } from './request-gdpr-consent-management-link';
 export { resendIcannVerification } from './resend-icann-verification';
 export { resolveDomainStatus } from './resolve-domain-status';
 export { startInboundTransfer } from './start-inbound-transfer';

--- a/client/lib/domains/request-gdpr-consent-management-link.js
+++ b/client/lib/domains/request-gdpr-consent-management-link.js
@@ -1,5 +1,5 @@
 import wpcom from 'calypso/lib/wp';
 
-export function requestGdprConsentManagementLink( domainName, onComplete ) {
-	return wpcom.undocumented().requestGdprConsentManagementLink( domainName, onComplete );
+export function requestGdprConsentManagementLink( domainName ) {
+	return wpcom.req.get( `/domains/${ domainName }/request-gdpr-consent-management-link` );
 }

--- a/client/lib/domains/request-gdpr-consent-management-link.js
+++ b/client/lib/domains/request-gdpr-consent-management-link.js
@@ -1,5 +1,0 @@
-import wpcom from 'calypso/lib/wp';
-
-export function requestGdprConsentManagementLink( domainName ) {
-	return wpcom.req.get( `/domains/${ domainName }/request-gdpr-consent-management-link` );
-}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1039,20 +1039,6 @@ Undocumented.prototype.oauth2ClientId = function ( clientId, fn ) {
 	);
 };
 
-Undocumented.prototype.requestGdprConsentManagementLink = function ( domain, callback ) {
-	return this.wpcom.req.get(
-		`/domains/${ domain }/request-gdpr-consent-management-link`,
-		function ( error, response ) {
-			if ( error ) {
-				callback( error );
-				return;
-			}
-
-			callback( null, response );
-		}
-	);
-};
-
 Undocumented.prototype.getDomainConnectSyncUxUrl = function (
 	domain,
 	providerId,

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -95,13 +95,13 @@ class ManageConsent extends Component {
 
 	requestConsentManagementLink = () => {
 		this.setState( { submitting: true } );
-		requestGdprConsentManagementLink( this.props.selectedDomainName, ( error ) => {
-			if ( error ) {
-				this.setState( { error: error.message, success: false, submitting: false } );
-			} else {
+		requestGdprConsentManagementLink( this.props.selectedDomainName )
+			.then( () => {
 				this.setState( { error: null, success: true, submitting: false } );
-			}
-		} );
+			} )
+			.catch( ( error ) => {
+				this.setState( { error: error.message, success: false, submitting: false } );
+			} );
 	};
 
 	goToContactsPrivacy = () => {

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -7,7 +7,8 @@ import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
-import { getSelectedDomain, requestGdprConsentManagementLink } from 'calypso/lib/domains';
+import { getSelectedDomain } from 'calypso/lib/domains';
+import wpcom from 'calypso/lib/wp';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import { domainManagementContactsPrivacy } from 'calypso/my-sites/domains/paths';
@@ -95,7 +96,8 @@ class ManageConsent extends Component {
 
 	requestConsentManagementLink = () => {
 		this.setState( { submitting: true } );
-		requestGdprConsentManagementLink( this.props.selectedDomainName )
+		wpcom.req
+			.get( `/domains/${ this.props.selectedDomainName }/request-gdpr-consent-management-link` )
 			.then( () => {
 				this.setState( { error: null, success: true, submitting: false } );
 			} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` GDPR consent email send method to `wpcom.req.get()`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/domains/manage/:domain/manage-consent/:domain` where `:domain` is one of your sites with custom domains.
* Click on the "Request Consent Management Email" button.
* Verify you still get a success message an email in your inbox shortly.

