### PR TITLE
Plugin Details: don't use errant plugin selector if no applicable sites are found.

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -52,8 +52,8 @@ function PluginDetails( props ) {
 	const translate = useTranslate();
 
 	const selectedSite = useSelector( getSelectedSite );
-	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
-	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
+	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
+	const siteIds = [ ...new Set( siteObjectsToSiteIds( sitesWithPlugins ) ) ];
 
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );
 	const wporgPlugin = useSelector( ( state ) => getWporgPlugin( state, props.pluginSlug ) );
@@ -77,7 +77,7 @@ function PluginDetails( props ) {
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
 
 	const isPluginInstalledOnsite =
-		sites.length && ! requestingPluginsForSites ? !! sitePlugin : false;
+		sitesWithPlugins.length && ! requestingPluginsForSites ? !! sitePlugin : false;
 
 	const fullPlugin = {
 		...plugin,
@@ -154,7 +154,11 @@ function PluginDetails( props ) {
 			<QueryJetpackPlugins siteIds={ siteIds } />
 			<SidebarNavigation />
 			<FixedNavigationHeader navigationItems={ getNavigationItems() } />
-			<PluginNotices pluginId={ fullPlugin.id } sites={ sites } plugins={ [ fullPlugin ] } />
+			<PluginNotices
+				pluginId={ fullPlugin.id }
+				sites={ sitesWithPlugins }
+				plugins={ [ fullPlugin ] }
+			/>
 
 			<div className="plugin-details__page">
 				<div className="plugin-details__layout plugin-details__top-section">
@@ -354,8 +358,8 @@ function Rating( { rating } ) {
 function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) {
 	const translate = useTranslate();
 
-	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
-	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
+	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
+	const siteIds = [ ...new Set( siteObjectsToSiteIds( sitesWithPlugins ) ) ];
 
 	const isFetching = useSelector( ( state ) => isWporgPluginFetching( state, props.pluginSlug ) );
 	const sitesWithPlugin = useSelector( ( state ) =>
@@ -370,7 +374,7 @@ function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) 
 	}
 
 	const notInstalledSites = sitesWithoutPlugin.map( ( siteId ) =>
-		sites.find( ( site ) => site.ID === siteId )
+		sitesWithPlugins.find( ( site ) => site.ID === siteId )
 	);
 
 	return (

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -76,7 +76,8 @@ function PluginDetails( props ) {
 	const isWpcom = selectedSite && ! isJetpackSite;
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
 
-	const isPluginInstalledOnsite = ! requestingPluginsForSites ? !! sitePlugin : null;
+	const isPluginInstalledOnsite =
+		sites.length && ! requestingPluginsForSites ? !! sitePlugin : false;
 
 	const fullPlugin = {
 		...plugin,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an attempt to fix a scenario where users who have initially installed **Plugin A** and then downgrade from Atomic won't be able to "Upgrade to Install" this same **Plugin A** unless they clear their indexed DB or do an action that get's plugins in indexed DB refreshed. 

**The problem**
- The `sites` selector here https://github.com/Automattic/wp-calypso/blob/9b11ccb37544c1f6afa3fcea3faea899edc36b74/client/my-sites/plugins/plugin-details.jsx#L55 doesn't return non-Atomic sites 
- `QueryJetpackPlugins` here https://github.com/Automattic/wp-calypso/blob/9b11ccb37544c1f6afa3fcea3faea899edc36b74/client/my-sites/plugins/plugin-details.jsx#L154 wouldn't have any sites to query and thus the plugins list in the indexed db remained stale from the previous state when the site was Atomic and the plugin was installed
- Tried passing the current site id in `QueryJetpackPlugins` but the call fails cause it's not a Jetpack site (it's downgraded)

**The fix**
- renames `sites` to `sitesWithPlugins` for better clarity
- regards `isPluginInstalledOnsite` as `false` if there are no `sitesWithPlugins` . It had to `false` since we where checking for `false` values (and not null) here https://github.com/Automattic/wp-calypso/blob/1067fd07c11ce26c5bbbabb3be06c2ff2eafcb8b/client/my-sites/plugins/plugin-details.jsx#L291

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**In Production**
* In a free site upgrade and install Contact Form
* Revert the site
* Go to `/plugins/contact-form-7/[site]`
* You will notice that you can no longer perform any action

<img width="1429" alt="SS 2021-11-12 at 16 13 39" src="https://user-images.githubusercontent.com/12430020/141480759-d90b793c-5eaf-430c-81d9-f4dfbf857917.png">


**On this branch**
Repeat the above steps, you should be able to "Upgrade and Install" again.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
