### PR TITLE
Center intro banner text in Jetpack pricing page on mobile

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -15,12 +15,14 @@ const Banner: React.FC = () => {
 					{ preventWidows( translate( 'Check out our new introductory pricing' ) ) }
 				</p>
 				<p className="intro-pricing-banner__call-to-action">
-					{ translate(
-						'Get the perfect Jetpack for your site with %(percent)d%% off the first term. Try it risk free with our %(days)d-day money-back guarantee.*',
-						{
-							args: { percent: INTRO_PRICING_DISCOUNT_PERCENTAGE, days: 14 },
-							comment: '* clause describing the money back guarantee',
-						}
+					{ preventWidows(
+						translate(
+							'Get the perfect Jetpack for your site with %(percent)d%% off the first term. Try it risk free with our %(days)d-day money-back guarantee.*',
+							{
+								args: { percent: INTRO_PRICING_DISCOUNT_PERCENTAGE, days: 14 },
+								comment: '* clause describing the money back guarantee',
+							}
+						)
 					) }
 				</p>
 			</div>

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -39,13 +39,15 @@
 
 .intro-pricing-banner__header {
 	margin-top: -8px;
-	margin-bottom: 8px;
+	margin-bottom: 1rem;
 
 	text-align: center;
 	font-size: $font-title-small;
 	font-weight: 700;
 
 	@include breakpoint-deprecated( '>660px' ) {
+		margin-bottom: 0.5rem;
+
 		text-align: initial;
 		font-size: $font-title-medium;
 	}
@@ -55,10 +57,12 @@
 	margin-bottom: initial;
 
 	font-size: $font-body-small;
+	text-align: center;
 	color: var( --studio-gray-60 );
 
 	@include breakpoint-deprecated( '>660px' ) {
 		font-size: $font-body;
+		text-align: left;
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR centers the intro banner text on mobile, and gives it more space.

Fixes 1164141197617539-as-1201305007019307

### Testing instructions

- Download this PR and run Calypso or cloud
- Visit the pricing page
- Check that the intro banner looks as in production for viewports wider than 480px
- Set the viewport width to less than 480px
- Check that the text is centered, and that there's more space between the text and title (see capture below)

### Screenshots

#### Before
<img width="429" alt="Screen Shot 2021-11-11 at 4 59 59 PM" src="https://user-images.githubusercontent.com/1620183/141375806-58d7f648-454c-48f3-84f6-8107d429e380.png">

#### After
<img width="376" alt="Screen Shot 2021-11-11 at 5 05 45 PM" src="https://user-images.githubusercontent.com/1620183/141375814-a6e5fbaf-ee6c-4045-9a66-773966d6c56f.png">

