### PR TITLE
Woop: Change landing page according to site plan

### DIFF
--- a/client/my-sites/woocommerce/controller.js
+++ b/client/my-sites/woocommerce/controller.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from 'page';
 import { createElement } from 'react';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -15,7 +16,7 @@ export function checkPrerequisites( context, next ) {
 	const siteId = site ? site.ID : null;
 
 	// Only allow AT sites to access.
-	if ( ! isAtomicSite( state, siteId ) ) {
+	if ( ! config.isEnabled( 'woop' ) && ! isAtomicSite( state, siteId ) ) {
 		return page.redirect( `/home/${ site.slug }` );
 	}
 

--- a/client/my-sites/woocommerce/controller.js
+++ b/client/my-sites/woocommerce/controller.js
@@ -15,7 +15,7 @@ export function checkPrerequisites( context, next ) {
 	const site = getSelectedSiteWithFallback( state );
 	const siteId = site ? site.ID : null;
 
-	// Only allow AT sites to access.
+	// Only allow AT sites to access, unless the woop feature flag is enabled.
 	if ( ! config.isEnabled( 'woop' ) && ! isAtomicSite( state, siteId ) ) {
 		return page.redirect( `/home/${ site.slug }` );
 	}

--- a/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
+++ b/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
@@ -574,14 +574,26 @@ class RequiredPluginsInstallView extends Component {
 	}
 
 	render() {
-		const { hasPendingAT, fixMode, translate } = this.props;
+		const {
+			hasPendingAT,
+			fixMode,
+			translate,
+			isFeatureActive,
+			upgradingPlan,
+			siteSlug,
+		} = this.props;
 		const { engineState, progress, totalSeconds } = this.state;
 
 		if ( ! hasPendingAT && 'CONFIRMING' === engineState ) {
 			return (
 				<>
 					<SetupNotices />
-					<WoopLandingPage startSetup={ this.startSetup } />
+					<WoopLandingPage
+						startSetup={ this.startSetup }
+						isFeatureActive={ isFeatureActive }
+						upgradingPlan={ upgradingPlan }
+						siteSlug={ siteSlug }
+					/>
 				</>
 			);
 		}

--- a/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
+++ b/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
@@ -77,6 +77,8 @@ class RequiredPluginsInstallView extends Component {
 			ID: PropTypes.number.isRequired,
 		} ),
 		skipConfirmation: PropTypes.bool,
+		isFeatureActive: PropTypes.bool,
+		upgradingPlan: PropTypes.object,
 	};
 
 	constructor( props ) {

--- a/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
+++ b/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
@@ -76,6 +76,7 @@ class RequiredPluginsInstallView extends Component {
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
 		} ),
+		skipSlug: PropTypes.string,
 		skipConfirmation: PropTypes.bool,
 		isFeatureActive: PropTypes.bool,
 		upgradingPlan: PropTypes.object,

--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -8,11 +8,14 @@ import { isLoaded as arePluginsLoaded } from 'calypso/state/plugins/installed/se
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import RequiredPluginsInstallView from './dashboard/required-plugins-install-view';
 
 function WooCommerce() {
 	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+
 	const areInstalledPluginsLoadedIntoState = useSelector( ( state ) =>
 		arePluginsLoaded( state, siteId )
 	);
@@ -40,6 +43,7 @@ function WooCommerce() {
 				{ areInstalledPluginsLoadedIntoState && (
 					<RequiredPluginsInstallView
 						siteId={ siteId }
+						siteSlug={ siteSlug }
 						isFeatureActive={ isWoopFeatureActive }
 						upgradingPlan={ upgradingPlan }
 					/>

--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -29,6 +29,10 @@ function WooCommerce() {
 		hasAvailableSiteFeature( state, siteId, FEATURE_WOOP )
 	);
 
+	/*
+	 * We pick the first plan from the available plans list.
+	 * The priority is defined by the store products list.
+	 */
 	const upgradingPlan =
 		useSelector( ( state ) => getProductBySlug( state, hasWoopFeatureAvailable?.[ 0 ] ) ) || {};
 

--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -3,6 +3,7 @@ import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import Main from 'calypso/components/main';
 import { isLoaded as arePluginsLoaded } from 'calypso/state/plugins/installed/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
@@ -39,6 +40,7 @@ function WooCommerce() {
 		<div className="woocommerce">
 			<Main class="main" wideLayout>
 				<DocumentHead title={ translate( 'WooCommerce' ) } />
+				<QuerySiteFeatures siteId={ siteId } />
 				<QueryJetpackPlugins siteIds={ [ siteId ] } />
 				{ areInstalledPluginsLoadedIntoState && (
 					<RequiredPluginsInstallView

--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -1,9 +1,13 @@
+import { FEATURE_WOOP } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Main from 'calypso/components/main';
 import { isLoaded as arePluginsLoaded } from 'calypso/state/plugins/installed/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
+import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import RequiredPluginsInstallView from './dashboard/required-plugins-install-view';
 
@@ -12,6 +16,17 @@ function WooCommerce() {
 	const areInstalledPluginsLoadedIntoState = useSelector( ( state ) =>
 		arePluginsLoaded( state, siteId )
 	);
+
+	const isWoopFeatureActive = useSelector( ( state ) =>
+		hasActiveSiteFeature( state, siteId, FEATURE_WOOP )
+	);
+
+	const hasWoopFeatureAvailable = useSelector( ( state ) =>
+		hasAvailableSiteFeature( state, siteId, FEATURE_WOOP )
+	);
+
+	const upgradingPlan =
+		useSelector( ( state ) => getProductBySlug( state, hasWoopFeatureAvailable?.[ 0 ] ) ) || {};
 
 	if ( ! siteId ) {
 		return null;
@@ -22,7 +37,13 @@ function WooCommerce() {
 			<Main class="main" wideLayout>
 				<DocumentHead title={ translate( 'WooCommerce' ) } />
 				<QueryJetpackPlugins siteIds={ [ siteId ] } />
-				{ areInstalledPluginsLoadedIntoState && <RequiredPluginsInstallView /> }
+				{ areInstalledPluginsLoadedIntoState && (
+					<RequiredPluginsInstallView
+						siteId={ siteId }
+						isFeatureActive={ isWoopFeatureActive }
+						upgradingPlan={ upgradingPlan }
+					/>
+				) }
 			</Main>
 		</div>
 	);

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -32,7 +32,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( {
 	function onCTAHandler() {
 		if ( ! isFeatureActive && upgradingPlan?.product_slug ) {
 			return ( window.location.href = addQueryArgs(
-				{ redirectTo: window.location.href },
+				{ redirect_to: window.location.href },
 				`/checkout/${ siteSlug }/${ upgradingPlan.product_slug }`
 			) );
 		}

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -48,6 +48,14 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( {
 		upgradingPlan.product_name
 	);
 
+	const headlineText = isFeatureActive
+		? __( 'Build exactly the eCommerce website you want.' )
+		: sprintf(
+				/* translators: %s: The upgrading plan name (ex.: WordPress.com Business) */
+				__( 'Upgrade to the %s plan and set up your WooCommerce store.' ),
+				upgradingPlan.product_name
+		  );
+
 	return (
 		<div className="woop__landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
@@ -57,11 +65,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( {
 			</FixedNavigationHeader>
 			<CtaSection
 				title={ __( 'Have something to sell?' ) }
-				headline={
-					isFeatureActive
-						? __( 'Build exactly the eCommerce website you want.' )
-						: __( 'Upgrade to the Premium plan and set up your WooCommerce store.' )
-				}
+				headline={ headlineText }
 				buttonText={ isFeatureActive ? __( 'Set up my store!' ) : upgradeButtonText }
 				buttonAction={ onCTAHandler }
 				ctaRef={ ctaRef }

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { useRef } from '@wordpress/element';
-import { translate } from 'i18n-calypso';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import './style.scss';
 import Image01 from 'calypso/assets/images/woocommerce/woop-cta-image01.jpeg';
 import Image02 from 'calypso/assets/images/woocommerce/woop-cta-image02.jpeg';
@@ -26,6 +27,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( {
 	isFeatureActive,
 	upgradingPlan,
 } ) => {
+	const { __ } = useI18n();
 	const navigationItems = [ { label: 'WooCommerce', href: `/woocommerce-installation` } ];
 	const ctaRef = useRef( null );
 
@@ -40,25 +42,27 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( {
 		startSetup();
 	}
 
+	const upgradeButtonText = sprintf(
+		/* translators: %s: The upgrading plan name (ex.: WordPress.com Business) */
+		__( 'Upgrade to %s' ),
+		upgradingPlan.product_name
+	);
+
 	return (
 		<div className="woop__landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
 				<Button onClick={ onCTAHandler } primary>
-					{ isFeatureActive
-						? translate( 'Set up my store!' )
-						: translate( 'Upgrade to Premium plan' ) }
+					{ isFeatureActive ? __( 'Set up my store!' ) : upgradeButtonText }
 				</Button>
 			</FixedNavigationHeader>
 			<CtaSection
-				title={ translate( 'Have something to sell?' ) }
+				title={ __( 'Have something to sell?' ) }
 				headline={
 					isFeatureActive
-						? translate( 'Build exactly the eCommerce website you want.' )
-						: translate( 'Upgrade to the Premium plan and set up your WooCommerce store.' )
+						? __( 'Build exactly the eCommerce website you want.' )
+						: __( 'Upgrade to the Premium plan and set up your WooCommerce store.' )
 				}
-				buttonText={
-					isFeatureActive ? translate( 'Set up my store!' ) : translate( 'Upgrade to Premium plan' )
-				}
+				buttonText={ isFeatureActive ? __( 'Set up my store!' ) : upgradeButtonText }
 				buttonAction={ onCTAHandler }
 				ctaRef={ ctaRef }
 			>

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -9,29 +9,57 @@ import Image04 from 'calypso/assets/images/woocommerce/woop-cta-image04.jpeg';
 import CtaSection from 'calypso/components/cta-section';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import MasonryWave from 'calypso/components/masonry-wave';
+import { addQueryArgs } from 'calypso/lib/url';
 
 interface Props {
 	startSetup: () => void;
+	isFeatureActive: boolean;
+	upgradingPlan: Record< string, unknown >;
+	siteSlug: string;
 }
 
 const images = [ { src: Image01 }, { src: Image02 }, { src: Image03 }, { src: Image04 } ];
 
-const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup } ) => {
+const WoopLandingPage: React.FunctionComponent< Props > = ( {
+	startSetup,
+	siteSlug,
+	isFeatureActive,
+	upgradingPlan,
+} ) => {
 	const navigationItems = [ { label: 'WooCommerce', href: `/woocommerce-installation` } ];
 	const ctaRef = useRef( null );
+
+	function onCTAHandler() {
+		if ( ! isFeatureActive && upgradingPlan?.product_slug ) {
+			return ( window.location.href = addQueryArgs(
+				{ redirectTo: window.location.href },
+				`/checkout/${ siteSlug }/${ upgradingPlan.product_slug }`
+			) );
+		}
+
+		startSetup();
+	}
 
 	return (
 		<div className="woop__landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
-				<Button onClick={ startSetup } primary>
-					{ translate( 'Set up my store!' ) }
+				<Button onClick={ onCTAHandler } primary>
+					{ isFeatureActive
+						? translate( 'Set up my store!' )
+						: translate( 'Upgrade to Premium plan' ) }
 				</Button>
 			</FixedNavigationHeader>
 			<CtaSection
 				title={ translate( 'Have something to sell?' ) }
-				headline={ translate( 'Build exactly the eCommerce website you want.' ) }
-				buttonText={ translate( 'Set up my store!' ) }
-				buttonAction={ startSetup }
+				headline={
+					isFeatureActive
+						? translate( 'Build exactly the eCommerce website you want.' )
+						: translate( 'Upgrade to the Premium plan and set up your WooCommerce store.' )
+				}
+				buttonText={
+					isFeatureActive ? translate( 'Set up my store!' ) : translate( 'Upgrade to Premium plan' )
+				}
+				buttonAction={ onCTAHandler }
 				ctaRef={ ctaRef }
 			>
 				<MasonryWave images={ images } />

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -42,19 +42,27 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( {
 		startSetup();
 	}
 
-	const upgradeButtonText = sprintf(
-		/* translators: %s: The upgrading plan name (ex.: WordPress.com Business) */
-		__( 'Upgrade to %s' ),
-		upgradingPlan.product_name
-	);
-
-	const headlineText = isFeatureActive
-		? __( 'Build exactly the eCommerce website you want.' )
-		: sprintf(
+	const upgradeButtonText = upgradingPlan.product_name
+		? sprintf(
 				/* translators: %s: The upgrading plan name (ex.: WordPress.com Business) */
-				__( 'Upgrade to the %s plan and set up your WooCommerce store.' ),
+				__( 'Upgrade to %s' ),
 				upgradingPlan.product_name
-		  );
+		  )
+		: __( 'Upgrade' );
+
+	let headlineText;
+
+	if ( isFeatureActive ) {
+		headlineText = __( 'Build exactly the eCommerce website you want.' );
+	} else {
+		headlineText = upgradingPlan.product_name
+			? sprintf(
+					/* translators: %s: The upgrading plan name (ex.: WordPress.com Business) */
+					__( 'Upgrade to the %s plan and set up your WooCommerce store.' ),
+					upgradingPlan.product_name
+			  )
+			: __( 'Upgrade to set up your WooCommerce store.' );
+	}
 
 	return (
 		<div className="woop__landing-page">

--- a/config/development.json
+++ b/config/development.json
@@ -134,6 +134,7 @@
 		"reader/gutenberg-for-comments": false,
 		"reader/list-management": true,
 		"recommend-plugins": true,
+		"redirect-fallback-browsers": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
@@ -162,8 +163,7 @@
 		"upsell/concierge-session": true,
 		"woocommerce/extension-referrers": true,
 		"woop": true,
-		"wpcom-user-bootstrap": false,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -89,6 +89,7 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,
+		"redirect-fallback-browsers": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
@@ -115,9 +116,9 @@
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
 		"woocommerce/extension-referrers": false,
-		"wpcom-user-bootstrap": true,
+		"woop": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -87,6 +87,7 @@ export const PREMIUM_DESIGN_FOR_STORES = 'premium-design-for-stores';
 export const FEATURE_SFTP_DATABASE = 'sftp-and-database-access';
 export const FEATURE_SITE_BACKUPS_AND_RESTORE = 'site-backups-and-restore';
 export const FEATURE_SECURITY_SETTINGS = 'security-settings';
+export const FEATURE_WOOP = 'woop';
 
 // Jetpack features constants
 export const FEATURE_BLANK = 'blank-feature';


### PR DESCRIPTION
#### Changes proposed in this Pull Request
### Branched off from https://github.com/Automattic/wp-calypso/issues/57419

This PR changes some content and behavior of the landing page depending on the site plan. When the plan supports the `woop` feature, the landing page allows starting the store installing process. Otherwise, it shows upgrading options.

#### Testing instructions

* Checkout this branch and click on the "WooCommerce" nav menu item on an Atomic site that doesn't have Woo installed.
* Verify that the new landing page displays.
* Verify that the landing page shows upgrade context when the site doesn't have the proper plan, for instance, a Free plan.
![image](https://user-images.githubusercontent.com/77539/142210345-6400ba27-d981-4342-b5e1-5b9c7d0db97f.png)
* Verify you can upgrade the plan by clicking on the UPgrade button.
* Verify once the checking process ends, it redirects to the woop landing page
* Check that clicking "Set up my store!" still works to install Woo.


https://user-images.githubusercontent.com/77539/142210595-685461c3-e74c-4099-897f-34f6cf4f35cf.mov

* Verify the landing page updates when you downgrade the plan


https://user-images.githubusercontent.com/77539/142210649-e45c6318-2e45-4c0d-bd59-9df8728408ee.mov



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
