### PR TITLE
Fix React prop warnings due to typo in DesignPickerStep

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -314,7 +314,7 @@ export default function DesignPickerStep( props ) {
 	);
 }
 
-DesignPicker.propTypes = {
+DesignPickerStep.propTypes = {
 	goToNextStep: PropTypes.func.isRequired,
 	signupDependencies: PropTypes.object.isRequired,
 	stepName: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Typo in #57986 when I converted `<DesignPickerStep>` to a functional component introduced a bunch of React prop warnings in the console.

<img width="1817" alt="Screenshot 2021-11-18 at 1 26 29 PM" src="https://user-images.githubusercontent.com/1500769/142314273-436805a6-ea28-4d66-b260-5b7601d1114c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nav to design picker step
* There should be no warnings about `<DesignPicker>` missing some required props

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
