### PR TITLE
InfiniteList: Add a special case if all items are rendered

### DIFF
--- a/client/components/infinite-list/scroll-helper.js
+++ b/client/components/infinite-list/scroll-helper.js
@@ -353,6 +353,14 @@ class ScrollHelper {
 		//       |
 		//       +---- container bottom relative to context, e.g. 5000
 		//
+
+		// If we are rendering all available items, we don't need to hide any.
+		const howManyRendered = this.lastRenderedIndex - this.firstRenderedIndex + 1;
+		const itemsLength = this.props?.items?.length || 0;
+		if ( howManyRendered === itemsLength ) {
+			return false;
+		}
+
 		const placeholderTop = this.containerBottom - this.bottomPlaceholderHeight;
 		return placeholderTop > this.bottomHideLevelUltraSoft;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The InfiniteList component will now notice if it has rendered all available items and stop expanding its placeholders if everything is already rendered.
  * The intuitive view is that the "should I expand" logic is assuming the number of items rendered is always bigger than what can fit in the available area. Here I've added extra logic to say if we've already rendered all possible items, we don't need to expand the placeholders anymore.

#### Screenshots

Before:
![2021-11-17_15-12](https://user-images.githubusercontent.com/937354/142283270-252527d0-83c8-4cd5-817e-7ce4cfdb2474.png)


After:
![2021-11-17_15-11](https://user-images.githubusercontent.com/937354/142283146-193e57de-aad1-4066-8cd2-2a5e637acddf.png)

#### Testing instructions

* Calypso -> Users -> Click on a non-admin user -> click on "Attribute all content to another user" in the delete section -> The dropdown should no longer have extra padding with a small number of users. However, if there are a large number of users, it should continue to work as before.

* **The biggest thing here is to make sure that other instances of the InfiniteList component are not affected.**
  * Some help: I've created the `test/fake-infinite-list` branch which adds an infinite list with a variable number of items (in the delete user section)
![2021-11-17_15-23](https://user-images.githubusercontent.com/937354/142284678-4548edcd-04f3-4337-b728-c60411c937cf.png)
  * branch `test/fake-infinite-list` has the fake infinite list **without** the fix in this PR (#58203)
  * branch `test/fake-infinite-list-with-fix` has the same fake infinite list **with** the fix in this PR (#58202)
  * Comparing the two branches should show that the fix does not affect the normal usage of infinite lists
* The regular 'team' and 'followers' tabs on the users page are also created with infinite lists and should not be affected.
* Possible other places to look (reader stream?):
![2021-11-17_15-28](https://user-images.githubusercontent.com/937354/142285325-16850669-6e2b-4a27-b5b2-b4f0791ff65a.png)
* Unit tests should continue to work: `yarn run jest -c=test/client/jest.config.js client/components/infinite-list/test/scroll-helper.js`





Related to #32964
