### PR TITLE
Plugin Details: show active installations instead of download.

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -72,6 +72,7 @@ export function getAllowedPluginData( plugin ) {
 		'banners',
 		'compatibility',
 		'description',
+		'active_installs',
 		'short_description',
 		'detailsFetched',
 		'downloaded',

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -316,12 +316,12 @@ function PluginDetails( props ) {
 							{ translate( 'Plugin details' ) }
 						</div>
 						<div className="plugin-details__plugin-details-content">
-							<div className="plugin-details__downloads">
-								<div className="plugin-details__downloads-text title">
-									{ translate( 'Downloads' ) }
+							<div className="plugin-details__active-installs">
+								<div className="plugin-details__active-installs-text title">
+									{ translate( 'Active installations' ) }
 								</div>
-								<div className="plugin-details__downloads-value value">
-									{ formatNumberCompact( fullPlugin.downloaded, 'en' ) }
+								<div className="plugin-details__active-installs-value value">
+									{ formatNumberCompact( fullPlugin.active_installs, 'en' ) }
 								</div>
 							</div>
 							<div className="plugin-details__tested">

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -16,7 +16,7 @@ import MainComponent from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import formatNumberCompact from 'calypso/lib/format-number-compact';
+import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { userCan } from 'calypso/lib/site/utils';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -321,7 +321,7 @@ function PluginDetails( props ) {
 									{ translate( 'Active installations' ) }
 								</div>
 								<div className="plugin-details__active-installs-value value">
-									{ formatNumberCompact( fullPlugin.active_installs, 'en' ) }
+									{ formatNumberMetric( fullPlugin.active_installs, 'en' ) }
 								</div>
 							</div>
 							<div className="plugin-details__tested">

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -329,7 +329,7 @@ $plugin-details-header-padding: 100px;
 			font-size: $font-body-small;
 			padding-bottom: 16px;
 
-			&.plugin-details__downloads-value {
+			&.plugin-details__active-installs-value {
 				font-size: $font-body;
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* show active installations instead of download in the plugin info

#### Testing instructions


- visit `/plugins/really-simple-ssl`
- inspect

|Before | After|
|-------|------|
|![SS 2021-11-17 at 20 19 28](https://user-images.githubusercontent.com/12430020/142259202-73092d3e-d773-45df-be65-74108a398896.png)|![SS 2021-11-17 at 20 20 25](https://user-images.githubusercontent.com/12430020/142259237-ab8471b4-766d-4d20-9581-0b7f07ec1054.png)|
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

