### PR TITLE
Playwright: Skip domain test to prevent bad data inflation

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-domains__add.ts
+++ b/test/e2e/specs/specs-playwright/wp-domains__add.ts
@@ -16,7 +16,7 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
 	let page: Page;
 
 	setupHooks( ( args ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Domain Add test starting failing over a long weekend, which lead to a lot of test data inflation (because it failed before the cleanup).

This has led to the need to do some repair on the test user.

We should disable the test for the moment to prevent any future data inflation until things back under control.

#### Testing instructions

Related to #58122
