### PR TITLE
Hero Flow: Hide floating FAB

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -183,6 +183,7 @@ class Layout extends Component {
 		const exemptedRoutes = [ '/log-in/jetpack' ];
 		const exemptedRoutesStartingWith = [
 			'/start/p2',
+			'/start/setup-site',
 			'/plugins/domain',
 			'/plugins/marketplace/setup',
 		];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As https://github.com/Automattic/wp-calypso/issues/57787 mentioned, we should hide floating FAB on all Hero Flow screens. Also, I'm checking that we should also hide FAB on the desktop as the original issue is the FAB is higher than normal but it seems that we don't need FAB on Hero Flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?siteSlug=<your_site>`
* Check FAB doesn't show on all Hero Flow screens

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57787
