### PR TITLE
Design Picker: Fix designs rearranging ~1 second after landing on design picker step

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -47,10 +47,12 @@ export default function DesignPickerStep( props ) {
 		getRecommendedThemes( state, 'auto-loading-homepage' )
 	);
 
+	const themesToBeTransformed = props.useDIFMThemes ? DIFMThemes : apiThemes;
+
 	useEffect(
 		() => {
 			dispatch( saveSignupStep( { stepName: props.stepName } ) );
-			if ( ! apiThemes.length ) {
+			if ( ! themesToBeTransformed.length ) {
 				dispatch( fetchRecommendedThemes( 'auto-loading-homepage' ) );
 			}
 		},
@@ -77,8 +79,6 @@ export default function DesignPickerStep( props ) {
 	}, [ props.stepSectionName ] );
 
 	const userLoggedIn = useSelector( isUserLoggedIn );
-
-	const themesToBeTransformed = props.useDIFMThemes ? DIFMThemes : apiThemes;
 
 	const designs = useMemo( () => {
 		// TODO fetching and filtering code should be pulled to a shared place that's usable by both

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -43,10 +43,16 @@ export default function DesignPickerStep( props ) {
 	const [ selectedDesign, setSelectedDesign ] = useState( null );
 	const scrollTop = useRef( 0 );
 
+	const apiThemes = useSelector( ( state ) =>
+		getRecommendedThemes( state, 'auto-loading-homepage' )
+	);
+
 	useEffect(
 		() => {
 			dispatch( saveSignupStep( { stepName: props.stepName } ) );
-			dispatch( fetchRecommendedThemes( 'auto-loading-homepage' ) );
+			if ( ! apiThemes.length ) {
+				dispatch( fetchRecommendedThemes( 'auto-loading-homepage' ) );
+			}
 		},
 		// Ignoring dependencies because we only want these actions to run on first mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -71,10 +77,6 @@ export default function DesignPickerStep( props ) {
 	}, [ props.stepSectionName ] );
 
 	const userLoggedIn = useSelector( isUserLoggedIn );
-
-	const apiThemes = useSelector( ( state ) =>
-		getRecommendedThemes( state, 'auto-loading-homepage' )
-	);
 
 	const themesToBeTransformed = props.useDIFMThemes ? DIFMThemes : apiThemes;
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Don't request themes via API if the theme data is already in the redux store
* Don't request themes via API in the DIFM flow

This fixes an issue where the themes rearranged themselves shortly after landing on the design picker. This is because the step requested fresh theme data every time it's rendered, and when that data was received from the server it invalidated our memoised shuffled designs.

I can't see any need for the user to get the absolute latest theme data without requiring a page refresh.

The sudden rearranging themes looks like this:

https://user-images.githubusercontent.com/1500769/142146497-9674cc95-949a-4055-b15e-1e257d34a9b1.mov



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the hero flow and proceed to a design picker step
* Go backwards in the flow
* Go back to the design picker, after waiting a second you shouldn't see the themes suddenly rearrange
* Check that the `/themes` API is called again after refreshing the page (want to ensure sure the Redux store isn't persisting the data locally somewhere)
* Test `/start/do-it-for-me` flow and confirm that the design picker works and doesn't ever make a request

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
