### PR TITLE
Playwright: wait for networkidle state in `SupportComponent.visitArticle`.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -182,6 +182,7 @@ export class SupportComponent {
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
+		await this.page.waitForLoadState( 'networkidle' );
 		const visitArticleLocator = this.page.locator( selectors.visitArticleButton );
 
 		const browserContext = this.page.context();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the fifth incarnation of this issue (and the final one before pulling the plug on this spec), wait for `networkidle` to fire before proceeding to visit the article.

#### Testing instructions


Related to https://github.com/Automattic/wp-calypso/issues/57851, https://github.com/Automattic/wp-calypso/issues/57768, https://github.com/Automattic/wp-calypso/issues/57615, https://github.com/Automattic/wp-calypso/issues/57342.
Closes https://github.com/Automattic/wp-calypso/issues/57946.
