### PR TITLE
`QueryJetpackSettings`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-jetpack-settings/README.md
+++ b/client/components/data/query-jetpack-settings/README.md
@@ -14,14 +14,9 @@ import QueryJetpackSettings from 'calypso/components/data/query-jetpack-settings
 import getJetpackSettings from 'calypso/state/selectors/get-jetpack-settings';
 
 function MyJetpackSettings( { settings, siteId } ) {
-	const query = {
-		token: 'skyfKuaiKjbd8mK0Ngo75XyzfeKjp8sA',
-		userEmail: 'exampleuser@yourgroovydomain.com',
-	};
-
 	return (
 		<div>
-			<QueryJetpackSettings query={ query } siteId={ siteId } />
+			<QueryJetpackSettings siteId={ siteId } />
 			{ map( settings, ( value, name ) => (
 				<div>
 					{ name }: { value.toString() }
@@ -46,12 +41,3 @@ export default connect( ( state, { siteId } ) => ( {
 </table>
 
 The site ID for which Jetpack Settings should be requested.
-
-### `query`
-
-<table>
-	<tr><th>Type</th><td>Object</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-</table>
-
-A query to use when requesting Jetpack Settings.

--- a/client/components/data/query-jetpack-settings/index.jsx
+++ b/client/components/data/query-jetpack-settings/index.jsx
@@ -1,44 +1,28 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestJetpackSettings } from 'calypso/state/jetpack/settings/actions';
 import isRequestingJetpackSettings from 'calypso/state/selectors/is-requesting-jetpack-settings';
 
-class QueryJetpackSettings extends Component {
-	static propTypes = {
-		query: PropTypes.object,
-		siteId: PropTypes.number,
-		// Connected props
-		requestingSettings: PropTypes.bool,
-		requestJetpackSettings: PropTypes.func,
-	};
-
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
+const request = ( siteId, query ) => ( dispatch, getState ) => {
+	if ( ! isRequestingJetpackSettings( getState(), siteId ) ) {
+		dispatch( requestJetpackSettings( siteId, query ) );
 	}
+};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId !== nextProps.siteId ) {
-			this.request( nextProps );
-		}
-	}
+function QueryJetpackSettings( { siteId, query } ) {
+	const dispatch = useDispatch();
 
-	request( props ) {
-		if ( props.requestingSettings || ! props.siteId ) {
-			return;
-		}
+	useEffect( () => {
+		dispatch( request( siteId, query ) );
+	}, [ dispatch, siteId, query ] );
 
-		props.requestJetpackSettings( props.siteId, props.query );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, { query, siteId } ) => ( {
-		requestingSettings: isRequestingJetpackSettings( state, siteId, query ),
-	} ),
-	{ requestJetpackSettings }
-)( QueryJetpackSettings );
+QueryJetpackSettings.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	query: PropTypes.object,
+};
+
+export default QueryJetpackSettings;

--- a/client/components/data/query-jetpack-settings/index.jsx
+++ b/client/components/data/query-jetpack-settings/index.jsx
@@ -4,25 +4,24 @@ import { useDispatch } from 'react-redux';
 import { requestJetpackSettings } from 'calypso/state/jetpack/settings/actions';
 import isRequestingJetpackSettings from 'calypso/state/selectors/is-requesting-jetpack-settings';
 
-const request = ( siteId, query ) => ( dispatch, getState ) => {
+const request = ( siteId ) => ( dispatch, getState ) => {
 	if ( ! isRequestingJetpackSettings( getState(), siteId ) ) {
-		dispatch( requestJetpackSettings( siteId, query ) );
+		dispatch( requestJetpackSettings( siteId ) );
 	}
 };
 
-function QueryJetpackSettings( { siteId, query } ) {
+function QueryJetpackSettings( { siteId } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( request( siteId, query ) );
-	}, [ dispatch, siteId, query ] );
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
 	return null;
 }
 
 QueryJetpackSettings.propTypes = {
 	siteId: PropTypes.number.isRequired,
-	query: PropTypes.object,
 };
 
 export default QueryJetpackSettings;

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -39,7 +39,7 @@ const receiveJetpackSettings = ( { siteId }, settings ) =>
  * @returns {object}   Dispatched http action
  */
 export const requestJetpackSettings = ( action ) => {
-	const { siteId, query } = action;
+	const { siteId } = action;
 
 	return http(
 		{
@@ -48,7 +48,6 @@ export const requestJetpackSettings = ( action ) => {
 			path: '/jetpack-blogs/' + siteId + '/rest-api/',
 			query: {
 				path: '/jetpack/v4/settings/',
-				query: JSON.stringify( query ),
 				json: true,
 			},
 		},

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -17,8 +17,6 @@ import {
 } from '../';
 
 describe( 'requestJetpackSettings()', () => {
-	const token = 'abcd1234';
-	const userEmail = 'example@yourgroovydomain.com';
 	const siteId = 12345678;
 
 	const action = {
@@ -37,39 +35,10 @@ describe( 'requestJetpackSettings()', () => {
 					path: '/jetpack-blogs/' + siteId + '/rest-api/',
 					query: {
 						path: '/jetpack/v4/settings/',
-						query: undefined,
 						json: true,
 					},
 				},
 				action
-			)
-		);
-	} );
-
-	test( 'should dispatch an action for GET HTTP request with a query including onboarding credentials', () => {
-		const query = {
-			onboarding: {
-				token,
-				jpUser: userEmail,
-			},
-		};
-		const actionWithAuth = { ...action, query };
-
-		const result = requestJetpackSettings( actionWithAuth );
-
-		expect( result ).toEqual(
-			http(
-				{
-					apiVersion: '1.1',
-					method: 'GET',
-					path: '/jetpack-blogs/' + siteId + '/rest-api/',
-					query: {
-						path: '/jetpack/v4/settings/',
-						query: JSON.stringify( query ),
-						json: true,
-					},
-				},
-				actionWithAuth
 			)
 		);
 	} );

--- a/client/state/jetpack/settings/actions.js
+++ b/client/state/jetpack/settings/actions.js
@@ -8,10 +8,9 @@ import {
 import 'calypso/state/data-layer/wpcom/jetpack/settings';
 import 'calypso/state/jetpack/init';
 
-export const requestJetpackSettings = ( siteId, query ) => ( {
+export const requestJetpackSettings = ( siteId ) => ( {
 	type: JETPACK_SETTINGS_REQUEST,
 	siteId,
-	query,
 	meta: {
 		dataLayer: {
 			trackRequest: true,

--- a/client/state/selectors/is-requesting-jetpack-settings.js
+++ b/client/state/selectors/is-requesting-jetpack-settings.js
@@ -7,9 +7,8 @@ import getRequest from 'calypso/state/selectors/get-request';
  *
  * @param  {object}  state       Global state tree
  * @param  {number}  siteId      The ID of the site we're querying
- * @param  {object}  query       An optional query to be passed to the JP settings endpoint
  * @returns {boolean}             Whether Jetpack settings are currently being requested
  */
-export default function isRequestingJetpackSettings( state, siteId, query ) {
-	return get( getRequest( state, requestJetpackSettings( siteId, query ) ), 'isLoading', false );
+export default function isRequestingJetpackSettings( state, siteId ) {
+	return get( getRequest( state, requestJetpackSettings( siteId ) ), 'isLoading', false );
 }

--- a/client/state/selectors/test/is-requesting-jetpack-settings.js
+++ b/client/state/selectors/test/is-requesting-jetpack-settings.js
@@ -48,10 +48,9 @@ describe( 'isRequestingJetpackSettings()', () => {
 		expect( output ).toBe( false );
 	} );
 
-	test( 'should return true if settings are currently being requested for a matching site ID and query', () => {
+	test( 'should return true if settings are currently being requested for a matching site ID', () => {
 		const siteId = 87654321;
-		const query = { foo: 'bar' };
-		const action = requestJetpackSettings( siteId, query );
+		const action = requestJetpackSettings( siteId );
 		const state = {
 			dataRequests: {
 				[ getRequestKey( action ) ]: {
@@ -60,23 +59,7 @@ describe( 'isRequestingJetpackSettings()', () => {
 			},
 		};
 
-		const output = isRequestingJetpackSettings( state, siteId, query );
+		const output = isRequestingJetpackSettings( state, siteId );
 		expect( output ).toBe( true );
-	} );
-
-	test( 'should return false if settings are currently being requested for matching site ID and non-matching query', () => {
-		const siteId = 87654321;
-		const query = { foo: 'bar' };
-		const action = requestJetpackSettings( siteId, { foo: 'baz' } );
-		const state = {
-			dataRequests: {
-				[ getRequestKey( action ) ]: {
-					status: 'pending',
-				},
-			},
-		};
-
-		const output = isRequestingJetpackSettings( state, siteId, query );
-		expect( output ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryJetpackSettings`: refactor away from `UNSAFE_*`

#### Testing instructions

* With a Jetpack site currently selected go to `/settings/security/<site>`
* Make sure you see a request to `/jetpack-blogs/<siteId>/rest-api` with query param `path` set to `/jetpack/v4/settings/`
