### PR TITLE
Onboarding: Avoid going to invalid step

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -527,7 +527,10 @@ class Signup extends Component {
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToStep = ( stepName, stepSectionName, flowName = this.props.flowName ) => {
-		if ( ! this.isEveryStepSubmitted() ) {
+		// The `stepName` might be undefined after the user finish the last step but the value of
+		// `isEveryStepSubmitted` is still false. Thus, check the `stepName` here to avoid going
+		// to invalid step.
+		if ( stepName && ! this.isEveryStepSubmitted() ) {
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
 			page( getStepUrl( flowName, stepName, stepSectionName, locale ) );
 		} else if ( this.isEveryStepSubmitted() ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As mentioned in https://github.com/Automattic/wp-calypso/pull/57640#issuecomment-963830018, we should avoid the user going to an invalid step after they finish the last step. So, check the `stepName` when the user goes to the next step to avoid this issue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* After you finish the last step (ex. Plan), you should not see the user change to `/start/user` again. Also, the `calypso_signup_step_start` with `prop step: user ` should not be fired again.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/57640, pau2Xa-3C5-p2