### PR TITLE
Video UI: Load poster if provided by the API

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -127,6 +127,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 							videoRef={ videoRef }
 							videoUrl={ currentVideo.url }
 							isPlaying={ isPlaying }
+							poster={ currentVideo.poster ? currentVideo.poster : false }
 						/>
 					) }
 					<div className="videos-ui__chapters">

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-const VideoPlayer = ( { videoRef, videoUrl, isPlaying } ) => {
+const VideoPlayer = ( { videoRef, videoUrl, isPlaying, poster = false } ) => {
 	useEffect( () => {
 		if ( isPlaying ) {
 			videoRef.current.play();
@@ -9,7 +9,7 @@ const VideoPlayer = ( { videoRef, videoUrl, isPlaying } ) => {
 
 	return (
 		<div key={ videoUrl } className="videos-ui__video">
-			<video ref={ videoRef } controls autoPlay={ isPlaying }>
+			<video controls ref={ videoRef } poster={ poster } autoPlay={ isPlaying }>
 				<source src={ videoUrl } />{ ' ' }
 				{ /* @TODO: check if tracks are available, the linter demands one */ }
 				<track src="caption.vtt" kind="captions" srcLang="en" label="english_captions" />


### PR DESCRIPTION
This PR adds the ability to load a poster for the video if it's provided by the API

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/142284437-02b372da-d9e0-4783-a0f4-e583782f8249.png) | ![image](https://user-images.githubusercontent.com/375980/142284389-6a82a5b8-3f69-41af-bde3-f331e4d89d74.png) |

#### Testing
1. Apply this patch to your sandbox if not merged: D70256-code 
2. Sandbox API
3. Load Video UI
4. Verify that the poster is being loaded correctly

Closes #58074