### PR TITLE
Section nav: increase bottom margin on mobile

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -29,10 +29,6 @@
 			padding-right: 50px;
 		}
 	}
-
-	@include breakpoint-deprecated( '<660px' ) {
-		margin-bottom: 9px;
-	}
 }
 
 .section-nav__mobile-header {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR increases the bottom margin of the section nav element, on mobile and across Calypso.

### Testing instructions

- Download the PR and run Calypso blue
- Visit, for instance, the Scan section on mobile (`http://calypso.localhost:3000/scan/<site>`)
- Check that the bottom margin of the nav section element is bigger, as seen below

### Screenshots

#### Before
<img width="383" alt="Screen Shot 2021-11-12 at 2 03 12 PM" src="https://user-images.githubusercontent.com/1620183/141521311-67cfc887-3896-452b-9e34-81d6ab4c75bd.png">

#### After
<img width="386" alt="Screen Shot 2021-11-12 at 2 02 12 PM" src="https://user-images.githubusercontent.com/1620183/141521320-c516ecee-e655-4eab-aca4-5d81bbd90157.png">
