### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` site connection to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -39,17 +39,6 @@ Undocumented.prototype.me = function () {
 	return new Me( this.wpcom );
 };
 
-/**
- * Test if a Jetpack Site is connected to .com
- *
- * @param {number} [siteId] The site ID
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.testConnectionJetpack = function ( siteId, fn ) {
-	debug( '/jetpack-blogs/:site_id:/test-connection query' );
-	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/test-connection' }, fn );
-};
-
 Undocumented.prototype.jetpackLogin = function ( siteId, _wp_nonce, redirect_uri, scope, state ) {
 	debug( '/jetpack-blogs/:site_id:/jetpack-login query' );
 	const endpointUrl = '/jetpack-blogs/' + siteId + '/jetpack-login';

--- a/client/state/sites/connection/actions.js
+++ b/client/state/sites/connection/actions.js
@@ -19,9 +19,8 @@ export const requestConnectionStatus = ( siteId ) => {
 			siteId,
 		} );
 
-		return wp
-			.undocumented()
-			.testConnectionJetpack( siteId )
+		return wp.req
+			.get( `/jetpack-blogs/${ siteId }/test-connection` )
 			.then( ( response ) => {
 				dispatch( {
 					type: SITE_CONNECTION_STATUS_RECEIVE,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` Jetpack site connection method to `wpcom.req.get()`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

Related: #58102

#### Testing instructions

* Go to `/home/:site` where `:site` is one of your sites.
* Open the site picker.
* Break one of your Jetpack sites remotely (add some error or exit early in `wp-config.php`).
* Verify connection of all Jetpack sites is still accurately fetched.
* Verify tests still pass: `yarn run test-client client/state/sites/connection/test/actions.js`