### PR TITLE
Update styling in Calypso blue activity log

### DIFF
--- a/client/components/jetpack-colophon/style.scss
+++ b/client/components/jetpack-colophon/style.scss
@@ -11,6 +11,7 @@
 		fill: currentColor;
 	}
 	@include breakpoint-deprecated( '<660px' ) {
+		font-size: $font-body-small;
 		margin-bottom: 24px;
 	}
 }

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -68,14 +68,15 @@
 	align-self: flex-start;
 	width: 52px;
 	margin: 1px 22px 0 10px;
-	padding: 4px 0 6px;
+	padding: 8px 0 6px;
 	background: var( --color-surface-backdrop );
+	line-height: 1;
 	text-align: center;
 	z-index: 1;
 
 	@include breakpoint-deprecated( '<480px' ) {
 		width: 40px;
-		margin: -2px 8px 0 0;
+		margin: 0 8px 0 0;
 	}
 
 	.is-loading & {
@@ -105,7 +106,7 @@
 	display: flex;
 	width: 24px;
 	height: 24px;
-	margin-top: 2px;
+	margin-top: 4px;
 	padding: 12px;
 	background: var( --color-neutral-20 );
 	color: var( --color-text-inverted );
@@ -311,6 +312,10 @@
 	@include breakpoint-deprecated( '<960px' ) {
 		margin-top: 8px;
 	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		margin-top: 12px;
+	}
 }
 
 .activity-log-item__description-content {
@@ -319,14 +324,38 @@
 	.activity-log-item.is-aggregated & {
 		margin-bottom: 0;
 	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		font-size: $font-body;
+	}
 }
 
 .activity-log-item__action {
 	display: flex;
+	flex-wrap: wrap;
 
 	@include breakpoint-deprecated( '<480px' ) {
-		margin-top: 16px;
+		margin-top: 12px;
 		text-align: left;
+	}
+
+	.button {
+		margin-top: 4px;
+		margin-bottom: 4px;
+	}
+
+	.button.is-compact {
+		display: flex;
+		align-items: center;
+
+		line-height: 1.2;
+		text-align: left;
+
+		.gridicon {
+			position: static;
+
+			margin: 0 0.5rem 0 0;
+		}
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the styling of various items in the Calypso blue activity log.

Fixes 1164141197617539-as-1201316822000563

### Testing instructions
- Download the PR and run Calypso blue
- Select a Jetpack site
- Visit `http://jetpack.cloud.localhost:3000/activity-log/<site>`

#### All viewports
1. Check that action buttons are aligned left, and centered horizontally

_Before_
<img width="246" alt="Screen Shot 2021-11-12 at 12 52 00 PM" src="https://user-images.githubusercontent.com/1620183/141514815-2c9ec1ae-02a0-48bd-b8b5-38137c7ba9dd.png">

_After_
<img width="298" alt="Screen Shot 2021-11-12 at 1 13 19 PM" src="https://user-images.githubusercontent.com/1620183/141514961-ebd32b94-aefd-4a1f-83fc-35817a5c3403.png">

2. Check that the time is aligned with the top of the card

_Before_
<img width="153" alt="Screen Shot 2021-11-12 at 12 42 04 PM" src="https://user-images.githubusercontent.com/1620183/141515060-6b1bcf8d-ece3-443e-a7c8-89f932762861.png">

_After_
<img width="125" alt="Screen Shot 2021-11-12 at 12 46 27 PM" src="https://user-images.githubusercontent.com/1620183/141515075-7ec9d1c7-749c-4574-a693-c28f759e01b0.png">

#### Mobile only

3. Check that "powered by" in the footer is smaller on mobile

_Before_
<img width="434" alt="Screen Shot 2021-11-12 at 12 37 31 PM" src="https://user-images.githubusercontent.com/1620183/141514685-a07fe14b-4915-4c03-b6e8-0d85d3d1c10f.png">
_After_
<img width="433" alt="Screen Shot 2021-11-12 at 12 41 23 PM" src="https://user-images.githubusercontent.com/1620183/141514705-903ab9ae-103a-403f-92ab-f986ed175000.png">

4. Check that the card main description is bigger, and that there's more spacing with the avatar above

_Before_
<img width="380" alt="Screen Shot 2021-11-12 at 12 46 51 PM" src="https://user-images.githubusercontent.com/1620183/141515229-90e29b5a-3c53-43c5-8657-2bfdb6b93d55.png">

_After_
<img width="375" alt="Screen Shot 2021-11-12 at 12 50 32 PM" src="https://user-images.githubusercontent.com/1620183/141515247-03f68a48-3daa-4aa6-a6da-46c05a8ab5b7.png">

