### PR TITLE
Add tag :latest to the latest image

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -107,6 +107,7 @@ object BuildDockerImage : BuildType({
 				namesAndTags = """
 					registry.a8c.com/calypso/app:build-%build.number%
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
+					registry.a8c.com/calypso/app:latest
 				""".trimIndent()
 			}
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -87,6 +87,7 @@ object BuildDockerImage : BuildType({
 				namesAndTags = """
 					registry.a8c.com/calypso/app:build-%build.number%
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
+					registry.a8c.com/calypso/app:latest
 				""".trimIndent()
 				commandArgs = """
 					--pull


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add tag `:latest` to the Docker image

This will allow us to reference the latest image from other projects (eg: wpcom-in-a-box)
