### PR TITLE
Update validation error message for TXT record

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -29,6 +29,7 @@ export const DOMAIN_EXPIRATION = `${ root }/domains/domain-expiration/`;
 export const DOMAIN_EXPIRATION_REDEMPTION = `${ root }/domains/domain-expiration/#renewing-a-domain-in-the-redemption-period`;
 export const DOMAIN_RECENTLY_REGISTERED = `${ root }/domains/register-domain/#waiting-for-domain-changes`;
 export const DOMAIN_PRICING_AND_AVAILABLE_TLDS = `${ root }/domains/domain-pricing-and-available-tlds`;
+export const DNS_TXT_RECORD_CHAR_LIMIT = `${ root }/domains/custom-dns/#txt-record-character-limit`;
 export const ECOMMERCE = `${ root }/ecommerce`;
 export const INCOMING_DOMAIN_TRANSFER_STATUSES = `${ root }/move-domain/incoming-domain-transfer/#checking-your-transfer-status-and-failed-transfers`;
 export const INCOMING_DOMAIN_TRANSFER_STATUSES_PENDING_CONFIRMATION = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#confirmation`;

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -2,11 +2,13 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import FormTextarea from 'calypso/components/forms/form-textarea';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 class TxtRecord extends Component {
 	static propTypes = {
@@ -19,10 +21,27 @@ class TxtRecord extends Component {
 	getValidationErrorMessage( value ) {
 		const { translate } = this.props;
 
+		const txtRecordSupportPageLink = (
+			<ExternalLink
+				href={ localizeUrl(
+					'https://wordpress.com/support/domains/custom-dns/#txt-record-character-limit'
+				) }
+				target="_blank"
+				icon={ false }
+			/>
+		);
+
 		if ( value?.length === 0 ) {
 			return translate( 'TXT records may not be empty' );
 		} else if ( value?.length > 255 ) {
-			return translate( 'TXT records may not exceed 255 characters' );
+			return translate(
+				'TXT records may not exceed 255 characters. {{supportLink}}Learn more{{/supportLink}}.',
+				{
+					components: {
+						supportLink: txtRecordSupportPageLink,
+					},
+				}
+			);
 		}
 
 		return null;

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -9,6 +9,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { DNS_TXT_RECORD_CHAR_LIMIT } from 'calypso/lib/url/support';
 
 class TxtRecord extends Component {
 	static propTypes = {
@@ -21,16 +22,6 @@ class TxtRecord extends Component {
 	getValidationErrorMessage( value ) {
 		const { translate } = this.props;
 
-		const txtRecordSupportPageLink = (
-			<ExternalLink
-				href={ localizeUrl(
-					'https://wordpress.com/support/domains/custom-dns/#txt-record-character-limit'
-				) }
-				target="_blank"
-				icon={ false }
-			/>
-		);
-
 		if ( value?.length === 0 ) {
 			return translate( 'TXT records may not be empty' );
 		} else if ( value?.length > 255 ) {
@@ -38,7 +29,13 @@ class TxtRecord extends Component {
 				'TXT records may not exceed 255 characters. {{supportLink}}Learn more{{/supportLink}}.',
 				{
 					components: {
-						supportLink: txtRecordSupportPageLink,
+						supportLink: (
+							<ExternalLink
+								href={ localizeUrl( DNS_TXT_RECORD_CHAR_LIMIT ) }
+								target="_blank"
+								icon={ false }
+							/>
+						),
 					},
 				}
 			);

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -8,7 +8,6 @@ import FormInputValidation from 'calypso/components/forms/form-input-validation'
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { DNS_TXT_RECORD_CHAR_LIMIT } from 'calypso/lib/url/support';
 
 class TxtRecord extends Component {
@@ -30,11 +29,7 @@ class TxtRecord extends Component {
 				{
 					components: {
 						supportLink: (
-							<ExternalLink
-								href={ localizeUrl( DNS_TXT_RECORD_CHAR_LIMIT ) }
-								target="_blank"
-								icon={ false }
-							/>
+							<ExternalLink href={ DNS_TXT_RECORD_CHAR_LIMIT } target="_blank" icon={ false } />
 						),
 					},
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR update the validation error message when a user try to create a TXT record longer than 255 characters: it adds a link to support page to better explain TXT record's limitations.

![Markup on 2021-11-16 at 17:14:21](https://user-images.githubusercontent.com/2797601/142022929-3fbe001c-8517-46d0-b01b-3641d5cd08fc.png)

![Markup on 2021-11-16 at 17:13:14](https://user-images.githubusercontent.com/2797601/142022944-37cfed44-b9c4-4fab-b818-c81648c7eaa8.png)

#### Testing instructions

* Try add a new TXT DNS record longer than 255 characters for a domain managed by WordPress.com (Calypso url:  `/domains/manage/[YOU-DOMAIN]/add-dns-record/[YOU-DOMAIN]`)

Related to https://github.com/Automattic/wp-calypso/issues/56326
