### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` read tag images to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -405,17 +405,6 @@ Undocumented.prototype.readFeedPost = function ( query, fn ) {
 	);
 };
 
-Undocumented.prototype.readTagImages = function ( query, fn ) {
-	const params = omit( query, 'tag' );
-	debug( '/read/tags/' + query.tag + '/images' );
-	params.apiVersion = '1.2';
-	return this.wpcom.req.get(
-		'/read/tags/' + encodeURIComponent( query.tag ) + '/images',
-		params,
-		fn
-	);
-};
-
 Undocumented.prototype.readSitePost = function ( query, fn ) {
 	const params = omit( query, [ 'site', 'postId' ] );
 	debug( '/read/sites/:site/post/:post' );

--- a/client/state/reader/tags/images/actions.js
+++ b/client/state/reader/tags/images/actions.js
@@ -43,16 +43,13 @@ export function requestTagImages( tag, limit = 5 ) {
 			tag,
 		} );
 
-		const query = {
-			tag,
-			number: limit,
-		};
-
 		debug( `Requesting tag images for tag ${ tag }` );
 
-		return wpcom
-			.undocumented()
-			.readTagImages( query )
+		return wpcom.req
+			.get( `/read/tags/${ encodeURIComponent( tag ) }/images`, {
+				apiVersion: '1.2',
+				number: limit,
+			} )
 			.then(
 				( data ) => {
 					dispatch( receiveTagImages( tag, ( data && data.images ) || [] ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` reader tag images retrieval method to `wpcom.req.get()`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/tag/wordpress`.
* Verify a tag image is still loaded correctly above the list of posts.
* Verify tests still pass: `yarn run test-client client/state/reader/tags/images/test/actions.js`
