### PR TITLE
QuerySiteConnectionStatus: Migrate away from `UNSAFE_` methods

### DIFF
--- a/client/components/data/query-site-connection-status/index.jsx
+++ b/client/components/data/query-site-connection-status/index.jsx
@@ -1,44 +1,23 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import isRequestingSiteConnectionStatus from 'calypso/state/selectors/is-requesting-site-connection-status';
 import { requestConnectionStatus } from 'calypso/state/sites/connection/actions';
 
-class QuerySiteConnectionStatus extends Component {
-	static propTypes = {
-		siteId: PropTypes.number,
-		requestingSiteConnectionStatus: PropTypes.bool,
-		requestConnectionStatus: PropTypes.func,
-	};
-
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( siteId && ! isRequestingSiteConnectionStatus( getState(), siteId ) ) {
+		dispatch( requestConnectionStatus( siteId ) );
 	}
+};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId !== nextProps.siteId ) {
-			this.request( nextProps );
-		}
-	}
+export default function QuerySiteConnectionStatus( { siteId } ) {
+	const dispatch = useDispatch();
 
-	request( props ) {
-		if ( props.requestingSiteConnectionStatus || ! props.siteId ) {
-			return;
-		}
+	useEffect( () => {
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
-		props.requestConnectionStatus( props.siteId );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			requestingSiteConnectionStatus: isRequestingSiteConnectionStatus( state, ownProps.siteId ),
-		};
-	},
-	{ requestConnectionStatus }
-)( QuerySiteConnectionStatus );
+QuerySiteConnectionStatus.propTypes = { siteId: PropTypes.number };

--- a/client/components/data/query-site-connection-status/index.jsx
+++ b/client/components/data/query-site-connection-status/index.jsx
@@ -20,4 +20,6 @@ export default function QuerySiteConnectionStatus( { siteId } ) {
 	return null;
 }
 
-QuerySiteConnectionStatus.propTypes = { siteId: PropTypes.number };
+QuerySiteConnectionStatus.propTypes = {
+	siteId: PropTypes.number.isRequired,
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `QuerySiteConnectionStatus` query component away from the `UNSAFE_` deprecated React component methods.

We also use the opportunity to refactor it to a functional component, which simplifies the code quite a bit.

Related: #58103.

#### Testing instructions

* Go to `/home/:site` where `:site` is one of your sites.
* Open the site picker.
* Break one of your Jetpack sites remotely (add some error or exit early in `wp-config.php`).
* Verify connection of all Jetpack sites is still accurately fetched.