### PR TITLE
Videos UI: Make play buttons full width again at two-column layouts.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -151,9 +151,6 @@
 				}
 			}
 		}
-		.videos-ui__play-button {
-			max-width: inherit;
-		}
 	}
 
 	@include break-xlarge {
@@ -177,6 +174,10 @@
 					width: 33%;
 				}
 			}
+		}
+
+		.videos-ui__play-button {
+			max-width: inherit;
 		}
 	}
 }

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -151,11 +151,13 @@
 				}
 			}
 		}
+		.videos-ui__play-button {
+			max-width: inherit;
+		}
 	}
 
 	@include break-xlarge {
 		.videos-ui__body {
-
 			padding: 0 80px 80px;
 			h3 {
 				margin: 80px 0 20px;


### PR DESCRIPTION
In #57865, I set a maximum size for the play button to improve their rendering in the single column layout – but didn't remove it once the layout switched to two columns.

| Before | After |
| --- | --- |
| <img width="1538" alt="Screen Shot 2021-11-10 at 2 25 54 PM" src="https://user-images.githubusercontent.com/349751/141203797-c00704a3-e305-482c-b74b-45e6d891d19a.png"> | <img width="1501" alt="Screen Shot 2021-11-10 at 2 25 44 PM" src="https://user-images.githubusercontent.com/349751/141203807-e3c2ed9d-1cba-4281-86cb-4eb92e24390a.png"> |

 