### PR TITLE
Moved the tour popup wizard above the site tagline field as it was blocking the site tagline field

### DIFF
--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -25,4 +25,4 @@ export const DoneButton = button( translate( 'Done' ) );
 export const EditButton = button( translate( 'Edit' ) );
 export const EditImageButton = button( translate( 'Edit Image' ), <Gridicon icon="pencil" /> );
 export const SiteTitleButton = button( translate( 'Site Title' ) );
-export const SiteTaglineButton = button( translate( 'Site tagline' ) );
+export const SiteTaglineButton = button( translate( 'Site Tagline' ) );

--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -25,3 +25,4 @@ export const DoneButton = button( translate( 'Done' ) );
 export const EditButton = button( translate( 'Edit' ) );
 export const EditImageButton = button( translate( 'Edit Image' ), <Gridicon icon="pencil" /> );
 export const SiteTitleButton = button( translate( 'Site Title' ) );
+export const SiteTaglineButton = button( translate( 'Site tagline' ) );

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -337,10 +337,3 @@ $guided-tour-step_border: 2px solid white;
 .guided-tours__step-dark.guided-tours__step-pointing-left-top::before {
 	left: -8.5px;
 }
-
-.card.guided-tours__step {
-	@include breakpoint-deprecated( '<480px' ) {
-		top: 90px !important;
-		left: 10px !important;
-	}
-}

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -337,3 +337,10 @@ $guided-tour-step_border: 2px solid white;
 .guided-tours__step-dark.guided-tours__step-pointing-left-top::before {
 	left: -8.5px;
 }
+
+.card.guided-tours__step {
+	@include breakpoint-deprecated( '<480px' ) {
+		top: 90px !important;
+		left: 10px !important;
+	}
+}

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -32,7 +32,7 @@ export const ChecklistSiteTitleTour = makeTour(
 							{
 								components: {
 									siteTitleButton: <SiteTitleButton />,
-									SiteTaglineButton: <SiteTaglineButton />,
+									siteTaglineButton: <SiteTaglineButton />,
 								},
 							}
 						) }

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -27,8 +27,8 @@ export const ChecklistSiteTitleTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'Update the {{siteTitleButton/}} field with a descriptive name ' +
-								'to let your visitors know which site they’re visiting.',
+							'Update the {{siteTitleButton/}} and tagline fields ' +
+								'to let visitors clearly identify your site.',
 							{
 								components: { siteTitleButton: <SiteTitleButton /> },
 							}

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { Fragment } from 'react';
-import { SiteTitleButton } from 'calypso/layout/guided-tours/button-labels';
+import { SiteTitleButton, SiteTaglineButton } from 'calypso/layout/guided-tours/button-labels';
 import {
 	ButtonRow,
 	Continue,
@@ -27,10 +27,13 @@ export const ChecklistSiteTitleTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'Update the {{siteTitleButton/}} and tagline fields ' +
+							'Update the {{siteTitleButton/}} and {{SiteTaglineButton/}} fields ' +
 								'to let visitors clearly identify your site.',
 							{
-								components: { siteTitleButton: <SiteTitleButton /> },
+								components: {
+									siteTitleButton: <SiteTitleButton />,
+									SiteTaglineButton: <SiteTaglineButton />,
+								},
 							}
 						) }
 					</p>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -27,7 +27,7 @@ export const ChecklistSiteTitleTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'Update the {{siteTitleButton/}} and {{SiteTaglineButton/}} fields ' +
+							'Update the {{siteTitleButton/}} and {{siteTaglineButton/}} fields ' +
 								'to let visitors clearly identify your site.',
 							{
 								components: {

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -17,8 +17,8 @@ export const ChecklistSiteTitleTour = makeTour(
 	<Tour { ...meta }>
 		<Step
 			name="init"
-			target="site-title-input"
-			placement="beside"
+			target="site-tagline-input"
+			placement="below"
 			style={ {
 				animationDelay: '0.7s',
 			} }

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -18,8 +18,7 @@ export const ChecklistSiteTitleTour = makeTour(
 		<Step
 			name="init"
 			target="site-title-input"
-			arrow="bottom-left"
-			placement="above"
+			placement="beside"
 			style={ {
 				animationDelay: '0.7s',
 			} }

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -18,8 +18,8 @@ export const ChecklistSiteTitleTour = makeTour(
 		<Step
 			name="init"
 			target="site-title-input"
-			arrow="top-left"
-			placement="below"
+			arrow="bottom-left"
+			placement="above"
 			style={ {
 				animationDelay: '0.7s',
 			} }


### PR DESCRIPTION
### Here is what has been implemented:

![](https://d.pr/i/2e3z9O+)
[Direct Link](https://d.pr/i/2e3z9O+)



### Here is the original:

![](https://d.pr/i/pdHvmE+)
[Direct Link](https://d.pr/i/pdHvmE+)

Moving the popup upwards, creates the space for the site tag line, hope that is fine.

@tyxla 






Related to #55513
Fixes #55513