### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` notification settings to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -105,31 +105,6 @@ UndocumentedMe.prototype.sendVerificationEmail = function ( callback ) {
 	return this.wpcom.req.post( { path: '/me/send-verification-email' }, callback );
 };
 
-UndocumentedMe.prototype.getNotificationSettings = function ( callback ) {
-	debug( '/me/notification/settings/' );
-
-	return this.wpcom.req.get( { apiVersion: '1.1', path: '/me/notifications/settings/' }, callback );
-};
-
-UndocumentedMe.prototype.updateNotificationSettings = function ( settings, applyToAll, callback ) {
-	let query = {};
-	debug( '/me/notification/settings/' );
-
-	if ( applyToAll ) {
-		query = { applyToAll: true };
-	}
-
-	return this.wpcom.req.post(
-		{
-			apiVersion: '1.1',
-			path: '/me/notifications/settings/',
-		},
-		query,
-		settings,
-		callback
-	);
-};
-
 /**
  * Connect the current account with a social service (e.g. Google/Facebook).
  *

--- a/client/state/notification-settings/actions.js
+++ b/client/state/notification-settings/actions.js
@@ -48,10 +48,8 @@ export const toggleWPcomEmailSetting = ( setting ) => toggle( 'wpcom', 'email', 
 export const fetchSettings = () => ( dispatch ) => {
 	dispatch( { type: NOTIFICATION_SETTINGS_FETCH } );
 
-	wpcom
-		.undocumented()
-		.me()
-		.getNotificationSettings()
+	wpcom.req
+		.get( '/me/notifications/settings/' )
 		.then( ( data ) =>
 			dispatch( {
 				type: NOTIFICATION_SETTINGS_FETCH_COMPLETE,
@@ -97,28 +95,24 @@ export const showSaveErrorNotice = () =>
 export const saveSettings = ( source, settings, applyToAll = false ) => ( dispatch ) => {
 	dispatch( { type: NOTIFICATION_SETTINGS_SAVE } );
 
-	wpcom
-		.undocumented()
-		.me()
-		.updateNotificationSettings(
-			buildSavePayload( source, settings ),
-			applyToAll,
-			( error, data ) => {
-				if ( error ) {
-					dispatch( showSaveErrorNotice() );
-					dispatch( {
-						type: NOTIFICATION_SETTINGS_SAVE_FAILED,
-						error,
-						data,
-					} );
-				} else {
-					dispatch( showSaveSuccessNotice() );
-					dispatch( {
-						type: NOTIFICATION_SETTINGS_SAVE_COMPLETE,
-						error,
-						data,
-					} );
-				}
-			}
-		);
+	const query = applyToAll ? { applyToAll: true } : {};
+
+	wpcom.req
+		.post( '/me/notifications/settings/', query, buildSavePayload( source, settings ) )
+		.then( ( data ) => {
+			dispatch( showSaveSuccessNotice() );
+			dispatch( {
+				type: NOTIFICATION_SETTINGS_SAVE_COMPLETE,
+				error: undefined,
+				data,
+			} );
+		} )
+		.catch( ( error ) => {
+			dispatch( showSaveErrorNotice() );
+			dispatch( {
+				type: NOTIFICATION_SETTINGS_SAVE_FAILED,
+				error,
+				data: undefined,
+			} );
+		} );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` notification settings methods to `wpcom.req.post()` and `wpcom.req.get()`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/me/notifications`
* Verify all notification settings are retrieved correctly.
* Change some settings and save them by clicking "Save Settings", verify they are saved correctly.
* Change some settings and save them for all sites by clicking "Save to all sites", verify they are saved correctly. 