### PR TITLE
Products: Remove formatProduct from yet more functions

### DIFF
--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -31,7 +31,7 @@ describe( 'ProductPurchaseFeaturesList basic tests', () => {
 		plan: PLAN_FREE,
 		isPlaceholder: false,
 		selectedSite: {
-			plan: PLAN_FREE,
+			plan: { product_slug: PLAN_FREE },
 		},
 	};
 
@@ -46,7 +46,7 @@ describe( 'ProductPurchaseFeaturesList getFeatures() tests', () => {
 		plan: PLAN_FREE,
 		isPlaceholder: false,
 		selectedSite: {
-			plan: PLAN_FREE,
+			plan: { product_slug: PLAN_FREE },
 		},
 	};
 
@@ -270,7 +270,7 @@ describe( 'ProductPurchaseFeaturesList feature functions', () => {
 		plan: PLAN_FREE,
 		isPlaceholder: false,
 		selectedSite: {
-			plan: PLAN_FREE,
+			plan: { product_slug: PLAN_FREE },
 		},
 	};
 
@@ -318,7 +318,7 @@ describe( '<HappinessSupportCard isJetpackFreePlan', () => {
 	const props = {
 		plan: PLAN_JETPACK_FREE,
 		selectedSite: {
-			plan: PLAN_JETPACK_FREE,
+			plan: { product_slug: PLAN_JETPACK_FREE },
 		},
 	};
 	test( 'Should set isJetpackFreePlan for free plan', () => {
@@ -339,7 +339,7 @@ describe( '<HappinessSupportCard isEligibleForLiveChat', () => {
 			plan: plan,
 			isPlaceholder: false,
 			selectedSite: {
-				plan,
+				plan: { product_slug: plan },
 			},
 		};
 		test( `Should be eligible for live chat for ${ plan }`, () => {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -80,10 +80,14 @@ class CancelPurchase extends Component {
 
 		const { purchase } = props;
 
+		if ( ! purchase ) {
+			return false;
+		}
+
 		// For domain transfers, we only allow cancel if it's also refundable
 		const isDomainTransferCancelable = isRefundable( purchase ) || ! isDomainTransfer( purchase );
 
-		return purchase && isCancelable( purchase ) && isDomainTransferCancelable;
+		return isCancelable( purchase ) && isDomainTransferCancelable;
 	};
 
 	redirect = ( props ) => {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -302,6 +302,7 @@ class ManagePurchase extends Component {
 			: translate( 'Upgrade Plan' );
 
 		if (
+			! purchase ||
 			! isPlan( purchase ) ||
 			isEcommerce( purchase ) ||
 			isComplete( purchase ) ||

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -691,10 +691,10 @@ class ManagePurchase extends Component {
 
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),
-			'is-personal': isPersonal( purchase ),
-			'is-premium': isPremium( purchase ),
-			'is-business': isBusiness( purchase ),
-			'is-jetpack-product': isJetpackProduct( purchase ),
+			'is-personal': purchase && isPersonal( purchase ),
+			'is-premium': purchase && isPremium( purchase ),
+			'is-business': purchase && isBusiness( purchase ),
+			'is-jetpack-product': purchase && isJetpackProduct( purchase ),
 		} );
 		const siteName = purchase.siteName;
 		const siteDomain = purchase.domain;

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -67,7 +67,7 @@ export default function PurchaseMeta( {
 
 	const isDataLoading = useSelector( isRequestingSites ) || ! hasLoadedPurchasesFromServer;
 
-	if ( isDataLoading || ! purchaseId ) {
+	if ( isDataLoading || ! purchaseId || ! purchase ) {
 		return <PurchaseMetaPlaceholder />;
 	}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -415,7 +415,7 @@ function PurchaseMetaExpiration( {
 	const hideAutoRenew =
 		purchase && JETPACK_LEGACY_PLANS.includes( purchase.productSlug ) && ! isRenewable( purchase );
 
-	if ( isDomainTransfer( purchase ) ) {
+	if ( ! purchase || isDomainTransfer( purchase ) ) {
 		return null;
 	}
 

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -68,9 +68,10 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 	const supportsAtomicUpgrade = useRef< boolean >();
 	useEffect( () => {
 		supportsAtomicUpgrade.current =
-			isBusiness( selectedSite?.plan ) ||
-			isEnterprise( selectedSite?.plan ) ||
-			isEcommerce( selectedSite?.plan );
+			selectedSite?.plan &&
+			( isBusiness( selectedSite.plan ) ||
+				isEnterprise( selectedSite.plan ) ||
+				isEcommerce( selectedSite.plan ) );
 	}, [ selectedSite ] );
 
 	// retrieve plugin data if not available

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -80,7 +80,7 @@ function renderWithRedux( ui ) {
 
 const props = {
 	site: {
-		plan: PLAN_FREE,
+		plan: { product_slug: PLAN_FREE },
 	},
 	selectedSite: {},
 	translate: ( x ) => x,
@@ -103,7 +103,11 @@ describe( 'SiteSettingsFormGeneral', () => {
 		[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( ( plan ) => {
 			test( `Business 1 year for (${ plan })`, () => {
 				const comp = shallow(
-					<SiteSettingsFormGeneral { ...props } siteIsJetpack={ false } site={ { plan } } />
+					<SiteSettingsFormGeneral
+						{ ...props }
+						siteIsJetpack={ false }
+						site={ { plan: { product_slug: plan } } }
+					/>
 				);
 				expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
 				expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_BUSINESS );
@@ -113,7 +117,11 @@ describe( 'SiteSettingsFormGeneral', () => {
 		[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( ( plan ) => {
 			test( `Business 2 year for (${ plan })`, () => {
 				const comp = shallow(
-					<SiteSettingsFormGeneral { ...props } siteIsJetpack={ false } site={ { plan } } />
+					<SiteSettingsFormGeneral
+						{ ...props }
+						siteIsJetpack={ false }
+						site={ { plan: { product_slug: plan } } }
+					/>
 				);
 				expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
 				expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_BUSINESS );
@@ -133,7 +141,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			testProps = {
 				...props,
 				siteIsJetpack: false,
-				site: { plan: PLAN_PERSONAL },
+				site: { plan: { product_slug: PLAN_PERSONAL } },
 				fields: {
 					blog_public: 1,
 					wpcom_coming_soon: 0,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -614,7 +614,7 @@ class Signup extends Component {
 		}
 
 		if ( isReskinned ) {
-			const domainItem = get( this.props, 'signupDependencies.domainItem', false );
+			const domainItem = get( this.props, 'signupDependencies.domainItem', {} );
 			const hasPaidDomain = isDomainRegistration( domainItem );
 			const destination = this.signupFlowController.getDestination();
 

--- a/packages/calypso-products/src/camel-or-snake-slug.ts
+++ b/packages/calypso-products/src/camel-or-snake-slug.ts
@@ -1,0 +1,5 @@
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function camelOrSnakeSlug( product: WithCamelCaseSlug | WithSnakeCaseSlug ): string {
+	return 'product_slug' in product ? product.product_slug : product.productSlug;
+}

--- a/packages/calypso-products/src/get-interval-type-for-term.ts
+++ b/packages/calypso-products/src/get-interval-type-for-term.ts
@@ -1,6 +1,6 @@
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from './constants';
 
-export function getIntervalTypeForTerm( term: string ): string {
+export function getIntervalTypeForTerm( term: string ): string | null {
 	switch ( term ) {
 		case TERM_MONTHLY:
 			return 'monthly';

--- a/packages/calypso-products/src/get-interval-type-for-term.ts
+++ b/packages/calypso-products/src/get-interval-type-for-term.ts
@@ -1,6 +1,6 @@
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from './constants';
 
-export function getIntervalTypeForTerm( term ) {
+export function getIntervalTypeForTerm( term: string ): string {
 	switch ( term ) {
 		case TERM_MONTHLY:
 			return 'monthly';

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -1,4 +1,5 @@
 export * from './main';
+export * from './camel-or-snake-slug';
 export * from './types';
 export * from './plans-utilities';
 export * from './constants';

--- a/packages/calypso-products/src/is-blogger.ts
+++ b/packages/calypso-products/src/is-blogger.ts
@@ -1,9 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { isBloggerPlan } from './main';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isBlogger( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return isBloggerPlan( product.product_slug );
-	}
-	return isBloggerPlan( product.productSlug );
+	return isBloggerPlan( camelOrSnakeSlug( product ) );
 }

--- a/packages/calypso-products/src/is-business.js
+++ b/packages/calypso-products/src/is-business.js
@@ -1,8 +1,0 @@
-import { formatProduct } from './format-product';
-import { isBusinessPlan } from './main';
-
-export function isBusiness( product ) {
-	product = formatProduct( product );
-
-	return isBusinessPlan( product.product_slug );
-}

--- a/packages/calypso-products/src/is-business.ts
+++ b/packages/calypso-products/src/is-business.ts
@@ -1,9 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { isBusinessPlan } from './main';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isBusiness( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return isBusinessPlan( product.product_slug );
-	}
-	return isBusinessPlan( product.productSlug );
+	return isBusinessPlan( camelOrSnakeSlug( product ) );
 }

--- a/packages/calypso-products/src/is-business.ts
+++ b/packages/calypso-products/src/is-business.ts
@@ -1,0 +1,9 @@
+import { isBusinessPlan } from './main';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isBusiness( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	if ( 'product_slug' in product ) {
+		return isBusinessPlan( product.product_slug );
+	}
+	return isBusinessPlan( product.productSlug );
+}

--- a/packages/calypso-products/src/is-chargeback.js
+++ b/packages/calypso-products/src/is-chargeback.js
@@ -1,8 +1,0 @@
-import { PLAN_CHARGEBACK } from './constants';
-import { formatProduct } from './format-product';
-
-export function isChargeback( product ) {
-	product = formatProduct( product );
-
-	return product.product_slug === PLAN_CHARGEBACK;
-}

--- a/packages/calypso-products/src/is-chargeback.ts
+++ b/packages/calypso-products/src/is-chargeback.ts
@@ -1,9 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { PLAN_CHARGEBACK } from './constants';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isChargeback( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return product.product_slug === PLAN_CHARGEBACK;
-	}
-	return product.productSlug === PLAN_CHARGEBACK;
+	return camelOrSnakeSlug( product ) === PLAN_CHARGEBACK;
 }

--- a/packages/calypso-products/src/is-chargeback.ts
+++ b/packages/calypso-products/src/is-chargeback.ts
@@ -1,0 +1,9 @@
+import { PLAN_CHARGEBACK } from './constants';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isChargeback( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	if ( 'product_slug' in product ) {
+		return product.product_slug === PLAN_CHARGEBACK;
+	}
+	return product.productSlug === PLAN_CHARGEBACK;
+}

--- a/packages/calypso-products/src/is-complete.js
+++ b/packages/calypso-products/src/is-complete.js
@@ -1,8 +1,0 @@
-import { formatProduct } from './format-product';
-import { isCompletePlan } from './main';
-
-export function isComplete( product ) {
-	product = formatProduct( product );
-
-	return isCompletePlan( product.product_slug );
-}

--- a/packages/calypso-products/src/is-complete.ts
+++ b/packages/calypso-products/src/is-complete.ts
@@ -1,9 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { isCompletePlan } from './main';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isComplete( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return isCompletePlan( product.product_slug );
-	}
-	return isCompletePlan( product.productSlug );
+	return isCompletePlan( camelOrSnakeSlug( product ) );
 }

--- a/packages/calypso-products/src/is-complete.ts
+++ b/packages/calypso-products/src/is-complete.ts
@@ -1,0 +1,9 @@
+import { isCompletePlan } from './main';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isComplete( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	if ( 'product_slug' in product ) {
+		return isCompletePlan( product.product_slug );
+	}
+	return isCompletePlan( product.productSlug );
+}

--- a/packages/calypso-products/src/is-concierge-session.ts
+++ b/packages/calypso-products/src/is-concierge-session.ts
@@ -1,8 +1,6 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isConciergeSession( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return 'concierge-session' === product.product_slug;
-	}
-	return 'concierge-session' === product.productSlug;
+	return 'concierge-session' === camelOrSnakeSlug( product );
 }

--- a/packages/calypso-products/src/is-delayed-domain-transfer.ts
+++ b/packages/calypso-products/src/is-delayed-domain-transfer.ts
@@ -1,5 +1,8 @@
 import { isDomainTransfer } from './is-domain-transfer';
 
-export function isDelayedDomainTransfer( product ) {
+export function isDelayedDomainTransfer( product: {
+	productSlug: string;
+	delayedProvisioning: boolean;
+} ): boolean {
 	return isDomainTransfer( product ) && product.delayedProvisioning;
 }

--- a/packages/calypso-products/src/is-domain-mapping.js
+++ b/packages/calypso-products/src/is-domain-mapping.js
@@ -1,7 +1,0 @@
-import { formatProduct } from './format-product';
-
-export function isDomainMapping( product ) {
-	product = formatProduct( product );
-
-	return product.product_slug === 'domain_map';
-}

--- a/packages/calypso-products/src/is-domain-mapping.ts
+++ b/packages/calypso-products/src/is-domain-mapping.ts
@@ -1,0 +1,8 @@
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isDomainMapping( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	if ( 'product_slug' in product ) {
+		return product.product_slug === 'domain_map';
+	}
+	return product.productSlug === 'domain_map';
+}

--- a/packages/calypso-products/src/is-domain-mapping.ts
+++ b/packages/calypso-products/src/is-domain-mapping.ts
@@ -1,8 +1,6 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isDomainMapping( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return product.product_slug === 'domain_map';
-	}
-	return product.productSlug === 'domain_map';
+	return camelOrSnakeSlug( product ) === 'domain_map';
 }

--- a/packages/calypso-products/src/is-domain-product.js
+++ b/packages/calypso-products/src/is-domain-product.js
@@ -1,9 +1,0 @@
-import { formatProduct } from './format-product';
-import { isDomainMapping } from './is-domain-mapping';
-import { isDomainRegistration } from './is-domain-registration';
-
-export function isDomainProduct( product ) {
-	product = formatProduct( product );
-
-	return isDomainMapping( product ) || isDomainRegistration( product );
-}

--- a/packages/calypso-products/src/is-domain-product.ts
+++ b/packages/calypso-products/src/is-domain-product.ts
@@ -1,0 +1,12 @@
+import { isDomainMapping } from './is-domain-mapping';
+import { isDomainRegistration } from './is-domain-registration';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isDomainProduct(
+	product: ( WithSnakeCaseSlug | WithCamelCaseSlug ) & {
+		is_domain_registration?: boolean;
+		isDomainRegistration?: boolean;
+	}
+): boolean {
+	return isDomainMapping( product ) || isDomainRegistration( product );
+}

--- a/packages/calypso-products/src/is-domain-redemption.js
+++ b/packages/calypso-products/src/is-domain-redemption.js
@@ -1,7 +1,0 @@
-import { formatProduct } from './format-product';
-
-export function isDomainRedemption( product ) {
-	product = formatProduct( product );
-
-	return product.product_slug === 'domain_redemption';
-}

--- a/packages/calypso-products/src/is-domain-redemption.ts
+++ b/packages/calypso-products/src/is-domain-redemption.ts
@@ -1,8 +1,6 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isDomainRedemption( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return product.product_slug === 'domain_redemption';
-	}
-	return product.productSlug === 'domain_redemption';
+	return camelOrSnakeSlug( product ) === 'domain_redemption';
 }

--- a/packages/calypso-products/src/is-domain-redemption.ts
+++ b/packages/calypso-products/src/is-domain-redemption.ts
@@ -1,0 +1,8 @@
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isDomainRedemption( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	if ( 'product_slug' in product ) {
+		return product.product_slug === 'domain_redemption';
+	}
+	return product.productSlug === 'domain_redemption';
+}

--- a/packages/calypso-products/src/is-domain-registration.js
+++ b/packages/calypso-products/src/is-domain-registration.js
@@ -1,7 +1,0 @@
-import { formatProduct } from './format-product';
-
-export function isDomainRegistration( product ) {
-	product = formatProduct( product );
-
-	return !! product.is_domain_registration;
-}

--- a/packages/calypso-products/src/is-domain-registration.ts
+++ b/packages/calypso-products/src/is-domain-registration.ts
@@ -1,0 +1,6 @@
+export function isDomainRegistration( product: {
+	is_domain_registration?: boolean;
+	isDomainRegistration?: boolean;
+} ): boolean {
+	return !! ( product.is_domain_registration || product.isDomainRegistration );
+}

--- a/packages/calypso-products/src/is-domain-transfer-product.js
+++ b/packages/calypso-products/src/is-domain-transfer-product.js
@@ -1,8 +1,0 @@
-import { formatProduct } from './format-product';
-import { isDomainTransfer } from './is-domain-transfer';
-
-export function isDomainTransferProduct( product ) {
-	product = formatProduct( product );
-
-	return isDomainTransfer( product );
-}

--- a/packages/calypso-products/src/is-domain-transfer.js
+++ b/packages/calypso-products/src/is-domain-transfer.js
@@ -1,8 +1,0 @@
-import { domainProductSlugs } from './constants';
-import { formatProduct } from './format-product';
-
-export function isDomainTransfer( product ) {
-	product = formatProduct( product );
-
-	return product.product_slug === domainProductSlugs.TRANSFER_IN;
-}

--- a/packages/calypso-products/src/is-domain-transfer.ts
+++ b/packages/calypso-products/src/is-domain-transfer.ts
@@ -1,0 +1,9 @@
+import { domainProductSlugs } from './constants';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isDomainTransfer( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	if ( 'product_slug' in product ) {
+		return product.product_slug === domainProductSlugs.TRANSFER_IN;
+	}
+	return product.productSlug === domainProductSlugs.TRANSFER_IN;
+}

--- a/packages/calypso-products/src/is-domain-transfer.ts
+++ b/packages/calypso-products/src/is-domain-transfer.ts
@@ -1,9 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { domainProductSlugs } from './constants';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isDomainTransfer( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return product.product_slug === domainProductSlugs.TRANSFER_IN;
-	}
-	return product.productSlug === domainProductSlugs.TRANSFER_IN;
+	return camelOrSnakeSlug( product ) === domainProductSlugs.TRANSFER_IN;
 }

--- a/packages/calypso-products/src/is-dot-com-plan.js
+++ b/packages/calypso-products/src/is-dot-com-plan.js
@@ -1,6 +1,0 @@
-import { isJetpackPlan } from './is-jetpack-plan';
-import { isPlan } from './is-plan';
-
-export function isDotComPlan( product ) {
-	return isPlan( product ) && ! isJetpackPlan( product );
-}

--- a/packages/calypso-products/src/is-dot-com-plan.ts
+++ b/packages/calypso-products/src/is-dot-com-plan.ts
@@ -1,0 +1,7 @@
+import { isJetpackPlan } from './is-jetpack-plan';
+import { isPlan } from './is-plan';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isDotComPlan( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	return isPlan( product ) && ! isJetpackPlan( product );
+}

--- a/packages/calypso-products/src/is-ecommerce.js
+++ b/packages/calypso-products/src/is-ecommerce.js
@@ -1,8 +1,0 @@
-import { formatProduct } from './format-product';
-import { isEcommercePlan } from './main';
-
-export function isEcommerce( product ) {
-	product = formatProduct( product );
-
-	return isEcommercePlan( product.product_slug );
-}

--- a/packages/calypso-products/src/is-ecommerce.ts
+++ b/packages/calypso-products/src/is-ecommerce.ts
@@ -1,9 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { isEcommercePlan } from './main';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isEcommerce( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	if ( 'product_slug' in product ) {
-		return isEcommercePlan( product.product_slug );
-	}
-	return isEcommercePlan( product.productSlug );
+	return isEcommercePlan( camelOrSnakeSlug( product ) );
 }

--- a/packages/calypso-products/src/is-ecommerce.ts
+++ b/packages/calypso-products/src/is-ecommerce.ts
@@ -1,0 +1,9 @@
+import { isEcommercePlan } from './main';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isEcommerce( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	if ( 'product_slug' in product ) {
+		return isEcommercePlan( product.product_slug );
+	}
+	return isEcommercePlan( product.productSlug );
+}

--- a/packages/calypso-products/src/is-enterprise.js
+++ b/packages/calypso-products/src/is-enterprise.js
@@ -1,8 +1,0 @@
-import { PLAN_WPCOM_ENTERPRISE } from './constants';
-import { formatProduct } from './format-product';
-
-export function isEnterprise( product ) {
-	product = formatProduct( product );
-
-	return product.product_slug === PLAN_WPCOM_ENTERPRISE;
-}

--- a/packages/calypso-products/src/is-enterprise.ts
+++ b/packages/calypso-products/src/is-enterprise.ts
@@ -1,7 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { PLAN_WPCOM_ENTERPRISE } from './constants';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isEnterprise( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
-	return slug === PLAN_WPCOM_ENTERPRISE;
+	return camelOrSnakeSlug( product ) === PLAN_WPCOM_ENTERPRISE;
 }

--- a/packages/calypso-products/src/is-enterprise.ts
+++ b/packages/calypso-products/src/is-enterprise.ts
@@ -1,0 +1,7 @@
+import { PLAN_WPCOM_ENTERPRISE } from './constants';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isEnterprise( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
+	return slug === PLAN_WPCOM_ENTERPRISE;
+}

--- a/packages/calypso-products/src/is-free-jetpack-plan.js
+++ b/packages/calypso-products/src/is-free-jetpack-plan.js
@@ -1,8 +1,0 @@
-import { PLAN_JETPACK_FREE } from './constants';
-import { formatProduct } from './format-product';
-
-export function isFreeJetpackPlan( product ) {
-	product = formatProduct( product );
-
-	return product.product_slug === PLAN_JETPACK_FREE;
-}

--- a/packages/calypso-products/src/is-free-jetpack-plan.ts
+++ b/packages/calypso-products/src/is-free-jetpack-plan.ts
@@ -1,0 +1,7 @@
+import { PLAN_JETPACK_FREE } from './constants';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isFreeJetpackPlan( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
+	return slug === PLAN_JETPACK_FREE;
+}

--- a/packages/calypso-products/src/is-free-jetpack-plan.ts
+++ b/packages/calypso-products/src/is-free-jetpack-plan.ts
@@ -1,7 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { PLAN_JETPACK_FREE } from './constants';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isFreeJetpackPlan( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
-	return slug === PLAN_JETPACK_FREE;
+	return camelOrSnakeSlug( product ) === PLAN_JETPACK_FREE;
 }

--- a/packages/calypso-products/src/is-free-plan.js
+++ b/packages/calypso-products/src/is-free-plan.js
@@ -1,8 +1,0 @@
-import { PLAN_FREE } from './constants';
-import { formatProduct } from './format-product';
-
-export function isFreePlanProduct( product ) {
-	product = formatProduct( product );
-
-	return product.product_slug === PLAN_FREE;
-}

--- a/packages/calypso-products/src/is-free-plan.ts
+++ b/packages/calypso-products/src/is-free-plan.ts
@@ -1,7 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { PLAN_FREE } from './constants';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isFreePlanProduct( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
-	return slug === PLAN_FREE;
+	return camelOrSnakeSlug( product ) === PLAN_FREE;
 }

--- a/packages/calypso-products/src/is-free-plan.ts
+++ b/packages/calypso-products/src/is-free-plan.ts
@@ -1,0 +1,7 @@
+import { PLAN_FREE } from './constants';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isFreePlanProduct( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
+	return slug === PLAN_FREE;
+}

--- a/packages/calypso-products/src/is-jetpack-plan.js
+++ b/packages/calypso-products/src/is-jetpack-plan.js
@@ -1,8 +1,0 @@
-import { formatProduct } from './format-product';
-import { isJetpackPlanSlug } from './is-jetpack-plan-slug';
-
-export function isJetpackPlan( product ) {
-	product = formatProduct( product );
-
-	return isJetpackPlanSlug( product.product_slug );
-}

--- a/packages/calypso-products/src/is-jetpack-plan.ts
+++ b/packages/calypso-products/src/is-jetpack-plan.ts
@@ -1,0 +1,7 @@
+import { isJetpackPlanSlug } from './is-jetpack-plan-slug';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isJetpackPlan( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
+	return isJetpackPlanSlug( slug );
+}

--- a/packages/calypso-products/src/is-jetpack-plan.ts
+++ b/packages/calypso-products/src/is-jetpack-plan.ts
@@ -1,7 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { isJetpackPlanSlug } from './is-jetpack-plan-slug';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isJetpackPlan( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
-	return isJetpackPlanSlug( slug );
+	return isJetpackPlanSlug( camelOrSnakeSlug( product ) );
 }

--- a/packages/calypso-products/src/is-jetpack-videopress.ts
+++ b/packages/calypso-products/src/is-jetpack-videopress.ts
@@ -1,10 +1,8 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { JETPACK_VIDEOPRESS_PRODUCTS } from './constants';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isJetpackVideoPress( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
 	const products = JETPACK_VIDEOPRESS_PRODUCTS as ReadonlyArray< string >;
-	if ( 'product_slug' in product ) {
-		return products.includes( product.product_slug );
-	}
-	return products.includes( product.productSlug );
+	return products.includes( camelOrSnakeSlug( product ) );
 }

--- a/packages/calypso-products/src/is-plan.ts
+++ b/packages/calypso-products/src/is-plan.ts
@@ -1,9 +1,8 @@
 import { PLAN_HOST_BUNDLE, PLAN_WPCOM_ENTERPRISE } from './constants';
 import { getPlansSlugs, isFreePlan } from './main';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
-type HasSnakeCaseProductSlug = { product_slug: string };
-type HasCamelCaseProductSlug = { productSlug: string };
-export function isPlan( product: HasSnakeCaseProductSlug | HasCamelCaseProductSlug ): boolean {
+export function isPlan( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
 	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
 	if ( isFreePlan( slug ) ) {
 		return false;

--- a/packages/calypso-products/src/is-plan.ts
+++ b/packages/calypso-products/src/is-plan.ts
@@ -1,9 +1,10 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { PLAN_HOST_BUNDLE, PLAN_WPCOM_ENTERPRISE } from './constants';
 import { getPlansSlugs, isFreePlan } from './main';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isPlan( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
+	const slug = camelOrSnakeSlug( product );
 	if ( isFreePlan( slug ) ) {
 		return false;
 	}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -27,7 +27,6 @@ export { isDomainProduct } from './is-domain-product';
 export { isDomainRedemption } from './is-domain-redemption';
 export { isDomainRegistration } from './is-domain-registration';
 export { isDomainTransfer } from './is-domain-transfer';
-export { isDomainTransferProduct } from './is-domain-transfer-product';
 export { isDotComPlan } from './is-dot-com-plan';
 export { isEcommerce } from './is-ecommerce';
 export { isEnterprise } from './is-enterprise';

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -1,6 +1,6 @@
 import {
 	isPlan,
-	isDomainTransferProduct,
+	isDomainTransfer,
 	isDomainProduct,
 	isDotComPlan,
 	isGSuiteOrGoogleWorkspace,
@@ -46,10 +46,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		return String( translate( 'Productivity and Collaboration Tools' ) );
 	}
 
-	if (
-		meta &&
-		( isDomainProduct( serverCartItem ) || isDomainTransferProduct( serverCartItem ) )
-	) {
+	if ( meta && ( isDomainProduct( serverCartItem ) || isDomainTransfer( serverCartItem ) ) ) {
 		if ( ! isRenewalItem ) {
 			return productName || '';
 		}
@@ -73,7 +70,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 export function getLabel( serverCartItem: ResponseCartProduct ): string {
 	if (
 		serverCartItem.meta &&
-		( isDomainProduct( serverCartItem ) || isDomainTransferProduct( serverCartItem ) )
+		( isDomainProduct( serverCartItem ) || isDomainTransfer( serverCartItem ) )
 	) {
 		return serverCartItem.meta;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the vein of https://github.com/Automattic/wp-calypso/pull/58136, #58080, and #58086, this PR removes more uses of the `formatProduct` function in the `calypso-products` package because it makes it difficult to determine types and in some cases is unnecessary.

In this PR specifically, we change the following functions and convert them to TypeScript. None of these changes modify the functionality of these functions, except that they now always require an object.

- `isFreePlanProduct`
- `isFreeJetpackPlan`
- `isEnterprise`
- `isEcommerce`
- `isJetpackPlan`
- `isDomainRedemption`
- `isDomainProduct`
- `isDomainRegistration`
- `isDomainMapping`
- `isComplete`
- `isChargeback`
- `isBusiness`
- `isDomainTransfer`
- `isDomainTransferProduct` (removed because it is a duplicate of `isDomainTransfer`)

#### Testing instructions

No specific testing should be necessary (but see below). The changes made to the above functions do not change the type of the object they accept (they continue to accept their arguments in snake_case or camelCase).

One thing to keep in mind about this change is that these functions will no longer work if passed something that's not an object (eg: a boolean or a string). I believe this is a good thing because any such use is probably a bug (see the tests altered in this PR), however, this type of change revealed [a breaking bug in signup](https://github.com/Automattic/wp-calypso/pull/58189) in the last PR of its kind, so it's worth going through the call sites of the functions above and making sure that they are never called with non-object values.