### PR TITLE
Plans: Activate real-time Jetpack products in Calypso

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,7 +15,7 @@
 	"difm_typeform_id": "YMiXMYId",
 	"difm_signup_typeform_id": "m3s2pdgI",
 	"features": {
-		"activity-log/display-rules": false,
+		"activity-log/display-rules": true,
 		"automated-transfer": true,
 		"async-payments": false,
 		"ad-tracking": false,
@@ -59,7 +59,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/user-licensing": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -24,7 +24,7 @@
 		}
 	],
 	"features": {
-		"activity-log/display-rules": false,
+		"activity-log/display-rules": true,
 		"activity-log/v2": true,
 		"always_use_logout_url": false,
 		"current-site/domain-warning": false,
@@ -33,7 +33,7 @@
 		"checkout/google-pay": true,
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -26,7 +26,7 @@
 	"oauth_client_id": 69041,
 	"features": {
 		"ad-tracking": true,
-		"activity-log/display-rules": false,
+		"activity-log/display-rules": true,
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
@@ -36,7 +36,7 @@
 		"i18n/community-translator": false,
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/pricing-page": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -18,7 +18,7 @@
 	"difm_signup_typeform_id": "m3s2pdgI",
 	"features": {
 		"ad-tracking": true,
-		"activity-log/display-rules": false,
+		"activity-log/display-rules": true,
 		"async-payments": false,
 		"automated-transfer": true,
 		"bilmur-script": true,
@@ -59,7 +59,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/only-realtime-products": false,
+		"jetpack/only-realtime-products": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,


### PR DESCRIPTION
Resolves `1200412004370260-as-1201368103210893`.

#### Changes proposed in this Pull Request

* Set the `activity-log/display-rules` feature flag to true in all environments, to enable Activity Log display limits.
* Set the `jetpack/only-realtime-products` feature flag to true in all environments, to enable real-time Jetpack Backup and Security in place of Daily products.

#### Testing instructions

* Verify that in all environment config files (e.g., `production.json`), the two aforementioned feature flags are set to `true`.
* No other testing necessary -- this PR affects production and horizon environments only.