### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` Jetpack SSO to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -83,20 +83,6 @@ Undocumented.prototype.jetpackAuthorize = function (
 	return this.wpcom.req.post( { path: endpointUrl }, params );
 };
 
-Undocumented.prototype.jetpackValidateSSONonce = function ( siteId, ssoNonce, fn ) {
-	debug( '/jetpack-blogs/:site_id:/sso-validate query' );
-	const endpointUrl = '/jetpack-blogs/' + siteId + '/sso-validate';
-	const params = { sso_nonce: ssoNonce };
-	return this.wpcom.req.post( { path: endpointUrl }, params, fn );
-};
-
-Undocumented.prototype.jetpackAuthorizeSSONonce = function ( siteId, ssoNonce, fn ) {
-	debug( '/jetpack-blogs/:site_id:/sso-authorize query' );
-	const endpointUrl = '/jetpack-blogs/' + siteId + '/sso-authorize';
-	const params = { sso_nonce: ssoNonce };
-	return this.wpcom.req.post( { path: endpointUrl }, params, fn );
-};
-
 Undocumented.prototype.jetpackIsUserConnected = function ( siteId ) {
 	debug( '/sites/:site_id:/jetpack-connect/is-user-connected query' );
 	const endpointUrl = '/sites/' + siteId + '/jetpack-connect/is-user-connected';

--- a/client/state/jetpack-connect/actions/authorize-sso.js
+++ b/client/state/jetpack-connect/actions/authorize-sso.js
@@ -23,9 +23,8 @@ export function authorizeSSO( siteId, ssoNonce, siteUrl ) {
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.jetpackAuthorizeSSONonce( siteId, ssoNonce )
+		return wpcom.req
+			.post( `/jetpack-blogs/${ siteId }/sso-authorize`, { sso_nonce: ssoNonce } )
 			.then( ( data ) => {
 				dispatch( recordTracksEvent( 'calypso_jpc_authorize_sso_success' ) );
 				dispatch( {

--- a/client/state/jetpack-connect/actions/validate-sso-nonce.js
+++ b/client/state/jetpack-connect/actions/validate-sso-nonce.js
@@ -23,9 +23,8 @@ export function validateSSONonce( siteId, ssoNonce ) {
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.jetpackValidateSSONonce( siteId, ssoNonce )
+		return wpcom.req
+			.post( `/jetpack-blogs/${ siteId }/sso-validate`, { sso_nonce: ssoNonce } )
 			.then( ( data ) => {
 				dispatch( recordTracksEvent( 'calypso_jpc_validate_sso_success' ) );
 				dispatch( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` Jetpack SSO methods to `wpcom.req.post()`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Pick a Jetpack site and enable its `Allow users to log in to this site using WordPress.com accounts` option under `/settings/security/:site`.
* Go to `/wp-admin` of your site and verify you can still login correctly with WP.com.
* Verify tests still pass: `yarn run test-client client/state/jetpack-connect/test/actions.js`
