### PR TITLE
e2e: I18n editor tests use locale translations instead of hardcoded French translations

### DIFF
--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -262,7 +262,7 @@ describeSkipNoTranslations(
 			gutenbergEditorPage = new GutenbergEditorPage( page );
 		} );
 
-		describeSkipNoTranslations.each( translations.fr.blocks || [] )(
+		describeSkipNoTranslations.each( localeTranslations.blocks )(
 			'Translations for block: $blockName',
 			( block ) => {
 				let frame: Frame;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix using hardcoded French block translations oversight instead of block translations for the provided `LOCALE` variable.

#### Testing instructions

* `cd test/e2e && LOCALE=he yarn jest test/e2e/specs/specs-i18n/wp-i18n__editor.ts`

Related to https://github.com/Automattic/wp-calypso/pull/57934#issuecomment-966545083
