### PR TITLE
Activity log: update spacing between filter controls

### DIFF
--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -118,21 +118,27 @@ export class Filterbar extends Component {
 			<div className="filterbar" id="filterbar">
 				<div className="filterbar__wrap card">
 					<span className="filterbar__label">{ translate( 'Filter by:' ) }</span>
-					<DateRangeSelector
-						isVisible={ this.state.showActivityDates }
-						onButtonClick={ this.toggleDateRangeSelector }
-						onClose={ this.closeDateRangeSelector }
-						filter={ filter }
-						siteId={ siteId }
-					/>
-					<ActionTypeSelector
-						filter={ filter }
-						siteId={ siteId }
-						isVisible={ this.state.showActivityTypes }
-						onButtonClick={ this.toggleActivityTypesSelector }
-						onClose={ this.closeActivityTypes }
-					/>
-					{ this.renderCloseButton() }
+					<ul className="filterbar__control-list">
+						<li>
+							<DateRangeSelector
+								isVisible={ this.state.showActivityDates }
+								onButtonClick={ this.toggleDateRangeSelector }
+								onClose={ this.closeDateRangeSelector }
+								filter={ filter }
+								siteId={ siteId }
+							/>
+						</li>
+						<li>
+							<ActionTypeSelector
+								filter={ filter }
+								siteId={ siteId }
+								isVisible={ this.state.showActivityTypes }
+								onButtonClick={ this.toggleActivityTypesSelector }
+								onClose={ this.closeActivityTypes }
+							/>
+						</li>
+						<li>{ this.renderCloseButton() }</li>
+					</ul>
 				</div>
 				<div className="filterbar__mobile-wrap" />
 			</div>

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -38,8 +38,20 @@
 		}
 	}
 
+	.filterbar__control-list {
+		display: flex;
+
+		margin: 0 0 0 4px;
+		padding: 0;
+
+		list-style-type: none;
+
+		> li {
+			margin: 4px;
+		}
+	}
+
 	.filterbar__selection.button {
-		margin: 8px;
 		padding: 8px;
 		border: 1px solid var( --color-neutral-20 );
 		border-radius: 2px;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adjusts the spacing between the controls of the activity log filter bar.

### Testing instructions

- Download the PR and run Calypso or cloud
- Select a Jetpack site
- Visit the Activity Log at `/activity-log/<site>/`
- Check that the padding between the filter bar controls is smaller, as shown in the capture below

### Screenshots

#### Before

<img width="317" alt="Screen Shot 2021-11-15 at 2 34 17 PM" src="https://user-images.githubusercontent.com/1620183/141843559-790687f2-21e5-405f-b025-efba03a8c102.png">


#### After
<img width="296" alt="Screen Shot 2021-11-15 at 2 34 22 PM" src="https://user-images.githubusercontent.com/1620183/141843577-cae60b42-5627-4bfe-9417-b34e7d56c332.png">


