### PR TITLE
Plugin Details: allow new plugins without reviews to be shown.

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -175,7 +175,8 @@ export function normalizePluginData( plugin, pluginData ) {
 				const cleanItem = {};
 				for ( const sectionKey of Object.keys( item ) ) {
 					if ( ! item[ sectionKey ] ) {
-						throw new Error( `Section expected for key ${ sectionKey }` );
+						// The current section hasn't value or is empty.
+						continue;
 					}
 					cleanItem[ sectionKey ] = sanitizeSectionContent( item[ sectionKey ] );
 				}
@@ -228,7 +229,6 @@ export function normalizePluginsList( pluginsList ) {
  * @param  {Array} logs      List of all notices
  * @param  {number} siteId   Site Object
  * @param  {string} pluginId Plugin ID
- *
  * @returns {Array} Array of filtered logs that match the criteria
  */
 export function filterNotices( logs, siteId, pluginId ) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request

All new plugins don't have or they might even lack other sections data 

![SS 2021-11-12 at 19 41 58](https://user-images.githubusercontent.com/12430020/141511071-37b09946-390e-4784-8aa6-03671112597a.png)

Instead of throwing an error which was resulting in an error inside a try-catch block and the plugin data not being added in the state, let's just ignore that specific empty section.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**In production**
* Go to https://wordpress.com/plugins/
* Click on any new plugin
* Plugin Details page won't load

Repeat in this branch and make sure that plugin details pages are loading.

FYI: this was happening for ages ;-) 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
