### PR TITLE
Design Picker: Fix type annotation for locale info in `useTranslate()` hook, which fixes text wrapping logic in design picker

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -72,7 +72,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 			<CalypsoShoppingCartProvider>
 				<StripeHookProvider
 					fetchStripeConfiguration={ getStripeConfiguration }
-					locale={ translate.locale }
+					locale={ translate.localeSlug }
 				>
 					<CompositeCheckout
 						redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -165,7 +165,7 @@ export default function DesignPickerStep( props ) {
 			<DesignPicker
 				designs={ designs }
 				theme={ props.isReskinned ? 'light' : 'dark' }
-				locale={ translate.locale }
+				locale={ translate.localeSlug }
 				onSelect={ pickDesign }
 				onPreview={ previewDesign }
 				className={ classnames( {
@@ -191,7 +191,7 @@ export default function DesignPickerStep( props ) {
 			hideExternalPreview,
 		} = props;
 
-		const previewUrl = getDesignUrl( selectedDesign, translate.locale, {
+		const previewUrl = getDesignUrl( selectedDesign, translate.localeSlug, {
 			iframe: true,
 			// If the user fills out the site title with write intent, we show it on the design preview
 			// Otherwise, use the title of selected design directly
@@ -237,7 +237,7 @@ export default function DesignPickerStep( props ) {
 
 		const text = translate( 'Choose a starting theme. You can change it later.' );
 
-		if ( englishLocales.includes( translate.locale ) ) {
+		if ( englishLocales.includes( translate.localeSlug ) ) {
 			// An English only trick so the line wraps between sentences.
 			return text
 				.replace( /\s/g, '\xa0' ) // Replace all spaces with non-breaking spaces

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -98,7 +98,7 @@ declare namespace i18nCalypso {
 
 	export function localize< C >( component: C ): LocalizedComponent< C >;
 
-	export function useTranslate(): typeof translate & { locale: string | undefined };
+	export function useTranslate(): typeof translate & { localeSlug: string | undefined };
 
 	export function reRenderTranslations(): void;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

The type info for the `useTranslate()` hook is incorrect. The type info implies that the `translate` function has a `.locale` property that can be used to access the current locale slug. However from reading the implementation you can see the prop is actually named `.localeSlug`. This is the underlying reason for why the special text wrapping code we use for English users in the design picker wasn't working, because we couldn't tell whether it was an English speaking user or not.
https://github.com/Automattic/wp-calypso/blob/4409e289226d0acb1a6a0f07ec431d1ea4afee4e/packages/i18n-calypso/src/use-translate.js#L6

This PR
* Fixes the type annotation for `useTranslate()` in `i18n-calypso`
* Updates `<DesignPickerStep>` so it's using the correct locale slug property
* Updates `<EditorCheckoutModal>` so it's using the correct locale slug property

FYI @sirbrillig @Automattic/shilling the only other place I could find that uses the `.locale` property from `useTranslate()` was in `<EditorCheckoutModal>`.
https://github.com/Automattic/wp-calypso/blob/4409e289226d0acb1a6a0f07ec431d1ea4afee4e/client/blocks/editor-checkout-modal/index.tsx#L75
~~I was too nervous to update it in this PR because I'm not sure how to test it.~~

**Before**

<img width="1147" alt="Screenshot 2021-11-18 at 2 00 16 PM" src="https://user-images.githubusercontent.com/1500769/142331885-cac11ca7-94d6-4197-9828-a50a92ddcfc0.png">


**After**
<img width="1147" alt="Screenshot 2021-11-18 at 1 59 09 PM" src="https://user-images.githubusercontent.com/1500769/142331822-6cf6ee83-bbe9-4e0b-b147-5c9dab916019.png">


### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test the design picker
* go through the hero flow to create a site (start from `/start` and use an `en` user)
* choose to select a design
* see that the design picker text wraps at the sentence breaks like we expect
* Use these directions to test the editor checkout modal https://github.com/Automattic/wp-calypso/pull/58219#issuecomment-972400265

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
