### PR TITLE
Improve appearance of the Jetpack license activation flow UIs

### DIFF
--- a/client/components/jetpack/licensing-activation/index.tsx
+++ b/client/components/jetpack/licensing-activation/index.tsx
@@ -5,6 +5,7 @@ import { FC } from 'react';
 import footerCardBackground from 'calypso/assets/images/jetpack/jp-licensing-checkout-footer-bg.svg';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import Main from 'calypso/components/main';
+import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
@@ -57,7 +58,7 @@ const LicensingActivation: FC< Props > = ( {
 					<h1
 						className={ classnames( 'licensing-activation__title', { 'is-loading': isLoading } ) }
 					>
-						{ title }
+						{ preventWidows( title ) }
 					</h1>
 					{ children }
 				</div>

--- a/client/components/jetpack/licensing-activation/style.scss
+++ b/client/components/jetpack/licensing-activation/style.scss
@@ -26,9 +26,16 @@
 
 .licensing-activation .button.is-primary,
 .licensing-activation .button.is-primary:visited {
+	font-size: $font-body;
+	font-weight: 400;
+
 	border-radius: 2px;
 	margin-top: 58px;
+
+	min-width: 140px;
+
 	@include jetpack-primary-button;
+
 	&.is-busy {
 		background-image: linear-gradient(
 			-45deg,

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -227,7 +227,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 								: 'licensing-thank-you-auto-activation__product-info'
 						}
 					>
-						{ translate( 'Hello %(username)s,', {
+						{ translate( 'Hello %(username)s!', {
 							args: {
 								username: userName,
 							},

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
@@ -72,7 +72,12 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 						{ translate( 'Learn more about how to install Jetpack' ) }
 					</ExternalLink>
 				</p>
-				<Button primary disabled={ false } onClick={ onContinue }>
+				<Button
+					className="licensing-thank-you-manual-activation-instructions__button"
+					primary
+					disabled={ false }
+					onClick={ onContinue }
+				>
 					{ translate( 'Continue ' ) }
 				</Button>
 			</LicensingActivation>

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -994,6 +994,10 @@
 	height: 28px;
 }
 
+.licensing-activation .licensing-thank-you-manual-activation-instructions__button.button {
+	margin-top: 0;
+}
+
 .licensing-thank-you-manual-activation-license-key__key {
 	margin-top: 40px;
 }
@@ -1004,7 +1008,7 @@
 	margin-top: 8px;
 
 	.licensing-thank-you-manual-activation-license-key__input.form-text-input {
-		margin-right: 16px;
+		margin-right: 8px;
 
 		background-color: var( --studio-gray-0 );
 
@@ -1016,8 +1020,9 @@
 	}
 }
 
-.licensing-thank-you-manual-activation-license-key__button {
-	min-width: 70px;
+.licensing-activation .licensing-thank-you-manual-activation-license-key__button.button {
+	margin-top: 0;
+	min-width: 100px;
 }
 
 .jetpack-checkout-thank-you {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update styles to make UIs look as closest as possible to designs (ceKxiVna5wfpmwFBsojrAx-fi-2219%3A25665).

#### Testing instructions
Prerequisite: a WPCOM Sandbox.

* Download this PR.
* Start Calypso Blue with `yarn start`.
* Sandbox `public-api.wordpress.com`.
* Add `add_filter( 'jetpack_license_checkout_m2_enabled', '__return_true' );` to `0-sandbox.php`.
* Visit https://cloud.jetpack.com/pricing.
* Purchase any Jetpack product.
* Once you're on the checkout page, replace `wordpress.com` with `calypso.localhost:3000`.
* Submit the checkout form.
* Go through the manual activation flow paying close attention to how things look.
* Go back to the initial activation UI and select a JN site to perform the automated activation.
* Again, verify that those UIs look as expected.

Related to 1201096622142517-as-1201330575264878

#### Manual flow

<img width="1379" alt="Screen Shot 2021-11-10 at 13 16 37" src="https://user-images.githubusercontent.com/3418513/141153174-236937fd-7148-4dc3-9807-2a36e46a6021.png">
<img width="1423" alt="Screen Shot 2021-11-10 at 13 16 43" src="https://user-images.githubusercontent.com/3418513/141153194-189a08a5-b8d2-4ec9-b244-3fafdf3fe297.png">
<img width="1423" alt="Screen Shot 2021-11-10 at 13 16 47" src="https://user-images.githubusercontent.com/3418513/141153201-b8330f88-4ebe-49cd-87d2-25f3217a4251.png">
<img width="1423" alt="Screen Shot 2021-11-10 at 13 16 49" src="https://user-images.githubusercontent.com/3418513/141153207-692adc3c-9b6b-4617-8447-eeb8f39a176d.png">
<img width="1423" alt="Screen Shot 2021-11-10 at 13 16 59" src="https://user-images.githubusercontent.com/3418513/141153481-736f667a-685a-4a71-8db2-6661d5f46d55.png">

#### Automated flow

<img width="1423" alt="Screen Shot 2021-11-10 at 13 20 18" src="https://user-images.githubusercontent.com/3418513/141153547-c90c50b7-dc49-4864-933c-4ad5fbb08fcb.png">
<img width="1423" alt="Screen Shot 2021-11-10 at 13 20 50" src="https://user-images.githubusercontent.com/3418513/141153570-a58ed361-d03d-43b2-b2cf-eec464f65677.png">

