### PR TITLE
Add data fetching persistence documentation

### DIFF
--- a/client/data/README.md
+++ b/client/data/README.md
@@ -1,0 +1,41 @@
+# Data
+
+This directory contains all services related to data fetching. Folders within this directory refer to domains of the application that are exposed through the services.
+
+Behind the abstraction, they are using `react-query` as the way to query and mutate data from the back-end. This is inline with the new approach on data fetching that Calypso is taking.
+
+## Persistence
+
+Query results are persisted by default because `react-query` is typically used to fetch and render server-side data. In `redux`, on the other hand, we require folks to opt-in to persistence because `redux` is often used for client-side UI state, which is typically not intended to be persisted.
+
+Persistence opt-out when using `react-query` is necessary in some cases. You can achieve that in two ways:
+
+- Dumb opt-out, where you pass a boolean to the `persist` property:
+
+```js
+function MyComponent() {
+	useQuery( queryKey, fetchFn, {
+		meta: {
+			persist: false,
+		},
+	} );
+
+	return null;
+}
+```
+
+- Smart opt-out, where you can pass a callback to decide whether or not to persist the query based on its data. Example:
+
+```ts
+function MyComponent() {
+	useQuery( queryKey, fetchFn, {
+		meta: {
+			persist: ( data: Theme[] ) => data.length > 0,
+		},
+	} );
+
+	return null;
+}
+```
+
+Persistence is disabled for queries that didn't succeed, regardless of the value defined in the `persist` property. Mutation results are not persisted.

--- a/client/data/README.md
+++ b/client/data/README.md
@@ -10,7 +10,7 @@ Query results are persisted by default because `react-query` is typically used t
 
 Persistence opt-out when using `react-query` is necessary in some cases. You can achieve that in two ways:
 
-- Dumb opt-out, where you pass a boolean to the `persist` property:
+- Simple opt-out, where you pass a boolean to the `persist` property:
 
 ```js
 function MyComponent() {

--- a/client/data/README.md
+++ b/client/data/README.md
@@ -1,6 +1,6 @@
 # Data
 
-This directory contains all services related to data fetching. Folders within this directory refer to domains of the application that are exposed through the services.
+This directory contains hooks and high-order components related to data fetching. Folders within this directory refer to certain areas of the data that powers Calypso as an application.
 
 Behind the abstraction, they are using `react-query` as the way to query and mutate data from the back-end. This is inline with the new approach on data fetching that Calypso is taking.
 

--- a/client/data/README.md
+++ b/client/data/README.md
@@ -2,7 +2,7 @@
 
 This directory contains hooks and high-order components related to data fetching. Folders within this directory refer to certain areas of the data that powers Calypso as an application.
 
-Behind the abstraction, they are using `react-query` as the way to query and mutate data from the back-end. This is inline with the new approach on data fetching that Calypso is taking.
+Behind the abstraction, they are using `react-query` as the way to query and mutate data from the back-end.
 
 ## Persistence
 


### PR DESCRIPTION
Related to #57679.

We want to include documentation about data fetching and how persistence works, including opting out of it.

For now, I have included documentation inside `client/data` about how `react-query` works and the rationale behind persistence. Let me know if we're missing more extensive documentation and external references to it.
