### PR TITLE
Fix showing Welcome Tour after publishing the post

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -6,7 +6,7 @@ import './public-path';
 import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 import { Guide, GuidePage } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { getQueryArg } from '@wordpress/url';
 import DraftPostModal from './draft-post-modal';
@@ -16,6 +16,10 @@ import WpcomNux from './welcome-modal/wpcom-nux';
 import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 
 function WelcomeTour() {
+	const [ showDraftPostModal ] = useState(
+		getQueryArg( window.location.href, 'showDraftPostModal' )
+	);
+
 	const { show, isLoaded, variant, isManuallyOpened, isNewPageLayoutModalOpen } = useSelect(
 		( select ) => {
 			const welcomeGuideStoreSelect = select( 'automattic/wpcom-welcome-guide' );
@@ -55,7 +59,6 @@ function WelcomeTour() {
 	}
 
 	if ( variant === DEFAULT_VARIANT ) {
-		const showDraftPostModal = getQueryArg( window.location.href, 'showDraftPostModal' );
 		return (
 			<LocaleProvider localeSlug={ window.wpcomBlockEditorNuxLocale ?? i18nDefaultLocaleSlug }>
 				{ showDraftPostModal ? <DraftPostModal /> : <LaunchWpcomWelcomeTour /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sometimes, if you close the "Welcome Modal", the “Welcome Tour” might show immediately after you published the post. The reason is that the URL might change without `showDraftPostModal` query args after you published the post, and then the “Welcome Tour” re-rendered so that it shows immediately.
* Thus, I change to save the value of `showDraftPostModal` in the component state so that the “Welcome Tour” won't show after you publish the post.

##### Before

https://user-images.githubusercontent.com/13596067/141428915-f0f868f6-7ecf-455f-9004-80541c48bc17.mov

##### After

https://user-images.githubusercontent.com/13596067/141428697-d3128a1b-047c-4bdb-a5db-44d4ec8f5532.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open another terminal and run `cd apps/editing-toolkit && yarn dev --sync`
* Ensure your API and your site domain point to the sandbox
* Go to the editor
* Execute `window.sessionStorage.setItem( 'wpcom_signup_complete_show_draft_post_modal', '1' );` in your devtool console.
* Refresh the page and you'll see the “Welcome Modal”
* Close the “Welcome Modal” and publish the post.
* Check you won't see the “Welcome Tour” after applying this change.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57702
