### PR TITLE
Update GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest an idea for this project!
+description: Suggest an idea for Calypso!
 title: "Feature Request:"
 labels: ["[Type] Feature Request"]
 body:
@@ -7,7 +7,8 @@ body:
     attributes:
       value: |
         Please, be as descriptive as possible. Issues lacking detail, or for any other reason than to request a feature, may be closed without action.
-  - type: input
+
+  - type: textarea
     id: what
     attributes:
       label: What

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -95,38 +95,6 @@ body:
 
         <br>
   - type: dropdown
-    id: os
-    attributes:
-      label: Operating System
-      description: (You may select more than one)
-      options:
-        - Windows
-        - macOS
-        - Linux
-        - Android
-        - iOS
-      multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-  - type: dropdown
-    id: browser
-    attributes:
-      label: Browser
-      description: (You may select more than one)
-      options:
-        - Google Chrome/Chromium
-        - Mozilla Firefox
-        - Microsoft Edge
-        - Microsoft Edge (legacy)
-        - Apple Safari
-      multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-  - type: dropdown
     id: site-type
     attributes:
       label: Simple, Atomic or both?

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -85,13 +85,9 @@ body:
 
         <br>
 
-        ### Additional context
+        # Additional context
 
-        Please provide whatever additional information you have available to you. If not, please scroll to the bottom and submit the issue.
-
-        <br>
-
-        ---
+        Please provide whatever additional context/information you have available to you in this section.
 
         <br>
   - type: dropdown
@@ -112,7 +108,7 @@ body:
     attributes:
       label: Theme-specific issue?
       placeholder: |
-        If yes, what is the theme name?
+        If so, add the affected theme name(s) here.
   - type: markdown
     attributes:
       value: |
@@ -120,9 +116,9 @@ body:
   - type: textarea
     id: other_notes
     attributes:
-      label: Other notes
+      label: Browser, operating system and other notes
       placeholder: |
-        e.g. Logs, CLI or console errors, notes, observations, etc.
+        Note the affected browser(s), operating system(s), console errors, notes, observations, Logs, CLI, etc, here.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -84,12 +84,6 @@ body:
         ---
 
         <br>
-
-        # Additional context
-
-        Please provide whatever additional context/information you have available to you in this section.
-
-        <br>
   - type: dropdown
     id: site-type
     attributes:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the templates used for Feature Request and Happiness Bug Reports.

Key changes:
- remove OS and Browser fields from bug report. Context for this change is in p1636785020259600-slack-C01UW7SB411 and in discussions the Quality Squad held as part of team meeting.
- change input for textarea in Feature Request.

#### Testing instructions

Check the forms.

- [ ] Feature Request https://github.com/Automattic/wp-calypso/blob/update/issue-templates/.github/ISSUE_TEMPLATE/feature_request.yml
- [ ] Happiness Bug Report https://github.com/Automattic/wp-calypso/blob/update/issue-templates/.github/ISSUE_TEMPLATE/happiness-bug-report.yml