### PR TITLE
Remove Quick Start upsell CTA from booking page

### DIFF
--- a/client/me/concierge/shared/upsell.js
+++ b/client/me/concierge/shared/upsell.js
@@ -1,4 +1,4 @@
-import { Button, CompactCard } from '@automattic/components';
+import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -25,13 +25,7 @@ class Upsell extends Component {
 					<Site siteId={ site.ID } />
 				</CompactCard>
 				<CompactCard>
-					<p>
-						{ translate( 'You do not have any available Quick Start sessions.' ) }{ ' ' }
-						{ translate( 'Click the button to purchase a new session.' ) }
-					</p>
-					<Button href={ `/checkout/offer-quickstart-session/${ site.slug }` } primary>
-						{ translate( 'Learn More' ) }
-					</Button>
+					<span>{ translate( 'You do not have any available Quick Start sessions.' ) }</span>
 				</CompactCard>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the CTA to purchase Quick Start sessions from the Quick Start booking page. The page simply states that the user doesn't have any Quick Start sessions.

#### Screenshots

##### Before

<img width="774" alt="Screenshot 2021-11-15 at 15 35 18" src="https://user-images.githubusercontent.com/3376401/141793813-cfed48b5-be48-4195-b226-acc0df55c500.png">

##### After

<img width="774" alt="Screenshot 2021-11-15 at 15 52 32" src="https://user-images.githubusercontent.com/3376401/141793825-da35122a-93d7-4a78-a6a2-438da93bb9df.png">


#### Testing instructions

* Run this branch locally or via the live branch (see [this comment](https://github.com/Automattic/wp-calypso/pull/58055#issuecomment-968938858) for the link)
* Navigate to `/me/quickstart` and select a site without any Quick Start sessions
* Verify that you are redirected to `/me/quickstart/:siteSlug/book`
* Verify that the page content tells you that you don't have any Quick Start sessions, but does _not_ have a CTA or path to buy a Quick Start session.