### PR TITLE
Domains: Map the entire contact info validation post body

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -113,10 +113,16 @@ class EditContactInfoFormCard extends Component {
 
 	validate = ( fieldValues, onComplete ) => {
 		wp.req
-			.post( '/me/domain-contact-information/validate', {
-				contactInformation: mapRecordKeysRecursively( fieldValues, camelToSnakeCase ),
-				domainNames: [ this.props.selectedDomain.name ],
-			} )
+			.post(
+				'/me/domain-contact-information/validate',
+				mapRecordKeysRecursively(
+					{
+						contactInformation: fieldValues,
+						domainNames: [ this.props.selectedDomain.name ],
+					},
+					camelToSnakeCase
+				)
+			)
 			.then( ( data ) => {
 				onComplete( null, mapRecordKeysRecursively( data.messages || {}, snakeToCamelCase ) );
 			} )

--- a/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
+++ b/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
@@ -128,10 +128,16 @@ class BulkEditContactInfo extends Component {
 		}
 
 		wp.req
-			.post( '/me/domain-contact-information/validate', {
-				contactInformation: mapRecordKeysRecursively( contactDetails, camelToSnakeCase ),
-				domainNames: this.props.domainNamesList ?? [],
-			} )
+			.post(
+				'/me/domain-contact-information/validate',
+				mapRecordKeysRecursively(
+					{
+						contactInformation: contactDetails,
+						domainNames: this.props.domainNamesList ?? [],
+					},
+					camelToSnakeCase
+				)
+			)
 			.then( ( data ) => {
 				let errorMessages = mapRecordKeysRecursively(
 					( data && data.messages ) || {},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts https://github.com/Automattic/wp-calypso/pull/58054/commits/5993e667ae2282cf727087c597033ae9938abdf9 from #58054, which essentially broke the validation logic because the endpoint expects the data in snake case, not in camel case. 

#### Testing instructions

* Go to `/domains/manage/:domain/edit-contact-info/:site` where `:domain` and `:site` correspond to one of your sites on a custom domain.
* Play with the validation of the form and verify it still works correctly.
