### PR TITLE
Hero Flow: Show the site title user filled out on the design preview

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -190,11 +190,16 @@ export default function DesignPickerStep( props ) {
 
 	function renderDesignPreview() {
 		const {
-			signupDependencies: { siteSlug },
+			signupDependencies: { siteSlug, siteTitle, intent },
 			hideExternalPreview,
 		} = props;
 
-		const previewUrl = getDesignUrl( selectedDesign, translate.locale, { iframe: true } );
+		const previewUrl = getDesignUrl( selectedDesign, translate.locale, {
+			iframe: true,
+			// If the user fills out the site title with write intent, we show it on the design preview
+			// Otherwise, use the title of selected design directly
+			site_title: intent === 'write' && siteTitle ? siteTitle : selectedDesign?.title,
+		} );
 
 		return (
 			<WebPreview


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As @jordesign mentioned in p58i-bpK-p2#comment-52359, it's nice to use the site title user filled out on the design preview. Thus, I add the site title to the query args if the user selects the write intent.

![Screen Shot 2021-11-12 at 5 28 40 PM](https://user-images.githubusercontent.com/13596067/141444124-cbea6ac9-e9ac-4cdf-a7ba-9bfabfa247bc.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?siteSlug=<your_site>`
* Select write intent
* Fill out the site title
* Pick “Choose the design” as the starting point and preview the design
* Check the site title is what you filled out in the previous step
* Go back to the intent screen and select build intent
* Preview the design
* Check the site title is the name of the design.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-bpK-p2#comment-52359