### PR TITLE
Do not pass false to isBlogger

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -308,7 +308,7 @@ class RegisterDomainStep extends Component {
 	}
 
 	checkForBloggerPlan() {
-		const plan = get( this.props, 'selectedSite.plan', false );
+		const plan = get( this.props, 'selectedSite.plan', {} );
 		const products = get( this.props, 'cart.products', [] );
 		const isBloggerPlan = isBlogger( plan ) || products.some( isBlogger );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This prevents passing `false` to the `isBlogger` function in the `RegisterDomainStep` of signup.

Fixes a regression caused by https://github.com/Automattic/wp-calypso/pull/58136

#### Testing instructions

Visit `/start` and verify that you get a signup flow.