### PR TITLE
Quick Start: Remove mention from eCommerce plan

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -972,8 +972,8 @@ const ConnectedPlanFeatures = connect(
 				const showMonthlyPrice = ! isJetpack || isSiteAT || ( ! relatedMonthlyPlan && showMonthly );
 				let features = planConstantObj.getPlanCompareFeatures();
 
-				// TODO: remove this once Quick Start sessions have been removed from Business Plan
-				if ( isWpComBusinessPlan( plan ) ) {
+				// TODO: remove this once Quick Start sessions have been removed from Business & eCommerce Plan
+				if ( isWpComBusinessPlan( plan ) || isWpComEcommercePlan( plan ) ) {
 					features = features.filter( ( feature ) => feature !== FEATURE_BUSINESS_ONBOARDING );
 				}
 


### PR DESCRIPTION
See #44452

#### Changes proposed in this Pull Request

* Adds eCommerce check to the logic that filters out the onboarding feature. 

#### Testing instructions

* Go to /plans
* Under the eCommerce Plans column there shouldn't be any Get personalized help feature.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pc4ICr-mc-p2
