### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` contact details to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -204,32 +204,6 @@ Undocumented.prototype.getAvailableTlds = function ( query = {} ) {
 };
 
 /**
- * Retrieves the domain contact information of the user.
- *
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.getDomainContactInformation = function ( fn ) {
-	debug( '/me/domain-contact-information query' );
-
-	return this._sendRequest(
-		{
-			path: '/me/domain-contact-information',
-			method: 'get',
-		},
-		function ( error, data ) {
-			if ( error ) {
-				return fn( error );
-			}
-
-			const newData = mapKeysRecursively( data, function ( key ) {
-				return key === '_headers' ? key : camelCase( key );
-			} );
-
-			fn( null, newData );
-		}
-	);
-};
-/**
  *
  * @param domain {string}
  * @param fn {function}

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -113,16 +113,10 @@ class EditContactInfoFormCard extends Component {
 
 	validate = ( fieldValues, onComplete ) => {
 		wp.req
-			.post(
-				'/me/domain-contact-information/validate',
-				mapRecordKeysRecursively(
-					{
-						contactInformation: fieldValues,
-						domainNames: [ this.props.selectedDomain.name ],
-					},
-					camelToSnakeCase
-				)
-			)
+			.post( '/me/domain-contact-information/validate', {
+				contactInformation: mapRecordKeysRecursively( fieldValues, camelToSnakeCase ),
+				domainNames: [ this.props.selectedDomain.name ],
+			} )
 			.then( ( data ) => {
 				onComplete( null, mapRecordKeysRecursively( data.messages || {}, snakeToCamelCase ) );
 			} )

--- a/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
+++ b/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
@@ -128,16 +128,10 @@ class BulkEditContactInfo extends Component {
 		}
 
 		wp.req
-			.post(
-				'/me/domain-contact-information/validate',
-				mapRecordKeysRecursively(
-					{
-						contactInformation: contactDetails,
-						domainNames: this.props.domainNamesList ?? [],
-					},
-					camelToSnakeCase
-				)
-			)
+			.post( '/me/domain-contact-information/validate', {
+				contactInformation: mapRecordKeysRecursively( contactDetails, camelToSnakeCase ),
+				domainNames: this.props.domainNamesList ?? [],
+			} )
 			.then( ( data ) => {
 				let errorMessages = mapRecordKeysRecursively(
 					( data && data.messages ) || {},

--- a/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
+++ b/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
@@ -1,4 +1,9 @@
 import { Button } from '@automattic/components';
+import {
+	mapRecordKeysRecursively,
+	camelToSnakeCase,
+	snakeToCamelCase,
+} from '@automattic/wpcom-checkout';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -14,8 +19,6 @@ import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import isRequestingContactDetailsCache from 'calypso/state/selectors/is-requesting-contact-details-cache';
 import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
-
-const wpcom = wp.undocumented();
 
 import './list-all.scss';
 
@@ -124,11 +127,22 @@ class BulkEditContactInfo extends Component {
 			return;
 		}
 
-		wpcom.validateDomainContactInformation(
-			contactDetails,
-			this.props.domainNamesList ?? [],
-			( error, data ) => {
-				let errorMessages = ( data && data.messages ) || {};
+		wp.req
+			.post(
+				'/me/domain-contact-information/validate',
+				mapRecordKeysRecursively(
+					{
+						contactInformation: contactDetails,
+						domainNames: this.props.domainNamesList ?? [],
+					},
+					camelToSnakeCase
+				)
+			)
+			.then( ( data ) => {
+				let errorMessages = mapRecordKeysRecursively(
+					( data && data.messages ) || {},
+					snakeToCamelCase
+				);
 				if ( Object.keys( errorMessages ).length > 0 ) {
 					errorMessages = Object.entries( errorMessages ).reduce( ( result, [ field, errors ] ) => {
 						result[ field ] = Array.isArray( errors ) ? errors.join( ' ' ) : errors;
@@ -139,8 +153,7 @@ class BulkEditContactInfo extends Component {
 				this.setState( {
 					errorMessages,
 				} );
-			}
-		);
+			} );
 	};
 
 	handleSaveContactInfo = () => this.props.handleSaveContactInfo( this.state.contactDetails );

--- a/client/state/domains/management/actions.js
+++ b/client/state/domains/management/actions.js
@@ -1,3 +1,4 @@
+import { mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/wpcom-checkout';
 import wpcom from 'calypso/lib/wp';
 import {
 	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
@@ -43,20 +44,22 @@ export function requestContactDetailsCache() {
 			type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST,
 		} );
 
-		wpcom.undocumented().getDomainContactInformation( ( error, data ) => {
-			if ( error ) {
+		wpcom.req
+			.get( '/me/domain-contact-information' )
+			.then( ( data ) => {
+				dispatch(
+					receiveContactDetailsCache( mapRecordKeysRecursively( data, snakeToCamelCase ) )
+				);
+				dispatch( {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_SUCCESS,
+				} );
+			} )
+			.catch( ( error ) => {
 				dispatch( {
 					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_FAILURE,
 					error,
 				} );
-				return;
-			}
-
-			dispatch( receiveContactDetailsCache( data ) );
-			dispatch( {
-				type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_SUCCESS,
 			} );
-		} );
 	};
 }
 

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -28,3 +28,4 @@ export * from './checkout-line-items';
 export * from './get-country-postal-code-support';
 export * from './map-record-keys-recursively';
 export * from './camel-to-snake-case';
+export * from './snake-to-camel-case';

--- a/packages/wpcom-checkout/src/snake-to-camel-case.ts
+++ b/packages/wpcom-checkout/src/snake-to-camel-case.ts
@@ -1,7 +1,7 @@
 /**
  * Convert a snake_case_word to a camelCaseWord.
  *
- * This is designed to work nearly identically to the lodash `snakeCase` function.
+ * This is designed to work nearly identically to the lodash `camelCase` function.
  */
 export function snakeToCamelCase( snakeCaseString: string ): string {
 	return snakeCaseString

--- a/packages/wpcom-checkout/src/snake-to-camel-case.ts
+++ b/packages/wpcom-checkout/src/snake-to-camel-case.ts
@@ -1,0 +1,12 @@
+/**
+ * Convert a snake_case_word to a camelCaseWord.
+ *
+ * This is designed to work nearly identically to the lodash `snakeCase` function.
+ */
+export function snakeToCamelCase( snakeCaseString: string ): string {
+	return snakeCaseString
+		.toLowerCase()
+		.replace( /([-_][a-z0-9])/g, ( group ) =>
+			group.toUpperCase().replace( '-', '' ).replace( '_', '' )
+		);
+}

--- a/packages/wpcom-checkout/test/snake-to-camel-case.ts
+++ b/packages/wpcom-checkout/test/snake-to-camel-case.ts
@@ -1,0 +1,23 @@
+import { snakeToCamelCase } from '../src/snake-to-camel-case';
+
+describe( 'snakeToCamelCase', () => {
+	it( 'transforms snake_case to camelCase for strings with two words', () => {
+		expect( snakeToCamelCase( 'camel_case' ) ).toBe( 'camelCase' );
+	} );
+
+	it( 'transforms snake_case to camelCase for strings with four words', () => {
+		expect( snakeToCamelCase( 'this_is_camel_case' ) ).toBe( 'thisIsCamelCase' );
+	} );
+
+	it( 'transforms snake_case to camelCase for strings with a number', () => {
+		expect( snakeToCamelCase( 'camel_case_1' ) ).toBe( 'camelCase1' );
+	} );
+
+	it( 'transforms snake_case to camelCase for strings with a number_followed by a capital', () => {
+		expect( snakeToCamelCase( 'camel_case_1_hi' ) ).toBe( 'camelCase1Hi' );
+	} );
+
+	it( 'transforms snake_case to camelCase for strings with multiple adjacent numbers', () => {
+		expect( snakeToCamelCase( 'hello_1234_thing' ) ).toBe( 'hello1234Thing' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` contact details methods to `wpcom.req`. 

As part of the work, we're reusing the existing `@automattic/wpcom-checkout` package `mapRecordKeysRecursively` that's a substitute of `mapKeysRecursively` and `camelToSnakeCase` that's our custom version of Lodash's `camelCase`. We also introduce a simple `snakeToCamelCase` to serve as our custom version of Lodash's `snakeCase` - cc @sirbrillig on these bits.

We also remove the `_sendRequest` method and the `mapKeysRecursively` helper function that now end up being unused.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/checkout/somedomain.fr` where `somedomain.fr` is a custom `.fr` domain you're going to purchase. 
* Verify your contact details are retrieved and populated into the form correctly.
* Go to `/domains/manage/:domain/edit-contact-info/:site` where `:domain` and `:site` correspond to one of your sites on a custom domain.
* Play with the validation of the form and verify it still works correctly.
* Verify all tests pass, specifically `yarn run test-packages packages/wpcom-checkout`.
* @Automattic/nomado is there any other flow / screen these need to be tested on?
