### PR TITLE
Emails: Update copy and hide placeholders on Email Comparison page

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -72,14 +72,12 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	const hasLastNameError = lastNameFieldTouched && null !== lastNameError;
 	const hasPasswordError = passwordFieldTouched && null !== passwordError;
 
-	const emailAddressPlaceholder = translate( 'Email' );
 	const emailAddressLabel = translate( 'Email address' );
 
 	const renderSingleDomain = () => {
 		return (
 			<LabelWrapper label={ emailAddressLabel }>
 				<FormTextInputWithAffixes
-					placeholder={ emailAddressPlaceholder }
 					value={ mailBox }
 					isError={ hasMailBoxError }
 					onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
@@ -100,7 +98,6 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 		return (
 			<LabelWrapper label={ emailAddressLabel }>
 				<FormTextInput
-					placeholder={ emailAddressPlaceholder }
 					value={ mailBox }
 					isError={ hasMailBoxError }
 					onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
@@ -130,7 +127,6 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 					<LabelWrapper label={ translate( 'First name' ) }>
 						<FormTextInput
 							autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
-							placeholder={ translate( 'First name' ) }
 							value={ firstName }
 							maxLength={ 60 }
 							isError={ hasFirstNameError }
@@ -150,7 +146,6 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 				<div className="gsuite-new-user-list__new-user-name-container">
 					<LabelWrapper label={ translate( 'Last name' ) }>
 						<FormTextInput
-							placeholder={ translate( 'Last name' ) }
 							value={ lastName }
 							maxLength={ 60 }
 							isError={ hasLastNameError }
@@ -182,7 +177,6 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 						<FormPasswordInput
 							autoCapitalize="off"
 							autoCorrect="off"
-							placeholder={ translate( 'Password' ) }
 							value={ password }
 							maxLength={ 100 }
 							isError={ hasPasswordError }

--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -19,7 +19,6 @@ function EmailProviderCard( {
 	description,
 	formattedPrice,
 	discount,
-	additionalPriceInformation,
 	detailsExpanded = false,
 	onExpandedChange = noop,
 	formFields,
@@ -70,12 +69,6 @@ function EmailProviderCard( {
 			<div className="email-providers-comparison__provider-price-and-button">
 				<div>
 					<PromoCardPrice formattedPrice={ formattedPrice } discount={ discount } />
-
-					{ additionalPriceInformation && (
-						<div className="email-providers-comparison__provider-additional-price-information">
-							{ additionalPriceInformation }
-						</div>
-					) }
 				</div>
 
 				{ showFeaturesToggleButton && (
@@ -115,7 +108,6 @@ EmailProviderCard.propTypes = {
 	description: PropTypes.string,
 	formattedPrice: PropTypes.node,
 	discount: PropTypes.string,
-	additionalPriceInformation: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 	formFields: PropTypes.node,
 	buttonLabel: PropTypes.string,
 	onButtonClick: PropTypes.func,

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -379,7 +379,7 @@ class EmailProvidersComparison extends Component {
 		const productIsDiscounted = hasDiscount( gSuiteProduct );
 		const monthlyPrice = getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode );
 		const formattedPrice = productIsDiscounted
-			? translate( '{{fullPrice/}} {{discountedPrice/}} /user /month billed annually', {
+			? translate( '{{fullPrice/}} {{discountedPrice/}} /mailbox /month billed annually', {
 					components: {
 						fullPrice: <span>{ monthlyPrice }</span>,
 						discountedPrice: (
@@ -391,7 +391,7 @@ class EmailProvidersComparison extends Component {
 					comment:
 						'{{fullPrice/}} is the formatted full price, e.g. $20; {{discountedPrice/}} is the discounted, formatted price, e.g. $10',
 			  } )
-			: translate( '{{price/}} /user /month billed annually', {
+			: translate( '{{price/}} /mailbox /month billed annually', {
 					components: {
 						price: <span>{ monthlyPrice }</span>,
 					},
@@ -521,7 +521,7 @@ class EmailProvidersComparison extends Component {
 			translate,
 		} = this.props;
 
-		const formattedPrice = translate( '{{price/}} /user /month billed monthly', {
+		const formattedPrice = translate( '{{price/}} /mailbox /month billed monthly', {
 			components: {
 				price: <span>{ formatCurrency( titanMailProduct?.cost ?? 0, currencyCode ) }</span>,
 			},

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -556,7 +556,6 @@ class EmailProvidersComparison extends Component {
 				mailboxes={ this.state.titanMailboxes }
 				selectedDomainName={ selectedDomainName }
 				onReturnKeyPress={ this.onTitanFormReturnKeyPress }
-				showLabels={ true }
 				validatedMailboxUuids={ this.state.validatedTitanMailboxUuids }
 			>
 				<Button

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -492,7 +492,7 @@ class EmailProvidersComparison extends Component {
 				logo={ { path: googleWorkspaceIcon } }
 				title={ getGoogleMailServiceFamily() }
 				description={ translate(
-					'Professional email integrated with Google Meet and other collaboration tools from Google.'
+					'Professional email integrated with Google Meet and other productivity tools from Google.'
 				) }
 				formattedPrice={ formattedPrice }
 				discount={ discount }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -423,15 +423,6 @@ class EmailProvidersComparison extends Component {
 			</span>
 		) : null;
 
-		const additionalPriceInformation = productIsDiscounted
-			? null
-			: translate( '%(price)s billed annually', {
-					args: {
-						standardPrice,
-					},
-					comment: "Annual price formatted with the currency (e.g. '$99.99')",
-			  } );
-
 		// If we don't have any users, initialize the list to have 1 empty user
 		const googleUsers =
 			( this.state.googleUsers ?? [] ).length === 0
@@ -496,7 +487,6 @@ class EmailProvidersComparison extends Component {
 				) }
 				formattedPrice={ formattedPrice }
 				discount={ discount }
-				additionalPriceInformation={ additionalPriceInformation }
 				formFields={ formFields }
 				detailsExpanded={ this.state.expanded.google }
 				onExpandedChange={ this.onExpandedStateChange }

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -196,13 +196,6 @@
 		}
 	}
 
-	.email-providers-comparison__provider-additional-price-information {
-		color: var( --color-text-subtle );
-		font-size: $font-body-extra-small;
-		font-style: normal;
-		margin-top: 3px;
-	}
-
 	.email-providers-comparison__provider-form-and-features {
 		display: none;
 	}

--- a/client/my-sites/email/titan-new-mailbox-list/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox-list/index.jsx
@@ -22,7 +22,6 @@ const TitanNewMailboxList = ( {
 	onMailboxesChange,
 	onReturnKeyPress = noop,
 	showAddAnotherMailboxButton = true,
-	showLabels = true,
 	validatedMailboxUuids = [],
 } ) => {
 	const translate = useTranslate();
@@ -86,7 +85,6 @@ const TitanNewMailboxList = ( {
 						mailbox={ mailbox }
 						onReturnKeyPress={ onReturnKeyPress }
 						showAllErrors={ validatedMailboxUuids.includes( mailbox.uuid ) }
-						showLabels={ showLabels }
 					/>
 
 					<div className="titan-new-mailbox-list__actions">
@@ -125,7 +123,6 @@ TitanNewMailboxList.propTypes = {
 	onMailboxesChange: PropTypes.func.isRequired,
 	onReturnKeyPress: PropTypes.func,
 	showAddAnotherMailboxButton: PropTypes.bool,
-	showLabels: PropTypes.bool,
 };
 
 export default TitanNewMailboxList;

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -1,5 +1,4 @@
 import { ToggleControl } from '@wordpress/components';
-import classNames from 'classnames';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
@@ -28,7 +27,6 @@ const TitanNewMailbox = ( {
 	},
 	selectedDomainName,
 	showAllErrors = false,
-	showLabels = true,
 } ) => {
 	const translate = useTranslate();
 	const isRtl = useRtl();
@@ -59,17 +57,12 @@ const TitanNewMailbox = ( {
 
 	return (
 		<>
-			<div
-				className={ classNames( 'titan-new-mailbox', {
-					'show-labels': showLabels,
-				} ) }
-			>
+			<div className="titan-new-mailbox">
 				<div className="titan-new-mailbox__name-and-remove">
 					<FormFieldset>
 						<FormLabel>
-							{ showLabels && translate( 'Full name' ) }
+							{ translate( 'Full name' ) }
 							<FormTextInput
-								placeholder={ translate( 'Full name' ) }
 								value={ name }
 								required
 								isError={ hasNameError }
@@ -87,9 +80,8 @@ const TitanNewMailbox = ( {
 				</div>
 				<FormFieldset>
 					<FormLabel>
-						{ showLabels && translate( 'Email address' ) }
+						{ translate( 'Email address' ) }
 						<FormTextInputWithAffixes
-							placeholder={ translate( 'Email address' ) }
 							value={ mailbox }
 							isError={ hasMailboxError }
 							onChange={ ( event ) => {
@@ -107,11 +99,10 @@ const TitanNewMailbox = ( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel>
-						{ showLabels && translate( 'Password' ) }
+						{ translate( 'Password' ) }
 						<FormPasswordInput
 							autoCapitalize="off"
 							autoCorrect="off"
-							placeholder={ translate( 'Password' ) }
 							value={ password }
 							maxLength={ 100 }
 							isError={ hasPasswordError }
@@ -142,18 +133,10 @@ const TitanNewMailbox = ( {
 
 				<FormFieldset>
 					<FormLabel>
-						{ showLabels &&
-							translate( 'Password reset email address', {
-								comment: 'This is the email address we will send password reset emails to',
-							} ) }
+						{ translate( 'Password reset email address', {
+							comment: 'This is the email address we will send password reset emails to',
+						} ) }
 						<FormTextInput
-							placeholder={
-								showLabels
-									? translate( 'Email address' )
-									: translate( 'Password reset email address', {
-											comment: 'This is the email address we will send password reset emails to',
-									  } )
-							}
 							value={ alternativeEmail }
 							isError={ hasAlternativeEmailError }
 							onChange={ ( event ) => {
@@ -179,7 +162,6 @@ TitanNewMailbox.propTypes = {
 	onReturnKeyPress: PropTypes.func.isRequired,
 	mailbox: getMailboxPropTypeShape(),
 	showAllErrors: PropTypes.bool,
-	showLabels: PropTypes.bool.isRequired,
 	selectedDomainName: PropTypes.string.isRequired,
 };
 

--- a/client/my-sites/email/titan-new-mailbox/style.scss
+++ b/client/my-sites/email/titan-new-mailbox/style.scss
@@ -1,6 +1,12 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.titan-new-mailbox .form-label > input[type=text],
+.titan-new-mailbox .form-label > .form-text-input-with-affixes,
+.titan-new-mailbox .form-label > .form-password-input {
+	margin-top: 5px;
+}
+
 .titan-new-mailbox .form-label .form-text-input-with-affixes__suffix,
 .titan-new-mailbox .form-label .form-text-input-with-affixes__prefix {
 	font-weight: normal;
@@ -41,20 +47,5 @@
 		.components-toggle-control p {
 			margin-bottom: 0;
 		}
-	}
-}
-
-.titan-new-mailbox.show-labels {
-	.form-fieldset .form-label {
-		color: var( --color-text );
-
-		> div,
-		> input {
-			margin-top: 5px;
-		}
-	}
-
-	.titan-new-mailbox__remove-mailbox-button {
-		margin-top: calc( 1.5em + 5px );
 	}
 }


### PR DESCRIPTION
This pull requests updates the `Email Comparison` page to:

* Update the description of Google Workspace to match changes from [this pull request](https://github.com/Automattic/wp-calypso/pull/58186)
* Refer to mailboxes instead of users in the price (i.e. `/user /month billed annually`)
* Remove duplicate billing information for Google Workspace (i.e. `billed annually`)
* Remove placeholders that just duplicate the labels of each form field

Note this last change is also visible on the `Add New Mailboxes` and `Set Up Mailbox` pages since they use the same forms for Titan and Google Workspace.

##### Email Comparison

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/142262583-afc2ed49-592a-4936-86ed-53be398765d3.png) <br/><br/><br/><br/><br/><br/><br/><br/>| ![image](https://user-images.githubusercontent.com/594356/142262644-fde0baf1-3ac5-4a96-8e6e-c72e4a2ae080.png)


##### Add New Mailboxes (Titan)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/142262401-11370264-2084-4535-a230-d4aab0fbe2f5.png) | ![image](https://user-images.githubusercontent.com/594356/142262468-6ab5b121-8090-4f98-baa8-30c827941d44.png)


##### Add New Mailboxes (Google Workspace)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/142262182-fc452653-1d4b-4e5c-8a4e-143a8be88524.png) | ![image](https://user-images.githubusercontent.com/594356/142262238-0ad4153d-8741-4cd2-ab62-0ed21d77fe74.png)

##### Set Up Mailbox

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/142262036-3ca2dad1-374b-46dc-a1cd-a6e312a72d9e.png) | ![image](https://user-images.githubusercontent.com/594356/142262075-35c14765-a3cb-4c6a-9563-aca15af41d5c.png)


#### Testing instructions

1. Run `git checkout update/email-comparison-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/58193#issuecomment-971861463)
2. Log into a WordPress.com account that has Titan, Google Workspace, and a domain with no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button to access the `Email Comparison` page
5. Assert that you see the changes mentioned above
6. Go back to the `Emails` page
7. Click a Titan account
8. Click the `Set up mailbox` button to access the `Set Up Mailbox` page
9. Assert that placeholders are no longer displayed
10. Go back, and click the `Add new mailboxes` option to access the `Add New Mailboxes` page
11. Assert that placeholders are no longer displayed
12. Go back to the `Emails` page
13. Click a Google Workspace account
14. Click the `Add new mailboxes` option to access the `Add New Mailboxes` page
15. Assert that placeholders are no longer displayed