### PR TITLE
Migrate wpcom.undocumented methods for creating sites and users

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -38,7 +38,7 @@ import TextControl from 'calypso/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { getLocaleSlug, localizeUrl } from 'calypso/lib/i18n-utils';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -246,87 +246,94 @@ class SignupForm extends Component {
 		] );
 
 		const data = mapKeys( pick( fields, fieldsForValidation ), ( value, key ) => snakeCase( key ) );
-		wpcom.undocumented().validateNewUser( data, ( error, response ) => {
-			if ( this.props.submitting ) {
-				// this is a stale callback, we have already signed up or are logging in
-				return;
-			}
-
-			if ( error || ! response ) {
-				return debug( error || 'User validation failed.' );
-			}
-
-			let messages = response.success
-				? {}
-				: mapKeys( response.messages, ( value, key ) => camelCase( key ) );
-
-			// Prevent "field is empty" error messages from displaying prematurely
-			// before the form has been submitted or before the field has been interacted with (is dirty).
-			if ( ! this.state.submitting ) {
-				messages = this.filterUntouchedFieldErrors( messages );
-			}
-
-			forEach( messages, ( fieldError, field ) => {
-				if ( ! formState.isFieldInvalid( this.state.form, field ) ) {
+		wpcom.req.post(
+			'/signups/validation/user',
+			{
+				...data,
+				locale: getLocaleSlug(),
+			},
+			( error, response ) => {
+				if ( this.props.submitting ) {
+					// this is a stale callback, we have already signed up or are logging in
 					return;
 				}
 
-				if ( field === 'username' && ! includes( usernamesSearched, fields.username ) ) {
-					recordTracksEvent( 'calypso_signup_username_validation_failed', {
-						error: keys( fieldError )[ 0 ],
-						username: fields.username,
-					} );
-
-					timesUsernameValidationFailed++;
+				if ( error || ! response ) {
+					return debug( error || 'User validation failed.' );
 				}
 
-				if ( field === 'password' ) {
-					recordTracksEvent( 'calypso_signup_password_validation_failed', {
-						error: keys( fieldError )[ 0 ],
-					} );
+				let messages = response.success
+					? {}
+					: mapKeys( response.messages, ( value, key ) => camelCase( key ) );
 
-					timesPasswordValidationFailed++;
+				// Prevent "field is empty" error messages from displaying prematurely
+				// before the form has been submitted or before the field has been interacted with (is dirty).
+				if ( ! this.state.submitting ) {
+					messages = this.filterUntouchedFieldErrors( messages );
 				}
-			} );
 
-			if ( fields.email ) {
-				if ( this.props.signupDependencies && this.props.signupDependencies.domainItem ) {
-					const domainInEmail = fields.email.split( '@' )[ 1 ];
-					if ( this.props.signupDependencies.domainItem.meta === domainInEmail ) {
-						// if the user tries to use an email address from the domain they're trying to register,
-						// show an error message.
-						messages = Object.assign( {}, messages, {
-							email: {
-								invalid: this.props.translate(
-									'Use a working email address, so you can receive our messages.'
-								),
-							},
+				forEach( messages, ( fieldError, field ) => {
+					if ( ! formState.isFieldInvalid( this.state.form, field ) ) {
+						return;
+					}
+
+					if ( field === 'username' && ! includes( usernamesSearched, fields.username ) ) {
+						recordTracksEvent( 'calypso_signup_username_validation_failed', {
+							error: keys( fieldError )[ 0 ],
+							username: fields.username,
 						} );
+
+						timesUsernameValidationFailed++;
+					}
+
+					if ( field === 'password' ) {
+						recordTracksEvent( 'calypso_signup_password_validation_failed', {
+							error: keys( fieldError )[ 0 ],
+						} );
+
+						timesPasswordValidationFailed++;
+					}
+				} );
+
+				if ( fields.email ) {
+					if ( this.props.signupDependencies && this.props.signupDependencies.domainItem ) {
+						const domainInEmail = fields.email.split( '@' )[ 1 ];
+						if ( this.props.signupDependencies.domainItem.meta === domainInEmail ) {
+							// if the user tries to use an email address from the domain they're trying to register,
+							// show an error message.
+							messages = Object.assign( {}, messages, {
+								email: {
+									invalid: this.props.translate(
+										'Use a working email address, so you can receive our messages.'
+									),
+								},
+							} );
+						}
 					}
 				}
-			}
 
-			// Catch this early for P2 signup flow.
-			if (
-				this.props.isP2Flow &&
-				fields.username &&
-				fields.password &&
-				fields.username === fields.password
-			) {
-				messages = Object.assign( {}, messages, {
-					password: {
-						invalid: this.props.translate(
-							'Your password cannot be the same as your username. Please pick a different password.'
-						),
-					},
-				} );
-			}
+				// Catch this early for P2 signup flow.
+				if (
+					this.props.isP2Flow &&
+					fields.username &&
+					fields.password &&
+					fields.username === fields.password
+				) {
+					messages = Object.assign( {}, messages, {
+						password: {
+							invalid: this.props.translate(
+								'Your password cannot be the same as your username. Please pick a different password.'
+							),
+						},
+					} );
+				}
 
-			onComplete( error, messages );
-			if ( ! this.state.validationInitialized ) {
-				this.setState( { validationInitialized: true } );
+				onComplete( error, messages );
+				if ( ! this.state.validationInitialized ) {
+					this.setState( { validationInitialized: true } );
+				}
 			}
-		} );
+		);
 	};
 
 	setFormState = ( state ) => {

--- a/client/lib/signup/step-actions/passwordless.js
+++ b/client/lib/signup/step-actions/passwordless.js
@@ -1,3 +1,5 @@
+import config from '@automattic/calypso-config';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wpcom from 'calypso/lib/wp';
 
 /**
@@ -9,11 +11,16 @@ import wpcom from 'calypso/lib/wp';
  * @param {string}   data.email
  */
 export function createPasswordlessUser( callback, { email } ) {
-	wpcom
-		.undocumented()
-		.usersEmailNew( { email }, null )
-		.then( ( response ) => callback( null, response ) )
-		.catch( ( err ) => callback( err ) );
+	wpcom.req.post(
+		'/users/email/new',
+		{
+			email,
+			locale: getLocaleSlug(),
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+		},
+		callback
+	);
 }
 
 /**
@@ -25,9 +32,13 @@ export function createPasswordlessUser( callback, { email } ) {
  * @param {string}   data.code
  */
 export function verifyPasswordlessUser( callback, { email, code } ) {
-	wpcom
-		.undocumented()
-		.usersEmailVerification( { email, code }, null )
+	wpcom.req
+		.post( '/users/email/verification', {
+			email,
+			code,
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+		} )
 		.then( ( response ) =>
 			callback( null, { email, username: email, bearer_token: response.token.access_token } )
 		)

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,26 +1,11 @@
-import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { camelCase, isPlainObject, omit, snakeCase, set } from 'lodash';
 import { stringify } from 'qs';
-import { getLanguage, getLocaleSlug } from 'calypso/lib/i18n-utils';
 import readerContentWidth from 'calypso/reader/lib/content-width';
 import Me from './me';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?
-
-/**
- * Some endpoints are restricted by OAuth client IDs and secrets
- * to prevent them being spammed. This adds these keys to the request
- * so that they will be successful. This is not a sufficent measure
- * against spam as these keys are exposed publicly
- *
- * @param { object } query - Add client_id and client_secret to the query.
- */
-function restrictByOauthKeys( query ) {
-	query.client_id = config( 'wpcom_signup_id' );
-	query.client_secret = config( 'wpcom_signup_key' );
-}
 
 /**
  * Create an `Undocumented` instance
@@ -364,143 +349,6 @@ Undocumented.prototype.readSitePostRelated = function ( query, fn ) {
 	return this.wpcom.req.get(
 		'/read/site/' + query.site_id + '/post/' + query.post_id + '/related',
 		params,
-		fn
-	);
-};
-
-/**
- * Sign up for a new user account
- * Create a new user
- *
- * @param {object} query - an object with the following values: email, username, password, first_name (optional), last_name (optional)
- * @param {Function} fn - Function to invoke when request is complete
- */
-Undocumented.prototype.usersNew = function ( query, fn ) {
-	debug( '/users/new' );
-
-	// This API call is restricted to these OAuth keys
-	restrictByOauthKeys( query );
-
-	// Set the language for the user
-	query.locale = getLocaleSlug();
-	const args = {
-		path: '/users/new',
-		body: query,
-	};
-	return this.wpcom.req.post( args, fn );
-};
-
-/**
- * Sign up for a new account with a social service (e.g. Google/Facebook).
- *
- * @param {object} query - an object with the following values: service, access_token, id_token (optional), signup_flow_name
- * @param {Function} fn - callback
- * @returns {Promise} A promise for the request
- */
-Undocumented.prototype.usersSocialNew = function ( query, fn ) {
-	query.locale = getLocaleSlug();
-
-	// This API call is restricted to these OAuth keys
-	restrictByOauthKeys( query );
-
-	const args = {
-		path: '/users/social/new',
-		body: query,
-	};
-
-	return this.wpcom.req.post( args, fn );
-};
-
-Undocumented.prototype.createUserAndSite = function ( query, fn ) {
-	debug( '/users/new' );
-
-	// This API call is restricted to these OAuth keys
-	restrictByOauthKeys( query );
-
-	// Set the language for the user
-	query.locale = getLocaleSlug();
-	const args = {
-		path: '/users/new',
-		body: query,
-	};
-	return this.wpcom.req.post( args, fn );
-};
-
-/**
- * Verify user for new signups
- *
- * @param {object} data - object containing an email address, username and password
- * @param {Function} fn - Function to invoke when request is complete
- */
-Undocumented.prototype.validateNewUser = function ( data, fn ) {
-	debug( '/signups/validation/user' );
-
-	data.locale = getLocaleSlug();
-
-	return this.wpcom.req.post( '/signups/validation/user/', null, data, fn );
-};
-
-/**
- * Sign up for a new passwordless user account
- *
- * @param {object} query - an object with the following values: email
- * @param {Function} fn - Function to invoke when request is complete
- */
-Undocumented.prototype.usersEmailNew = function ( query, fn ) {
-	debug( '/users/email/new' );
-
-	// This API call is restricted to these OAuth keys
-	restrictByOauthKeys( query );
-
-	const args = {
-		path: '/users/email/new',
-		body: query,
-	};
-	return this.wpcom.req.post( args, fn );
-};
-
-/**
- * Verify a new passwordless user account
- *
- * @param {object} query - an object with the following values: email, code
- * @param {Function} fn - Function to invoke when request is complete
- */
-Undocumented.prototype.usersEmailVerification = function ( query, fn ) {
-	debug( '/users/email/verification' );
-
-	// This API call is restricted to these OAuth keys
-	restrictByOauthKeys( query );
-
-	const args = {
-		path: '/users/email/verification',
-		body: query,
-	};
-	return this.wpcom.req.post( args, fn );
-};
-
-/**
- * Create a new site
- *
- * @param {object} query - object containing an site address
- * @param {Function} fn - Function to invoke when request is complete
- */
-Undocumented.prototype.sitesNew = function ( query, fn ) {
-	const localeSlug = getLocaleSlug();
-
-	debug( '/sites/new' );
-
-	// This API call is restricted to these OAuth keys
-	restrictByOauthKeys( query );
-
-	// Set the language for the user
-	query.lang_id = getLanguage( localeSlug ).value;
-	query.locale = localeSlug;
-
-	return this.wpcom.req.post(
-		{
-			path: '/sites/new',
-			body: query,
-		},
 		fn
 	);
 };

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.ts
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.ts
@@ -1,5 +1,7 @@
+import config from '@automattic/calypso-config';
 import i18n from 'i18n-calypso';
 import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wp from 'calypso/lib/wp';
 import { stringifyBody } from 'calypso/state/login/utils';
 
@@ -80,7 +82,7 @@ export async function createAccount( {
 	const blogName = newSiteParams?.blog_name;
 
 	try {
-		const response = await wp.undocumented().createUserAndSite( {
+		const response = await wp.req.post( '/users/new', {
 			email,
 			'g-recaptcha-error': recaptchaError,
 			'g-recaptcha-response': recaptchaToken || undefined,
@@ -90,6 +92,9 @@ export async function createAccount( {
 			validate: false,
 			new_site_params: newSiteParams,
 			should_create_site: ! siteId,
+			locale: getLocaleSlug(),
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
 		} );
 
 		if ( ! isCreateAccountResponse( response ) || ! response.success ) {

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import bodyParser from 'body-parser';
 import qs from 'qs';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wpcom from 'calypso/lib/wp';
 
 function loginEndpointData() {
@@ -35,11 +36,13 @@ function loginWithApple( request, response, next ) {
 	// However Apple sends the user data only once,
 	// so let's query our sign-up endpoint with the `signup_flow_name=no-signup` to make sure the user data is saved
 	if ( userEmail ) {
-		wpcom
-			.undocumented()
-			.usersSocialNew( {
+		wpcom.req
+			.post( '/users/social/new', {
 				...loginEndpointData(),
 				...request.user_openid_data,
+				locale: getLocaleSlug(),
+				client_id: config( 'wpcom_signup_id' ),
+				client_secret: config( 'wpcom_signup_key' ),
 			} )
 			.catch( () => {
 				// ignore errors

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { includes, isEmpty, map, deburr, get } from 'lodash';
@@ -8,6 +9,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
+import { getLanguage, getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { login } from 'calypso/lib/paths';
 import wpcom from 'calypso/lib/wp';
@@ -140,11 +142,17 @@ class P2Site extends Component {
 		}
 
 		if ( ! isEmpty( fields.site ) ) {
-			wpcom.undocumented().sitesNew(
+			const locale = getLocaleSlug();
+			wpcom.req.post(
+				'/sites/new',
 				{
 					blog_name: fields.site,
 					blog_title: fields.siteTitle,
 					validate: true,
+					locale,
+					lang_id: getLanguage( locale ).value,
+					client_id: config( 'wpcom_signup_id' ),
+					client_secret: config( 'wpcom_signup_key' ),
 				},
 				( error, response ) => {
 					debug( error, response );

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { includes, isEmpty, map } from 'lodash';
@@ -10,6 +11,7 @@ import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
+import { getLanguage, getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { login } from 'calypso/lib/paths';
 import wpcom from 'calypso/lib/wp';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -88,11 +90,17 @@ class Site extends Component {
 	};
 
 	validate = ( fields, onComplete ) => {
-		wpcom.undocumented().sitesNew(
+		const locale = getLocaleSlug();
+		wpcom.req.post(
+			'/sites/new',
 			{
 				blog_name: fields.site,
 				blog_title: fields.site,
 				validate: true,
+				locale,
+				lang_id: getLanguage( locale ).value,
+				client_id: config( 'wpcom_signup_id' ),
+				client_secret: config( 'wpcom_signup_key' ),
 			},
 			function ( error, response ) {
 				let messages = {};

--- a/client/state/auth/actions.js
+++ b/client/state/auth/actions.js
@@ -28,8 +28,6 @@ export const sendEmailLogin = (
 		createAccount = false,
 	}
 ) => {
-	//Kind of weird usage, but this is a straight port from undocumented.js for now.
-	//I can move this to the caller, if there's equivalent info in the state tree
 	const locale = getLocaleSlug();
 	const lang_id = getLanguage( locale ).value;
 

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -1,6 +1,8 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { get, truncate } from 'lodash';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wpcom from 'calypso/lib/wp';
 import { acceptedNotice } from 'calypso/my-sites/invites/utils';
 import {
@@ -167,10 +169,13 @@ function inviteAccepted( invite ) {
 
 export function createAccount( userData, invite ) {
 	return ( dispatch ) => {
-		const result = wpcom.undocumented().usersNew( {
+		const result = wpcom.req.post( '/users/new', {
 			...userData,
 			validate: false,
 			send_verification_email: userData.email !== invite.sentTo,
+			locale: getLocaleSlug(),
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
 		} );
 
 		result

--- a/client/state/jetpack-connect/actions/create-account.js
+++ b/client/state/jetpack-connect/actions/create-account.js
@@ -1,3 +1,5 @@
+import config from '@automattic/calypso-config';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -13,7 +15,6 @@ import 'calypso/state/jetpack-connect/init';
  * @param  {string} userData.username Username
  * @param  {string} userData.password Password
  * @param  {string} userData.email    Email
- *
  * @returns {Promise}                  Resolves to { username, bearerToken }
  */
 export function createAccount( userData ) {
@@ -21,7 +22,12 @@ export function createAccount( userData ) {
 		dispatch( recordTracksEvent( 'calypso_jpc_create_account' ) );
 
 		try {
-			const data = await wpcom.undocumented().usersNew( userData );
+			const data = await wpcom.req.post( '/users/new', {
+				...userData,
+				locale: getLocaleSlug(),
+				client_id: config( 'wpcom_signup_id' ),
+				client_secret: config( 'wpcom_signup_key' ),
+			} );
 			const bearerToken = makeJsonSchemaParser(
 				{
 					type: 'object',

--- a/client/state/jetpack-connect/actions/create-social-account.js
+++ b/client/state/jetpack-connect/actions/create-social-account.js
@@ -1,3 +1,5 @@
+import config from '@automattic/calypso-config';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -13,7 +15,6 @@ import 'calypso/state/jetpack-connect/init';
  * @param  {string}  socialInfo.access_token An OAuth2 acccess token
  * @param  {?string} socialInfo.id_token     (Optional) a JWT id_token which contains the signed user info
  * @param  {?string} flowName                Name of the flow that the user is going through
- *
  * @returns {Promise}                         Resolves to { username, bearerToken }
  */
 export function createSocialAccount( socialInfo, flowName = 'jetpack-connect' ) {
@@ -21,9 +22,12 @@ export function createSocialAccount( socialInfo, flowName = 'jetpack-connect' ) 
 		dispatch( recordTracksEvent( 'calypso_jpc_social_createaccount' ) );
 
 		try {
-			const { username, bearer_token } = await wpcom.undocumented().usersSocialNew( {
+			const { username, bearer_token } = await wpcom.req.post( '/users/social/new', {
 				...socialInfo,
 				signup_flow_name: flowName,
+				locale: getLocaleSlug(),
+				client_id: config( 'wpcom_signup_id' ),
+				client_secret: config( 'wpcom_signup_key' ),
 			} );
 			dispatch( recordTracksEvent( 'calypso_jpc_social_createaccount_success' ) );
 			return { username, bearerToken: bearer_token };

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -394,7 +394,7 @@ describe( '#createAccount()', () => {
 	test( 'should resolve with the username and bearer token', async () => {
 		const userData = { username: 'happyuser' };
 		const data = { bearer_token: '1234 abcd' };
-		jest.spyOn( wpcom.req.post ).mockImplementation( () => Promise.resolve( data ) );
+		jest.spyOn( wpcom.req, 'post' ).mockImplementation( () => Promise.resolve( data ) );
 
 		await expect( createAccount( userData )( () => {} ) ).resolves.toEqual( {
 			username: userData.username,
@@ -405,7 +405,7 @@ describe( '#createAccount()', () => {
 	test( 'should reject with the error', async () => {
 		const userData = { username: 'happyuser' };
 		const error = { code: 'user_exists' };
-		jest.spyOn( wpcom.req.post ).mockImplementation( () => Promise.reject( error ) );
+		jest.spyOn( wpcom.req, 'post' ).mockImplementation( () => Promise.reject( error ) );
 
 		await expect( createAccount( userData )( () => {} ) ).rejects.toBe( error );
 	} );
@@ -422,7 +422,7 @@ describe( '#createSocialAccount()', () => {
 			error: 'an_error_code',
 			message: 'An error message',
 		};
-		jest.spyOn( wpcom.req.post ).mockImplementation( () => Promise.reject( error ) );
+		jest.spyOn( wpcom.req, 'post' ).mockImplementation( () => Promise.reject( error ) );
 
 		await expect( createSocialAccount()( () => {} ) ).rejects.toEqual( {
 			code: error.error,
@@ -434,7 +434,7 @@ describe( '#createSocialAccount()', () => {
 	test( 'should resolve with the username and bearer token', async () => {
 		const bearerToken = 'foobar';
 		const username = 'a_happy_user';
-		jest.spyOn( wpcom.req.post ).mockImplementation( () =>
+		jest.spyOn( wpcom.req, 'post' ).mockImplementation( () =>
 			Promise.resolve( {
 				bearer_token: bearerToken,
 				username,

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -394,11 +394,7 @@ describe( '#createAccount()', () => {
 	test( 'should resolve with the username and bearer token', async () => {
 		const userData = { username: 'happyuser' };
 		const data = { bearer_token: '1234 abcd' };
-		jest.spyOn( wpcom, 'undocumented' ).mockImplementation( () => ( {
-			usersNew() {
-				return Promise.resolve( data );
-			},
-		} ) );
+		jest.spyOn( wpcom.req.post ).mockImplementation( () => Promise.resolve( data ) );
 
 		await expect( createAccount( userData )( () => {} ) ).resolves.toEqual( {
 			username: userData.username,
@@ -409,11 +405,7 @@ describe( '#createAccount()', () => {
 	test( 'should reject with the error', async () => {
 		const userData = { username: 'happyuser' };
 		const error = { code: 'user_exists' };
-		jest.spyOn( wpcom, 'undocumented' ).mockImplementation( () => ( {
-			usersNew() {
-				return Promise.reject( error );
-			},
-		} ) );
+		jest.spyOn( wpcom.req.post ).mockImplementation( () => Promise.reject( error ) );
 
 		await expect( createAccount( userData )( () => {} ) ).rejects.toBe( error );
 	} );
@@ -430,11 +422,7 @@ describe( '#createSocialAccount()', () => {
 			error: 'an_error_code',
 			message: 'An error message',
 		};
-		jest.spyOn( wpcom, 'undocumented' ).mockImplementation( () => ( {
-			usersSocialNew() {
-				return Promise.reject( error );
-			},
-		} ) );
+		jest.spyOn( wpcom.req.post ).mockImplementation( () => Promise.reject( error ) );
 
 		await expect( createSocialAccount()( () => {} ) ).rejects.toEqual( {
 			code: error.error,
@@ -446,14 +434,12 @@ describe( '#createSocialAccount()', () => {
 	test( 'should resolve with the username and bearer token', async () => {
 		const bearerToken = 'foobar';
 		const username = 'a_happy_user';
-		jest.spyOn( wpcom, 'undocumented' ).mockImplementation( () => ( {
-			usersSocialNew() {
-				return Promise.resolve( {
-					bearer_token: bearerToken,
-					username,
-				} );
-			},
-		} ) );
+		jest.spyOn( wpcom.req.post ).mockImplementation( () =>
+			Promise.resolve( {
+				bearer_token: bearerToken,
+				username,
+			} )
+		);
 
 		await expect( createSocialAccount()( () => {} ) ).resolves.toEqual( {
 			bearerToken,

--- a/client/state/login/actions/create-social-user.js
+++ b/client/state/login/actions/create-social-user.js
@@ -1,4 +1,6 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wpcom from 'calypso/lib/wp';
 import {
 	SOCIAL_CREATE_ACCOUNT_REQUEST,
@@ -27,9 +29,14 @@ export const createSocialUser = ( socialInfo, flowName ) => ( dispatch ) => {
 		},
 	} );
 
-	return wpcom
-		.undocumented()
-		.usersSocialNew( { ...socialInfo, signup_flow_name: flowName } )
+	return wpcom.req
+		.post( '/users/social/new', {
+			...socialInfo,
+			signup_flow_name: flowName,
+			locale: getLocaleSlug(),
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+		} )
 		.then(
 			( wpcomResponse ) => {
 				const data = {

--- a/client/state/signup/optional-dependencies/actions.js
+++ b/client/state/signup/optional-dependencies/actions.js
@@ -1,3 +1,4 @@
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wpcom from 'calypso/lib/wp';
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'calypso/state/action-types';
 
@@ -23,9 +24,10 @@ export const fetchUsernameSuggestion = ( username ) => async ( dispatch ) => {
 	// Clear out the state variable before sending the call.
 	dispatch( setUsernameSuggestion( '' ) );
 
-	const response = await wpcom.undocumented().validateNewUser( {
+	const response = await wpcom.req.post( '/signups/validation/user', {
 		givesuggestions: 1,
 		username,
+		locale: getLocaleSlug(),
 	} );
 
 	if ( ! response ) {


### PR DESCRIPTION
Migrates `wpcom.undocumented()` methods that create new sites and users: `sitesNew`, `usersNew`, `usersSocialNew`, plus a few validation ones.

Most of them need a `locale` param and OAuth stuff in `client_id` and `client_secret`. These used to be added in the `undocumented()` wrapper, and now I'm just adding them at each call site individually, without any common helper. Maybe it's a bad idea.

This removes dependency on `i18n-utils` from the `undocumented` module, so it should reduce entrypoint size more than usual. I discovered this opportunity when investigating why the `apps/inline-help` bundle (#55189) is still so big.