### PR TITLE
(wip) media: migrate to `react-query`

### DIFF
--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -1,88 +1,57 @@
-import { isEqual } from 'lodash';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
-import passToChildren from 'calypso/lib/react-pass-to-children';
-import { setQuery } from 'calypso/state/media/actions';
-import { fetchNextMediaPage } from 'calypso/state/media/thunks';
-import getMediaSortedByDate from 'calypso/state/selectors/get-media-sorted-by-date';
-import hasNextMediaPage from 'calypso/state/selectors/has-next-media-page';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import useMediaQuery from 'calypso/data/media/use-media-query';
 import utils from './utils';
 
-export class MediaListData extends Component {
-	static displayName = 'MediaListData';
+const getQuery = ( { search, source, filter, postId } ) => {
+	const query = {};
 
-	static propTypes = {
-		siteId: PropTypes.number.isRequired,
-		source: PropTypes.string,
-		postId: PropTypes.number,
-		filter: PropTypes.string,
-		search: PropTypes.string,
-	};
-
-	UNSAFE_componentWillMount() {
-		this.props.setQuery( this.props.siteId, this.getQuery() );
+	if ( search ) {
+		query.search = search;
 	}
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const nextQuery = this.getQuery( nextProps );
-
-		if ( this.props.siteId !== nextProps.siteId || ! isEqual( nextQuery, this.getQuery() ) ) {
-			this.props.setQuery( nextProps.siteId, nextQuery );
-		}
-	}
-
-	getQuery = ( props ) => {
-		const query = {};
-
-		props = props || this.props;
-
-		if ( props.search ) {
-			query.search = props.search;
-		}
-
-		if ( props.filter && ! props.source ) {
-			if ( props.filter === 'this-post' ) {
-				if ( props.postId ) {
-					query.post_ID = props.postId;
-				}
-			} else {
-				query.mime_type = utils.getMimeBaseTypeFromFilter( props.filter );
+	if ( filter && ! source ) {
+		if ( filter === 'this-post' ) {
+			if ( postId ) {
+				query.post_ID = postId;
 			}
+		} else {
+			query.mime_type = utils.getMimeBaseTypeFromFilter( filter );
 		}
-
-		if ( props.source ) {
-			query.source = props.source;
-			query.path = 'recent';
-
-			if ( props.source === 'google_photos' ) {
-				// Add any query params specific to Google Photos
-				return utils.getGoogleQuery( query, props );
-			}
-		}
-
-		return query;
-	};
-
-	fetchData = () => {
-		this.props.fetchNextMediaPage( this.props.siteId );
-	};
-
-	render() {
-		return passToChildren( this, {
-			mediaHasNextPage: this.props.hasNextPage,
-			mediaOnFetchNextPage: this.fetchData,
-		} );
 	}
-}
 
-MediaListData.defaultProps = {
-	setQuery: () => {},
+	if ( source ) {
+		query.source = source;
+		query.path = 'recent';
+
+		// @TODO
+		// if ( source === 'google_photos' ) {
+		// 	// Add any query params specific to Google Photos
+		// 	return utils.getGoogleQuery( query, props );
+		// }
+	}
+
+	return query;
 };
 
-const mapStateToProps = ( state, ownProps ) => ( {
-	media: getMediaSortedByDate( state, ownProps.siteId ),
-	hasNextPage: hasNextMediaPage( state, ownProps.siteId ),
-} );
+export const withMedia = createHigherOrderComponent(
+	( Component ) => ( props ) => {
+		const { site, postId, filter, search, source } = props;
+		const fetchOptions = getQuery( { search, source, filter, postId } );
+		const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useMediaQuery(
+			site.ID,
+			fetchOptions
+		);
 
-export default connect( mapStateToProps, { fetchNextMediaPage, setQuery } )( MediaListData );
+		return (
+			<Component
+				{ ...props }
+				media={ data?.media ?? [] }
+				hasNextPage={ hasNextPage }
+				fetchNextPage={ fetchNextPage }
+				isLoading={ isLoading }
+				isFetchingNextPage={ isFetchingNextPage }
+			/>
+		);
+	},
+	'WithMedia'
+);

--- a/client/data/media/use-delete-media-mutation.js
+++ b/client/data/media/use-delete-media-mutation.js
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+function useDeleteMediaMutation() {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		( { siteId, mediaId } ) => wp.req.post( `/sites/${ siteId }/media/${ mediaId }/delete` ),
+		{
+			onSuccess( data, { siteId } ) {
+				queryClient.invalidateQueries( [ 'media', siteId ] );
+			},
+		}
+	);
+
+	const { mutate } = mutation;
+
+	const deleteMedia = useCallback(
+		( siteId, mediaItem ) => {
+			mutate( { siteId, mediaId: mediaItem.ID } );
+		},
+		[ mutate ]
+	);
+
+	return { deleteMedia, ...mutation };
+}
+
+export default useDeleteMediaMutation;

--- a/client/data/media/use-media-query.js
+++ b/client/data/media/use-media-query.js
@@ -1,0 +1,28 @@
+import { useInfiniteQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+const defaults = {
+	number: 20,
+};
+
+const useMediaQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
+	const { source } = fetchOptions;
+	const path = source ? `/meta/external-media/${ source }` : `/sites/${ siteId }/media`;
+
+	return useInfiniteQuery(
+		[ 'media', siteId, fetchOptions ],
+		( { pageParam } ) =>
+			wpcom.req.get( path, { ...defaults, ...fetchOptions, page_handle: pageParam } ),
+		{
+			...queryOptions,
+			getNextPageParam: ( lastPage ) => lastPage.meta?.next_page,
+			select: ( data ) => ( {
+				media: data.pages.flatMap( ( page ) => page.media ),
+				total: data.pages[ 0 ].found,
+				...data,
+			} ),
+		}
+	);
+};
+
+export default useMediaQuery;

--- a/client/data/media/with-delete-media.js
+++ b/client/data/media/with-delete-media.js
@@ -1,0 +1,13 @@
+import { createHigherOrderComponent } from '@wordpress/compose';
+import React from 'react';
+import useDeleteMediaMutation from './use-delete-media-mutation';
+
+const withDeleteMedia = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const { deleteMedia } = useDeleteMediaMutation();
+		return <Wrapped { ...props } deleteMedia={ deleteMedia } />;
+	},
+	'WithDeleteMedia'
+);
+
+export default withDeleteMedia;

--- a/client/data/media/with-delete-media.js
+++ b/client/data/media/with-delete-media.js
@@ -1,5 +1,4 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
-import React from 'react';
 import useDeleteMediaMutation from './use-delete-media-mutation';
 
 const withDeleteMedia = createHigherOrderComponent(

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -6,7 +6,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import MediaListData from 'calypso/components/data/media-list-data';
+import { withMedia } from 'calypso/components/data/media-list-data';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
@@ -407,27 +407,25 @@ export class MediaLibraryContent extends Component {
 		].join( '-' );
 
 		return (
-			<MediaListData
-				siteId={ this.props.site.ID }
-				postId={ this.props.postId }
+			<MediaLibraryList
+				key={ listKey }
+				site={ this.props.site }
 				filter={ this.props.filter }
+				filterRequiresUpgrade={ this.props.filterRequiresUpgrade }
 				search={ this.props.search }
 				source={ this.props.source }
-			>
-				<MediaLibraryList
-					key={ listKey }
-					site={ this.props.site }
-					filter={ this.props.filter }
-					filterRequiresUpgrade={ this.props.filterRequiresUpgrade }
-					search={ this.props.search }
-					containerWidth={ this.props.containerWidth }
-					thumbnailType={ this.getThumbnailType() }
-					single={ this.props.single }
-					scrollable={ this.props.scrollable }
-					onSourceChange={ this.props.onSourceChange }
-					mediaScale={ this.props.mediaScale }
-				/>
-			</MediaListData>
+				containerWidth={ this.props.containerWidth }
+				thumbnailType={ this.getThumbnailType() }
+				single={ this.props.single }
+				scrollable={ this.props.scrollable }
+				onSourceChange={ this.props.onSourceChange }
+				mediaScale={ this.props.mediaScale }
+				mediaHasNextPage={ this.props.hasNextPage }
+				mediaOnFetchNextPage={ this.props.fetchNextPage }
+				isLoading={ this.props.isLoading }
+				isFetchingNextPage={ this.props.isFetchingNextPage }
+				media={ this.props.media }
+			/>
 		);
 	}
 
@@ -519,6 +517,8 @@ export default withMobileBreakpoint(
 			deleteKeyringConnection,
 			clearMediaErrors,
 			changeMediaSource,
-		}
-	)( localize( MediaLibraryContent ) )
+		},
+		null,
+		{ pure: false }
+	)( localize( withMedia( MediaLibraryContent ) ) )
 );

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -517,8 +517,6 @@ export default withMobileBreakpoint(
 			deleteKeyringConnection,
 			clearMediaErrors,
 			changeMediaSource,
-		},
-		null,
-		{ pure: false }
+		}
 	)( localize( withMedia( MediaLibraryContent ) ) )
 );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -1,5 +1,4 @@
 import { withRtl } from 'i18n-calypso';
-import { clone, filter, findIndex } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement, Component } from 'react';
 import ReactDom from 'react-dom';
@@ -9,7 +8,6 @@ import SortedGrid from 'calypso/components/sorted-grid';
 import { getMimePrefix } from 'calypso/lib/media/utils';
 import { selectMediaItems } from 'calypso/state/media/actions';
 import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
-import isFetchingNextPage from 'calypso/state/selectors/is-fetching-next-page';
 import ListItem from './list-item';
 import ListNoContent from './list-no-content';
 import ListNoResults from './list-no-results';
@@ -99,14 +97,16 @@ export class MediaLibraryList extends Component {
 		// seeking to select a single item
 		let selectedItems;
 		if ( this.props.single ) {
-			selectedItems = filter( this.props.selectedItems, { ID: item.ID } );
+			selectedItems = this.props.selectedItems.filter( ( { ID } ) => ID === item.ID );
 		} else {
-			selectedItems = clone( this.props.selectedItems );
+			selectedItems = [ ...this.props.selectedItems ];
 		}
 
-		const selectedItemsIndex = findIndex( selectedItems, { ID: item.ID } );
+		const selectedItemsIndex = selectedItems.findIndex( ( { ID } ) => ID === item.ID );
 		const isToBeSelected = -1 === selectedItemsIndex;
-		const selectedMediaIndex = findIndex( this.props.media, { ID: item.ID } );
+		const selectedMediaIndex = this.props.media.findIndex(
+			( mediaItem ) => mediaItem.ID === item.ID
+		);
 
 		let start = selectedMediaIndex;
 		let end = selectedMediaIndex;
@@ -117,9 +117,7 @@ export class MediaLibraryList extends Component {
 		}
 
 		for ( let i = start; i <= end; i++ ) {
-			const interimIndex = findIndex( selectedItems, {
-				ID: this.props.media[ i ].ID,
-			} );
+			const interimIndex = selectedItems.findIndex( ( { ID } ) => ID === this.props.media[ i ].ID );
 
 			if ( isToBeSelected && -1 === interimIndex ) {
 				selectedItems.push( this.props.media[ i ] );
@@ -154,9 +152,9 @@ export class MediaLibraryList extends Component {
 	};
 
 	renderItem = ( item ) => {
-		const index = findIndex( this.props.media, { ID: item.ID } );
-		const selectedItems = this.props.selectedItems;
-		const selectedIndex = findIndex( selectedItems, { ID: item.ID } );
+		const { selectedItems, media } = this.props;
+		const index = media.findIndex( ( { ID } ) => ID === item.ID );
+		const selectedIndex = selectedItems.findIndex( ( { ID } ) => ID === item.ID );
 		const ref = this.getItemRef( item );
 
 		const showGalleryHelp =
@@ -210,7 +208,12 @@ export class MediaLibraryList extends Component {
 			return <ListPlanUpgradeNudge filter={ this.props.filter } site={ this.props.site } />;
 		}
 
-		if ( ! this.props.mediaHasNextPage && this.props.media && 0 === this.props.media.length ) {
+		if (
+			! this.props.isLoading &&
+			! this.props.mediaHasNextPage &&
+			this.props.media &&
+			0 === this.props.media.length
+		) {
 			return createElement( this.props.search ? ListNoResults : ListNoContent, {
 				site: this.props.site,
 				filter: this.props.filter,
@@ -242,7 +245,7 @@ export class MediaLibraryList extends Component {
 				items={ this.props.media || [] }
 				itemsPerRow={ this.getItemsPerRow() }
 				lastPage={ ! this.props.mediaHasNextPage }
-				fetchingNextPage={ this.props.isFetchingNextPage }
+				fetchingNextPage={ this.props.isLoading || this.props.isFetchingNextPage }
 				guessedItemHeight={ this.getMediaItemHeight() }
 				fetchNextPage={ onFetchNextPage }
 				getItemRef={ this.getItemRef }
@@ -258,7 +261,6 @@ export class MediaLibraryList extends Component {
 export default connect(
 	( state, { site } ) => ( {
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
-		isFetchingNextPage: isFetchingNextPage( state, site?.ID ),
 	} ),
 	{ selectMediaItems }
 )( withRtl( withLocalizedMoment( MediaLibraryList ) ) );

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -10,6 +10,7 @@ import QueryMedia from 'calypso/components/data/query-media';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
+import withDeleteMedia from 'calypso/data/media/with-delete-media';
 import accept from 'calypso/lib/accept';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getMimeType } from 'calypso/lib/media/utils';
@@ -19,7 +20,7 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { EditorMediaModalDetail } from 'calypso/post-editor/media-modal/detail';
 import EditorMediaModalDialog from 'calypso/post-editor/media-modal/dialog';
 import { selectMediaItems, changeMediaSource, clearSite } from 'calypso/state/media/actions';
-import { editMedia, deleteMedia } from 'calypso/state/media/thunks';
+import { editMedia } from 'calypso/state/media/thunks';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
@@ -226,8 +227,8 @@ class Media extends Component {
 	 * @param  {Function} [callback] - callback function
 	 */
 	deleteMedia( callback ) {
-		const { translate } = this.props;
-		const selectedCount = this.props.selectedItems.length;
+		const { translate, selectedItems } = this.props;
+		const selectedCount = selectedItems.length;
 		const confirmMessage = translate(
 			'Are you sure you want to delete this item? ' +
 				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
@@ -292,7 +293,10 @@ class Media extends Component {
 		const selected =
 			selectedItems && selectedItems.length ? selectedItems : this.props.selectedItems;
 
-		this.props.deleteMedia( site.ID, selected );
+		this.props.selectMediaItems( site.ID, [] );
+		selected
+			.filter( ( { ID } ) => typeof ID === 'number' )
+			.forEach( ( ID ) => this.props.deleteMedia( site.ID, ID ) );
 	};
 
 	getAnalyticsPath = () => {
@@ -450,8 +454,7 @@ const mapStateToProps = ( state, { mediaId } ) => {
 
 export default connect( mapStateToProps, {
 	editMedia,
-	deleteMedia,
 	selectMediaItems,
 	changeMediaSource,
 	clearSite,
-} )( localize( Media ) );
+} )( localize( withDeleteMedia( Media ) ) );

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -14,7 +14,7 @@ class MediaModalSecondaryActions extends Component {
 	static propTypes = {
 		user: PropTypes.object,
 		site: PropTypes.object,
-		selectedItems: PropTypes.array,
+		selectedItems: PropTypes.arrayOf( PropTypes.object ),
 		onDelete: PropTypes.func,
 		onViewDetails: PropTypes.func,
 	};

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -192,7 +192,7 @@ export const selectedItems = ( state = {}, action ) => {
 			const { media, siteId } = action;
 			return {
 				...state,
-				[ siteId ]: media.map( ( mediaItem ) => mediaItem.ID ),
+				[ siteId ]: media,
 			};
 		}
 		case MEDIA_ITEM_CREATE: {

--- a/client/state/media/thunks/delete-media.js
+++ b/client/state/media/thunks/delete-media.js
@@ -16,8 +16,8 @@ export const deleteMedia = ( siteId, item ) => ( dispatch ) => {
 	const items = Array.isArray( item ) ? item : [ item ];
 
 	items
-		.filter( ( i ) => typeof i.ID === 'number' )
-		.forEach( ( mediaItem ) => {
-			dispatch( deleteMediaItem( siteId, mediaItem.ID ) );
+		.filter( ( id ) => typeof id === 'number' )
+		.forEach( ( id ) => {
+			dispatch( deleteMediaItem( siteId, id ) );
 		} );
 };

--- a/client/state/selectors/get-media-library-selected-items.js
+++ b/client/state/selectors/get-media-library-selected-items.js
@@ -1,5 +1,3 @@
-import getMediaItem from 'calypso/state/selectors/get-media-item';
-
 import 'calypso/state/media/init';
 
 /**
@@ -14,13 +12,5 @@ export default ( state, siteId ) => {
 		return [];
 	}
 
-	const selectedMediaIds = state.media.selectedItems[ siteId ];
-
-	if ( ! selectedMediaIds ) {
-		return [];
-	}
-
-	return selectedMediaIds
-		.map( ( mediaId ) => getMediaItem( state, siteId, mediaId ) )
-		.filter( ( media ) => media );
+	return state.media.selectedItems?.[ siteId ] ?? [];
 };


### PR DESCRIPTION
early draft of migrating the media library in Calypso to use React Query for data fetching
