### PR TITLE
Videos UI - fix designs in mobile view to better reflect Figma design.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -98,18 +98,18 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 					<div className="videos-ui__summary">
 						<ul>
 							<li>
-								<Gridicon icon="checkmark" size={ 16 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
 								{ translate( 'Learn the basics of blogging' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 16 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
 								{ translate( 'Familiarize yourself with WordPress' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 16 } /> { translate( 'Upskill and save hours' ) }
+								<Gridicon icon="checkmark" size={ 18 } /> { translate( 'Upskill and save hours' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 16 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
 								{ translate( 'Set yourself up for blogging success' ) }
 							</li>
 						</ul>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -98,18 +98,18 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 					<div className="videos-ui__summary">
 						<ul>
 							<li>
-								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 16 } />{ ' ' }
 								{ translate( 'Learn the basics of blogging' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 16 } />{ ' ' }
 								{ translate( 'Familiarize yourself with WordPress' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 18 } /> { translate( 'Upskill and save hours' ) }
+								<Gridicon icon="checkmark" size={ 16 } /> { translate( 'Upskill and save hours' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 16 } />{ ' ' }
 								{ translate( 'Set yourself up for blogging success' ) }
 							</li>
 						</ul>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -98,18 +98,18 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 					<div className="videos-ui__summary">
 						<ul>
 							<li>
-								<Gridicon icon="checkmark" size={ 12 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
 								{ translate( 'Learn the basics of blogging' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 12 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
 								{ translate( 'Familiarize yourself with WordPress' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 12 } /> { translate( 'Upskill and save hours' ) }
+								<Gridicon icon="checkmark" size={ 18 } /> { translate( 'Upskill and save hours' ) }
 							</li>
 							<li>
-								<Gridicon icon="checkmark" size={ 12 } />{ ' ' }
+								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
 								{ translate( 'Set yourself up for blogging success' ) }
 							</li>
 						</ul>

--- a/client/components/videos-ui/style-video-links-bar.scss
+++ b/client/components/videos-ui/style-video-links-bar.scss
@@ -2,7 +2,8 @@
 @import '@wordpress/base-styles/mixins';
 
 .videos-ui__header-links {
-    padding: 24px;
+    padding: 20px;
+    padding-bottom: 15px;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -17,6 +17,7 @@
 			display: flex;
 			flex-direction: column;
 			padding: 20px;
+			padding-top: 15px;
 
 			ul {
 				margin: 40px 0 0;
@@ -24,15 +25,29 @@
 
 			li {
 				list-style: none;
-				margin-bottom: 14px;
+				margin-bottom: 10px;
 				font-size: $font-body-small;
 			}
+
 			h2 {
 				@include onboarding-font-recoleta;
-				font-size: $font-title-large;
+				//font-size: $font-title-large;
+				font-size: $font-headline-small;
+				letter-spacing: 0;
+				height: 40px;
 
 				&:first-child {
 					color: rgba( 255, 255, 255, 0.5 );
+				}
+			}
+
+			.videos-ui__summary {
+				padding-left: 2.55px;
+
+				svg {
+					padding-right: 16px;
+					fill: rgba( 255, 255, 255, 0.6 );
+					vertical-align: text-bottom;
 				}
 			}
 		}
@@ -71,8 +86,13 @@
 				background: #1d262a;
 				border-bottom: 1px solid #343c3f;
 
+				&:first-child {
+					border-radius: 2px 2px 0 0;
+				}
+
 				&:last-child {
 					border-bottom: none;
+					border-radius: 0 0 2px 2px;
 				}
 
 				.videos-ui__duration {
@@ -107,12 +127,20 @@
 
 					div {
 						padding: 20px;
+						padding-top: 12px;
 						overflow-y: auto;
+						p {
+							color: rgba( 255, 255, 255, 0.72 );
+						}
 					}
 				}
 
 				.videos-ui__play-button {
 					width: 100%;
+					span {
+						font-weight: 600;
+						color: #101517;
+					}
 				}
 
 				&.selected .videos-ui__active-video-content {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -87,12 +87,12 @@
 				border-bottom: 1px solid #343c3f;
 
 				&:first-child {
-					border-radius: 4px 4px 0 0;
+					border-radius: 2px 2px 0 0;
 				}
 
 				&:last-child {
 					border-bottom: none;
-					border-radius: 0 0 4px 4px;
+					border-radius: 0 0 2px 2px;
 				}
 
 				.videos-ui__duration {
@@ -141,9 +141,9 @@
 				.videos-ui__play-button {
 					width: 100%;
 					border: 0;
-					border-radius: 4px;
+					border-radius: 2px;
 					span {
-						font-weight: 500;
+						font-weight: 400;
 						color: #101517;
 					}
 				}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -56,7 +56,7 @@
 	.videos-ui__body {
 		max-width: 1280px;
 		margin: 0 auto;
-		padding: 20px;
+		padding: 64px 20px 41px;
 
 		h3 {
 			font-size: $font-title-medium;
@@ -87,16 +87,19 @@
 				border-bottom: 1px solid #343c3f;
 
 				&:first-child {
-					border-radius: 2px 2px 0 0;
+					border-radius: 4px 4px 0 0;
 				}
 
 				&:last-child {
 					border-bottom: none;
-					border-radius: 0 0 2px 2px;
+					border-radius: 0 0 4px 4px;
 				}
 
 				.videos-ui__duration {
 					color: rgba( 255, 255, 255, 0.5 );
+					span {
+						margin-left: 10px;
+					}
 				}
 
 				.videos-ui__status-icon {
@@ -137,6 +140,8 @@
 
 				.videos-ui__play-button {
 					width: 100%;
+					border: 0;
+					border-radius: 4px;
 					span {
 						font-weight: 500;
 						color: #101517;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -17,8 +17,6 @@
 			display: flex;
 			flex-direction: column;
 			padding: 20px;
-			max-width: 1280px;
-			margin: auto;
 
 			ul {
 				margin: 40px 0 0;
@@ -43,10 +41,11 @@
 	.videos-ui__body {
 		max-width: 1280px;
 		margin: 0 auto;
+		padding: 20px;
 
 		h3 {
 			font-size: $font-title-medium;
-			margin: 20px;
+			margin-bottom: 24px;
 		}
 
 		.videos-ui__video-content {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -138,7 +138,7 @@
 				.videos-ui__play-button {
 					width: 100%;
 					span {
-						font-weight: 600;
+						font-weight: 500;
 						color: #101517;
 					}
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the mobile view of the Videos UI to better reflect spacing indicated by the Figma design.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out a copy of #57515 and merge this branch into it locally in order to test the Videos UI in the modal.
* Verify that at a screen size of 375px wide, the modal UI displays with appropriate padding of 20px around both the header and content sections.

Before:
![image](https://user-images.githubusercontent.com/13437011/141187787-260471d9-abae-4352-981f-311ecb470df8.png)

After: 
![image](https://user-images.githubusercontent.com/13437011/141187575-0adb73e7-24f9-4c85-93fd-43b0c24a8bc7.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57868
