### PR TITLE
Domains: Enable transfer for previously mapped domains

### DIFF
--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -68,6 +68,7 @@ function TransferDomainStepStart( {
 				const availabilityData = await wpcom.domain( domain ).isAvailable( {
 					apiVersion: '1.3',
 					is_cart_pre_check: false,
+					blog_id: selectedSite?.ID,
 				} );
 
 				if ( domainAvailability.TRANSFER_PENDING_SAME_USER !== availabilityData.status ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The changes to the transfer flow introduced a regression where the user wouldn't be able to start a transfer for a previously mapped domain they own, as reported in p2MSmN-8Nz-p2. This PR fixes it, enabling the user to proceed with the transfer.

#### Testing instructions
- Using a site with a mapped domain `A`, browse to `/domains/add/use-my-domain/:site`;
- Try to use the same domain `A` with the transfer option;
- Check that it is possible to continue the transfer for the domain `A`;