### PR TITLE
Videos UI - fix designs in desktop view to better reflect Figma design

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -166,7 +166,23 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 													className="videos-ui__play-button"
 													onClick={ () => onVideoPlayClick( data[ 0 ], videoInfo ) }
 												>
-													<Gridicon icon="play" />
+													<svg
+														width="12"
+														height="14"
+														viewBox="0 0 12 14"
+														fill="none"
+														xmlns="http://www.w3.org/2000/svg"
+													>
+														<path
+															d="M1.9165 1.75L10.0832 7L1.9165 12.25V1.75Z"
+															fill="#101517"
+															stroke="#101517"
+															stroke-width="2"
+															stroke-linecap="round"
+															stroke-linejoin="round"
+														/>
+													</svg>
+
 													<span>{ translate( 'Play video' ) }</span>
 												</Button>
 											</div>

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -97,9 +97,8 @@
 
 				.videos-ui__duration {
 					color: rgba( 255, 255, 255, 0.5 );
-					span {
-						margin-left: 10px;
-					}
+					display: inline-block;
+					margin-left: 10px;
 				}
 
 				.videos-ui__status-icon {
@@ -146,6 +145,13 @@
 					span {
 						font-weight: 400;
 						color: #101517;
+						display: inline-block;
+						vertical-align: middle;
+					}
+
+					svg {
+						padding-right: 10px;
+						vertical-align: middle;
 					}
 				}
 
@@ -170,18 +176,20 @@
 	@include break-medium {
 		.videos-ui__header {
 			.videos-ui__header-content {
+				max-width: 1160px;
+				margin: auto;
 				flex-direction: row;
 				justify-content: space-between;
 				padding: 80px;
 
 				.videos-ui__titles {
 					flex-basis: auto;
-					width: 60%;
+					width: 65.5%;
+					font-size: $font-headline-small;
 				}
-
 				.videos-ui__summary {
 					flex-basis: auto;
-					width: 33%;
+					width: 31%;
 				}
 
 				ul {
@@ -193,6 +201,9 @@
 
 	@include break-xlarge {
 		.videos-ui__body {
+			max-width: 1160px;
+			margin: auto;
+
 			padding: 0 80px 80px;
 			h3 {
 				margin: 80px 0 20px;
@@ -204,12 +215,12 @@
 
 				.videos-ui__video {
 					flex-basis: auto;
-					width: 60%;
+					width: 65.5%;
 				}
 
 				.videos-ui__chapters {
 					flex-basis: auto;
-					width: 33%;
+					width: 31%;
 				}
 			}
 		}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -31,7 +31,6 @@
 
 			h2 {
 				@include onboarding-font-recoleta;
-				//font-size: $font-title-large;
 				font-size: $font-headline-small;
 				letter-spacing: 0;
 				height: 40px;
@@ -48,6 +47,10 @@
 					padding-right: 16px;
 					fill: rgba( 255, 255, 255, 0.6 );
 					vertical-align: text-bottom;
+				}
+
+				li {
+					color: rgba( 255, 255, 255, 0.88 );
 				}
 			}
 		}
@@ -180,16 +183,17 @@
 				margin: auto;
 				flex-direction: row;
 				justify-content: space-between;
-				padding: 80px;
+				padding: 60px;
 
 				.videos-ui__titles {
 					flex-basis: auto;
 					width: 65.5%;
-					font-size: $font-headline-small;
 				}
+
 				.videos-ui__summary {
 					flex-basis: auto;
 					width: 31%;
+					padding-top: 16px;
 				}
 
 				ul {
@@ -200,6 +204,17 @@
 	}
 
 	@include break-xlarge {
+		.videos-ui__header {
+			.videos-ui__header-content {
+                .videos-ui__titles {
+                    h2 {
+                        font-size: $font-headline-medium;
+                        height: 60px;
+                    }
+                }
+			}
+		}
+
 		.videos-ui__body {
 			max-width: 1160px;
 			margin: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR follows on from the changes in https://github.com/Automattic/wp-calypso/pull/57924, further refining the videos UI to better reflect Figma requirements.

Before:

<img width="1155" alt="CleanShot 2021-11-11 at 16 05 54@2x" src="https://user-images.githubusercontent.com/13437011/141376204-9095cd81-5e5e-43fc-b924-8f27f9ae9a8b.png">

After:

<img width="1147" alt="CleanShot 2021-11-11 at 16 04 51@2x" src="https://user-images.githubusercontent.com/13437011/141376233-90898020-7d60-43ba-9ede-3fe2e5832f7d.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out a copy of #57515 and merge this branch into it locally in order to test the Videos UI in the modal.
* Verify that at a screen size of 1440px wide, the modal UI displays with spacing and sizing equivalent to the mockups in Figma at EuqfSnWpfYx8fgiBlVmbuA-fi-3649%3A1656


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57867