### PR TITLE
Packages: Move case and mapping methods to `js-utils` package

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -1,9 +1,6 @@
 import { makeRedirectResponse, makeErrorResponse } from '@automattic/composite-checkout';
-import {
-	mapRecordKeysRecursively,
-	camelToSnakeCase,
-	tryToGuessPostalCodeFormat,
-} from '@automattic/wpcom-checkout';
+import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
+import { tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import wp from 'calypso/lib/wp';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -1,4 +1,4 @@
-import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/wpcom-checkout';
+import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
 import wp from 'calypso/lib/wp';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { createAccount } from '../payment-method-helpers';

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -1,9 +1,5 @@
 import { Card, Dialog } from '@automattic/components';
-import {
-	mapRecordKeysRecursively,
-	camelToSnakeCase,
-	snakeToCamelCase,
-} from '@automattic/wpcom-checkout';
+import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty, isEqual, includes, snakeCase } from 'lodash';
 import page from 'page';

--- a/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
+++ b/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
@@ -1,9 +1,5 @@
 import { Button } from '@automattic/components';
-import {
-	mapRecordKeysRecursively,
-	camelToSnakeCase,
-	snakeToCamelCase,
-} from '@automattic/wpcom-checkout';
+import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';

--- a/client/state/domains/management/actions.js
+++ b/client/state/domains/management/actions.js
@@ -1,4 +1,4 @@
-import { mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/wpcom-checkout';
+import { mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import wpcom from 'calypso/lib/wp';
 import {
 	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,

--- a/packages/js-utils/src/camel-to-snake-case.ts
+++ b/packages/js-utils/src/camel-to-snake-case.ts
@@ -10,7 +10,7 @@
  * - Numbers are considered to be capital letters of a different type.
  * - Multiple adjacent captial letters of the same type are considered part of the same word.
  */
-export function camelToSnakeCase( camelCaseString: string ): string {
+export default function camelToSnakeCase( camelCaseString: string ): string {
 	return (
 		camelCaseString
 			// collapse all spaces into an underscore

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -1,2 +1,5 @@
+export { default as camelToSnakeCase } from './camel-to-snake-case';
+export { default as mapRecordKeysRecursively } from './map-record-keys-recursively';
 export { default as shuffle } from './shuffle';
+export { default as snakeToCamelCase } from './snake-to-camel-case';
 export { default as uniqueBy } from './unique-by';

--- a/packages/js-utils/src/map-record-keys-recursively.ts
+++ b/packages/js-utils/src/map-record-keys-recursively.ts
@@ -9,7 +9,7 @@
  * it finds, so any objects contained within arrays that are properties of the
  * original object will be returned unchanged.
  */
-export function mapRecordKeysRecursively(
+export default function mapRecordKeysRecursively(
 	record: Record< string, unknown >,
 	transform: ( original: string ) => string
 ): Record< string, unknown > {

--- a/packages/js-utils/src/snake-to-camel-case.ts
+++ b/packages/js-utils/src/snake-to-camel-case.ts
@@ -3,7 +3,7 @@
  *
  * This is designed to work nearly identically to the lodash `camelCase` function.
  */
-export function snakeToCamelCase( snakeCaseString: string ): string {
+export default function snakeToCamelCase( snakeCaseString: string ): string {
 	return snakeCaseString
 		.toLowerCase()
 		.replace( /([-_][a-z0-9])/g, ( group ) =>

--- a/packages/js-utils/src/test/camel-to-snake-case.ts
+++ b/packages/js-utils/src/test/camel-to-snake-case.ts
@@ -1,4 +1,4 @@
-import { camelToSnakeCase } from '../src/camel-to-snake-case';
+import camelToSnakeCase from '../camel-to-snake-case';
 
 describe( 'camelToSnakeCase', () => {
 	it( 'transforms camelCase to snake_case for strings with two words', () => {

--- a/packages/js-utils/src/test/map-record-keys-recursively.ts
+++ b/packages/js-utils/src/test/map-record-keys-recursively.ts
@@ -1,5 +1,5 @@
-import { camelToSnakeCase } from '../src/camel-to-snake-case';
-import { mapRecordKeysRecursively } from '../src/map-record-keys-recursively';
+import camelToSnakeCase from '../camel-to-snake-case';
+import mapRecordKeysRecursively from '../map-record-keys-recursively';
 
 describe( 'mapRecordKeysRecursively', () => {
 	it( 'transforms the keys of a string/string record', () => {

--- a/packages/js-utils/src/test/snake-to-camel-case.ts
+++ b/packages/js-utils/src/test/snake-to-camel-case.ts
@@ -1,4 +1,4 @@
-import { snakeToCamelCase } from '../src/snake-to-camel-case';
+import snakeToCamelCase from '../snake-to-camel-case';
 
 describe( 'snakeToCamelCase', () => {
 	it( 'transforms snake_case to camelCase for strings with two words', () => {

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -26,6 +26,3 @@ export * from './get-introductory-offer-interval-display';
 export * from './join-classes';
 export * from './checkout-line-items';
 export * from './get-country-postal-code-support';
-export * from './map-record-keys-recursively';
-export * from './camel-to-snake-case';
-export * from './snake-to-camel-case';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a straightforward follow-up to https://github.com/Automattic/wp-calypso/pull/58054#discussion_r749410159 where we move the `camelToSnakeCase`, `snakeToCamelCase` and `mapRecordKeysRecursively` methods to the `@automattic/js-utils` package.

The main rationale for the move is that it doesn't make sense for some portions of the code (domains) to be consuming these from the `@automattic/wpcom-checkout` package. They're also pretty generic, so they belong to a generic package.

#### Testing instructions

* Verify Calypso builds well.
* Verify all tests still pass.