### PR TITLE
Video UI: Bottom bar on mobile

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -1,16 +1,14 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
-import { useSelector } from 'react-redux';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
+import VideoLinksBar from './video-links-bar';
 import VideoPlayer from './video-player';
 import './style.scss';
 
-const VideosUi = ( { shouldDisplayTopLinks = false }, onBackClick = () => {} ) => {
+const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) => {
 	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );
 	const [ selectedVideoIndex, setSelectedVideoIndex ] = useState( null );
 
@@ -83,28 +81,13 @@ const VideosUi = ( { shouldDisplayTopLinks = false }, onBackClick = () => {} ) =
 	return (
 		<div className="videos-ui">
 			<div className="videos-ui__header">
-				<div className="videos-ui__header-links">
-					<div>
-						<Gridicon icon="my-sites" size={ 24 } />
-						{ shouldDisplayTopLinks && (
-							<a href="/" className="videos-ui__back-link" onClick={ onBackClick }>
-								<Gridicon icon="chevron-left" size={ 24 } />
-								<span>{ translate( 'Back' ) }</span>
-							</a>
-						) }
-					</div>
-					<div>
-						{ shouldDisplayTopLinks && (
-							<a
-								href={ `/post/${ siteSlug }` }
-								className="videos-ui__skip-link"
-								onClick={ skipClickHandler }
-							>
-								{ translate( 'Skip and draft first post' ) }
-							</a>
-						) }
-					</div>
-				</div>
+				<VideoLinksBar
+					displayIcon={ true }
+					displayLinks={ shouldDisplayTopLinks }
+					extraClasses={ 'desktop' }
+					onBackClick={ onBackClick }
+					skipClickHandler={ skipClickHandler }
+				/>
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
 						<h2>{ translate( 'Watch five videos.' ) }</h2>
@@ -192,6 +175,13 @@ const VideosUi = ( { shouldDisplayTopLinks = false }, onBackClick = () => {} ) =
 					</div>
 				</div>
 			</div>
+			<VideoLinksBar
+				displayIcon={ false }
+				displayLinks={ shouldDisplayTopLinks }
+				extraClasses={ 'mobile' }
+				onBackClick={ onBackClick }
+				skipClickHandler={ skipClickHandler }
+			/>
 		</div>
 	);
 };

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -84,7 +84,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 				<VideoLinksBar
 					displayIcon={ true }
 					displayLinks={ shouldDisplayTopLinks }
-					extraClasses={ 'desktop' }
+					isFooter={ false }
 					onBackClick={ onBackClick }
 					skipClickHandler={ skipClickHandler }
 				/>
@@ -178,7 +178,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 			<VideoLinksBar
 				displayIcon={ false }
 				displayLinks={ shouldDisplayTopLinks }
-				extraClasses={ 'mobile' }
+				isFooter={ true }
 				onBackClick={ onBackClick }
 				skipClickHandler={ skipClickHandler }
 			/>

--- a/client/components/videos-ui/style-video-links-bar.scss
+++ b/client/components/videos-ui/style-video-links-bar.scss
@@ -1,0 +1,29 @@
+.videos-ui__header-links {
+    padding: 24px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    font-size: $font-body-small;
+
+    div,
+    a {
+        display: flex;
+        color: #fff;
+        align-items: center;
+    }
+
+    .videos-ui__back-link {
+        margin-left: 24px;
+    }
+
+    .videos-ui__bar {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+
+        .videos-ui__bar-skip-link {
+            text-decoration: underline;
+        }
+    }
+}

--- a/client/components/videos-ui/style-video-links-bar.scss
+++ b/client/components/videos-ui/style-video-links-bar.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .videos-ui__header-links {
     padding: 24px;
     display: flex;
@@ -5,6 +8,16 @@
     align-items: center;
     justify-content: space-between;
     font-size: $font-body-small;
+
+    &.videos-ui__is-footer {
+        border-top: 1px solid rgba( 255, 255, 255, 0.1 );
+        margin-top: auto;
+    }
+    .videos-ui__bar {
+        &.desktop {
+            display: none;
+        }
+    }
 
     div,
     a {
@@ -26,4 +39,14 @@
             text-decoration: underline;
         }
     }
+	@include break-small {
+        .videos-ui__bar {
+            &.desktop {
+                display: flex;
+            }
+            &.mobile {
+                display: none;
+            }
+        }
+	}
 }

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -9,16 +9,6 @@
 	display: flex;
 	flex-direction: column;
 
-	.videos-ui__header-links {
-		&.desktop {
-			display: none;
-		}
-		&.mobile {
-			border-top: 1px solid rgba( 255, 255, 255, 0.1 );
-			margin-top: auto;
-		}
-	}
-
 	.videos-ui__header {
 		background: #151b1e;
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.1 );
@@ -129,17 +119,6 @@
 				&.selected .videos-ui__active-video-content {
 					height: 250px;
 				}
-			}
-		}
-	}
-
-	@include break-small {
-		.videos-ui__header-links {
-			&.desktop {
-				display: flex;
-			}
-			&.mobile {
-				display: none;
 			}
 		}
 	}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -6,30 +6,22 @@
 .videos-ui {
 	background: #101517;
 	color: #fff;
+	display: flex;
+	flex-direction: column;
+
+	.videos-ui__header-links {
+		&.desktop {
+			display: none;
+		}
+		&.mobile {
+			border-top: 1px solid rgba( 255, 255, 255, 0.1 );
+			margin-top: auto;
+		}
+	}
+
 	.videos-ui__header {
 		background: #151b1e;
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.1 );
-
-		.videos-ui__header-links {
-			padding: 24px;
-			display: flex;
-			flex-direction: row;
-			align-items: center;
-			justify-content: space-between;
-			font-size: $font-body-small;
-			div,
-			a {
-				display: flex;
-				color: #fff;
-				align-items: center;
-			}
-			.videos-ui__back-link {
-				margin-left: 24px;
-			}
-			.videos-ui__skip-link {
-				text-decoration: underline;
-			}
-		}
 
 		.videos-ui__header-content {
 			display: flex;
@@ -60,7 +52,7 @@
 
 	.videos-ui__body {
 		max-width: 1280px;
-		margin: auto;
+		margin: 0 auto;
 
 		h3 {
 			font-size: $font-title-medium;
@@ -137,6 +129,17 @@
 				&.selected .videos-ui__active-video-content {
 					height: 250px;
 				}
+			}
+		}
+	}
+
+	@include break-small {
+		.videos-ui__header-links {
+			&.desktop {
+				display: flex;
+			}
+			&.mobile {
+				display: none;
 			}
 		}
 	}

--- a/client/components/videos-ui/video-links-bar.jsx
+++ b/client/components/videos-ui/video-links-bar.jsx
@@ -9,19 +9,23 @@ import './style-video-links-bar.scss';
 const VideoLinksBar = ( {
 	displayIcon,
 	displayLinks,
-	extraClasses,
+	isFooter = false,
 	onBackClick = () => {},
 	skipClickHandler = () => {},
 } ) => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const classes = classNames( 'videos-ui__header-links', extraClasses ?? '' );
+	const classes = classNames( 'videos-ui__bar', isFooter ? 'mobile' : 'desktop' );
 
 	return (
-		<div className={ classes }>
+		<div
+			className={ classNames( 'videos-ui__header-links', {
+				'videos-ui__is-footer': isFooter,
+			} ) }
+		>
 			{ displayIcon && <Gridicon icon="my-sites" size={ 24 } /> }
 			{ displayLinks && (
-				<div className="videos-ui__bar">
+				<div className={ classes }>
 					<div>
 						<a
 							href="/"

--- a/client/components/videos-ui/video-links-bar.jsx
+++ b/client/components/videos-ui/video-links-bar.jsx
@@ -1,0 +1,48 @@
+import { Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
+
+import './style-video-links-bar.scss';
+
+const VideoLinksBar = ( {
+	displayIcon,
+	displayLinks,
+	extraClasses,
+	onBackClick = () => {},
+	skipClickHandler = () => {},
+} ) => {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const classes = classNames( 'videos-ui__header-links', extraClasses ?? '' );
+
+	return (
+		<div className={ classes }>
+			{ displayIcon && <Gridicon icon="my-sites" size={ 24 } /> }
+			{ displayLinks && (
+				<div className="videos-ui__bar">
+					<div>
+						<a
+							href="/"
+							className={ classNames( {
+								'videos-ui__back-link': displayIcon,
+							} ) }
+							onClick={ onBackClick }
+						>
+							<Gridicon icon="chevron-left" size={ 24 } />
+							<span>{ translate( 'Back' ) }</span>
+						</a>
+					</div>
+					<div className="videos-ui__bar-skip-link">
+						<a href={ `/post/${ siteSlug }` } onClick={ skipClickHandler }>
+							{ translate( 'Skip and draft first post' ) }
+						</a>
+					</div>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default VideoLinksBar;

--- a/client/components/videos-ui/video-links-bar.jsx
+++ b/client/components/videos-ui/video-links-bar.jsx
@@ -40,7 +40,7 @@ const VideoLinksBar = ( {
 					</div>
 					<div className="videos-ui__bar-skip-link">
 						<a href={ `/post/${ siteSlug }` } onClick={ skipClickHandler }>
-							{ translate( 'Skip and draft first post' ) }
+							{ translate( 'Draft your first post' ) }
 						</a>
 					</div>
 				</div>


### PR DESCRIPTION
This PR makes the link bar appear on bottom on mobile bringing the UI closer to the Figma.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/141181739-a0c9c63b-4c0e-4d32-8995-9eed077d1afb.png) | ![image](https://user-images.githubusercontent.com/375980/141184678-9a527a8f-d213-4d08-a65d-b8463f2a6970.png)|

#### Testing instructions

1. Go to the modal branch: 
```sh
git checkout videos-ui-home-modal
```
2. Cherry pick changes from this PR: 
```sh
git cherry-pick 71c715fe469^..a901f8d5f4
```
3. Verify the modal looks good on mobile: bar on the bottom, WordPress icon on top and no WP icon on bottom.
4. Verify the modal still looks good on desktop. 

Related to #57859