### PR TITLE
Make failure conditions match on TeamCity

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -680,6 +680,16 @@ object PreReleaseE2ETests : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
+		nonZeroExitCode = false
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
 	}
 })
 
@@ -777,6 +787,16 @@ object QuarantinedE2ETests: BuildType( {
 	}
 
 	failureConditions {
-		executionTimeoutMin = 10
+		executionTimeoutMin = 20
+		nonZeroExitCode = false
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
 	}
 })

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -789,14 +789,5 @@ object QuarantinedE2ETests: BuildType( {
 	failureConditions {
 		executionTimeoutMin = 20
 		nonZeroExitCode = false
-		failOnMetricChange {
-			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
-			threshold = 50
-			units = BuildFailureOnMetric.MetricUnit.PERCENTS
-			comparison = BuildFailureOnMetric.MetricComparison.LESS
-			compareTo = build {
-				buildRule = lastSuccessful()
-			}
-		}
 	}
 })


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes the failure conditions for the Quarantined and Pre-Release builds more closely match other Playwright build types.

Namely, this allows non-zero exit code (for muted test failures), and puts test count metric checks into Pre-Release

#### Testing instructions

- [ ] Builds should still run correctly.

Related to #
