### PR TITLE
Gutenboarding Import: add missing query params between step sections

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -171,12 +171,16 @@ export class NavigationLink extends Component {
 			this.props.cssClass
 		);
 
+		const hrefUrl =
+			this.props.direction === 'forward' && this.props.forwardUrl
+				? this.props.forwardUrl
+				: this.getBackUrl();
 		return (
 			<Button
 				primary={ primary }
 				borderless={ borderless }
 				className={ buttonClasses }
-				href={ this.getBackUrl() }
+				href={ hrefUrl }
 				onClick={ this.handleClick }
 				rel={ this.props.rel }
 			>

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -113,6 +113,7 @@ class StepWrapper extends Component {
 			<NavigationLink
 				direction="forward"
 				goToNextStep={ goToNextStep }
+				forwardUrl={ this.props.forwardUrl }
 				defaultDependencies={ defaultDependencies }
 				flowName={ flowName }
 				stepName={ stepName }

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -16,6 +16,9 @@ interface Props {
 	isReskinned: boolean;
 	signupDependencies: any;
 	stepName: string;
+	queryObject: {
+		siteSlug: string;
+	};
 }
 
 const EXCLUDE_STEPS: { [ key: string ]: string[] } = {
@@ -30,7 +33,7 @@ const EXTERNAL_FLOW: { [ key: string ]: string } = {
 export default function IntentStep( props: Props ): React.ReactNode {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const { goToNextStep, stepName } = props;
+	const { goToNextStep, stepName, queryObject } = props;
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
 	const branchSteps = useBranchSteps( stepName );
@@ -39,7 +42,7 @@ export default function IntentStep( props: Props ): React.ReactNode {
 		recordTracksEvent( 'calypso_signup_intent_select', { intent } );
 
 		if ( EXTERNAL_FLOW[ intent ] ) {
-			page( getStepUrl( EXTERNAL_FLOW[ intent ] ) );
+			page( getStepUrl( EXTERNAL_FLOW[ intent ] ) + '?siteSlug=' + queryObject.siteSlug );
 		} else {
 			branchSteps( EXCLUDE_STEPS[ intent ] );
 			dispatch( submitSignupStep( { stepName }, { intent } ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Provides a solution for keeping URL query params while the user switches between importer steps.

#### Testing instructions

* Go to /start/importer?siteSlug={YOUR_SITE}
* Switch between import pages
* Hit browser refresh button
* The capture page will be presented without console error

Related to #57131
