### PR TITLE
Disable react peer updates in interpolate components

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,13 @@
 		},
 		{
 			"extends": "monorepo:react",
-			"prPriority": 1
+			"prPriority": 1,
+			"ignorePaths": [ "packages/interpolate-components" ]
+		},
+		{
+			"extends": [ "monorepo:react", ":disablePeerDependencies" ],
+			"prPriority": 1,
+			"includePaths": [ "packages/interpolate-components" ]
 		},
 		{
 			"packagePatterns": [ "^redux$", "^react-redux$" ],


### PR DESCRIPTION
### Changes proposed in this Pull Request
This modifies the react update policy in renovate specifically for the interpolate components package. We need this peer dependency to stay on react 16. However, renovate constantly tries to update it, which is not what we want.

This config ideally should only stop the react peer dependency in this one package from being updated. Everything else should stay the same.

### Testing instructions
Can only be tested in prod
