### PR TITLE
e2e: Improve block editor I18n tests reliability

### DIFF
--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -14,16 +14,21 @@ import {
 import { Page, Frame } from 'playwright';
 import type { LanguageSlug } from '@automattic/languages';
 
+interface TranslationsBlock {
+	blockName: string;
+	blockEditorSelector: string;
+	blockEditorContent: string[];
+	blockPanelTitle: string;
+}
+
 type Translations = {
 	[ language in LanguageSlug ]?: Partial< {
-		blocks: {
-			blockName: string;
-			blockEditorSelector: string;
-			blockEditorContent: string[];
-			blockPanelTitle: string;
-		}[];
+		blocks: TranslationsBlock[];
 	} >;
 };
+
+const EMPTY_TRANSLATIONS_BLOCKS = [ {} as TranslationsBlock ];
+
 const translations: Translations = {
 	en: {
 		blocks: [
@@ -262,7 +267,7 @@ describeSkipNoTranslations(
 			gutenbergEditorPage = new GutenbergEditorPage( page );
 		} );
 
-		describeSkipNoTranslations.each( localeTranslations.blocks )(
+		describeSkipNoTranslations.each( localeTranslations?.blocks || EMPTY_TRANSLATIONS_BLOCKS )(
 			'Translations for block: $blockName',
 			( block ) => {
 				let frame: Frame;

--- a/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
+++ b/test/e2e/specs/specs-i18n/wp-i18n__editor.ts
@@ -288,9 +288,15 @@ describeSkipNoTranslations(
 				it( 'Render block title translations', async () => {
 					await gutenbergEditorPage.openSettings();
 					await frame.click( block.blockEditorSelector );
+
+					// Ensure topmost block parent is selected.
+					async function clickBlockParentSelector() {
+						await frame.click( '.block-editor-block-parent-selector__button' );
+						return clickBlockParentSelector();
+					}
 					await Promise.race( [
 						frame.waitForSelector( `${ block.blockEditorSelector }.is-selected` ),
-						frame.click( '.block-editor-block-parent-selector__button' ),
+						clickBlockParentSelector(),
 					] );
 
 					await frame.waitForSelector(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix skipping tests for locales without predefined translations.
* Fix selecting the topmost block.

#### Testing instructions

* Confirm all tests for locale with predefined tests pass and other tests for other locales are skipped with:
```
cd test/e2e
for locale in 'en' 'de' 'fr' 'he' 'nl'; do
	LOCALE="${locale}" yarn jest test/e2e/specs/specs-i18n/wp-i18n__editor.ts
done
```
