### PR TITLE
Videos UI: Limit the size of the play button at wider single column widths.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -141,6 +141,12 @@
 		}
 	}
 
+	@include break-small {
+		.videos-ui__play-button {
+			max-width: 300px;
+		}
+	}
+
 	@include break-medium {
 		.videos-ui__header {
 			.videos-ui__header-content {


### PR DESCRIPTION
The play button is currently full width, regardless of the single column width (which we've bumped up considerably in #57857. This PR limits the button to 300px.

Fixes https://github.com/Automattic/wp-calypso/issues/57865

![2021-11-10 12 28 13](https://user-images.githubusercontent.com/349751/141188998-7285e4bf-d82c-4e96-93dd-29ea55258b19.gif)

