### PR TITLE
Videos UI: Add a hover state to the play buttons.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -113,7 +113,13 @@
 				}
 
 				.videos-ui__play-button {
+					opacity: 90%;
 					width: 100%;
+				}
+
+				.videos-ui__play-button:hover,
+				.videos-ui__play-button:active {
+					opacity: 100%;
 				}
 
 				&.selected .videos-ui__active-video-content {


### PR DESCRIPTION
This PR add a hover state to the video play buttons.

Fixes #57583.

![2021-11-10 14 34 07](https://user-images.githubusercontent.com/349751/141204991-75f66e13-64e4-4b92-b819-a259a3ca3720.gif)

**Testing Instructions**
* Apply this branch to your local dev environment.
* Add the `VideosUi` component some where (like My Home).
* Verify the button has the expected hover state.