### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` support alternates to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -435,17 +435,6 @@ Undocumented.prototype.readSitePostRelated = function ( query, fn ) {
 	);
 };
 
-Undocumented.prototype.supportAlternates = function ( query, fn ) {
-	const params = omit( query, [ 'site', 'postId' ] );
-	debug( '/support/alternates/:site/posts/:post' );
-	addReaderContentWidth( params );
-	return this.wpcom.req.get(
-		'/support/alternates/' + query.site + '/posts/' + query.postId,
-		params,
-		fn
-	);
-};
-
 /**
  * Sign up for a new user account
  * Create a new user

--- a/client/state/support-articles-alternates/actions.js
+++ b/client/state/support-articles-alternates/actions.js
@@ -37,9 +37,8 @@ export const fetchAlternates = ( payload ) => ( dispatch ) => {
 
 	dispatch( fetchAlternatesRequest( postKey ) );
 
-	return wpcom
-		.undocumented()
-		.supportAlternates( { site: blogId, postId } )
+	return wpcom.req
+		.get( `/support/alternates/${ blogId }/posts/${ postId }` )
 		.then( ( data ) => {
 			dispatch( fetchAlternatesReceive( postKey, data ) );
 			return dispatch( fetchAlternatesRequestSuccess( postKey ) );

--- a/client/state/support-articles-alternates/test/actions.js
+++ b/client/state/support-articles-alternates/test/actions.js
@@ -11,14 +11,6 @@ import {
 	fetchAlternatesRequestFailure,
 } from '../actions';
 
-const mockSupportAlternates = jest.fn( () => Promise.resolve() );
-
-jest.mock( 'calypso/lib/wp', () => ( {
-	undocumented: () => ( {
-		supportAlternates: mockSupportAlternates,
-	} ),
-} ) );
-
 describe( 'actions', () => {
 	describe( 'fetchAlternatesReceive()', () => {
 		test( 'should return an action object', () => {

--- a/client/state/support-articles-alternates/test/actions.js
+++ b/client/state/support-articles-alternates/test/actions.js
@@ -9,7 +9,6 @@ import {
 	fetchAlternatesRequest,
 	fetchAlternatesRequestSuccess,
 	fetchAlternatesRequestFailure,
-	fetchAlternates,
 } from '../actions';
 
 const mockSupportAlternates = jest.fn( () => Promise.resolve() );
@@ -59,19 +58,6 @@ describe( 'actions', () => {
 				type: SUPPORT_ARTICLE_ALTERNATES_REQUEST_FAILURE,
 				postKey: 'post-key',
 				error: {},
-			} );
-		} );
-	} );
-
-	describe( 'fetchAlternates()', () => {
-		test( 'should call support wpcom().undocumented().supportAlternates()', () => {
-			const postKey = { blogId: 1, postId: 1 };
-			const dispatchMock = jest.fn();
-			fetchAlternates( postKey )( dispatchMock );
-
-			expect( mockSupportAlternates ).toHaveBeenCalledWith( {
-				site: postKey.blogId,
-				postId: postKey.postId,
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` support alternate fetching method to `wpcom.req.get()`. 

This also cleans up a few unused details:
* We are removing the unnecessary `addReaderContentWidth()` call - I don't see this argument needed by the relevant endpoint.
* We're transforming the `params` to an object, only to restructure them again before use. This is simplified in the new version of the code.
* We're removing an unnecessary test and a related mock.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Set your user's Calypso interface language to Español.
* Go to `/home/:site`.
* Verify support alternates (request to `support/alternates/...` still succeeds.
* Click on the "Más información" link under "La Biblioteca de fotos gratuitas de WordPress.com". 
* Verify it displays the article in Spanish language.
* Verify tests pass: `yarn run test-client client/state/support-articles-alternates/test/actions.js`