### PR TITLE
Design Picker: Show Blank Canvas on every category, remove "No Category", and add the "Show All" filter

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -741,6 +741,7 @@ export function generateSteps( {
 			optionalDependencies: [ 'selectedDesign' ],
 			props: {
 				showDesignPickerCategories: config.isEnabled( 'signup/design-picker-categories' ),
+				showDesignPickerCategoriesAllFilter: config.isEnabled( 'signup/design-picker-categories' ),
 			},
 		},
 		'difm-design-setup-site': {
@@ -755,6 +756,7 @@ export function generateSteps( {
 				hideExternalPreview: true,
 				useDIFMThemes: true,
 				showDesignPickerCategories: true,
+				showDesignPickerCategoriesAllFilter: false,
 			},
 		},
 		'difm-design': {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -86,9 +86,7 @@ class DesignPickerStep extends Component {
 		const allThemes = this.props.themes
 			.filter( ( { id } ) => ! EXCLUDED_THEMES.includes( id ) )
 			.map( ( { id, name, taxonomies } ) => ( {
-				categories: taxonomies?.theme_subject ?? [
-					{ name: this.props.translate( 'No Category' ), slug: 'CLIENT_ONLY-no-category' },
-				],
+				categories: taxonomies?.theme_subject ?? [],
 				// Blank Canvas uses the theme_picks taxonomy with a "featured" term in order to
 				// appear prominently in theme galleries.
 				showFirst: !! taxonomies?.theme_picks?.find( ( { slug } ) => slug === 'featured' ),

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -35,6 +35,8 @@ const EXCLUDED_THEMES = [
 ];
 
 export default function DesignPickerStep( props ) {
+	const { flowName, stepName, isReskinned } = props;
+
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -255,8 +257,6 @@ export default function DesignPickerStep( props ) {
 	}
 
 	const isMobile = useViewportMatch( 'small', '<' );
-
-	const { flowName, stepName, isReskinned } = props;
 
 	if ( selectedDesign ) {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -89,6 +89,9 @@ class DesignPickerStep extends Component {
 				categories: taxonomies?.theme_subject ?? [
 					{ name: this.props.translate( 'No Category' ), slug: 'CLIENT_ONLY-no-category' },
 				],
+				// Blank Canvas uses the theme_picks taxonomy with a "featured" term in order to
+				// appear prominently in theme galleries.
+				showFirst: !! taxonomies?.theme_picks?.find( ( { slug } ) => slug === 'featured' ),
 				features: [],
 				is_premium: false,
 				slug: id,

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -168,6 +168,9 @@ class DesignPickerStep extends Component {
 				} ) }
 				highResThumbnails
 				showCategoryFilter={ this.props.showDesignPickerCategories }
+				defaultCategorySelection={
+					this.props.signupDependencies.intent === 'write' ? 'blog' : null
+				}
 				showAllFilter={ this.props.showDesignPickerCategoriesAllFilter }
 				categoriesHeading={
 					<FormattedHeader

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -168,6 +168,7 @@ class DesignPickerStep extends Component {
 				} ) }
 				highResThumbnails
 				showCategoryFilter={ this.props.showDesignPickerCategories }
+				showAllFilter={ this.props.showDesignPickerCategoriesAllFilter }
 				categoriesHeading={
 					<FormattedHeader
 						id={ 'step-header' }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -5,14 +5,12 @@ import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useEffect, useState, ReactNode } from 'react';
-import { SHOW_ALL_SLUG } from '../constants';
+import { useCategorization } from '../hooks/use-categorization';
 import {
 	getAvailableDesigns,
 	getDesignUrl,
 	mShotOptions,
 	isBlankCanvasDesign,
-	gatherCategories,
 	filterDesignsByCategory,
 	sortDesigns,
 } from '../utils';
@@ -207,7 +205,7 @@ export interface DesignPickerProps {
 	highResThumbnails?: boolean;
 	showCategoryFilter?: boolean;
 	showAllFilter?: boolean;
-	categoriesHeading?: ReactNode;
+	categoriesHeading?: React.ReactNode;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -226,28 +224,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	showAllFilter = false,
 	categoriesHeading,
 } ) => {
-	const { __ } = useI18n();
-
-	const categories = gatherCategories( designs );
-	if ( showAllFilter && designs.length ) {
-		categories.push( {
-			name: __( 'Show All', __i18n_text_domain__ ),
-			slug: SHOW_ALL_SLUG,
-		} );
-	}
-	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
-		categories[ 0 ]?.slug ?? null
+	const [ categories, selectedCategory, setSelectedCategory ] = useCategorization(
+		designs,
+		showAllFilter
 	);
-
-	useEffect( () => {
-		// When the category list changes check that the current selection
-		// still matches one of the given slugs, and if it doesn't reset
-		// the current selection.
-		const findResult = categories.find( ( { slug } ) => slug === selectedCategory );
-		if ( ! findResult ) {
-			setSelectedCategory( categories[ 0 ]?.slug ?? null );
-		}
-	}, [ categories, selectedCategory ] );
 
 	const filteredDesigns = ! showCategoryFilter
 		? designs

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -13,6 +13,7 @@ import {
 	isBlankCanvasDesign,
 	gatherCategories,
 	filterDesignsByCategory,
+	sortDesigns,
 } from '../utils';
 import { DesignPickerCategoryFilter } from './design-picker-category-filter';
 import MShotsImage from './mshots-image';
@@ -240,6 +241,8 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	const filteredDesigns = ! showCategoryFilter
 		? designs
 		: filterDesignsByCategory( designs, selectedCategory );
+
+	filteredDesigns.sort( sortDesigns );
 
 	return (
 		<div className={ classnames( 'design-picker', `design-picker--theme-${ theme }`, className ) }>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -205,6 +205,7 @@ export interface DesignPickerProps {
 	highResThumbnails?: boolean;
 	showCategoryFilter?: boolean;
 	showAllFilter?: boolean;
+	defaultCategorySelection?: string | null;
 	categoriesHeading?: React.ReactNode;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -221,12 +222,14 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	className,
 	highResThumbnails = false,
 	showCategoryFilter = false,
+	defaultCategorySelection = null,
 	showAllFilter = false,
 	categoriesHeading,
 } ) => {
 	const [ categories, selectedCategory, setSelectedCategory ] = useCategorization(
 		designs,
-		showAllFilter
+		showAllFilter,
+		defaultCategorySelection
 	);
 
 	const filteredDesigns = ! showCategoryFilter

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -5,6 +5,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { useMemo } from 'react';
 import { useCategorization } from '../hooks/use-categorization';
 import {
 	getAvailableDesigns,
@@ -230,11 +231,14 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 } ) => {
 	const categories = useCategorization( designs, showAllFilter );
 
-	const filteredDesigns = ! showCategoryFilter
-		? designs
-		: filterDesignsByCategory( designs, selectedCategory );
+	const filteredDesigns = useMemo( () => {
+		const result = ! showCategoryFilter
+			? designs.slice() // cloning because otherwise .sort() would mutate the original prop
+			: filterDesignsByCategory( designs, selectedCategory );
 
-	filteredDesigns.sort( sortDesigns );
+		result.sort( sortDesigns );
+		return result;
+	}, [ designs, selectedCategory, showCategoryFilter ] );
 
 	return (
 		<div className={ classnames( 'design-picker', `design-picker--theme-${ theme }`, className ) }>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -205,7 +205,8 @@ export interface DesignPickerProps {
 	highResThumbnails?: boolean;
 	showCategoryFilter?: boolean;
 	showAllFilter?: boolean;
-	defaultCategorySelection?: string | null;
+	selectedCategory?: string | null;
+	onSelectedCategoryChange?: ( categorySlug: string | null ) => void;
 	categoriesHeading?: React.ReactNode;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -222,15 +223,12 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	className,
 	highResThumbnails = false,
 	showCategoryFilter = false,
-	defaultCategorySelection = null,
+	selectedCategory = null,
+	onSelectedCategoryChange = () => undefined,
 	showAllFilter = false,
 	categoriesHeading,
 } ) => {
-	const [ categories, selectedCategory, setSelectedCategory ] = useCategorization(
-		designs,
-		showAllFilter,
-		defaultCategorySelection
-	);
+	const categories = useCategorization( designs, showAllFilter );
 
 	const filteredDesigns = ! showCategoryFilter
 		? designs
@@ -244,7 +242,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				<DesignPickerCategoryFilter
 					categories={ categories }
 					selectedCategory={ selectedCategory }
-					onSelect={ setSelectedCategory }
+					onSelect={ onSelectedCategoryChange }
 					heading={ categoriesHeading }
 				/>
 			) }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -6,6 +6,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useState, ReactNode } from 'react';
+import { SHOW_ALL_SLUG } from '../constants';
 import {
 	getAvailableDesigns,
 	getDesignUrl,
@@ -205,6 +206,7 @@ export interface DesignPickerProps {
 	className?: string;
 	highResThumbnails?: boolean;
 	showCategoryFilter?: boolean;
+	showAllFilter?: boolean;
 	categoriesHeading?: ReactNode;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -221,9 +223,18 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	className,
 	highResThumbnails = false,
 	showCategoryFilter = false,
+	showAllFilter = false,
 	categoriesHeading,
 } ) => {
+	const { __ } = useI18n();
+
 	const categories = gatherCategories( designs );
+	if ( showAllFilter && designs.length ) {
+		categories.push( {
+			name: __( 'Show All', __i18n_text_domain__ ),
+			slug: SHOW_ALL_SLUG,
+		} );
+	}
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
 		categories[ 0 ]?.slug ?? null
 	);

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -4,6 +4,8 @@ export const FONT_TITLES: Partial< Record< Font, string > > = {
 	'Playfair Display': 'Playfair',
 };
 
+export const SHOW_ALL_SLUG = 'CLIENT_ONLY_SHOW_ALL_SLUG';
+
 /**
  * Pairings of fontFamilies
  *

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,0 +1,53 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useState } from 'react';
+import { SHOW_ALL_SLUG } from '../constants';
+import { Category, Design } from '../types';
+import { gatherCategories } from '../utils';
+
+type UseCategorizationResult = [
+	Category[],
+	string | null,
+	( categorySlug: string | null ) => void
+];
+
+export function useCategorization(
+	designs: Design[],
+	showAllFilter: boolean
+): UseCategorizationResult {
+	const { __ } = useI18n();
+
+	const categories = gatherCategories( designs );
+	if ( showAllFilter && designs.length ) {
+		categories.unshift( {
+			name: __( 'Show All', __i18n_text_domain__ ),
+			slug: SHOW_ALL_SLUG,
+		} );
+	}
+
+	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
+		chooseDefaultSelection( categories )
+	);
+
+	useEffect( () => {
+		// When the category list changes check that the current selection
+		// still matches one of the given slugs, and if it doesn't reset
+		// the current selection.
+		const findResult = categories.find( ( { slug } ) => slug === selectedCategory );
+		if ( ! findResult ) {
+			setSelectedCategory( chooseDefaultSelection( categories ) );
+		}
+	}, [ categories, selectedCategory ] );
+
+	return [ categories, selectedCategory, setSelectedCategory ];
+}
+
+/**
+ * Chooses which category is the one that should be used by default. It'll be
+ * whichever category is first in the list.
+ *
+ * @param categories the categories from which the default will be selected
+ * @returns the default category or null if none is available
+ */
+function chooseDefaultSelection( categories: Category[] ): string | null {
+	return categories[ 0 ]?.slug ?? null;
+}

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -12,7 +12,8 @@ type UseCategorizationResult = [
 
 export function useCategorization(
 	designs: Design[],
-	showAllFilter: boolean
+	showAllFilter: boolean,
+	defaultSelection: string | null
 ): UseCategorizationResult {
 	const { __ } = useI18n();
 
@@ -25,7 +26,7 @@ export function useCategorization(
 	}
 
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
-		chooseDefaultSelection( categories )
+		chooseDefaultSelection( categories, defaultSelection )
 	);
 
 	useEffect( () => {
@@ -34,20 +35,29 @@ export function useCategorization(
 		// the current selection.
 		const findResult = categories.find( ( { slug } ) => slug === selectedCategory );
 		if ( ! findResult ) {
-			setSelectedCategory( chooseDefaultSelection( categories ) );
+			setSelectedCategory( chooseDefaultSelection( categories, defaultSelection ) );
 		}
-	}, [ categories, selectedCategory ] );
+	}, [ categories, defaultSelection, selectedCategory ] );
 
 	return [ categories, selectedCategory, setSelectedCategory ];
 }
 
 /**
- * Chooses which category is the one that should be used by default. It'll be
- * whichever category is first in the list.
+ * Chooses which category is the one that should be used by default.
+ * If `defaultSelection` is a valid category slug then it'll be used, otherwise it'll be whichever
+ * category appears first in the list.
  *
  * @param categories the categories from which the default will be selected
+ * @param defaultSelection use this category as the default selection if possible
  * @returns the default category or null if none is available
  */
-function chooseDefaultSelection( categories: Category[] ): string | null {
+function chooseDefaultSelection(
+	categories: Category[],
+	defaultSelection: string | null
+): string | null {
+	if ( defaultSelection && categories.find( ( { slug } ) => slug === defaultSelection ) ) {
+		return defaultSelection;
+	}
+
 	return categories[ 0 ]?.slug ?? null;
 }

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,20 +1,9 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useState } from 'react';
 import { SHOW_ALL_SLUG } from '../constants';
 import { Category, Design } from '../types';
 import { gatherCategories } from '../utils';
 
-type UseCategorizationResult = [
-	Category[],
-	string | null,
-	( categorySlug: string | null ) => void
-];
-
-export function useCategorization(
-	designs: Design[],
-	showAllFilter: boolean,
-	defaultSelection: string | null
-): UseCategorizationResult {
+export function useCategorization( designs: Design[], showAllFilter: boolean ): Category[] {
 	const { __ } = useI18n();
 
 	const categories = gatherCategories( designs );
@@ -25,39 +14,5 @@ export function useCategorization(
 		} );
 	}
 
-	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
-		chooseDefaultSelection( categories, defaultSelection )
-	);
-
-	useEffect( () => {
-		// When the category list changes check that the current selection
-		// still matches one of the given slugs, and if it doesn't reset
-		// the current selection.
-		const findResult = categories.find( ( { slug } ) => slug === selectedCategory );
-		if ( ! findResult ) {
-			setSelectedCategory( chooseDefaultSelection( categories, defaultSelection ) );
-		}
-	}, [ categories, defaultSelection, selectedCategory ] );
-
-	return [ categories, selectedCategory, setSelectedCategory ];
-}
-
-/**
- * Chooses which category is the one that should be used by default.
- * If `defaultSelection` is a valid category slug then it'll be used, otherwise it'll be whichever
- * category appears first in the list.
- *
- * @param categories the categories from which the default will be selected
- * @param defaultSelection use this category as the default selection if possible
- * @returns the default category or null if none is available
- */
-function chooseDefaultSelection(
-	categories: Category[],
-	defaultSelection: string | null
-): string | null {
-	if ( defaultSelection && categories.find( ( { slug } ) => slug === defaultSelection ) ) {
-		return defaultSelection;
-	}
-
-	return categories[ 0 ]?.slug ?? null;
+	return categories;
 }

--- a/packages/design-picker/src/hooks/use-category-selection.ts
+++ b/packages/design-picker/src/hooks/use-category-selection.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useCategorization } from './use-categorization';
+import type { Category, Design } from '../types';
+
+type UseCategorySelectionResult = [ string | null, ( categorySlug: string | null ) => void ];
+
+export function useCategorySelection(
+	designs: Design[],
+	showAllFilter: boolean,
+	defaultSelection: string | null
+): UseCategorySelectionResult {
+	const categories = useCategorization( designs, showAllFilter );
+	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
+		chooseDefaultSelection( categories, defaultSelection )
+	);
+
+	useEffect( () => {
+		// When the category list changes check that the current selection
+		// still matches one of the given slugs, and if it doesn't reset
+		// the current selection.
+		const findResult = categories.find( ( { slug } ) => slug === selectedCategory );
+		if ( ! findResult ) {
+			setSelectedCategory( chooseDefaultSelection( categories, defaultSelection ) );
+		}
+	}, [ categories, defaultSelection, selectedCategory ] );
+
+	return [ selectedCategory, setSelectedCategory ];
+}
+
+/**
+ * Chooses which category is the one that should be used by default.
+ * If `defaultSelection` is a valid category slug then it'll be used, otherwise it'll be whichever
+ * category appears first in the list.
+ *
+ * @param categories the categories from which the default will be selected
+ * @param defaultSelection use this category as the default selection if possible
+ * @returns the default category or null if none is available
+ */
+function chooseDefaultSelection(
+	categories: Category[],
+	defaultSelection: string | null
+): string | null {
+	if ( defaultSelection && categories.find( ( { slug } ) => slug === defaultSelection ) ) {
+		return defaultSelection;
+	}
+
+	return categories[ 0 ]?.slug ?? null;
+}

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -10,3 +10,4 @@ export {
 } from './utils';
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS } from './constants';
 export type { FontPair, Design } from './types';
+export { useCategorySelection } from './hooks/use-category-selection';

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -28,6 +28,9 @@ export interface Design {
 	title: string;
 	features: Array< DesignFeatures >;
 
+	// This design will appear at the top, regardless of category
+	showFirst?: boolean;
+
 	/**
 	 * Quickly hide a design from the picker without having to remove
 	 * it from the list of available design configs (stored in the

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './available-designs-config';
 export * from './available-designs';
 export * from './fonts';
+import { SHOW_ALL_SLUG } from '../constants';
 import type { Category, Design } from '../types';
 
 export function gatherCategories( designs: Design[] ): Category[] {
@@ -20,6 +21,10 @@ export function filterDesignsByCategory(
 	categorySlug: string | null
 ): Design[] {
 	if ( ! categorySlug ) {
+		return designs;
+	}
+
+	if ( categorySlug === SHOW_ALL_SLUG ) {
 		return designs;
 	}
 

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -13,6 +13,8 @@ export function gatherCategories( designs: Design[] ): Category[] {
 	return [ ...allCategories.entries() ].map( ( [ slug, name ] ) => ( { slug, name } ) );
 }
 
+// Returns designs that match the category slug. Designs with `showFirst` are always
+// included in every category.
 export function filterDesignsByCategory(
 	designs: Design[],
 	categorySlug: string | null
@@ -21,7 +23,19 @@ export function filterDesignsByCategory(
 		return designs;
 	}
 
-	return designs.filter( ( { categories } ) =>
-		categories.find( ( { slug } ) => slug === categorySlug )
+	return designs.filter(
+		( { categories, showFirst } ) =>
+			showFirst || categories.find( ( { slug } ) => slug === categorySlug )
 	);
+}
+
+// Ensures that designs with `showFirst` appear first.
+export function sortDesigns( a: Design, b: Design ): number {
+	if ( a.showFirst === b.showFirst ) {
+		return 0;
+	}
+	if ( a.showFirst ) {
+		return -1;
+	}
+	return 1;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make some adjustments to the category picker now that theme categories have been updated.

* Show "featured" (e.g. Blank Canvas) themes at the top of every category
* Remove the "No Category" filter. If a theme doesn't have a category, and it's not "featured" then it won't appear in the design picker
* Adds a "Show All" filter to the category sidebar

<img width="1556" alt="Screenshot 2021-11-12 at 8 00 36 PM" src="https://user-images.githubusercontent.com/1500769/141424530-4d6403c6-d559-4098-bf49-554d19636bf9.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on `calypso.localhost` so that the category sidebar feature flag is enabled
* Go through the hero flow and not the changes have been made to the design picker

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56567
