### PR TITLE
Bump the supported iOS version to 3 versions ago

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -168,6 +168,6 @@
 		"woop": true,
 		"wpcom-user-bootstrap": false,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": false
+		"redirect-fallback-browsers": true
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -112,7 +112,7 @@
 		"use-translation-chunks": true,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": false
+		"redirect-fallback-browsers": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -121,7 +121,7 @@
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": false
+		"redirect-fallback-browsers": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -87,6 +87,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"wpcom-user-bootstrap": false,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": false
+		"redirect-fallback-browsers": true
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,7 +130,7 @@
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": false
+		"redirect-fallback-browsers": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 			"last 1 ChromeAndroid versions",
 			"last 2 Firefox versions",
 			"last 2 Safari versions",
-			"last 2 iOS versions",
+			"last 3 iOS versions",
 			"last 2 Edge versions",
 			"last 2 Opera versions",
 			"Firefox ESR",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the issue #58061
It  undoes https://github.com/Automattic/wp-calypso/pull/58065 
By bumping the iOS version number to last 3 supported versions. 

#### Testing instructions
Remove any cookies.
login with a simulator that is running iOS 14 browser.
Notice that you are not redirected to the
/browsehappy?from=%2F page

