### PR TITLE
Customize site list styling

### DIFF
--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -66,6 +66,7 @@ class PluginAction extends Component {
 				disabled={ this.props.inProgress || this.props.disabled || !! this.props.disabledInfo }
 				id={ this.props.htmlFor }
 				label={ this.renderLabel() }
+				aria-label={ this.props.label }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -27,7 +27,7 @@ class PluginAction extends Component {
 			/* eslint-disable jsx-a11y/click-events-have-key-events */
 			/* eslint-disable jsx-a11y/no-static-element-interactions */
 			<span
-				className="plugin-action__label"
+				className={ classNames( 'plugin-action__label', { hide: this.props.hideLabel } ) }
 				ref={ this.disabledInfoLabelRef }
 				onClick={ this.handleAction }
 			>

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -24,6 +24,8 @@ class PluginAction extends Component {
 		}
 
 		return (
+			/* eslint-disable jsx-a11y/click-events-have-key-events */
+			/* eslint-disable jsx-a11y/no-static-element-interactions */
 			<span
 				className="plugin-action__label"
 				ref={ this.disabledInfoLabelRef }
@@ -32,6 +34,8 @@ class PluginAction extends Component {
 				{ this.props.label }
 				{ this.renderDisabledInfo() }
 			</span>
+			/* eslint-enable jsx-a11y/click-events-have-key-events */
+			/* eslint-enable jsx-a11y/no-static-element-interactions */
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -45,7 +45,7 @@
 	display: flex;
 	flex-direction: row-reverse;
 	align-items: center;
-	font-size: $font-body-extra-small;
+	font-size: $font-body-small;
 	line-height: 16px;
 	margin-right: 8px;
 	cursor: pointer;

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -48,7 +48,10 @@
 	line-height: 16px;
 	margin-right: 8px;
 	cursor: pointer;
-	display: none;
+
+	&.hide {
+		display: none;
+	}
 
 	.is-disabled & {
 		color: var( --color-neutral-20 );
@@ -58,10 +61,6 @@
 	.has-disabled-info & {
 		cursor: default;
 		flex-direction: row;
-	}
-
-	@media screen and ( max-width: 1040px ) {
-		display: block;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -49,6 +49,7 @@
 	line-height: 16px;
 	margin-right: 8px;
 	cursor: pointer;
+	display: none;
 
 	.is-disabled & {
 		color: var( --color-neutral-20 );
@@ -78,4 +79,16 @@
 
 .plugin-action__disabled-info-list {
 	margin-left: 16px;
+}
+
+.plugin-activate-toggle, .plugin-autoupdate-toggle {
+	.components-toggle-control {
+		.components-base-control__field {
+			display: flex;
+
+			.components-form-toggle {
+				margin-right: 8px;
+			}
+		}
+	}
 }

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -42,7 +42,6 @@
 }
 
 .plugin-action__label {
-	display: flex;
 	flex-direction: row-reverse;
 	align-items: center;
 	font-size: $font-body-small;
@@ -61,7 +60,7 @@
 		flex-direction: row;
 	}
 
-	@media screen and ( max-width: 782px ) {
+	@media screen and ( max-width: 1040px ) {
 		display: block;
 	}
 }

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -60,6 +60,10 @@
 		cursor: default;
 		flex-direction: row;
 	}
+
+	@media screen and ( max-width: 782px ) {
+		display: block;
+	}
 }
 
 .plugin-action__disabled-info.info-popover {

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -91,7 +91,7 @@ export class PluginActivateToggle extends Component {
 	}
 
 	render() {
-		const { inProgress, site, plugin, disabled, translate } = this.props;
+		const { inProgress, site, plugin, disabled } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -111,7 +111,6 @@ export class PluginActivateToggle extends Component {
 			<PluginAction
 				disabled={ disabled }
 				className="plugin-activate-toggle"
-				label={ translate( 'Active', { context: 'plugin status' } ) }
 				inProgress={ inProgress }
 				status={ plugin && plugin.active }
 				action={ this.toggleActivation }

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -91,7 +91,7 @@ export class PluginActivateToggle extends Component {
 	}
 
 	render() {
-		const { inProgress, site, plugin, disabled } = this.props;
+		const { inProgress, site, plugin, disabled, translate } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -111,6 +111,7 @@ export class PluginActivateToggle extends Component {
 			<PluginAction
 				disabled={ disabled }
 				className="plugin-activate-toggle"
+				label={ translate( 'Active', { context: 'plugin status' } ) }
 				inProgress={ inProgress }
 				status={ plugin && plugin.active }
 				action={ this.toggleActivation }

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -91,7 +91,7 @@ export class PluginActivateToggle extends Component {
 	}
 
 	render() {
-		const { inProgress, site, plugin, disabled, translate } = this.props;
+		const { inProgress, site, plugin, disabled, translate, hideLabel } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -116,7 +116,7 @@ export class PluginActivateToggle extends Component {
 				status={ plugin && plugin.active }
 				action={ this.toggleActivation }
 				htmlFor={ 'activate-' + plugin.slug + '-' + site.ID }
-				{ ...this.props }
+				hideLabel={ hideLabel }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -116,6 +116,7 @@ export class PluginActivateToggle extends Component {
 				status={ plugin && plugin.active }
 				action={ this.toggleActivation }
 				htmlFor={ 'activate-' + plugin.slug + '-' + site.ID }
+				{ ...this.props }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -133,16 +133,22 @@ export class PluginAutoUpdateToggle extends Component {
 	}
 
 	render() {
-		const { inProgress, site, plugin, disabled } = this.props;
+		const { inProgress, site, plugin, disabled, translate } = this.props;
 		if ( ! site.jetpack ) {
 			return null;
 		}
 
 		const getDisabledInfo = this.getDisabledInfo();
+		const label = translate( 'Autoupdates', {
+			comment:
+				'this goes next to an icon that displays if the plugin has "autoupdates", both enabled and disabled',
+		} );
 
 		return (
 			<PluginAction
 				disabled={ disabled }
+				label={ label }
+				className="plugin-autoupdate-toggle"
 				status={ plugin.autoupdate }
 				action={ this.toggleAutoUpdates }
 				inProgress={ inProgress }

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -154,6 +154,7 @@ export class PluginAutoUpdateToggle extends Component {
 				inProgress={ inProgress }
 				disabledInfo={ getDisabledInfo }
 				htmlFor={ 'autoupdates-' + plugin.slug + '-' + site.ID }
+				{ ...this.props }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -133,7 +133,7 @@ export class PluginAutoUpdateToggle extends Component {
 	}
 
 	render() {
-		const { inProgress, site, plugin, disabled, translate } = this.props;
+		const { inProgress, site, plugin, disabled, translate, hideLabel } = this.props;
 		if ( ! site.jetpack ) {
 			return null;
 		}
@@ -154,7 +154,7 @@ export class PluginAutoUpdateToggle extends Component {
 				inProgress={ inProgress }
 				disabledInfo={ getDisabledInfo }
 				htmlFor={ 'autoupdates-' + plugin.slug + '-' + site.ID }
-				{ ...this.props }
+				hideLabel={ hideLabel }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -133,21 +133,16 @@ export class PluginAutoUpdateToggle extends Component {
 	}
 
 	render() {
-		const { inProgress, site, plugin, translate, disabled } = this.props;
+		const { inProgress, site, plugin, disabled } = this.props;
 		if ( ! site.jetpack ) {
 			return null;
 		}
 
 		const getDisabledInfo = this.getDisabledInfo();
-		const label = translate( 'Autoupdates', {
-			comment:
-				'this goes next to an icon that displays if the plugin has "autoupdates", both enabled and disabled',
-		} );
 
 		return (
 			<PluginAction
 				disabled={ disabled }
-				label={ label }
 				status={ plugin.autoupdate }
 				action={ this.toggleAutoUpdates }
 				inProgress={ inProgress }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -475,9 +475,10 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 					count: sitesWithPlugin.length,
 					comment: 'header for list of sites a plugin is installed on',
 				} ) }
-				titlePrimary
 				sites={ sitesWithPlugin }
 				plugin={ plugin }
+				titlePrimary
+				showAdditionalHeaders
 			/>
 			{ plugin.wporg && (
 				<PluginSiteList

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -470,17 +470,22 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 		<div className="plugin-details__sites-list">
 			<PluginSiteList
 				className="plugin-details__installed-on"
-				title={ translate( 'Installed on', {
+				title={ translate( 'Installed on %d site', 'Installed on %d sites', {
+					args: [ sitesWithPlugin.length ],
+					count: sitesWithPlugin.length,
 					comment: 'header for list of sites a plugin is installed on',
 				} ) }
+				titlePrimary
 				sites={ sitesWithPlugin }
 				plugin={ plugin }
 			/>
 			{ plugin.wporg && (
 				<PluginSiteList
 					className="plugin-details__not-installed-on"
-					title={ translate( 'Available sites', {
+					title={ translate( 'Available on %d site', 'Available on %d sites', {
 						comment: 'header for list of sites a plugin can be installed on',
+						args: [ notInstalledSites.length ],
+						count: notInstalledSites.length,
 					} ) }
 					sites={ notInstalledSites }
 					plugin={ plugin }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -473,7 +473,11 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 			<div className="plugin-details__sites-list">
 				<PluginSiteList
 					className="plugin-details__installed-on"
-					title={ getInstalledOnTitle( { translate, selectedSite, count: sitesWithPlugin.length } ) }
+					title={ getInstalledOnTitle( {
+						translate,
+						selectedSite,
+						count: sitesWithPlugin.length,
+					} ) }
 					sites={ sitesWithPlugin }
 					plugin={ plugin }
 					titlePrimary
@@ -482,7 +486,11 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 				{ plugin.wporg && (
 					<PluginSiteList
 						className="plugin-details__not-installed-on"
-						title={ getAvailabeOnTitle( { translate, selectedSite, count: notInstalledSites.length } ) }
+						title={ getAvailabeOnTitle( {
+							translate,
+							selectedSite,
+							count: notInstalledSites.length,
+						} ) }
 						sites={ notInstalledSites }
 						plugin={ plugin }
 					/>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -467,31 +467,33 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 	);
 
 	return (
-		<div className="plugin-details__sites-list">
-			<PluginSiteList
-				className="plugin-details__installed-on"
-				title={ translate( 'Installed on %d site', 'Installed on %d sites', {
-					args: [ sitesWithPlugin.length ],
-					count: sitesWithPlugin.length,
-					comment: 'header for list of sites a plugin is installed on',
-				} ) }
-				sites={ sitesWithPlugin }
-				plugin={ plugin }
-				titlePrimary
-				showAdditionalHeaders
-			/>
-			{ plugin.wporg && (
+		<div className="plugin-details__sites-list-background">
+			<div className="plugin-details__sites-list">
 				<PluginSiteList
-					className="plugin-details__not-installed-on"
-					title={ translate( 'Available on %d site', 'Available on %d sites', {
-						comment: 'header for list of sites a plugin can be installed on',
-						args: [ notInstalledSites.length ],
-						count: notInstalledSites.length,
+					className="plugin-details__installed-on"
+					title={ translate( 'Installed on %d site', 'Installed on %d sites', {
+						args: [ sitesWithPlugin.length ],
+						count: sitesWithPlugin.length,
+						comment: 'header for list of sites a plugin is installed on',
 					} ) }
-					sites={ notInstalledSites }
+					sites={ sitesWithPlugin }
 					plugin={ plugin }
+					titlePrimary
+					showAdditionalHeaders
 				/>
-			) }
+				{ plugin.wporg && (
+					<PluginSiteList
+						className="plugin-details__not-installed-on"
+						title={ translate( 'Available on %d site', 'Available on %d sites', {
+							comment: 'header for list of sites a plugin can be installed on',
+							args: [ notInstalledSites.length ],
+							count: notInstalledSites.length,
+						} ) }
+						sites={ notInstalledSites }
+						plugin={ plugin }
+					/>
+				) }
+			</div>
 		</div>
 	);
 }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -447,6 +447,8 @@ function onClickInstallPlugin( { dispatch, selectedSite, slug, upgradeAndInstall
 function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) {
 	const translate = useTranslate();
 
+	const selectedSite = useSelector( getSelectedSite );
+
 	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sitesWithPlugins ) ) ];
 
@@ -471,11 +473,7 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 			<div className="plugin-details__sites-list">
 				<PluginSiteList
 					className="plugin-details__installed-on"
-					title={ translate( 'Installed on %d site', 'Installed on %d sites', {
-						args: [ sitesWithPlugin.length ],
-						count: sitesWithPlugin.length,
-						comment: 'header for list of sites a plugin is installed on',
-					} ) }
+					title={ getInstalledOnTitle( { translate, selectedSite, count: sitesWithPlugin.length } ) }
 					sites={ sitesWithPlugin }
 					plugin={ plugin }
 					titlePrimary
@@ -484,11 +482,7 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 				{ plugin.wporg && (
 					<PluginSiteList
 						className="plugin-details__not-installed-on"
-						title={ translate( 'Available on %d site', 'Available on %d sites', {
-							comment: 'header for list of sites a plugin can be installed on',
-							args: [ notInstalledSites.length ],
-							count: notInstalledSites.length,
-						} ) }
+						title={ getAvailabeOnTitle( { translate, selectedSite, count: notInstalledSites.length } ) }
 						sites={ notInstalledSites }
 						plugin={ plugin }
 					/>
@@ -496,6 +490,34 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 			</div>
 		</div>
 	);
+}
+
+function getInstalledOnTitle( { translate, selectedSite, count } ) {
+	const installedOnSingleSiteTitle = translate( 'Installed on', {
+		comment: 'header for list of sites a plugin is installed on',
+	} );
+
+	const installedOnMultiSiteTitle = translate( 'Installed on %d site', 'Installed on %d sites', {
+		comment: 'header for list of sites a plugin is installed on',
+		args: [ count ],
+		count,
+	} );
+
+	return selectedSite ? installedOnSingleSiteTitle : installedOnMultiSiteTitle;
+}
+
+function getAvailabeOnTitle( { translate, selectedSite, count } ) {
+	const availableOnSingleSiteTitle = translate( 'Available sites', {
+		comment: 'header for list of sites a plugin can be installed on',
+	} );
+
+	const availabeOnMultiSiteTitle = translate( 'Available on %d site', 'Available on %d sites', {
+		comment: 'header for list of sites a plugin can be installed on',
+		args: [ count ],
+		count,
+	} );
+
+	return selectedSite ? availableOnSingleSiteTitle : availabeOnMultiSiteTitle;
 }
 
 function PluginDoesNotExistView() {

--- a/client/my-sites/plugins/plugin-install-button/style.scss
+++ b/client/my-sites/plugins/plugin-install-button/style.scss
@@ -54,5 +54,6 @@
 .plugin-site-jetpack__container {
 	.plugin-install-button__install.embed {
 		margin: 0;
+		position: relative;
 	}
 }

--- a/client/my-sites/plugins/plugin-install-button/style.scss
+++ b/client/my-sites/plugins/plugin-install-button/style.scss
@@ -50,3 +50,9 @@
 	text-transform: uppercase;
 	white-space: nowrap;
 }
+
+.plugin-site-jetpack__container {
+	.plugin-install-button__install.embed {
+		margin: 0;
+	}
+}

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 
-import { Gridicon } from '@automattic/components';
+import { Icon, trash } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -165,9 +165,11 @@ class PluginRemoveButton extends Component {
 			  } );
 		if ( this.props.inProgress ) {
 			return (
-				<span className="plugin-action plugin-remove-button__remove">
-					{ this.props.translate( 'Removing…' ) }
-				</span>
+				<div className="plugin-action">
+					<span className="plugin-remove-button__remove">
+						{ this.props.translate( 'Removing…' ) }
+					</span>
+				</div>
 			);
 		}
 
@@ -183,7 +185,7 @@ class PluginRemoveButton extends Component {
 				className="plugin-remove-button__remove-link"
 			>
 				<a onClick={ handleClick } className="plugin-remove-button__remove-icon">
-					<Gridicon icon="trash" size={ 18 } />
+					<Icon icon={ trash } />
 				</a>
 			</PluginAction>
 		);

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import accept from 'calypso/lib/accept';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -175,6 +176,14 @@ class PluginRemoveButton extends Component {
 		}
 
 		const handleClick = disabled ? null : this.removeAction;
+
+		if ( this.props.menuItem ) {
+			return (
+				<PopoverMenuItem onClick={ handleClick } className="plugin-remove-button__remove-icon">
+					{ label }
+				</PopoverMenuItem>
+			);
+		}
 
 		return (
 			<PluginAction

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 
+import { Button } from '@wordpress/components';
 import { Icon, trash } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
@@ -177,16 +178,16 @@ class PluginRemoveButton extends Component {
 
 		return (
 			<PluginAction
-				label={ label }
 				htmlFor={ 'remove-plugin-' + this.props.site.ID }
 				action={ this.removeAction }
 				disabled={ disabled }
 				disabledInfo={ disabledInfo }
 				className="plugin-remove-button__remove-link"
 			>
-				<a onClick={ handleClick } className="plugin-remove-button__remove-icon">
+				<Button onClick={ handleClick } className="plugin-remove-button__remove-icon">
 					<Icon icon={ trash } />
-				</a>
+					{ label }
+				</Button>
 			</PluginAction>
 		);
 	};

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -21,18 +21,8 @@
 }
 
 .plugin-remove-button__remove-icon {
-	display: block;
-    margin-right: 8px;
-    cursor: pointer;
-
-	.gridicons-trash {
-		display: block;
-		color: var( --color-neutral-light );
-		cursor: pointer;
-		&:hover {
-			color: var( --color-error );
-		}
-	}
+	color: var( --studio-gray-80 );
+	font-size: $font-body-small;
 }
 
 .plugin-remove-button__remove-link.is-disabled .plugin-remove-button__remove-icon .gridicons-trash {

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -13,7 +13,6 @@
 
 .plugin-remove-button__remove-link .plugin-action__children {
 	display: inline-flex;
-	flex-direction: row-reverse;
 }
 
 .plugin-site__actions .plugin-remove-button__remove {
@@ -23,7 +22,8 @@
 
 .plugin-remove-button__remove-icon {
 	display: block;
-	margin: -2px 3px 0;
+    margin-right: 8px;
+    cursor: pointer;
 
 	.gridicons-trash {
 		display: block;

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -1,5 +1,7 @@
+import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -23,6 +25,22 @@ const PluginSiteJetpack = ( props ) => {
 	const pluginOnSite = useSelector( ( state ) =>
 		getPluginOnSite( state, props.site.ID, props.plugin.slug )
 	);
+	const [ isMobileLayout, setIsMobileLayout ] = useState();
+
+	useEffect( () => {
+		if ( isWithinBreakpoint( '<1040px' ) ) {
+			setIsMobileLayout( true );
+		}
+		const unsubscribe = subscribeIsWithinBreakpoint( '<1040px', ( isMobile ) =>
+			setIsMobileLayout( isMobile )
+		);
+
+		return () => {
+			if ( typeof unsubscribe === 'function' ) {
+				unsubscribe();
+			}
+		};
+	}, [] );
 
 	if ( ! props.site || ! props.plugin ) {
 		return null;
@@ -66,10 +84,17 @@ const PluginSiteJetpack = ( props ) => {
 				<PluginAutoupdateToggle site={ props.site } plugin={ pluginOnSite } wporg={ true } />
 			) }
 			<div className="plugin-site-jetpack__action plugin-action last-actions">
-				{ canToggleRemove && <PluginRemoveButton plugin={ pluginOnSite } site={ props.site } /> }
-				{ settingsLink && (
+				{ ! isMobileLayout && canToggleRemove && (
+					<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } />
+				) }
+				{ ( isMobileLayout || settingsLink ) && (
 					<EllipsisMenu position={ 'bottom' }>
-						<PopoverMenuItem href={ settingsLink }>{ translate( 'Settings' ) }</PopoverMenuItem>
+						{ settingsLink && (
+							<PopoverMenuItem href={ settingsLink }>{ translate( 'Settings' ) }</PopoverMenuItem>
+						) }
+						{ isMobileLayout && (
+							<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } menuItem />
+						) }
 					</EllipsisMenu>
 				) }
 				{ showAutoManagedMessage && (

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -70,8 +70,7 @@ const PluginSiteJetpack = ( props ) => {
 		remove: canToggleRemove = true,
 	} = props?.allowedActions;
 
-	const showAutoManagedMessage = props.isAutoManaged || false;
-
+	const { isAutoManaged = false } = props;
 	const settingsLink = pluginOnSite?.action_links?.Settings ?? null;
 
 	return (
@@ -83,26 +82,27 @@ const PluginSiteJetpack = ( props ) => {
 			{ canToggleAutoupdate && (
 				<PluginAutoupdateToggle site={ props.site } plugin={ pluginOnSite } wporg={ true } />
 			) }
-			<div className="plugin-site-jetpack__action plugin-action last-actions">
-				{ ! isMobileLayout && canToggleRemove && (
-					<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } />
-				) }
-				{ ( isMobileLayout || settingsLink ) && (
-					<EllipsisMenu position={ 'bottom' }>
-						{ settingsLink && (
-							<PopoverMenuItem href={ settingsLink }>{ translate( 'Settings' ) }</PopoverMenuItem>
-						) }
-						{ isMobileLayout && (
-							<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } menuItem />
-						) }
-					</EllipsisMenu>
-				) }
-				{ showAutoManagedMessage && (
-					<div className="plugin-site-jetpack__automanage-notice">
-						{ translate( 'Auto-managed on this site' ) }
-					</div>
-				) }
-			</div>
+			{ isAutoManaged ? (
+				<div className="plugin-site-jetpack__automanage-notice">
+					{ translate( 'Auto-managed on this site' ) }
+				</div>
+			) : (
+				<div className="plugin-site-jetpack__action plugin-action last-actions">
+					{ ! isMobileLayout && canToggleRemove && (
+						<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } />
+					) }
+					{ ( isMobileLayout || settingsLink ) && (
+						<EllipsisMenu position={ 'bottom' }>
+							{ settingsLink && (
+								<PopoverMenuItem href={ settingsLink }>{ translate( 'Settings' ) }</PopoverMenuItem>
+							) }
+							{ isMobileLayout && (
+								<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } menuItem />
+							) }
+						</EllipsisMenu>
+					) }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -3,14 +3,11 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import Site from 'calypso/blocks/site';
-import FoldableCard from 'calypso/components/foldable-card';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
-import PluginUpdateIndicator from 'calypso/my-sites/plugins/plugin-site-update-indicator';
 import {
 	getPluginOnSite,
 	isPluginActionInProgress,
@@ -52,12 +49,10 @@ class PluginSiteJetpack extends Component {
 
 	renderInstallPlugin = () => {
 		return (
-			<FoldableCard
-				compact
-				className="plugin-site-jetpack"
-				header={ <Site site={ this.props.site } indicator={ false } /> }
-				actionButton={ this.renderInstallButton() }
-			/>
+			<div className="plugin-site-jetpack__container">
+				<div className="plugin-site-jetpack__domain">{ this.props.site.domain }</div>
+				<div>{ this.renderInstallButton() }</div>
+			</div>
 		);
 	};
 
@@ -73,37 +68,19 @@ class PluginSiteJetpack extends Component {
 		const settingsLink = this.props?.pluginOnSite?.action_links?.Settings ?? null;
 
 		return (
-			<FoldableCard
-				compact
-				clickableHeader
-				className="plugin-site-jetpack"
-				header={ <Site site={ this.props.site } indicator={ false } /> }
-				summary={
-					<PluginUpdateIndicator
+			<div className="plugin-site-jetpack__container">
+				<div className="plugin-site-jetpack__domain">{ this.props.site.domain }</div>
+				{ canToggleActivation && (
+					<PluginActivateToggle site={ this.props.site } plugin={ this.props.pluginOnSite } />
+				) }
+				{ canToggleAutoupdate && (
+					<PluginAutoupdateToggle
 						site={ this.props.site }
-						plugin={ this.props.plugin }
-						expanded={ false }
+						plugin={ this.props.pluginOnSite }
+						wporg={ true }
 					/>
-				}
-				expandedSummary={
-					<PluginUpdateIndicator
-						site={ this.props.site }
-						plugin={ this.props.plugin }
-						expanded={ true }
-					/>
-				}
-			>
-				<div>
-					{ canToggleActivation && (
-						<PluginActivateToggle site={ this.props.site } plugin={ this.props.pluginOnSite } />
-					) }
-					{ canToggleAutoupdate && (
-						<PluginAutoupdateToggle
-							site={ this.props.site }
-							plugin={ this.props.pluginOnSite }
-							wporg={ true }
-						/>
-					) }
+				) }
+				<div className="plugin-site-jetpack__action plugin-action last-actions">
 					{ canToggleRemove && (
 						<PluginRemoveButton plugin={ this.props.pluginOnSite } site={ this.props.site } />
 					) }
@@ -118,7 +95,7 @@ class PluginSiteJetpack extends Component {
 						</div>
 					) }
 				</div>
-			</FoldableCard>
+			</div>
 		);
 	};
 

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -1,8 +1,9 @@
-import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
@@ -85,9 +86,11 @@ class PluginSiteJetpack extends Component {
 						<PluginRemoveButton plugin={ this.props.pluginOnSite } site={ this.props.site } />
 					) }
 					{ settingsLink && (
-						<Button compact href={ settingsLink }>
-							{ this.props.translate( `Settings` ) }
-						</Button>
+						<EllipsisMenu position={ 'bottom' }>
+							<PopoverMenuItem href={ settingsLink }>
+								{ this.props.translate( 'Settings' ) }
+							</PopoverMenuItem>
+						</EllipsisMenu>
 					) }
 					{ showAutoManagedMessage && (
 						<div className="plugin-site-jetpack__automanage-notice">

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -50,7 +50,7 @@ const PluginSiteJetpack = ( props ) => {
 		return (
 			<div className="plugin-site-jetpack__container">
 				<div className="plugin-site-jetpack__domain">{ props.site.domain }</div>
-				<div>
+				<div className="plugin-site-jetpack__install-button">
 					{
 						<PluginInstallButton
 							isEmbed={ true }

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -10,6 +10,7 @@ import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggl
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
+import PluginUpdateIndicator from 'calypso/my-sites/plugins/plugin-site-update-indicator';
 import {
 	getPluginOnSite,
 	isPluginActionInProgress,
@@ -97,8 +98,13 @@ const PluginSiteJetpack = ( props ) => {
 				</div>
 			) : (
 				<div className="plugin-site-jetpack__action plugin-action last-actions">
-					{ ! isMobileLayout && canToggleRemove && (
-						<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } />
+					{ ! isMobileLayout && (
+						<>
+							<PluginUpdateIndicator site={ props.site } plugin={ props.plugin } expanded />
+							{ canToggleRemove && (
+								<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } />
+							) }
+						</>
 					) }
 					{ ( isMobileLayout || settingsLink ) && (
 						<EllipsisMenu position={ 'bottom' }>
@@ -106,7 +112,15 @@ const PluginSiteJetpack = ( props ) => {
 								<PopoverMenuItem href={ settingsLink }>{ translate( 'Settings' ) }</PopoverMenuItem>
 							) }
 							{ isMobileLayout && (
-								<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } menuItem />
+								<>
+									<PluginUpdateIndicator
+										site={ props.site }
+										plugin={ props.plugin }
+										expanded
+										menuItem
+									/>
+									<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } menuItem />
+								</>
 							) }
 						</EllipsisMenu>
 					) }

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -77,10 +77,19 @@ const PluginSiteJetpack = ( props ) => {
 		<div className="plugin-site-jetpack__container">
 			<div className="plugin-site-jetpack__domain">{ props.site.domain }</div>
 			{ canToggleActivation && (
-				<PluginActivateToggle site={ props.site } plugin={ pluginOnSite } />
+				<PluginActivateToggle
+					site={ props.site }
+					plugin={ pluginOnSite }
+					hideLabel={ ! isMobileLayout }
+				/>
 			) }
 			{ canToggleAutoupdate && (
-				<PluginAutoupdateToggle site={ props.site } plugin={ pluginOnSite } wporg={ true } />
+				<PluginAutoupdateToggle
+					site={ props.site }
+					plugin={ pluginOnSite }
+					wporg={ true }
+					hideLabel={ ! isMobileLayout }
+				/>
 			) }
 			{ isAutoManaged ? (
 				<div className="plugin-site-jetpack__automanage-notice">

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -34,6 +34,7 @@
 
 .plugin-site-jetpack__container {
 	display: flex;
+	align-items: center;
 	background: var( --studio-white );
 	border: 1px solid var( --studio-gray-5 );
 	border-top: 0;

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -51,5 +51,9 @@
 	.last-actions {
 		display: flex;
 		justify-content: space-between;
+
+		button.ellipsis-menu__toggle {
+			padding: 0;
+		}
 	}
 }

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -36,6 +36,7 @@
 	display: flex;
 	background: var( --studio-white );
 	border: 1px solid var( --studio-gray-5 );
+	border-top: 0;
 	padding: 16px 24px;
 	
 	.plugin-site-jetpack__domain {

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -42,12 +42,16 @@
 	
 	.plugin-site-jetpack__domain {
 		flex: 8 8 0;
-		overflow-wrap: anywhere;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+		font-weight: 500;
 	}
 
  	.plugin-action {
 		flex: 4 4 0;
 		margin-top: 0;
+		color: var( --studio-gray-50 );
 	}
 
 	.last-actions {
@@ -56,6 +60,33 @@
 
 		button.ellipsis-menu__toggle {
 			padding: 0;
+		}
+	}
+
+	@media screen and ( max-width: 782px ) {
+		flex-wrap: wrap;
+		border-top: 1px solid var( --studio-gray-5 );
+
+		.plugin-site-jetpack__domain {
+			order: 1;
+			flex: 90%;
+			padding: 7px 0;
+		}
+	
+		 .plugin-action {
+			order: 3;
+			flex: 50%;
+			padding: 7px 0;
+		}
+	
+		.last-actions {
+			order: 2;
+			flex: 10%;
+			justify-content: flex-end;
+
+			.plugin-remove-button__remove-link {
+				display: none;
+			}
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -31,3 +31,25 @@
 	line-height: 1;
 	padding: 6px 0;
 }
+
+.plugin-site-jetpack__container {
+	display: flex;
+	background: var( --studio-white );
+	border: 1px solid var( --studio-gray-5 );
+	padding: 16px 24px;
+	
+	.plugin-site-jetpack__domain {
+		flex: 8 8 0;
+		overflow-wrap: anywhere;
+	}
+
+ 	.plugin-action {
+		flex: 4 4 0;
+		margin-top: 0;
+	}
+
+	.last-actions {
+		display: flex;
+		justify-content: space-between;
+	}
+}

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -63,6 +63,10 @@
 		}
 	}
 
+	.plugin-site-jetpack__install-button {
+		order: 2;
+	}
+
 	@media screen and ( max-width: 1040px ) {
 		flex-wrap: wrap;
 		border-top: 1px solid var( --studio-gray-5 );

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -45,7 +45,7 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
-		font-weight: 500;
+		font-weight: 500; /* stylelint-disable-line */
 	}
 
  	.plugin-action {
@@ -82,6 +82,7 @@
 		.last-actions {
 			order: 2;
 			flex: 10%;
+			min-width: 5%;
 			justify-content: flex-end;
 
 			.plugin-remove-button__remove-link {

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -65,6 +65,10 @@
 
 	.plugin-site-jetpack__install-button {
 		order: 2;
+
+		@media screen and ( max-width: 1040px ) {
+			padding: 10px 0;
+		}
 	}
 
 	@media screen and ( max-width: 1040px ) {

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -39,7 +39,7 @@
 	border: 1px solid var( --studio-gray-5 );
 	border-top: 0;
 	padding: 16px 24px;
-	
+
 	.plugin-site-jetpack__domain {
 		flex: 8 8 0;
 		text-overflow: ellipsis;
@@ -48,7 +48,7 @@
 		font-weight: 500; /* stylelint-disable-line */
 	}
 
- 	.plugin-action {
+	.plugin-action {
 		flex: 4 4 0;
 		margin-top: 0;
 		color: var( --studio-gray-50 );
@@ -63,22 +63,23 @@
 		}
 	}
 
-	@media screen and ( max-width: 782px ) {
+	@media screen and ( max-width: 1040px ) {
 		flex-wrap: wrap;
 		border-top: 1px solid var( --studio-gray-5 );
+		padding: 0 12px;
 
 		.plugin-site-jetpack__domain {
 			order: 1;
 			flex: 90%;
 			padding: 7px 0;
 		}
-	
-		 .plugin-action {
+
+		.plugin-action {
 			order: 3;
 			flex: 50%;
 			padding: 7px 0;
 		}
-	
+
 		.last-actions {
 			order: 2;
 			flex: 10%;

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -50,6 +50,8 @@
 	.last-actions {
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
+		flex-wrap: wrap;
 
 		button.ellipsis-menu__toggle {
 			padding: 0;

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -25,13 +25,6 @@
 	}
 }
 
-.plugin-site-jetpack__automanage-notice {
-	color: var( --color-neutral-light );
-	font-size: $font-body-extra-small;
-	line-height: 1;
-	padding: 6px 0;
-}
-
 .plugin-site-jetpack__container {
 	display: flex;
 	align-items: center;
@@ -61,6 +54,14 @@
 		button.ellipsis-menu__toggle {
 			padding: 0;
 		}
+	}
+
+	.plugin-site-jetpack__automanage-notice {
+		flex: 4 4 0;
+		color: var( --color-neutral-light );
+		font-size: $font-body-extra-small;
+		line-height: 1;
+		text-align: center;
 	}
 
 	.plugin-site-jetpack__install-button {
@@ -97,6 +98,13 @@
 			.plugin-remove-button__remove-link {
 				display: none;
 			}
+		}
+
+		.plugin-site-jetpack__automanage-notice {
+			order: 2;
+			flex: 90%;
+			text-align: left;
+			padding-bottom: 10px;
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -34,7 +34,7 @@
 	padding: 16px 24px;
 
 	.plugin-site-jetpack__domain {
-		flex: 8 8 0;
+		flex: 2 2 0;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
@@ -42,7 +42,7 @@
 	}
 
 	.plugin-action {
-		flex: 4 4 0;
+		flex: 1 1 0;
 		margin-top: 0;
 		color: var( --studio-gray-50 );
 	}
@@ -57,7 +57,7 @@
 	}
 
 	.plugin-site-jetpack__automanage-notice {
-		flex: 4 4 0;
+		flex: 1 1 0;
 		color: var( --color-neutral-light );
 		font-size: $font-body-extra-small;
 		line-height: 1;

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -1,5 +1,7 @@
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { compact } from 'lodash';
+import PropTypes from 'prop-types';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import PluginSite from 'calypso/my-sites/plugins/plugin-site/plugin-site';
@@ -13,7 +15,8 @@ import isConnectedSecondaryNetworkSite from 'calypso/state/selectors/is-connecte
 
 import './style.scss';
 
-export function PluginSiteList( props ) {
+const PluginSiteList = ( props ) => {
+	const translate = useTranslate();
 	const siteIds = siteObjectsToSiteIds( props.sites );
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, props.plugin.slug )
@@ -42,24 +45,43 @@ export function PluginSiteList( props ) {
 	if ( ! props.sites || props.sites.length === 0 ) {
 		return null;
 	}
-
 	return (
 		<div className={ classNames( 'plugin-site-list', props.className ) }>
 			<div className={ classNames( 'plugin-site-list__title', { primary: props.titlePrimary } ) }>
 				{ props.title }
 			</div>
-			{ sitesWithSecondarySites.map( ( { site, secondarySites } ) => (
-				<PluginSite
-					key={ 'pluginSite' + site.ID }
-					site={ site }
-					secondarySites={ getSecondaryPluginSites( site, secondarySites ) }
-					plugin={ props.plugin }
-					wporg={ props.wporg }
-				/>
-			) ) }
+			<div className="plugin-site-list__content">
+				<div className="plugin-site-list__header">
+					<div className="plugin-site-list__header-title domain">{ translate( 'Domain' ) }</div>
+					{ props.showAdditionalHeaders && (
+						<>
+							<div className="plugin-site-list__header-title">{ translate( 'Active' ) }</div>
+							<div className="plugin-site-list__header-title">{ translate( 'Autoupdates' ) }</div>
+							<div className="plugin-site-list__header-title empty" />
+						</>
+					) }
+				</div>
+
+				{ sitesWithSecondarySites.map( ( { site, secondarySites } ) => (
+					<PluginSite
+						key={ 'pluginSite' + site.ID }
+						site={ site }
+						secondarySites={ getSecondaryPluginSites( site, secondarySites ) }
+						plugin={ props.plugin }
+						wporg={ props.wporg }
+					/>
+				) ) }
+			</div>
 		</div>
 	);
-}
+};
+
+PluginSiteList.propTypes = {
+	plugin: PropTypes.object,
+	sites: PropTypes.array,
+	sitesWithSecondarySites: PropTypes.array,
+	title: PropTypes.string,
+};
 
 // TODO: make this memoized after sites-list is removed and `sites` comes from Redux
 function getSitesWithSecondarySites( state, sites ) {

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import { compact } from 'lodash';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import SectionHeader from 'calypso/components/section-header';
 import PluginSite from 'calypso/my-sites/plugins/plugin-site/plugin-site';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import {
@@ -46,7 +45,9 @@ export function PluginSiteList( props ) {
 
 	return (
 		<div className={ classNames( 'plugin-site-list', props.className ) }>
-			<SectionHeader label={ props.title } />
+			<div className={ classNames( 'plugin-site-list__title', { primary: props.titlePrimary } ) }>
+				{ props.title }
+			</div>
 			{ sitesWithSecondarySites.map( ( { site, secondarySites } ) => (
 				<PluginSite
 					key={ 'pluginSite' + site.ID }

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -1,8 +1,7 @@
 import classNames from 'classnames';
 import { compact } from 'lodash';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import PluginSite from 'calypso/my-sites/plugins/plugin-site/plugin-site';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
@@ -15,50 +14,50 @@ import isConnectedSecondaryNetworkSite from 'calypso/state/selectors/is-connecte
 
 import './style.scss';
 
-export class PluginSiteList extends Component {
-	static propTypes = {
-		plugin: PropTypes.object,
-		sites: PropTypes.array,
-		sitesWithSecondarySites: PropTypes.array,
-		title: PropTypes.string,
-	};
+export function PluginSiteList( props ) {
+	const siteIds = siteObjectsToSiteIds( props.sites );
+	const sitesWithPlugin = useSelector( ( state ) =>
+		getSiteObjectsWithPlugin( state, siteIds, props.plugin.slug )
+	);
+	const sitesWithSecondarySites = useSelector( ( state ) =>
+		getSitesWithSecondarySites( state, props.sites )
+	);
+	const pluginsOnSites = useSelector( ( state ) =>
+		getPluginOnSites( state, siteIds, props.plugin.slug )
+	);
 
-	getSecondaryPluginSites( site, secondarySites ) {
-		const pluginsOnSites = this.props.pluginsOnSites?.sites[ site.ID ];
-		const secondarySitesWithPlugin = this.props.sitesWithPlugin.filter(
-			( siteWithPlugin ) =>
-				secondarySites && secondarySites.some( ( secSite ) => secSite.ID === siteWithPlugin.ID )
-		);
-		const secondaryPluginSites = pluginsOnSites ? secondarySitesWithPlugin : secondarySites;
-		return compact( secondaryPluginSites );
+	const getSecondaryPluginSites = useCallback(
+		( site, secondarySites ) => {
+			const pluginsOnSite = pluginsOnSites?.sites[ site.ID ];
+			const secondarySitesWithPlugin = sitesWithPlugin.filter(
+				( siteWithPlugin ) =>
+					secondarySites && secondarySites.some( ( secSite ) => secSite.ID === siteWithPlugin.ID )
+			);
+			const secondaryPluginSites = pluginsOnSite ? secondarySitesWithPlugin : secondarySites;
+
+			return compact( secondaryPluginSites );
+		},
+		[ pluginsOnSites, sitesWithPlugin ]
+	);
+
+	if ( ! props.sites || props.sites.length === 0 ) {
+		return null;
 	}
 
-	renderPluginSite( { site, secondarySites } ) {
-		return (
-			<PluginSite
-				key={ 'pluginSite' + site.ID }
-				site={ site }
-				secondarySites={ this.getSecondaryPluginSites( site, secondarySites ) }
-				plugin={ this.props.plugin }
-				wporg={ this.props.wporg }
-			/>
-		);
-	}
-
-	render() {
-		if ( ! this.props.sites || this.props.sites.length === 0 ) {
-			return null;
-		}
-		const classes = classNames( 'plugin-site-list', this.props.className );
-		const pluginSites = this.props.sitesWithSecondarySites.map( this.renderPluginSite, this );
-
-		return (
-			<div className={ classes }>
-				<SectionHeader label={ this.props.title } />
-				{ pluginSites }
-			</div>
-		);
-	}
+	return (
+		<div className={ classNames( 'plugin-site-list', props.className ) }>
+			<SectionHeader label={ props.title } />
+			{ sitesWithSecondarySites.map( ( { site, secondarySites } ) => (
+				<PluginSite
+					key={ 'pluginSite' + site.ID }
+					site={ site }
+					secondarySites={ getSecondaryPluginSites( site, secondarySites ) }
+					plugin={ props.plugin }
+					wporg={ props.wporg }
+				/>
+			) ) }
+		</div>
+	);
 }
 
 // TODO: make this memoized after sites-list is removed and `sites` comes from Redux
@@ -71,12 +70,4 @@ function getSitesWithSecondarySites( state, sites ) {
 		} ) );
 }
 
-export default connect( ( state, { plugin, sites } ) => {
-	const siteIds = siteObjectsToSiteIds( sites );
-
-	return {
-		sitesWithPlugin: getSiteObjectsWithPlugin( state, siteIds, plugin.slug ),
-		sitesWithSecondarySites: getSitesWithSecondarySites( state, sites ),
-		pluginsOnSites: getPluginOnSites( state, siteIds, plugin.slug ),
-	};
-} )( PluginSiteList );
+export default PluginSiteList;

--- a/client/my-sites/plugins/plugin-site-list/style.scss
+++ b/client/my-sites/plugins/plugin-site-list/style.scss
@@ -22,7 +22,7 @@
 		background: var( --studio-white );
 		border: 1px solid var( --studio-gray-5 );
 		padding: 8px 24px;
-		
+
 		.plugin-site-list__header-title {
 			flex: 4 4 0;
 			color: var( --studio-gray-50 );
@@ -32,10 +32,10 @@
 			}
 		}
 
-		@media screen and ( max-width: 782px ) {
+		@media screen and ( max-width: 1040px ) {
 			display: none;
 		}
-	}	
+	}
 
 	.plugin-site-list__header-title {
 		flex-grow: 4;

--- a/client/my-sites/plugins/plugin-site-list/style.scss
+++ b/client/my-sites/plugins/plugin-site-list/style.scss
@@ -31,6 +31,10 @@
 				flex: 8 8 0;
 			}
 		}
+
+		@media screen and ( max-width: 782px ) {
+			display: none;
+		}
 	}	
 
 	.plugin-site-list__header-title {

--- a/client/my-sites/plugins/plugin-site-list/style.scss
+++ b/client/my-sites/plugins/plugin-site-list/style.scss
@@ -1,4 +1,6 @@
 .plugin-site-list {
+	font-size: $font-body-small;
+
 	.foldable-card__main {
 		flex: 3 1;
 	}
@@ -8,11 +10,34 @@
 
 	.plugin-site-list__title {
 		padding: 20px 0;
-		font-size: $font-body-small;
 		color: var( --studio-gray-60 );
 
 		&.primary {
 			color: var( --studio-green-30 );
+		}
+	}
+
+	.plugin-site-list__header {
+		display: flex;
+		background: var( --studio-white );
+		border: 1px solid var( --studio-gray-5 );
+		padding: 8px 24px;
+		
+		.plugin-site-list__header-title {
+			flex: 4 4 0;
+			color: var( --studio-gray-50 );
+
+			&.domain {
+				flex: 8 8 0;
+			}
+		}
+	}	
+
+	.plugin-site-list__header-title {
+		flex-grow: 4;
+
+		&.domain {
+			flex-grow: 8;
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-site-list/style.scss
+++ b/client/my-sites/plugins/plugin-site-list/style.scss
@@ -5,4 +5,14 @@
 	.foldable-card__secondary {
 		flex: 2 1;
 	}
+
+	.plugin-site-list__title {
+		padding: 20px 0;
+		font-size: $font-body-small;
+		color: var( --studio-gray-60 );
+
+		&.primary {
+			color: var( --studio-green-30 );
+		}
+	}
 }

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -3,6 +3,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
@@ -75,9 +76,18 @@ class PluginSiteUpdateIndicator extends Component {
 				args: { version: this.props.pluginOnSite.update.new_version },
 			} );
 		}
+
+		if ( this.props.menuItem ) {
+			return <PopoverMenuItem onClick={ this.updatePlugin }>{ message }</PopoverMenuItem>;
+		}
+
 		return (
-			<div className="plugin-site-update-indicator__button">
-				<button className="button" onClick={ this.updatePlugin } disabled={ isUpdating }>
+			<div className="plugin-site-update-indicator__button-container">
+				<button
+					className="plugin-site-update-indicator__button button"
+					onClick={ this.updatePlugin }
+					disabled={ isUpdating }
+				>
 					{ message }
 				</button>
 			</div>
@@ -96,7 +106,7 @@ class PluginSiteUpdateIndicator extends Component {
 			if ( ! this.props.expanded ) {
 				/* eslint-disable wpcalypso/jsx-gridicon-size */
 				return (
-					<span className="plugin-site-update-indicator">
+					<span className="plugin-site-update-indicator__icon">
 						<Gridicon icon="sync" size={ 20 } />
 					</span>
 				);

--- a/client/my-sites/plugins/plugin-site-update-indicator/style.scss
+++ b/client/my-sites/plugins/plugin-site-update-indicator/style.scss
@@ -1,4 +1,4 @@
-.plugin-site-update-indicator {
+.plugin-site-update-indicator__icon {
 	line-height: 32px;
 	vertical-align: bottom;
 
@@ -7,6 +7,7 @@
 	}
 }
 
-.plugin-site-update-indicator__button {
+.plugin-site-update-indicator__button-container {
 	margin-top: 8px;
+	flex: 40%;
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,3 +1,4 @@
+@import '@wordpress/base-styles/variables';
 @import './grid-mixins.scss';
 
 .is-section-plugins .main {
@@ -152,8 +153,6 @@ $plugin-details-header-padding: 100px;
 }
 
 .plugin-details__top-section {
-	border-bottom: 1px solid var( --studio-gray-5 );
-
 	.plugin-details__layout-col-right.no-cta {
 		visibility: hidden;
 
@@ -163,8 +162,6 @@ $plugin-details-header-padding: 100px;
 	}
 
 	&.is-placeholder {
-		border-bottom: none;
-
 		.plugin-details__name,
 		.plugin-details__price,
 		.plugin-details__description,
@@ -269,6 +266,8 @@ $plugin-details-header-padding: 100px;
 }
 
 .plugin-details__body {
+	border-top: 1px solid var( --studio-gray-5 );
+
 	.plugin-details__plugin-details-title {
 		padding: 15px 0;
 		display: none;
@@ -363,8 +362,21 @@ $plugin-details-header-padding: 100px;
 	}
 }
 
-.plugin-details__sites-list {
+.plugin-details__sites-list-background + .plugin-details__body {
+	border-top: none;
+}
+
+.plugin-details__sites-list-background {
 	background-color: var( --studio-gray-0 );
 	padding-top: 20px;
 	padding-bottom: 60px;
+	position: relative;
+	transform: translateX(-50%);
+	left: 50%;
+	width: calc( 100vw - $sidebar-width );
+}
+
+.plugin-details__sites-list {
+	max-width: 1040px;
+	margin: auto;
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -372,7 +372,7 @@ $plugin-details-header-padding: 100px;
 	position: relative;
 	transform: translateX( -50% );
 	left: 50%;
-	width: calc( 100vw - var( --sidebar-width-max ) - 1px );
+	width: calc( 100vw - var( --sidebar-width-max ) + 1px );
 
 	@media screen and ( max-width: 782px ) {
 		width: 100vw;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,4 +1,3 @@
-@import '@wordpress/base-styles/variables';
 @import './grid-mixins.scss';
 
 .is-section-plugins .main {
@@ -373,7 +372,7 @@ $plugin-details-header-padding: 100px;
 	position: relative;
 	transform: translateX(-50%);
 	left: 50%;
-	width: calc( 100vw - $sidebar-width );
+	width: calc( 100vw - var( --sidebar-width-max ) - 1px);
 }
 
 .plugin-details__sites-list {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -370,9 +370,13 @@ $plugin-details-header-padding: 100px;
 	padding-top: 20px;
 	padding-bottom: 60px;
 	position: relative;
-	transform: translateX(-50%);
+	transform: translateX( -50% );
 	left: 50%;
-	width: calc( 100vw - var( --sidebar-width-max ) - 1px);
+	width: calc( 100vw - var( --sidebar-width-max ) - 1px );
+
+	@media screen and ( max-width: 782px ) {
+		width: 100vw;
+	}
 }
 
 .plugin-details__sites-list {
@@ -383,7 +387,11 @@ $plugin-details-header-padding: 100px;
 		padding: 0 40px;
 	}
 
-	@media screen and (max-width: 1040px) {
+	@media screen and ( max-width: 1040px ) {
 		padding: 0 48px;
+	}
+
+	@media screen and ( max-width: 660px ) {
+		padding: 0 24px;
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -362,3 +362,9 @@ $plugin-details-header-padding: 100px;
 		}
 	}
 }
+
+.plugin-details__sites-list {
+	background-color: var( --studio-gray-0 );
+	padding-top: 20px;
+	padding-bottom: 60px;
+}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -378,4 +378,12 @@ $plugin-details-header-padding: 100px;
 .plugin-details__sites-list {
 	max-width: 1040px;
 	margin: auto;
+
+	@media screen and ( max-width: 1400px ) {
+		padding: 0 40px;
+	}
+
+	@media screen and (max-width: 1040px) {
+		padding: 0 48px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Turn `PluginSiteList` into a functional React component
* Update the CSS of the Site list section to match the Figma layout at oU6nEIeiKSg8CayhEtgR6b-fi-6559%3A49151

PS: `PluginSiteNetwork` handle sites with *secondary* sites but as it is n independent component we can handle it on a separate PR.

#### Testing instructions
- Go to `/plugins` without a selected site
- Click in a plugin, it will redirect you to the plugin details page
- Check if the site list layout matches the below and try to use the buttons **install**, **active**, **autoupdates** and **remove**

![Screen Shot 2021-11-17 at 18 21 09](https://user-images.githubusercontent.com/5039531/142291894-9f7d9312-f0c1-4d48-a92a-65ebd24e39f7.png)

- Select a site
- Check if the plugin is installed, if not, install
- Check if the layout matches the below

![Screen Shot 2021-11-18 at 14 46 11](https://user-images.githubusercontent.com/5039531/142485780-6020f07f-89e5-4c98-8c99-4885398e5845.png)

- Check the multi-site version on mobile or emulate it via your browsers
- Check if the layout matches the below


![Screen Shot 2021-11-23 at 13 18 12](https://user-images.githubusercontent.com/5039531/143072652-8e302067-82ae-4c16-8e88-9b004fe39b9e.png)


---

Fixes #57747
