### PR TITLE
Playwright: extend timeout when clicking on renew plan button from Plans page.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -65,14 +65,11 @@ export class IndividualPurchasePage {
 	 * Renew purchase by clicking on the "Renew Now" card button (as opposed to the inline "Renew now" button).
 	 */
 	async clickRenewNowCardButton(): Promise< void > {
-		// This triggers a real navigation.
+		// This triggers a real navigation to the `/checkout/<site_name>` endpoint.
 		await Promise.all( [
-			this.page.waitForNavigation(),
+			this.page.waitForNavigation( { timeout: 45 * 1000, waitUntil: 'networkidle' } ),
 			this.page.click( selectors.renewNowCardButton ),
 		] );
-
-		// We're landing on the cart page, which has a lot of async loading, so let's make sure we let everything settle.
-		await this.page.waitForLoadState( 'networkidle' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to scale back the scope of `Plans: Purchases` spec.

Key changes:
- significantly cut back the scope of the spec - now only tests the process of adding plan upgrade to the cart.
- update some inline comments.

Details:
The checkout and cart is quite well-tested in the overall suite. it appears that there is little need or value in testing whether clicking on the different plans add the expected item into the cart, and even if there is value it should likely be split out into two specs since the actions being tested in each subsuite are not quite related to one another.

#### Testing instructions

- [ ] normal tests
  - [ ] mobile
  - [ ] desktop

Closes https://github.com/Automattic/wp-calypso/issues/57931.