### PR TITLE
Jetpack Checkout: handle unknown activation error

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -68,6 +68,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 	const supportTicketRequestStatus = useSelector( ( state ) =>
 		getSupportTicketRequestStatus( state, receiptId )
 	);
+
 	const destinationSiteId = useSelector( ( state ) =>
 		getJetpackCheckoutSupportTicketDestinationSiteId( state, jetpackTemporarySiteId )
 	);
@@ -78,19 +79,22 @@ const LicensingActivationThankYou: FC< Props > = ( {
 	const [ selectedSite, setSelectedSite ] = useState( '' );
 	const [ error, setError ] = useState< TranslateResult | false >( false );
 
+	const manualActivationUrl = useMemo( () => {
+		return addQueryArgs(
+			{
+				receiptId,
+				source,
+				jetpackTemporarySiteId,
+			},
+			`/checkout/jetpack/thank-you/licensing-manual-activate/${ productSlug }`
+		);
+	}, [ jetpackTemporarySiteId, productSlug, source, receiptId ] );
+
 	const onContinue = useCallback(
 		( e ) => {
 			e.preventDefault();
 			setError( false );
 			if ( selectedSite === 'activate-license-manually' ) {
-				const manualActivationUrl = addQueryArgs(
-					{
-						receiptId,
-						source,
-						jetpackTemporarySiteId,
-					},
-					`/checkout/jetpack/thank-you/licensing-manual-activate/${ productSlug }`
-				);
 				return page( manualActivationUrl );
 			}
 			dispatch(
@@ -111,7 +115,15 @@ const LicensingActivationThankYou: FC< Props > = ( {
 				)
 			);
 		},
-		[ selectedSite, dispatch, productSlug, receiptId, source, jetpackTemporarySiteId ]
+		[
+			dispatch,
+			manualActivationUrl,
+			jetpackTemporarySiteId,
+			productSlug,
+			receiptId,
+			selectedSite,
+			source,
+		]
 	);
 
 	useEffect( () => {
@@ -146,6 +158,24 @@ const LicensingActivationThankYou: FC< Props > = ( {
 					)
 				);
 			}
+
+			if ( destinationSiteId === 0 ) {
+				return setError(
+					translate(
+						'There was a problem activating %(productName)s on {{strong}}%(selectedSite)s{{/strong}}. Try with a different site or {{a}}activate your product manually{{/a}}.',
+						{
+							components: {
+								strong: <strong />,
+								a: <a href={ manualActivationUrl } />,
+							},
+							args: {
+								productName,
+								selectedSite: urlToSlug( selectedSite ),
+							},
+						}
+					)
+				);
+			}
 			// If the destinationSiteId is greater than 0, then the subscription transfer was successful.
 			const thankYouCompletedUrl = addQueryArgs(
 				{
@@ -157,14 +187,15 @@ const LicensingActivationThankYou: FC< Props > = ( {
 		}
 	}, [
 		destinationSiteId,
-		supportTicketRequestStatus,
-		incompatibleProductIds,
-		selectedSite,
 		error,
-		translate,
-		productSlug,
-		productsList,
+		incompatibleProductIds,
+		manualActivationUrl,
 		productName,
+		productsList,
+		productSlug,
+		selectedSite,
+		supportTicketRequestStatus,
+		translate,
 	] );
 
 	const siteSelectOptions = useMemo( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Handle unknown activation errors.

#### Testing instructions
Prerequisite: a WPCOM Sandbox.

* Download this PR.
* Start Calypso Blue with `yarn start`.
* Sandbox `public-api.wordpress.com`.
* Add `add_filter( 'jetpack_license_checkout_m2_enabled', '__return_true' );` to `0-sandbox.php`.
* Create a JN site.
* Connect the recently created site.
* Visit https://cloud.jetpack.com/pricing (without a site to make a site-less purchase).
* Select any Jetpack product.
* Once you're on the checkout page, replace `wordpress.com` with `calypso.localhost:3000`.
* Submit the checkout form.
* Once you're on the post-purchase thank you page, verify that the dropdown includes the recently created JN site.
* Open a new tab and disconnect the recently created site (you can do that from the site WP Admin).
* Go back to the tab where the post-purchase thank you page is, and select the recently created JN site.
* Click the continue button.
* Verify that you see an error message that contains a link to manually activate the product (see capture for a reference).
* Click the link to activate the product manually.
* Continue the flow until you reach the last step.
* Verify that you see a license key.

Related to 1201096622142517-as-1201362055559962

#### Demo
<img width="1392" alt="Screen Shot 2021-11-15 at 17 31 42" src="https://user-images.githubusercontent.com/3418513/141851640-4f11ce1d-1a00-4ab0-b370-3daa8f7326b1.png">