### PR TITLE
Guards the plugin install URL against plans that cannot be transferred to atomic

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -199,7 +199,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 						title={ translate(
 							"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
 						) }
-						action={ translate( 'Upgrade to Business plan' ) }
+						action={ translate( 'Upgrade to Business Plan' ) }
 						actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/${ productSlug }/install/${ selectedSite?.slug }#step2` }
 					/>
 				) : (

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -1,8 +1,8 @@
-// import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
+import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
@@ -16,7 +16,8 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { installPlugin, activatePlugin } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite, getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
-import { getPlugin } from 'calypso/state/plugins/wporg/selectors';
+import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
+import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
 import getPluginUploadProgress from 'calypso/state/selectors/get-plugin-upload-progress';
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
@@ -34,8 +35,8 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 	const isUploadFlow = ! productSlug;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	const [ initializeInstallFlow, setInitializeInstallFlow ] = useState( false );
-	const [ moveToAtomicFlow, setMoveToAtomicFlow ] = useState( false );
-	const [ atomicError ] = useState( false );
+	const [ atomicFlow, setAtomicFlow ] = useState( false );
+	const [ nonInstallablePlanError, setNonInstallablePlanError ] = useState( false );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
@@ -44,6 +45,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 	const pluginUploadProgress = useSelector( ( state ) => getPluginUploadProgress( state, siteId ) );
 	const pluginUploadError = useSelector( ( state ) => getPluginUploadError( state, siteId ) );
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, productSlug ) );
+	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, productSlug ) );
 	const uploadedPluginSlug = useSelector( ( state ) =>
 		getUploadedPluginId( state, siteId )
 	) as string;
@@ -62,6 +64,31 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 		getStatusForPlugin( state, siteId, productSlug )
 	);
 
+	const supportsAtomicUpgrade = useRef< boolean >();
+	useEffect( () => {
+		supportsAtomicUpgrade.current =
+			isBusiness( selectedSite?.plan ) ||
+			isEnterprise( selectedSite?.plan ) ||
+			isEcommerce( selectedSite?.plan );
+	}, [ selectedSite ] );
+
+	// retrieve plugin data if not available
+	useEffect( () => {
+		if ( ! isWporgPluginFetched ) {
+			dispatch( wporgFetchPluginData( productSlug ) );
+		}
+	}, [ isWporgPluginFetched, productSlug ] );
+
+	// Check if the user plan is enough for installation
+	// if not, check again in 2s and show an error message
+	useEffect( () => {
+		if ( ! supportsAtomicUpgrade.current ) {
+			waitFor( 2 ).then(
+				() => ! supportsAtomicUpgrade.current && setNonInstallablePlanError( true )
+			);
+		}
+	} );
+
 	// Upload flow startup
 	useEffect( () => {
 		if ( 100 === pluginUploadProgress ) {
@@ -75,32 +102,32 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 	// Installing plugin flow startup
 	useEffect( () => {
 		if ( ! isUploadFlow && ! initializeInstallFlow && wporgPlugin && selectedSite ) {
-			// const upgradablePlan = isBusiness( selectedSite.plan ) || isEnterprise( selectedSite.plan ) || isEcommerce( selectedSite.plan );
+			const triggerInstallFlow = () => {
+				setInitializeInstallFlow( true );
+				waitFor( 1 ).then( () => setCurrentStep( 1 ) );
+			};
 
-			if ( selectedSite?.jetpack ) {
+			if ( selectedSite.jetpack ) {
 				// initialize plugin installing
 				dispatch( installPlugin( siteId, wporgPlugin, false ) );
-			} else {
-				// initialize atomic flow
-				setMoveToAtomicFlow( true );
-				dispatch( initiateTransfer( siteId, null, productSlug ) );
-			}
 
-			setInitializeInstallFlow( true );
-			waitFor( 1 ).then( () => setCurrentStep( 1 ) );
+				triggerInstallFlow();
+			} else if ( supportsAtomicUpgrade.current ) {
+				// initialize atomic flow
+				setAtomicFlow( true );
+				dispatch( initiateTransfer( siteId, null, productSlug ) );
+
+				triggerInstallFlow();
+			}
 		}
-	}, [ isUploadFlow, siteId, wporgPlugin, productSlug ] );
+	}, [ isUploadFlow, initializeInstallFlow, selectedSite, siteId, wporgPlugin, productSlug ] );
 
 	// Validate completition of atomic transfer flow
 	useEffect( () => {
-		if (
-			moveToAtomicFlow &&
-			currentStep === 1 &&
-			transferStates.COMPLETE === automatedTransferStatus
-		) {
+		if ( atomicFlow && currentStep === 1 && transferStates.COMPLETE === automatedTransferStatus ) {
 			setCurrentStep( 2 );
 		}
-	}, [ moveToAtomicFlow, automatedTransferStatus ] );
+	}, [ atomicFlow, automatedTransferStatus ] );
 
 	// Validate plugin is already installed and activate
 	useEffect( () => {
@@ -124,7 +151,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 	useEffect( () => {
 		if (
 			( installedPlugin && pluginActive ) ||
-			( moveToAtomicFlow && transferStates.COMPLETE === automatedTransferStatus )
+			( atomicFlow && transferStates.COMPLETE === automatedTransferStatus )
 		) {
 			waitFor( 1 ).then( () =>
 				page.redirect(
@@ -143,7 +170,10 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 
 	return (
 		<ThemeProvider theme={ theme }>
-			<PageViewTracker path="/marketplace/product/install/:site" title="Plugins > Installing" />
+			<PageViewTracker
+				path="/marketplace/:productSlug?/install/:site?"
+				title="Plugins > Installing"
+			/>
 			{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 			<Masterbar>
 				<Item>{ translate( 'Plugin Installation' ) }</Item>
@@ -151,8 +181,8 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 			<div className="marketplace-plugin-upload-status__root">
 				{ pluginUploadError ||
 				pluginInstallStatus.error ||
-				atomicError ||
-				automatedTransferStatus === transferStates.FAILURE ? (
+				( atomicFlow && automatedTransferStatus === transferStates.FAILURE ) ||
+				nonInstallablePlanError ? (
 					<EmptyContent
 						illustration="/calypso/images/illustrations/error.svg"
 						title={ translate( 'An error occurred while installing the plugin.' ) }

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -179,10 +179,10 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 				<Item>{ translate( 'Plugin Installation' ) }</Item>
 			</Masterbar>
 			<div className="marketplace-plugin-upload-status__root">
+				{ /* eslint-disable-next-line no-nested-ternary */ }
 				{ pluginUploadError ||
 				pluginInstallStatus.error ||
-				( atomicFlow && automatedTransferStatus === transferStates.FAILURE ) ||
-				nonInstallablePlanError ? (
+				( atomicFlow && automatedTransferStatus === transferStates.FAILURE ) ? (
 					<EmptyContent
 						illustration="/calypso/images/illustrations/error.svg"
 						title={ translate( 'An error occurred while installing the plugin.' ) }
@@ -192,6 +192,15 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 								? `/plugins/upload/${ selectedSiteSlug }`
 								: `/plugins/${ productSlug }/${ selectedSiteSlug }`
 						}
+					/>
+				) : nonInstallablePlanError ? (
+					<EmptyContent
+						illustration="/calypso/images/illustrations/error.svg"
+						title={ translate(
+							"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
+						) }
+						action={ translate( 'Upgrade to Business plan' ) }
+						actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/${ productSlug }/install/${ selectedSite?.slug }#step2` }
 					/>
 				) : (
 					<MarketplaceProgressBar steps={ steps } currentStep={ currentStep } />


### PR DESCRIPTION
#### Description

Guards the plugin install URL against plans that cannot be transferred to atomic.

Before this change, this operation was silent, failing as the server forbids the transfer to atomic from lower plans.

#### Changes proposed in this Pull Request

Check if the user plan is enough for plugin installation, if not, check again in 2s and show an error message.

#### Testing instructions
* Go to the plugin install URL with a free or premium website: http://calypso.localhost:3000/marketplace/wordpress-seo/install/[free_site]
* After around 2 seconds you should see the following error:
![Screen Shot 2021-11-11 at 13 41 55](https://user-images.githubusercontent.com/5039531/141350104-668aa9b3-43ed-4f8b-95ad-536a10785c1c.png)



* Try to go to the same URL with a business or e-commerce site: http://calypso.localhost:3000/marketplace/wordpress-seo/install/[business_site]
* The plugin installation should proceed as expected and you should see a thank you page.
---

Fixes #57891
