### PR TITLE
Remove incompatible plugins from the popular list.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -32,6 +32,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import urlSearch from 'calypso/lib/url-search';
 import NoResults from 'calypso/my-sites/no-results';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
+import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
@@ -63,7 +64,6 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-
 import './style.scss';
 
 /**
@@ -545,8 +545,9 @@ export class PluginsBrowser extends Component {
 
 /**
  * Filter the popular plugins list.
- * Remove the displayed featured plugins from the popular list to
- * avoid showing them twice
+ *
+ * Remove the incompatible plugins and the displayed featured
+ * plugins from the popular list to avoid showing them twice.
  *
  * @param {Array} popularPlugins
  * @param {Array} featuredPlugins
@@ -558,7 +559,10 @@ function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 			.map( ( plugin ) => [ plugin.slug, plugin.slug ] )
 	);
 
-	return popularPlugins.filter( ( plugin ) => ! displayedFeaturedSlugsMap.has( plugin.slug ) );
+	return popularPlugins.filter(
+		( plugin ) =>
+			! displayedFeaturedSlugsMap.has( plugin.slug ) && isCompatiblePlugin( plugin.slug )
+	);
 }
 
 export default flow(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove incompatible plugins from the popular list.

#### Testing instructions

* Go to `/plugins`
* Verify if there are no incompatible plugins on the popular list
* You can verify it by clicking on each plugin on the popular list and checking no banner about incompatibility is showed

#### Demo

![Screen Shot 2021-11-17 at 13 53 55](https://user-images.githubusercontent.com/5039531/142255758-3df3f2b9-db42-470b-9aa1-57d53f34161c.png)

