### PR TITLE
Activity log: hide top pagination and stick filterbar in Jetpack cloud on mobile

### DIFF
--- a/client/components/activity-card-list/style.scss
+++ b/client/components/activity-card-list/style.scss
@@ -4,8 +4,33 @@
 	}
 }
 
+.activity-card-list__pagination-top {
+	@include breakpoint-deprecated( '<480px' ) {
+		display: none;
+	}
+}
+
 .activity-card-list__pagination-bottom {
 	margin-bottom: 1rem;
+}
+
+.activity-card-list__filterbar-ctn.is-sticky {
+	@include breakpoint-deprecated( '<480px' ) {
+		position: fixed;
+		top: var( --masterbar-height );
+		left: 0;
+		right: 0;
+		z-index: z-index( 'root', '.masterbar' );
+
+		padding: 0 16px;
+
+		background-color: var( --color-surface-backdrop );
+		border-bottom: 1px solid var( --color-neutral-10 );
+
+		.filterbar {
+			margin-bottom: 0;
+		}
+	}
 }
 
 @include breakpoint-deprecated( '<660px' ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR hides the top pagination and makes the filter bar stick in the Jetpack cloud activity log, on mobile.

Fixes [1164141197617539-as-1201316822000575](1164141197617539-as-1201316822000595)

### Testing instructions
- Download the PR and run Jetpack cloud
- Select a Jetpack site
- Visit `http://jetpack.cloud.localhost:3000/activity-log/<site>`
- Check that the page behaves as in production for viewports wider than 480px
- Set the viewport width to less than 480px, and refresh the page
- Check that the top pagination is not visible anymore, and that the filter bar sticks to the top

### Screenshots
https://user-images.githubusercontent.com/1620183/141500586-37f7b7c6-a3c6-4f82-bde2-888c78ffcb68.mov