### PR TITLE
Update/jetpack black friday sale

### DIFF
--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -29,11 +29,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const [ isClosed, setIsClosed ] = useState( false );
-	const blackFridaySaleText = translate( 'Black Friday Sale!' );
-	// creating this variable just to trigger the string for translation
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const cyberMondaySaleText = translate( 'Cyber Monday Sale!' );
-
+	const saleTitle = coupon.sale_title;
 	const now = moment.utc().unix();
 	const expiryDate = moment.utc( coupon?.expiry_date ).unix();
 	const isBeforeExpiry = coupon && now <= expiryDate;
@@ -60,7 +56,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 				<div className="sale-banner" role="banner" aria-label={ translate( 'Discount Banner' ) }>
 					<div className="sale-banner__content">
 						<div>
-							<b>{ blackFridaySaleText }</b>
+							<b>{ saleTitle }</b>
 							&nbsp;
 							{ translate(
 								'Get %(discount)d%% off your first year on all Jetpack products & plans.',

--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -29,6 +29,11 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const [ isClosed, setIsClosed ] = useState( false );
+	const blackFridaySaleText = translate( 'Black Friday Sale!' );
+	// creating this variable just to trigger the string for translation
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const cyberMondaySaleText = translate( 'Cyber Monday Sale!' );
+
 	const now = moment.utc().unix();
 	const expiryDate = moment.utc( coupon?.expiry_date ).unix();
 	const isBeforeExpiry = coupon && now <= expiryDate;
@@ -55,11 +60,14 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 				<div className="sale-banner" role="banner" aria-label={ translate( 'Discount Banner' ) }>
 					<div className="sale-banner__content">
 						<div>
-							<b>{ translate( 'End of Summer Sale!' ) }</b>
+							<b>{ blackFridaySaleText }</b>
 							&nbsp;
-							{ translate( 'Get %(discount)d%% off your first year of Jetpack.', {
-								args: { discount: coupon.discount },
-							} ) }
+							{ translate(
+								'Get %(discount)d%% off your first year on all Jetpack products & plans.',
+								{
+									args: { discount: coupon.discount },
+								}
+							) }
 						</div>
 						<span className="sale-banner__countdown-timer">
 							{ translate( 'Sale ends in: %(days)dd %(hours)dh %(minutes)dm %(seconds)ss', {

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -6,6 +6,7 @@ export interface JetpackSaleCoupon {
 	discount: number;
 	start_date: string;
 	expiry_date: string;
+	sale_title: string;
 }
 
 export function isTreatmentPlansReorderTest( state: AppState ): boolean {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the copy of the sale banner according to pbNhbs-1rl-p2
* Update the code to use the Sale title from the API

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the Test Plan from D70003-code and make sure the API is returning a valid coupon (the Public API has to be pointing to your sandbox)
* Checkout this PR locally
* Run `yarn start-jetpack-cloud` and go to http://jetpack.cloud.localhost:3000/pricing
* Make sure the Sale Banner is displayed with the updated copy

![image](https://user-images.githubusercontent.com/5714212/141385425-0127e82b-0d52-4234-89f4-c214f7b834f8.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->