### PR TITLE
Add email setup to DNS Records page

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -12,6 +12,7 @@ import { getSelectedDomain, isRegisteredDomain } from 'calypso/lib/domains';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import DnsRecordsList from 'calypso/my-sites/domains/domain-management/dns/dns-records-list';
+import EmailSetup from 'calypso/my-sites/domains/domain-management/email-setup';
 import {
 	domainManagementEdit,
 	domainManagementNameServers,
@@ -101,6 +102,7 @@ class DnsRecords extends Component {
 					selectedSite={ selectedSite }
 					selectedDomainName={ selectedDomainName }
 				/>
+				<EmailSetup selectedDomainName={ selectedDomainName } />
 			</Main>
 		);
 	}

--- a/client/my-sites/domains/domain-management/email-setup/index.jsx
+++ b/client/my-sites/domains/domain-management/email-setup/index.jsx
@@ -9,7 +9,7 @@ import { dnsTemplates } from 'calypso/lib/domains/constants';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import EmailProvider from '../dns/email-provider';
 
-import './email-setup.scss';
+import './style.scss';
 
 class EmailSetup extends Component {
 	static propTypes = {

--- a/client/my-sites/domains/domain-management/email-setup/style.scss
+++ b/client/my-sites/domains/domain-management/email-setup/style.scss
@@ -24,3 +24,9 @@
 		border-top: none;
 	}
 }
+
+.dns-records.main {
+	* + .email-setup {
+		margin-top: 32px;
+	}
+}

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -17,6 +17,7 @@ import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/b
 import NonPrimaryDomainPlanUpsell from 'calypso/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import IcannVerificationCard from 'calypso/my-sites/domains/domain-management/components/icann-verification';
+import EmailSetup from 'calypso/my-sites/domains/domain-management/email-setup';
 import {
 	domainManagementEdit,
 	domainManagementList,
@@ -35,7 +36,6 @@ import {
 } from './constants';
 import CustomNameserversForm from './custom-nameservers-form';
 import DnsTemplates from './dns-templates';
-import EmailSetup from './email-setup';
 import FetchError from './fetch-error';
 import withDomainNameservers from './with-domain-nameservers';
 import WpcomNameserversToggle from './wpcom-nameservers-toggle';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the new email setup component to the bottom of the new DNS page

#### Testing instructions

Be sure to set the feature flag: `?flags=domains/dns-records-redesign`
Browse to the DNS page and make sure that the email setup component is shown at the bottom.
Make sure that you can add records using the setup component.