### PR TITLE
Activity log: adjust size and spacing in Jetpack cloud

### DIFF
--- a/client/my-sites/activity/activity-log-v2/style.scss
+++ b/client/my-sites/activity/activity-log-v2/style.scss
@@ -12,6 +12,20 @@ main.activity-log-v2 {
 	.filterbar .filterbar__wrap.card {
 		display: flex;
 	}
+
+	.activity-card-list__date-group-date {
+		@include breakpoint-deprecated( '<660px' ) {
+			font-size: $font-title-small;
+		}
+	}
+
+	.activity-card-list__date-group-content {
+		.activity-card:last-child {
+			@include breakpoint-deprecated( '<660px' ) {
+				margin-bottom: 48px;
+			}
+		}
+	}
 }
 
 .activity-log-v2__header {
@@ -24,7 +38,7 @@ main.activity-log-v2 {
 	// use sub-section styling at mobile sizes
 	@include breakpoint-deprecated( '<660px' ) {
 		h2 {
-			font-size: $font-body;
+			font-size: $font-title-small;
 			font-weight: 600;
 			line-height: 23px;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR implements some improvements to the Jetpack cloud activity log, on mobile:
- It increases the header and date font sizes
- It increase the spacing between date groups

Fixes 1164141197617539-as-1201316822000591

### Testing instructions
- Download the PR and run Jetpack cloud
- Select a Jetpack site
- Visit `http://jetpack.cloud.localhost:3000/activity-log/<site>`
- Check that the page behaves as in production for viewports wider than 660px
- Set the viewport width to less than 660px
- Check that the header and date font sizes are bigger
- Check that the spacing between date groups is bigger

### Screenshots

#### Before
<img src="https://user-images.githubusercontent.com/1620183/141504914-1ab70d49-67ff-42c6-bc0c-8182a449fc11.png" width="250">
<img src="https://user-images.githubusercontent.com/1620183/141504929-965e4450-7ed4-4db9-88c7-817a8a27448f.png" width="250">

#### After
<img src="https://user-images.githubusercontent.com/1620183/141504946-8871fcc3-3445-44f9-872b-05bd91dc5462.png" width="250">
<img src="https://user-images.githubusercontent.com/1620183/141504950-d66f4625-ff11-4532-831c-bc798406087e.png" width="250">


