### PR TITLE
People: Update name value for Jetpack/Atomic sites to point to most up to date source

### DIFF
--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -125,6 +125,11 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 			name = translate( 'Loading Users', {
 				context: 'Placeholder text while fetching users.',
 			} );
+		}
+		//Jetpack/Atomic sites use linked_user_info to get the most up to date name
+		//See https://github.com/Automattic/wp-calypso/issues/55175
+		else if ( user.linked_user_info ) {
+			name = user.linked_user_info?.name;
 		} else if ( user.name ) {
 			name = user.name;
 		} else if ( user.label ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Jetpack/Atomic sites sync data to WP.com mirror sites, but after the initial sync, not all data gets sent.
* Jetpack Sync only checks for changes in the user ID and capabilities after the initial sync; if a site gets disconnected, the rest of the user data does not get updated on reconnection/resync.
* This means you can end up in a situation where the People page on a Jetpack/Atomic site displays an old, out of date display name for a user, if the user updated their display name on WP.com while their Jetpack/Atomic site was disconnected.
* ...but we can access the most up-to-date name value via the API in a `linked_user_info` object that comes directly from WP.com's user info rather than the site's, so pointing to that value on the front end for Jetpack/Atomic sites shows the correct name, even if the synced site data is incorrect. If there's a mismatch, the user doesn't need to know about it.
* This is not a fix for the syncing problem, but a stopgap for showing the most up-to-date user info on the front end. 

Fixes #55175

**Before**

Red lines indicate the old, incorrect display name, name we want to display indicated by a green arrow:

<img width="863" alt="Screen Shot 2021-11-16 at 2 33 32 PM" src="https://user-images.githubusercontent.com/2124984/142053408-a2ebd780-3a0c-4899-8765-d71b41caff1c.png">

**After**

Green lines indicate the correct display name is now shown:

<img width="835" alt="Screen Shot 2021-11-16 at 2 34 50 PM" src="https://user-images.githubusercontent.com/2124984/142053505-f577c31e-db34-450d-a924-90a794884332.png">

#### Testing instructions

* Spin up an Atomic test site
* Note your current Display Name under `/me` and visit your test site's people admin: `/people/team/[site]` -- you'll see your Display Name listed as a user
* Disconnect the Atomic test site from Jetpack via CLI: `wp jetpack disconnect blog`
* Update your Display Name under `/me` to something new
* Go back to `/people/team/[site]` and you'll see the old Display Name value
* Reconnect your site to Jetpack from `/wp-admin` -- the old Display Name value will persist at `/people/team/[site]`
* Switch to this PR and view `/people/team/[site]`; you'll see the correct, updated Display Name.