### PR TITLE
Video UI: Fix title break on small sizes and summary wrapping

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -17,10 +17,10 @@
 			display: flex;
 			flex-direction: column;
 			padding: 20px;
-			padding-top: 15px;
+			padding-top: 21px;
 
 			ul {
-				margin: 40px 0 0;
+				margin: 38px 0 0;
 			}
 
 			li {
@@ -33,7 +33,7 @@
 				@include onboarding-font-recoleta;
 				font-size: $font-headline-small;
 				letter-spacing: 0;
-				height: 40px;
+				line-height: 1.1;
 
 				&:first-child {
 					color: rgba( 255, 255, 255, 0.5 );
@@ -187,12 +187,10 @@
 
 				.videos-ui__titles {
 					flex-basis: auto;
-					width: 65.5%;
 				}
 
 				.videos-ui__summary {
 					flex-basis: auto;
-					width: 31%;
 					padding-top: 16px;
 				}
 


### PR DESCRIPTION
This PR fixes
 * title rendering on narrow screens
 * weird wrapping of the summary on medium breaks

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/141835682-e3b10aed-e68e-4709-827b-f453fae85205.png)  | ![image](https://user-images.githubusercontent.com/375980/141835374-a9f25863-1556-4088-b7ac-6b3faf58da8f.png)  |
| ![image](https://user-images.githubusercontent.com/375980/141835576-b7b1d0f7-382b-4ca4-ac20-d52bbcd3cd62.png) | ![image](https://user-images.githubusercontent.com/375980/141835427-83db57b7-f833-484d-bf89-ad6ee4c2f551.png) |

#### Testing
* Check out a copy of #58020 and merge this branch into it locally in order to test the Videos UI in the modal (you might need to rebase from trunk).
* Verify that the title overflows correctly on small widths. 
* Verify that the summary wraps correctly on medium breaks.

Closes #58063
