### PR TITLE
Videos UI: Add a hover state to the play buttons.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -164,6 +164,10 @@
 		}
 	}
 
+	.videos-ui__play-button:hover {
+		opacity: 80%;
+	}
+
 	@include break-small {
 		.videos-ui__play-button {
 			max-width: 300px;


### PR DESCRIPTION
Add a hover state to the play buttons.

![2021-11-16 09 27 43](https://user-images.githubusercontent.com/349751/142036008-d60944f7-3168-4cf4-879d-46bc04a96528.gif)

**Testing Instructions**
* Load this PR's `calypso.live` branch.
* On My Home, click "Start learning" in the first educational card.
* Hover over play buttons and verify they get slightly darker.

Fixes #58126.