### PR TITLE
Domains: Fix back button behavior for "Use a domain I own" flow on onboarding

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { BackButton } from '@automattic/onboarding';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
@@ -310,11 +311,32 @@ function UseMyDomain( props ) {
 			case inputMode.domainInput:
 				return __( 'Use a domain I own' );
 			case inputMode.transferDomain:
-				/* translators: %s - the name of the domain the user will add to their site */
-				return sprintf( __( 'Transfer %s' ), domainName );
+				return createInterpolateElement(
+					sprintf(
+						/* translators: %(domainName)s - the name of the domain the user will add to their site */
+						__( 'Transfer <span>%(domainName)s</span>' ),
+						{
+							domainName,
+						}
+					),
+					{
+						span: <span />,
+					}
+				);
+
 			default:
-				/* translators: %s - the name of the domain the user will add to their site */
-				return sprintf( __( 'Use a domain I own: %s' ), domainName );
+				return createInterpolateElement(
+					sprintf(
+						/* translators: %(domainName)s - the name of the domain the user will add to their site */
+						__( 'Use a domain I own: <span>%(domainName)s</span>' ),
+						{
+							domainName,
+						}
+					),
+					{
+						span: <span />,
+					}
+				);
 		}
 	}, [ domainName, mode, __ ] );
 

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -8,6 +8,13 @@
 	flex-direction: column;
 	padding: 36px 24px;
 
+	&__page-heading {
+		.formatted-header__title {
+			display: flex;
+			flex-wrap: wrap;
+		}
+	}
+
 	& &__domain-illustration {
 		//margin-top: 56px;
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -560,14 +560,14 @@ class DomainsStep extends Component {
 			const searchParams = new URLSearchParams( window.location.search );
 
 			Object.entries( params ).forEach( ( [ key, value ] ) => searchParams.set( key, value ) );
-			const newurl =
+			const newUrl =
 				window.location.protocol +
 				'//' +
 				window.location.host +
 				window.location.pathname +
 				'?' +
 				decodeURIComponent( searchParams.toString() );
-			window.history.pushState( { path: newurl }, '', newurl );
+			window.history.pushState( { path: newUrl }, '', newUrl );
 		}
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -588,7 +588,7 @@ class DomainsStep extends Component {
 						analyticsSection={ this.getAnalyticsSection() }
 						basePath={ this.props.path }
 						initialQuery={ initialQuery }
-						initialMode={ queryObject.step }
+						initialMode={ queryObject.step ?? inputMode.domainInput }
 						onNextStep={ this.setCurrentFlowStep }
 						isSignupStep
 						showHeader={ false }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -565,7 +565,7 @@ class DomainsStep extends Component {
 				window.location.host +
 				window.location.pathname +
 				'?' +
-				searchParams.toString();
+				decodeURIComponent( searchParams.toString() );
 			window.history.pushState( { path: newurl }, '', newurl );
 		}
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -555,10 +555,11 @@ class DomainsStep extends Component {
 		this.handleAddMapping( 'useYourDomainForm', domain );
 	};
 
-	insertUrlParam( key, value ) {
+	insertUrlParams( params ) {
 		if ( history.pushState ) {
 			const searchParams = new URLSearchParams( window.location.search );
-			searchParams.set( key, value );
+
+			Object.entries( params ).forEach( ( [ key, value ] ) => searchParams.set( key, value ) );
 			const newurl =
 				window.location.protocol +
 				'//' +
@@ -572,8 +573,7 @@ class DomainsStep extends Component {
 
 	setCurrentFlowStep( { mode, domain } ) {
 		this.setState( { currentStep: mode }, () => {
-			this.insertUrlParam( 'step', this.state.currentStep );
-			this.insertUrlParam( 'initialQuery', domain );
+			this.insertUrlParams( { step: this.state.currentStep, initialQuery: domain } );
 		} );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Since the back button has been removed in the mobile web in #57288, we need to fix the browser's default back button behavior for the "Use a domain I own" flow on onboarding. This PR fixes it. 
There's also a small mobile style change for breaking the domain name into a new line when it overflows.

Related to #56366.

#### Preview
https://user-images.githubusercontent.com/18705930/141148725-00e676db-3e8e-4166-9c91-bd2e1002fc48.mov

#### Testing instructions
- Browse to one of the following paths: `/new`, `/start/premium`, `/start/domains`;
- Try simulating the mobile viewport;
- Make sure that everything is working as intended and the back button works properly.