### PR TITLE
State: Refactor away from `_.overSome`

### DIFF
--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -9,7 +9,6 @@ import {
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { overSome } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -47,6 +46,7 @@ import { isSiteWordadsUnsafe } from 'calypso/state/wordads/status/selectors';
 import './style.scss';
 import 'calypso/my-sites/stats/stats-module/style.scss';
 
+const overSome = ( ...checks ) => ( item ) => checks.some( ( check ) => check( item ) );
 const isEligbleJetpackPlan = overSome( isPremium, isBusiness, isEcommerce, isSecurityDaily );
 
 class AdsWrapper extends Component {

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -14,7 +14,7 @@ import {
 } from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { compact, overSome } from 'lodash';
+import { compact } from 'lodash';
 import page from 'page';
 import { FunctionComponent, Fragment, useState, useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -53,6 +53,8 @@ interface ConnectedProps {
 	trackLearnLink: ( feature: string ) => void;
 	trackCtaButton: ( feature: string ) => void;
 }
+
+const overSome = ( ...checks ) => ( item ) => checks.some( ( check ) => check( item ) );
 
 const wpcom = wp.undocumented();
 

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -1,4 +1,4 @@
-import { get, has, includes, overSome } from 'lodash';
+import { get, has, includes } from 'lodash';
 import { GUIDED_TOUR_UPDATE, ROUTE_SET, SITE_SETTINGS_RECEIVE } from 'calypso/state/action-types';
 import { THEMES_REQUEST_SUCCESS } from 'calypso/state/themes/action-types';
 
@@ -24,6 +24,7 @@ const isRelevantActionType = ( action ) =>
 	has( relevantTypes, action.type ) &&
 	( typeof relevantTypes[ action.type ] !== 'function' || relevantTypes[ action.type ]( action ) );
 
+const overSome = ( checks ) => ( item ) => checks.some( ( check ) => check( item ) );
 const isRelevantAction = overSome( [ isRelevantActionType, hasRelevantAnalytics ] );
 
 const newAction = ( action ) => ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the few remaining usages of Lodash's `overSome` in favor of a simple custom one-liner inline implementation.

#### Testing instructions

* Let `:site` is a site that has WordAds enabled and is on a premium or a more expensive plan.
* Verify `/earn/:site` still works well.
* Verify `/earn/ads-earnings/:site` still works well.
* Verify tests still pass: `yarn run test-client client/state/ui/action-log/test/reducer.js` 
