### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` country states to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -269,18 +269,6 @@ Undocumented.prototype.getDomainPrice = function ( domain, fn ) {
 	);
 };
 
-Undocumented.prototype.getDomainRegistrationSupportedStates = function ( countryCode, fn ) {
-	debug( '/domains/supported-states/ query' );
-
-	return this._sendRequest(
-		{
-			path: '/domains/supported-states/' + countryCode,
-			method: 'get',
-		},
-		fn
-	);
-};
-
 function mapKeysRecursively( object, fn ) {
 	return Object.keys( object ).reduce( function ( mapped, key ) {
 		let value = object[ key ];

--- a/client/state/country-states/actions.js
+++ b/client/state/country-states/actions.js
@@ -27,9 +27,8 @@ export function requestCountryStates( countryCode ) {
 			countryCode,
 		} );
 
-		return wpcom
-			.undocumented()
-			.getDomainRegistrationSupportedStates( countryCode )
+		return wpcom.req
+			.get( `/domains/supported-states/${ countryCode }` )
 			.then( ( countryStates ) => {
 				dispatch( receiveCountryStates( countryStates, countryCode ) );
 				dispatch( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` country state method to `wpcom.req.get()`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/domains/manage/:domain/edit-contact-info/:site` where `:domain` and `:site` correspond on to one of your sites on a custom domain.
* Select "United States", "Canada" or "Australia" in the country field.
* Verify states/provinces are loaded correctly in the corresponding field.
* Verify tests pass: `yarn run test-client client/state/country-states/test/actions.js`