### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` import site to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,6 +1,5 @@
 import debugFactory from 'debug';
 import { omit } from 'lodash';
-import { stringify } from 'qs';
 import readerContentWidth from 'calypso/reader/lib/content-width';
 import Me from './me';
 
@@ -474,24 +473,6 @@ Undocumented.prototype.updateImporter = function ( siteId, importerStatus ) {
 	return this.wpcom.req.post( {
 		path: `/sites/${ siteId }/imports/${ importerStatus.importerId }`,
 		formData: [ [ 'importStatus', JSON.stringify( importerStatus ) ] ],
-	} );
-};
-
-Undocumented.prototype.importWithSiteImporter = function (
-	siteId,
-	importerStatus,
-	params,
-	targetUrl
-) {
-	debug( `/sites/${ siteId }/site-importer/import-site?${ stringify( params ) }` );
-
-	return this.wpcom.req.post( {
-		path: `/sites/${ siteId }/site-importer/import-site?${ stringify( params ) }`,
-		apiNamespace: 'wpcom/v2',
-		formData: [
-			[ 'import_status', JSON.stringify( importerStatus ) ],
-			[ 'site_url', targetUrl ],
-		],
 	} );
 };
 

--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -130,9 +130,15 @@ export const importSite = ( {
 	dispatch( recordTracksEvent( 'calypso_site_importer_start_import_request', trackingParams ) );
 	dispatch( startSiteImporterImport() );
 
-	wpcom
-		.undocumented()
-		.importWithSiteImporter( siteId, toApi( importerStatus ), params, targetSiteUrl )
+	wpcom.req
+		.post( {
+			path: `/sites/${ siteId }/site-importer/import-site?${ stringify( params ) }`,
+			apiNamespace: 'wpcom/v2',
+			formData: [
+				[ 'import_status', JSON.stringify( toApi( importerStatus ) ) ],
+				[ 'site_url', targetSiteUrl ],
+			],
+		} )
 		.then( ( response ) => {
 			dispatch( recordTracksEvent( 'calypso_site_importer_start_import_success', trackingParams ) );
 			dispatch( siteImporterImportSuccessful( response ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` `importWithSiteImporter` method to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see p4TIVU-9KX-p2.

#### Testing instructions

* Go to `/import/:site` where `:site` is one of your WP.com simple sites.
* Choose "Wix".
* Input the URL of one of your Wix sites. If you don't have one, pick one from PCYsg-i88-p2.
* Start the import and verify it still works well.