### PR TITLE
Enable `jetpack/user-licensing` feature flag in stage and wpcalypso environments

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -58,7 +58,7 @@
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
-		"jetpack/user-licensing": false,
+		"jetpack/user-licensing": true,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -65,7 +65,7 @@
 		"jetpack/only-realtime-products": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
-		"jetpack/user-licensing": false,
+		"jetpack/user-licensing": true,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable the `jetpack/user-licensing` feature flag in stage and wpcalypso environments in preparation for an incoming call for testing. This change will enable the new post-purchase UX for users who make site-less purchases (designs in p6TEKc-5p8-p2).  

#### Testing instructions

* Code review.
* Open the `Link to Calypso live` (see one of the github-actions below`).
* Go to cloud.jetpack.com/pricing.
* Select a paid product.
* Once you are on the checkout page, replace `wordpress.com` with the domain of `Link to Calypso live`. 
* Complete the purchase.
* Verify that you are taken to the new post-purchase flow.

Related to 1201096622142517-as-1201400491645524