### PR TITLE
Stop loading editor site launch directory

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -143,14 +143,6 @@ function load_timeline_block() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_timeline_block' );
 
 /**
- * Load Editor Site Launch.
- */
-function load_editor_site_launch() {
-	require_once __DIR__ . '/editor-site-launch/index.php';
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_editor_site_launch' );
-
-/**
  * Add front-end CoBlocks gallery block scripts.
  *
  * This function performs the same enqueueing duties as `CoBlocks_Block_Assets::frontend_scripts`,


### PR DESCRIPTION
### Changes proposed in this Pull Request
Work towards #53118

The motivation is that a dependency update can cause the `editor-site-launch` bundle to change, which causes noise in GH PRs. Since it is unused (but will be used in the future) we can do the following in two deploys:

1. Stop loading the directory (this PR)
2. Stop generating the bundle (#58312)

This leaves the directory in a state where work can be resumed in the future, but stops unnecessary bundle generation in the meantime.

The only thing which would block this approach is if any PHP or JS code inside the `editor-site-launch` directory is utilized by anything.

### Testing instructions
1. Load ETK on a sandbox
2. Smoke test
3. Anything related to site launch??