### PR TITLE
Update flakey e2e reporting template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
@@ -1,6 +1,6 @@
 name: Flaky E2E Spec Report
-description: Noticed an erratic E2E spec? Report it!
-title: "Flaky E2E:"
+description: Report an intermittently failing E2E test.
+title: "Flaky E2E: "
 labels: "Flaky e2e"
 body:
   - type: markdown
@@ -12,24 +12,11 @@ body:
     attributes:
       label: Spec file
       placeholder: eg. wp-likes__post.js
-    validations:
-      required: true
   - type: input
-    id: suite
+    id: spec
     attributes:
-      label: Suite or step
-      placeholder: eg. Like new post
-  - type: dropdown
-    id: framework
-    attributes:
-      label: Framework
-      description: Which framework does the spec belong to?
-      options:
-        - Selenium
-        - Playwright
-      multiple: true
-    validations:
-      required: true
+      label: TeamCity ID
+      placeholder: eg. 648729
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
@@ -16,7 +16,7 @@ body:
     id: teamcity_id
     attributes:
       label: TeamCity ID
-      description: Six-digit ID present at end of URL like https://teamcity.a8c.com/.../<id>
+      description: Digits present at end of URL like https://teamcity.a8c.com/.../id
       placeholder: eg. 648729
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
@@ -13,7 +13,7 @@ body:
       label: Spec file
       placeholder: eg. wp-likes__post.js
   - type: input
-    id: spec
+    id: teamcity_id
     attributes:
       label: TeamCity ID
       placeholder: eg. 648729

--- a/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
@@ -16,6 +16,7 @@ body:
     id: teamcity_id
     attributes:
       label: TeamCity ID
+      description: Six-digit ID present at end of URL like https://teamcity.a8c.com/.../<id>
       placeholder: eg. 648729
   - type: textarea
     id: logs


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the reporting template for flakey e2e.

Key changes:
- remove framework dropdown.
- add optional TeamCity ID field.

#### Testing instructions

Check out the updated template [here](https://github.com/Automattic/wp-calypso/blob/update/flakey-e2e-report-template/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml).

