### PR TITLE
Domain: Create new domain settings page stub

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -81,14 +81,15 @@ export default {
 	},
 
 	domainManagementEdit( pageContext, next ) {
+		let component = DomainManagement.Edit;
 		if ( config.isEnabled( 'domains/settings-page-redesign' ) ) {
-			// TODO: set different component for the new domain settings page
+			component = DomainManagement.Settings;
 		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementEdit( ':site', ':domain', pageContext.canonicalPath ) }
 				analyticsTitle="Domain Management > Edit"
-				component={ DomainManagement.Edit }
+				component={ component }
 				context={ pageContext }
 				needsContactDetails
 				needsDomains

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -16,6 +16,7 @@ import ListAll from './list/list-all';
 import ManageConsent from './manage-consent';
 import NameServers from './name-servers';
 import Security from './security';
+import Settings from './settings';
 import SiteRedirectSettings from './site-redirect';
 import Transfer from './transfer';
 import TransferOut from './transfer/transfer-out';
@@ -39,6 +40,7 @@ export default {
 	SiteDomains,
 	NameServers,
 	Security,
+	Settings,
 	SiteRedirect,
 	SiteRedirectSettings,
 	TransferIn,

--- a/client/my-sites/domains/domain-management/settings/index.jsx
+++ b/client/my-sites/domains/domain-management/settings/index.jsx
@@ -1,11 +1,17 @@
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 
 const Settings = () => {
-	return <Main>Page goes here.</Main>;
+	return (
+		<Main wideLayout>
+			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+			Page goes here.
+		</Main>
+	);
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/my-sites/domains/domain-management/settings/index.jsx
+++ b/client/my-sites/domains/domain-management/settings/index.jsx
@@ -1,0 +1,16 @@
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import Main from 'calypso/components/main';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+
+const Settings = () => {
+	return <Main>Page goes here.</Main>;
+};
+
+export default connect( ( state, ownProps ) => {
+	return {
+		currentRoute: getCurrentRoute( state ),
+		hasDomainOnlySite: isDomainOnlySite( state, ownProps.selectedSite.ID ),
+	};
+} )( localize( Settings ) );

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,11 +1,10 @@
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 
-const Settings = () => {
+const Settings = (): JSX.Element => {
 	return (
 		<Main wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
@@ -19,4 +18,4 @@ export default connect( ( state, ownProps ) => {
 		currentRoute: getCurrentRoute( state ),
 		hasDomainOnlySite: isDomainOnlySite( state, ownProps.selectedSite.ID ),
 	};
-} )( localize( Settings ) );
+} )( Settings );


### PR DESCRIPTION
### Changes proposed in this Pull Request

**Note**: Maybe we should deploy this only when we start actively working on the settings page, otherwise it might get a little annoying having to change back to the old `Edit` component to access the other domain pages 😅 

This PR creates a new `Settings` component which will be the redesigned domain settings page. It's just a stub for now and was basically a copy-paste of the original `Edit` component (/my-sites/domains/domain-management/edit/index.jsx) - this will help us work on the redesign in parallel.

This is part of the domain management redesign project described in pcYYhz-m2-p2.

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select one of your domains
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Ensure a blank page with white background and a "Page goes here" message is rendered
