### PR TITLE
Added warning message to export library card

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -35,6 +35,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/export/',
 		post_id: 2087,
 	},
+	'export-media-library': {
+		link: 'https://wordpress.com/support/export/#exporting-the-media-library',
+		post_id: 2087,
+	},
 	'getting-started-video': {
 		link:
 			'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com',

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -56,6 +56,11 @@ class ExportMediaCard extends Component {
 											'Download all the media library files (images, videos, audio and documents) from your site.'
 										) }
 									</h2>
+									<h2 className="export-media-card__warning">
+										{ translate(
+											'Depending on your media library size and/or connection speed you might need to use a download manager.'
+										) }
+									</h2>
 								</div>
 							}
 							summary={ exportMediaButton }

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -59,7 +59,7 @@ class ExportMediaCard extends Component {
 									</h2>
 									<h2 className="export-media-card__warning">
 										{ translate(
-											'Depending on your media library size and/or connection speed you might need to use a download manager. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+											'Depending on your media library size and/or connection speed, you might need to use a download manager. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 											{
 												components: {
 													learnMoreLink: (

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -59,9 +59,18 @@ class ExportMediaCard extends Component {
 									</h2>
 									<h2 className="export-media-card__warning">
 										{ translate(
-											'Depending on your media library size and/or connection speed you might need to use a download manager.'
+											'Depending on your media library size and/or connection speed you might need to use a download manager. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+											{
+												components: {
+													learnMoreLink: (
+														<InlineSupportLink
+															supportContext="export-media-library"
+															showIcon={ false }
+														/>
+													),
+												},
+											}
 										) }
-										<InlineSupportLink supportContext="export-media-library" showIcon={ false } />
 									</h2>
 								</div>
 							}

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import QueryMediaExport from 'calypso/components/data/query-media-export';
 import QueryMediaStorage from 'calypso/components/data/query-media-storage';
 import FoldableCard from 'calypso/components/foldable-card';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getMediaExportUrl from 'calypso/state/selectors/get-media-export-url';
 import getMediaStorageUsed from 'calypso/state/selectors/get-media-storage-used';
@@ -60,6 +61,7 @@ class ExportMediaCard extends Component {
 										{ translate(
 											'Depending on your media library size and/or connection speed you might need to use a download manager.'
 										) }
+										<InlineSupportLink supportContext="export-media-library" showIcon={ false } />
 									</h2>
 								</div>
 							}

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -13,9 +13,15 @@
 }
 
 .export-card__subtitle,
+.export-media-card__warning,
 .export-media-card__subtitle {
 	font-size: $font-body-small;
 	color: var( --color-neutral-70 );
+}
+
+.export-media-card__warning {
+	margin-top: 10px;
+	font-style: italic;
 }
 
 .export-card .foldable-card__summary div {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a warning message , `Depending on your media library size and/or connection speed you might need to use a download manager.`, as a workaround for #28033.

#### Testing instructions

* Open any blog on Calypso
* Go to Tools => Export

![image](https://user-images.githubusercontent.com/3801502/142431884-34cac2c8-fe3f-416d-aa5a-da1becec8a51.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #28033