### PR TITLE
Adjust styling of activity log restore banner controls on mobile

### DIFF
--- a/client/my-sites/activity/activity-log-banner/style.scss
+++ b/client/my-sites/activity/activity-log-banner/style.scss
@@ -56,6 +56,18 @@
 	margin-bottom: 8px;
 	font-weight: 600;
 }
+
+.activity-log-banner__controls {
+	@include breakpoint-deprecated( '<480px' ) {
+		display: flex;
+		flex-wrap: wrap;
+
+		> .button {
+			flex: 1;
+		}
+	}
+}
+
 .activity-log-banner__action {
 	width: 50px;
 }

--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -137,19 +137,21 @@ class SuccessBanner extends PureComponent {
 			>
 				{ params.track }
 				<p>{ params.taskFinished }</p>
-				{ params.actionButton }
-				{ ! backupUrl && (
-					<Button className="activity-log-banner__success-gotit" onClick={ this.handleDismiss }>
-						{ translate( 'Thanks, got it!' ) }
-					</Button>
-				) }
-				<HappychatButton
-					className="activity-log-banner__happychat-button"
-					onClick={ params.trackHappyChat }
-				>
-					<Gridicon icon="chat" />
-					<span>{ translate( 'Get help' ) }</span>
-				</HappychatButton>
+				<div className="activity-log-banner__controls">
+					{ params.actionButton }
+					{ ! backupUrl && (
+						<Button className="activity-log-banner__success-gotit" onClick={ this.handleDismiss }>
+							{ translate( 'Thanks, got it!' ) }
+						</Button>
+					) }
+					<HappychatButton
+						className="activity-log-banner__happychat-button"
+						onClick={ params.trackHappyChat }
+					>
+						<Gridicon icon="chat" />
+						<span>{ translate( 'Get help' ) }</span>
+					</HappychatButton>
+				</div>
 			</ActivityLogBanner>
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adjusts the styling of the controls in the activity log restore banner, on mobile.

Fixes 1164141197617539-as-1201316822000570

### Testing instructions
- Download the PR and run Calypso blue
- Select a Jetpack site that has backups
- Restore the site to a previous point in time
- Visit `http://jetpack.cloud.localhost:3000/activity-log/<site>`
- You should see a banner at the top of the page
- Check that it looks like the capture below on mobile

### Screenshots

_Before_

<img width="431" alt="Screen Shot 2021-11-12 at 1 27 31 PM" src="https://user-images.githubusercontent.com/1620183/141518652-f80684b3-35bd-4663-addf-557b64bca6fb.png">

_After
<img width="428" alt="Screen Shot 2021-11-12 at 1 40 30 PM" src="https://user-images.githubusercontent.com/1620183/141518665-896eba1e-c2b9-41ee-a5af-a34c8eec1ceb.png">
_
