### PR TITLE
Checkout: Remove Quickstart mentions from Thank you screens

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -6,12 +6,11 @@ import { connect, useSelector } from 'react-redux';
 import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
 import analyticsImage from 'calypso/assets/images/illustrations/google-analytics.svg';
 import jetpackBackupImage from 'calypso/assets/images/illustrations/jetpack-backup.svg';
-import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
 import updatesImage from 'calypso/assets/images/illustrations/updates.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getProductsList, getProductDisplayCost } from 'calypso/state/products-list/selectors';
+import { getProductsList } from 'calypso/state/products-list/selectors';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
@@ -26,7 +25,6 @@ const BusinessPlanDetails = ( {
 	selectedFeature,
 	purchases,
 	hasProductsList,
-	conciergeSessionDisplayCost,
 } ) => {
 	const shouldPromoteJetpack = useSelector( ( state ) =>
 		isJetpackSectionEnabledForSite( state, selectedSite?.ID )
@@ -34,32 +32,6 @@ const BusinessPlanDetails = ( {
 
 	const plan = find( sitePlans.data, isBusiness );
 	const googleAppsWasPurchased = purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
-
-	const locale = i18n.getLocaleSlug();
-	const isEnglish = -1 !== [ 'en', 'en-gb' ].indexOf( locale );
-
-	const detailDescriptionWithPrice = i18n.translate(
-		'Schedule a %(price)s Quick Start session with a Happiness Engineer to set up your site and learn more about WordPress.com.',
-		{
-			args: {
-				price: conciergeSessionDisplayCost,
-			},
-		}
-	);
-
-	//TODO: remove this once price translations are finished and just use detailDescriptionWithPrice.
-	let detailDescription = i18n.translate(
-		'Schedule a Quick Start session with a Happiness Engineer to set up your site and learn more about WordPress.com.'
-	);
-
-	if (
-		isEnglish ||
-		i18n.hasTranslation(
-			'Schedule a %(price)s Quick Start session with a Happiness Engineer to set up your site and learn more about WordPress.com.'
-		)
-	) {
-		detailDescription = detailDescriptionWithPrice;
-	}
 
 	return (
 		<div>
@@ -70,17 +42,6 @@ const BusinessPlanDetails = ( {
 				selectedSite={ selectedSite }
 				hasDomainCredit={ plan && plan.hasDomainCredit }
 			/>
-
-			{ ( isEnglish || i18n.hasTranslation( 'Purchase a session' ) ) && (
-				<PurchaseDetail
-					icon={ <img alt="" src={ conciergeImage } /> }
-					title={ i18n.translate( 'Get personalized help' ) }
-					description={ detailDescription }
-					buttonText={ i18n.translate( 'Purchase a session' ) }
-					href={ `/checkout/offer-quickstart-session` }
-					onClick={ trackOnboardingButtonClick }
-				/>
-			) }
 
 			<PurchaseDetail
 				icon={ <img alt={ i18n.translate( 'Earn Illustration' ) } src={ earnImage } /> }
@@ -141,6 +102,5 @@ export default connect( ( state ) => {
 	const productsList = getProductsList( state );
 	return {
 		hasProductsList: Object.keys( productsList ).length > 0,
-		conciergeSessionDisplayCost: getProductDisplayCost( state, 'concierge-session' ),
 	};
 } )( BusinessPlanDetails );

--- a/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
@@ -3,16 +3,10 @@ import i18n from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import analyticsImage from 'calypso/assets/images/illustrations/google-analytics.svg';
-import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
 import updatesImage from 'calypso/assets/images/illustrations/updates.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
-
-function trackOnboardingButtonClick() {
-	recordTracksEvent( 'calypso_checkout_thank_you_onboarding_click' );
-}
 
 const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchases } ) => {
 	const plan = find( sitePlans.data, isEcommerce );
@@ -25,18 +19,6 @@ const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purch
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }
 				hasDomainCredit={ plan && plan.hasDomainCredit }
-			/>
-
-			<PurchaseDetail
-				icon={ <img alt="" src={ conciergeImage } /> }
-				title={ i18n.translate( 'Get personalized help' ) }
-				description={ i18n.translate(
-					'Schedule a Quick Start session with a Happiness Engineer to set up ' +
-						'your site and learn more about WordPress.com.'
-				) }
-				buttonText={ i18n.translate( 'Schedule a session' ) }
-				href={ `/me/quickstart/${ selectedSite.slug }/book` }
-				onClick={ trackOnboardingButtonClick }
 			/>
 
 			{ ! selectedFeature && (


### PR DESCRIPTION
See pc4ICr-mc-p2/#comment-644

#### Changes proposed in this Pull Request

* Removes Quickstart upsells on Business and eCommerce plan upsells

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a business plan for a test site
* Double-check that the Quickstart upsell is not shown on the Thank you screen.

It doesn't looks like we're actually showing the eCommerce thank you screen, but instead nudge users to directly set up their store.

#### After:
<img width="1510" alt="Screen Shot 2021-11-15 at 3 03 13 PM" src="https://user-images.githubusercontent.com/1398304/141867206-136f9f57-f57d-4c7e-a44e-344a8c527add.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


