### PR TITLE
Create placeholder loading page

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -421,7 +421,29 @@ function PluginDoesNotExistView() {
 }
 
 function PluginPlaceholder() {
-	return <MainComponent wideLayout>{ /* TODO: Create Placeholder */ }</MainComponent>;
+	return (
+		<MainComponent wideLayout>
+			<div className="plugin-details__page">
+				<div className="plugin-details__layout plugin-details__top-section">
+					<div className="plugin-details__layout-col plugin-details__layout-col-left">
+						<div className="plugin-details__tags is-placeholder">...</div>
+						<div className="plugin-details__header is-placeholder">
+							<div className="plugin-details__name">...</div>
+							<div className="plugin-details__description">...</div>
+							<div className="plugin-details__additional-info">...</div>
+						</div>
+					</div>
+					<div className="plugin-details__layout-col plugin-details__layout-col-right">
+						<div className="plugin-details__header is-placeholder">
+							<div className="plugin-details__price">...</div>
+							<div className="plugin-details__install">...</div>
+							<div className="plugin-details__t-and-c">...</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</MainComponent>
+	);
 }
 
 export default PluginDetails;

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -424,17 +424,17 @@ function PluginPlaceholder() {
 	return (
 		<MainComponent wideLayout>
 			<div className="plugin-details__page">
-				<div className="plugin-details__layout plugin-details__top-section">
+				<div className="plugin-details__layout plugin-details__top-section is-placeholder">
 					<div className="plugin-details__layout-col plugin-details__layout-col-left">
-						<div className="plugin-details__tags is-placeholder">...</div>
-						<div className="plugin-details__header is-placeholder">
+						<div className="plugin-details__tags">...</div>
+						<div className="plugin-details__header">
 							<div className="plugin-details__name">...</div>
 							<div className="plugin-details__description">...</div>
 							<div className="plugin-details__additional-info">...</div>
 						</div>
 					</div>
 					<div className="plugin-details__layout-col plugin-details__layout-col-right">
-						<div className="plugin-details__header is-placeholder">
+						<div className="plugin-details__header">
 							<div className="plugin-details__price">...</div>
 							<div className="plugin-details__install">...</div>
 							<div className="plugin-details__t-and-c">...</div>

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -143,6 +143,14 @@ $plugin-details-header-padding: 100px;
 	}
 }
 
+%placeholder {
+	cursor: default;
+	color: transparent;
+	user-select: none;
+	background-color: var( --color-neutral-0 );
+	animation: loading-fade 1.6s ease-in-out infinite;
+}
+
 .plugin-details__top-section {
 	border-bottom: 1px solid var( --studio-gray-5 );
 
@@ -153,19 +161,30 @@ $plugin-details-header-padding: 100px;
 			display: none;
 		}
 	}
+
+	&.is-placeholder {
+		border-bottom: none;
+
+		.plugin-details__name,
+		.plugin-details__price,
+		.plugin-details__description,
+		.plugin-details__additional-info,
+		.plugin-details__install,
+		.plugin-details__t-and-c {
+			@extend %placeholder;
+		}
+
+		.plugin-details__tags {
+			@extend %placeholder;
+			width: 50%;
+		}
+	}
 }
 
 .plugin-details__page {
 	@media screen and ( max-width: 1040px ) {
 		padding: 16px;
 	}
-}
-
-%placeholder {
-	cursor: default;
-	color: transparent;
-	background-color: var( --color-neutral-0 );
-	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
 .plugin-details__tags {
@@ -178,11 +197,6 @@ $plugin-details-header-padding: 100px;
 	@media screen and ( max-width: 1040px ) {
 		top: -5px;
 	}
-
-	&.is-placeholder {
-		@extend %placeholder;
-		width: 50%;
-	}
 }
 
 .plugin-details__header {
@@ -190,17 +204,6 @@ $plugin-details-header-padding: 100px;
 	flex-direction: column;
 	justify-content: center;
 	padding: $plugin-details-header-padding 0;
-
-	&.is-placeholder {
-		.plugin-details__name,
-		.plugin-details__price,
-		.plugin-details__description,
-		.plugin-details__additional-info,
-		.plugin-details__install,
-		.plugin-details__t-and-c {
-			@extend %placeholder;
-		}
-	}
 
 	.plugin-details__name,
 	.plugin-details__price {
@@ -241,7 +244,7 @@ $plugin-details-header-padding: 100px;
 	}
 
 	.plugin-details__install {
-		padding-bottom: 20px;
+		margin-bottom: 20px;
 
 		.plugin-details__install-button {
 			width: 100%;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -161,6 +161,13 @@ $plugin-details-header-padding: 100px;
 	}
 }
 
+%placeholder {
+	cursor: default;
+	color: transparent;
+	background-color: var( --color-neutral-0 );
+	animation: loading-fade 1.6s ease-in-out infinite;
+}
+
 .plugin-details__tags {
 	position: absolute;
 	font-size: $font-body-extra-small;
@@ -171,6 +178,11 @@ $plugin-details-header-padding: 100px;
 	@media screen and ( max-width: 1040px ) {
 		top: -5px;
 	}
+
+	&.is-placeholder {
+		@extend %placeholder;
+		width: 50%;
+	}
 }
 
 .plugin-details__header {
@@ -179,15 +191,14 @@ $plugin-details-header-padding: 100px;
 	justify-content: center;
 	padding: $plugin-details-header-padding 0;
 
-	.plugin-details__name,
-	.plugin-details__price,
-	.plugin-details__description,
-	.plugin-details__additional-info {
-		&.is-placeholder {
-			cursor: default;
-			color: transparent;
-			background-color: var( --color-neutral-0 );
-			animation: loading-fade 1.6s ease-in-out infinite;
+	&.is-placeholder {
+		.plugin-details__name,
+		.plugin-details__price,
+		.plugin-details__description,
+		.plugin-details__additional-info,
+		.plugin-details__install,
+		.plugin-details__t-and-c {
+			@extend %placeholder;
 		}
 	}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -16,7 +16,8 @@ body.is-section-plugins.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
 }
 
-.plugin__installed-on, .plugin-details__installed-on {
+.plugin__installed-on,
+.plugin-details__installed-on {
 	margin-bottom: 16px;
 }
 
@@ -178,17 +179,30 @@ $plugin-details-header-padding: 100px;
 	justify-content: center;
 	padding: $plugin-details-header-padding 0;
 
-	.plugin-details__name, .plugin-details__price {
+	.plugin-details__name,
+	.plugin-details__price,
+	.plugin-details__description,
+	.plugin-details__additional-info {
+		&.is-placeholder {
+			cursor: default;
+			color: transparent;
+			background-color: var( --color-neutral-0 );
+			animation: loading-fade 1.6s ease-in-out infinite;
+		}
+	}
+
+	.plugin-details__name,
+	.plugin-details__price {
 		font-family: $brand-serif;
 		font-size: $font-title-large;
 		color: var( --studio-gray-100 );
-		padding: 16px 0;
+		margin: 16px 0;
 	}
 
 	.plugin-details__description {
 		font-size: $font-title-small;
 		color: var( --studio-gray-70 );
-		padding-bottom: 30px;
+		margin-bottom: 30px;
 	}
 
 	.plugin-details__additional-info {
@@ -225,7 +239,7 @@ $plugin-details-header-padding: 100px;
 			color: var( --studio-white );
 		}
 	}
-	
+
 	.plugin-details__t-and-c {
 		font-size: $font-body-extra-small;
 		color: var( --studio-gray-50 );
@@ -319,11 +333,11 @@ $plugin-details-header-padding: 100px;
 		.plugin-details__plugin-details-title {
 			display: block;
 		}
-		
+
 		.plugin-details__layout-col-left {
 			order: 2;
 		}
-		
+
 		.plugin-details__layout-col-right {
 			order: 1;
 			margin-top: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Show placeholders to the plugin details page while data is fetched.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to plugins page
- Select a plugin
- Check that the loading state has a design matching below:

| |Before | After|
|---|-------|------|
| Desktop | ![image](https://user-images.githubusercontent.com/11555574/142018466-86a98ea3-1c5f-4399-99a4-74c2aac84acc.png) | ![image](https://user-images.githubusercontent.com/11555574/142019033-58434c29-5f08-4b27-b7f6-698c94efc4f8.png) |
| Mobile | ![image](https://user-images.githubusercontent.com/11555574/142018581-dcbc01c1-a5f1-4510-9c30-a58551e7d8e6.png)| ![image](https://user-images.githubusercontent.com/11555574/142018889-85cd6774-1504-47ec-9b0c-c4d4a6a27b7a.png) |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57748
