### PR TITLE
Domains: Add navigation header again to DNS records page

### DIFF
--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -79,13 +79,6 @@ class Dns extends Component {
 		);
 	}
 
-	renderHeader() {
-		const { translate, selectedDomainName } = this.props;
-		<Header onClick={ this.goBack } selectedDomainName={ selectedDomainName }>
-			{ translate( 'DNS Records' ) }
-		</Header>;
-	}
-
 	renderBreadcrumbs() {
 		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
 
@@ -135,7 +128,7 @@ class Dns extends Component {
 	}
 
 	renderMain() {
-		const { dns, selectedDomainName, selectedSite } = this.props;
+		const { dns, selectedDomainName, selectedSite, translate } = this.props;
 		const domain = getSelectedDomain( this.props );
 		const hasWpcomNameservers = domain?.hasWpcomNameservers ?? false;
 		const domainConnectEnabled = some( dns.records, {
@@ -146,9 +139,9 @@ class Dns extends Component {
 
 		return (
 			<Main wideLayout className="dns">
-				{ config.isEnabled( 'domains/dns-records-redesign' )
-					? this.renderBreadcrumbs()
-					: this.renderHeader() }
+				<Header onClick={ this.goBack } selectedDomainName={ selectedDomainName }>
+					{ translate( 'DNS Records' ) }
+				</Header>
 				<Card>
 					<DnsDetails />
 					<DnsList


### PR DESCRIPTION
### Changes proposed in this Pull Request

#57328 added feature toggling in the DNS records page to show either the new breadcrumbs component or the old navigation header. However, in the old component case, the component was not being returned by the method and so was not being rendered - this PR fixes this. This addresses issue #58017.

This is the header that was missing:

![Annotation on 2021-11-12 at 19-19-46](https://user-images.githubusercontent.com/5324818/141542009-c2bd64c9-8f52-4fd6-a4be-f976230086d1.png)

### Testing instructions

- Open the live Calypso link
- Navigate to "Upgrades > Domains"
- Select a domain
- Select "Change your name servers & DNS records"
- Click "DNS records"
- Ensure the page has the header highlighted in the screenshot above