### PR TITLE
Plugin Details: Adds star ratings.

### DIFF
--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -9,7 +9,7 @@ import './style.scss';
 export default class Rating extends PureComponent {
 	static defaultProps = {
 		rating: 0,
-		size: 24,
+		size: 18,
 	};
 
 	static propTypes = {

--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -4,11 +4,11 @@ import Rating from 'calypso/components/rating';
 
 describe( '<Rating />', () => {
 	describe( 'check props size', () => {
-		test( 'should be set to 24px if no size', () => {
+		test( 'should be set to 18px if no size', () => {
 			const wrapper = shallow( <Rating /> );
 
 			const component = wrapper.find( 'div.rating' );
-			expect( component.props().style.width ).to.equal( '120px' ); // 24 * 5 = 120;
+			expect( component.props().style.width ).to.equal( '90px' ); // 18 * 5 = 120;
 		} );
 
 		test( 'should use size if passed', () => {
@@ -32,7 +32,7 @@ describe( '<Rating />', () => {
 
 	describe( 'check props rating', () => {
 		test( 'should render full width mask for no rating', () => {
-			const size = 24; // use default size
+			const size = 24;
 			const wrapper = shallow( <Rating size={ size } /> );
 
 			const component = wrapper.find( 'div.rating__overlay' );
@@ -42,7 +42,7 @@ describe( '<Rating />', () => {
 
 		test( 'should render rating clipping mask properly', () => {
 			[ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ].forEach( function ( ratingValue ) {
-				const size = 24; // use default size
+				const size = 24;
 				const wrapper = shallow( <Rating rating={ ratingValue } size={ size } /> );
 
 				const roundRating = Math.round( ratingValue / 10 ) * 10;

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -16,6 +16,7 @@ import formatNumberCompact from 'calypso/lib/format-number-compact';
 import { userCan } from 'calypso/lib/site/utils';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
+import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
@@ -188,12 +189,14 @@ function PluginDetails( props ) {
 										<a href={ fullPlugin.author_url }>{ fullPlugin.author_name }</a>
 									</div>
 								</div>
-								<div className="plugin-details__info">
-									<div className="plugin-details__info-title">{ translate( 'Ratings' ) }</div>
-									<div className="plugin-details__info-value">
-										<Rating rating={ fullPlugin.rating } />
+								{ !! fullPlugin.rating && (
+									<div className="plugin-details__info">
+										<div className="plugin-details__info-title">{ translate( 'Ratings' ) }</div>
+										<div className="plugin-details__info-value">
+											<PluginRatings rating={ fullPlugin.rating } />
+										</div>
 									</div>
-								</div>
+								) }
 								<div className="plugin-details__info">
 									<div className="plugin-details__info-title">{ translate( 'Last updated' ) }</div>
 									<div className="plugin-details__info-value">
@@ -345,14 +348,6 @@ function onClickInstallPlugin( { dispatch, selectedSite, slug, upgradeAndInstall
 	} else {
 		page( installPluginURL );
 	}
-}
-
-/* TODO: add the stars icons */
-function Rating( { rating } ) {
-	// const inverseRating = 100 - Math.round( rating / 10 ) * 10;
-	// const noFillOutlineCount = Math.floor( inverseRating / 20 ); // (5 - noFillOutlineCount) gives the number of stars to add
-
-	return rating / 20;
 }
 
 function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) {

--- a/client/my-sites/plugins/plugin-ratings/README.md
+++ b/client/my-sites/plugins/plugin-ratings/README.md
@@ -1,6 +1,7 @@
 # Plugin Ratings
 
-This component is used to display the detail of how the ratings of a plugin are divided.
+This component is used to display the detail of how the ratings of a plugin are divided
+or just rating stars.
 
 ## How to use
 
@@ -8,11 +9,14 @@ This component is used to display the detail of how the ratings of a plugin are 
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings';
 
 function render() {
-	return <PluginRatings plugin={ this.props.plugin } barWidth={ 100 } />;
+	return <PluginRatings plugin={ 90 } />;
 }
 ```
 
 ## Props
 
-- `plugin`: A plugin object
-- `barWidth`: Width in pixels for the percentage bars of the component
+- `rating`: The plugin rating (0-100)
+- `ratings`: An object or array with the Plugin ratings
+- `downloaded`: The plugin current downloads number
+- `slug`: The Plugin slug
+- `numRatings`: The total ratings this plugin has received

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -12,14 +12,10 @@ const ratingTiers = [ 5, 4, 3, 2, 1 ];
 class PluginRatings extends Component {
 	static propTypes = {
 		rating: PropTypes.number,
-		ratings: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ),
-		downloaded: PropTypes.number,
-		slug: PropTypes.string,
-		numRatings: PropTypes.number,
-	};
-
-	static defaultProps = {
-		barWidth: 88,
+		ratings: PropTypes?.oneOfType( [ PropTypes.object, PropTypes.array ] ),
+		downloaded: PropTypes?.number,
+		slug: PropTypes?.string,
+		numRatings: PropTypes?.number,
 	};
 
 	buildReviewUrl( ratingTier ) {
@@ -94,34 +90,37 @@ class PluginRatings extends Component {
 	}
 
 	render() {
-		const { placeholder, ratings, rating, numRatings } = this.props;
+		const { placeholder, ratings, rating, numRatings, downloaded } = this.props;
 
 		if ( placeholder ) {
 			return this.renderPlaceholder();
 		}
 
-		if ( ! ratings ) {
+		if ( ! rating ) {
 			return null;
 		}
 
-		const tierViews = ratingTiers.map( this.renderRatingTier );
+		const tierViews = ratings && ratingTiers.map( this.renderRatingTier );
 		return (
 			<div className="plugin-ratings">
 				<div className="plugin-ratings__rating-stars">
 					<Rating rating={ rating } />
+					<span className="plugin-ratings__number">{ rating / 20 }</span>
 				</div>
-				<div className="plugin-ratings__rating-text">
-					{ this.props.translate(
-						'Based on %(ratingsNumber)s rating',
-						'Based on %(ratingsNumber)s ratings',
-						{
-							count: numRatings,
-							args: { ratingsNumber: numRatings },
-						}
-					) }
-				</div>
-				<div className="plugin-ratings__rating-tiers">{ tierViews }</div>
-				{ this.renderDownloaded() }
+				{ numRatings && (
+					<div className="plugin-ratings__rating-text">
+						{ this.props.translate(
+							'Based on %(ratingsNumber)s rating',
+							'Based on %(ratingsNumber)s ratings',
+							{
+								count: numRatings,
+								args: { ratingsNumber: numRatings },
+							}
+						) }
+					</div>
+				) }
+				{ tierViews && <div className="plugin-ratings__rating-tiers">{ tierViews }</div> }
+				{ downloaded && this.renderDownloaded() }
 			</div>
 		);
 	}

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -9,11 +9,16 @@
 }
 
 .plugin-ratings__rating-stars {
-	font-size: $font-title-medium;
+	display: flex;
+	align-items: center;
 
 	@include breakpoint-deprecated( '<480px' ) {
 		display: inline-block;
 		margin-right: 8px;
+	}
+
+	.rating {
+		margin-right: 5px;
 	}
 }
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* updates the `PluginRatings` component to display items if respecting props are provided
* updates the `PluginRatings` to show the rating number
* updates the `Rating` component to use `18px` size default prop, this component is currently used only for plugins
* uses `PluginRatings` in `PluginDetails`. If ratings are 0 (probably this is a new plugin), don't display Ratings at all

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1095" alt="SS 2021-11-16 at 10 46 48" src="https://user-images.githubusercontent.com/12430020/141952525-c64decbb-1111-4462-b124-852ea7f10681.png">|<img width="1095" alt="SS 2021-11-16 at 10 46 27" src="https://user-images.githubusercontent.com/12430020/141952482-d95e3752-eae0-4b73-87fb-0ad4f0a79da1.png">|

* Visit `/plugins/woocommerce`
* Inspect how ratings appear
* Visit a very new plugin eg `/plugins/rocketfuel-payment-gateway`
* Ratings should not appear at all

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57746
