### PR TITLE
Videos UI - update top links to reflect modal controls

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -88,6 +88,8 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 					displayIcon={ true }
 					displayLinks={ shouldDisplayTopLinks }
 					displaySkipLink={ false }
+					displayBackLink={ false }
+					displayCloseLink={ true }
 					onBackClick={ onBackClick }
 					skipClickHandler={ skipClickHandler }
 				/>

--- a/client/components/videos-ui/style-video-bar.scss
+++ b/client/components/videos-ui/style-video-bar.scss
@@ -33,6 +33,7 @@
 
         .videos-ui__bar-skip-link {
             text-decoration: underline;
+			cursor: pointer;
         }
     }
 

--- a/client/components/videos-ui/video-header-bar.jsx
+++ b/client/components/videos-ui/video-header-bar.jsx
@@ -9,7 +9,9 @@ import './style-video-bar.scss';
 const VideoHeaderBar = ( {
 	displayIcon,
 	displayLinks,
-	displaySkipLink,
+	displayBackLink = false,
+	displaySkipLink = false,
+	displayCloseLink = false,
 	onBackClick = () => {},
 	skipClickHandler = () => {},
 } ) => {
@@ -22,24 +24,31 @@ const VideoHeaderBar = ( {
 			{ displayLinks && (
 				<div className={ classNames( 'videos-ui__bar-content', 'videos-ui__desktop' ) }>
 					<div>
-						<a
-							href="/"
-							className={ classNames( {
-								'videos-ui__back-link': displayIcon,
-							} ) }
-							onClick={ onBackClick }
-						>
-							<Gridicon icon="chevron-left" size={ 24 } />
-							<span>{ translate( 'Back' ) }</span>
-						</a>
+						{ displayBackLink && (
+							<a
+								href="/"
+								className={ classNames( {
+									'videos-ui__back-link': displayIcon,
+								} ) }
+								onClick={ onBackClick }
+							>
+								<Gridicon icon="chevron-left" size={ 24 } />
+								<span>{ translate( 'Back' ) }</span>
+							</a>
+						) }
 					</div>
-					{ displaySkipLink && (
-						<div className="videos-ui__bar-skip-link">
+					<div className="videos-ui__bar-skip-link">
+						{ displaySkipLink && (
 							<a href={ `/post/${ siteSlug }` } onClick={ skipClickHandler }>
 								{ translate( 'Draft your first post' ) }
 							</a>
-						</div>
-					) }
+						) }
+						{ displayCloseLink && (
+							<span role="button" onKeyDown={ onBackClick } tabIndex={ 0 } onClick={ onBackClick }>
+								<Gridicon icon="cross" size={ 24 } />
+							</span>
+						) }
+					</div>
 				</div>
 			) }
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the behavior of the Videos UI so that the right-hand link (previously "Draft your first post") is replaced by an X icon to close the modal. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR locally.
* Verify that at desktop sizes, the Videos UI modal now displays an X icon which closes the modal, in place of the previous "Draft your first post" link text, and that the "Back" link on the upper bar is no longer displayed.

![image](https://user-images.githubusercontent.com/13437011/142280367-45e0303b-c94a-4cef-8f55-8d5e8605d096.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58079
