### PR TITLE
Remove usages of Lodash zipObject

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -1,4 +1,4 @@
-import { map, zipObject, size, filter, get, compact, partition } from 'lodash';
+import { map, size, filter, get, partition } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -162,22 +162,18 @@ export class ConversationCommentList extends Component {
 
 		const minId = Math.min( ...commentIds );
 		const startingCommentIds = ( sortedComments || [] )
-			.filter( ( comment ) => {
-				return comment.ID >= minId || comment.isPlaceholder;
-			} )
+			.filter( ( comment ) => comment.ID >= minId || comment.isPlaceholder )
 			.map( ( comment ) => comment.ID );
 
-		const parentIds = compact(
-			map( startingCommentIds, ( id ) => this.getParentId( commentsTree, id ) )
-		);
-		const commentExpansions = Array( startingCommentIds.length ).fill(
-			POST_COMMENT_DISPLAY_TYPES.excerpt
-		);
-		const parentExpansions = Array( parentIds.length ).fill( POST_COMMENT_DISPLAY_TYPES.excerpt );
+		const parentIds = startingCommentIds
+			.map( ( id ) => this.getParentId( commentsTree, id ) )
+			.filter( Boolean );
 
-		const startingExpanded = zipObject(
-			startingCommentIds.concat( parentIds ),
-			commentExpansions.concat( parentExpansions )
+		const startingExpanded = Object.fromEntries(
+			[ startingCommentIds, ...parentIds ].map( ( id ) => [
+				id,
+				POST_COMMENT_DISPLAY_TYPES.excerpt,
+			] )
 		);
 
 		return { ...startingExpanded, ...expansions };

--- a/client/lib/form-state/test/index.js
+++ b/client/lib/form-state/test/index.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { mapValues, zipObject } from 'lodash';
+import { mapValues } from 'lodash';
 import formState from '../';
 
 function checkNthState( n, callback ) {
@@ -19,10 +19,7 @@ function testController( options ) {
 
 	const defaults = {
 		loadFunction: function ( onComplete ) {
-			const fieldValues = zipObject(
-				fieldNames,
-				fieldNames.map( () => 'loaded' )
-			);
+			const fieldValues = Object.fromEntries( fieldNames.map( ( name ) => [ name, 'loaded' ] ) );
 			onComplete( null, fieldValues );
 		},
 

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -7,7 +7,6 @@ import {
 	reject,
 	isEqual,
 	get,
-	zipObject,
 	includes,
 	omit,
 	startsWith,
@@ -251,17 +250,18 @@ export const expansions = ( state = {}, action ) => {
 			const stateKey = getStateKey( siteId, postId );
 			const currentExpansions = state[ stateKey ] || {};
 
-			const newDisplayTypes = map( commentIds, ( id ) => {
-				if (
-					! has( currentExpansions, id ) ||
-					expansionValue( displayType ) > expansionValue( currentExpansions[ id ] )
-				) {
-					return displayType;
-				}
-				return currentExpansions[ id ];
-			} );
 			// generate object of { [ commentId ]: displayType }
-			const newVal = zipObject( commentIds, newDisplayTypes );
+			const newVal = Object.fromEntries(
+				commentIds.map( ( id ) => {
+					if (
+						! has( currentExpansions, id ) ||
+						expansionValue( displayType ) > expansionValue( currentExpansions[ id ] )
+					) {
+						return [ id, displayType ];
+					}
+					return [ id, currentExpansions[ id ] ];
+				} )
+			);
 
 			return {
 				...state,

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -1,5 +1,5 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { includes, map, pick, zipObject } from 'lodash';
+import { includes, pick } from 'lodash';
 import moment from 'moment';
 import {
 	INVITES_DELETE_REQUEST,
@@ -213,10 +213,7 @@ export function deleting( state = {}, action ) {
 			const inviteDeletionRequests = Object.assign(
 				{},
 				state[ action.siteId ],
-				zipObject(
-					action.inviteIds,
-					map( action.inviteIds, () => 'requesting' )
-				)
+				Object.fromEntries( action.inviteIds.map( ( id ) => [ id, 'requesting' ] ) )
 			);
 			return Object.assign( {}, state, { [ action.siteId ]: inviteDeletionRequests } );
 		}
@@ -224,10 +221,7 @@ export function deleting( state = {}, action ) {
 			const inviteDeletionFailures = Object.assign(
 				{},
 				state[ action.siteId ],
-				zipObject(
-					action.inviteIds,
-					map( action.inviteIds, () => 'failure' )
-				)
+				Object.fromEntries( action.inviteIds.map( ( id ) => [ id, 'failure' ] ) )
 			);
 			return Object.assign( {}, state, { [ action.siteId ]: inviteDeletionFailures } );
 		}
@@ -235,10 +229,7 @@ export function deleting( state = {}, action ) {
 			const inviteDeletionSuccesses = Object.assign(
 				{},
 				state[ action.siteId ],
-				zipObject(
-					action.inviteIds,
-					map( action.inviteIds, () => 'success' )
-				)
+				Object.fromEntries( action.inviteIds.map( ( id ) => [ id, 'success' ] ) )
 			);
 			return Object.assign( {}, state, { [ action.siteId ]: inviteDeletionSuccesses } );
 		}


### PR DESCRIPTION
Removes all usages of `_.zipObject` from the codebase. They can be all very conventiently replaced by `Object.fromEntries`.

**How to test:**
Verify that none of the affected features are broken:
- post conversations in Reader
- expanding comments in Comments
- deleting invites