### PR TITLE
Design Picker: Enable design picker categories in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -113,6 +113,7 @@
 		"signup/social": true,
 		"signup/setup-site-after-checkout": true,
 		"signup/hero-flow": true,
+		"signup/design-picker-categories": true,
 		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're about ready to ship design picker categories, so enable in `wpcalypso` to make it easier to test.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
