### PR TITLE
My Home: Remove animation for DotPager height

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -1,9 +1,8 @@
-import { useResizeObserver } from '@wordpress/compose';
 import { Icon, arrowRight } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import { times } from 'lodash';
-import { Children, useState, useEffect, useRef } from 'react';
+import { Children, useState, useEffect } from 'react';
 
 import './style.scss';
 
@@ -77,27 +76,13 @@ const Controls = ( { showControlLabels = false, currentPage, numberOfPages, setC
 
 export const DotPager = ( {
 	showControlLabels = false,
-	hasDynamicHeight = false,
 	children,
 	className,
 	onPageSelected,
 	...props
 } ) => {
 	const [ currentPage, setCurrentPage ] = useState( 0 );
-	const [ pagesStyle, setPagesStyle ] = useState();
-	const pagesRef = useRef();
-	const [ resizeObserver, sizes ] = useResizeObserver();
 	const numPages = Children.count( children );
-
-	useEffect( () => {
-		if ( ! hasDynamicHeight ) {
-			return;
-		}
-
-		const targetHeight = pagesRef.current?.children[ currentPage ]?.offsetHeight;
-
-		setPagesStyle( targetHeight ? { height: targetHeight } : undefined );
-	}, [ hasDynamicHeight, currentPage, sizes.width, setPagesStyle, children ] );
 
 	useEffect( () => {
 		if ( currentPage >= numPages ) {
@@ -107,7 +92,6 @@ export const DotPager = ( {
 
 	return (
 		<div className={ className } { ...props }>
-			{ resizeObserver }
 			<Controls
 				showControlLabels={ showControlLabels }
 				currentPage={ currentPage }
@@ -117,7 +101,7 @@ export const DotPager = ( {
 					setCurrentPage( index );
 				} }
 			/>
-			<div className="dot-pager__pages" ref={ pagesRef } style={ pagesStyle }>
+			<div className="dot-pager__pages">
 				{ Children.map( children, ( child, index ) => (
 					<div
 						className={ classnames( 'dot-pager__page', {

--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -5,8 +5,6 @@
 	display: flex;
 	align-items: flex-start;
 	position: relative;
-	transition: height 0.5s ease-in-out;
-	@include reduce-motion( 'transition' );
 }
 
 .dot-pager__page {
@@ -20,6 +18,7 @@
 	&.is-prev,
 	&.is-next {
 		opacity: 0;
+		height: 0;
 	}
 
 	&.is-prev {

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -98,7 +98,6 @@ const Primary = ( { cards, trackCard } ) => {
 				'primary__is-urgent': isUrgent,
 			} ) }
 			showControlLabels="true"
-			hasDynamicHeight
 			onPageSelected={ handlePageSelected }
 		>
 			{ cards.map(

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -58,7 +58,6 @@ const LearnGrow = () => {
 	return (
 		<DotPager
 			className="learn-grow__content customer-home__card"
-			hasDynamicHeight
 			onPageSelected={ handlePageSelected }
 		>
 			{ cards.map(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #55049 we're animating the height of the `DotPage` slider container. While this looks nice, it does trigger a bunch of React commits that also trigger re-renders, just for a single slide change:

![](https://cldup.com/LpbwlWHdQN.png)

For comparison, if we remove the animation (keeping the resizing simpler), it results in a single commit:

![](https://cldup.com/PDFf4Ds3Um.png)

This was one of the most expensive renders I was able to reproduce when playing with the My Home page, and I believe it's not worth it just for the animation.

#### Testing instructions

* Go to `/home/:site` where `:site` is one of your sites on a Business plan.
* Tinker with the slider and verify it still resizes well, just lacks the animation of the container.
* Test on mobile too, verify things look okay there.
* Test with the [React Profiler](https://reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html). Verify that for a single slide change there's a single commit with this branch, while on `trunk` we have dozens (40+ in my testing).