### PR TITLE
State: Cleanup notification settings action creators

### DIFF
--- a/client/state/notification-settings/actions.js
+++ b/client/state/notification-settings/actions.js
@@ -56,10 +56,9 @@ export const fetchSettings = () => ( dispatch ) => {
 				data,
 			} )
 		)
-		.catch( ( error ) =>
+		.catch( () =>
 			dispatch( {
 				type: NOTIFICATION_SETTINGS_FETCH_FAILED,
-				error,
 			} )
 		);
 };
@@ -103,16 +102,13 @@ export const saveSettings = ( source, settings, applyToAll = false ) => ( dispat
 			dispatch( showSaveSuccessNotice() );
 			dispatch( {
 				type: NOTIFICATION_SETTINGS_SAVE_COMPLETE,
-				error: undefined,
 				data,
 			} );
 		} )
-		.catch( ( error ) => {
+		.catch( () => {
 			dispatch( showSaveErrorNotice() );
 			dispatch( {
 				type: NOTIFICATION_SETTINGS_SAVE_FAILED,
-				error,
-				data: undefined,
 			} );
 		} );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/58001#discussion_r749083868 where we were migrating `wpcom.undocumented()` calls for notification settings. 

This PR cleans up the action creators as suggested in the above review.

#### Testing instructions

* Go to `/me/notifications`
* Verify all notification settings are retrieved correctly.
* Change some settings and save them by clicking "Save Settings", verify they are saved correctly.
* Change some settings and save them for all sites by clicking "Save to all sites", verify they are saved correctly. 
* Verify tests pass: `yarn run test-client client/state/notification-settings`