### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` social connect to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import inherits from 'inherits';
 import WPCOM from 'wpcom';
@@ -103,77 +102,6 @@ UndocumentedMe.prototype.sendVerificationEmail = function ( callback ) {
 	debug( '/me/send-verification-email' );
 
 	return this.wpcom.req.post( { path: '/me/send-verification-email' }, callback );
-};
-
-/**
- * Connect the current account with a social service (e.g. Google/Facebook).
- *
- * @param {object} config Object containing the config.
- * @param {string} config.service Social service associated with token, e.g. google.
- * @param {string} config.access_token OAuth2 Token returned from service.
- * @param {string} config.id_token (Optional) OpenID Connect Token returned from service.
- * @param {string} config.user_name (Optional) The user name associated with this connection, in case it's not part of id_token.
- * @param {string} config.user_email (Optional) The user name associated with this connection, in case it's not part of id_token.
- * @param {string} config.redirect_to - The URL to redirect to after connecting.
- * @param {Function} fn - The callback for the request.
- * @returns {Promise} A promise for the request
- */
-UndocumentedMe.prototype.socialConnect = function (
-	{ service, access_token, id_token, user_name, user_email, redirect_to },
-	fn
-) {
-	const body = {
-		service,
-		access_token,
-		id_token,
-		user_name,
-		user_email,
-		redirect_to,
-
-		// This API call is restricted to these OAuth keys
-		client_id: config( 'wpcom_signup_id' ),
-		client_secret: config( 'wpcom_signup_key' ),
-	};
-
-	const args = {
-		path: '/me/social-login/connect',
-		body: body,
-	};
-
-	/*
-	 * Before attempting the social connect, we reload the proxy.
-	 * This ensures that the proxy iframe has set the correct API cookie,
-	 * particularly after the user has logged in, but Calypso hasn't
-	 * been reloaded yet.
-	 */
-	require( 'wpcom-proxy-request' ).reloadProxy();
-
-	this.wpcom.req.post( { metaAPI: { accessAllUsersBlogs: true } } );
-
-	return this.wpcom.req.post( args, fn );
-};
-
-/**
- * Disconnect the current account with a social service (e.g. Google/Facebook).
- *
- * @param {string} service - Social service associated with token, e.g. google.
- * @param {Function} fn - callback
- * @returns {Promise} A promise for the request
- */
-UndocumentedMe.prototype.socialDisconnect = function ( service, fn ) {
-	const body = {
-		service,
-		// This API call is restricted to these OAuth keys
-		client_id: config( 'wpcom_signup_id' ),
-		client_secret: config( 'wpcom_signup_key' ),
-	};
-
-	const args = {
-		path: '/me/social-login/disconnect',
-		body: body,
-	};
-
-	return this.wpcom.req.post( args, fn );
 };
 
 export default UndocumentedMe;

--- a/client/state/login/actions/connect-social-user.js
+++ b/client/state/login/actions/connect-social-user.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -12,14 +13,19 @@ import 'calypso/state/login/init';
 /**
  * Connects the current WordPress.com account with a third-party social account (Google ...).
  *
- * @param  {object}   socialInfo     Object containing { service, access_token, id_token, redirectTo }
- *           {string}   service      The external social service name
- *           {string}   access_token OAuth2 access token provided by the social service
- *           {string}   id_token     JWT ID token such as the one provided by Google OpenID Connect
- * @param  {string}   redirectTo     Url to redirect the user to upon successful login
- * @returns {Function}                A thunk that can be dispatched
+ * @param {object} socialInfo              Object containing the social service config data
+ * @param {string} socialInfo.service      Social service associated with token, e.g. google.
+ * @param {string} socialInfo.access_token OAuth2 Token returned from service.
+ * @param {string} socialInfo.id_token     (Optional) OpenID Connect Token returned from service.
+ * @param {string} socialInfo.user_name    (Optional) The user name associated with this connection, in case it's not part of id_token.
+ * @param {string} socialInfo.user_email   (Optional) The user email associated with this connection, in case it's not part of id_token.
+ * @param {string} redirectTo              Url to redirect the user to upon successful login
+ * @returns {Function} A thunk that can be dispatched
  */
-export const connectSocialUser = ( socialInfo, redirectTo ) => ( dispatch ) => {
+export const connectSocialUser = (
+	{ service, access_token, id_token, user_name, user_email },
+	redirectTo
+) => ( dispatch ) => {
 	dispatch( {
 		type: SOCIAL_CONNECT_ACCOUNT_REQUEST,
 		notice: {
@@ -27,10 +33,29 @@ export const connectSocialUser = ( socialInfo, redirectTo ) => ( dispatch ) => {
 		},
 	} );
 
-	return wpcom
-		.undocumented()
-		.me()
-		.socialConnect( { ...socialInfo, redirect_to: redirectTo } )
+	/*
+	 * Before attempting the social connect, we reload the proxy.
+	 * This ensures that the proxy iframe has set the correct API cookie,
+	 * particularly after the user has logged in, but Calypso hasn't
+	 * been reloaded yet.
+	 */
+	require( 'wpcom-proxy-request' ).reloadProxy();
+
+	wpcom.req.post( { metaAPI: { accessAllUsersBlogs: true } } );
+
+	return wpcom.req
+		.post( '/me/social-login/connect', {
+			service,
+			access_token,
+			id_token,
+			user_name,
+			user_email,
+			redirect_to: redirectTo,
+
+			// This API call is restricted to these OAuth keys
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+		} )
 		.then(
 			( wpcomResponse ) => {
 				dispatch( {

--- a/client/state/login/actions/disconnect-social-user.js
+++ b/client/state/login/actions/disconnect-social-user.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -23,10 +24,14 @@ export const disconnectSocialUser = ( socialService ) => ( dispatch ) => {
 		},
 	} );
 
-	return wpcom
-		.undocumented()
-		.me()
-		.socialDisconnect( socialService )
+	return wpcom.req
+		.post( '/me/social-login/disconnect', {
+			service: socialService,
+
+			// This API call is restricted to these OAuth keys
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+		} )
 		.then(
 			() => {
 				dispatch( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` social connect methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Start as a logged-out user.
* Go to `/log-in`
* Verify you can login with a Google account.
* Go to `/log-in` again
* Verify you can disconnect the Google account.

Note: I think this will be a bit tricky to test without landing it, due to limitations with third-party cookies.