### PR TITLE
Emails: Remove warning for user level ToS acceptance from email management header

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -38,11 +38,9 @@ const EmailPlanHeader = ( {
 				<div>
 					<h2>{ domain.name }</h2>
 
-					{ emailAccount?.warnings?.[ 0 ] && (
-						<span className="email-plan-header__status">
-							<MaterialIcon icon={ icon } /> { text }
-						</span>
-					) }
+					<span className="email-plan-header__status">
+						<MaterialIcon icon={ icon } /> { text }
+					</span>
 				</div>
 
 				{ hasEmailSubscription && emailAccount && (

--- a/client/my-sites/email/email-management/home/email-plan-header.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.jsx
@@ -38,9 +38,11 @@ const EmailPlanHeader = ( {
 				<div>
 					<h2>{ domain.name }</h2>
 
-					<span className="email-plan-header__status">
-						<MaterialIcon icon={ icon } /> { text }
-					</span>
+					{ emailAccount?.warnings?.[ 0 ] && (
+						<span className="email-plan-header__status">
+							<MaterialIcon icon={ icon } /> { text }
+						</span>
+					) }
 				</div>
 
 				{ hasEmailSubscription && emailAccount && (

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -124,10 +124,6 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 			return errorStatus;
 		}
 
-		if ( hasPendingGSuiteUsers( domain ) ) {
-			return errorStatus;
-		}
-
 		return activeStatus;
 	}
 

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -10,7 +10,6 @@ import {
 	getGSuiteMailboxCount,
 	getGSuiteSubscriptionId,
 	hasGSuiteWithUs,
-	hasPendingGSuiteUsers,
 	isPendingGSuiteTOSAcceptance,
 } from 'calypso/lib/gsuite';
 import {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are showing a user level warning at a "Account level". This means that in the email management header we are showing a warning that should be only displayed at user/mailbox level.

#### Testing instructions

- Buy a Google Workspace subscription
- Accept ToS
- Create a new mailbox

Expected:
![image](https://user-images.githubusercontent.com/5689927/142629639-34e7390d-f557-4bfb-838a-7ee52cc296bc.png)

Actual:
![image](https://user-images.githubusercontent.com/5689927/142630923-c64d2872-1c11-4625-9467-f4525a263afe.png)

Related to {1200182182542585-as-1201399344994999}
