### PR TITLE
Videos UI: Stop UI from bouncing when selecting a new video.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -220,7 +220,6 @@
 
 		.videos-ui__body {
 			max-width: 1160px;
-			margin: auto;
 
 			padding: 0 80px 80px;
 			h3 {


### PR DESCRIPTION
The video player and videos section has been bouncing whenever a user selects a new video. This PR stops that behaviour and restores the proper distance between the course title and the header section above it.

| Before | After |
| --- | --- |
| ![142241260-6b89b1ed-4f52-43ec-b341-b7366e03e3ad](https://user-images.githubusercontent.com/349751/142285856-4040b9fa-ffe4-401c-a0a4-ff273a9c724f.gif) | ![2021-11-17 13 32 54](https://user-images.githubusercontent.com/349751/142285929-4fdc2eb3-61a0-42b6-8adb-9ccef9572b6a.gif) |

Fixes https://github.com/Automattic/wp-calypso/issues/58182. 