### PR TITLE
Remove unnecessary/unused code in DomainRegistrationSuggestion component

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -2,7 +2,6 @@ import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, includes } from 'lodash';
-import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -220,18 +219,9 @@ class DomainRegistrationSuggestion extends Component {
 		const {
 			showHstsNotice,
 			suggestion: { domain_name: domain },
-			translate,
 		} = this.props;
 
-		let isAvailable = false;
-
-		//If we're on the Mapping or Transfer pages, add a note about availability
-		if ( includes( page.current, '/mapping' ) || includes( page.current, '/transfer' ) ) {
-			isAvailable = true;
-		}
-
-		let title = isAvailable ? translate( '%s is available!', { args: domain } ) : domain;
-		title = this.renderDomainParts( domain );
+		const title = this.renderDomainParts( domain );
 
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change remove some unnecessary code and unnecessary pre-assignment of `title` variable.

#### Testing instructions

Open domains suggestions screen and verify that the suggestions are rendered as **domain.tld**

Related to https://github.com/Automattic/wp-calypso/pull/55034#discussion_r734469200
