### PR TITLE
Playwright: add retry mechanism to CloseAccountFlow, take 2.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { reloadAndRetry } from '../../../element-helper';
 import type { LanguageSlug } from '@automattic/languages';
 
 const selectors = {
@@ -40,7 +41,18 @@ export class AccountSettingsPage {
 	 * Closes the currently logged in user's account.
 	 */
 	async closeAccount(): Promise< void > {
-		// Wait for the async navigation
+		/**
+		 * Closure to handle the scenario where purchase(s) have been cancelled on the frontend,
+		 * but the backend still thinks there are valid purchases.
+		 * This is typically observed for more 'involved' purchases such as domains.
+		 *
+		 * @param {Page} page Page object.
+		 */
+		async function waitForPurchasesRemoved( page: Page ): Promise< void > {
+			await page.waitForSelector( 'a:text("Manage purchases")', { state: 'hidden' } );
+		}
+
+		// Wait for the async navigation after clicking on the initial `Close Account` link at /me/account.
 		await Promise.all( [
 			this.page.waitForNavigation(),
 			this.page.click( selectors.closeAccountLink ),
@@ -51,13 +63,22 @@ export class AccountSettingsPage {
 		// The only thing that doesn't appear until all the loading is done is the sidebar of items to be deleted.
 		// So we must wait for that text before continuing, or our close account button click can get swallowed!
 		await this.page.waitForSelector( selectors.deletedItemsSidebar );
+
+		// Ensure the button is not `Manage Purchases` but rather `Close Account` a few times.
+		await reloadAndRetry( this.page, waitForPurchasesRemoved );
+
+		// `Close Account` button on /me/account/close.
 		await this.page.click( selectors.closeAccountButton );
 
+		// `Are you sure?` modal.
 		await this.page.click( selectors.modalContinueButton );
+
+		// Final attempt to save the situation in getting the user to type their account username.
 		const username = await this.page
 			.waitForSelector( selectors.usernameSpan )
 			.then( ( element ) => element.innerText() );
 		await this.page.fill( selectors.usernameConfirmationInput, username );
+		// Confirm closure.
 		await this.page.click( selectors.modalCloseAccountButton );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -49,7 +49,7 @@ export class AccountSettingsPage {
 		 * @param {Page} page Page object.
 		 */
 		async function waitForPurchasesRemoved( page: Page ): Promise< void > {
-			await page.waitForSelector( selectors.closeAccountLink );
+			await page.waitForSelector( selectors.closeAccountButton );
 		}
 
 		// Wait for the async navigation after clicking on the initial `Close Account` link at /me/account.

--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -49,7 +49,7 @@ export class AccountSettingsPage {
 		 * @param {Page} page Page object.
 		 */
 		async function waitForPurchasesRemoved( page: Page ): Promise< void > {
-			await page.waitForSelector( 'a:text("Manage purchases")', { state: 'hidden' } );
+			await page.waitForSelector( selectors.closeAccountLink );
 		}
 
 		// Wait for the async navigation after clicking on the initial `Close Account` link at /me/account.


### PR DESCRIPTION
(Copied from original PR https://github.com/Automattic/wp-calypso/pull/57920).

#### Changes proposed in this Pull Request

This PR adds the usage of retry mechanism to the `CloseAccountFlow` during the initial steps.

Key changes:
- new closure to wait on the button to stop reading "Manage purchases".
- insert the retry mechanism after clicking on the initial link in `/me/account`.

Details:
Some purchases such as domains take some additional time to process its cancellation in the backend, and this has likely been the cause of several failures in the past week. 

For instance, TeamCity ID 6956467 shows that domain cancellation proceed as normal, but when the user attempted to close their account by accessing `/me/account` they were met with screen insisting that they have active purchases remaining on their account and that it must be cancelled first.

#### Testing instructions

The flakiness occurs only intermittently, so the best approach is to monitor the behavior while the `wp-domains__add` spec runs in the quarantined job.

Related to https://github.com/Automattic/wp-calypso/pull/57879.
Closes #57845.
Closes https://github.com/Automattic/wp-calypso/issues/57513.