### PR TITLE
Videos UI: Add back missing elements from rebases.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -8,7 +8,7 @@ import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-sl
 import VideoPlayer from './video-player';
 import './style.scss';
 
-const VideosUi = ( { shouldDisplayTopLinks = false }, onBackClick = () => {} ) => {
+const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -190,3 +190,7 @@
 		}
 	}
 }
+
+.blank-canvas .videos-ui {
+	min-height: 100vh;
+}


### PR DESCRIPTION
These two fixes went missing at some point in recent rebases and merges.

* Ensure videos UI is full height when contained by a `BlankCanvas`.
* Fix broken prop destructuring.