### PR TITLE
Expand supported browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"evergreen": [
 			"last 2 Chrome versions",
 			"last 1 ChromeAndroid versions",
-			"last 2 Firefox versions",
+			"Firefox >= 73",
 			"last 2 Safari versions",
 			"last 3 iOS versions",
 			"last 2 Edge versions",


### PR DESCRIPTION
### Changes proposed in this Pull Request
This is an experiment to see how the bundlesize changes with a larger range of supported browsers.

There is no real method to my approach, other than roughly checking https://caniuse.com/usage-table to see if any versions a few years back still have several users. 

Another approach would be check which versions start supporting things like const and async