### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` external services to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -350,25 +350,6 @@ Undocumented.prototype.validateDomainContactInformation = function (
 };
 
 /**
- * Return a list of third-party services that WordPress.com can integrate with for a specific site
- *
- * @param {number|string} siteId The site ID or domain
- * @param {Function} fn The callback function
- * @returns {Promise} A Promise to resolve when complete
- */
-
-Undocumented.prototype.sitesExternalServices = function ( siteId, fn ) {
-	debug( '/sites/:site-id:/external-services query' );
-	return this.wpcom.req.get(
-		{
-			path: '/sites/' + siteId + '/external-services',
-			apiNamespace: 'wpcom/v2',
-		},
-		fn
-	);
-};
-
-/**
  * Delete a site
  *
  * @param  {number|string} siteId The site ID or domain

--- a/client/state/sharing/services/actions.js
+++ b/client/state/sharing/services/actions.js
@@ -21,9 +21,12 @@ export function requestKeyringServices() {
 		} );
 
 		const siteId = getSelectedSiteId( getState() );
-		return wpcom
-			.undocumented()
-			.sitesExternalServices( siteId )
+
+		return wpcom.req
+			.get( {
+				path: `/sites/${ siteId }/external-services`,
+				apiNamespace: 'wpcom/v2',
+			} )
 			.then( ( response ) => {
 				dispatch( {
 					type: KEYRING_SERVICES_RECEIVE,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` external Keyring services to `wpcom.req.get()`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `marketing/connections/:site` where `:site` is one of your WP.com sites.
* Verify that the services are displayed (Facebook, Twitter, etc.)
* Verify all tests pass: `yarn run test-client client/state/sharing/services/test/actions.js`
