### PR TITLE
Fixing opacity CSS declaration for videos UI

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -169,7 +169,7 @@
 	}
 
 	.videos-ui__play-button:hover {
-		opacity: 80%;
+		opacity: 0.8;
 	}
 
 	@include break-small {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR attempts to address [an issue](https://github.com/Automattic/wp-calypso/issues/58181) where the button opacity in the videos UI is being set to 1% on hover - but only in production and calypso.live. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View this PR in calypso.live
* Verify that the buttons in the videos UI modal appear at 80% opacity when hovered over.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58181
