### PR TITLE
Adjust Backup section styles on mobile

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -9,6 +9,7 @@ import {
 	GROUP_WPCOM,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
+import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import { size } from 'lodash';
 import PropTypes from 'prop-types';
@@ -157,7 +158,7 @@ export class Banner extends Component {
 		if ( iconPath ) {
 			iconComponent = <img src={ iconPath } alt="" />;
 		} else {
-			iconComponent = <Gridicon icon={ icon || 'star' } size={ 18 } />;
+			iconComponent = <Gridicon icon={ icon || 'star' } size={ isMobile() ? 24 : 18 } />;
 		}
 
 		return (

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -2,7 +2,8 @@
 	border-left: 3px solid;
 	cursor: default;
 	display: flex;
-	padding: 12px 6px 12px 12px;
+	align-items: flex-start;
+	padding: 12px;
 	line-height: 29px;
 
 	&.is-dismissible {
@@ -22,7 +23,7 @@
 
 	@include banner-color( var( --color-accent ) );
 
-	&.is-jetpack:not(.is-atomic) {
+	&.is-jetpack:not( .is-atomic ) {
 		@include banner-color( var( --color-jetpack ) );
 	}
 
@@ -48,6 +49,8 @@
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
+		align-items: center;
+
 		padding: 12px 16px;
 
 		&.is-dismissible {
@@ -72,7 +75,7 @@
 		border-radius: 50%;
 		flex-shrink: 0;
 		height: 24px;
-		margin-right: 16px;
+		margin-right: 12px;
 		width: 24px;
 		align-items: center;
 		justify-content: center;
@@ -192,7 +195,7 @@
 .banner__action {
 	align-self: center;
 	font-size: $font-body-extra-small;
-	margin: 8px 0 0;
+	margin: 12px 0 0;
 	text-align: left;
 	width: 100%;
 
@@ -211,6 +214,13 @@
 
 		.has-call-to-action & .plan-price {
 			margin-bottom: 8px;
+		}
+	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		.button {
+			display: block;
+			flex: 1;
 		}
 	}
 

--- a/client/components/jetpack/daily-backup-status/style.scss
+++ b/client/components/jetpack/daily-backup-status/style.scss
@@ -55,6 +55,10 @@
 	font-weight: 600;
 	border-bottom: 1px solid var( --studio-gray-10 );
 	padding-bottom: 16px;
+
+	@include breakpoint-deprecated( '<480px' ) {
+		margin-top: 40px;
+	}
 }
 
 .daily-backup-status__section-header {
@@ -165,6 +169,10 @@
 	font-style: italic;
 	padding-top: 16px;
 	color: var( --studio-gray-40 );
+
+	@include breakpoint-deprecated( '<480px' ) {
+		margin-bottom: 8px;
+	}
 }
 
 .daily-backup-status__daily {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -78,6 +78,10 @@
 	&.banner.card {
 		@include banner-color( var( --color-jetpack ) );
 	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		margin-bottom: 16px;
+	}
 }
 
 /* WordPress.com-only styles */


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adjusts the styling of the Backup section on mobile.

### Testing instructions

- Download this PR and run Calypso
- Select a Jetpack site that doesn't have server credentials entered
- Visit `http://calypso.localhost:3000/backup/<site>`
- Check that the page looks the same for viewports wider than 480px
- Resize your browser to less than 480px wide and refresh the page
- Check that the changes shown below are applied

### Screenshots

_Before_
<img width="387" alt="Screen Shot 2021-11-12 at 2 21 54 PM" src="https://user-images.githubusercontent.com/1620183/141525718-e2dd4a14-a2ae-4d71-bcec-b5570d4f2966.png">
<img width="204" alt="Screen Shot 2021-11-12 at 2 39 01 PM" src="https://user-images.githubusercontent.com/1620183/141525720-654d5b24-bc7b-4c95-8a22-c0968b0f820f.png">

_After_

Spacing is a bit bigger
![1](https://user-images.githubusercontent.com/1620183/141525887-8a53ff93-06c0-46ae-a6af-bea53cfefe9f.png)

Button is full width, icon bigger and aligned with the top, and spacing a bit bigger
![2](https://user-images.githubusercontent.com/1620183/141526129-aa10c80f-0068-4bcd-8b7f-0928ecff2952.png)


