### PR TITLE
Filter the popular plugins list.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -552,12 +552,10 @@ export class PluginsBrowser extends Component {
  * @param {Array} featuredPlugins
  */
 function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
-	const displayedFeaturedSlugs = featuredPlugins
-		.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins
-		.map( ( plugin ) => plugin.slug );
-
 	const displayedFeaturedSlugsMap = new Map(
-		displayedFeaturedSlugs.map( ( slug ) => [ slug, slug ] )
+		featuredPlugins
+			.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins
+			.map( ( plugin ) => [ plugin.slug, plugin.slug ] )
 	);
 
 	return popularPlugins.filter( ( plugin ) => ! displayedFeaturedSlugsMap.has( plugin.slug ) );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -546,12 +546,12 @@ export class PluginsBrowser extends Component {
 /**
  * Filter the popular plugins list.
  * Remove the displayed featured plugins from the popular list to
- * avoid show them twice
+ * avoid showing them twice
  *
  * @param {Array} popularPlugins
  * @param {Array} featuredPlugins
  */
-function filterPopularList( popularPlugins = [], featuredPlugins = [] ) {
+function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 	const displayedFeaturedSlugs = featuredPlugins
 		.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins
 		.map( ( plugin ) => plugin.slug );
@@ -599,7 +599,7 @@ export default flow(
 				recommendedPlugins: recommendedPlugins || [],
 				pluginsByCategory: getPluginsListByCategory( state, category ),
 				pluginsByCategoryNew: getPluginsListByCategory( state, 'new' ),
-				pluginsByCategoryPopular: filterPopularList( popularPlugins, featuredPlugins ),
+				pluginsByCategoryPopular: filterPopularPlugins( popularPlugins, featuredPlugins ),
 				pluginsByCategoryFeatured: featuredPlugins,
 				pluginsBySearchTerm: getPluginsListBySearchTerm( state, search ),
 				pluginsPagination: getPluginsListPagination( state, search ),

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -543,6 +543,26 @@ export class PluginsBrowser extends Component {
 	}
 }
 
+/**
+ * Filter the popular plugins list.
+ * Remove the displayed featured plugins from the popular list to
+ * avoid show them twice
+ *
+ * @param {Array} popularPlugins
+ * @param {Array} featuredPlugins
+ */
+function filterPopularList( popularPlugins = [], featuredPlugins = [] ) {
+	const displayedFeaturedSlugs = featuredPlugins
+		.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins
+		.map( ( plugin ) => plugin.slug );
+
+	const displayedFeaturedSlugsMap = new Map(
+		displayedFeaturedSlugs.map( ( slug ) => [ slug, slug ] )
+	);
+
+	return popularPlugins.filter( ( plugin ) => ! displayedFeaturedSlugsMap.has( plugin.slug ) );
+}
+
 export default flow(
 	localize,
 	urlSearch,
@@ -556,6 +576,8 @@ export default flow(
 				( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
 			const hasPremiumPlan = sitePlan && ( hasBusinessPlan || isPremium( sitePlan ) );
 			const recommendedPlugins = getRecommendedPlugins( state, selectedSiteId );
+			const featuredPlugins = getPluginsListByCategory( state, 'featured' );
+			const popularPlugins = getPluginsListByCategory( state, 'popular' );
 
 			return {
 				selectedSiteId,
@@ -577,8 +599,8 @@ export default flow(
 				recommendedPlugins: recommendedPlugins || [],
 				pluginsByCategory: getPluginsListByCategory( state, category ),
 				pluginsByCategoryNew: getPluginsListByCategory( state, 'new' ),
-				pluginsByCategoryPopular: getPluginsListByCategory( state, 'popular' ),
-				pluginsByCategoryFeatured: getPluginsListByCategory( state, 'featured' ),
+				pluginsByCategoryPopular: filterPopularList( popularPlugins, featuredPlugins ),
+				pluginsByCategoryFeatured: featuredPlugins,
 				pluginsBySearchTerm: getPluginsListBySearchTerm( state, search ),
 				pluginsPagination: getPluginsListPagination( state, search ),
 				isFetchingPluginsByCategory: isFetchingPluginsList( state, category ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the displayed featured plugins from the popular plugins list to avoid showing them twice.

#### Testing instructions
1. On the live version
1. Go to `/plugins`
1. See as there are repeated plugins on the **Featured** list and **Popular** list

-

1. On this branch version
1. Go to `/plugins`
1. Check if there are no repeated plugins on the **Featured** list and **Popular** list


### Demo
The **Before** version has **Contact form 7**, **Yoast SEO** and **WooCommerce** which were already showed on Featured list. The **After** version removes all of those.

|Before | After|
|-------|------|
|![Screen Shot 2021-11-16 at 12 12 12](https://user-images.githubusercontent.com/5039531/142024297-ddc7fc24-5adf-49ce-b417-abcc7b8959c0.png)|![Screen Shot 2021-11-16 at 12 12 40](https://user-images.githubusercontent.com/5039531/142024337-f0709d1d-0b5f-425b-b30b-24e8c39953f7.png)|

---

Fixes #57752
