### PR TITLE
Site Editor tracking e2e - Some 11.9 related test fixes.

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -451,12 +451,14 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				const editor = await SiteEditorComponent.Expect( this.driver );
 				// Reset Global Styles before testing.
 				await editor.clickGlobalStylesResetButton();
-				await editor.saveGlobalStyles( { pauseAfter: true } );
+				await editor.maybeSaveGlobalStyles( { pauseAfter: true } );
 				await clearEventsStack( this.driver );
 				await testGlobalStylesColorAndTypography( this.driver, editor );
 			} );
 
-			it( 'global color palette settings', async function () {
+			// Skip palette tests for the time being.  The palette has changed substantially enough
+			// to require other updates to tracking.
+			it.skip( 'global color palette settings', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
 				await testGlobalStylesColorPalette( this.driver, editor );
 			} );
@@ -466,7 +468,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				await testGlobalStylesColorAndTypography( this.driver, editor, { blocksLevel: true } );
 			} );
 
-			it( 'block level color palette settings', async function () {
+			it.skip( 'block level color palette settings', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
 				await editor.clickGlobalStylesMenuItem( 'Blocks' );
 				await editor.clickGlobalStylesMenuItem( 'Column' );
@@ -475,6 +477,15 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 			afterEach( async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
+				await editor.closeGlobalStyles();
+			} );
+
+			after( async function () {
+				// Reset Global Styles as cleanup.
+				const editor = await SiteEditorComponent.Expect( this.driver );
+				await editor.toggleGlobalStyles();
+				await editor.clickGlobalStylesResetButton();
+				await editor.maybeSaveGlobalStyles();
 				await editor.closeGlobalStyles();
 			} );
 		} );
@@ -496,7 +507,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 				// Reset global styles before testing.
 				await editor.clickGlobalStylesResetButton();
-				await editor.saveGlobalStyles( { pauseAfter: true } );
+				await editor.maybeSaveGlobalStyles( { pauseAfter: true } );
 				await clearEventsStack( this.driver );
 
 				await editor.clickGlobalStylesMenuItem( 'Typography' );
@@ -507,19 +518,18 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				await editor.clickGlobalStylesBackButton();
 				await editor.changeGlobalStylesColor( 'Links', { valueIndex: 2 } );
 				await editor.clickGlobalStylesBackButton();
-				await editor.saveGlobalStyles( { pauseAfter: true } );
+				await editor.maybeSaveGlobalStyles( { pauseAfter: true } );
 				const saveEvents = ( await getEventsStack( this.driver ) ).filter(
 					( event ) => event[ 0 ] === 'wpcom_block_editor_global_styles_save'
 				);
 				assert.strictEqual( saveEvents.length, 3 );
-
-				// Clean up by resetting to be safe.
-				await editor.clickGlobalStylesResetButton();
-				await editor.saveGlobalStyles();
 			} );
 
 			after( async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
+				// Clean up by resetting to be safe.
+				await editor.clickGlobalStylesResetButton();
+				await editor.maybeSaveGlobalStyles();
 				await editor.closeGlobalStyles();
 			} );
 		} );
@@ -1134,7 +1144,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				);
 				const removeBlockOptionsItemLocator = driverHelper.createTextLocator(
 					By.css( '[aria-label="Options"] button' ),
-					'Remove block'
+					'Remove Heading'
 				);
 				await driverHelper.clickWhenClickable( this.driver, blockToolbarOptionsLocator );
 				await driverHelper.clickWhenClickable( this.driver, removeBlockOptionsItemLocator );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This includes a couple minor fixes to update Site Editor e2es to work with gutenberg 11.9.
1. Adds safety to entity fetching calls to account for items no longer being preloaded.
2. Adds a safety to the global styles save method to gracefully bail if there is nothing to save.
3. Skips global styles palette tests for the time being, as these were recently updated to no longer be the theme palette and are now all user defined.  This will require a follow up including an update to how we track these changes.
4. Account for block removal buttons new label of `Remove ${blockName}` instead of `Remove block`. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run the `wp-calypso-gutenberg-site-editor-tracking-spec.js` and verify the tests no longer fail at these points.  

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #