### PR TITLE
Domains: Add functionality to edit DNS records

### DIFF
--- a/client/my-sites/domains/domain-management/README.md
+++ b/client/my-sites/domains/domain-management/README.md
@@ -9,6 +9,7 @@ Supported routes:
 - `/domains/manage/:domain/contacts-privacy/:site` - displays contacts and privacy information for a domain
 - `/domains/manage/:domain/dns/:site` - manages DNS records for a domain
 - `/domains/manage/:domain/add-dns-record/:site` - add new DNS record for a domain
+- `/domains/manage/:domain/edit-dns-record/:site` - update DNS record for a domain
 - `/domains/manage/:domain/edit/:site` - displays domain details
 - `/domains/manage/:domain/edit-contact-info/:site` - manages contact information for a domain
 - `/domains/manage/:domain/name-servers/:site` - manages name servers for a domain

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -7,6 +7,7 @@ import {
 	domainManagementContactsPrivacy,
 	domainManagementDns,
 	domainManagementDnsAddRecord,
+	domainManagementDnsEditRecord,
 	domainManagementEdit,
 	domainManagementEditContactInfo,
 	domainManagementList,
@@ -212,6 +213,19 @@ export default {
 			<DomainManagementData
 				analyticsPath={ domainManagementDnsAddRecord( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Name Servers and DNS > DNS Records > Add a record"
+				component={ DomainManagement.AddDnsRecord }
+				context={ pageContext }
+				selectedDomainName={ pageContext.params.domain }
+			/>
+		);
+		next();
+	},
+
+	domainManagementDnsEditRecord( pageContext, next ) {
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementDnsEditRecord( ':site', ':domain' ) }
+				analyticsTitle="Domain Management > Name Servers and DNS > DNS Records > Edit record"
 				component={ DomainManagement.AddDnsRecord }
 				context={ pageContext }
 				selectedDomainName={ pageContext.params.domain }

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -34,7 +34,7 @@ class AddDnsRecord extends Component {
 	getRecordBeingEdited() {
 		const { dns } = this.props;
 		const searchParams = new URLSearchParams( window.location.search );
-		const recordId = searchParams.get( 'record' );
+		const recordId = searchParams.get( 'recordId' );
 
 		return recordId ? dns.records?.find( ( record ) => recordId === record.id ) : null;
 	}

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -24,7 +24,7 @@ import DnsAddNew from './dns-add-new';
 
 import './add-dns-record.scss';
 
-class AddDnsRecprd extends Component {
+class AddDnsRecord extends Component {
 	static propTypes = {
 		dns: PropTypes.object.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
@@ -169,4 +169,4 @@ export default connect(
 		};
 	},
 	{ successNotice, errorNotice, fetchDns }
-)( localize( AddDnsRecprd ) );
+)( localize( AddDnsRecord ) );

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -10,7 +10,6 @@ import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
-import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import {
 	domainManagementDns,
 	domainManagementEdit,
@@ -28,7 +27,6 @@ import './add-dns-record.scss';
 class AddDnsRecprd extends Component {
 	static propTypes = {
 		dns: PropTypes.object.isRequired,
-		showPlaceholder: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
@@ -132,16 +130,12 @@ class AddDnsRecprd extends Component {
 	}
 
 	render() {
-		const { showPlaceholder, selectedDomainName } = this.props;
+		const { selectedDomainName } = this.props;
 
 		return (
 			<Fragment>
 				<QueryDomainDns domain={ selectedDomainName } />
-				{ showPlaceholder ? (
-					<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
-				) : (
-					this.renderMain()
-				) }
+				{ this.renderMain() }
 			</Fragment>
 		);
 	}
@@ -151,12 +145,10 @@ export default connect(
 	( state, { selectedDomainName } ) => {
 		const selectedSite = getSelectedSite( state );
 		const dns = getDomainDns( state, selectedDomainName );
-		const showPlaceholder = false; // ! dns.hasLoadedFromServer;
 
 		return {
 			selectedSite,
 			dns,
-			showPlaceholder,
 			currentRoute: getCurrentRoute( state ),
 		};
 	},

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -109,7 +109,6 @@ class AddDnsRecprd extends Component {
 				},
 			}
 		);
-
 		const recordBeingEdited = this.getRecordBeingEdited();
 		const headerText = recordBeingEdited
 			? translate( 'Edit DNS record' )

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -31,8 +31,20 @@ class AddDnsRecprd extends Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
 
-	renderBreadcrumbs = () => {
+	getRecordBeingEdited() {
+		const { dns } = this.props;
+		const searchParams = new URLSearchParams( window.location.search );
+		const recordId = searchParams.get( 'record' );
+
+		if ( recordId ) {
+			return dns.records && dns.records.find( ( record ) => recordId === record.id );
+		}
+		return null;
+	}
+
+	renderBreadcrumbs() {
 		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
+		const recordBeingEdited = this.getRecordBeingEdited();
 
 		const items = [
 			{
@@ -48,7 +60,9 @@ class AddDnsRecprd extends Component {
 				href: domainManagementDns( selectedSite.slug, selectedDomainName ),
 			},
 			{
-				label: translate( 'Add a record', { comment: 'DNS record' } ),
+				label: recordBeingEdited
+					? translate( 'Edit record', { comment: 'DNS record' } )
+					: translate( 'Add a record', { comment: 'DNS record' } ),
 			},
 		];
 
@@ -96,16 +110,17 @@ class AddDnsRecprd extends Component {
 			}
 		);
 
+		const recordBeingEdited = this.getRecordBeingEdited();
+		const headerText = recordBeingEdited
+			? translate( 'Edit DNS record' )
+			: translate( 'Add a new DNS record' );
+
 		return (
 			<Main wideLayout className="add-dns-record">
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<div className="add-dns-record__fullwidth">
 					{ this.renderBreadcrumbs() }
-					<FormattedHeader
-						brandFont
-						headerText={ translate( 'Add a new DNS record' ) }
-						align="left"
-					/>
+					<FormattedHeader brandFont headerText={ headerText } align="left" />
 					<p className="add-dns-record__mobile-subtitle">{ mobileSubtitleText }</p>
 				</div>
 				<div className="add-dns-record__main">
@@ -113,6 +128,7 @@ class AddDnsRecprd extends Component {
 						isSubmittingForm={ dns.isSubmittingForm }
 						selectedDomainName={ selectedDomainName }
 						goBack={ this.goBack }
+						recordToEdit={ recordBeingEdited }
 					/>
 				</div>
 				<div className="add-dns-record__sidebar">

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -85,7 +85,7 @@ class AddDnsRecprd extends Component {
 	};
 
 	renderMain() {
-		const { dns, selectedDomainName, translate } = this.props;
+		const { dns, selectedDomainName, selectedSite, translate } = this.props;
 		const dnsSupportPageLink = (
 			<ExternalLink
 				href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) }
@@ -126,6 +126,7 @@ class AddDnsRecprd extends Component {
 					<DnsAddNew
 						isSubmittingForm={ dns.isSubmittingForm }
 						selectedDomainName={ selectedDomainName }
+						selectedSiteSlug={ selectedSite.slug }
 						goBack={ this.goBack }
 						recordToEdit={ recordBeingEdited }
 					/>

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -36,10 +36,7 @@ class AddDnsRecord extends Component {
 		const searchParams = new URLSearchParams( window.location.search );
 		const recordId = searchParams.get( 'record' );
 
-		if ( recordId ) {
-			return dns.records && dns.records.find( ( record ) => recordId === record.id );
-		}
-		return null;
+		return recordId ? dns.records?.find( ( record ) => recordId === record.id ) : null;
 	}
 
 	renderBreadcrumbs() {

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { includes, find, flatMap } from 'lodash';
 import page from 'page';
@@ -165,7 +166,9 @@ class DnsAddNew extends React.Component {
 				formState.getAllFieldValues( this.state.fields ),
 				selectedDomainName
 			);
-			this.formStateController.resetFields( this.getFieldsForType( this.state.type ) );
+			if ( ! config.isEnabled( 'domains/dns-records-redesign' ) ) {
+				this.formStateController.resetFields( this.getFieldsForType( this.state.type ) );
+			}
 
 			if ( recordToEdit ) {
 				this.props.updateDns( selectedDomainName, [ normalizedData ], [ recordToEdit ] ).then(

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -144,7 +144,7 @@ class DnsAddNew extends React.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( prevProps.recordToEdit !== this.props.recordToEdit ) {
+		if ( prevProps.recordToEdit !== this.props.recordToEdit && this.props.recordToEdit ) {
 			this.loadRecord();
 		}
 	}

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -141,6 +141,7 @@ class DnsAddNew extends React.Component {
 			return obj;
 		}, {} );
 
+		this.setState( { type: recordToEdit.type } );
 		this.formStateController.resetFields( recordAttributes );
 	}
 

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -228,21 +228,22 @@ class DnsAddNew extends React.Component {
 		return ! formState.isFieldInvalid( this.state.fields, fieldName );
 	};
 
-	recordFields() {
-		return this.dnsRecords.map( ( dnsRecord ) => {
-			const { component: Component, types: showTypes } = dnsRecord;
+	renderFields() {
+		const selectedRecordType = this.dnsRecords.find( ( dnsRecord ) =>
+			dnsRecord.types.includes( this.state.fields.type.value )
+		);
 
-			return (
-				<Component
-					key={ showTypes.join( ',' ) }
+		return (
+			selectedRecordType && (
+				<selectedRecordType.component
 					selectedDomainName={ this.props.selectedDomainName }
-					show={ includes( showTypes, this.state.fields.type.value ) }
+					show={ true }
 					fieldValues={ formState.getAllFieldValues( this.state.fields ) }
 					isValid={ this.isValid }
 					onChange={ this.onChange }
 				/>
-			);
-		} );
+			)
+		);
 	}
 
 	render() {
@@ -273,7 +274,7 @@ class DnsAddNew extends React.Component {
 					</FormSelect>
 					<FormSettingExplanation>{ selectedType.description }</FormSettingExplanation>
 				</FormFieldset>
-				{ this.recordFields() }
+				{ this.renderFields() }
 				<div className="dns__form-buttons">
 					<FormButton disabled={ isSubmitDisabled } onClick={ this.onAddDnsRecord }>
 						{ buttonLabel }

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -154,9 +154,9 @@ class DnsAddNew extends React.Component {
 		this.setState( { fields } );
 	};
 
-	onAddDnsRecord = ( event ) => {
+	onAddOrUpdateDnsRecord = ( event ) => {
 		event.preventDefault();
-		const { recordToEdit, selectedDomainName, selectedSite, translate } = this.props;
+		const { recordToEdit, selectedDomainName, translate } = this.props;
 
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			if ( hasErrors ) {
@@ -173,34 +173,29 @@ class DnsAddNew extends React.Component {
 
 			if ( recordToEdit ) {
 				this.props.updateDns( selectedDomainName, [ normalizedData ], [ recordToEdit ] ).then(
-					() => {
-						page( domainManagementDns( selectedSite.slug, selectedDomainName ) );
-						this.props.successNotice( translate( 'The DNS record has been updated.' ), {
-							duration: 5000,
-						} );
-					},
-					( error ) => {
-						this.props.errorNotice(
-							error.message || translate( 'The DNS record has not been updated.' )
-						);
-					}
+					() => this.handleSuccess( translate( 'The DNS record has been updated.' ) ),
+					( error ) =>
+						this.handleError( error, translate( 'The DNS record has not been updated.' ) )
 				);
 				return;
 			}
 
 			this.props.addDns( selectedDomainName, normalizedData ).then(
-				() => {
-					page( domainManagementDns( selectedSite.slug, selectedDomainName ) );
-					this.props.successNotice( translate( 'The DNS record has been added.' ), {
-						duration: 5000,
-					} );
-				},
-				( error ) =>
-					this.props.errorNotice(
-						error.message || translate( 'The DNS record has not been added.' )
-					)
+				() => this.handleSuccess( translate( 'The DNS record has been added.' ) ),
+				( error ) => this.handleError( error, translate( 'The DNS record has not been added.' ) )
 			);
 		} );
+	};
+
+	handleSuccess = ( message ) => {
+		const { selectedSite, selectedDomainName } = this.props;
+
+		page( domainManagementDns( selectedSite.slug, selectedDomainName ) );
+		this.props.successNotice( message, { duration: 5000 } );
+	};
+
+	handleError = ( error, message ) => {
+		this.props.errorNotice( error.message || message );
 	};
 
 	onChange = ( event ) => {
@@ -277,7 +272,7 @@ class DnsAddNew extends React.Component {
 				</FormFieldset>
 				{ this.renderFields() }
 				<div className="dns__form-buttons">
-					<FormButton disabled={ isSubmitDisabled } onClick={ this.onAddDnsRecord }>
+					<FormButton disabled={ isSubmitDisabled } onClick={ this.onAddOrUpdateDnsRecord }>
 						{ buttonLabel }
 					</FormButton>
 

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -137,12 +137,27 @@ class DnsAddNew extends React.Component {
 
 		const selectedDnsRecordFields = this.getFieldsForType( recordToEdit.type );
 		const recordAttributes = Object.keys( selectedDnsRecordFields ).reduce( ( obj, field ) => {
-			obj[ field ] = recordToEdit[ field ];
+			obj[ field ] = this.getProcessedRecordValue( field );
 			return obj;
 		}, {} );
 
 		this.setState( { type: recordToEdit.type } );
 		this.formStateController.resetFields( recordAttributes );
+	}
+
+	getProcessedRecordValue( field ) {
+		const { recordToEdit } = this.props;
+
+		const isRootDomainRecord = recordToEdit.name === `${ recordToEdit.domain }.`;
+		if ( isRootDomainRecord && 'name' === field ) {
+			return '';
+		}
+
+		if ( [ 'data', 'target' ].includes( field ) && 'TXT' !== recordToEdit.type ) {
+			return recordToEdit[ field ].replace( /\.$/, '' );
+		}
+
+		return recordToEdit[ field ];
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -1,5 +1,6 @@
 import { localize } from 'i18n-calypso';
 import { includes, find, flatMap } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -9,6 +10,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import formState from 'calypso/lib/form-state';
+import { domainManagementDns } from 'calypso/my-sites/domains/paths';
 import { addDns } from 'calypso/state/domains/dns/actions';
 import { validateAllFields, getNormalizedData } from 'calypso/state/domains/dns/utils';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -22,6 +24,7 @@ class DnsAddNew extends React.Component {
 	static propTypes = {
 		isSubmittingForm: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
+		selectedSiteSlug: PropTypes.string,
 		goBack: PropTypes.func,
 		recordToEdit: PropTypes.object,
 	};
@@ -165,10 +168,12 @@ class DnsAddNew extends React.Component {
 			this.formStateController.resetFields( this.getFieldsForType( this.state.type ) );
 
 			this.props.addDns( this.props.selectedDomainName, normalizedData ).then(
-				() =>
+				() => {
+					page( domainManagementDns( this.props.selectedSiteSlug, this.props.selectedDomainName ) );
 					this.props.successNotice( translate( 'The DNS record has been added.' ), {
 						duration: 5000,
-					} ),
+					} );
+				},
 				( error ) =>
 					this.props.errorNotice(
 						error.message || translate( 'The DNS record has not been added.' )

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -224,21 +224,15 @@ class DnsAddNew extends React.Component {
 		return ! formState.isFieldInvalid( this.state.fields, fieldName );
 	};
 
-	renderFields() {
-		const selectedRecordType = this.dnsRecords.find( ( dnsRecord ) =>
-			dnsRecord.types.includes( this.state.fields.type.value )
-		);
-
+	renderFields( selectedRecordType ) {
 		return (
-			selectedRecordType && (
-				<selectedRecordType.component
-					selectedDomainName={ this.props.selectedDomainName }
-					show={ true }
-					fieldValues={ formState.getAllFieldValues( this.state.fields ) }
-					isValid={ this.isValid }
-					onChange={ this.onChange }
-				/>
-			)
+			<selectedRecordType.component
+				selectedDomainName={ this.props.selectedDomainName }
+				show={ true }
+				fieldValues={ formState.getAllFieldValues( this.state.fields ) }
+				isValid={ this.isValid }
+				onChange={ this.onChange }
+			/>
 		);
 	}
 
@@ -250,7 +244,7 @@ class DnsAddNew extends React.Component {
 			formState.isSubmitButtonDisabled( this.state.fields ) ||
 			this.props.isSubmittingForm ||
 			formState.hasErrors( this.state.fields );
-		const selectedType = this.dnsRecords.find( ( record ) =>
+		const selectedRecordType = this.dnsRecords.find( ( record ) =>
 			record.types.includes( this.state.type )
 		);
 		const buttonLabel = recordToEdit
@@ -268,9 +262,9 @@ class DnsAddNew extends React.Component {
 					>
 						{ options }
 					</FormSelect>
-					<FormSettingExplanation>{ selectedType.description }</FormSettingExplanation>
+					<FormSettingExplanation>{ selectedRecordType.description }</FormSettingExplanation>
 				</FormFieldset>
-				{ this.renderFields() }
+				{ selectedRecordType && this.renderFields( selectedRecordType ) }
 				<div className="dns__form-buttons">
 					<FormButton disabled={ isSubmitDisabled } onClick={ this.onAddOrUpdateDnsRecord }>
 						{ buttonLabel }

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -15,6 +15,7 @@ import { domainManagementDns } from 'calypso/my-sites/domains/paths';
 import { addDns, updateDns } from 'calypso/state/domains/dns/actions';
 import { validateAllFields, getNormalizedData } from 'calypso/state/domains/dns/utils';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ARecord from './a-record';
 import CnameRecord from './cname-record';
 import MxRecord from './mx-record';
@@ -25,7 +26,7 @@ class DnsAddNew extends React.Component {
 	static propTypes = {
 		isSubmittingForm: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
-		selectedSiteSlug: PropTypes.string,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		goBack: PropTypes.func,
 		recordToEdit: PropTypes.object,
 	};
@@ -155,7 +156,7 @@ class DnsAddNew extends React.Component {
 
 	onAddDnsRecord = ( event ) => {
 		event.preventDefault();
-		const { recordToEdit, selectedDomainName, selectedSiteSlug, translate } = this.props;
+		const { recordToEdit, selectedDomainName, selectedSite, translate } = this.props;
 
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			if ( hasErrors ) {
@@ -173,7 +174,7 @@ class DnsAddNew extends React.Component {
 			if ( recordToEdit ) {
 				this.props.updateDns( selectedDomainName, [ normalizedData ], [ recordToEdit ] ).then(
 					() => {
-						page( domainManagementDns( selectedSiteSlug, selectedDomainName ) );
+						page( domainManagementDns( selectedSite.slug, selectedDomainName ) );
 						this.props.successNotice( translate( 'The DNS record has been updated.' ), {
 							duration: 5000,
 						} );
@@ -189,7 +190,7 @@ class DnsAddNew extends React.Component {
 
 			this.props.addDns( selectedDomainName, normalizedData ).then(
 				() => {
-					page( domainManagementDns( selectedSiteSlug, selectedDomainName ) );
+					page( domainManagementDns( selectedSite.slug, selectedDomainName ) );
 					this.props.successNotice( translate( 'The DNS record has been added.' ), {
 						duration: 5000,
 					} );
@@ -291,9 +292,15 @@ class DnsAddNew extends React.Component {
 	}
 }
 
-export default connect( null, {
-	addDns,
-	updateDns,
-	errorNotice,
-	successNotice,
-} )( localize( DnsAddNew ) );
+export default connect(
+	( state ) => {
+		const selectedSite = getSelectedSite( state );
+		return { selectedSite };
+	},
+	{
+		addDns,
+		updateDns,
+		errorNotice,
+		successNotice,
+	}
+)( localize( DnsAddNew ) );

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -23,6 +23,7 @@ class DnsAddNew extends React.Component {
 		isSubmittingForm: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		goBack: PropTypes.func,
+		recordToEdit: PropTypes.object,
 	};
 
 	constructor( props ) {
@@ -119,7 +120,29 @@ class DnsAddNew extends React.Component {
 			},
 		} );
 
-		this.setFormState( this.formStateController.getInitialState() );
+		if ( this.props.recordToEdit ) {
+			this.loadRecord();
+		} else {
+			this.setFormState( this.formStateController.getInitialState() );
+		}
+	}
+
+	loadRecord() {
+		const { recordToEdit } = this.props;
+
+		const selectedDnsRecordFields = this.getFieldsForType( recordToEdit.type );
+		const recordAttributes = Object.keys( selectedDnsRecordFields ).reduce( ( obj, field ) => {
+			obj[ field ] = recordToEdit[ field ];
+			return obj;
+		}, {} );
+
+		this.formStateController.resetFields( recordAttributes );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.recordToEdit !== this.props.recordToEdit ) {
+			this.loadRecord();
+		}
 	}
 
 	setFormState = ( fields ) => {

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -278,9 +278,12 @@ class DnsAddNew extends React.Component {
 					<FormButton disabled={ isSubmitDisabled } onClick={ this.onAddDnsRecord }>
 						{ buttonLabel }
 					</FormButton>
-					<FormButton isPrimary={ false } type="button" onClick={ this.props.goBack }>
-						{ translate( 'Cancel' ) }
-					</FormButton>
+
+					{ config.isEnabled( 'domains/dns-records-redesign' ) && (
+						<FormButton isPrimary={ false } type="button" onClick={ this.props.goBack }>
+							{ translate( 'Cancel' ) }
+						</FormButton>
+					) }
 				</div>
 			</form>
 		);

--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -17,6 +17,7 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 			}
 			popoverClassName="dns-records-list-item__action-menu-popover"
 			position="top left"
+			disabled={ actions.length === 0 }
 		>
 			{ actions.map( ( action ) => {
 				return (

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -184,6 +184,10 @@ class DnsRecordsList extends Component {
 	}
 
 	getActionsForDnsRecord( record ) {
+		if ( record.protected_field ) {
+			return [];
+		}
+
 		if ( this.isDomainConnectRecord( record ) ) {
 			return [
 				record.enabled ? this.disableRecordAction : this.enableRecordAction,

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -1,11 +1,13 @@
 import { edit, Icon, info, redo, trash } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
 import { domainConnect } from 'calypso/lib/domains/constants';
 import DnsRecordsListHeader from 'calypso/my-sites/domains/domain-management/dns/dns-records-list-header';
+import { domainManagementDnsEditRecord } from 'calypso/my-sites/domains/paths';
 import { addDns, deleteDns } from 'calypso/state/domains/dns/actions';
 import { isDeletingLastMXRecord } from 'calypso/state/domains/dns/utils';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
@@ -70,8 +72,7 @@ class DnsRecordsList extends Component {
 			/>
 		),
 		title: this.props.translate( 'Edit' ),
-		// TODO: Add the correct callback function once the DNS add page is complete
-		callback: () => {},
+		callback: ( record ) => this.editDns( record ),
 	};
 
 	deleteRecordAction = {
@@ -106,6 +107,11 @@ class DnsRecordsList extends Component {
 	handleDialogClose = ( result ) => {
 		this.state.dialog.onClose( result );
 		this.setState( { dialog: this.noDialog() } );
+	};
+
+	editDns = ( record ) => {
+		const { selectedDomainName, selectedSite } = this.props;
+		page( domainManagementDnsEditRecord( selectedSite.slug, selectedDomainName, record.id ) );
 	};
 
 	deleteDns = ( record, action = 'delete', confirmed = false ) => {

--- a/client/my-sites/domains/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/mx-record.jsx
@@ -80,7 +80,6 @@ class MxRecord extends Component {
 						isError={ ! isAuxValid }
 						onChange={ onChange }
 						value={ fieldValues.aux }
-						defaultValue="10"
 					/>
 					{ ! isAuxValid && (
 						<FormInputValidation text={ translate( 'Invalid Priority' ) } isError />

--- a/client/my-sites/domains/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/srv-record.jsx
@@ -77,13 +77,7 @@ class SrvRecord extends Component {
 
 				<FormFieldset>
 					<FormLabel>{ translate( 'Priority', { context: 'Dns Record' } ) }</FormLabel>
-					<FormTextInput
-						name="aux"
-						isError={ ! isAuxValid }
-						onChange={ onChange }
-						value={ aux }
-						defaultValue="10"
-					/>
+					<FormTextInput name="aux" isError={ ! isAuxValid } onChange={ onChange } value={ aux } />
 					{ ! isAuxValid && (
 						<FormInputValidation text={ translate( 'Invalid Priority' ) } isError />
 					) }
@@ -96,7 +90,6 @@ class SrvRecord extends Component {
 						isError={ ! isWeightValid }
 						onChange={ onChange }
 						value={ weight }
-						defaultValue="10"
 					/>
 					{ ! isWeightValid && (
 						<FormInputValidation text={ translate( 'Invalid Weight' ) } isError />

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -111,6 +111,11 @@ export default function () {
 	);
 
 	registerStandardDomainManagementPages(
+		paths.domainManagementDnsEditRecord,
+		domainManagementController.domainManagementDnsEditRecord
+	);
+
+	registerStandardDomainManagementPages(
 		paths.domainManagementNameServers,
 		domainManagementController.domainManagementNameServers
 	);

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -133,7 +133,7 @@ export function domainManagementDnsAddRecord( siteName, domainName, relativeTo =
 export function domainManagementDnsEditRecord( siteName, domainName, recordId, relativeTo = null ) {
 	return (
 		domainManagementEditBase( siteName, domainName, 'add-dns-record', relativeTo ) +
-		'?record=' +
+		'?recordId=' +
 		encodeURI( recordId )
 	);
 }

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -131,11 +131,11 @@ export function domainManagementDnsAddRecord( siteName, domainName, relativeTo =
 }
 
 export function domainManagementDnsEditRecord( siteName, domainName, recordId, relativeTo = null ) {
-	return (
-		domainManagementEditBase( siteName, domainName, 'add-dns-record', relativeTo ) +
-		'?recordId=' +
-		encodeURI( recordId )
-	);
+	let path = domainManagementEditBase( siteName, domainName, 'edit-dns-record', relativeTo );
+	if ( recordId ) {
+		path += '?recordId=' + encodeURI( recordId );
+	}
+	return path;
 }
 
 export function domainManagementRedirectSettings( siteName, domainName, relativeTo = null ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -130,6 +130,14 @@ export function domainManagementDnsAddRecord( siteName, domainName, relativeTo =
 	return domainManagementEditBase( siteName, domainName, 'add-dns-record', relativeTo );
 }
 
+export function domainManagementDnsEditRecord( siteName, domainName, recordId, relativeTo = null ) {
+	return (
+		domainManagementEditBase( siteName, domainName, 'add-dns-record', relativeTo ) +
+		'?record=' +
+		encodeURI( recordId )
+	);
+}
+
 export function domainManagementRedirectSettings( siteName, domainName, relativeTo = null ) {
 	return domainManagementEditBase( siteName, domainName, 'redirect-settings', relativeTo );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the domain DNS management pages so it's possible to edit existing DNS records. When the "Edit" menu option is clicked in the record list page, you're taken to a "Edit DNS record" page where you can update the selected DNS record. The selected record's ID is passed via an URL query string parameter named `recordId`. This PR creates a new route (`/domains/manage/:domain/edit-dns-record/:site`) for this new DNS record edit page.

This is part of the domain pages redesign project described in pcYYhz-m2-p2. 

#### Screenshots:

Edit record menu option:

<img width="1085" alt="Screen Shot 2021-11-16 at 20 02 11" src="https://user-images.githubusercontent.com/5324818/142082337-19a5f7ca-22de-4a4a-a23b-1aa38432aa50.png">

Edit DNS record page:

<img width="1075" alt="Screen Shot 2021-11-16 at 20 03 00" src="https://user-images.githubusercontent.com/5324818/142082359-316b2617-07cb-4886-8f21-4529b5197479.png">

### Testing instructions

Build this branch locally or open the live Calypso link, go to "Upgrades > Domains" and select a registered domain. Go to its DNS management page and append `?flags=domains/dns-records-redesign` to your URL. Now you should be able to access the "Edit" option. 

Please try updating DNS records of different types and ensure they are updated correctly. Also try reloading while in the `edit-dns-record` page and ensure the record gets loaded correctly in that situation too. It would be nice to add a loading state in that scenario, while the record is being fetched from the backend, but I think we can do that in a later PR.
