### PR TITLE
Start Importer: Add initial e2e tests

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/index.ts
+++ b/packages/calypso-e2e/src/lib/flows/index.ts
@@ -1,5 +1,6 @@
 export * from './new-post-flow';
 export * from './gutenboarding-flow';
 export * from './close-account-flow';
+export * from './start-import-flow';
 export * from './start-site-flow';
 export * from './change-ui-language-flow';

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -7,6 +7,12 @@ const selectors = {
 
 	// Inputs
 	urlInput: 'input.capture__input',
+
+	// Headers
+	scanningHeader: 'h1:text("Scanning your site")',
+
+	// Buttons
+	checkUrlButton: 'form.capture__input-wrapper button.action-buttons__next',
 };
 
 /**
@@ -34,12 +40,34 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Validates that we've landed on the URL capture page.
+	 */
+	async validateURLCapturePage(): Promise< void > {
+		await this.page.waitForSelector( selectors.urlInput );
+	}
+
+	/**
+	 * Validates that we've landed on the scanning page.
+	 */
+	async validateScanningPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.scanningHeader );
+	}
+
+	/**
+	 * Validates that we've landed on the import page.
+	 */
+	async validateImportPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.button( 'Import your content' ) );
+	}
+
+	/**
 	 * Enter the URL to import from.
 	 *
 	 * @param {string} url The source URL.
 	 */
 	async enterURL( url: string ): Promise< void > {
 		await this.page.fill( selectors.urlInput, url );
+		await this.page.click( selectors.checkUrlButton );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -1,0 +1,51 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	// Generic
+	button: ( text: string ) => `button:text("${ text }")`,
+	backLink: 'a:text("Back")',
+
+	// Inputs
+	urlInput: 'input.capture__input',
+};
+
+/**
+ * Class encapsulating the flow when starting a new start importer ('/start/importer')
+ */
+export class StartImportFlow {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the flow.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Given text, clicks on the first instance of the button with the text.
+	 *
+	 * @param {string} text User-visible text on the button.
+	 */
+	async clickButton( text: string ): Promise< void > {
+		await this.page.click( selectors.button( text ) );
+	}
+
+	/**
+	 * Enter the URL to import from.
+	 *
+	 * @param {string} url The source URL.
+	 */
+	async enterURL( url: string ): Promise< void > {
+		await this.page.fill( selectors.urlInput, url );
+	}
+
+	/**
+	 * Navigate back one screen in the flow.
+	 */
+	async goBackOneScreen(): Promise< void > {
+		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.backLink ) ] );
+	}
+}

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -21,10 +21,11 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 
 	describe( 'Follow the WordPress flow', function () {
 		it( 'Navigate to Capture page', async function () {
-			await page.goto( DataHelper.getCalypsoURL( 'start/importer', { siteSlug: siteTitle } ) );
+			await page.goto( DataHelper.getCalypsoURL( '/start/importer', { siteSlug: siteTitle } ) );
 		} );
 
 		it( 'Start a WordPress import', async () => {
+			startImportFlow = new StartImportFlow( page );
 			await startImportFlow.enterURL( 'pento.net' );
 		} );
 	} );

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -1,0 +1,31 @@
+/**
+ * @group calypso-release
+ */
+
+import { setupHooks, DataHelper, LoginPage, StartImportFlow } from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
+	const siteTitle = DataHelper.getBlogName();
+	let page: Page;
+	let startImportFlow: StartImportFlow;
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log in', async function () {
+		const loginPage = new LoginPage( page );
+		await loginPage.login( { account: 'defaultUser' } );
+	} );
+
+	describe( 'Follow the WordPress flow', function () {
+		it( 'Navigate to Capture page', async function () {
+			await page.goto( DataHelper.getCalypsoURL( 'start/importer', { siteSlug: siteTitle } ) );
+		} );
+
+		it( 'Start a WordPress import', async () => {
+			await startImportFlow.enterURL( 'pento.net' );
+		} );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -1,5 +1,5 @@
 /**
- * @group calypso-release
+ * @group calypso-pr
  */
 
 import { setupHooks, DataHelper, LoginPage, StartImportFlow } from '@automattic/calypso-e2e';

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -6,12 +6,12 @@ import { setupHooks, DataHelper, LoginPage, StartImportFlow } from '@automattic/
 import { Page } from 'playwright';
 
 describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
-	const siteTitle = DataHelper.getBlogName();
 	let page: Page;
 	let startImportFlow: StartImportFlow;
 
 	setupHooks( ( args ) => {
 		page = args.page;
+		startImportFlow = new StartImportFlow( page );
 	} );
 
 	it( 'Log in', async function () {
@@ -21,12 +21,16 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 
 	describe( 'Follow the WordPress flow', function () {
 		it( 'Navigate to Capture page', async function () {
-			await page.goto( DataHelper.getCalypsoURL( '/start/importer', { siteSlug: siteTitle } ) );
+			await page.goto(
+				DataHelper.getCalypsoURL( '/start/importer', { siteSlug: 'e2eflowtesting4.wordpress.com' } )
+			);
+			await startImportFlow.validateURLCapturePage();
 		} );
 
 		it( 'Start a WordPress import', async () => {
-			startImportFlow = new StartImportFlow( page );
-			await startImportFlow.enterURL( 'pento.net' );
+			await startImportFlow.enterURL( 'make.wordpress.org' );
+			await startImportFlow.validateScanningPage();
+			await startImportFlow.validateImportPage();
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds initial e2e test structure for the onboarding importer flow. 

Includes a demo test for the first few steps of the WordPress importer flow.

#### Testing instructions

Test suite can be run manually with `yarn jest specs/specs-playwright/wp-start__importer.ts`.