### PR TITLE
Videos UI - Update "Draft Your First Post" text

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -100,7 +100,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false }, onBackClick = () => {} ) =
 								className="videos-ui__skip-link"
 								onClick={ skipClickHandler }
 							>
-								{ translate( 'Skip and draft first post' ) }
+								{ translate( 'Draft your first post' ) }
 							</a>
 						) }
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the text on the Videos UI, changing "Skip and draft first post" to "Draft your first post"

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out a copy of https://github.com/Automattic/wp-calypso/pull/57515 and merge this branch into it locally in order to test the Videos UI in the modal.
* Verify that the upper right link in the modal displays with the new text.

Before:

![image](https://user-images.githubusercontent.com/13437011/141185636-7cab7c78-a4ce-4364-89ad-599b8e1ccc86.png)


After:

![image](https://user-images.githubusercontent.com/13437011/141186101-911ad02b-c798-4460-98f1-501edb33ee2b.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57676
