### PR TITLE
Onboarding import: improvements list

### DIFF
--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -6,7 +6,14 @@ export function importSite( context, next ) {
 	const engine = context.query?.engine;
 	const fromSite = decodeURIComponentIfValid( context.query?.[ 'from-site' ] );
 
-	const afterStartImport = () => page.replace( context.pathname );
+	const afterStartImport = () => {
+		let path = context.pathname;
+
+		if ( fromSite ) {
+			path += '?from-site=' + fromSite;
+		}
+		page.replace( path );
+	};
 
 	context.primary = (
 		<SectionImport engine={ engine } fromSite={ fromSite } afterStartImport={ afterStartImport } />

--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import page from 'page';
+import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import SectionMigrate from 'calypso/my-sites/migrate/section-migrate';
 import { getSiteId } from 'calypso/state/sites/selectors';
 
@@ -16,8 +17,18 @@ export function migrateSite( context, next ) {
 		const sourceSiteId =
 			context.params.sourceSiteId &&
 			getSiteId( context.store.getState(), context.params.sourceSiteId );
+		const fromSite =
+			( context.query &&
+				context.query[ 'from-site' ] &&
+				decodeURIComponentIfValid( context.query[ 'from-site' ] ) ) ||
+			'';
+
 		context.primary = (
-			<SectionMigrate sourceSiteId={ sourceSiteId } step={ context.migrationStep } />
+			<SectionMigrate
+				sourceSiteId={ sourceSiteId }
+				step={ context.migrationStep }
+				url={ fromSite }
+			/>
 		);
 		return next();
 	}

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -55,6 +55,10 @@ class SectionMigrate extends Component {
 			return page( `/import/${ this.props.targetSiteSlug }` );
 		}
 
+		if ( this.props.url ) {
+			this.setMigrationState( { url: this.props.url } );
+		}
+
 		if ( true === this.props.startMigration ) {
 			this._startedMigrationFromCart = true;
 			this._timeStartedMigrationFromCart = new Date().getTime();

--- a/client/signup/steps/import/capture/index.tsx
+++ b/client/signup/steps/import/capture/index.tsx
@@ -1,6 +1,7 @@
 import { NextButton } from '@automattic/onboarding';
 import { Icon, chevronRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import * as React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { analyzeUrl, resetError } from 'calypso/state/imports/url-analyzer/actions';
@@ -60,12 +61,19 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 		isValid && urlValue && runProcess();
 	};
 
+	const showSubmitButton = isValid && urlValue && ! analyzerError;
+
 	return (
 		<>
 			{ ! isAnalyzing && (
 				<div className="import-layout__center">
 					<div className="capture__content">
-						<form className="capture__input-wrapper" onSubmit={ onFormSubmit.bind( this ) }>
+						<form
+							className={ classnames( 'capture__input-wrapper', {
+								'capture__input-wrapper-padding': showSubmitButton,
+							} ) }
+							onSubmit={ onFormSubmit.bind( this ) }
+						>
 							<input
 								className="capture__input"
 								// eslint-disable-next-line jsx-a11y/no-autofocus
@@ -77,7 +85,7 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 								onChange={ onInputChange }
 								value={ urlValue }
 							/>
-							{ isValid && urlValue && ! analyzerError && (
+							{ showSubmitButton && (
 								<NextButton type={ 'submit' }>
 									<Icon icon={ chevronRight } />
 								</NextButton>

--- a/client/signup/steps/import/capture/style.scss
+++ b/client/signup/steps/import/capture/style.scss
@@ -11,8 +11,7 @@ $placeholder-color: #909398;
 	.capture__input-wrapper {
 		position: relative;
 		margin: auto;
-		max-width: 450px;
-		padding-right: 50px;
+		max-width: 500px;
 
 		.components-button.action-buttons__next.is-primary {
 			position: absolute;
@@ -25,6 +24,11 @@ $placeholder-color: #909398;
 				top: 4px;
 			}
 		}
+	}
+
+	.capture__input-wrapper-padding {
+		max-width: 450px;
+		padding-right: 50px;
 	}
 
 	.capture__input {

--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -70,7 +70,7 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 	};
 
 	const goToImporterPage = ( platform: string ): void => {
-		const importerUrl = getImporterUrl( signupDependencies.siteSlug, platform );
+		const importerUrl = getImporterUrl( signupDependencies.siteSlug, platform, urlData.url );
 
 		importerUrl.includes( 'wp-admin' )
 			? ( window.location.href = importerUrl )

--- a/client/signup/steps/import/ready/index.tsx
+++ b/client/signup/steps/import/ready/index.tsx
@@ -179,7 +179,7 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 							sprintf(
 								/* translators: the website could be any domain (eg: "yourname.com") */
 								__(
-									'It looks like <strong>%(website)s</strong> is already on WordPress.com. Try a different address or start buidling a new site instead.'
+									'It looks like <strong>%(website)s</strong> is already on WordPress.com. Try a different address or start building a new site instead.'
 								),
 								{
 									website: convertToFriendlyWebsiteName( urlData.url ),

--- a/client/signup/steps/import/util.ts
+++ b/client/signup/steps/import/util.ts
@@ -52,12 +52,17 @@ export function getWpComMigrateUrl( siteSlug: string ): string {
 	return '/migrate/{siteSlug}'.replace( '{siteSlug}', siteSlug );
 }
 
-export function getWpComImporterUrl( siteSlug: string, platform: string ): string {
-	const wpComBase = '/import/{siteSlug}?engine={importer}';
+export function getWpComImporterUrl(
+	siteSlug: string,
+	platform: string,
+	fromSite?: string
+): string {
+	const wpComBase = '/import/{siteSlug}?engine={importer}&from-site={fromSite}';
 
 	return wpComBase
 		.replace( '{siteSlug}', siteSlug )
-		.replace( '{importer}', getPlatformImporterName( platform ) );
+		.replace( '{importer}', getPlatformImporterName( platform ) )
+		.replace( '{fromSite}', fromSite || '' );
 }
 
 export function getWpOrgImporterUrl( siteSlug: string, platform: string ): string {
@@ -68,12 +73,12 @@ export function getWpOrgImporterUrl( siteSlug: string, platform: string ): strin
 		.replace( '{importer}', getPlatformImporterName( platform ) );
 }
 
-export function getImporterUrl( siteSlug: string, platform: string ): string {
+export function getImporterUrl( siteSlug: string, platform: string, fromSite?: string ): string {
 	if ( platform === 'wordpress' ) {
 		return getWpComMigrateUrl( siteSlug );
 	} else if ( orgImporters.includes( platform ) ) {
 		return getWpOrgImporterUrl( siteSlug, platform );
 	}
 
-	return getWpComImporterUrl( siteSlug, platform );
+	return getWpComImporterUrl( siteSlug, platform, fromSite );
 }

--- a/client/signup/steps/import/util.ts
+++ b/client/signup/steps/import/util.ts
@@ -48,8 +48,10 @@ export function convertToFriendlyWebsiteName( website: string ): string {
 /**
  * Importer URL helpers
  */
-export function getWpComMigrateUrl( siteSlug: string ): string {
-	return '/migrate/{siteSlug}'.replace( '{siteSlug}', siteSlug );
+export function getWpComMigrateUrl( siteSlug: string, fromSite?: string ): string {
+	return '/migrate/{siteSlug}?from-site={fromSite}'
+		.replace( '{siteSlug}', siteSlug )
+		.replace( '{fromSite}', fromSite || '' );
 }
 
 export function getWpComImporterUrl(
@@ -75,7 +77,7 @@ export function getWpOrgImporterUrl( siteSlug: string, platform: string ): strin
 
 export function getImporterUrl( siteSlug: string, platform: string, fromSite?: string ): string {
 	if ( platform === 'wordpress' ) {
-		return getWpComMigrateUrl( siteSlug );
+		return getWpComMigrateUrl( siteSlug, fromSite );
 	} else if ( orgImporters.includes( platform ) ) {
 		return getWpOrgImporterUrl( siteSlug, platform );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Typo error fix
* UX improvement of Capture screen on the mobile device
* The entered URL is carried over between the onboarding flow and importer. Once the user decides to import site content, it's being redirected to the detected importer with prepopulated site URL.

#### Testing instructions

**UX Improvement**
* Change device mode to the `mobile`
* Go to `/start/importer?siteSlug=<SLUG>.wordpress.com`
* Check out input field size, it's fully stretched until you reach the valid URL and see the confirmation GO button

**Carry over entered URL**

1. Go to `/start/importer?siteSlug=<SLUG>.wordpress.com`
2. Enter `make.wordpress.org`
3. Click on the `Import your content` button
4. Check out the prepopulated input field the value from step 2

#### Screenshots
<table border="0">
<tr>
<td>
<img width="400" alt="Screenshot 2021-11-19 at 11 54 58" src="https://user-images.githubusercontent.com/1241413/142634391-c9dc5f36-c4cb-4761-9a74-35ebbbb2d6fb.png">
</td>
<td>
<img width="376" alt="Screenshot 2021-11-19 at 14 57 49" src="https://user-images.githubusercontent.com/1241413/142634412-982b77b0-ac46-4253-9188-fc52b2679ae9.png">
</td>
</tr>
</table>

<img width="762" alt="Screenshot 2021-11-19 at 15 05 01" src="https://user-images.githubusercontent.com/1241413/142635551-c7206fbe-8964-4955-84dc-7f903c06ecc5.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: #57131, #58160
