### PR TITLE
Add onboarding Wix importer

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -354,6 +354,16 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'siteSlug' ],
 		},
 		{
+			name: 'from',
+			steps: [ 'importer' ],
+			destination: '/',
+			pageTitle: translate( 'Import your site content' ),
+			description: 'Onboarding - start from importer',
+			lastModified: '2021-11-15',
+			hideFlowProgress: true,
+			enableBranchSteps: true,
+		},
+		{
 			name: 'reader',
 			steps: [ 'reader-landing', 'user' ],
 			destination: '/',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -355,7 +355,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'from',
-			steps: [ 'importer' ],
+			steps: [ 'importing' ],
 			destination: '/',
 			pageTitle: translate( 'Import your site content' ),
 			description: 'Onboarding - start from importer',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -81,6 +81,7 @@ const stepNameToModuleName = {
 	list: 'import',
 	capture: 'import',
 	ready: 'import',
+	importer: 'import-from',
 	confirm: 'woocommerce-install',
 	transfer: 'woocommerce-install',
 	install: 'woocommerce-install',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -81,7 +81,7 @@ const stepNameToModuleName = {
 	list: 'import',
 	capture: 'import',
 	ready: 'import',
-	importer: 'import-from',
+	importing: 'import-from',
 	confirm: 'woocommerce-install',
 	transfer: 'woocommerce-install',
 	install: 'woocommerce-install',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -778,6 +778,9 @@ export function generateSteps( {
 		ready: {
 			stepName: 'ready',
 		},
+		importer: {
+			stepName: 'importer',
+		},
 
 		// Woocommerce Install steps
 		confirm: {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -778,8 +778,8 @@ export function generateSteps( {
 		ready: {
 			stepName: 'ready',
 		},
-		importer: {
-			stepName: 'importer',
+		importing: {
+			stepName: 'importing',
 		},
 
 		// Woocommerce Install steps

--- a/client/signup/select-items-alt/style.scss
+++ b/client/signup/select-items-alt/style.scss
@@ -50,6 +50,7 @@
 		padding: 0;
 		min-width: 130px;
 		border: none;
+		background: none;
 		color: #101517;
 		text-decoration: underline;
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import WixImporter from './wix';
 
+import './style.scss';
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface Props {

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -1,5 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import React from 'react';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import WixImporter from './wix';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -9,6 +11,7 @@ interface Props {
 }
 
 const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
+	const { stepSectionName } = props;
 	return (
 		<StepWrapper
 			flowName={ 'import-from' }
@@ -17,7 +20,11 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 			hideNext={ true }
 			hideFormattedHeader={ true }
 			stepContent={
-				<div className="import__onboarding-page">Import from { props.stepSectionName }</div>
+				<div className="import__onboarding-page">
+					{ stepSectionName === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) && (
+						<WixImporter />
+					) }
+				</div>
 			}
 		/>
 	);

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import StepWrapper from 'calypso/signup/step-wrapper';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+interface Props {
+	stepName: string;
+	stepSectionName: string;
+}
+
+const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
+	return (
+		<StepWrapper
+			flowName={ 'import-from' }
+			hideSkip={ true }
+			hideBack={ true }
+			hideNext={ true }
+			hideFormattedHeader={ true }
+			stepContent={
+				<div className="import__onboarding-page">Import from { props.stepSectionName }</div>
+			}
+		/>
+	);
+};
+
+export default ImportOnboardingFrom;

--- a/client/signup/steps/import-from/style.scss
+++ b/client/signup/steps/import-from/style.scss
@@ -1,0 +1,12 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '../import/style';
+
+.import__onboarding-page {
+	.onboarding-progress {
+		margin: auto;
+
+		@include break-small {
+			min-width: 465px;
+		}
+	}
+}

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const WixImporter: React.FunctionComponent = () => {
+	return <div>Wix Importer</div>;
+};
+
+export default WixImporter;

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -1,7 +1,23 @@
+import { ProgressBar } from '@automattic/components';
+import { Progress, Title, SubTitle } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import React from 'react';
 
 const WixImporter: React.FunctionComponent = () => {
-	return <div>Wix Importer</div>;
+	const { __ } = useI18n();
+
+	return (
+		<div className={ classnames( 'import-layout__center' ) }>
+			<Progress>
+				<Title>{ __( 'Importing' ) }...</Title>
+				<ProgressBar color={ 'black' } compact={ true } value={ 33 } />
+				<SubTitle>
+					{ __( "This may take a few minutes. We'll notify you by email when it's done." ) }
+				</SubTitle>
+			</Progress>
+		</div>
+	);
 };
 
 export default WixImporter;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -181,6 +181,7 @@
 		"setup-site",
 		"do-it-for-me",
 		"importer",
+		"from",
 		"woocommerce-install"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",

--- a/config/development.json
+++ b/config/development.json
@@ -76,6 +76,7 @@
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/import": true,
+		"gutenboarding/import-from-wix": true,
 		"help": true,
 		"home/layout-dev": true,
 		"importers/substack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,6 +51,7 @@
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/import": true,
+		"gutenboarding/import-from-wix": true,
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -8,3 +8,4 @@ export {
 } from './action-buttons';
 export { default as FeatureIcon } from './feature-icon';
 export { default as ScrollToTop } from './scroll-to-top';
+export { default as Progress } from './progress';

--- a/packages/onboarding/src/progress/index.tsx
+++ b/packages/onboarding/src/progress/index.tsx
@@ -1,0 +1,30 @@
+import classnames from 'classnames';
+import * as React from 'react';
+
+import './style.scss';
+
+interface Props {
+	align?: 'center' | 'left' | 'right';
+	className?: string;
+}
+
+const Progress: React.FunctionComponent< Props > = ( {
+	className,
+	align = 'center',
+	children,
+	...additionalProps
+} ) => {
+	return (
+		<div
+			className={ classnames(
+				`onboarding-progress onboarding-progress__align-${ align }`,
+				className
+			) }
+			{ ...additionalProps }
+		>
+			{ children }
+		</div>
+	);
+};
+
+export default Progress;

--- a/packages/onboarding/src/progress/style.scss
+++ b/packages/onboarding/src/progress/style.scss
@@ -1,0 +1,33 @@
+.onboarding-progress {
+
+	&__align-center {
+		text-align: center;
+	}
+
+	&__align-right {
+		text-align: right;
+	}
+
+	&__align-left {
+		text-align: left;
+	}
+
+	.onboarding-title {
+		font-family: var( --font-base, var( --font-base-default ) );
+		color: var( --studio-gray-80 );
+		font-size: 1.75rem; /* stylelint-disable-line */
+		line-height: 1em;
+		margin-bottom: 2rem;
+	}
+
+	.onboarding-subtitle {
+		color: var( --studio-gray-40 );
+		font-size: 0.875rem;
+		line-height: 1.5rem;
+	}
+
+	.progress-bar {
+		margin-bottom: 2em;
+		background: var( --studio-gray-5 );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Introduced a new onboarding flow that lives on the route `/start/from/importing/<IMPORTER_NAME>`
* Introduced Onboarding Progress component
* Registered a Wix onboarding flow `/start/from/importing/wix`

The flow has been feature flagged. The flag is `gutenboarding/import-from-wix`

#### Testing instructions

* go to `/start/from/importing/wix`
* you should see the static screen with progress bar

#### Screenshot
<img width="656" alt="Screenshot 2021-11-16 at 17 16 13" src="https://user-images.githubusercontent.com/1241413/142023214-ee911ff9-d5fc-4885-9952-ad15d2b70941.png">

Related to #57131
