### PR TITLE
User: remove isRTL computed attribute

### DIFF
--- a/client/lib/user/shared-utils/get-computed-attributes.js
+++ b/client/lib/user/shared-utils/get-computed-attributes.js
@@ -1,4 +1,3 @@
-import { getLanguage } from 'calypso/lib/i18n-utils/utils';
 import { withoutHttp } from 'calypso/lib/url';
 
 function getSiteSlug( url ) {
@@ -7,12 +6,10 @@ function getSiteSlug( url ) {
 }
 
 export function getComputedAttributes( attributes ) {
-	const language = getLanguage( attributes.language );
 	const primaryBlogUrl = attributes.primary_blog_url || '';
 	return {
 		primarySiteSlug: getSiteSlug( primaryBlogUrl ),
 		localeSlug: attributes.language,
 		localeVariant: attributes.locale_variant,
-		isRTL: !! ( language && language.rtl ),
 	};
 }

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -21,7 +21,6 @@ export type OptionalUserData = {
 	email_verified: boolean;
 	has_unseen_notes: boolean;
 	is_new_reader: boolean;
-	isRTL: boolean;
 	is_valid_google_apps_country: boolean;
 	localeSlug: string;
 	localeVariant: string;


### PR DESCRIPTION
We're adding a `user.isRTL` computed attribute to the `user` object, but trying to find its usages, I didn't find any. So I'm removing that attribute here, and removing the `i18n-utils` dependency (and the `@automattic/languages` transitive one) from a module that's used absolutely everywhere.

Found this opportunity when investigating why the Inline Help widget app (#55189) bundles `@automattic/languages`.

**How to test:**
@tyxla Can you verify that the `isRTL` attribute is really not used?