### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` Jetpack keys to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -40,17 +40,6 @@ Undocumented.prototype.me = function () {
 };
 
 /**
- * Fetches plugin registration keys for WordPress.org sites with paid services
- *
- * @param {number} [siteId] The site ID
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.fetchJetpackKeys = function ( siteId, fn ) {
-	debug( '/jetpack-blogs/:site_id:/keys query' );
-	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/keys' }, fn );
-};
-
-/**
  * Test if a Jetpack Site is connected to .com
  *
  * @param {number} [siteId] The site ID

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -297,24 +297,24 @@ export function fetchInstallInstructions( siteId ) {
 			} );
 		}, 1 );
 
-		wpcom.undocumented().fetchJetpackKeys( siteId, ( error, data ) => {
-			if ( error ) {
+		wpcom.req
+			.get( `/jetpack-blogs/${ siteId }/keys` )
+			.then( ( data ) => {
+				data = normalizePluginInstructions( data );
+
+				dispatch( {
+					type: PLUGIN_SETUP_INSTRUCTIONS_RECEIVE,
+					siteId,
+					data,
+				} );
+			} )
+			.catch( () => {
 				dispatch( {
 					type: PLUGIN_SETUP_INSTRUCTIONS_RECEIVE,
 					siteId,
 					data: [],
 				} );
-				return;
-			}
-
-			data = normalizePluginInstructions( data );
-
-			dispatch( {
-				type: PLUGIN_SETUP_INSTRUCTIONS_RECEIVE,
-				siteId,
-				data,
 			} );
-		} );
 	};
 }
 

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -300,12 +300,10 @@ export function fetchInstallInstructions( siteId ) {
 		wpcom.req
 			.get( `/jetpack-blogs/${ siteId }/keys` )
 			.then( ( data ) => {
-				data = normalizePluginInstructions( data );
-
 				dispatch( {
 					type: PLUGIN_SETUP_INSTRUCTIONS_RECEIVE,
 					siteId,
-					data,
+					data: normalizePluginInstructions( data ),
 				} );
 			} )
 			.catch( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` Jetpack keys fetch method to `wpcom.req.get()`. 

We're also updating the code to use `.then()` and `.catch()` instead of a callback.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/me/purchases`
* Click on a Jetpack plan purchase
* Verify that the keys under "Backups and security scanning API key" and "Anti-spam API key" are fetched and displayed correctly.

