### PR TITLE
Playwright: QoL improvements to the authentication cookie mechanism

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -179,12 +179,14 @@ export class LoginPage {
 				await Promise.all( [
 					// Shorter than usual timoout, because with a cookie file the login process
 					// should not take more than a few seconds.
-					this.page.waitForNavigation( { url: landingUrl, waitUntil: 'load', timeout: 15 * 1000 } ),
+					this.page.waitForNavigation( { url: landingUrl, waitUntil: 'load', timeout: 7 * 1000 } ),
 					this.page.goto( getCalypsoURL( '/' ) ),
 				] );
 				return;
-			} catch {
-				console.log( 'Unable to log in using cookie file, retrying a normal login.' );
+			} catch ( err: unknown ) {
+				if ( err instanceof Error ) {
+					console.log( `${ err.message }, retrying username/password based authentication.` );
+				}
 				// noop
 			}
 		}

--- a/test/e2e/lib/jest/globalSetup.ts
+++ b/test/e2e/lib/jest/globalSetup.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'fs/promises';
+import { mkdir, stat, access, unlink } from 'fs/promises';
 import path from 'path';
 import config from 'config';
 import { chromium } from 'playwright';
@@ -11,17 +11,23 @@ export default async (): Promise< void > => {
 
 	// If configuration file is not found, log a message and exit this setup.
 	if ( config.util.equalsDeep( config.util.toObject(), {} ) ) {
+		/*
+		Must use a `console.error` here. Throwing an error would halt Jest execution
+		and throw a wall of red text at the user.
+		*/
 		console.error( 'No decrypted configuration file was found.' );
 		return;
 	}
-
-	const browser = await chromium.launch();
-	const calypsoBaseURL = config.get( 'calypsoBaseURL' );
 
 	// Create a directory to store the generated cookie file.
 	// The cookie file will be stored in the `test/e2e/cookies` directory.
 	const cookieBasePath = path.join( __dirname, '../../', 'cookies' );
 	await mkdir( cookieBasePath, { recursive: true } );
+
+	// Launch Chromium then retrieve the base URL for the environment we're testing.
+	const browser = await chromium.launch();
+	const calypsoBaseURL = config.get( 'calypsoBaseURL' );
+
 	// This is important!
 	// Jest does not permit values created in globalSetup/globalTeardown to be read
 	// by the test suites themselves. See https://jestjs.io/docs/configuration#globalsetup-string.
@@ -33,7 +39,34 @@ export default async (): Promise< void > => {
 	const userList = [ 'gutenbergSimpleSiteUser', 'eCommerceUser', 'defaultUser' ];
 
 	for await ( const user of userList ) {
+		/*
+		This section is nearly identical to the snippet in `BrowserManager.setLoginCookie`, but
+		instead of checking that cookies are older than 3 days, this checks whether the cookies
+		are newer than 3 days. If so, presumably the cookies are still good to use and the iteration
+		is skipped.
+		*/
+		const cookiePath = path.join( cookieBasePath, `${ user }.json` );
+
+		try {
+			await access( cookiePath );
+			const stats = await stat( cookiePath );
+			const createdTime = Math.trunc( stats.birthtimeMs );
+			const currentTime = new Date();
+
+			if ( createdTime > currentTime.setDate( currentTime.getDate() - 3 ) ) {
+				console.log( `\nCookie file on disk for ${ user } is recent, skipping.` );
+				continue;
+			} else {
+				// Remove the stale cookie file as BrowserContext.storageState does not
+				// overwrite files.
+				await unlink( cookiePath );
+			}
+		} catch {
+			// noop
+		}
+
 		const [ username, password ] = config.get( 'testAccounts' )[ user ];
+		console.log( `${ user }: ${ username }, ${ password }` );
 
 		// This is important!
 		// If the e2e test user agent string is not set, log ins will fail to calypso.live
@@ -55,7 +88,6 @@ export default async (): Promise< void > => {
 		] );
 
 		// Save signed-in state.
-		const cookiePath = path.join( cookieBasePath, `${ user }.json` );
 		await page.context().storageState( { path: cookiePath } );
 	}
 

--- a/test/e2e/lib/jest/globalSetup.ts
+++ b/test/e2e/lib/jest/globalSetup.ts
@@ -39,14 +39,14 @@ export default async (): Promise< void > => {
 	const userList = [ 'gutenbergSimpleSiteUser', 'eCommerceUser', 'defaultUser' ];
 
 	for await ( const user of userList ) {
+		const cookiePath = path.join( cookieBasePath, `${ user }.json` );
+
 		/*
 		This section is nearly identical to the snippet in `BrowserManager.setLoginCookie`, but
 		instead of checking that cookies are older than 3 days, this checks whether the cookies
 		are newer than 3 days. If so, presumably the cookies are still good to use and the iteration
-		is skipped.
+		is short-circuited.
 		*/
-		const cookiePath = path.join( cookieBasePath, `${ user }.json` );
-
 		try {
 			await access( cookiePath );
 			const stats = await stat( cookiePath );

--- a/test/e2e/lib/jest/globalSetup.ts
+++ b/test/e2e/lib/jest/globalSetup.ts
@@ -66,7 +66,6 @@ export default async (): Promise< void > => {
 		}
 
 		const [ username, password ] = config.get( 'testAccounts' )[ user ];
-		console.log( `${ user }: ${ username }, ${ password }` );
 
 		// This is important!
 		// If the e2e test user agent string is not set, log ins will fail to calypso.live


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes some quality of life improvements to the authentication cookie saving mechanism.

Key changes:
- check whether the cookie file is recent enough (3 days) in `globalSetup`.
- if the cookie file is recent, skip the authentication & save process.
- additional check in `BrowserManager.setLoginCookie` to check whether the cookie file found is recent.
- if the cookie file is not recent, go straight to the traditional username/password login branch.

Details:
These changes are primarily aimed at users running the test suites locally. In a CI environment, no change should be observed.

When running tests locally and wanting to save the authenticated cookies, the environment variable `SAVE_AUTH_COOKIES` is either prepended to the `yarn jest` call, or exported permanently to the environment.

Prior to this PR, subsequent invocations of `yarn jest` must take care to remove the `SAVE_AUTH_COOKIES` env var, or otherwise spend up to 10 seconds while the cookies are refreshed. This is tedious when quickly debugging or fixing something.

With this PR, the authentication cookie saving mechanism will only replace the cookie file if the cookie is determined to be stale. If the cookie files are considered recent enough, `globalSetup` is short-circuited.

Further checks in `BrowserManager.setLoginCookie` also serves to short-circuit the branch in `LoginPage.login` if a stale cookie is found. Compare this to current method where 15 seconds must elapse before the traditional login using username/password is attempted.

#### Testing instructions

- [x] tests execute as expected.

Related to #
