### PR TITLE
Fix wrong importer query parameters

### DIFF
--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -53,8 +53,8 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 	): string => {
 		let stepUrl = getStepUrl( flowName, stepName, stepSectionName );
 
-		if ( Object.keys( dependency ).length ) {
-			stepUrl += '?' + stringify( dependency );
+		if ( typeof dependency?.siteSlug !== 'undefined' ) {
+			stepUrl += '?' + stringify( { siteSlug: dependency.siteSlug } );
 		}
 
 		return stepUrl;


### PR DESCRIPTION
The `StepWrapper` component received spurious query parameters. Now it just accepts the signup dependencies.

#### Changes proposed in this Pull Request

* Removed useless query parameters from importer URL

#### Testing instructions

* Go to /start/importer/capture
* Click "I don't have a site address"
* Ensure that `siteSlug` is the only URL query parameter

Related to #58166
