### PR TITLE
Improve Activity log UX on mobile in Calypso blue

### DIFF
--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -1,3 +1,7 @@
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 // Activity Log
 
 .activity-log__wrapper {
@@ -29,6 +33,10 @@
 		background: var( --color-neutral-10 );
 		background: linear-gradient( var( --color-neutral-10 ), var( --color-surface-backdrop ) );
 	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		margin-top: 2rem;
+	}
 }
 
 .activity-log__time-period {
@@ -57,6 +65,12 @@
 	&.is-bottom-pagination {
 		margin: 14px 0 48px;
 	}
+
+	&.is-top-pagination {
+		@include breakpoint-deprecated( '<480px' ) {
+			display: none;
+		}
+	}
 }
 
 .activity-log__fader {
@@ -68,4 +82,14 @@
 	z-index: 179;
 	height: 15%;
 	pointer-events: none;
+}
+
+.activity-log__filterbar-ctn.is-sticky {
+	@include breakpoint-deprecated( '<480px' ) {
+		position: fixed;
+		top: var( --masterbar-height );
+		left: 0;
+		right: 0;
+		z-index: z-index( 'root', '.masterbar' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR hides the top pagination and makes the filter bar stick in the Calypso blue activity log, on mobile.

Fixes 1164141197617539-as-1201316822000575

### Testing instructions
- Download the PR and run Calypso blue
- Select a Jetpack site
- Visit `http://calypso.localhost:3000/activity-log/<site>`
- Check that the page behaves as in production for viewports wider than 480px
- Set the viewport width to less than 480px, and refresh the page
- Check that the top pagination is not visible anymore, and that the filter bar sticks to the top

### Screenshots


https://user-images.githubusercontent.com/1620183/141373920-1c2d36b7-7020-4f7d-89a5-b081ed041227.mov



