### PR TITLE
Domains: Add breadcrumbs to DNS records page placeholder

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -37,6 +37,7 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: 16px;
+	min-height: 40px;
 
 	@include break-mobile {
 		padding: 16px 0;

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -34,13 +34,7 @@ class AddDnsRecprd extends Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.renderBreadcrumbs = this.renderBreadcrumbs.bind( this );
-		this.goBack = this.goBack.bind( this );
-	}
-
-	renderBreadcrumbs() {
+	renderBreadcrumbs = () => {
 		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
 
 		const items = [
@@ -72,7 +66,7 @@ class AddDnsRecprd extends Component {
 		return (
 			<Breadcrumbs items={ items } mobileItem={ mobileItem } buttons={ [] } mobileButtons={ [] } />
 		);
-	}
+	};
 
 	goBack = () => {
 		const { selectedSite, selectedDomainName } = this.props;

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -132,21 +131,17 @@ class AddDnsRecprd extends Component {
 		);
 	}
 
-	renderPlaceholder() {
-		return config.isEnabled( 'domains/dns-records-redesign' ) ? (
-			<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
-		) : (
-			<DomainMainPlaceholder goBack={ this.goBack } />
-		);
-	}
-
 	render() {
 		const { showPlaceholder, selectedDomainName } = this.props;
 
 		return (
 			<Fragment>
 				<QueryDomainDns domain={ selectedDomainName } />
-				{ showPlaceholder ? this.renderPlaceholder() : this.renderMain() }
+				{ showPlaceholder ? (
+					<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
+				) : (
+					this.renderMain()
+				) }
 			</Fragment>
 		);
 	}

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -32,6 +33,12 @@ class AddDnsRecprd extends Component {
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
+
+	constructor( props ) {
+		super( props );
+		this.renderBreadcrumbs = this.renderBreadcrumbs.bind( this );
+		this.goBack = this.goBack.bind( this );
+	}
 
 	renderBreadcrumbs() {
 		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
@@ -131,13 +138,21 @@ class AddDnsRecprd extends Component {
 		);
 	}
 
+	renderPlaceholder() {
+		return config.isEnabled( 'domains/dns-records-redesign' ) ? (
+			<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
+		) : (
+			<DomainMainPlaceholder goBack={ this.goBack } />
+		);
+	}
+
 	render() {
 		const { showPlaceholder, selectedDomainName } = this.props;
 
 		return (
 			<Fragment>
 				<QueryDomainDns domain={ selectedDomainName } />
-				{ showPlaceholder ? <DomainMainPlaceholder goBack={ this.goBack } /> : this.renderMain() }
+				{ showPlaceholder ? this.renderPlaceholder() : this.renderMain() }
 			</Fragment>
 		);
 	}

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -107,21 +106,17 @@ class DnsRecords extends Component {
 		);
 	}
 
-	renderPlaceholder() {
-		return config.isEnabled( 'domains/dns-records-redesign' ) ? (
-			<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
-		) : (
-			<DomainMainPlaceholder goBack={ this.goBack } />
-		);
-	}
-
 	render() {
 		const { showPlaceholder, selectedDomainName } = this.props;
 
 		return (
 			<Fragment>
 				<QueryDomainDns domain={ selectedDomainName } />
-				{ showPlaceholder ? this.renderPlaceholder() : this.renderMain() }
+				{ showPlaceholder ? (
+					<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
+				) : (
+					this.renderMain()
+				) }
 			</Fragment>
 		);
 	}

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -39,14 +39,8 @@ class DnsRecords extends Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.renderBreadcrumbs = this.renderBreadcrumbs.bind( this );
-		this.goBack = this.goBack.bind( this );
-	}
-
-	renderBreadcrumbs() {
-		const { dns, domains, translate, selectedSite, currentRoute, selectedDomainName } = this.props;
+	renderBreadcrumbs = () => {
+		const { domains, translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
 		const pointsToWpcom = selectedDomain?.pointsToWpcom ?? false;
 
@@ -90,7 +84,7 @@ class DnsRecords extends Component {
 				mobileButtons={ buttons }
 			/>
 		);
-	}
+	};
 
 	renderMain() {
 		const { dns, selectedDomainName, selectedSite, translate } = this.props;

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -37,6 +38,12 @@ class DnsRecords extends Component {
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
+
+	constructor( props ) {
+		super( props );
+		this.renderBreadcrumbs = this.renderBreadcrumbs.bind( this );
+		this.goBack = this.goBack.bind( this );
+	}
 
 	renderBreadcrumbs() {
 		const { dns, domains, translate, selectedSite, currentRoute, selectedDomainName } = this.props;
@@ -106,13 +113,21 @@ class DnsRecords extends Component {
 		);
 	}
 
+	renderPlaceholder() {
+		return config.isEnabled( 'domains/dns-records-redesign' ) ? (
+			<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
+		) : (
+			<DomainMainPlaceholder goBack={ this.goBack } />
+		);
+	}
+
 	render() {
 		const { showPlaceholder, selectedDomainName } = this.props;
 
 		return (
 			<Fragment>
 				<QueryDomainDns domain={ selectedDomainName } />
-				{ showPlaceholder ? <DomainMainPlaceholder goBack={ this.goBack } /> : this.renderMain() }
+				{ showPlaceholder ? this.renderPlaceholder() : this.renderMain() }
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds the breadcrumbs for the DNS records page when in the loading state.

#### Preview
![image](https://user-images.githubusercontent.com/18705930/141996436-fbc4acbd-acc5-4db5-ae08-148fca069fd3.png)

#### Testing instructions
- Go to `/domains/manage/:domain/dns/:domain`;
- Check that when the page loads it looks like the screenshot in the preview section;

_You can also try setting the `showPlaceholder` prop for the `DnsRecords` component as `true`._
