### PR TITLE
Hero Flow: Add tracks event to draft post modal and first post published modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/index.js
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -47,6 +48,7 @@ const DraftPostModal = () => {
 				</>
 			}
 			onRequestClose={ closeModal }
+			onOpen={ () => recordTracksEvent( 'calypso_editor_wpcom_draft_post_modal_show' ) }
 		/>
 	);
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/index.tsx
@@ -1,4 +1,5 @@
 import { Modal } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import React from 'react';
 import './style.scss';
@@ -11,6 +12,7 @@ interface Props {
 	imageSrc: string;
 	actionButtons: React.ReactElement;
 	onRequestClose: () => void;
+	onOpen?: () => void;
 }
 
 const NuxModal: React.FC< Props > = ( {
@@ -21,7 +23,18 @@ const NuxModal: React.FC< Props > = ( {
 	imageSrc,
 	actionButtons,
 	onRequestClose,
+	onOpen,
 } ) => {
+	const prevIsOpen = useRef< boolean | null >( null );
+
+	useEffect( () => {
+		if ( ! prevIsOpen.current && isOpen ) {
+			onOpen?.();
+		}
+
+		prevIsOpen.current = isOpen;
+	}, [ prevIsOpen, isOpen, onOpen ] );
+
 	if ( ! isOpen ) {
 		return null;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
@@ -71,6 +72,7 @@ const PostPublishedModal: React.FC = () => {
 				</Button>
 			}
 			onRequestClose={ closeModal }
+			onOpen={ () => recordTracksEvent( 'calypso_editor_wpcom_first_post_published_modal_show' ) }
 		/>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add tracks event when the following modals show
  * Draft your post modal
  * The first post published modal

| calypso_editor_wpcom_draft_post_modal_show | calypso_editor_wpcom_first_post_published_modal_show |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/141756609-5a39af54-2d60-4a7d-b859-b4fe06206edb.png) | ![image](https://user-images.githubusercontent.com/13596067/141756657-ac7ba60b-f909-4a58-860a-e7b7db8fd550.png) |


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open another terminal and run `cd apps/editing-toolkit && yarn dev --sync`
* Ensure your API and domain point to your sandbox
* Go to `/start`
* Finish the Onboarding flow
* Finish the Hero flow with `Write` intent
* When you land on the editor, you should see `calypso_editor_wpcom_draft_post_modal_show` event fired.
* When you publish the post, you should see `calypso_editor_wpcom_first_post_published_modal_show`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I remember this one but I forget where I saw 😅
