### PR TITLE
Jetpack Search: update section styling

### DIFF
--- a/client/my-sites/jetpack-search/content.tsx
+++ b/client/my-sites/jetpack-search/content.tsx
@@ -52,7 +52,7 @@ const JetpackSearchContent: FunctionComponent< Props > = ( {
 				<div className="jetpack-search__content">
 					{ iconComponent }
 					{ headerText && <h1 className="jetpack-search__header">{ headerText }</h1> }
-					<p>{ translate( 'Your visitors are getting our fastest search experience.' ) }</p>
+					<p>{ bodyText }</p>
 					<Button
 						primary
 						className="jetpack-search__button"

--- a/client/my-sites/jetpack-search/content.tsx
+++ b/client/my-sites/jetpack-search/content.tsx
@@ -1,9 +1,8 @@
+import { Button, Card } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent, ReactNode, Fragment } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackUpsell from 'calypso/components/jetpack/upsell';
-import PromoCard from 'calypso/components/promo-section/promo-card';
-import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 interface Props {
@@ -49,20 +48,21 @@ const JetpackSearchContent: FunctionComponent< Props > = ( {
 				align="left"
 				brandFont
 			/>
-			<PromoCard title={ headerText } image={ iconComponent } isPrimary>
-				<p className="jetpack-search__content-body-text">{ bodyText }</p>
-
-				<PromoCardCTA
-					cta={ {
-						text: buttonText,
-						action: {
-							url: buttonLink,
-							onClick: onClick ? onClick : null,
-							selfTarget: true,
-						},
-					} }
-				/>
-			</PromoCard>
+			<Card>
+				<div className="jetpack-search__content">
+					{ iconComponent }
+					{ headerText && <h1 className="jetpack-search__header">{ headerText }</h1> }
+					<p>{ translate( 'Your visitors are getting our fastest search experience.' ) }</p>
+					<Button
+						primary
+						className="jetpack-search__button"
+						href={ buttonLink as string }
+						onClick={ onClick || undefined }
+					>
+						{ buttonText }
+					</Button>
+				</div>
+			</Card>
 		</Fragment>
 	);
 };

--- a/client/my-sites/jetpack-search/style.scss
+++ b/client/my-sites/jetpack-search/style.scss
@@ -1,12 +1,25 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.jetpack-search .formatted-header.is-left-align {
+	margin-top: 20px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-top: 4px;
+		margin-bottom: 18px;
+	}
+}
+
 .jetpack-search__placeholder {
-	.action-panel__title, .jetpack-search__content-body-text, .promo-card__cta-button, .upsell__header-text, .upsell__body-text {
+	.jetpack-search__header,
+	.jetpack-search__content p,
+	.jetpack-search__button,
+	.upsell__header-text,
+	.upsell__body-text {
 		@include placeholder( --color-neutral-10 );
 	}
 
-	.promo-card__cta-button {
+	.jetpack-search__button {
 		border: 0;
 
 		&:hover {
@@ -26,13 +39,56 @@
 }
 
 .jetpack-search__logo {
+	text-align: center;
 
-	@include break-xlarge() {
-		margin-right: 48px;
+	@include breakpoint-deprecated( '>660px' ) {
+		text-align: left;
 	}
-	
+
 	img {
 		height: 72px;
 		width: auto;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-left: -14px;
+		}
+	}
+}
+
+.jetpack-search__header {
+	color: var( --studio-black );
+	font-size: $font-title-medium;
+	font-weight: 600;
+	line-height: 1;
+	margin: 16px 0;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		font-size: $font-headline-small;
+		margin: 20px 0 24px;
+	}
+}
+
+.jetpack-search__content {
+	flex: 1 0 auto;
+
+	p {
+		font-size: $font-body;
+		margin-bottom: 16px;
+		line-height: 24px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-bottom: 24px;
+		}
+	}
+}
+
+.jetpack-search__button {
+	margin: 16px 0;
+	width: 100%;
+	text-align: center;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		width: auto;
+		text-align: left;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the styles of the Jetpack Search section to match Scan.

### Testing instructions

- Download this PR and run Calypso
- Select a Jetpack site that has access to Search
- Visit `http://calypso.localhost:3000/jetpack-search/<site>`
- Check that the section looks like the captures below on both mobile and desktop

### Screenshots

_Before_
<img width="806" alt="Screen Shot 2021-11-12 at 5 55 14 PM" src="https://user-images.githubusercontent.com/1620183/141593833-ce2344bb-c812-4c18-b31c-2d9e624d3116.png">
<img width="242" alt="Screen Shot 2021-11-12 at 5 59 03 PM" src="https://user-images.githubusercontent.com/1620183/141593835-b66215fd-7e27-4fa1-ab4f-6c908fd8fed9.png">

_After_
<img width="810" alt="Screen Shot 2021-11-12 at 5 58 18 PM" src="https://user-images.githubusercontent.com/1620183/141593846-e9549faf-e0d1-46fc-8de8-c575685022e5.png">
<img width="242" alt="Screen Shot 2021-11-12 at 6 01 54 PM" src="https://user-images.githubusercontent.com/1620183/141593849-3da31852-2e77-44aa-ad4f-abaa6dc7f6ac.png">

