### PR TITLE
Fix Site editor close button slot/fill for 11.9

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -2,7 +2,7 @@
 
 import { createBlock, parse } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
-import { dispatch, select, subscribe, use } from '@wordpress/data';
+import { dispatch, select, subscribe, use, useSelect } from '@wordpress/data';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -496,6 +496,12 @@ function handleCloseEditor( calypsoPort ) {
 				const [ closeUrl, setCloseUrl ] = useState( calypsoifyGutenberg.closeUrl );
 				const [ label, setLabel ] = useState( calypsoifyGutenberg.closeButtonLabel );
 
+				const siteIconUrl = useSelect(
+					( _select ) =>
+						_select( 'core' ).getEntityRecord( 'root', '__unstableBase', undefined )?.site_icon_url,
+					[]
+				);
+
 				useEffect( () => {
 					addAction(
 						'updateCloseButtonOverrides',
@@ -510,12 +516,22 @@ function handleCloseEditor( calypsoPort ) {
 							'updateCloseButtonOverrides',
 							'a8c/wpcom-block-editor/CloseWpcomBlockEditor'
 						);
-				} );
+				}, [] );
 
 				const SiteEditorDashboardFill = editSitePackage?.__experimentalMainDashboardButton;
 				if ( ! SiteEditorDashboardFill ) {
 					return null;
 				}
+
+				const buttonIcon = siteIconUrl ? (
+					<img
+						alt={ __( 'Site Icon' ) }
+						className="iframe-bridge-server__edit-site-navigation-link-site-icon edit-site-navigation-link__site-icon"
+						src={ siteIconUrl }
+					/>
+				) : (
+					wordpress
+				);
 
 				return (
 					<SiteEditorDashboardFill>
@@ -525,7 +541,7 @@ function handleCloseEditor( calypsoPort ) {
 								href={ closeUrl }
 								onClick={ dispatchAction }
 								label={ label }
-								icon={ wordpress }
+								icon={ buttonIcon }
 								iconSize={ 36 }
 							/>
 						</div>

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1,10 +1,7 @@
 /* global calypsoifyGutenberg, Image, MessageChannel, MessagePort, requestAnimationFrame */
 
 import { createBlock, parse } from '@wordpress/blocks';
-import {
-	Button,
-	__experimentalNavigationBackButton as NavigationBackButton,
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
@@ -495,21 +492,43 @@ function handleCloseEditor( calypsoPort ) {
 	// Add back to dashboard fill for Site Editor when edit-site package is available.
 	if ( editSitePackage ) {
 		registerPlugin( 'a8c-wpcom-block-editor-site-editor-back-to-dashboard-override', {
-			render: () => {
+			render: function SiteEditorCloseButton() {
+				const [ closeUrl, setCloseUrl ] = useState( calypsoifyGutenberg.closeUrl );
+				const [ label, setLabel ] = useState( calypsoifyGutenberg.closeButtonLabel );
+
+				useEffect( () => {
+					addAction(
+						'updateCloseButtonOverrides',
+						'a8c/wpcom-block-editor/CloseWpcomBlockEditor',
+						( data ) => {
+							setCloseUrl( data.closeUrl );
+							setLabel( data.label );
+						}
+					);
+					return () =>
+						removeAction(
+							'updateCloseButtonOverrides',
+							'a8c/wpcom-block-editor/CloseWpcomBlockEditor'
+						);
+				} );
+
 				const SiteEditorDashboardFill = editSitePackage?.__experimentalMainDashboardButton;
-				if ( ! SiteEditorDashboardFill || ! NavigationBackButton ) {
+				if ( ! SiteEditorDashboardFill ) {
 					return null;
 				}
 
 				return (
 					<SiteEditorDashboardFill>
-						<NavigationBackButton
-							backButtonLabel={ __( 'Dashboard' ) }
-							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-							className="edit-site-navigation-panel__back-to-dashboard"
-							href={ calypsoifyGutenberg.closeUrl }
-							onClick={ dispatchAction }
-						/>
+						<div className="iframe-bridge-server__edit-site-navigation-link edit-site-navigation-link">
+							<Button
+								className="iframe-bridge-server__edit-site-navigation-link-button edit-site-navigation-link__button has-icon"
+								href={ closeUrl }
+								onClick={ dispatchAction }
+								label={ label }
+								icon={ wordpress }
+								iconSize={ 36 }
+							/>
+						</div>
 					</SiteEditorDashboardFill>
 				);
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, we filled this slot with items corresponding to the `< Dashboard` button in the navigation sidebar.  Now with the navigation sidebar removed, and this slot/fIll being moved to the standard close button in the top-left, we need to update this fill so it does not end up looking like:

![image](https://user-images.githubusercontent.com/28742426/141307854-58e43675-e55d-40ad-aa6e-f7fb23caab85.png)

After this, the slotfill should look as expected with the WP logo or site icon if it is set:

![Screen Shot 2021-11-11 at 8 41 34 AM](https://user-images.githubusercontent.com/28742426/141308116-3549adf7-2e6b-4e31-b160-05f2f083257d.png)

![Screen Shot 2021-11-11 at 8 41 08 AM](https://user-images.githubusercontent.com/28742426/141308132-86fa5aef-7b29-4b24-ae67-e97e9b44da12.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This has been cherry picked into Gutenberg 11.9 release after the RC-4 release.  v11.9.0 is now installed on a sandbox but is not yet released to edge sites.  Either update your sandbox to load this version instead of rc.4, or sync Gutenberg `trunk`.  After the  v11.9.0 candidate lands on edge sites, this extra step should not be necessary.
* Sync this wpcom-block-editor change to your sandbox.
* Load the site editor and verify the close button looks and behaves as expected.
* If your site has a site icon set (this can be done in the customizer -> site identity), this should be visible instead of the WP logo.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
