### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` google apps pass reset to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -627,16 +627,6 @@ Undocumented.prototype.changeTheme = function ( siteSlug, data, fn ) {
 	);
 };
 
-Undocumented.prototype.resetPasswordForMailbox = function ( domainName, mailbox, fn ) {
-	debug( '/domains/:domainName/google-apps/:mailbox/get-new-password' );
-	return this.wpcom.req.post(
-		{
-			path: '/domains/' + domainName + '/google-apps/' + mailbox + '/get-new-password',
-		},
-		fn
-	);
-};
-
 Undocumented.prototype.isSiteImportable = function ( site_url ) {
 	debug( `/wpcom/v2/imports/is-site-importable?${ site_url }` );
 

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
@@ -64,14 +64,14 @@ function PendingGSuiteTosNoticeDialog( props ) {
 	const onPasswordClick = ( event ) => {
 		event.preventDefault();
 
-		const wpcom = wp.undocumented();
 		const mailbox = props.user.split( '@' )[ 0 ];
 
-		wpcom.resetPasswordForMailbox( props.domainName, mailbox ).then(
-			( data ) => {
+		wp.req
+			.post( `/domains/${ props.domainName }/google-apps/${ mailbox }/get-new-password` )
+			.then( ( data ) => {
 				setPassword( data.password );
-			},
-			() => {
+			} )
+			.catch( () => {
 				props.errorNotice(
 					translate(
 						'There was a problem resetting the password for %(gsuiteEmail)s. Please {{link}}contact support{{/link}}.',
@@ -88,8 +88,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 
 				setOpenTracked( false );
 				props.onClose();
-			}
-		);
+			} );
 
 		trackEvent(
 			`Clicked "Get Password" link in G Suite pending ToS dialog via ${ props.section }`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` Google Apps password reset to `wpcom.req.post()`. 

We're also updating the code to use `.then()` and `.catch()` instead of a callback.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Follow the test instructions in #31562.