### PR TITLE
Playwright: GutenbergEditorPage to retry if iframed editor cannot be located.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -102,7 +102,9 @@ export class GutenbergEditorPage {
 	}
 
 	/**
-	 * Dismisses the Welcome Tour (card) if it is present.
+	 * Dismisses the Welcome Tour (card) if it is present, then return the editor frame.
+	 *
+	 * @returns {Promise<Frame>} iframe holding the editor.
 	 */
 	async dismissWelcomeTour(): Promise< Frame > {
 		const frame = await this.getEditorFrame();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR incorporates the retry mechanism which has proven to be successful for other flaky e2e issues such as https://github.com/Automattic/wp-calypso/issues/57844, https://github.com/Automattic/wp-calypso/pull/57969 and https://github.com/Automattic/wp-calypso/pull/57802.

Key changes:
- define a new closure in `waitUntilLoaded`, based on the `GutenbergEditorPage.getEditorFrame` method but adjusted to accept an instance of a `Page` object.
- within the closure, use the Locator API, which encapsulates the logic for retrieving the element at any time.

#### Testing instructions

The source issue #57460 is difficult to intentionally reproduce. It would be best to have this change run in production E2E tests over the next few days in order to monitor whether this change fixed the issue.

Fixes #57460.