### PR TITLE
State: Refactor away from `_.takeWhile` and `_.takeRightWhile`

### DIFF
--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -1,4 +1,4 @@
-import { findIndex, last, takeRightWhile, takeWhile, filter } from 'lodash';
+import { findIndex, last, filter } from 'lodash';
 import moment from 'moment';
 import { keysAreEqual } from 'calypso/reader/post-key';
 import {
@@ -13,6 +13,19 @@ import {
 } from 'calypso/state/reader/action-types';
 import { keyedReducer, combineReducers } from 'calypso/state/utils';
 import { combineXPosts } from './utils';
+
+const takeWhile = ( array, predicate ) => {
+	const [ x, ...xs ] = array;
+
+	if ( array.length > 0 && predicate( x ) ) {
+		return [ x, ...takeWhile( xs, predicate ) ];
+	}
+	return [];
+};
+
+const takeRightWhile = ( array, predicate ) => {
+	return takeWhile( [ ...array ].reverse(), predicate );
+};
 
 /*
  * Contains a list of post-keys representing the items of a stream.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the sole usages of Lodash's `takeWhile` and `takeRightWhile` in favor of custom inline implementations.

#### Testing instructions

Verify reader streams still work well.

#### Note

I was unable to reproduce this behavior because I can't get any stream endpoint to return a `gap` argument as part of the payload. Anyone have an idea where that should come from? cc @Automattic/reader 