### PR TITLE
Hack to fix the glitch that appears on some design picker thumbnails

### DIFF
--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -36,7 +36,7 @@ export const mShotOptions = ( { preview }: Design, highRes: boolean ): MShotsOpt
 		vpw: 1600,
 		vph: preview === 'static' ? 1040 : 1600,
 		// When `w` was 1200 it created a visual glitch on one thumbnail. #57261
-		w: highRes ? 1201 : 600,
+		w: highRes ? 1199 : 600,
 		screen_height: 3600,
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reported in p1637195778492000-slack-C029SB8JT8S, the Russell thumbnail in the design picker has a black border on the right-hand.

<img width="608" alt="Screen Shot 2021-11-18 at 10 35 32 am" src="https://user-images.githubusercontent.com/1500769/142355788-ddb55cca-7010-4c77-b40e-aa857d5911ba.png">


We've run into this issue before in #57261 where Paxton had the same problem.

We fixed the issue in #57261 by tweaking the thumbnail size to something that wouldn't create the glitch. This PR finds a different random number to fix the glitch.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through onboarding and confirm that none of the thumbnails in the design picker have the glitch with the black border on the right hand side
* Especially confirm that we haven't reintroduced the glitch for Paxton
* Test `/start/do-it-for-me` and confirm that none of those thumbnails have the glitch either.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
