### PR TITLE
Fix how connecting a domain works with domains that already point to us

### DIFF
--- a/client/components/domains/use-my-domain/utilities/connect-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/connect-domain-action.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import page from 'page';
+import { stepSlug } from 'calypso/components/domains/connect-domain-step/constants';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList, domainMappingSetup } from 'calypso/my-sites/domains/paths';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -26,7 +27,7 @@ export const connectDomainAction = (
 				domain,
 				...verificationData,
 			} )
-			.then( () => {
+			.then( ( result ) => {
 				dispatch(
 					successNotice(
 						__( 'Domain connected! Please make sure to follow the next steps below.' ),
@@ -36,7 +37,8 @@ export const connectDomainAction = (
 						}
 					)
 				);
-				page( domainMappingSetup( selectedSite.slug, domain ) );
+				const step = result.points_to_wpcom ? stepSlug.SUGGESTED_CONNECTED : '';
+				page( domainMappingSetup( selectedSite.slug, domain, step ) );
 			} )
 			.catch( ( error ) => {
 				if ( 'ownership_verification_failed' !== error.error ) {


### PR DESCRIPTION
When you're connecting a domain to wordpress.com that is already pointed to us (usually happens for subdomains of domains purchased with us) we still guide you through the domain connection steps flow which is unnecessary. Let's just skip directly to the CONNECTED step.

Me and @gius80 worked on this together and he'll take over for some TypeScript goodness :)

#### Changes proposed in this Pull Request

* Skip to the `SUGGESTED_CONNECTED` step when you connect a domain that's already pointing to wordpress.com

#### Testing instructions

* Apply D70281-code on your sandbox
* Try to map a domain that is already using the wordpress.com name servers - make sure that you're sent directly to the last step of the connect a domain flow
* If you're mapping a domain that's not pointing to us you should land on the regular connect a domain flow

Related to #55996
