### PR TITLE
Do not use webpack4 APIs

### DIFF
--- a/build-tools/webpack/generate-chunks-map-plugin.js
+++ b/build-tools/webpack/generate-chunks-map-plugin.js
@@ -20,9 +20,12 @@ class GenerateChunksMapPlugin {
 
 			const chunksMap = {};
 			for ( const chunk of chunks ) {
-				const files = chunk.files;
-				const name = Array.from( files ).find( ( file ) => /\.js$/.test( file ) ) || files[ 0 ];
-				const modules = [ ...chunk.modulesIterable ]
+				// This logic assumes there is only one `.js`. If there are more than one `.js` file linked to a chunk,
+				// this will be non deterministic as `chunk.files` iteration order is not guaranteed.
+				const name = Array.from( chunk.files ).find( ( file ) => /\.js$/.test( file ) );
+				if ( ! name ) continue;
+
+				const modules = [ ...compilation.chunkGraph.getChunkModulesIterable( chunk ) ]
 					.reduce( ( acc, item ) => acc.concat( item.modules || item ), [] )
 					.map( ( { userRequest } ) => userRequest && path.relative( '.', userRequest ) )
 					.filter( ( module ) => !! module );

--- a/build-tools/webpack/generate-chunks-map-plugin.js
+++ b/build-tools/webpack/generate-chunks-map-plugin.js
@@ -18,7 +18,8 @@ class GenerateChunksMapPlugin {
 			// Generate chunks map
 			const { chunks } = compilation;
 
-			const chunksMap = chunks.reduce( ( map, chunk ) => {
+			const chunksMap = {};
+			for ( const chunk of chunks ) {
 				const files = chunk.files;
 				const name = files.find( ( file ) => /\.js$/.test( file ) ) || files[ 0 ];
 				const modules = [ ...chunk.modulesIterable ]
@@ -26,10 +27,8 @@ class GenerateChunksMapPlugin {
 					.map( ( { userRequest } ) => userRequest && path.relative( '.', userRequest ) )
 					.filter( ( module ) => !! module );
 
-				map[ name ] = modules;
-
-				return map;
-			}, {} );
+				chunksMap[ name ] = modules;
+			}
 
 			// Write chunks map
 			fs.writeFileSync( this.output, JSON.stringify( chunksMap ) );

--- a/build-tools/webpack/generate-chunks-map-plugin.js
+++ b/build-tools/webpack/generate-chunks-map-plugin.js
@@ -21,7 +21,7 @@ class GenerateChunksMapPlugin {
 			const chunksMap = {};
 			for ( const chunk of chunks ) {
 				const files = chunk.files;
-				const name = files.find( ( file ) => /\.js$/.test( file ) ) || files[ 0 ];
+				const name = Array.from( files ).find( ( file ) => /\.js$/.test( file ) ) || files[ 0 ];
 				const modules = [ ...chunk.modulesIterable ]
 					.reduce( ( acc, item ) => acc.concat( item.modules || item ), [] )
 					.map( ( { userRequest } ) => userRequest && path.relative( '.', userRequest ) )

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -380,6 +380,10 @@ const webpackConfig = {
 				},
 		  }
 		: {} ),
+
+	experiments: {
+		backCompat: false,
+	},
 };
 
 module.exports = webpackConfig;


### PR DESCRIPTION
## Background

When Webpack 5 shipped, they included a "compatibility layer" with Wepback 4. There are a few APIs that are deprecated and throw a warning when used. Disabling the compact layer makes [Webpack faster](https://engineering.tines.com/blog/understanding-why-our-build-got-15x-slower-with-webpack) (allegedly), and surfaces those warnings as errors.

## Changes
 
* Disable [webpack 4 compat APIs](https://webpack.js.org/configuration/experiments/#experimentsbackcompat)
* Fix usage of webpack 4 APIs in `generate-chunks-map-plugin.js`

## Test

Build this branch with `NODE_ENV=production CALYPSO_ENV=production MINIFY=false BUILD_TRANSLATION_CHUNKS=true yarn build` and run the same process on `trunk`. Then compare `public/chunks-map.json` in both builds.

There will be some minor differences caused by `chunk.files` changes (see comment)
