### PR TITLE
People: Delete User: Fix CSS for "attribute to author" dropdown

### DIFF
--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -9,6 +9,7 @@ import InfiniteList from 'calypso/components/infinite-list';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import UserItem from 'calypso/components/user';
 import { hasTouch } from 'calypso/lib/touch-detect';
+import 'calypso/components/popover-menu/style.scss';
 
 /**
  * Module variables


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Import needed CSS for the dropdown used to select a user labeled with "Attribute all content to another user" in the delete section of users
  * The `<AuthorSwitcherShell` component uses `<PopoverMenuItem` without using `<PopoverMenu`. `<PopoverMenu` imports the styles needed to render the items properly, so I made SwitcherShell also import the style.


#### Testing instructions


* Have a blog with three+ users on it
* Visit `/people/team/<sitename>`
* Click on a user who is not the owner
* Scroll down and select "Attribute all content to another user"
* Observe the author selection dropdown

Before PR, users are displayed horizontally:
![2021-11-18_13-44](https://user-images.githubusercontent.com/937354/142496642-b6667963-dee2-4172-93af-bfc4a58dcf29.png)

After PR, users are displayed vertically:
![2021-11-18_13-44_1](https://user-images.githubusercontent.com/937354/142496675-b57e5e33-b18c-497a-9c10-c829eb78dd34.png)


Related to #58254
