### PR TITLE
Videos UI - Updating component to have customizable finish link

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -7,7 +7,11 @@ import VideoLinksBar from './video-links-bar';
 import VideoPlayer from './video-player';
 import './style.scss';
 
-const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) => {
+const VideosUi = ( {
+	shouldDisplayTopLinks = false,
+	onBackClick = () => {},
+	finishLink = null,
+} ) => {
 	const translate = useTranslate();
 	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );
 	const [ selectedVideoIndex, setSelectedVideoIndex ] = useState( null );
@@ -67,11 +71,6 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 		}
 	};
 
-	const skipClickHandler = () =>
-		recordTracksEvent( 'calypso_courses_skip_to_draft', {
-			course: course.slug,
-		} );
-
 	useEffect( () => {
 		if ( course ) {
 			recordTracksEvent( 'calypso_courses_view', {
@@ -86,10 +85,9 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 				<VideoLinksBar
 					displayIcon={ true }
 					displayLinks={ shouldDisplayTopLinks }
-					displaySkipLink={ false }
 					isFooter={ false }
 					onBackClick={ onBackClick }
-					skipClickHandler={ skipClickHandler }
+					finishLink={ finishLink }
 				/>
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
@@ -197,10 +195,9 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 			<VideoLinksBar
 				displayIcon={ false }
 				displayLinks={ shouldDisplayTopLinks }
-				displaySkipLink={ false }
 				isFooter={ true }
 				onBackClick={ onBackClick }
-				skipClickHandler={ skipClickHandler }
+				finishLink={ finishLink }
 			/>
 		</div>
 	);

--- a/client/components/videos-ui/style-video-links-bar.scss
+++ b/client/components/videos-ui/style-video-links-bar.scss
@@ -36,8 +36,9 @@
         justify-content: space-between;
         width: 100%;
 
-        .videos-ui__bar-skip-link {
+        .videos-ui__bar-finish-link {
             text-decoration: underline;
+			cursor: pointer;
         }
     }
 	@include break-small {

--- a/client/components/videos-ui/video-links-bar.jsx
+++ b/client/components/videos-ui/video-links-bar.jsx
@@ -1,21 +1,17 @@
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 
 import './style-video-links-bar.scss';
 
 const VideoLinksBar = ( {
 	displayIcon,
 	displayLinks,
-	displaySkipLink,
+	finishLink = null,
 	isFooter = false,
 	onBackClick = () => {},
-	skipClickHandler = () => {},
 } ) => {
 	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const classes = classNames( 'videos-ui__bar', isFooter ? 'mobile' : 'desktop' );
 
 	return (
@@ -39,13 +35,7 @@ const VideoLinksBar = ( {
 							<span>{ translate( 'Back' ) }</span>
 						</a>
 					</div>
-					{ displaySkipLink && (
-						<div className="videos-ui__bar-skip-link">
-							<a href={ `/post/${ siteSlug }` } onClick={ skipClickHandler }>
-								{ translate( 'Draft your first post' ) }
-							</a>
-						</div>
-					) }
+					<div className="videos-ui__bar-finish-link">{ finishLink }</div>
 				</div>
 			) }
 		</div>

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import VideosUi from 'calypso/components/videos-ui';
 
@@ -6,11 +7,21 @@ import './style.scss';
 const BloggingQuickStartModal = ( props ) => {
 	const { isVisible = false, onClose = () => {} } = props;
 
+	const finishLink = (
+		<span role="button" onKeyDown={ onClose } onClick={ onClose } tabIndex={ 0 }>
+			<Gridicon icon="cross" size={ 18 } />
+		</span>
+	);
+
 	return (
 		isVisible && (
 			<BlankCanvas className={ 'blogging-quick-start-modal' }>
 				<BlankCanvas.Content>
-					<VideosUi shouldDisplayTopLinks={ true } onBackClick={ onClose } />
+					<VideosUi
+						shouldDisplayTopLinks={ true }
+						onBackClick={ onClose }
+						finishLink={ finishLink }
+					/>
 				</BlankCanvas.Content>
 			</BlankCanvas>
 		)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the behavior of the Videos UI so that the right-hand link (previously "Draft your first post") is replaced by an X icon to close the modal. It also refactors the component code so that this link is customizable based on where the base `VideosUi` component is being loaded.

(I went around in circles on this one a little and I'm a little concerned I may have overengineered it, but my intention is that we should be able to provide custom JSX/behavior for this link when instantiating `VideosUi`, potentially in multiple places.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR locally.
* Verify that at both mobile and desktop sizes, the Videos UI modal now displays an X icon which closes the modal, in place of the previous "Draft your first post" link text.

![image](https://user-images.githubusercontent.com/13437011/142072945-b53d24d6-a5e5-4747-97d4-6d8ba5cddb34.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58079
