### PR TITLE
Update/Fix 'getSiteSlug' createSelector function

### DIFF
--- a/client/state/sites/selectors/get-site-slug.js
+++ b/client/state/sites/selectors/get-site-slug.js
@@ -3,6 +3,7 @@ import { withoutHttp, urlToSlug } from 'calypso/lib/url';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import getSiteOption from './get-site-option';
+import getSiteOptions from './get-site-options';
 import isSiteConflicting from './is-site-conflicting';
 
 /**
@@ -25,5 +26,5 @@ export default createSelector(
 
 		return urlToSlug( site.URL );
 	},
-	[ getSitesItems ]
+	( state, siteId ) => [ getSitesItems( state ), getSiteOptions( state, siteId ) ]
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `client/state/sites/selectors/get-site-slug.js` createSelector function contains incorrect values for the second argument (which should be an array of functions that returns the parts of the state tree that the selector depends on). As a result, the selector was incorrectly memoized and it was also causing a TSLint error ( `expected 1 arguments, but got 2` ) in VSCode.


#### Testing instructions

For more information on the `createSelector` function, you can read: https://github.com/Automattic/wp-calypso/blob/38c37bbfe35b8c741c4e346637987ddc0fb3ab59/packages/state-utils/src/create-selector/README.md

See that prior to this PR,  in the `createSelector` function of `get-site-slug.js`, the second argument contains only `[ getSitesItems ]`.  This not correct.  The selector depends on more parts of the state tree than only `getSitesItems`.

See that the `getSiteSlug` selector depends on the state tree from 2 other selectors, 1. `getSiteItems` (called from within `getRawSite`) and 2. `getSitesOptions`( called from within `getSiteOption`), therefore the second argument of the `createSelector` function should return an array of those 2 functions, ,ie- `[ getSitesItems( state ), getSiteOptions( state, siteId ) ]`.  And this PR makes this correction. Verify that this makes sense and seems reasonable to you.

Before checking out this PR branch:

To see the TSLint error, go to any TypeScript (`.ts`) file that utilizes the `getSiteSlug( state, siteId )` function.  
- For example, open file `client/jetpack-cloud/controller.ts`.
- See on line 48 that the `getSiteSlug` function has a TSLint error (2nd argument is underlined in red) that says `Expected 1 argument, but got 2`);

Now checkout this branch and `yarn start`:

- Verify that there is **no longer** a TSLint error in any `.ts(x)` file that the `getSiteSlug` function is called.

 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
