### PR TITLE
Remove unnecessary check condition for variable isBusy

### DIFF
--- a/client/my-sites/domains/domain-management/list/free-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.jsx
@@ -50,7 +50,7 @@ export default function FreeDomainItem( {
 
 			{ shouldShowManageButton && ! isBusy && (
 				<EllipsisMenu
-					disabled={ isBusy || disabled }
+					disabled={ disabled }
 					toggleTitle={ __( 'Free WordPress address options' ) }
 					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
 					popoverClassName="free-domain-item__popover"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR remove unnecessary check condition for variable `isBusy` in the `disable` attribute of `EllipsisMenu` component. Variable is already tested as `false`.

#### Testing instructions
Open domains list and check that everything works as expected.

Related to https://github.com/Automattic/wp-calypso/pull/57126#discussion_r738766582
