### PR TITLE
Hero Flow: Integrate video courses

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -395,7 +395,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'setup-site',
-			steps: [ 'intent', 'site-options', 'starting-point', 'design-setup-site' ],
+			steps: [ 'intent', 'site-options', 'starting-point', 'courses', 'design-setup-site' ],
 			destination: getDestinationFromIntent,
 			description:
 				'Sets up a site that has already been created and paid for (if purchases were made)',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -7,6 +7,7 @@ const stepNameToModuleName = {
 	'clone-jetpack': 'clone-jetpack',
 	'clone-ready': 'clone-ready',
 	'clone-cloning': 'clone-cloning',
+	courses: 'courses',
 	'creds-confirm': 'creds-confirm',
 	'creds-complete': 'creds-complete',
 	'creds-permission': 'creds-permission',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -766,6 +766,9 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem', 'typeformResponseId' ],
 			apiRequestFunction: addPlanToCart,
 		},
+		courses: {
+			stepName: 'courses',
+		},
 
 		// ↓ importer steps
 		list: {

--- a/client/signup/icons/index.tsx
+++ b/client/signup/icons/index.tsx
@@ -54,6 +54,12 @@ export const write: ReactElement = (
 	</SVG>
 );
 
+export const play: ReactElement = (
+	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M5 3L19 12L5 21V3Z" stroke="#8C8F94" strokeWidth="1.6" strokeLinecap="round" />
+	</SVG>
+);
+
 export const design: ReactElement = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Path

--- a/client/signup/select-items/index.tsx
+++ b/client/signup/select-items/index.tsx
@@ -12,6 +12,7 @@ export interface SelectItem< T > {
 	icon: React.ReactElement;
 	value: T;
 	actionText: TranslateResult;
+	disabled?: boolean;
 }
 
 interface Props< T > {

--- a/client/signup/select-items/index.tsx
+++ b/client/signup/select-items/index.tsx
@@ -12,7 +12,7 @@ export interface SelectItem< T > {
 	icon: React.ReactElement;
 	value: T;
 	actionText: TranslateResult;
-	disabled?: boolean;
+	hidden?: boolean;
 }
 
 interface Props< T > {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -28,6 +28,8 @@ class StepWrapper extends Component {
 		isLargeSkipLayout: PropTypes.bool,
 		isExternalBackUrl: PropTypes.bool,
 		headerButton: PropTypes.node,
+		isWideLayout: PropTypes.bool,
+		isFullLayout: PropTypes.bool,
 		isHorizontalLayout: PropTypes.bool,
 		queryParams: PropTypes.object,
 	};
@@ -166,6 +168,7 @@ class StepWrapper extends Component {
 			hideNext,
 			isLargeSkipLayout,
 			isWideLayout,
+			isFullLayout,
 			skipButtonAlign,
 			align,
 			headerImageUrl,
@@ -182,6 +185,7 @@ class StepWrapper extends Component {
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-horizontal-layout': isHorizontalLayout,
 			'is-wide-layout': isWideLayout,
+			'is-full-layout': isFullLayout,
 			'is-large-skip-layout': isLargeSkipLayout,
 			'has-navigation': hasNavigation,
 		} );

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -55,7 +55,7 @@
 
 	@mixin unstick {
 		position: absolute;
-		top: 2px;
+		top: 1px;
 		left: 11px;
 		right: 16px;
 		padding: 0;
@@ -118,6 +118,11 @@
 	// width column.
 	&.is-wide-layout {
 		max-width: 1040px;
+	}
+
+	// Some steps (like courses) have their width limitation
+	&.is-full-layout {
+		max-width: unset;
 	}
 
 	// Some steps (intent gathering) use a horizontal layout

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -77,11 +77,17 @@
 
 	.step-wrapper__navigation-link {
 		font-size: 0.875rem;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 
 		&.button.is-primary {
-			border-radius: 4px; /* stylelint-disable-line scales/radii */
+			border-radius: 4px;
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
+
+			.signup__step.is-courses & {
+				color: #101517;
+				background-color: #ffffff;
+				border-color: transparent;
+			}
 		}
 
 		&.has-underline {

--- a/client/signup/steps/courses/footer.tsx
+++ b/client/signup/steps/courses/footer.tsx
@@ -1,0 +1,5 @@
+const Footer = () => {
+	return null;
+};
+
+export default Footer;

--- a/client/signup/steps/courses/footer.tsx
+++ b/client/signup/steps/courses/footer.tsx
@@ -1,5 +1,31 @@
-const Footer = () => {
-	return null;
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+
+interface Props {
+	isCourseComplete?: boolean;
+	onStartWriting: () => void;
+}
+
+const CoursesFooter: React.FC< Props > = ( { isCourseComplete, onStartWriting } ) => {
+	const translate = useTranslate();
+
+	if ( ! isCourseComplete ) {
+		return null;
+	}
+
+	return (
+		<div className="courses__footer">
+			<div className="courses__footer-content">
+				{ translate(
+					"You did it! Now it's time to put your skills to work and draft your first post."
+				) }
+				<Button className="courses__footer-button" onClick={ onStartWriting }>
+					{ translate( 'Start writing' ) }
+				</Button>
+			</div>
+		</div>
+	);
 };
 
-export default Footer;
+export default CoursesFooter;

--- a/client/signup/steps/courses/header.tsx
+++ b/client/signup/steps/courses/header.tsx
@@ -1,0 +1,10 @@
+import WordPressLogo from 'calypso/components/wordpress-logo';
+import type { ReactElement } from 'react';
+
+const CoursesHeader = (): ReactElement => (
+	<div className="courses__header">
+		<WordPressLogo size={ 24 } className="courses__header-logo" />
+	</div>
+);
+
+export default CoursesHeader;

--- a/client/signup/steps/courses/index.tsx
+++ b/client/signup/steps/courses/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import VideosUi from 'calypso/components/videos-ui';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
+import Footer from './footer';
 import './style.scss';
 
 interface Props {
@@ -23,7 +24,7 @@ export default function CoursesStep( props: Props ): React.ReactNode {
 		<StepWrapper
 			className="courses"
 			hideFormattedHeader
-			stepContent={ <VideosUi /> }
+			stepContent={ <VideosUi headerBar={ null } footerBar={ <Footer /> } /> }
 			skipLabelText={ translate( 'Draft your first post' ) }
 			skipButtonAlign="top"
 			{ ...props }

--- a/client/signup/steps/courses/index.tsx
+++ b/client/signup/steps/courses/index.tsx
@@ -1,0 +1,32 @@
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import VideosUi from 'calypso/components/videos-ui';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { saveSignupStep } from 'calypso/state/signup/progress/actions';
+import './style.scss';
+
+interface Props {
+	stepName: string;
+}
+
+export default function CoursesStep( props: Props ): React.ReactNode {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const { stepName } = props;
+
+	React.useEffect( () => {
+		dispatch( saveSignupStep( { stepName } ) );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	return (
+		<StepWrapper
+			className="courses"
+			hideFormattedHeader
+			stepContent={ <VideosUi /> }
+			skipLabelText={ translate( 'Draft your first post' ) }
+			skipButtonAlign="top"
+			{ ...props }
+		/>
+	);
+}

--- a/client/signup/steps/courses/index.tsx
+++ b/client/signup/steps/courses/index.tsx
@@ -4,7 +4,8 @@ import { useDispatch } from 'react-redux';
 import VideosUi from 'calypso/components/videos-ui';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
-import Footer from './footer';
+import CoursesFooter from './footer';
+import CoursesHeader from './header';
 import './style.scss';
 
 interface Props {
@@ -23,8 +24,9 @@ export default function CoursesStep( props: Props ): React.ReactNode {
 	return (
 		<StepWrapper
 			className="courses"
+			isFullLayout
 			hideFormattedHeader
-			stepContent={ <VideosUi headerBar={ null } footerBar={ <Footer /> } /> }
+			stepContent={ <VideosUi headerBar={ <CoursesHeader /> } footerBar={ <CoursesFooter /> } /> }
 			skipLabelText={ translate( 'Draft your first post' ) }
 			skipButtonAlign="top"
 			{ ...props }

--- a/client/signup/steps/courses/index.tsx
+++ b/client/signup/steps/courses/index.tsx
@@ -1,21 +1,33 @@
+import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import VideosUi from 'calypso/components/videos-ui';
+import { COURSE_SLUGS, useCourseData } from 'calypso/data/courses';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { saveSignupStep } from 'calypso/state/signup/progress/actions';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import CoursesFooter from './footer';
 import CoursesHeader from './header';
 import './style.scss';
 
 interface Props {
 	stepName: string;
+	goToNextStep: () => void;
 }
 
 export default function CoursesStep( props: Props ): React.ReactNode {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const { stepName } = props;
+	const { stepName, goToNextStep } = props;
+	const isMobile = useViewportMatch( 'small', '<' );
+	const courseSlug = COURSE_SLUGS.BLOGGING_QUICK_START;
+	const { isCourseComplete } = useCourseData( courseSlug );
+	const hideSkip = isMobile && isCourseComplete;
+
+	const onStartWriting = () => {
+		dispatch( submitSignupStep( { stepName } ) );
+		goToNextStep();
+	};
 
 	React.useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
@@ -26,9 +38,23 @@ export default function CoursesStep( props: Props ): React.ReactNode {
 			className="courses"
 			isFullLayout
 			hideFormattedHeader
-			stepContent={ <VideosUi headerBar={ <CoursesHeader /> } footerBar={ <CoursesFooter /> } /> }
+			stepContent={
+				<VideosUi
+					courseSlug={ courseSlug }
+					HeaderBar={ CoursesHeader }
+					FooterBar={ () => (
+						<CoursesFooter
+							isCourseComplete={ isCourseComplete }
+							onStartWriting={ onStartWriting }
+						/>
+					) }
+				/>
+			}
+			hideSkip={ hideSkip }
+			hideNext={ ! hideSkip }
 			skipLabelText={ translate( 'Draft your first post' ) }
 			skipButtonAlign="top"
+			nextLabelText={ translate( 'Start writing' ) }
 			{ ...props }
 		/>
 	);

--- a/client/signup/steps/courses/style.scss
+++ b/client/signup/steps/courses/style.scss
@@ -2,7 +2,8 @@
 @import '@wordpress/base-styles/_mixins.scss';
 
 .courses {
-	&:before {
+	// Not good but this way can easily change the background color for courses step
+	&::before {
 		content: '';
 		position: fixed;
 		left: 0;
@@ -12,7 +13,7 @@
 		background-color: #101517;
 	}
 
-	&__header {
+	.courses__header {
 		position: absolute;
 		top: -60px;
 		left: 0;
@@ -55,6 +56,48 @@
 	.videos-ui {
 		position: relative;
 		width: 100%;
+		min-height: calc( 100vh - 60px );
 		margin-top: 12px;
+	}
+
+	.courses__footer {
+		display: none;
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		padding: 0 20px;
+		box-shadow: 0 -1px 0 #2c3234;
+		background-color: #101517;
+		animation: appear 0.3s ease-in-out;
+		@include reduce-motion( 'animation' );
+
+		.courses__footer-content {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			width: 100%;
+			height: 72px;
+			max-width: 1160px;
+			margin: 0 auto;
+		}
+
+		.courses__footer-button {
+			flex-shrink: 0;
+			margin-left: 20px;
+			border-radius: 4px;
+			border-color: transparent;
+			color: #101517;
+			font-weight: 500;
+			transition: opacity 0.2s ease-out;
+
+			&:hover {
+				opacity: 0.9;
+			}
+		}
+
+		@include break-small {
+			display: block;
+		}
 	}
 }

--- a/client/signup/steps/courses/style.scss
+++ b/client/signup/steps/courses/style.scss
@@ -1,0 +1,23 @@
+.courses {
+	.action-buttons {
+		border: 0;
+		box-shadow: 0 -1px 0 #2c3234;
+		background-color: #101517;
+
+		.button.navigation-link.is-borderless {
+			color: #fff !important;
+		}
+
+		.button.navigation-link.is-borderless svg {
+			fill: #fff !important;
+		}
+	}
+
+	.videos-ui {
+		position: fixed;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 0;
+	}
+}

--- a/client/signup/steps/courses/style.scss
+++ b/client/signup/steps/courses/style.scss
@@ -1,4 +1,39 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 .courses {
+	&:before {
+		content: '';
+		position: fixed;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 0;
+		background-color: #101517;
+	}
+
+	&__header {
+		position: absolute;
+		top: -60px;
+		left: 0;
+		right: 0;
+		height: 60px;
+		display: flex;
+		align-items: center;
+		padding: 0 20px;
+		background-color: #151b1e;
+
+		.courses__header-logo {
+			margin-top: 4px;
+			fill: #fff;
+			stroke: #fff;
+		}
+
+		@include break-small {
+			padding: 0 24px;
+		}
+	}
+
 	.action-buttons {
 		border: 0;
 		box-shadow: 0 -1px 0 #2c3234;
@@ -6,18 +41,20 @@
 
 		.button.navigation-link.is-borderless {
 			color: #fff !important;
+
+			svg {
+				fill: #fff !important;
+			}
 		}
 
-		.button.navigation-link.is-borderless svg {
-			fill: #fff !important;
+		@include break-small {
+			box-shadow: none;
 		}
 	}
 
 	.videos-ui {
-		position: fixed;
-		left: 0;
-		right: 0;
-		top: 0;
-		bottom: 0;
+		position: relative;
+		width: 100%;
+		margin-top: 12px;
 	}
 }

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -26,7 +26,7 @@ interface Props {
 
 const EXCLUDE_STEPS: { [ key: string ]: string[] } = {
 	write: [],
-	build: [ 'site-options', 'starting-point' ],
+	build: [ 'site-options', 'starting-point', 'courses' ],
 };
 
 const EXTERNAL_FLOW: { [ key: string ]: string } = {

--- a/client/signup/steps/starting-point/index.tsx
+++ b/client/signup/steps/starting-point/index.tsx
@@ -17,11 +17,11 @@ interface Props {
 	initialContext: any;
 }
 
-// TODO: Adding take the masterclass
 const EXCLUDE_STEPS: { [ key in StartingPointFlag ]: string[] } = {
-	write: [ 'design-setup-site' ],
-	design: [],
-	'skip-to-my-home': [ 'design-setup-site' ],
+	write: [ 'courses', 'design-setup-site' ],
+	courses: [ 'design-setup-site' ],
+	design: [ 'courses' ],
+	'skip-to-my-home': [ 'courses', 'design-setup-site' ],
 };
 
 export default function StartingPointStep( props: Props ): React.ReactNode {

--- a/client/signup/steps/starting-point/starting-point.tsx
+++ b/client/signup/steps/starting-point/starting-point.tsx
@@ -1,6 +1,8 @@
-import { localize, LocalizeProps } from 'i18n-calypso';
+import { isEnabled } from '@automattic/calypso-config';
+import { englishLocales } from '@automattic/i18n-utils';
+import { localize, LocalizeProps, getLocaleSlug } from 'i18n-calypso';
 import React from 'react';
-import { write, design } from '../../icons';
+import { write, play, design } from '../../icons';
 import SelectItems, { SelectItem } from '../../select-items';
 import type { StartingPointFlag } from './types';
 
@@ -22,6 +24,17 @@ const useStartingPoints = ( { translate }: Pick< Props, 'translate' > ): Startin
 			actionText: translate( 'Start writing' ),
 		},
 		{
+			key: 'courses',
+			title: translate( 'Take the Masterclass' ),
+			description: translate( ' Learn the blogging basics in minutes ' ),
+			icon: play,
+			value: 'courses',
+			actionText: translate( 'Start learning' ),
+			disabled: ! (
+				isEnabled( 'signup/starting-point-courses' ) && englishLocales.includes( getLocaleSlug() )
+			),
+		},
+		{
 			key: 'design',
 			title: translate( 'Choose a design' ),
 			description: translate( 'Make your blog feel like home' ),
@@ -35,7 +48,12 @@ const useStartingPoints = ( { translate }: Pick< Props, 'translate' > ): Startin
 const StartingPoint: React.FC< Props > = ( { onSelect, translate } ) => {
 	const startingPoints = useStartingPoints( { translate } );
 
-	return <SelectItems items={ startingPoints } onSelect={ onSelect } />;
+	return (
+		<SelectItems
+			items={ startingPoints.filter( ( { disabled } ) => ! disabled ) }
+			onSelect={ onSelect }
+		/>
+	);
 };
 
 export default localize( StartingPoint );

--- a/client/signup/steps/starting-point/starting-point.tsx
+++ b/client/signup/steps/starting-point/starting-point.tsx
@@ -1,6 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { englishLocales } from '@automattic/i18n-utils';
-import { localize, LocalizeProps, getLocaleSlug } from 'i18n-calypso';
+import { localize, LocalizeProps } from 'i18n-calypso';
 import React from 'react';
 import { write, play, design } from '../../icons';
 import SelectItems, { SelectItem } from '../../select-items';
@@ -30,9 +29,7 @@ const useStartingPoints = ( { translate }: Pick< Props, 'translate' > ): Startin
 			icon: play,
 			value: 'courses',
 			actionText: translate( 'Start learning' ),
-			disabled: ! (
-				isEnabled( 'signup/starting-point-courses' ) && englishLocales.includes( getLocaleSlug() )
-			),
+			disabled: ! isEnabled( 'signup/starting-point-courses' ),
 		},
 		{
 			key: 'design',

--- a/client/signup/steps/starting-point/starting-point.tsx
+++ b/client/signup/steps/starting-point/starting-point.tsx
@@ -25,7 +25,7 @@ const useStartingPoints = ( { translate }: Pick< Props, 'translate' > ): Startin
 		},
 		{
 			key: 'courses',
-			title: translate( 'Take the Masterclass' ),
+			title: translate( 'Watch Blogging videos' ),
 			description: translate( ' Learn the blogging basics in minutes ' ),
 			icon: play,
 			value: 'courses',

--- a/client/signup/steps/starting-point/starting-point.tsx
+++ b/client/signup/steps/starting-point/starting-point.tsx
@@ -29,7 +29,7 @@ const useStartingPoints = ( { translate }: Pick< Props, 'translate' > ): Startin
 			icon: play,
 			value: 'courses',
 			actionText: translate( 'Start learning' ),
-			disabled: ! isEnabled( 'signup/starting-point-courses' ),
+			hidden: ! isEnabled( 'signup/starting-point-courses' ),
 		},
 		{
 			key: 'design',
@@ -47,7 +47,7 @@ const StartingPoint: React.FC< Props > = ( { onSelect, translate } ) => {
 
 	return (
 		<SelectItems
-			items={ startingPoints.filter( ( { disabled } ) => ! disabled ) }
+			items={ startingPoints.filter( ( { hidden } ) => ! hidden ) }
 			onSelect={ onSelect }
 		/>
 	);

--- a/client/signup/steps/starting-point/types.ts
+++ b/client/signup/steps/starting-point/types.ts
@@ -1,1 +1,1 @@
-export type StartingPointFlag = 'write' | 'design' | 'skip-to-my-home';
+export type StartingPointFlag = 'write' | 'courses' | 'design' | 'skip-to-my-home';

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -338,19 +338,30 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup-header {
 		.wordpress-logo {
 			position: absolute;
-			left: 24px;
+			left: 20px;
 			top: 20px;
 			fill: var( --color-text );
+			stroke: var( --color-text );
 			transform-origin: 0 0;
 		}
 		.signup-header__right {
 			top: 22px;
-			right: 24px;
+			right: 20px;
 
 			.flow-progress-indicator {
 				font-weight: 500; /* stylelint-disable-line */
 				font-size: 0.875rem;
 				color: var( --studio-gray-30 );
+			}
+		}
+
+		@include break-small {
+			.wordpress-logo {
+				left: 24px;
+			}
+
+			.signup-header__right {
+				right: 24px;
 			}
 		}
 	}
@@ -770,7 +781,8 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 
-	.signup__step.is-design-setup-site, .signup__step.is-difm-design-setup-site {
+	.signup__step.is-design-setup-site,
+	.signup__step.is-difm-design-setup-site {
 		.step-wrapper__header {
 			@include breakpoint-deprecated( '<660px' ) {
 				margin-left: 0;

--- a/config/development.json
+++ b/config/development.json
@@ -140,6 +140,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/hero-flow-non-en": true,
+		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,6 +92,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
+		"signup/starting-point-courses": false,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,

--- a/config/production.json
+++ b/config/production.json
@@ -97,6 +97,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
+		"signup/starting-point-courses": false,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -98,6 +98,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
+		"signup/starting-point-courses": false,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,7 +108,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/hero-flow-non-en": true,
-		"signup/starting-point-courses": false,
+		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,6 +108,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/hero-flow-non-en": true,
+		"signup/starting-point-courses": false,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `signup/starting-point-courses` to control showing “Take the masterclass” starting point or not and now is only for English user
* Add “Watching Blogging videos” into the list of the starting point
  ![image](https://user-images.githubusercontent.com/13596067/148170962-94159b87-ae73-49bd-be9b-103ceeee2f85.png)
* Integrate the video UI but keep the navigation bar of the signup framework.

Note that we should ensure the tracks event fired correctly in the Hero Flow.


**Desktop**

https://user-images.githubusercontent.com/13596067/144579365-7bf62f3f-3983-4507-b903-4265451d67de.mov

**Mobile**

https://user-images.githubusercontent.com/13596067/144579894-10dff7a3-320e-4b53-ba30-3482018c8fcc.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?siteSlug=<your_site>`
* Select write intent
* Fill out the site options
* Select “Take the masterclass” as starting point
* Check the following things:
  * Video UI show correctly.
  * The “Back” button works correctly
  * “Draft your post” button works correctly
  * The footer shows after you complete the courses. Clicking the “start writing” button makes you complete the flow and land on the editor  
  * Ensure the tracks event works correctly

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Related to #
Blogger Flow: Video UI branch from starting-point screen #58262
