### PR TITLE
Move paid signup to quarantined tests

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-signup__paid.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__paid.ts
@@ -1,5 +1,5 @@
 /**
- * @group calypso-release
+ * @group quarantined
  */
 
 import {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It looks like paid signup is having some flakiness due to Stripe. For the time being, we will quarantine the paid signup flow, until we can get the stripe errors to be more stable.

The free signup spec stays in place in pre-release tests, ensuring some coverage of the new E2E flow.

#### Testing instructions

- [x] Paid tests run in quarantine suite, not pre-release

Related to #57958
