### PR TITLE
Playwright: Domains add script - remove network idle wait

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-domains__add.ts
+++ b/test/e2e/specs/specs-playwright/wp-domains__add.ts
@@ -91,7 +91,6 @@ describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), functio
 
 	describe( 'Cancel domain', function () {
 		it( 'Return to Home dashboard', async function () {
-			await page.pause();
 			const navbarComponent = new NavbarComponent( page );
 			await navbarComponent.clickMySites();
 		} );

--- a/test/e2e/specs/specs-playwright/wp-domains__add.ts
+++ b/test/e2e/specs/specs-playwright/wp-domains__add.ts
@@ -81,7 +81,6 @@ describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), functio
 			await Promise.all( [
 				page.waitForNavigation( {
 					url: '**/checkout/thank-you/**',
-					waitUntil: 'networkidle',
 					// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
 					timeout: 90 * 1000,
 				} ),
@@ -92,6 +91,7 @@ describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), functio
 
 	describe( 'Cancel domain', function () {
 		it( 'Return to Home dashboard', async function () {
+			await page.pause();
 			const navbarComponent = new NavbarComponent( page );
 			await navbarComponent.clickMySites();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Domains add script fails because it waits for a `networkidle` event on the Thank You page. For whatever reason (seems like a polling web request, or maybe something the redirect lifecycle), that event doesn't fire on the Thank You page. 

Note that this test will still be broken for that user because the domain data inflated due to the test failure in a way that prevent cancelling the domain because the purchases web request times out.

#### Testing instructions

- [ ] `yarn jest specs/specs-playwright/wp-domains__add.ts`

Related to #
