### PR TITLE
Titan: Hide placeholders and fix margin on post-checkout upsell

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
@@ -147,7 +147,6 @@ const ProfessionalEmailUpsell = ( {
 						<FormLabel>
 							{ translate( 'Enter email address' ) }
 							<FormTextInputWithAffixes
-								placeholder={ translate( 'Email address' ) }
 								value={ mailboxData.mailbox.value }
 								isError={ hasMailboxError }
 								onChange={ ( event ) => {
@@ -169,7 +168,6 @@ const ProfessionalEmailUpsell = ( {
 							<FormPasswordInput
 								autoCapitalize="off"
 								autoCorrect="off"
-								placeholder={ translate( 'Password' ) }
 								value={ mailboxData.password.value }
 								maxLength={ 100 }
 								isError={ hasPasswordError }

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -30,6 +30,7 @@
 .professional-email-upsell__pricing {
 	display: flex;
 	flex-direction: column;
+	margin-top: 10px;
 
 	@include break-mobile {
 		flex-direction: row;


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/58193 which removes placeholders in form fields (since they just duplicate labels). It also addresses [this comment](https://github.com/Automattic/wp-calypso/pull/56690#issuecomment-934462787) that requested a margin to be increased:

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/142440962-a49a46a8-e4ec-44c8-9667-1d99c8ad1615.png) | ![image](https://user-images.githubusercontent.com/594356/142441021-3a6abb08-9b82-4175-99ae-fbe61267cdf1.png)

#### Testing instructions

1. Run `git checkout update/titan-post-checkout-upsell` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/58240#issuecomment-972950613)
2. Log into a WordPress.com account that has a domain
3. Navigate to the [`Billing History` page](http://calypso.localhost:3000/purchases/billing-history)
4. Find a payment for your domain, and click the corresponding `View receipt` link
5. Note the receipt identifier
6. Use the domain name, receipt id, and site slug to build the url of the post-checkout upsell:
```
http://calypso.localhost:3000/checkout/offer-professional-email/:domain/:receipt_id/:site
```
7. Load that page, and assert that placeholders are no longer displayed
8. Assert that the margin above the price has increased
