### PR TITLE
Videos UI - automatically open first or current video item in accordion on load

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -46,12 +46,14 @@ const VideosUi = ( { shouldDisplayTopLinks = false }, onBackClick = () => {} ) =
 			// @TODO add logic to pick the first unseen video
 			const initialVideoId = 'find-theme';
 			setCurrentVideoKey( initialVideoId );
+			setSelectedVideoIndex( Object.keys( course.videos ).indexOf( initialVideoId ) );
 		}
 	}, [ currentVideoKey, course ] );
 
 	useEffect( () => {
 		if ( currentVideoKey && course ) {
 			setCurrentVideo( course.videos[ currentVideoKey ] );
+			setSelectedVideoIndex( Object.keys( course.videos ).indexOf( currentVideoKey ) );
 		}
 	}, [ currentVideoKey, course ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the Videos UI to automatically open the first video (or the user's current video in the course if there is one - currently not relevant since we are not yet tracking video completion) when the UI component loads.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out a copy of #57515 and merge this branch into it locally in order to test the Videos UI in the modal.
* Verify that when opening the modal, the first accordion item is automatically open and the correct video is loaded.

![image](https://user-images.githubusercontent.com/13437011/141190076-078babf0-441c-4c4b-97f5-eb448b859ab9.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57913
