### PR TITLE
Plugin Installation: Adds WordPressWordmark in the masterbar.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import successImage from 'calypso/assets/images/marketplace/success.png';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import { ThankYou } from 'calypso/components/thank-you';
+import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
@@ -21,6 +22,10 @@ const ThankYouContainer = styled.div`
 			height: auto;
 		}
 	}
+`;
+
+const WordPressWordmarkStyled = styled( WordPressWordmark )`
+	align-self: center;
 `;
 
 const MarketplaceThankYou = ( { productSlug } ): JSX.Element => {
@@ -84,6 +89,7 @@ const MarketplaceThankYou = ( { productSlug } ): JSX.Element => {
 					tooltip={ translate( 'Go to home' ) }
 					tipTarget="close"
 				/>
+				<WordPressWordmarkStyled />
 			</Masterbar>
 			<ThankYouContainer>
 				<ThankYou

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
+import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -176,6 +177,7 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 			/>
 			{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 			<Masterbar>
+				<WordPressWordmark className="marketplace-plugin-upload-status__wpcom-wordmark" />
 				<Item>{ translate( 'Plugin Installation' ) }</Item>
 			</Masterbar>
 			<div className="marketplace-plugin-upload-status__root">

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/style.scss
@@ -2,17 +2,24 @@ body.is-section-marketplace.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
 }
 
-.is-section-marketplace.has-no-sidebar {
-	.layout__content {
-		height: 100vh;
-		@media ( max-width: 782px ) {
-			padding: 0;
+.is-section-marketplace {
+	&.has-no-sidebar {
+		.layout__content {
 			height: 100vh;
-			.layout__primary {
+			@media ( max-width: 782px ) {
+				padding: 0;
 				height: 100vh;
+				.layout__primary {
+					height: 100vh;
+				}
 			}
 		}
 	}
+}
+
+.marketplace-plugin-upload-status__wpcom-wordmark {
+	align-self: center;
+	margin-left: 10px;
 }
 
 .marketplace-plugin-upload-status__root {


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Adds WordPressWordmark in the masterbar for plugin installation and plugin thank you page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1432" alt="SS 2021-11-15 at 11 01 11" src="https://user-images.githubusercontent.com/12430020/141752526-86df12b2-7526-47a9-9f3d-1c24d1caef25.png">|![SS 2021-11-15 at 11 01 27](https://user-images.githubusercontent.com/12430020/141752567-d0bcc719-c541-4562-99fb-92c6ea7a1d57.png)|

|Before | After|
|-------|------|
|<img width="1258" alt="SS 2021-11-15 at 11 04 23" src="https://user-images.githubusercontent.com/12430020/141753046-d8c30aa4-0ebd-46e9-95d3-47acaf04b86b.png">|![SS 2021-11-15 at 11 04 45](https://user-images.githubusercontent.com/12430020/141753101-681e68bb-595b-42ce-a520-26eacfc17b3d.png)|

- Go to `/marketplace/test/install/[domain]`
- Inspect the WordPressWordmark in the masterbar
- Repeat for `/marketplace/thank-you/test/[domain]`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

