### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` delete site to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -206,17 +206,6 @@ Undocumented.prototype.getDomainPrice = function ( domain, fn ) {
 	);
 };
 
-/**
- * Delete a site
- *
- * @param  {number|string} siteId The site ID or domain
- * @param  {Function} fn Function to invoke when request is complete
- */
-Undocumented.prototype.deleteSite = function ( siteId, fn ) {
-	debug( '/sites/:site_id/delete query' );
-	return this.wpcom.req.post( { path: '/sites/' + siteId + '/delete' }, fn );
-};
-
 function addReaderContentWidth( params ) {
 	if ( params.content_width ) {
 		return;

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -185,9 +185,8 @@ export function deleteSite( siteId ) {
 			)
 		);
 
-		return wpcom
-			.undocumented()
-			.deleteSite( siteId )
+		return wpcom.req
+			.post( `/sites/${ siteId }/delete` )
 			.then( () => {
 				dispatch( receiveDeletedSite( siteId ) );
 				dispatch(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR migrates the `wpcom.undocumented()` site deletion method to `wpcom.req`.

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

- Select (or create) a site you can delete as a test.
- Starting from /settings/general, scroll to the bottom and select `Delete your site permanently`
- On the following page click the `Delete site` button, and enter the site address to confirm.
- Verify the success message is displayed and the site is in fact deleted