### PR TITLE
Hero Flow: don't shuffle the designs if the user goes back from the preview

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -47,6 +47,7 @@ class DesignPickerStep extends Component {
 	};
 
 	state = {
+		designs: [],
 		selectedDesign: null,
 		scrollTop: 0,
 	};
@@ -61,6 +62,10 @@ class DesignPickerStep extends Component {
 			this.updateSelectedDesign();
 			this.updateScrollPosition();
 		}
+
+		if ( prevProps.themes !== this.props.themes ) {
+			this.updateDesigns();
+		}
 	}
 
 	updateScrollPosition() {
@@ -72,6 +77,10 @@ class DesignPickerStep extends Component {
 				document.scrollingElement.scrollTop = this.state.scrollTop;
 			} );
 		}
+	}
+
+	updateDesigns() {
+		this.setState( { designs: this.getDesigns() } );
 	}
 
 	fetchThemes() {
@@ -107,9 +116,10 @@ class DesignPickerStep extends Component {
 
 	updateSelectedDesign() {
 		const { stepSectionName } = this.props;
+		const { designs } = this.state;
 
 		this.setState( {
-			selectedDesign: this.getDesigns().find( ( { theme } ) => theme === stepSectionName ),
+			selectedDesign: designs.find( ( { theme } ) => theme === stepSectionName ),
 		} );
 	}
 
@@ -153,11 +163,9 @@ class DesignPickerStep extends Component {
 	};
 
 	renderDesignPicker() {
-		const designs = this.getDesigns();
-
 		return (
 			<DesignPicker
-				designs={ designs }
+				designs={ this.state.designs }
 				theme={ this.props.isReskinned ? 'light' : 'dark' }
 				locale={ this.props.locale } // props.locale obtained via `localize` HoC
 				onSelect={ this.pickDesign }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As mentioned in p58i-bpK-p2#comment-52458, we shouldn't shuffle the designs at every render. Thus, I make the change to save the shuffled designs into the component state so that the user can see the same order after coming back from the design preview.
* Furthermore, if we want, we can also persist the randomized design into the store only when the user lands on the Hero Flow (which is how `/new` flow does. See: p58i-bpK-p2#comment-52459) to ensure the order stays the same after the user refreshes/back browsing.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your_site>`
* When you go to the Design Picker step, preview one of the themes
* After you go back, you should see the order stays the same.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-bpK-p2#comment-52458