### PR TITLE
Emails: Improve placeholder for professional email nudge

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -255,9 +255,7 @@ export class UpsellNudge extends Component {
 					<div className="upsell-nudge__placeholders upsell-nudge__form-placeholder">
 						<div>
 							<div className="upsell-nudge__placeholder-row is-placeholder" />
-							<br />
 							<div className="upsell-nudge__placeholder-row is-placeholder" />
-							<br />
 							<div className="upsell-nudge__placeholder-button-container">
 								<div className="upsell-nudge__placeholder-button is-placeholder" />
 								<div className="upsell-nudge__placeholder-button is-placeholder" />

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -188,7 +188,7 @@ export class UpsellNudge extends Component {
 				<QueryStoredCards />
 				{ ! hasProductsList && <QueryProductsList /> }
 				{ ! hasSitePlans && <QuerySitePlans siteId={ selectedSiteId } /> }
-				{ this.renderPlaceholders() }
+				{ isLoading ? this.renderPlaceholders() : this.renderContent() }
 				{ this.state.showPurchaseModal && this.renderPurchaseModal() }
 				{ this.preloadIconsForPurchaseModal() }
 			</Main>

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -188,7 +188,7 @@ export class UpsellNudge extends Component {
 				<QueryStoredCards />
 				{ ! hasProductsList && <QueryProductsList /> }
 				{ ! hasSitePlans && <QuerySitePlans siteId={ selectedSiteId } /> }
-				{ isLoading ? this.renderPlaceholders() : this.renderContent() }
+				{ this.renderPlaceholders() }
 				{ this.state.showPurchaseModal && this.renderPurchaseModal() }
 				{ this.preloadIconsForPurchaseModal() }
 			</Main>
@@ -251,7 +251,7 @@ export class UpsellNudge extends Component {
 						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__price-placeholder" />
 					</div>
 				</div>
-				<div>
+				<div className="upsell-nudge__placeholders upsell-nudge__form-container-placeholder">
 					<div className="upsell-nudge__placeholders upsell-nudge__form-placeholder">
 						<div>
 							<div className="upsell-nudge__placeholder-row is-placeholder" />

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -195,7 +195,7 @@ export class UpsellNudge extends Component {
 		);
 	}
 
-	renderPlaceholders() {
+	renderGenericPlaceholder() {
 		const { receiptId } = this.props;
 		return (
 			<>
@@ -239,6 +239,52 @@ export class UpsellNudge extends Component {
 				</CompactCard>
 			</>
 		);
+	}
+
+	renderProfessionalEmailUpsellPlaceholder() {
+		return (
+			<>
+				<div className="upsell-nudge__placeholders">
+					<div>
+						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__hold-tight-placeholder" />
+						<div className="upsell-nudge__placeholder-row is-placeholder" />
+						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__price-placeholder" />
+					</div>
+				</div>
+				<div>
+					<div className="upsell-nudge__placeholders upsell-nudge__form-placeholder">
+						<div>
+							<div className="upsell-nudge__placeholder-row is-placeholder" />
+							<br />
+							<div className="upsell-nudge__placeholder-row is-placeholder" />
+							<br />
+							<div className="upsell-nudge__placeholder-button-container">
+								<div className="upsell-nudge__placeholder-button is-placeholder" />
+								<div className="upsell-nudge__placeholder-button is-placeholder" />
+							</div>
+						</div>
+					</div>
+					<div className="upsell-nudge__placeholders upsell-nudge__benefits-placeholder">
+						<div>
+							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+						</div>
+					</div>
+				</div>
+			</>
+		);
+	}
+
+	renderPlaceholders() {
+		const { upsellType } = this.props;
+
+		if ( upsellType === 'professional-email-upsell' ) {
+			return this.renderProfessionalEmailUpsellPlaceholder();
+		}
+		return this.renderGenericPlaceholder();
 	}
 
 	renderContent() {

--- a/client/my-sites/checkout/upsell-nudge/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/style.scss
@@ -14,7 +14,7 @@
 .upsell-nudge__placeholder-row {
 	height: 40px;
 	flex: 0 0 100%;
-	margin-bottom: 15px;
+	margin-bottom: 20px;
 }
 
 .upsell-nudge__placeholder-button {
@@ -44,7 +44,6 @@
 .upsell-nudge__form-placeholder {
 	width: 100%;
 	margin-top: 64px;
-	float: left;
 	margin-right: 0px;
 	@include break-medium {
 		width: 60%;
@@ -65,7 +64,6 @@
 }
 
 .upsell-nudge__feature-placeholder {
-	margin-bottom: 20px;
 	height: 20px;
 }
 

--- a/client/my-sites/checkout/upsell-nudge/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/style.scss
@@ -55,7 +55,6 @@
 .upsell-nudge__benefits-placeholder {
 	width: 100%;
 	margin-top: 64px;
-	float: right;
 	margin-left: 0px;
 	@include break-medium {
 		width: 40%;

--- a/client/my-sites/checkout/upsell-nudge/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .upsell-nudge__placeholders {
 	display: flex;
 	flex-direction: column;
@@ -39,21 +42,26 @@
 }
 
 .upsell-nudge__form-placeholder {
-	>div {
-		padding: 12px;
-	}
-	width: 60%;
+	width: 100%;
 	margin-top: 64px;
 	float: left;
+	margin-right: 0px;
+	@include break-medium {
+		width: 60%;
+		margin-right: 8px;
+	}
+
 }
 
 .upsell-nudge__benefits-placeholder {
-	>div {
-		padding: 12px 46px;
-	}
-	width: 40%;
+	width: 100%;
 	margin-top: 64px;
 	float: right;
+	margin-left: 0px;
+	@include break-medium {
+		width: 40%;
+		margin-left: 8px;
+	}
 }
 
 .upsell-nudge__feature-placeholder {
@@ -79,4 +87,12 @@
 	width: 0;
 	height: 0;
 	overflow: hidden;
+}
+
+.upsell-nudge__form-container-placeholder {
+	display: flex;
+	flex-direction: column;
+	@include break-medium {
+		flex-direction: row;
+	}
 }

--- a/client/my-sites/checkout/upsell-nudge/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/style.scss
@@ -24,6 +24,49 @@
 	}
 }
 
+.upsell-nudge__price-placeholder {
+	width: 33%;
+	margin: 0 auto;
+	height: 20px;
+}
+
+.upsell-nudge__hold-tight-placeholder {
+	width: 33%;
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 20px;
+	height: 20px;
+}
+
+.upsell-nudge__form-placeholder {
+	>div {
+		padding: 12px;
+	}
+	width: 60%;
+	margin-top: 64px;
+	float: left;
+}
+
+.upsell-nudge__benefits-placeholder {
+	>div {
+		padding: 12px 46px;
+	}
+	width: 40%;
+	margin-top: 64px;
+	float: right;
+}
+
+.upsell-nudge__feature-placeholder {
+	margin-bottom: 20px;
+	height: 20px;
+}
+
+.upsell-nudge__price-placeholder {
+	width: 33%;
+	margin: 0 auto;
+	height: 20px;
+}
+
 .upsell-nudge__placeholder-button-container {
 	display: flex;
 	justify-content: space-between;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change adds a placeholder that fits better with the Professional Email upsell nudge

#### Testing instructions

1. - The first thing we need to do is find an existing receipt ID for one of your sites. Follow these steps to find a site slug and receipt ID:
2. - For a site with purchases on it, navigate to Upgrades -> Purchases and then click on the "Billing History" tab
3. - For one of the items in the list, click on the "View receipt" link
4. - Look at the URL and note the last two /-separated pieces -- these are the site slug and receipt ID (in that order)
5. - Run this branch locally or via the live branch
6. - Manually type the following path into the browser location box: /checkout/offer-professional-email/:domainName/:receiptId/:siteSlug with :receiptId and :siteSlug replaced by the two values above (which we use in the reverse order for this URL) and :domainName with a domain of your own.

You should see for a split second the following placeholder:
![image](https://user-images.githubusercontent.com/5689927/141285743-6fbdeb17-d264-4730-a139-c20d1ad53b83.png)

Which temporary replaces the following form:
![image](https://user-images.githubusercontent.com/5689927/141285871-76abf6c4-e57b-452f-9399-1ae7b45255ad.png)

If by any chance you can't get the placeholder to appear, please, checkout this branch and modify the code doing the following changes:
![image](https://user-images.githubusercontent.com/5689927/141286030-69eb1c2b-6205-4c6b-a5a7-41748390804d.png)


Related to 1200182182542585-as-1201064348369955
