### PR TITLE
WPCOM: Migrate wpcom.undocumented() domain availability to wpcom.req

### DIFF
--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -43,8 +43,14 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 				message: transferDomainError.AUTH_CODE,
 			} );
 
-		const checkAvailabilityResult = await wpcomDomain.isDomainAvailable( selectedSite.ID, false );
-
+		const checkAvailabilityResult = await wpcom.req.get(
+			`/domains/${ encodeURIComponent( domain ) }/is-available`,
+			{
+				blog_id: selectedSite.ID,
+				apiVersion: '1.3',
+				is_cart_pre_check: false,
+			}
+		);
 		const addTransferToCartAndCheckout = async () => {
 			let supportsPrivacy = false;
 

--- a/client/lib/domains/check-domain-availability.js
+++ b/client/lib/domains/check-domain-availability.js
@@ -19,6 +19,6 @@ export function checkDomainAvailability( params, onComplete ) {
 			onComplete( null, data );
 		} )
 		.catch( ( error ) => {
-			onComplete( error );
+			onComplete( error.error );
 		} );
 }

--- a/client/lib/domains/check-domain-availability.js
+++ b/client/lib/domains/check-domain-availability.js
@@ -10,14 +10,20 @@ export function checkDomainAvailability( params, onComplete ) {
 		return;
 	}
 
-	wpcom
-		.undocumented()
-		.isDomainAvailable( domainName, blogId, isCartPreCheck, function ( serverError, result ) {
+	wpcom.req.get(
+		`/domains/${ encodeURIComponent( domainName ) }/is-available`,
+		{
+			blog_id: blogId,
+			apiVersion: '1.3',
+			is_cart_pre_check: isCartPreCheck,
+		},
+		function ( serverError, result ) {
 			if ( serverError ) {
 				onComplete( serverError.error );
 				return;
 			}
 
 			onComplete( null, result );
-		} );
+		}
+	);
 }

--- a/client/lib/domains/check-domain-availability.js
+++ b/client/lib/domains/check-domain-availability.js
@@ -9,21 +9,16 @@ export function checkDomainAvailability( params, onComplete ) {
 		onComplete( null, { status: domainAvailability.EMPTY_QUERY } );
 		return;
 	}
-
-	wpcom.req.get(
-		`/domains/${ encodeURIComponent( domainName ) }/is-available`,
-		{
+	wpcom.req
+		.get( `/domains/${ encodeURIComponent( domainName ) }/is-available`, {
 			blog_id: blogId,
 			apiVersion: '1.3',
 			is_cart_pre_check: isCartPreCheck,
-		},
-		function ( serverError, result ) {
-			if ( serverError ) {
-				onComplete( serverError.error );
-				return;
-			}
-
-			onComplete( null, result );
-		}
-	);
+		} )
+		.then( ( data ) => {
+			onComplete( null, data );
+		} )
+		.catch( ( error ) => {
+			onComplete( error );
+		} );
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -81,27 +81,6 @@ Undocumented.prototype.settings = function ( siteId, method = 'get', data = {}, 
 };
 
 /**
- * Determine whether a domain name is available for registration
- *
- * @param {string} domain - The domain name to check.
- * @param {number} blogId - Optional blogId to determine if domain is used on another site.
- * @param {boolean} isCartPreCheck - specifies whether this availability check is for a domain about to be added to the cart.
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.isDomainAvailable = function ( domain, blogId, isCartPreCheck, fn ) {
-	return this.wpcom.req.get(
-		`/domains/${ encodeURIComponent( domain ) }/is-available`,
-		{
-			blog_id: blogId,
-			apiVersion: '1.3',
-			is_cart_pre_check: isCartPreCheck,
-		},
-		fn
-	);
-};
-
-/**
  * Get the inbound transfer status for this domain
  *
  * @param {string} domain - The domain name to check.

--- a/packages/wpcom.js/src/lib/domain.js
+++ b/packages/wpcom.js/src/lib/domain.js
@@ -203,26 +203,6 @@ class Domain {
 			fn
 		);
 	};
-
-	/**
-	 * Determine whether a domain name is available for registration
-	 *
-	 * @param {number} blogId - Optional blogId to determine if domain is used on another site.
-	 * @param {boolean} isCartPreCheck - specifies whether this availability check is for a domain about to be added to the cart.
-	 * @param {Function} fn The callback function
-	 * @returns {Promise} A promise that resolves when the request completes
-	 */
-	isDomainAvailable = function ( blogId, isCartPreCheck, fn ) {
-		return this.wpcom.req.get(
-			`${ root + encodeURIComponent( this._id ) }/is-available`,
-			{
-				blog_id: blogId,
-				apiVersion: '1.3',
-				is_cart_pre_check: isCartPreCheck,
-			},
-			fn
-		);
-	};
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR migrates the wpcom.undocumented() domain availability check method to wpcom.req.

Part of the ongoing effort to get rid of wpcom.undocumented().

UPDATE: As [noted below](https://github.com/Automattic/wp-calypso/pull/58243#discussion_r753098511), `wpcom.undocumented.isDomainAvailable()` was introduced to `wpcom.domain()`. This PR now refactors that as well.

#### Testing instructions

**Test wpcom.undocumented() migration**
- Start from /domains/manage/`site`
- Click the button to search for a domain
- Enter a domain you know is already registered, and make sure it properly notes that it's unavailable
- Search for a random domain that should be available, make sure that's properly processed

**Test wpcom.domain() migration**
This implementation deals with the availability of a domain during transfer. Since we're only interested in the availability check, you'll first need to disable some preceding checks that will otherwise block your testing progress.

- In `client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx`, comment out lines **36-42** and **44-53**. This skips the domain lock check so you can test on any domain without actually unlocking it first (without this step you need to use a domain you've actually unlocked). Important: the `onNextStep();` call on line **43** must remain active
- In `client/components/domains/use-my-domain/utilities/transfer-domain-action.ts`, comment out lines **38-44**. This skips the domain Auth Code check so any value you enter will be accepted (without this step you need to submit a valid auth code for an actual test domain).
- That should remove the extra checks that come before the code we're actually migrating. Start from /domains/manage/`site`
- Click the button labeled `I have a domain`
- Enter any registered domain name and click Next
- Click the blue `Select` button to Transfer your domain
- Click through the `Start setup`, `I found the domain's settings page`,  and `I've unlocked my domain` steps
- Enter a filler authorization code. It can be any string, since it won't actually be checked against anything
- Click on `Check readiness for transfer`. This is when the domain's transfer availability is checked, which is what we're looking for.
- Verify that the domain transfer is successfully added to your cart

If you have a moment, run a quick search for any implementations of `wpcom.undocumented().isDomainAvailable()` or `wpcom.domain().isDomainAvailable()`I may have missed.
