### PR TITLE
Disable the browser fallback check for now.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -168,6 +168,6 @@
 		"woop": true,
 		"wpcom-user-bootstrap": false,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"redirect-fallback-browsers": false
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -112,7 +112,7 @@
 		"use-translation-chunks": true,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"redirect-fallback-browsers": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -121,7 +121,7 @@
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"redirect-fallback-browsers": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -87,6 +87,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"wpcom-user-bootstrap": false,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"redirect-fallback-browsers": false
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,7 +130,7 @@
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"redirect-fallback-browsers": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

THis PR removed the Browser feature because any iPhone user running ios 14 got the browserhappy page. 

#### Testing instructions

Remove any cookies. 
login with a simulator that is running iOS 14 browser.
Notice that you are not redirected to the 
/browsehappy?from=%2F page


Related to https://github.com/Automattic/wp-calypso/issues/58061

