### PR TITLE
Fixup some PropTypes to avoid warnings

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -57,7 +57,7 @@ export class Banner extends Component {
 		showIcon: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		target: PropTypes.string,
-		title: PropTypes.string.isRequired,
+		title: PropTypes.node.isRequired,
 		tracksImpressionName: PropTypes.string,
 		tracksClickName: PropTypes.string,
 		tracksDismissName: PropTypes.string,

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -23,9 +23,8 @@ export class RegionAddressFieldsets extends Component {
 		shouldAutoFocusAddressField: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,
 		contactDetailsErrors: PropTypes.shape(
-			Object.assign(
-				{},
-				...CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => ( { [ field ]: PropTypes.string } ) )
+			Object.fromEntries(
+				CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => [ field, PropTypes.node ] )
 			)
 		),
 	};

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -34,15 +34,13 @@ export class ManagedContactDetailsFormFields extends Component {
 	static propTypes = {
 		eventFormName: PropTypes.string,
 		contactDetails: PropTypes.shape(
-			Object.assign(
-				{},
-				...CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => ( { [ field ]: PropTypes.string } ) )
+			Object.fromEntries(
+				CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => [ field, PropTypes.string ] )
 			)
 		).isRequired,
 		contactDetailsErrors: PropTypes.shape(
-			Object.assign(
-				{},
-				...CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => ( { [ field ]: PropTypes.string } ) )
+			Object.fromEntries(
+				CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => [ field, PropTypes.node ] )
 			)
 		),
 		countriesList: PropTypes.array.isRequired,
@@ -58,9 +56,8 @@ export class ManagedContactDetailsFormFields extends Component {
 
 	static defaultProps = {
 		eventFormName: 'Domain contact details form',
-		contactDetails: Object.assign(
-			{},
-			...CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => ( { [ field ]: '' } ) )
+		contactDetails: Object.fromEntries(
+			CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => [ field, '' ] )
 		),
 		getIsFieldDisabled: () => {},
 		onContactDetailsChange: () => {},

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -32,7 +32,7 @@ import { getAllCartItems } from '../../../lib/cart-values/cart-items';
 class CartFreeUserPlanUpsell extends Component {
 	static propTypes = {
 		cart: PropTypes.object,
-		isCartPendingUpdate: PropTypes.bool.isRequired,
+		isCartPendingUpdate: PropTypes.bool,
 		addItemToCart: PropTypes.func.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		hasPaidPlan: PropTypes.bool,


### PR DESCRIPTION
Fixes several component `PropType`s to avoid warnings in development mode:

**`<Banner title />` in `/settings/performance/:site`**: that screen renders a `Banner` with no `title`, as a loading placeholder:

<img width="738" alt="Screenshot 2021-11-19 at 12 49 49" src="https://user-images.githubusercontent.com/664258/142618626-ea41b346-0d5a-4bac-8347-9f0b668f911a.png">

But because the prop-type is `PropTypes.string.isRequired`, it triggers a warning:

<img width="762" alt="Screenshot 2021-11-19 at 12 50 11" src="https://user-images.githubusercontent.com/664258/142618737-3db8b357-64d0-4d43-994d-23adb3dda806.png">

I'm fixing that by declaring `PropTypes.node.isRequired` instead, because `undefined`/`null` is a valid value there.

**`contactDetailsErrors` in domain contact details forms**: sometimes there fields are not just strings, but React fragments returned by `translate()`. Changing from `PropTypes.string` to `PropTypes.node` fixes warnings.

**`<CartFreeUserPlanUpsell isCartPendingUpdate />`**: the component works OK even if the prop is `undefined`, interpreted as falsy, so we can remove the `.isRequired` suffix.

The last two warnings are displayed when running unit tests for Composite Checkout:
```
yarn test-client client/my-sites/checkout/composite-checkout
```
Verify that after this PR, this part of unit tests finishes without any warnings.