### PR TITLE
Fix plugin installed status on simple sites.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -45,6 +45,8 @@ const MarketplaceThankYou = ( { productSlug } ): JSX.Element => {
 			setRetries( retries + 1 );
 			waitFor( 1 ).then( () => dispatch( fetchSitePlugins( siteId ) ) );
 		}
+		// Do not add retries in dependencies to avoid infinite loop.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isRequestingPlugins, plugin, dispatch, siteId ] );
 
 	const thankYouImage = {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -2,16 +2,18 @@ import { ThemeProvider } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useSelector } from 'react-redux';
+import { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import successImage from 'calypso/assets/images/marketplace/success.png';
-import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import { ThankYou } from 'calypso/components/thank-you';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import theme from 'calypso/my-sites/marketplace/theme';
-import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
+import { waitFor } from 'calypso/my-sites/marketplace/util';
+import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
+import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -29,11 +31,21 @@ const WordPressWordmarkStyled = styled( WordPressWordmark )`
 `;
 
 const MarketplaceThankYou = ( { productSlug } ): JSX.Element => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 	const plugin = useSelector( ( state ) => getPluginOnSite( state, siteId, productSlug ) );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const [ retries, setRetries ] = useState( 0 );
+
+	useEffect( () => {
+		if ( ! isRequestingPlugins && ! plugin && retries < 10 ) {
+			setRetries( retries + 1 );
+			waitFor( 1 ).then( () => dispatch( fetchSitePlugins( siteId ) ) );
+		}
+	}, [ isRequestingPlugins, plugin, dispatch, siteId ] );
 
 	const thankYouImage = {
 		alt: '',
@@ -55,7 +67,7 @@ const MarketplaceThankYou = ( { productSlug } ): JSX.Element => {
 					'Get to know your plugin and customize it, so you can hit the ground running.'
 				),
 				stepCta: (
-					<FullWidthButton href={ setupURL } primary busy={ ! plugin }>
+					<FullWidthButton href={ setupURL } primary busy={ ! plugin && retries < 10 }>
 						{ translate( 'Manage plugin' ) }
 					</FullWidthButton>
 				),
@@ -81,7 +93,6 @@ const MarketplaceThankYou = ( { productSlug } ): JSX.Element => {
 
 	return (
 		<ThemeProvider theme={ theme }>
-			{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 			<Masterbar>
 				<Item
 					icon="cross"

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,7 +1,6 @@
 import { ThemeProvider } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import successImage from 'calypso/assets/images/marketplace/success.png';
@@ -81,7 +80,12 @@ const MarketplaceThankYou = ( { productSlug } ): JSX.Element => {
 					'Take your site to the next level. We have all the solutions to help you grow and thrive.'
 				),
 				stepCta: (
-					<FullWidthButton href={ `/plugins/${ siteSlug }` }>
+					<FullWidthButton
+						onClick={ () =>
+							// Force reload the page.
+							( document.location.href = `${ document.location.origin }/plugins/${ siteSlug }` )
+						}
+					>
 						{ translate( 'Explore plugins' ) }
 					</FullWidthButton>
 				),
@@ -98,7 +102,9 @@ const MarketplaceThankYou = ( { productSlug } ): JSX.Element => {
 			<Masterbar>
 				<Item
 					icon="cross"
-					onClick={ () => page( `/plugins/${ siteSlug }` ) }
+					onClick={ () =>
+						( document.location.href = `${ document.location.origin }/plugins/${ siteSlug }` )
+					} // Force reload the page.
 					tooltip={ translate( 'Go to home' ) }
 					tipTarget="close"
 				/>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,8 +1,4 @@
-import {
-	isWpComBusinessPlan,
-	isWpComEcommercePlan,
-	isEnterprise,
-} from '@automattic/calypso-products';
+import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -371,9 +367,9 @@ function CTA( {
 	}
 
 	const shouldUpgrade = ! (
-		isWpComBusinessPlan( selectedSite.plan ) ||
+		isBusiness( selectedSite.plan ) ||
 		isEnterprise( selectedSite.plan ) ||
-		isWpComEcommercePlan( selectedSite.plan ) ||
+		isEcommerce( selectedSite.plan ) ||
 		isJetpack ||
 		isVip
 	);

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -133,16 +133,16 @@ class PluginsBrowserListElement extends Component {
 }
 
 export default compose(
-	connect( ( state, { currentSites, plugin, site } ) => {
+	connect( ( state, { currentSites, plugin } ) => {
 		const selectedSiteId = getSelectedSiteId( state );
-
+		const isJetpack = isJetpackSite( state, selectedSiteId );
 		const sitesWithPlugin =
-			site && currentSites
+			isJetpack && currentSites
 				? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), plugin.slug )
 				: [];
 
 		return {
-			isJetpackSite: isJetpackSite( state, selectedSiteId ),
+			isJetpackSite: isJetpack,
 			sitesWithPlugin,
 		};
 	} ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* uses correct selectors for plans in plugin details page. `isWpComBusinessPlan` wasn't resolving correctly so I just reused the ones for showing the nudge https://github.com/Automattic/wp-calypso/blob/038f3877a3e639dceda8ba5e5dcbf6bc18d94632/client/my-sites/plugins/plugins-browser/index.jsx#L554-L556
* avoid getting plugin status for non Jetpack sites in plugin browser item
* creates and uses a mechanism for retrying to fetch plugin data in thank you page. **Right after** a successful Atomic transfer, the `fetchSitePlugins` https://github.com/Automattic/wp-calypso/blob/2f3fc556dfa199386ea5816947910d7ab91904a2/client/state/plugins/installed/actions.js#L506 might return some error statuses (`This site is not jetpack`, `The user doesn't have permissions`) in which case we retry up to 10 times.
* clicking any calypso link in thank you page will reloads the browser as a workaround to get a refreshed state.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On a simple Business site (doesn't need upgrade but needs Atomic transfer)

**Scenario 1**
* install a plugin
* make sure that "Manage Plugin" in Thank you page gets clickable after a while
* clicking "Explore Plugins" get in the plugin browser list which correctly states the installed plugins

![SS 2021-11-17 at 16 36 09](https://user-images.githubusercontent.com/12430020/142221020-57561d5c-6467-4269-826b-786c5912a064.gif)

**Scenario 2**
* visit `/marketplace/thank-you/woocommerce2/[DOMAIN]` (non existent plugin)
* make sure that after 10 retries (hitting the `plugins` endpoint) "Manage Plugin" in Thank you page gets clickable

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57999
