### PR TITLE
Plans: Move CRM and Free cards into 3-column layout

### DIFF
--- a/client/components/jetpack/card/product-without-price/style.scss
+++ b/client/components/jetpack/card/product-without-price/style.scss
@@ -119,35 +119,3 @@
 		margin: 16px;
 	}
 }
-
-.jetpack-plans__iteration--only-realtime-products .product-without-price {
-	@include breakpoint-deprecated( '>660px' ) {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		grid-column-gap: 32px;
-
-		.product-without-price__title {
-			grid-row: 1;
-			grid-column: 1 / span 2;
-			margin-block-end: initial;
-		}
-
-		.product-without-price__button {
-			grid-row: 3;
-			grid-column: 1;
-			margin: initial;
-			align-self: flex-end;
-		}
-
-		.product-without-price__subheadline {
-			grid-row: 2;
-			grid-column: 2;
-		}
-
-		.product-without-price__features-list {
-			grid-row: 3;
-			grid-column: 2;
-			margin: 0 0 0 16px;
-		}
-	}
-}

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/style.scss
@@ -1,26 +1,34 @@
-.jetpack-crm-free-card.with-price {
-	.display-price {
-		min-height: 133px;
+.jetpack-plans__iteration--only-realtime-products {
+	.jetpack-free-card .display-price__price-free {
+		padding-block-start: 24px;
 	}
 
-	.display-price__above-price-text {
-		display: block;
-		margin-inline-start: 2px;
-		margin-block-start: 38px;
-
-		font-size: 1rem;
-		font-weight: 700;
-
-		// Adjust leading margin so that different UI fonts
-		// still align to the price the same way
-		&.is-jetpack-cloud {
-			margin-inline-start: 4px;
+	.jetpack-crm-free-card,
+	.jetpack-free-card {
+		.display-price {
+			min-height: 133px;
+			margin-block-start: 38px;
 		}
-	}
 
-	.display-price__price-free {
-		line-height: $font-headline-medium;
-		letter-spacing: -2px;
+		.display-price__above-price-text {
+			display: block;
+			margin-inline-start: 2px;
+
+			font-size: 1rem;
+			font-weight: 700;
+
+			// Adjust leading margin so that different UI fonts
+			// still align to the price the same way
+			&.is-jetpack-cloud {
+				margin-inline-start: 4px;
+			}
+		}
+
+		.display-price__price-free {
+			display: block;
+			line-height: $font-headline-medium;
+			letter-spacing: -2px;
+		}
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
@@ -1,40 +1,18 @@
-import { useTranslate } from 'i18n-calypso';
-import { FC, useMemo } from 'react';
-import ProductCardWithoutPrice from 'calypso/components/jetpack/card/product-without-price';
-import useJetpackFreeButtonProps from './use-jetpack-free-button-props';
-import type { JetpackFreeProps } from 'calypso/my-sites/plans/jetpack-plans/types';
+import {
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
+import CardWithPrice, { CardWithPriceProps } from './with-price';
+import CardWithoutPrice, { CardWithoutPriceProps } from './without-price';
 
-const JetpackFreeCard: FC< JetpackFreeProps > = ( { fullWidth, siteId, urlQueryArgs } ) => {
-	const translate = useTranslate();
-	const { href: buttonHref, onClick: onButtonClick } = useJetpackFreeButtonProps(
-		siteId,
-		urlQueryArgs
-	);
+const Wrapper: React.FC< CardWithPriceProps | CardWithoutPriceProps > = ( props ) => {
+	return getForCurrentCROIteration( ( iteration: Iterations ) => {
+		if ( iteration === Iterations.ONLY_REALTIME_PRODUCTS ) {
+			return <CardWithPrice { ...props } />;
+		}
 
-	const features = useMemo(
-		() => [
-			translate( 'Brute force attack protection' ),
-			translate( 'Site stats' ),
-			translate( 'Content Delivery Network' ),
-		],
-		[ translate ]
-	);
-
-	return (
-		<ProductCardWithoutPrice
-			fullWidth={ fullWidth }
-			className="jetpack-free-card"
-			productSlug="free"
-			displayName={ translate( 'Jetpack Free' ) }
-			description={ translate(
-				'Power up your WordPress site with essential security and performance features.'
-			) }
-			productFeatures={ features }
-			buttonHref={ buttonHref }
-			onButtonClick={ onButtonClick }
-			buttonLabel={ translate( 'Start for free' ) }
-		/>
-	);
+		return <CardWithoutPrice { ...props } />;
+	} );
 };
 
-export default JetpackFreeCard;
+export default Wrapper;

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/with-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/with-price.tsx
@@ -1,0 +1,57 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC, useMemo } from 'react';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
+import useJetpackFreeButtonProps from './use-jetpack-free-button-props';
+import type { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+export type CardWithPriceProps = {
+	siteId: number | null;
+	urlQueryArgs: QueryArgs;
+};
+
+const useFreeItem = () => {
+	const translate = useTranslate();
+
+	return useMemo(
+		() => ( {
+			isFree: true,
+			displayName: translate( 'Jetpack Free' ),
+			features: {
+				items: [
+					{ text: translate( 'Brute force attack protection' ) },
+					{ text: translate( 'Site stats' ) },
+					{ text: translate( 'Content Delivery Network' ) },
+				],
+			},
+		} ),
+		[ translate ]
+	);
+};
+
+const JetpackFreeCard: FC< CardWithPriceProps > = ( { siteId, urlQueryArgs } ) => {
+	const translate = useTranslate();
+	const freeProduct = useFreeItem();
+
+	const { href: buttonHref, onClick: onButtonClick } = useJetpackFreeButtonProps(
+		siteId,
+		urlQueryArgs
+	);
+
+	return (
+		<JetpackProductCard
+			className="jetpack-free-card"
+			hideSavingLabel
+			buttonPrimary
+			item={ freeProduct }
+			headerLevel={ 3 }
+			description={ translate(
+				'Power up your WordPress site with essential security and performance features.'
+			) }
+			buttonLabel={ translate( 'Start for free' ) }
+			buttonURL={ buttonHref }
+			onButtonClick={ onButtonClick }
+		/>
+	);
+};
+
+export default JetpackFreeCard;

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/without-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/without-price.tsx
@@ -1,0 +1,42 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC, useMemo } from 'react';
+import ProductCardWithoutPrice from 'calypso/components/jetpack/card/product-without-price';
+import useJetpackFreeButtonProps from './use-jetpack-free-button-props';
+import type { JetpackFreeProps } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+export type CardWithoutPriceProps = JetpackFreeProps;
+
+const JetpackFreeCard: FC< CardWithoutPriceProps > = ( { fullWidth, siteId, urlQueryArgs } ) => {
+	const translate = useTranslate();
+	const { href: buttonHref, onClick: onButtonClick } = useJetpackFreeButtonProps(
+		siteId,
+		urlQueryArgs
+	);
+
+	const features = useMemo(
+		() => [
+			translate( 'Brute force attack protection' ),
+			translate( 'Site stats' ),
+			translate( 'Content Delivery Network' ),
+		],
+		[ translate ]
+	);
+
+	return (
+		<ProductCardWithoutPrice
+			fullWidth={ fullWidth }
+			className="jetpack-free-card"
+			productSlug="free"
+			displayName={ translate( 'Jetpack Free' ) }
+			description={ translate(
+				'Power up your WordPress site with essential security and performance features.'
+			) }
+			productFeatures={ features }
+			buttonHref={ buttonHref }
+			onButtonClick={ onButtonClick }
+			buttonLabel={ translate( 'Start for free' ) }
+		/>
+	);
+};
+
+export default JetpackFreeCard;

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -1,13 +1,10 @@
 import {
-	PLAN_JETPACK_FREE,
-	JETPACK_CRM_FREE_PRODUCTS,
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	PLAN_JETPACK_SECURITY_T1_YEARLY,
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
-	PRODUCT_JETPACK_CRM_FREE,
 } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -27,7 +24,6 @@ import PlanUpgradeSection from '../plan-upgrade';
 import PlansFilterBar from '../plans-filter-bar';
 import ProductCard from '../product-card';
 import { getProductPosition } from '../product-grid/products-order';
-import slugToSelectorProduct from '../slug-to-selector-product';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import ProductGridSection from './section';
 import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from './utils';
@@ -126,10 +122,6 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	}, [ duration, currentPlanSlug, translate ] );
 
 	const { shouldWrap: shouldWrapGrid, gridRef } = useWrapGridForSmallScreens( 3 );
-	const {
-		shouldWrap: shouldWrapOtherItems,
-		gridRef: otherItemsGridRef,
-	} = useWrapGridForSmallScreens( 3 );
 	const { availableProducts, purchasedProducts, includedInPlanProducts } = useGetPlansGridProducts(
 		siteId
 	);
@@ -180,41 +172,19 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		],
 	} ) ?? [ PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_SECURITY_DAILY_MONTHLY ];
 
-	const getOtherItemsProductCard = ( product: SelectorProduct ) => {
-		if ( PLAN_JETPACK_FREE === product.productSlug ) {
-			return showFreeCard ? (
-				<li key={ product.productSlug }>
-					<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
-				</li>
-			) : undefined;
-		}
-
-		if ( JETPACK_CRM_FREE_PRODUCTS.includes( product.productSlug ) ) {
-			return (
-				<li key={ product.productSlug }>
-					<JetpackCrmFreeCard
-						fullWidth={ ! showFreeCard }
-						siteId={ siteId }
-						duration={ duration }
-					/>
-				</li>
-			);
-		}
-
-		return (
-			<li key={ product.iconSlug }>
-				<ProductCard
-					item={ product }
-					onClick={ onSelectProduct }
-					siteId={ siteId }
-					currencyCode={ currencyCode }
-					selectedTerm={ duration }
-					scrollCardIntoView={ scrollCardIntoView }
-					createButtonURL={ createButtonURL }
-				/>
-			</li>
-		);
-	};
+	const getOtherItemsProductCard = ( product: SelectorProduct ) => (
+		<li key={ product.iconSlug }>
+			<ProductCard
+				item={ product }
+				onClick={ onSelectProduct }
+				siteId={ siteId }
+				currencyCode={ currencyCode }
+				selectedTerm={ duration }
+				scrollCardIntoView={ scrollCardIntoView }
+				createButtonURL={ createButtonURL }
+			/>
+		</li>
+	);
 
 	return (
 		<>
@@ -265,30 +235,19 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 			<ProductGridSection title={ translate( 'More Products' ) }>
 				{ getForCurrentCROIteration( {
 					[ Iterations.ONLY_REALTIME_PRODUCTS ]: (
-						<>
-							<ul className="product-grid__product-grid" ref={ otherItemsGridRef }>
-								{ otherItems
-									.slice( 0, shouldWrapOtherItems ? undefined : 3 )
-									.map( getOtherItemsProductCard ) }
-							</ul>
-							{ ! shouldWrapOtherItems && (
-								<>
-									<ul className="product-grid__product-grid second-grid">
-										{ [ ...otherItems, slugToSelectorProduct( PRODUCT_JETPACK_CRM_FREE ) ]
-											.slice( 3, 5 )
-											.map( getOtherItemsProductCard ) }
-									</ul>
-								</>
-							) }
-							<div className="product-grid__free">
-								{ shouldWrapOtherItems && (
-									<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
-								) }
-								{ showFreeCard && (
+						<ul className="product-grid__product-grid">
+							{ otherItems.map( getOtherItemsProductCard ) }
+
+							<li>
+								<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
+							</li>
+
+							{ showFreeCard && (
+								<li>
 									<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
-								) }
-							</div>
-						</>
+								</li>
+							) }
+						</ul>
 					),
 				} ) ?? (
 					<>


### PR DESCRIPTION
Resolves `1200412004370260-as-1201368103210886`.

#### Changes proposed in this Pull Request

* Update pricing grid so that Jetpack CRM and Jetpack Free appear as "normal" cards, with no special width or layout rules to separate them on the page.

#### Testing instructions

1. In Calypso Blue and/or Green, visit the pricing page.
2. Verify the Jetpack CRM card (and the Jetpack Free card, if present) flows as part of the same grid as the other product upgrades. Test various screen widths to ensure the page reflows smoothly.
3. Verify the "Free" price display is visible on the Jetpack Free card, and that its elements all align with their counterparts on the CRM card.

#### Reference screenshots

<img height="275" alt="Screen Shot 2021-11-12 at 13 19 55" src="https://user-images.githubusercontent.com/670067/141527292-8533783d-1ab6-472a-9250-20ca5f2a73a8.png"> <img height="275" alt="Screen Shot 2021-11-12 at 13 19 32" src="https://user-images.githubusercontent.com/670067/141527290-d0a85cc9-5da6-45a7-a68b-0a79e191502d.png"> <img height="275" alt="Screen Shot 2021-11-12 at 13 19 07" src="https://user-images.githubusercontent.com/670067/141527287-728979aa-6a5e-4e19-97cb-d1bf520e55de.png">

<img height="275" alt="Screen Shot 2021-11-12 at 13 29 59" src="https://user-images.githubusercontent.com/670067/141527296-043c9975-cbe5-4d3a-b930-f372632e24f4.png"> <img height="275" alt="Screen Shot 2021-11-12 at 13 29 36" src="https://user-images.githubusercontent.com/670067/141527295-5ac513af-bfaa-416f-8eb2-e82816ed4453.png"> <img height="275" alt="Screen Shot 2021-11-12 at 13 28 53" src="https://user-images.githubusercontent.com/670067/141527293-1761e54c-fbf0-4911-b110-ec131cb31aff.png">