### PR TITLE
Stats: remove usages of lodash range

### DIFF
--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -65,6 +65,7 @@ class Month extends PureComponent {
 
 const StatsViewsMonths = ( props ) => {
 	const { translate, dataKey, data, numberFormat, moment, siteSlug } = props;
+	const dataEntries = data ? Object.entries( data ) : [];
 	const isAverageChart = dataKey === 'average';
 	let earliestDate = moment();
 	const today = moment();
@@ -83,7 +84,7 @@ const StatsViewsMonths = ( props ) => {
 		return sum;
 	};
 
-	const allMonths = Object.entries( data || {} ).flatMap( ( [ yearNumber, year ] ) =>
+	const allMonths = dataEntries.flatMap( ( [ yearNumber, year ] ) =>
 		Object.entries( year ).map( ( [ monthIndex, month ] ) => {
 			// keep track of earliest date to fill in zeros when applicable
 			const momentMonth = momentFromMonthYear( monthIndex, yearNumber );
@@ -95,9 +96,7 @@ const StatsViewsMonths = ( props ) => {
 	);
 
 	const highestMonth = Math.max( ...allMonths );
-	const yearsObject = Object.fromEntries(
-		Object.keys( data || {} ).map( ( year ) => [ year, 0 ] )
-	);
+	const yearsObject = Object.fromEntries( dataEntries.map( ( [ year ] ) => [ year, 0 ] ) );
 	const monthsArray = Array.from( { length: 12 }, ( _, month ) => month ); // [ 0, 1, ..., 11 ]
 	const monthsObject = Object.fromEntries( monthsArray.map( ( month ) => [ month, 0 ] ) );
 	const totals = {
@@ -107,7 +106,7 @@ const StatsViewsMonths = ( props ) => {
 		monthsCount: { ...monthsObject },
 	};
 
-	const years = Object.entries( data || {} ).map( ( [ year, item ] ) => {
+	const years = dataEntries.map( ( [ year, item ] ) => {
 		const cells = monthsArray.map( ( month ) => {
 			let value = item[ month ]?.[ dataKey ] ?? null;
 			let displayValue;

--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -1,6 +1,5 @@
 import { Popover } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { map, range, flatten, keys, zipObject, times, size, concat, merge } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { createRef, createElement, PureComponent } from 'react';
@@ -51,18 +50,15 @@ class Month extends PureComponent {
 				ref: this.monthRef,
 				onClick: this.openPopover,
 			},
-			concat(
-				children,
-				<Popover
-					isVisible={ this.state.showPopover }
-					onClose={ this.closePopover }
-					position={ position }
-					key="popover"
-					context={ this.monthRef.current }
-				>
-					<div style={ { padding: '10px' } }>{ value }</div>
-				</Popover>
-			)
+			<>{ children }</>,
+			<Popover
+				isVisible={ this.state.showPopover }
+				onClose={ this.closePopover }
+				position={ position }
+				context={ this.monthRef.current }
+			>
+				<div style={ { padding: '10px' } }>{ value }</div>
+			</Popover>
 		);
 	}
 }
@@ -87,42 +83,33 @@ const StatsViewsMonths = ( props ) => {
 		return sum;
 	};
 
-	const allMonths = flatten(
-		map( data, ( year, yearNumber ) => {
-			return map( year, ( month, monthIndex ) => {
-				// keep track of earliest date to fill in zeros when applicable
-				const momentMonth = momentFromMonthYear( monthIndex, yearNumber );
-				if ( momentMonth.isBefore( earliestDate ) ) {
-					earliestDate = moment( momentMonth );
-				}
-				return month[ dataKey ];
-			} );
+	const allMonths = Object.entries( data || {} ).flatMap( ( [ yearNumber, year ] ) =>
+		Object.entries( year ).map( ( [ monthIndex, month ] ) => {
+			// keep track of earliest date to fill in zeros when applicable
+			const momentMonth = momentFromMonthYear( monthIndex, yearNumber );
+			if ( momentMonth.isBefore( earliestDate ) ) {
+				earliestDate = moment( momentMonth );
+			}
+			return month[ dataKey ];
 		} )
 	);
 
 	const highestMonth = Math.max( ...allMonths );
-	const yearsObject = zipObject(
-		keys( data ),
-		times( size( data ), () => {
-			return 0;
-		} )
+	const yearsObject = Object.fromEntries(
+		Object.keys( data || {} ).map( ( year ) => [ year, 0 ] )
 	);
-	const monthsObject = zipObject(
-		range( 0, 12 ),
-		times( 12, () => {
-			return 0;
-		} )
-	);
+	const monthsArray = Array.from( { length: 12 }, ( _, month ) => month ); // [ 0, 1, ..., 11 ]
+	const monthsObject = Object.fromEntries( monthsArray.map( ( month ) => [ month, 0 ] ) );
 	const totals = {
-		years: merge( {}, yearsObject ),
-		months: merge( {}, monthsObject ),
-		yearsCount: merge( {}, yearsObject ),
-		monthsCount: merge( {}, monthsObject ),
+		years: { ...yearsObject },
+		months: { ...monthsObject },
+		yearsCount: { ...yearsObject },
+		monthsCount: { ...monthsObject },
 	};
 
-	const years = map( data, ( item, year ) => {
-		const cells = map( range( 0, 12 ), ( month ) => {
-			let value = item[ month ] ? item[ month ][ dataKey ] : null;
+	const years = Object.entries( data || {} ).map( ( [ year, item ] ) => {
+		const cells = monthsArray.map( ( month ) => {
+			let value = item[ month ]?.[ dataKey ] ?? null;
 			let displayValue;
 			const momentMonth = momentFromMonthYear( month, year );
 			let className;


### PR DESCRIPTION
Removes usages of `_.range` from Stats components -- there are two of them. Accidentally, both components were rather Lodash-heavy and I was able to remove Lodash from them completely, not only `range`.

**How to test:**
First, look at stats for a specific post, `/stats/post/:post/:site`, and switch to the "Months" tab. It should show stats how the post performed over the years and months:

<img width="868" alt="Screenshot 2021-11-15 at 11 28 12" src="https://user-images.githubusercontent.com/664258/141767433-170a6a32-1096-4f53-99f1-e7b338794a0a.png">

Second, go to `/stats/insights/:site` and look at this summary table:

<img width="845" alt="Screenshot 2021-11-15 at 11 20 13" src="https://user-images.githubusercontent.com/664258/141767625-15c8af6e-1450-4a35-a220-64e2ec15a79e.png">

Verify that it still renders correctly, including clickable popovers on month headers.
