### PR TITLE
My Sites: Fix Jetpack sites' listing on the "My Home" (`/home`) page

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -56,9 +56,9 @@ class Sites extends Component {
 			return true;
 		}
 
-		// Supported on Simple and Atomic Sites
+		// filter out all VIP sites
 		if ( /^\/home/.test( path ) ) {
-			return ! site.is_vip && ! ( site.jetpack && ! site.options.is_automated_transfer );
+			return ! site.is_vip;
 		}
 
 		return site;


### PR DESCRIPTION
Sites displayed on the "My Home" page (`/home`) are filtered based on the following rule:

https://github.com/Automattic/wp-calypso/blob/b019e5848b267df5de134270fe1175a59b8292bc/client/my-sites/sites/index.jsx#L59-L62

It looks like the rule was originally added to filter out VIP sites only, but it is filtering out all Jetpack-connected sites as well (issue reported in https://github.com/Automattic/wp-calypso/issues/57295).

To add more specificity, the condition `! site.is_vip && ! ( site.jetpack && ! site.options.is_automated_transfer )` returns `false` for every Jetpack-connected site. This results in each Jetpack-connected site to be left out from the `sites` array that is then rendered in the `Site Selector` component:

https://github.com/Automattic/wp-calypso/blob/b019e5848b267df5de134270fe1175a59b8292bc/client/components/site-selector/index.jsx#L279-L281

#### Changes proposed in this Pull Request

* Remove part of the condition (`! ( site.jetpack && ! site.options.is_automated_transfer )`) to make sure only VIP sites are filtered out.

Hey @gwwar and @kwight 👋🏼 I am tagging you here in case there's something I might have missed in relation to VIP sites (as the filter was originally added in https://github.com/Automattic/wp-calypso/pull/39090). I don't think the change would have any effect on VIP sites, just wanted to double-check with you.

#### Screenshots

Before:
![Markup on 2021-11-11 at 11:16:07](https://user-images.githubusercontent.com/25105483/141280968-f1a9a075-abb3-4877-b44d-e2cc45474c69.png)

After:
![Markup on 2021-11-11 at 11:17:41](https://user-images.githubusercontent.com/25105483/141280992-3389448e-fb42-42e6-90f9-8ca66de010a1.png)

#### Testing instructions
It shouldn't be possible to reproduce https://github.com/Automattic/wp-calypso/issues/57295.

In steps:
1. Create a WPORG site. You can use https://jurassic.ninja/
2. Connect it to your WordPress.com account.
3. The Jetpack-connected site should show up in the list under "My Sites" https://wordpress.com/home - in the same way as it is showing up on other similar pages, e.g. https://wordpress.com/media and https://wordpress.com/settings/general

Related to https://github.com/Automattic/wp-calypso/issues/57295
