### PR TITLE
Lodash: remove usages of uniqWith

### DIFF
--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { withStorageKey } from '@automattic/state-utils';
-import { uniqWith, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,
@@ -47,17 +47,19 @@ export const meta = withSchemaValidation( metaSchema, ( state = DEFAULT_META_STA
 
 export const link = withSchemaValidation( linkSchema, ( state = [], action ) => {
 	switch ( action.type ) {
-		case DOCUMENT_HEAD_LINK_SET:
+		case DOCUMENT_HEAD_LINK_SET: {
 			if ( ! action.link ) {
 				return state;
 			}
 
 			// Append action.link to the state array and prevent duplicate objects.
 			// Works with action.link being a single link object or an array of link objects.
-			return uniqWith(
-				[ ...state, ...( Array.isArray( action.link ) ? action.link : [ action.link ] ) ],
-				isEqual
-			);
+			const links = Array.isArray( action.link ) ? action.link : [ action.link ];
+			state = links.reduce( ( accuState, newLink ) => {
+				const isNew = ! accuState.some( ( accuLink ) => isEqual( accuLink, newLink ) );
+				return isNew ? [ ...accuState, newLink ] : accuState;
+			}, state );
+		}
 	}
 
 	return state;

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -55,7 +55,7 @@ export const link = withSchemaValidation( linkSchema, ( state = [], action ) => 
 			// Append action.link to the state array and prevent duplicate objects.
 			// Works with action.link being a single link object or an array of link objects.
 			const links = Array.isArray( action.link ) ? action.link : [ action.link ];
-			state = links.reduce( ( accuState, newLink ) => {
+			return links.reduce( ( accuState, newLink ) => {
 				const isNew = ! accuState.some( ( accuLink ) => isEqual( accuLink, newLink ) );
 				return isNew ? [ ...accuState, newLink ] : accuState;
 			}, state );

--- a/client/state/document-head/test/reducer.js
+++ b/client/state/document-head/test/reducer.js
@@ -96,5 +96,23 @@ describe( 'reducer', () => {
 
 			expect( newState ).toEqual( expectedState );
 		} );
+
+		test( 'should deduplicate when setting new link tags', () => {
+			const state = deepFreeze( [ { rel: 'some-rel', href: 'https://wordpress.org' } ] );
+			const newState = link( state, {
+				type: DOCUMENT_HEAD_LINK_SET,
+				link: [
+					{ rel: 'some-rel', href: 'https://wordpress.org' },
+					{ rel: 'another-rel', href: 'https://automattic.com' },
+				],
+			} );
+
+			const expectedState = [
+				{ rel: 'some-rel', href: 'https://wordpress.org' },
+				{ rel: 'another-rel', href: 'https://automattic.com' },
+			];
+
+			expect( newState ).toEqual( expectedState );
+		} );
 	} );
 } );

--- a/client/state/document-head/test/reducer.js
+++ b/client/state/document-head/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import {
 	DOCUMENT_HEAD_LINK_SET,
@@ -14,13 +13,13 @@ describe( 'reducer', () => {
 		test( 'should default to an empty string', () => {
 			const state = title( undefined, {} );
 
-			expect( state ).to.equal( '' );
+			expect( state ).toBe( '' );
 		} );
 
 		test( 'should properly set a new title', () => {
 			const newState = title( undefined, { type: DOCUMENT_HEAD_TITLE_SET, title: 'new title' } );
 
-			expect( newState ).to.equal( 'new title' );
+			expect( newState ).toBe( 'new title' );
 		} );
 	} );
 
@@ -28,7 +27,7 @@ describe( 'reducer', () => {
 		test( 'should default to a zero', () => {
 			const state = unreadCount( undefined, {} );
 
-			expect( state ).to.equal( 0 );
+			expect( state ).toBe( 0 );
 		} );
 
 		test( 'should properly set a new unread count', () => {
@@ -37,14 +36,14 @@ describe( 'reducer', () => {
 				count: 123,
 			} );
 
-			expect( newState ).to.equal( 123 );
+			expect( newState ).toBe( 123 );
 		} );
 
 		it( 'should return initial state on route set action', () => {
 			const original = 123;
 			const state = unreadCount( original, { type: ROUTE_SET } );
 
-			expect( state ).to.equal( 0 );
+			expect( state ).toBe( 0 );
 		} );
 	} );
 
@@ -52,7 +51,7 @@ describe( 'reducer', () => {
 		test( 'should default to "og:site_name" set to "WordPress.com" array', () => {
 			const state = meta( undefined, {} );
 
-			expect( state ).to.eql( DEFAULT_META_STATE );
+			expect( state ).toEqual( DEFAULT_META_STATE );
 		} );
 
 		test( 'should set a new meta tag', () => {
@@ -69,7 +68,7 @@ describe( 'reducer', () => {
 
 			const expectedState = [ { content: 'another content', type: 'another type' } ];
 
-			expect( newState ).to.eql( expectedState );
+			expect( newState ).toEqual( expectedState );
 		} );
 	} );
 
@@ -77,7 +76,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty array', () => {
 			const state = link( undefined, {} );
 
-			expect( state ).to.eql( [] );
+			expect( state ).toEqual( [] );
 		} );
 
 		test( 'should set a new link tag', () => {
@@ -95,7 +94,7 @@ describe( 'reducer', () => {
 				{ rel: 'another-rel', href: 'https://automattic.com' },
 			];
 
-			expect( newState ).to.eql( expectedState );
+			expect( newState ).toEqual( expectedState );
 		} );
 	} );
 } );

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -1,4 +1,4 @@
-import { findIndex, last, takeRightWhile, takeWhile, filter, uniqWith } from 'lodash';
+import { findIndex, last, takeRightWhile, takeWhile, filter } from 'lodash';
 import moment from 'moment';
 import { keysAreEqual } from 'calypso/reader/post-key';
 import {
@@ -53,7 +53,11 @@ export const items = ( state = [], action ) => {
 				return combineXPosts( [ ...beforeGap, ...streamItems, ...nextGap, ...afterGap ] );
 			}
 
-			newState = uniqWith( [ ...state, ...streamItems ], keysAreEqual );
+			// add the `streamItems` to state, but only ones that aren't already there
+			newState = streamItems.reduce( ( accuState, streamItem ) => {
+				const isNew = ! accuState.some( ( accuItem ) => keysAreEqual( accuItem, streamItem ) );
+				return isNew ? [ ...accuState, streamItem ] : accuState;
+			}, state );
 
 			// Find any x-posts
 			newXPosts = filter( streamItems, ( postKey ) => postKey.xPostMetadata );

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -40,6 +40,14 @@ describe( 'streams.items reducer', () => {
 		expect( nextState ).toEqual( [ time2PostKey, time1PostKey ] );
 	} );
 
+	it( 'should accept new items with duplicates removed', () => {
+		const prevState = deepfreeze( [ time2PostKey ] );
+		const action = receivePage( { streamItems: [ time2PostKey, time1PostKey ] } );
+		const nextState = items( prevState, action );
+
+		expect( nextState ).toEqual( [ time2PostKey, time1PostKey ] );
+	} );
+
 	it( 'should add new posts to existing items', () => {
 		const prevState = deepfreeze( [ time2PostKey ] );
 		const action = receivePage( { streamItems: [ time1PostKey ] } );


### PR DESCRIPTION
Removes all usages of `uniqWith`, all of them in reducers, from the codebase. And replaces them with a `.reduce` loop.

**How to test:**
Verify that unit tests for both reducers still pass, and that the affected features (document head links, reader streams) still work.