### PR TITLE
Jetpack licensing: Remove Atomic sites from select dropdown list

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -34,6 +34,7 @@ interface Props {
 type JetpackSite = {
 	ID: number;
 	URL: string;
+	is_wpcom_atomic: boolean;
 };
 
 type Product = {
@@ -167,18 +168,20 @@ const LicensingActivationThankYou: FC< Props > = ( {
 	] );
 
 	const siteSelectOptions = useMemo( () => {
-		return jetpackSites.map( ( site: JetpackSite ) => ( {
-			value: site?.URL,
-			label: site.URL,
-			props: {
-				key: site.ID,
-				selected: site.URL === selectedSite,
-				value: site.URL,
-				onClick: () => {
-					setSelectedSite( site.URL );
+		return jetpackSites
+			.filter( ( site: JetpackSite ) => ! site.is_wpcom_atomic )
+			.map( ( site: JetpackSite ) => ( {
+				value: site?.URL,
+				label: site.URL,
+				props: {
+					key: site.ID,
+					selected: site.URL === selectedSite,
+					value: site.URL,
+					onClick: () => {
+						setSelectedSite( site.URL );
+					},
 				},
-			},
-		} ) );
+			} ) );
 	}, [ jetpackSites, selectedSite ] );
 
 	const lastSelectOption = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes Atomic sites from the select dropdown list on the licensing post-checkout auto-activation UI.

Related to 1201096622142517-as-1201359356270076

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Prerequisite: Ensure you have an Atomic site registered in your WordPress.com user account.

- As a regression check, checkout the `trunk` branch and go to http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_scan and verify the sites select dropdown list **does** contain your Atomic site.
- Download this PR and `yarn start`
- Go to http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_scan
- Verify the sites select dropdown **does not contain your Atomic site** and only contains your non-atomic self-hosted Jetpack sites.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
