### PR TITLE
Desing Docs: adds AnnouncementModal, FixedNavigationHeader, Breadcrumb.

### DIFF
--- a/client/blocks/announcement-modal/docs/example.jsx
+++ b/client/blocks/announcement-modal/docs/example.jsx
@@ -37,10 +37,9 @@ const AnnouncementModalExample = () => {
 		},
 	];
 
-	const TriggerButton = () => <Button onClick={ () => setShow( true ) }>Show</Button>;
 	return (
 		<>
-			<TriggerButton />
+			<Button onClick={ () => setShow( true ) }>Show</Button>
 			{ show && (
 				<AnnouncementModal
 					announcementId={ announcementId }

--- a/client/blocks/announcement-modal/docs/example.jsx
+++ b/client/blocks/announcement-modal/docs/example.jsx
@@ -1,32 +1,22 @@
-import { useState, useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PlaceholderImage from 'calypso/assets/images/marketplace/plugins-revamp.png';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
 import Button from 'calypso/components/forms/form-button';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { setPreference } from 'calypso/state/preferences/actions';
 
 const AnnouncementModalExample = () => {
 	const dispatch = useDispatch();
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
-	const hasPreferences = useSelector( hasReceivedRemotePreferences );
 	const announcementId = 'example';
 	const dismissPreference = `announcement-modal-${ announcementId }-${ userId }`;
-	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
-	const [ show, setShow ] = useState( false );
+	console.log( 'example reload' );
 
-	useEffect( () => {
-		if ( ! hasPreferences ) {
-			return;
-		}
-
-		if ( isDismissed ) {
-			// Override the dismissing mechanism of the AnnouncementModal and just utilize useState here.
-			dispatch( savePreference( dismissPreference, 0 ) );
-			setShow( false );
-		}
-	}, [ isDismissed, hasPreferences, dismissPreference, dispatch ] );
+	useLayoutEffect( () => {
+		// Initially hide for users visiting devdocs.
+		dispatch( setPreference( dismissPreference, 1 ) );
+	}, [] );
 
 	const pages = [
 		{
@@ -39,14 +29,16 @@ const AnnouncementModalExample = () => {
 
 	return (
 		<>
-			<Button onClick={ () => setShow( true ) }>Show</Button>
-			{ show && (
-				<AnnouncementModal
-					announcementId={ announcementId }
-					pages={ pages }
-					finishButtonText="Close"
-				/>
-			) }
+			<Button
+				onClick={ () => setTimeout( () => dispatch( setPreference( dismissPreference, 0 ) ), 200 ) }
+			>
+				Show
+			</Button>
+			<AnnouncementModal
+				announcementId={ announcementId }
+				pages={ pages }
+				finishButtonText="Close"
+			/>
 		</>
 	);
 };

--- a/client/blocks/announcement-modal/docs/example.jsx
+++ b/client/blocks/announcement-modal/docs/example.jsx
@@ -1,7 +1,24 @@
+import { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import PlaceholderImage from 'calypso/assets/images/marketplace/plugins-revamp.png';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
-import PlaceholderImage from 'calypso/images/extensions/woocommerce/image-placeholder.png';
+import Button from 'calypso/components/forms/form-button';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 
-export default function AnnouncementModalExample() {
+const AnnouncementModalExample = () => {
+	const announcementId = 'announcement-modal-example';
+	const [ show, setShow ] = useState( false );
+	const dispatch = useDispatch();
+	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const hasPreferences = useSelector( hasReceivedRemotePreferences );
+	const dismissPreference = `announcement-modal-${ announcementId }-${ userId }`;
+
+	if ( ! hasPreferences ) {
+		return null;
+	}
+
 	const pages = [
 		{
 			heading: 'All the plugins and more',
@@ -9,12 +26,30 @@ export default function AnnouncementModalExample() {
 				'This page may look different as we’ve made some changes to improve the experience for you. Stay tuned for even more exciting updates to come!',
 			featureImage: PlaceholderImage,
 		},
-		{
-			heading: 'All the plugins and more Page 2',
-			content:
-				'This page may look different as we’ve made some changes to improve the experience for you. Stay tuned for even more exciting updates to come!',
-			featureImage: PlaceholderImage,
-		},
 	];
-	return <AnnouncementModal announcementId="my-new-super-duper-feature" pages={ pages } />;
-}
+
+	const TriggerButton = () => (
+		<Button onClick={ () => dispatch( savePreference( dismissPreference, 0 ) ) && setShow( true ) }>
+			Show
+		</Button>
+	);
+
+	if ( show ) {
+		return (
+			<>
+				{ TriggerButton() }
+				<AnnouncementModal
+					announcementId={ announcementId }
+					pages={ pages }
+					finishButtonText="Close"
+				/>
+			</>
+		);
+	}
+
+	return TriggerButton();
+};
+
+AnnouncementModalExample.displayName = 'AnnouncementModal';
+
+export default AnnouncementModalExample;

--- a/client/blocks/announcement-modal/docs/example.jsx
+++ b/client/blocks/announcement-modal/docs/example.jsx
@@ -11,7 +11,6 @@ const AnnouncementModalExample = () => {
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const announcementId = 'example';
 	const dismissPreference = `announcement-modal-${ announcementId }-${ userId }`;
-	console.log( 'example reload' );
 
 	useLayoutEffect( () => {
 		// Initially hide for users visiting devdocs.

--- a/client/blocks/announcement-modal/docs/example.jsx
+++ b/client/blocks/announcement-modal/docs/example.jsx
@@ -1,23 +1,32 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PlaceholderImage from 'calypso/assets/images/marketplace/plugins-revamp.png';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
 import Button from 'calypso/components/forms/form-button';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
-import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 
 const AnnouncementModalExample = () => {
-	const announcementId = 'announcement-modal-example';
-	const [ show, setShow ] = useState( false );
 	const dispatch = useDispatch();
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const hasPreferences = useSelector( hasReceivedRemotePreferences );
+	const announcementId = 'example';
 	const dismissPreference = `announcement-modal-${ announcementId }-${ userId }`;
+	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
+	const [ show, setShow ] = useState( false );
 
-	if ( ! hasPreferences ) {
-		return null;
-	}
+	useEffect( () => {
+		if ( ! hasPreferences ) {
+			return;
+		}
+
+		if ( isDismissed ) {
+			// Override the dismissing mechanism of the AnnouncementModal and just utilize useState here.
+			dispatch( savePreference( dismissPreference, 0 ) );
+			setShow( false );
+		}
+	}, [ isDismissed, hasPreferences, dismissPreference, dispatch ] );
 
 	const pages = [
 		{
@@ -28,26 +37,19 @@ const AnnouncementModalExample = () => {
 		},
 	];
 
-	const TriggerButton = () => (
-		<Button onClick={ () => dispatch( savePreference( dismissPreference, 0 ) ) && setShow( true ) }>
-			Show
-		</Button>
-	);
-
-	if ( show ) {
-		return (
-			<>
-				{ TriggerButton() }
+	const TriggerButton = () => <Button onClick={ () => setShow( true ) }>Show</Button>;
+	return (
+		<>
+			<TriggerButton />
+			{ show && (
 				<AnnouncementModal
 					announcementId={ announcementId }
 					pages={ pages }
 					finishButtonText="Close"
 				/>
-			</>
-		);
-	}
-
-	return TriggerButton();
+			) }
+		</>
+	);
 };
 
 AnnouncementModalExample.displayName = 'AnnouncementModal';

--- a/client/components/breadcrumb/docs/example.jsx
+++ b/client/components/breadcrumb/docs/example.jsx
@@ -1,10 +1,14 @@
 import Breadcrumb from 'calypso/components/breadcrumb';
 
-export default function BreadcrumbExample() {
+const BreadcrumbExample = () => {
 	const navigationItems = [
 		{ label: 'Plugins', href: `/plugins` },
 		{ label: 'Search', href: `/plugins?s=woo` },
 		{ label: 'Woocommerce' },
 	];
 	return <Breadcrumb items={ navigationItems } />;
-}
+};
+
+BreadcrumbExample.displayName = 'Breadcrumb';
+
+export default BreadcrumbExample;

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -16,7 +16,7 @@ const StyledLi = styled.li`
 	font-weight: 500;
 	--color-link: var( --studio-gray-100 );
 
-	:first-child {
+	:first-of-type {
 		font-size: 16px;
 		font-weight: 600;
 		--color-link: var( --studio-gray-80 );

--- a/client/components/fixed-navigation-header/docs/example.jsx
+++ b/client/components/fixed-navigation-header/docs/example.jsx
@@ -1,9 +1,25 @@
+import styled from '@emotion/styled';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 
-export default function FixedNavigationHeaderExample() {
+const FixedNavigationHeaderStyled = styled( FixedNavigationHeader )`
+	position: relative;
+	top: inherit;
+	left: inherit;
+	width: 100%;
+`;
+
+const FixedNavigationHeaderExample = () => {
 	const navigationItems = [
 		{ label: 'Plugins', href: `/plugins` },
 		{ label: 'Search', href: `/plugins?s=woo` },
 	];
-	return <FixedNavigationHeader navigationItems={ navigationItems } />;
-}
+	return (
+		<FixedNavigationHeaderStyled navigationItems={ navigationItems }>
+			Some Children Elements
+		</FixedNavigationHeaderStyled>
+	);
+};
+
+FixedNavigationHeaderExample.displayName = 'FixedNavigationHeader';
+
+export default FixedNavigationHeaderExample;

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -4,6 +4,7 @@ import { trim } from 'lodash';
 import page from 'page';
 import { Component, Fragment } from 'react';
 import AllSites from 'calypso/blocks/all-sites/docs/example';
+import AnnouncementModalExample from 'calypso/blocks/announcement-modal/docs/example';
 import AuthorCompactProfile from 'calypso/blocks/author-compact-profile/docs/example';
 import AuthorSelector from 'calypso/blocks/author-selector/docs/example';
 import CalendarButton from 'calypso/blocks/calendar-button/docs/example';
@@ -116,6 +117,7 @@ export default class AppComponents extends Component {
 					{ isEnabled( 'devdocs/color-scheme-picker' ) && (
 						<ColorSchemePicker readmeFilePath="color-scheme-picker" />
 					) }
+					<AnnouncementModalExample readmeFilePath="announcement-modal" />
 					<AllSites readmeFilePath="all-sites" />
 					<AuthorSelector readmeFilePath="author-selector" />
 					<CalendarButton readmeFilePath="calendar-button" />

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -198,7 +198,7 @@ export default class DesignAssets extends Component {
 					<FeatureGate readmeFilePath="feature-example" />
 					<FilePickers readmeFilePath="file-picker" />
 					<FixedNavigationHeader
-						searchKeywords="header,navigatio,breadcrumbs"
+						searchKeywords="breadcrumbs"
 						readmeFilePath="fixed-navigation-header"
 					/>
 					<FocusableExample readmeFilePath="focusable" />

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -19,6 +19,7 @@ import Animate from 'calypso/components/animate/docs/example';
 import BackButton from 'calypso/components/back-button/docs/example';
 import Badge from 'calypso/components/badge/docs/example';
 import Banner from 'calypso/components/banner/docs/example';
+import Breadcrumb from 'calypso/components/breadcrumb/docs/example';
 import BulkSelect from 'calypso/components/bulk-select/docs/example';
 import ButtonGroups from 'calypso/components/button-group/docs/example';
 import CardHeading from 'calypso/components/card-heading/docs/example';
@@ -38,6 +39,7 @@ import ExternalLink from 'calypso/components/external-link/docs/example';
 import FAQ from 'calypso/components/faq/docs/example';
 import FeatureGate from 'calypso/components/feature-example/docs/example';
 import FilePickers from 'calypso/components/file-picker/docs/example';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header/docs/example';
 import FocusableExample from 'calypso/components/focusable/docs/example';
 import FoldableCard from 'calypso/components/foldable-card/docs/example';
 import FoldableFAQ from 'calypso/components/foldable-faq/docs/example';
@@ -172,6 +174,7 @@ export default class DesignAssets extends Component {
 					<BackButton readmeFilePath="back-button" />
 					<Badge readmeFilePath="badge" />
 					<Banner readmeFilePath="banner" />
+					<Breadcrumb searchKeywords="navigation" readmeFilePath="breadcrumb" />
 					<BulkSelect readmeFilePath="bulk-select" />
 					<ButtonGroups readmeFilePath="button-group" />
 					<Buttons readmeFilePath="/packages/components/src/button" />
@@ -194,6 +197,10 @@ export default class DesignAssets extends Component {
 					<FAQ readmeFilePath="faq" />
 					<FeatureGate readmeFilePath="feature-example" />
 					<FilePickers readmeFilePath="file-picker" />
+					<FixedNavigationHeader
+						searchKeywords="header,navigatio,breadcrumbs"
+						readmeFilePath="fixed-navigation-header"
+					/>
 					<FocusableExample readmeFilePath="focusable" />
 					<FoldableCard readmeFilePath="foldable-card" />
 					<FoldableFAQ readmeFilePath="foldable-faq" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refines AnnouncementModal, FixedNavigationHeader examples
* Desing Docs: adds AnnouncementModal, FixedNavigationHeader, Breadcrumb.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/devdocs/design`
* make sure you can find FixedNavigationHeader, Breadcrumb and their ReadMe links work (clicking on the header)
* go to `/devdocs/blocks`
* make sure you can find AnnouncementModal and it works by clicking `Show` and then dismissing it

<img width="1594" alt="SS 2021-11-11 at 10 54 55" src="https://user-images.githubusercontent.com/12430020/141268082-60958ec8-1ba1-4063-97b5-cfea02cdc10c.png">

<img width="1594" alt="SS 2021-11-11 at 10 55 19" src="https://user-images.githubusercontent.com/12430020/141268130-a42f8b33-0a59-4cc5-80eb-dedc8dac2bdb.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-9Rf-p2#comment-11289