### PR TITLE
DotPager: Replace useResizeObserver by native resize event

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -1,9 +1,8 @@
-import { useResizeObserver } from '@wordpress/compose';
 import { Icon, arrowRight } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import { times } from 'lodash';
-import { Children, useState, useEffect, useRef } from 'react';
+import { Children, useState, useEffect, useRef, useCallback } from 'react';
 
 import './style.scss';
 
@@ -86,18 +85,27 @@ export const DotPager = ( {
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 	const [ pagesStyle, setPagesStyle ] = useState();
 	const pagesRef = useRef();
-	const [ resizeObserver, sizes ] = useResizeObserver();
 	const numPages = Children.count( children );
-
-	useEffect( () => {
+	const updateLayout = useCallback( () => {
 		if ( ! hasDynamicHeight ) {
 			return;
 		}
 
-		const targetHeight = pagesRef.current?.children[ currentPage ]?.offsetHeight;
-
+		const targetHeight = pagesRef.current?.querySelector( '.is-current' )?.offsetHeight;
 		setPagesStyle( targetHeight ? { height: targetHeight } : undefined );
-	}, [ hasDynamicHeight, currentPage, sizes.width, setPagesStyle, children ] );
+	}, [ hasDynamicHeight, setPagesStyle ] );
+
+	useEffect( () => {
+		updateLayout();
+	}, [ currentPage, updateLayout ] );
+
+	useEffect( () => {
+		window.addEventListener( 'resize', updateLayout );
+
+		return () => {
+			window.removeEventListener( 'resize', updateLayout );
+		};
+	}, [ updateLayout ] );
 
 	useEffect( () => {
 		if ( currentPage >= numPages ) {
@@ -107,7 +115,6 @@ export const DotPager = ( {
 
 	return (
 		<div className={ className } { ...props }>
-			{ resizeObserver }
 			<Controls
 				showControlLabels={ showControlLabels }
 				currentPage={ currentPage }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As we found there are lots of `resize` calls with `useResizeObserver` when switching between pages, replacing `useResizeObserver` with native resize event to improve the performance.

![image](https://user-images.githubusercontent.com/13596067/142180646-bf6937b2-0f22-429c-a823-7578f557699b.png)
All of these tasks are triggered by `resize` event when using `useResizeObserver` for  a single slide change

**React commits from [React Profiler](https://reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html) for a single slide change:**

**Before**

![image](https://user-images.githubusercontent.com/13596067/142180221-8b3f1960-3bf7-4014-88d1-c6837b580191.png)

**After**

![image](https://user-images.githubusercontent.com/13596067/142180020-9c9f297f-7ca5-4696-8d56-633751be4feb.png)

Note that the reason for commits are as followed:
* AppBanner (0.6ms)
* DotPager > Controls as `currentPage` and `setCurrentPage` changed (0.1ms)
* DotPager > Controls as `setCurrentPage` changed (0.8ms)
* AppBanner (0.1ms)

We can also add `useCallback` for `setCurrentPage` if needed but it seems to be okay for now.

**Compared with https://github.com/Automattic/wp-calypso/pull/58100**

![image](https://user-images.githubusercontent.com/13596067/142178622-a1e50f7b-6ce1-4662-b1bd-c3df19028c55.png)

**Flame Chart under CPU with 6x slowdown**

**Before**

![image](https://user-images.githubusercontent.com/13596067/142172908-1cfe8858-8f5a-4cee-9ee7-e663ecca7a13.png)

**After**

![image](https://user-images.githubusercontent.com/13596067/142176735-6d0bb449-7337-481b-981d-1ac30154003f.png)

**Compared with https://github.com/Automattic/wp-calypso/pull/58100**

![image](https://user-images.githubusercontent.com/13596067/142177434-34f6394d-6a6a-4ecc-8923-d8900fe5ddca.png)

**Videos under the CPU with 6x slowdown**

**Before**

https://user-images.githubusercontent.com/13596067/142181131-2d49c440-f2c0-4233-982c-a062c8f2e9d1.mov

**After**

https://user-images.githubusercontent.com/13596067/142181157-195d24d8-551c-4d2a-ab59-78aea4ecc39b.mov

**Compared with https://github.com/Automattic/wp-calypso/pull/58100**

https://user-images.githubusercontent.com/13596067/142181185-845a44ce-cb51-4abf-936c-bd8fa4677f1f.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/home/:site` where `:site` is one of your sites on a Business plan.
* Switch between pages and verify it still resizes well

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/58100
