### PR TITLE
`QuerySiteConnectionStatus`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-site-connection-status/index.jsx
+++ b/client/components/data/query-site-connection-status/index.jsx
@@ -1,44 +1,26 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import isRequestingSiteConnectionStatus from 'calypso/state/selectors/is-requesting-site-connection-status';
 import { requestConnectionStatus } from 'calypso/state/sites/connection/actions';
 
-class QuerySiteConnectionStatus extends Component {
-	static propTypes = {
-		siteId: PropTypes.number,
-		requestingSiteConnectionStatus: PropTypes.bool,
-		requestConnectionStatus: PropTypes.func,
-	};
-
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( ! isRequestingSiteConnectionStatus( getState(), siteId ) ) {
+		dispatch( requestConnectionStatus( siteId ) );
 	}
+};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId !== nextProps.siteId ) {
-			this.request( nextProps );
-		}
-	}
+function QuerySiteConnectionStatus( { siteId } ) {
+	const dispatch = useDispatch();
 
-	request( props ) {
-		if ( props.requestingSiteConnectionStatus || ! props.siteId ) {
-			return;
-		}
+	useEffect( () => {
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
-		props.requestConnectionStatus( props.siteId );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			requestingSiteConnectionStatus: isRequestingSiteConnectionStatus( state, ownProps.siteId ),
-		};
-	},
-	{ requestConnectionStatus }
-)( QuerySiteConnectionStatus );
+QuerySiteConnectionStatus.propTypes = {
+	siteId: PropTypes.number.isRequired,
+};
+export default QuerySiteConnectionStatus;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QuerySiteConnectionStatus`: refactor away from `UNSAFE_*`

#### Testing instructions

* Select a Jetpack site, go to `/`
* Make sure you see a network request to `/jetpack-blogs/<siteId>/test-connection`
* When opening the sites selector you should see such a request for any of your Jetpack sites