### PR TITLE
chore: Clean up babel names

### DIFF
--- a/packages/calypso-babel-config/config.js
+++ b/packages/calypso-babel-config/config.js
@@ -1,6 +1,8 @@
 module.exports = ( { isBrowser = true, outputPOT = 'build' } = {} ) => ( {
 	presets: [ [ require.resolve( './presets/default' ), { bugfixes: true } ] ],
-	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: true, ignore: ! isBrowser } ] ],
+	plugins: [
+		[ '@automattic/babel-plugin-transform-wpcalypso-async', { async: true, ignore: ! isBrowser } ],
+	],
 	env: {
 		production: {
 			plugins: [ 'babel-plugin-transform-react-remove-prop-types' ],
@@ -20,7 +22,7 @@ module.exports = ( { isBrowser = true, outputPOT = 'build' } = {} ) => ( {
 			],
 		},
 		test: {
-			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
+			presets: [ [ '@babel/preset-env', { targets: { node: 'current' } } ] ],
 			plugins: [ 'babel-plugin-dynamic-import-node' ],
 		},
 	},

--- a/packages/calypso-babel-config/presets/dependencies.js
+++ b/packages/calypso-babel-config/presets/dependencies.js
@@ -3,7 +3,7 @@ module.exports = () => ( {
 	sourceType: 'unambiguous',
 	presets: [
 		[
-			'@babel/env',
+			'@babel/preset-env',
 			{
 				modules: false,
 				useBuiltIns: 'entry',

--- a/packages/wpcom.js/babel.config.js
+++ b/packages/wpcom.js/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	presets: [
 		[
-			'@babel/env',
+			'@babel/preset-env',
 			{
 				useBuiltIns: 'usage',
 				corejs: 2,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Babel supports a short name (eg: `@babel/env`) that [gets normalized](https://babeljs.io/docs/en/options#name-normalization) to the full name (`@babel/preset-env`)

However, using the short name makes it harder to find where a plugin is used, as you have to remeber to search for `@automattic/babel-plugin-foo` and `@automattic/foo`.

This PR changes the names in our config to use the fill name (i.e. add `babel-preset-` or `babel-plugin-`  as required)

