### PR TITLE
Videos UI: Better align wrapping content in the header checklist.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -44,6 +44,9 @@
 				padding-left: 2.55px;
 
 				svg {
+					flex-basis: 18px;
+					flex-grow: 0;
+					flex-shrink: 0;
 					padding-right: 16px;
 					fill: rgba( 255, 255, 255, 0.6 );
 					vertical-align: text-bottom;
@@ -51,6 +54,7 @@
 
 				li {
 					color: rgba( 255, 255, 255, 0.88 );
+					display: flex;
 				}
 			}
 		}


### PR DESCRIPTION
When content for the checklist wraps, we want the wrapping text to align with the text above it, not fully left-aligned under the checkmark. This isn't an immediate problem with our current English-only content, but will be a problem as soon as we deploy translations.

Fixes #58071.

| Before | After |
| --- | --- |
| <img width="475" alt="Screen Shot 2021-11-15 at 1 48 25 PM" src="https://user-images.githubusercontent.com/349751/141858593-5550a81e-a3a5-4496-884a-a9a886351db7.png"> | <img width="475" alt="Screen Shot 2021-11-15 at 1 43 27 PM" src="https://user-images.githubusercontent.com/349751/141858606-f4baae1f-43a5-4687-aa87-174c8d95e21b.png"> |

**Testing Instructions**
* Load this PR's `calypso.live` branch.
* On My Home, click "Start learning" in the first educational card.
* Use the dev tools to inflate the length of one of the checkmarks' content.
* Verify it wraps as expected.