### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` domain mapping to `wpcom.req`

### DIFF
--- a/client/components/domains/use-my-domain/utilities/connect-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/connect-domain-action.js
@@ -13,18 +13,19 @@ export const connectDomainAction = (
 	const siteHasPaidPlan = isSiteOnPaidPlan( getState(), selectedSite.ID );
 
 	if ( selectedSite.is_vip ) {
-		wpcom
-			.site( selectedSite.ID )
-			.addVipDomainMapping( domain )
+		wpcom.req
+			.post( `/sites/${ selectedSite.ID }/vip-domain-mapping`, { domain } )
 			.then( () => page( domainManagementList( selectedSite.slug ) ) )
 			.catch( ( error ) => {
 				dispatch( errorNotice( error.message ) );
 				onDone();
 			} );
 	} else if ( siteHasPaidPlan ) {
-		wpcom
-			.site( selectedSite.ID )
-			.addDomainMapping( domain, verificationData )
+		wpcom.req
+			.post( `/sites/${ selectedSite.ID }/add-domain-mapping`, {
+				domain,
+				...verificationData,
+			} )
 			.then( () => {
 				dispatch(
 					successNotice(

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -814,27 +814,6 @@ Undocumented.prototype.addDomainMapping = function ( siteId, domainName, fn ) {
 	);
 };
 
-/**
- * Add domain mapping for VIP clients.
- *
- * @param {number} siteId The site ID
- * @param {string} [domainName] Name of the domain mapping
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.addVipDomainMapping = function ( siteId, domainName, fn ) {
-	debug( '/site/:site_id/vip-domain-mapping' );
-	return this.wpcom.req.post(
-		{
-			path: `/sites/${ siteId }/vip-domain-mapping`,
-			body: {
-				domain: domainName,
-			},
-		},
-		fn
-	);
-};
-
 /*
  * Change the theme of a given site.
  *

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -793,27 +793,6 @@ Undocumented.prototype.transferToSite = function ( siteId, domainName, targetSit
 	);
 };
 
-/**
- * Add domain mapping for eligible clients.
- *
- * @param {number} siteId The site ID
- * @param {string} [domainName] Name of the domain mapping
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.addDomainMapping = function ( siteId, domainName, fn ) {
-	debug( '/site/:site_id/add-domain-mapping' );
-	return this.wpcom.req.post(
-		{
-			path: `/sites/${ siteId }/add-domain-mapping`,
-			body: {
-				domain: domainName,
-			},
-		},
-		fn
-	);
-};
-
 /*
  * Change the theme of a given site.
  *

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -12,7 +12,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import Notice from 'calypso/components/notice';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
@@ -26,8 +26,6 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-
-const wpcom = wp.undocumented();
 
 export class MapDomain extends Component {
 	static propTypes = {
@@ -111,9 +109,8 @@ export class MapDomain extends Component {
 		// We don't go through the usual checkout process
 		// Instead, we add the mapping directly
 		if ( selectedSite.is_vip ) {
-			wpcom
-				.site( selectedSite.ID )
-				.addVipDomainMapping( domain )
+			wpcom.req
+				.post( `/sites/${ selectedSite.ID }/vip-domain-mapping`, { domain } )
 				.then(
 					() => {
 						page( domainManagementList( selectedSiteSlug ) );
@@ -127,8 +124,10 @@ export class MapDomain extends Component {
 				} );
 			return;
 		} else if ( this.props.isSiteOnPaidPlan ) {
-			wpcom
-				.addDomainMapping( selectedSite.ID, domain )
+			wpcom.req
+				.post( `/sites/${ selectedSite.ID }/add-domain-mapping`, {
+					domain,
+				} )
 				.then(
 					() => {
 						this.props.successNotice(

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -125,9 +125,7 @@ export class MapDomain extends Component {
 			return;
 		} else if ( this.props.isSiteOnPaidPlan ) {
 			wpcom.req
-				.post( `/sites/${ selectedSite.ID }/add-domain-mapping`, {
-					domain,
-				} )
+				.post( `/sites/${ selectedSite.ID }/add-domain-mapping`, { domain } )
 				.then(
 					() => {
 						this.props.successNotice(

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -112,7 +112,8 @@ export class MapDomain extends Component {
 		// Instead, we add the mapping directly
 		if ( selectedSite.is_vip ) {
 			wpcom
-				.addVipDomainMapping( selectedSite.ID, domain )
+				.site( selectedSite.ID )
+				.addVipDomainMapping( domain )
 				.then(
 					() => {
 						page( domainManagementList( selectedSiteSlug ) );

--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -399,36 +399,6 @@ class Site {
 	wordAds() {
 		return new SiteWordAds( this._id, this.wpcom );
 	}
-
-	/**
-	 * Add a domain mapping to a site.
-	 *
-	 * @param {string} domain - domain to map
-	 * @param {object} extraData - extra data passed to the endpoint
-	 * @param {object} [query] - query object parameter
-	 * @param {Function} fn - callback function
-	 * @returns {Function} request handler
-	 */
-	addDomainMapping( domain, extraData, query, fn ) {
-		return this.wpcom.req.post(
-			`${ this.path }/add-domain-mapping`,
-			query,
-			{ domain, ...extraData },
-			fn
-		);
-	}
-
-	/**
-	 * Add a VIP domain mapping
-	 *
-	 * @param {string} domain - domain to map
-	 * @param {object} [query] - query object parameter
-	 * @param {Function} fn - callback function
-	 * @returns {Function} request handler
-	 */
-	addVipDomainMapping( domain, query, fn ) {
-		return this.wpcom.req.post( `${ this.path }/vip-domain-mapping`, query, { domain }, fn );
-	}
 }
 
 // add methods in runtime


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` domain mapping method to use `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/domains/add/mapping/:site` where `:site` is a regular.
* Pick a custom domain to map and click the "Add" button.
* Verify the domain gets mapped successfully and you're redirected to the domain management page of that domain.
* Try the same for a VIP site.
