### PR TITLE
`QueryFeedSearch`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-reader-feeds-search/index.jsx
+++ b/client/components/data/query-reader-feeds-search/index.jsx
@@ -1,38 +1,26 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import {
 	requestFeedSearch,
 	SORT_BY_LAST_UPDATED,
 	SORT_BY_RELEVANCE,
 } from 'calypso/state/reader/feed-searches/actions';
 
-class QueryFeedSearch extends Component {
-	static propTypes = {
-		query: PropTypes.string,
-		excludeFollowed: PropTypes.bool,
-		sort: PropTypes.oneOf( [ SORT_BY_LAST_UPDATED, SORT_BY_RELEVANCE ] ),
-	};
+function QueryFeedSearch( { query, excludeFollowed, sort } ) {
+	const dispatch = useDispatch();
 
-	UNSAFE_componentWillMount() {
-		this.props.requestFeedSearch( {
-			query: this.props.query,
-			excludeFollowed: this.props.excludeFollowed,
-			sort: this.props.sort,
-		} );
-	}
+	useEffect( () => {
+		dispatch( requestFeedSearch( { query, excludeFollowed, sort } ) );
+	}, [ dispatch, query, excludeFollowed, sort ] );
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		nextProps.requestFeedSearch( {
-			query: nextProps.query,
-			excludeFollowed: nextProps.excludeFollowed,
-			sort: nextProps.sort,
-		} );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect( null, { requestFeedSearch } )( QueryFeedSearch );
+QueryFeedSearch.propTypes = {
+	query: PropTypes.string,
+	excludeFollowed: PropTypes.bool,
+	sort: PropTypes.oneOf( [ SORT_BY_LAST_UPDATED, SORT_BY_RELEVANCE ] ),
+};
+
+export default QueryFeedSearch;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryFeedSearch`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/read` and hit _Search_ in the top left
* Perform a search; you should see requests to `/read/feed` (in the Network tab filtering for `/read/feed?` hides other requests which aren't relevant)
* To the right, below _Sites_ you should see a list of sites
* If you change the order or scroll down you should see requests according to your actions
