### PR TITLE
Playwright: Update the I18N TeamCity build for Playwright

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -702,9 +702,9 @@ private object I18NTests : BuildType({
 	description = "Runs tests related to i18n"
 
 	artifactRules = """
-		reports => reports
 		logs.tgz => logs.tgz
 		screenshots => screenshots
+		trace => trace
 	""".trimIndent()
 
 	vcs {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -748,15 +748,13 @@ private object I18NTests : BuildType({
 				export DEBUG=pw:api
 				export HEADLESS=true
 				export TARGET_DEVICE=desktop
+				export LOCALES=%LOCALES%
 
 				# Decrypt config
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
 				# Run the test
-				IFS="," read -r -a TARGET_LOCALES <<< "%LOCALES%"
-				for locale in ${'$'}{TARGET_LOCALES[@]}; do
-					LOCALE="${'$'}{locale}" yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=i18n
-				done
+				yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=i18n
 			""".trimIndent()
 		}
 		bashNodeScript {

--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -85,8 +85,6 @@ export function getLaunchConfiguration( chromeVersion: string ): BrowserContextO
 	config.userAgent = userAgent;
 	// Explicitly resize captured video resolution to the viewport size.
 	config.recordVideo = { dir: os.tmpdir(), size: config.viewport as ViewportSize };
-	// Specify the user locale.
-	config.locale = getLocale();
 
 	return config;
 }

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -9,7 +9,8 @@ import type { Browser, BrowserContext, Logger, Page } from 'playwright';
 export let browser: Browser;
 
 export interface LaunchOptions {
-	logger: Logger;
+	logger?: Logger;
+	locale?: string;
 }
 
 /**
@@ -35,6 +36,10 @@ export async function newBrowserContext(
 	// Add logging details.
 	if ( launchOptions?.logger ) {
 		config.logger = launchOptions.logger;
+	}
+
+	if ( launchOptions?.locale ) {
+		config.locale = launchOptions.locale;
 	}
 
 	// Launch a new BrowserContext with launch configuration.

--- a/packages/calypso-e2e/src/environment.ts
+++ b/packages/calypso-e2e/src/environment.ts
@@ -6,6 +6,6 @@ export const COOKIES_PATH = process.env.COOKIES_PATH ?? '';
  * @returns {string[]} Array of lowercase strings.
  */
 export const LOCALES = (): string[] => {
-	const locales = process.env.I18N_LOCALES ?? '';
+	const locales = process.env.LOCALES ?? '';
 	return locales.split( ',' ).map( ( locale ) => locale.toLowerCase() );
 };

--- a/packages/calypso-e2e/src/environment.ts
+++ b/packages/calypso-e2e/src/environment.ts
@@ -1,1 +1,11 @@
 export const COOKIES_PATH = process.env.COOKIES_PATH ?? '';
+
+/**
+ * List of locales, used in i18n testing.
+ *
+ * @returns {string[]} Array of lowercase strings.
+ */
+export const LOCALES = (): string[] => {
+	const locales = process.env.I18N_LOCALES ?? '';
+	return locales.split( ',' ).map( ( locale ) => locale.toLowerCase() );
+};

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -215,7 +215,7 @@ const translations: Translations = {
 	},
 };
 
-describe( 'Translations: Editor', function () {
+describe( 'I18N: Editor', function () {
 	let page: Page;
 	// Filter out the locales that do not have valid translation content defined above.
 	const locales = Object.keys( translations ).filter( ( locale ) =>
@@ -266,13 +266,13 @@ describe( 'Translations: Editor', function () {
 				let frame: Frame;
 				let gutenbergEditorPage: GutenbergEditorPage;
 
-				beforeAll( async function () {
+				it( 'Insert test block', async function () {
 					gutenbergEditorPage = new GutenbergEditorPage( page );
-					frame = await gutenbergEditorPage.getEditorFrame();
 					await gutenbergEditorPage.addBlock( block.blockName, block.blockEditorSelector );
 				} );
 
 				it( 'Render block content translations', async function () {
+					frame = await gutenbergEditorPage.getEditorFrame();
 					await Promise.all(
 						block.blockEditorContent.map( ( content: any ) =>
 							frame.waitForSelector( `${ block.blockEditorSelector } ${ content }`, {

--- a/test/e2e/specs/specs-i18n/wp-i18n__gutenboarding.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__gutenboarding.ts
@@ -5,62 +5,62 @@
 import {
 	setupHooks,
 	validatePageTranslations,
-	BrowserHelper,
 	DataHelper,
 	GutenboardingFlow,
+	TestEnvironment,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-const locale = BrowserHelper.getLocale();
-
-describe( `Gutenboarding translations @i18n (${ locale })`, function () {
-	let gutenboardingFlow: GutenboardingFlow;
+describe( 'I18N: Gutenboarding', function () {
 	let page: Page;
+	let gutenboardingFlow: GutenboardingFlow;
 
-	setupHooks( ( args ) => {
+	setupHooks( ( args: { page: Page } ) => {
 		page = args.page;
 	} );
 
-	it( 'Navigate to /new', async function () {
-		await page.goto( DataHelper.getCalypsoURL( 'new' ) );
-		gutenboardingFlow = new GutenboardingFlow( page );
-	} );
+	describe.each( TestEnvironment.LOCALES() )( 'Locale: %s', function ( locale ) {
+		it( 'Navigate to /new', async function () {
+			await page.goto( DataHelper.getCalypsoURL( 'new' ) );
+			gutenboardingFlow = new GutenboardingFlow( page );
+		} );
 
-	it( `Change the locale (${ locale })`, async function () {
-		await gutenboardingFlow.switchLanguage( locale );
-	} );
+		it( `Change the locale (${ locale })`, async function () {
+			await gutenboardingFlow.switchLanguage( locale );
+		} );
 
-	it( `Display translations on aquire intent page (${ locale })`, async function () {
-		await validatePageTranslations( page, locale );
-		await gutenboardingFlow.clickSkipButton();
-	} );
+		it( `Display translations on aquire intent page (${ locale })`, async function () {
+			await validatePageTranslations( page, locale );
+			await gutenboardingFlow.clickSkipButton();
+		} );
 
-	it( `Display translations on design selector page (${ locale })`, async function () {
-		await validatePageTranslations( page, locale );
-		await gutenboardingFlow.selectDesign( 'Stratford' );
-	} );
+		it( `Display translations on design selector page (${ locale })`, async function () {
+			await validatePageTranslations( page, locale );
+			await gutenboardingFlow.selectDesign( 'Stratford' );
+		} );
 
-	it( `Display translations on style preview page (${ locale })`, async function () {
-		await gutenboardingFlow.selectFont( 'Raleway' );
-		await validatePageTranslations( page, locale );
-		await gutenboardingFlow.clickNextButton();
-	} );
+		it( `Display translations on style preview page (${ locale })`, async function () {
+			await gutenboardingFlow.selectFont( 'Raleway' );
+			await validatePageTranslations( page, locale );
+			await gutenboardingFlow.clickNextButton();
+		} );
 
-	it( `Display translations on domains page (${ locale })`, async function () {
-		await gutenboardingFlow.searchDomain( DataHelper.getRandomPhrase() );
-		await gutenboardingFlow.selectDomain( '.wordpress.com' );
-		await validatePageTranslations( page, locale );
-		await gutenboardingFlow.clickNextButton();
-	} );
+		it( `Display translations on domains page (${ locale })`, async function () {
+			await gutenboardingFlow.searchDomain( DataHelper.getRandomPhrase() );
+			await gutenboardingFlow.selectDomain( '.wordpress.com' );
+			await validatePageTranslations( page, locale );
+			await gutenboardingFlow.clickNextButton();
+		} );
 
-	it( `Display translations on features page (${ locale })`, async function () {
-		await gutenboardingFlow.selectFeatures( [] );
-		await validatePageTranslations( page, locale );
-		await gutenboardingFlow.clickSkipButton();
-	} );
+		it( `Display translations on features page (${ locale })`, async function () {
+			await gutenboardingFlow.selectFeatures( [] );
+			await validatePageTranslations( page, locale );
+			await gutenboardingFlow.clickSkipButton();
+		} );
 
-	it( `Display translations on plans page (${ locale })`, async function () {
-		await gutenboardingFlow.expandAllPlans();
-		await validatePageTranslations( page, locale );
+		it( `Display translations on plans page (${ locale })`, async function () {
+			await gutenboardingFlow.expandAllPlans();
+			await validatePageTranslations( page, locale );
+		} );
 	} );
 } );

--- a/test/e2e/specs/specs-i18n/wp-i18n__logged-out-redirect.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__logged-out-redirect.ts
@@ -10,7 +10,7 @@ describe( 'I18N: Homepage Redirect', function () {
 		args.page;
 	} );
 
-	it.each( TestEnvironment.LOCALES() )( 'Locale: %s', async function ( locale ) {
+	it.each( TestEnvironment.LOCALES() )( 'Homepage Redirect (%s)', async function ( locale ) {
 		// Launch a new BrowserContext with the custom locale specified.
 		const browserContext = await BrowserManager.newBrowserContext( { locale: locale } );
 		const testPage = await browserContext.newPage();

--- a/test/e2e/specs/specs-i18n/wp-i18n__logged-out-redirect.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__logged-out-redirect.ts
@@ -2,19 +2,17 @@
  * @group i18n
  */
 
-import { setupHooks, DataHelper, BrowserHelper } from '@automattic/calypso-e2e';
+import { setupHooks, DataHelper, TestEnvironment } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-const locale = BrowserHelper.getLocale();
-
-describe( `Logged out homepage redirect test @i18n (${ locale })`, function () {
+describe.skip( 'I18N: Homepage Redirect', function () {
 	let page: Page;
 
 	setupHooks( ( args ) => {
 		page = args.page;
 	} );
 
-	it( `Redirect to correct URL for wordpress.com (${ locale })`, async function () {
+	it.each( TestEnvironment.LOCALES() )( 'Locale: %s', async function ( locale ) {
 		await page.goto( DataHelper.getCalypsoURL() );
 
 		// Locale slug for English is not included in the path name.

--- a/test/e2e/specs/specs-i18n/wp-i18n__logged-out-redirect.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__logged-out-redirect.ts
@@ -2,21 +2,26 @@
  * @group i18n
  */
 
-import { setupHooks, DataHelper, TestEnvironment } from '@automattic/calypso-e2e';
+import { setupHooks, DataHelper, TestEnvironment, BrowserManager } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-describe.skip( 'I18N: Homepage Redirect', function () {
-	let page: Page;
-
-	setupHooks( ( args ) => {
-		page = args.page;
+describe( 'I18N: Homepage Redirect', function () {
+	setupHooks( ( args: { page: Page } ) => {
+		args.page;
 	} );
 
 	it.each( TestEnvironment.LOCALES() )( 'Locale: %s', async function ( locale ) {
-		await page.goto( DataHelper.getCalypsoURL() );
+		// Launch a new BrowserContext with the custom locale specified.
+		const browserContext = await BrowserManager.newBrowserContext( { locale: locale } );
+		const testPage = await browserContext.newPage();
+
+		await testPage.goto( DataHelper.getCalypsoURL() );
 
 		// Locale slug for English is not included in the path name.
 		const localePath = locale === 'en' ? '' : `${ locale }/`;
-		await page.waitForURL( DataHelper.getCalypsoURL( localePath ) );
+		await testPage.waitForURL( DataHelper.getCalypsoURL( localePath ) );
+
+		// Close the test context.
+		await browserContext.close();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With PRs #57707 and #56940, our I18N tests are now in Playwright!

As a result, we need to update the TeamCity build job to use Playwright and Jest.

Otherwise, this should be an exact port of the old Selenium build!

Key changes:
- use TeamCity to define a list of locales to be tested, under `LOCALES` in the build parameter.
- new function to return the comma-delimited list of locales as an array of strings in `environment.ts`.
- refactor all three i18n tests to use `describe.each` or `it.each` to iterate over the list of locales.
- changes to block testing steps in Editor: i18n to ensure more reliable tests.

Details:
Previously the i18n tests ran on a loop that was baked into the TeamCity configuration, which looked like this:
```
for locale in ${'$'}{LOCALE[@]}; do
    """.trimIndent()
	  BROWSERLOCALE="${'$'}{locale}" yarn magellan --config=magellan-i18n.json --max_workers=%E2E_WORKERS% --local_browser=chrome --mocha_args="--reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter.json" || true
done
```

This causes issues with TeamCity's parsing of the build log and all sorts of other intelligent things TeamCity does for each build. With this change, instead of using a baked-in for loop, the locales that must be tested will be defined as an comma-delimited environment variable. This variable is parsed by the `TesEnvironment.LOCALES` method which returns an array of strings representing the locale.

Each i18n test has been fitted with Jest's native parametrization which will result in nice output that's friendly for TeamCity to parse, as well as eliminating repetitive work.

Additionally, `I18N: Editor` spec was refactored to remove unnecessary logic in order to make it easier to follow.

Sample output:
```
 I18N: Gutenboarding
16:27:25       Locale: en
16:27:25         ✓ Navigate to /new (474 ms)
16:27:25         ✓ Change the locale (en) (669 ms)
16:27:25         ✓ Display translations on aquire intent page (en) (407 ms)
16:27:25         ✓ Display translations on design selector page (en) (346 ms)
16:27:25         ✓ Display translations on style preview page (en) (611 ms)
16:27:25         ✓ Display translations on domains page (en) (960 ms)
16:27:25         ✓ Display translations on features page (en) (413 ms)
16:27:25         ✓ Display translations on plans page (en) (337 ms)
16:27:25       Locale: es
16:27:25         ✓ Navigate to /new (171 ms)
16:27:25         ✓ Change the locale (es) (1043 ms)
16:27:25         ✓ Display translations on aquire intent page (es) (325 ms)
16:27:25         ✓ Display translations on design selector page (es) (414 ms)
16:27:25         ✓ Display translations on style preview page (es) (554 ms)
16:27:25         ✓ Display translations on domains page (es) (1097 ms)
16:27:25         ✓ Display translations on features page (es) (474 ms)
16:27:25         ✓ Display translations on plans page (es) (467 ms)
```

#### Testing instructions

- [x] I18N Tests
  - [x] TeamCity
  - [ ] Local

Closes #57777