### PR TITLE
Fix crash when removing Google sub from purchases

### DIFF
--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -83,7 +83,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 		}
 	};
 
-	saveSurveyResults = async () => {
+	saveSurveyResults = () => {
 		const { purchase } = this.props;
 		const { surveyAnswerId, surveyAnswerText } = this.state;
 		const surveyData = {
@@ -94,14 +94,11 @@ class GSuiteCancelPurchaseDialog extends Component {
 			type: 'remove',
 		};
 
-		const response = await this.props.submitSurvey(
+		this.props.submitSurvey(
 			'calypso-gsuite-remove-purchase',
 			purchase.siteId,
 			enrichedSurveyData( surveyData, purchase )
 		);
-		if ( ! response.success ) {
-			this.props.errorNotice( response.err );
-		}
 	};
 
 	removePurchase = async () => {


### PR DESCRIPTION
Fixes #58167. The #57141 refactor replaced a direct `wpcom.marketing().survey` call with a `submitSurvey` Redux action, but the difference is that the Redux action doesn't return the `response` -- only a `Promise<void>`.

Fixed by noticing that the `submitSurvey` Redux action already shows an error notice when the request fails. The `saveSurveyResults` doesn't need to do it again. And because that was the only reason why we awaited the `response`, the entire `await` can be removed.