### PR TITLE
E2E: discontinue use of `gutenbergSimpleSiteUser` where possible.

### DIFF
--- a/test/e2e/lib/jest/globalSetup.ts
+++ b/test/e2e/lib/jest/globalSetup.ts
@@ -30,7 +30,7 @@ export default async (): Promise< void > => {
 	// its presence when running each test file.
 	process.env.COOKIES_PATH = cookieBasePath;
 
-	const userList = [ 'gutenbergSimpleSiteUser', 'eCommerceUser', 'defaultUser' ];
+	const userList = [ 'simpleSitePersonalPlanUser', 'eCommerceUser', 'defaultUser' ];
 
 	for await ( const user of userList ) {
 		const [ username, password ] = config.get( 'testAccounts' )[ user ];

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -23,7 +23,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	let page: Page;
 	let testFiles: { image: TestFile; image_reserved_name: TestFile; audio: TestFile };
 
-	setupHooks( ( args ) => {
+	setupHooks( ( args: { page: Page } ) => {
 		page = args.page;
 	} );
 
@@ -39,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 
 	it( 'Log in', async function () {
 		const loginPage = new LoginPage( page );
-		await loginPage.login( { account: 'gutenbergSimpleSiteUser' } );
+		await loginPage.login( { account: 'simpleSitePersonalPlanUser' } );
 	} );
 
 	it( 'Start new post', async function () {

--- a/test/e2e/specs/specs-playwright/wp-editor__navbar.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__navbar.ts
@@ -14,7 +14,6 @@ import { Page } from 'playwright';
 
 describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 	let page: Page;
-	const mainUser = 'gutenbergSimpleSiteUser';
 
 	setupHooks( ( args ) => {
 		page = args.page;
@@ -22,7 +21,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 
 	it( 'Log in', async function () {
 		const loginPage = new LoginPage( page );
-		await loginPage.login( { account: mainUser } );
+		await loginPage.login( { account: 'simpleSitePersonalPlanUser' } );
 	} );
 
 	it( 'Start new post', async function () {

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let publishedPostPage: PublishedPostPage;
 	const user = BrowserHelper.targetGutenbergEdge()
 		? 'gutenbergSimpleSiteEdgeUser'
-		: 'gutenbergSimpleSiteUser';
+		: 'simpleSitePersonalPlanUser';
 
 	setupHooks( ( args ) => {
 		page = args.page;

--- a/test/e2e/specs/specs-playwright/wp-likes__comment-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__comment-spec.js
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 
 		it( 'Log in', async function () {
 			const loginPage = new LoginPage( page );
-			await loginPage.login( { account: 'gutenbergSimpleSiteUser' } );
+			await loginPage.login( { account: 'simpleSitePersonalPlanUser' } );
 		} );
 
 		it( 'Start new post', async function () {

--- a/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
@@ -21,7 +21,7 @@ const quote =
 
 describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 	let page;
-	const postingUser = 'gutenbergSimpleSiteUser';
+	const postingUser = 'simpleSitePersonalPlanUser';
 	const likeUser = 'defaultUser';
 
 	setupHooks( ( args ) => {

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.ts
@@ -28,6 +28,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 
 	describe.each`
 		siteType      | user
+		${ 'Simple' } | ${ 'simpleSitePersonalPlanUser' }
 		${ 'Atomic' } | ${ 'eCommerceUser' }
 	`( 'Edit Image ($siteType)', function ( { user } ) {
 		let mediaPage: MediaPage;

--- a/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
@@ -13,8 +13,6 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-const userOnPremiumPlan = 'defaultUser';
-
 describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 	let page: Page;
 	let plansPage: PlansPage;
@@ -28,7 +26,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 	describe( 'Initial navigation', function () {
 		it( 'Log in', async function () {
 			const loginPage = new LoginPage( page );
-			await loginPage.login( { account: userOnPremiumPlan } );
+			await loginPage.login( { account: 'defaultUser' } );
 		} );
 
 		it( 'Navigate to Upgrades > Plans', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR replaces the use of `gutenbergSimpleSiteUser` where possible with newer user(s) set up for the purpose.

Key changes:
- use `simpleSitePersonalPlanUser` where possible.
- add back accidentally removed `Simple` site parametrization in `Media: Edit` spec.

Details:
This PR has been necessitated by https://github.com/Automattic/wp-calypso/issues/57660 repeatedly occurring for the user `gutenbergSimpleSiteUser` in a subset of specs. This will help with efforts to stamp out flakiness in the e2e test suites.

I've set up the user `simpleSitePersonalPlanUser` to closely mimic the feature set of `gutenbergSimpleSiteUser`, so for practical purposes there should be no difference in the execution of tests.

#### Testing instructions

- [x] ensure new users are being used in TeamCity logs.

Related to #57660