### PR TITLE
Add canInstallWooOnPlans selector

### DIFF
--- a/client/state/selectors/can-install-woo-on-plans.js
+++ b/client/state/selectors/can-install-woo-on-plans.js
@@ -1,0 +1,23 @@
+import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { getSite } from 'calypso/state/sites/selectors';
+
+/**
+ * Returns true if the current user is eligible to install WooCommerce on Plans.
+ *
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {?boolean} True if the user can participate in the free to paid upsell
+ */
+export default function canInstallWooOnPlans( state, siteId ) {
+	const productSlug = getSite( state, siteId )?.plan?.product_slug;
+
+	if ( ! productSlug ) {
+		return false;
+	}
+
+	return (
+		canCurrentUser( state, siteId, 'manage_options' ) &&
+		( isBusinessPlan( productSlug ) || isEcommercePlan( productSlug ) )
+	);
+}

--- a/client/state/selectors/test/can-install-woo-on-plans.js
+++ b/client/state/selectors/test/can-install-woo-on-plans.js
@@ -1,0 +1,82 @@
+import {
+	PLAN_FREE,
+	PLAN_PREMIUM,
+	PLAN_PERSONAL,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+} from '@automattic/calypso-products';
+import canInstallWooOnPlans from 'calypso/state/selectors/can-install-woo-on-plans';
+
+describe( 'canInstallWooOnPlans', () => {
+	test( 'free', () => {
+		const state = {
+			sites: {
+				items: {
+					1: { plan: { product_slug: PLAN_FREE } },
+				},
+			},
+			currentUser: { capabilities: { 1: { manage_options: true } } },
+		};
+		expect( canInstallWooOnPlans( state, 1 ) ).toBe( false );
+	} );
+
+	test( 'personal', () => {
+		const state = {
+			sites: {
+				items: {
+					1: { plan: { product_slug: PLAN_PERSONAL } },
+				},
+			},
+			currentUser: { capabilities: { 1: { manage_options: true } } },
+		};
+		expect( canInstallWooOnPlans( state, 1 ) ).toBe( false );
+	} );
+
+	test( 'premium', () => {
+		const state = {
+			sites: {
+				items: {
+					1: { plan: { product_slug: PLAN_PREMIUM } },
+				},
+			},
+			currentUser: { capabilities: { 1: { manage_options: true } } },
+		};
+		expect( canInstallWooOnPlans( state, 1 ) ).toBe( false );
+	} );
+
+	test( 'business', () => {
+		const state = {
+			sites: {
+				items: {
+					1: { plan: { product_slug: PLAN_BUSINESS } },
+				},
+			},
+			currentUser: { capabilities: { 1: { manage_options: true } } },
+		};
+		expect( canInstallWooOnPlans( state, 1 ) ).toBe( true );
+	} );
+
+	test( 'ecommerce', () => {
+		const state = {
+			sites: {
+				items: {
+					1: { plan: { product_slug: PLAN_ECOMMERCE } },
+				},
+			},
+			currentUser: { capabilities: { 1: { manage_options: true } } },
+		};
+		expect( canInstallWooOnPlans( state, 1 ) ).toBe( true );
+	} );
+
+	test( 'requires capability manage_options', () => {
+		const state = {
+			sites: {
+				items: {
+					1: { plan: { product_slug: PLAN_BUSINESS } },
+				},
+			},
+			currentUser: { capabilities: { 1: { manage_options: false } } },
+		};
+		expect( canInstallWooOnPlans( state, 1 ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add selector to test for site and user eligibility for the woo installer
* For use in https://github.com/Automattic/wp-calypso/pull/57918

#### Testing instructions

```
yarn run test-client client/state/selectors/test/can-install-woo-on-plans.js
```

Related to #57918
