### PR TITLE
Disable selection of PHP 7.3 for WoA sites

### DIFF
--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -41,17 +41,11 @@ const PhpVersionCard = ( {
 	const getPhpVersions = () => {
 		return [
 			{
-				label: translate( '7.2', {
-					comment: 'PHP Version for a version switcher',
-				} ),
-				value: '7.2',
-				disabled: true, // EOL 30th November, 2020
-			},
-			{
 				label: translate( '7.3', {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: '7.3',
+				disabled: true, // EOL 6th December, 2021
 			},
 			{
 				label: translate( '7.4 (recommended)', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

PHP 7.3 is EOL on Dec 6, 2021. Ref https://www.php.net/supported-versions.php

This PR disables selection of PHP 7.3 for WoA sites.

<img width="739" alt="Screen Shot 2021-11-18 at 12 23 24 PM" src="https://user-images.githubusercontent.com/530877/142465517-23d75cc6-5d54-4eac-aa9e-dfe832f3f5aa.png">

But if a site currently has PHP 7.3 selected, PHP 7.3 will continue to show in the drop down menu.

<img width="745" alt="Screen Shot 2021-11-18 at 12 22 19 PM" src="https://user-images.githubusercontent.com/530877/142465534-06fff349-6db3-46f7-9966-376b8c7272cb.png">


#### Testing instructions

1. Pick a test site
2. Use the hosting page on WordPress.com to select PHP 7.3 for that site
3. Look at the hosting page for your site on calypso.localhost or calypso.live
4. Verify that PHP 7.3 is shown selected in the drop down
5. Select PHP 7.4 and click the button to save the change
6. Note that PHP 7.3 is no longer in the drop down
