### PR TITLE
Design Picker: Re-add step header and subheader

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, { isBlankCanvasDesign, getDesignUrl } from '@automattic/design-picker';
 import { englishLocales } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
@@ -162,7 +161,7 @@ class DesignPickerStep extends Component {
 				onSelect={ this.pickDesign }
 				onPreview={ this.previewDesign }
 				className={ classnames( {
-					'design-picker-step__has-categories': isEnabled( 'signup/design-picker-categories' ),
+					'design-picker-step__has-categories': this.props.showDesignPickerCategories,
 				} ) }
 				highResThumbnails
 				showCategoryFilter={ this.props.showDesignPickerCategories }
@@ -208,9 +207,9 @@ class DesignPickerStep extends Component {
 	}
 
 	headerText() {
-		const { translate } = this.props;
+		const { showDesignPickerCategories, translate } = this.props;
 
-		if ( isEnabled( 'signup/design-picker-categories' ) ) {
+		if ( showDesignPickerCategories ) {
 			return translate( 'Themes' );
 		}
 
@@ -218,9 +217,9 @@ class DesignPickerStep extends Component {
 	}
 
 	subHeaderText() {
-		const { locale, translate } = this.props;
+		const { locale, showDesignPickerCategories, translate } = this.props;
 
-		if ( ! isEnabled( 'signup/design-picker-categories' ) ) {
+		if ( ! showDesignPickerCategories ) {
 			return translate(
 				'Pick your favorite homepage layout. You can customize or change it later.'
 			);
@@ -286,7 +285,7 @@ class DesignPickerStep extends Component {
 			<StepWrapper
 				{ ...this.props }
 				className={ classnames( {
-					'design-picker__has-categories': isEnabled( 'signup/design-picker-categories' ),
+					'design-picker__has-categories': this.props.showDesignPickerCategories,
 				} ) }
 				hideFormattedHeader
 				stepContent={ this.renderDesignPicker() }

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -281,13 +281,22 @@ class DesignPickerStep extends Component {
 			);
 		}
 
+		const headerProps = this.props.showDesignPickerCategories
+			? { hideFormattedHeader: true }
+			: {
+					fallbackHeaderText: this.headerText(),
+					headerText: this.headerText(),
+					fallbackSubHeaderText: this.subHeaderText(),
+					subHeaderText: this.subHeaderText(),
+			  };
+
 		return (
 			<StepWrapper
 				{ ...this.props }
 				className={ classnames( {
 					'design-picker__has-categories': this.props.showDesignPickerCategories,
 				} ) }
-				hideFormattedHeader
+				{ ...headerProps }
 				stepContent={ this.renderDesignPicker() }
 				align={ isReskinned ? 'left' : 'center' }
 				skipButtonAlign={ isReskinned ? 'top' : 'bottom' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I introduced a regression when styling the category picker in #56814. The step header moved to the sidebar when the category picker is shown. But in the process, I entirely removed the header when the category picker is hidden (which is currently is in production).

I've made the design picker step use the `showDesignPickerCategories` prop consistently, and then I've made sure that the header is shown when it's `false`.

Before:
<img width="2032" alt="Screenshot 2021-11-11 at 10 55 07 AM" src="https://user-images.githubusercontent.com/1500769/141210374-0ac78c4d-88f0-4033-a102-b76ed6e55b7d.png">

After:
<img width="1703" alt="Screenshot 2021-11-11 at 12 33 30 PM" src="https://user-images.githubusercontent.com/1500769/141210454-a81c7386-3f3f-45cb-9e9b-9cebd8cf478b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The category picker always appears in development so to disable it either
  * Change this flag to `false` and rebuild Calypso https://github.com/Automattic/wp-calypso/blob/5f812a471fcee0dd03571891e0b05bb1dd7c7cde/config/development.json#L153 or
  * Change this step prop to `false` https://github.com/Automattic/wp-calypso/blob/5f812a471fcee0dd03571891e0b05bb1dd7c7cde/client/signup/config/steps-pure.js#L743

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57915
