### PR TITLE
Domains: Create stub for new domain transfer page

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -298,11 +298,9 @@ export default {
 
 	domainManagementTransfer( pageContext, next ) {
 		let component = DomainManagement.Transfer;
-
 		if ( config.isEnabled( 'domains/transfers-redesign' ) ) {
 			component = DomainManagement.TransferPage;
 		}
-
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransfer( ':site', ':domain' ) }

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -297,14 +297,17 @@ export default {
 	},
 
 	domainManagementTransfer( pageContext, next ) {
+		let component = DomainManagement.Transfer;
+
 		if ( config.isEnabled( 'domains/transfers-redesign' ) ) {
-			// TODO: set different component for the new transfer page
+			component = DomainManagement.TransferPage;
 		}
+
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransfer( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Transfer"
-				component={ DomainManagement.Transfer }
+				component={ component }
 				context={ pageContext }
 				needsDomains
 				selectedDomainName={ pageContext.params.domain }

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -19,6 +19,7 @@ import Security from './security';
 import SiteRedirectSettings from './site-redirect';
 import Transfer from './transfer';
 import TransferOut from './transfer/transfer-out';
+import TransferPage from './transfer/transfer-page';
 import TransferToOtherSite from './transfer/transfer-to-other-site';
 import TransferToOtherUser from './transfer/transfer-to-other-user';
 
@@ -43,6 +44,7 @@ export default {
 	SiteRedirectSettings,
 	TransferIn,
 	TransferOut,
+	TransferPage,
 	TransferToOtherSite,
 	TransferToOtherUser,
 	Transfer,

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.jsx
@@ -2,6 +2,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
@@ -12,7 +13,12 @@ import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const TransferPage = () => {
-	return <Main>The page goes here</Main>;
+	return (
+		<Main wideLayout>
+			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+			The page goes heres
+		</Main>
+	);
 };
 
 const transferPageComponent = connect( ( state, ownProps ) => {

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.jsx
@@ -1,0 +1,36 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Main from 'calypso/components/main';
+import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import isPrimaryDomainBySiteId from 'calypso/state/selectors/is-primary-domain-by-site-id';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const TransferPage = () => {
+	return <Main>The page goes here</Main>;
+};
+
+const transferPageComponent = connect( ( state, ownProps ) => {
+	const domain = getSelectedDomain( ownProps );
+	const siteId = getSelectedSiteId( state );
+	return {
+		currentRoute: getCurrentRoute( state ),
+		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, siteId ),
+		isAtomic: isSiteAutomatedTransfer( state, siteId ),
+		isDomainOnly: isDomainOnlySite( state, siteId ),
+		isMapping: Boolean( domain ) && isMappedDomain( domain ),
+		isPrimaryDomain: isPrimaryDomainBySiteId( state, siteId, ownProps.selectedDomainName ),
+		primaryDomain: getPrimaryDomainBySiteId( state, siteId ),
+	};
+} )( localize( TransferPage ) );
+
+transferPageComponent.propTypes = {
+	selectedDomainName: PropTypes.string.isRequired,
+};
+
+export default transferPageComponent;

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -9,9 +9,8 @@ import isPrimaryDomainBySiteId from 'calypso/state/selectors/is-primary-domain-b
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { TransferPageProps } from './types';
 
-const TransferPage = ( props: TransferPageProps ): JSX.Element => {
+const TransferPage = (): JSX.Element => {
 	return (
 		<Main className="transfer-page" wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -1,5 +1,3 @@
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -11,12 +9,13 @@ import isPrimaryDomainBySiteId from 'calypso/state/selectors/is-primary-domain-b
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { TransferPageProps } from './types';
 
-const TransferPage = () => {
+const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 	return (
-		<Main wideLayout>
+		<Main className="transfer-page" wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-			The page goes heres
+			The page goes here
 		</Main>
 	);
 };
@@ -33,10 +32,6 @@ const transferPageComponent = connect( ( state, ownProps ) => {
 		isPrimaryDomain: isPrimaryDomainBySiteId( state, siteId, ownProps.selectedDomainName ),
 		primaryDomain: getPrimaryDomainBySiteId( state, siteId ),
 	};
-} )( localize( TransferPage ) );
-
-transferPageComponent.propTypes = {
-	selectedDomainName: PropTypes.string.isRequired,
-};
+} )( TransferPage );
 
 export default transferPageComponent;

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
@@ -1,0 +1,3 @@
+export type TransferPageProps = {
+	selectedDomainName: string;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR creates a new `TransferPage` component which will be the redesigned domain transfer page. It's just a stub for now and was basically a copy-paste of the original `Transfer` component (`/my-sites/domains/domain-management/transfer/index.jsx`) - this will help us work on the redesign in parallel.

This is part of the domain management redesign project described in pcYYhz-m2-p2.

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select one of your registered domains
- If you're in the live Calypso link, please append `?flags=domains/transfers-redesign` to your URL to enable the appropriate feature flag
- Select the "Transfer your domain" options
- Ensure a blank page with white background and a "The page goes here" message is rendered