### PR TITLE
Rename legacy FSE selectors

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -26,7 +26,7 @@ import { isWordadsInstantActivationEligible } from 'calypso/lib/ads/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
 import { hasDomainCredit, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AdvertisingRemoved from './advertising-removed';
@@ -398,7 +398,7 @@ export default connect(
 			isAutomatedTransfer,
 			selectedSite,
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
-			showCustomizerFeature: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
+			showCustomizerFeature: ! isSiteUsingLegacyFSE( state, selectedSiteId ),
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			scheduleId: getConciergeScheduleId( state ),
 			isMonthlyPlan: TERM_MONTHLY === getPlan( ownProps.plan )?.term,

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { requestSiteChecklist } from 'calypso/state/checklist/actions';
-import isSiteEligibleForFullSiteEditing from 'calypso/state/selectors/is-site-eligible-for-full-site-editing';
+import isSiteEligibleForLegacyFSE from 'calypso/state/selectors/is-site-eligible-for-legacy-fse';
 
 export default function QuerySiteChecklist( { siteId } ) {
 	const dispatch = useDispatch();
 	const isSiteEligibleForFSE = useSelector( ( state ) =>
-		isSiteEligibleForFullSiteEditing( state, siteId )
+		isSiteEligibleForLegacyFSE( state, siteId )
 	);
 
 	useEffect( () => {

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import isSiteEligibleForFullSiteEditing from 'calypso/state/selectors/is-site-eligible-for-full-site-editing';
+import isSiteEligibleForLegacyFSE from 'calypso/state/selectors/is-site-eligible-for-legacy-fse';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -68,6 +68,6 @@ export default connect( ( state ) => {
 		isAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
 		selectedSite: getSelectedSite( state ),
 		siteIsUnlaunched: isUnlaunchedSite( state, selectedSiteId ),
-		isSiteEligibleForFSE: isSiteEligibleForFullSiteEditing( state, selectedSiteId ),
+		isSiteEligibleForFSE: isSiteEligibleForLegacyFSE( state, selectedSiteId ),
 	};
 } )( CurrentSiteDomainWarnings );

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -12,7 +12,7 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
 	getSiteFrontPage,
@@ -341,7 +341,7 @@ const mapStateToProps = ( state ) => {
 		customizeUrl: getCustomizerUrl( state, siteId ),
 		menusUrl: getCustomizerUrl( state, siteId, 'menus' ),
 		isNewlyCreatedSite: isNewSite( state, siteId ),
-		showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
+		showCustomizer: ! isSiteUsingLegacyFSE( state, siteId ),
 		canAddEmail,
 		siteSlug,
 		isStaticHomePage,

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -8,7 +8,7 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
 import {
 	getSiteFrontPage,
 	getCustomizerUrl,
@@ -156,7 +156,7 @@ const mapStateToProps = ( state ) => {
 		customizeUrl: getCustomizerUrl( state, siteId ),
 		menusUrl: getCustomizerUrl( state, siteId, 'menus' ),
 		isNewlyCreatedSite: isNewSite( state, siteId ),
-		showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
+		showCustomizer: ! isSiteUsingLegacyFSE( state, siteId ),
 		isP2Hub,
 		siteSlug,
 		isStaticHomePage,

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
 import {
 	getSiteFrontPageType,
 	getSitePostsPage,
@@ -46,9 +46,9 @@ class BlogPostsPage extends Component {
 	};
 
 	render() {
-		const { isFullSiteEditing } = this.props;
+		const { isLegacyFSE } = this.props;
 
-		if ( isFullSiteEditing ) {
+		if ( isLegacyFSE ) {
 			return null;
 		}
 
@@ -92,6 +92,6 @@ export default connect( ( state, props ) => {
 		isFrontPage: getSiteFrontPageType( state, props.site.ID ) === 'posts',
 		postsPage: getSitePostsPage( state, props.site.ID ),
 		frontPage: getSiteFrontPage( state, props.site.ID ),
-		isFullSiteEditing: isSiteUsingFullSiteEditing( state, props.site.ID ),
+		isLegacyFSE: isSiteUsingLegacyFSE( state, props.site.ID ),
 	};
 }, mapDispatchToProps )( localize( BlogPostsPage ) );

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -27,7 +27,7 @@ import { getPreviewURL, userCan } from 'calypso/state/posts/utils';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
 import { shouldLoadGutenframe } from 'calypso/state/selectors/should-load-gutenframe/';
 import { updateSiteFrontPage } from 'calypso/state/sites/actions';
 import {
@@ -251,11 +251,11 @@ class Page extends Component {
 		} );
 
 	getPostsPageItem() {
-		const { canManageOptions, isFullSiteEditing, page, translate } = this.props;
+		const { canManageOptions, isLegacyFSE, page, translate } = this.props;
 
 		if (
 			! canManageOptions ||
-			isFullSiteEditing ||
+			isLegacyFSE ||
 			! this.props.hasStaticFrontPage ||
 			'publish' !== page.status ||
 			this.props.isFrontPage
@@ -765,7 +765,7 @@ const mapState = ( state, props ) => {
 			isJetpackSite( state, pageSiteId ),
 		wpAdminGutenberg: ! shouldLoadGutenframe( state, pageSiteId, 'page' ),
 		duplicateUrl: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' ),
-		isFullSiteEditing: isSiteUsingFullSiteEditing( state, pageSiteId ),
+		isLegacyFSE: isSiteUsingLegacyFSE( state, pageSiteId ),
 		canManageOptions: canCurrentUser( state, pageSiteId, 'manage_options' ),
 	};
 };

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -57,7 +57,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import isSiteChecklistComplete from 'calypso/state/selectors/is-site-checklist-complete';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import {
@@ -1160,7 +1160,7 @@ function mapStateToProps( state, props ) {
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		isMigrationInProgress,
 		isVip: isVipSite( state, selectedSiteId ),
-		showCustomizerLink: ! isSiteUsingFullSiteEditing( state, selectedSiteId ) && siteId,
+		showCustomizerLink: ! isSiteUsingLegacyFSE( state, selectedSiteId ) && siteId,
 		showSiteEditor: isFSEActive,
 		siteEditorUrl: getSiteEditorUrl( state, selectedSiteId ),
 		siteId,

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -4,7 +4,7 @@ import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
-import isSiteEligibleForFullSiteEditing from 'calypso/state/selectors/is-site-eligible-for-full-site-editing';
+import isSiteEligibleForLegacyFSE from 'calypso/state/selectors/is-site-eligible-for-legacy-fse';
 import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 import { THEME_FILTERS_REQUEST, THEME_FILTERS_ADD } from 'calypso/state/themes/action-types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -38,7 +38,7 @@ registerHandlers( 'state/data-layer/wpcom/theme-filters/index.js', {
 		( store, action ) => {
 			const state = store.getState();
 			const selectedSiteId = getSelectedSiteId( state );
-			const isFse = isSiteEligibleForFullSiteEditing( state, selectedSiteId );
+			const isFse = isSiteEligibleForLegacyFSE( state, selectedSiteId );
 			const isCoreFse = isSiteUsingCoreSiteEditor( state, selectedSiteId );
 
 			return themeFiltersHandlers( store, {

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -1,6 +1,6 @@
 import getFrontPageEditorUrl from 'calypso/state/selectors/get-front-page-editor-url';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
 import shouldCustomizeHomepageWithGutenberg from 'calypso/state/selectors/should-customize-homepage-with-gutenberg';
 import { getThemeCustomizeUrl, isThemeActive } from 'calypso/state/themes/selectors';
 
@@ -23,8 +23,7 @@ export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId, 
 	}
 
 	const shouldUseGutenberg =
-		shouldCustomizeHomepageWithGutenberg( state, siteId ) ||
-		isSiteUsingFullSiteEditing( state, siteId );
+		shouldCustomizeHomepageWithGutenberg( state, siteId ) || isSiteUsingLegacyFSE( state, siteId );
 	const frontPageEditorUrl = getFrontPageEditorUrl( state, siteId );
 
 	// If the theme is not active or getFrontPageEditorUrl has returned 'false', use the other function to preview customization with the theme.

--- a/client/state/selectors/get-customize-url.js
+++ b/client/state/selectors/get-customize-url.js
@@ -1,6 +1,6 @@
 import getFrontPageEditorUrl from 'calypso/state/selectors/get-front-page-editor-url';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
 import { getThemeCustomizeUrl } from 'calypso/state/themes/selectors';
 /**
  * Returns the URL for clicking on "Customize". The block editor URL is returned for sites with
@@ -19,7 +19,7 @@ export default function getCustomizeUrl( state, themeId, siteId, isFSEActive = f
 	}
 
 	// Legacy dotcom FSE
-	if ( isSiteUsingFullSiteEditing( state, siteId ) ) {
+	if ( isSiteUsingLegacyFSE( state, siteId ) ) {
 		return getFrontPageEditorUrl( state, siteId );
 	}
 

--- a/client/state/selectors/is-site-eligible-for-legacy-fse.js
+++ b/client/state/selectors/is-site-eligible-for-legacy-fse.js
@@ -7,7 +7,7 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
  * @param {object} siteId Site ID
  * @returns {boolean} True if the site is eligible for Full Site Editing, otherwise false
  */
-export default function isSiteEligibleForFullSiteEditing( state, siteId ) {
+export default function isSiteEligibleForLegacyFSE( state, siteId ) {
 	const site = getRawSite( state, siteId );
 	return site?.is_fse_eligible ?? false;
 }

--- a/client/state/selectors/is-site-using-legacy-fse.js
+++ b/client/state/selectors/is-site-using-legacy-fse.js
@@ -8,7 +8,7 @@ import { hasStaticFrontPage } from 'calypso/state/sites/selectors';
  * @param {object} siteId Site ID
  * @returns {boolean} True if the site is using Full Site Editing, otherwise false
  */
-export default function isSiteUsingFullSiteEditing( state, siteId ) {
+export default function isSiteUsingLegacyFSE( state, siteId ) {
 	const site = getRawSite( state, siteId );
 	const isActive = site?.is_fse_active ?? false;
 	return isActive && hasStaticFrontPage( state, siteId );

--- a/client/state/selectors/test/is-site-eligible-for-full-site-editing.js
+++ b/client/state/selectors/test/is-site-eligible-for-full-site-editing.js
@@ -1,4 +1,4 @@
-import isSiteEligibleForFullSiteEditing from '../is-site-eligible-for-full-site-editing';
+import isSiteEligibleForLegacyFSE from '../is-site-eligible-for-legacy-fse';
 
 function getSitesState( siteData = {} ) {
 	return {
@@ -12,28 +12,28 @@ function getSitesState( siteData = {} ) {
 	};
 }
 
-describe( 'isSiteUsingFullSiteEditing', () => {
+describe( 'isSiteEligibleForLegacyFSE', () => {
 	test( 'returns false if site does not exist', () => {
 		const state = { sites: { items: {} } };
-		const isFSE = isSiteEligibleForFullSiteEditing( state, 1 );
+		const isFSE = isSiteEligibleForLegacyFSE( state, 1 );
 		expect( isFSE ).toBe( false );
 	} );
 
 	test( 'returns true if site exists, has is_fse_eligble set to true', () => {
 		const state = getSitesState( { is_fse_eligible: true } );
-		const isFSE = isSiteEligibleForFullSiteEditing( state, 123 );
+		const isFSE = isSiteEligibleForLegacyFSE( state, 123 );
 		expect( isFSE ).toBe( true );
 	} );
 
 	test( 'returns false if site exists, has is_fse_eligible set to false', () => {
 		const state = getSitesState( { is_fse_eligible: false } );
-		const isFSE = isSiteEligibleForFullSiteEditing( state, 123 );
+		const isFSE = isSiteEligibleForLegacyFSE( state, 123 );
 		expect( isFSE ).toBe( false );
 	} );
 
 	test( 'returns false if site exists, but has no is_fse_eligible prop', () => {
 		const state = getSitesState();
-		const isFSE = isSiteEligibleForFullSiteEditing( state, 123 );
+		const isFSE = isSiteEligibleForLegacyFSE( state, 123 );
 		expect( isFSE ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-site-using-full-site-editing.js
+++ b/client/state/selectors/test/is-site-using-full-site-editing.js
@@ -1,9 +1,9 @@
-import isSiteUsingFullSiteEditing from '../is-site-using-full-site-editing';
+import isSiteUsingLegacyFSE from '../is-site-using-legacy-fse';
 
-describe( 'isSiteUsingFullSiteEditing', () => {
+describe( 'isSiteUsingLegacyFSE', () => {
 	test( 'returns false if site does not exist', () => {
 		const state = { sites: { items: {} } };
-		const isFSE = isSiteUsingFullSiteEditing( state, 1 );
+		const isFSE = isSiteUsingLegacyFSE( state, 1 );
 		expect( isFSE ).toBe( false );
 	} );
 
@@ -21,7 +21,7 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 				},
 			},
 		};
-		const isFSE = isSiteUsingFullSiteEditing( state, 123 );
+		const isFSE = isSiteUsingLegacyFSE( state, 123 );
 		expect( isFSE ).toBe( true );
 	} );
 
@@ -39,7 +39,7 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 				},
 			},
 		};
-		const isFSE = isSiteUsingFullSiteEditing( state, 123 );
+		const isFSE = isSiteUsingLegacyFSE( state, 123 );
 		expect( isFSE ).toBe( false );
 	} );
 
@@ -56,7 +56,7 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 				},
 			},
 		};
-		const isFSE = isSiteUsingFullSiteEditing( state, 123 );
+		const isFSE = isSiteUsingLegacyFSE( state, 123 );
 		expect( isFSE ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
Follow up to [discussion](https://github.com/Automattic/wp-calypso/pull/57626#discussion_r742903636) on https://github.com/Automattic/wp-calypso/pull/57626 - this renames legacy FSE selectors to be slightly less confusing by calling them "LegacyFSE" instead of "FullSiteEditing".

### Testing
* Verify these selectors are indeed for legacy FSE.
* Verify we are not missing updating any usage of the old selector's import/name.
* Run this PR and verify that legacy FSE and core FSE flows continue to work as expected.
