### PR TITLE
Plans: Re-add missing product slugs to Free product cards, for e2e testing

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/with-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/with-price.tsx
@@ -18,11 +18,13 @@ import './style.scss';
 const CRM_FREE_URL =
 	'https://jetpackcrm.com/pricing?utm_source=jetpack&utm_medium=web&utm_campaign=pricing_i4&utm_content=pricing';
 
-const useCrmFreeItem = () => {
+const useCrmFreeItem = ( duration: Duration ) => {
 	const translate = useTranslate();
 
 	return useMemo(
 		() => ( {
+			productSlug:
+				duration === TERM_MONTHLY ? PRODUCT_JETPACK_CRM_FREE_MONTHLY : PRODUCT_JETPACK_CRM_FREE,
 			isFree: true,
 			displayName: translate( 'Jetpack CRM' ),
 			features: {
@@ -33,7 +35,7 @@ const useCrmFreeItem = () => {
 				],
 			},
 		} ),
-		[ translate ]
+		[ duration, translate ]
 	);
 };
 
@@ -44,12 +46,7 @@ export type CardWithPriceProps = {
 
 const CardWithPrice: React.FC< CardWithPriceProps > = ( { duration, siteId } ) => {
 	const translate = useTranslate();
-	const crmFreeProduct = useCrmFreeItem();
-	const slug = useMemo(
-		() =>
-			duration === TERM_MONTHLY ? PRODUCT_JETPACK_CRM_FREE_MONTHLY : PRODUCT_JETPACK_CRM_FREE,
-		[ duration ]
-	);
+	const crmFreeProduct = useCrmFreeItem( duration );
 
 	const dispatch = useDispatch();
 	const trackCallback = useCallback(
@@ -63,9 +60,9 @@ const CardWithPrice: React.FC< CardWithPriceProps > = ( { duration, siteId } ) =
 	);
 
 	const onButtonClick = useCallback( () => {
-		storePlan( slug );
+		storePlan( crmFreeProduct.productSlug );
 		trackCallback();
-	}, [ slug, trackCallback ] );
+	}, [ crmFreeProduct, trackCallback ] );
 
 	return (
 		<JetpackProductCard

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/with-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/with-price.tsx
@@ -14,6 +14,7 @@ const useFreeItem = () => {
 
 	return useMemo(
 		() => ( {
+			productSlug: 'free',
 			isFree: true,
 			displayName: translate( 'Jetpack Free' ),
 			features: {


### PR DESCRIPTION
Resolves `p1636998721291900-slack-CQXNTE9K9`.

#### Changes proposed in this Pull Request

* Add correct product slug property values to the Free and CRM Free product cards, so that the `data-e2e-product-slug` attribute is populated and end-to-end tests can be run without issues.

#### Testing instructions

1. Navigate to the pricing page in either Calypso Blue or Calypso Green.
2. Inspect either the Jetpack CRM or Jetpack Free product card.
3. Verify each card has a custom HTML property called `data-e2e-product-slug`, with a value corresponding to the product you're inspecting. For Jetpack CRM, this slug should alternate between monthly and yearly when you click the billing term toggle at the top of the page.
4. Ensure all unit and e2e tests are passing.