### PR TITLE
Videos UI: Correct checkmark list alignment.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -205,12 +205,16 @@
 	@include break-xlarge {
 		.videos-ui__header {
 			.videos-ui__header-content {
-                .videos-ui__titles {
-                    h2 {
-                        font-size: $font-headline-medium;
-                        height: 60px;
-                    }
-                }
+				.videos-ui__titles {
+					h2 {
+						font-size: $font-headline-medium;
+						height: 60px;
+					}
+				}
+
+				.videos-ui__summary {
+					width: 31%;
+				}
 			}
 		}
 

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -131,8 +131,7 @@
 				.videos-ui__active-video-content {
 					overflow: hidden;
 					max-height: 0;
-					transition:
-						max-height 0.2s ease-out;
+					transition: max-height 0.2s ease-out;
 
 					div {
 						padding: 20px;


### PR DESCRIPTION
At some point, the checkmark list became right-aligned to its container. This PR corrects its container width, fixing the alignment with the videos section below.

| Current | PR |
| --- | --- |
| <img width="1428" alt="Screen Shot 2021-11-16 at 1 24 15 PM" src="https://user-images.githubusercontent.com/349751/142068092-7a09604c-5141-452a-abd4-bfaf56335ed8.png"> | <img width="1429" alt="Screen Shot 2021-11-16 at 1 20 30 PM" src="https://user-images.githubusercontent.com/349751/142068112-062a88dd-9833-4b64-8cd4-b9ad58070476.png"> |

Fixes #58143.

 