### PR TITLE
WPCOM: Migrate wpcom.undocumented() domain transfer status to wpcom.req

### DIFF
--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -27,7 +27,9 @@ const TransferDomainStepUnlock = ( {
 
 	const getDomainLockStatus = useCallback( async () => {
 		setCheckInProgress( true );
-		const { unlocked } = await wpcom.undocumented().getInboundTransferStatus( domain );
+		const { unlocked } = await wpcom.req.get(
+			`/domains/${ encodeURIComponent( domain ) }/inbound-transfer-status`
+		);
 		setCheckInProgress( false );
 		return unlocked;
 	}, [ domain, setCheckInProgress ] );

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -133,9 +133,9 @@ function UseMyDomain( props ) {
 		setIsFetchingAvailability( true );
 		let inboundTransferStatusResult = {};
 		try {
-			inboundTransferStatusResult = await wpcom
-				.undocumented()
-				.getInboundTransferStatus( domainName );
+			inboundTransferStatusResult = await wpcom.req.get(
+				`/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`
+			);
 		} catch {}
 
 		const inboundTransferStatusInfo = {

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -131,12 +131,9 @@ function UseMyDomain( props ) {
 	const setDomainTransferData = useCallback( async () => {
 		// TODO: remove this try-catch when the next statuses get added on the API
 		setIsFetchingAvailability( true );
-		let inboundTransferStatusResult = {};
-		try {
-			inboundTransferStatusResult = await wpcom.req.get(
-				`/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`
-			);
-		} catch {}
+		const inboundTransferStatusResult = await wpcom.req
+			.get( `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status` )
+			.catch( () => ( {} ) );
 
 		const inboundTransferStatusInfo = {
 			creationDate: inboundTransferStatusResult.creation_date,

--- a/client/components/domains/use-my-domain/utilities/get-domain-inbound-transfer-status-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-domain-inbound-transfer-status-info.js
@@ -1,9 +1,9 @@
 import wpcom from 'calypso/lib/wp';
 
 export async function getDomainInboundTransferStatusInfo( domainName ) {
-	const inboundTransferStatusResult = await wpcom
-		.undocumented()
-		.getInboundTransferStatus( domainName );
+	const inboundTransferStatusResult = await wpcom.req.get( {
+		path: `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`,
+	} );
 
 	return {
 		creationDate: inboundTransferStatusResult.creation_date,

--- a/client/components/domains/use-my-domain/utilities/get-domain-inbound-transfer-status-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-domain-inbound-transfer-status-info.js
@@ -1,9 +1,9 @@
 import wpcom from 'calypso/lib/wp';
 
 export async function getDomainInboundTransferStatusInfo( domainName ) {
-	const inboundTransferStatusResult = await wpcom.req.get( {
-		path: `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`,
-	} );
+	const inboundTransferStatusResult = await wpcom.req.get(
+		`/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`
+	);
 
 	return {
 		creationDate: inboundTransferStatusResult.creation_date,

--- a/client/lib/domains/check-inbound-transfer-status.js
+++ b/client/lib/domains/check-inbound-transfer-status.js
@@ -7,9 +7,7 @@ export function checkInboundTransferStatus( domainName, onComplete ) {
 	}
 
 	wpcom.req
-		.get( {
-			path: `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`,
-		} )
+		.get( `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status` )
 		.then( ( data ) => {
 			onComplete( null, data );
 		} )

--- a/client/lib/domains/check-inbound-transfer-status.js
+++ b/client/lib/domains/check-inbound-transfer-status.js
@@ -6,12 +6,14 @@ export function checkInboundTransferStatus( domainName, onComplete ) {
 		return;
 	}
 
-	wpcom.undocumented().getInboundTransferStatus( domainName, function ( serverError, result ) {
-		if ( serverError ) {
-			onComplete( serverError.error );
-			return;
-		}
-
-		onComplete( null, result );
-	} );
+	wpcom.req
+		.get( {
+			path: `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`,
+		} )
+		.then( ( data ) => {
+			onComplete( null, data );
+		} )
+		.catch( ( error ) => {
+			onComplete( error.error );
+		} );
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -38,22 +38,6 @@ Undocumented.prototype.checkAuthCode = function ( domain, authCode, fn ) {
 };
 
 /**
- * Get the inbound transfer status for this domain
- *
- * @param {string} domain - The domain name to check.
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.getInboundTransferStatus = function ( domain, fn ) {
-	return this.wpcom.req.get(
-		{
-			path: `/domains/${ encodeURIComponent( domain ) }/inbound-transfer-status`,
-		},
-		fn
-	);
-};
-
-/**
  * Starts an inbound domain transfer that is in the pending_start state.
  *
  * @param {number|string} siteId The site ID


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` domain transfer status methods to `wpcom.req`.

#### Testing instructions
Sorry for the super detailed process below. This method was called in four separate places, and one of those was invoked separately for existing sites and for new sites, so there are five total points of contact spanning three different flows. The steps below should hit all of them.

**First flow:**
- Start at `/domains/manage/[DOMAIN]/transfer/precheck/[SITE]`. Verify that the domain's lock status is correctly shown. If possible, test against both a locked an unlocked domain to confirm. (Note: this is an older flow that's due to be removed, but we want to keep it functional for as long as it's still around)
- This tests the first implementation of the fix, found in `check-inbound-transfer-status.js`

For the next two flows, we'll want to prevent the `UseMyDomain` component from passing transfer status info to the `DomainTransferStatusStart` component, forcing that component to run its own check on the status.
Edit `client/components/domains/use-my-domain/index.jsx` and comment out line 251: `domainInboundTransferStatusInfo={ domainInboundTransferStatusInfo }`.

**Second flow:**
- Start at `/domains/add/use-my-domain/[SITE]`
- Enter any available domain, confirm that it presents a message asking if you'd like to register instead of transfer
- Enter any registered domain that you know is currently locked (we're about to test the lock status check). Confirm it moves you on to the transfer/connect domain step for the domain you entered.
	- We've just tested the second implementation of the refactor in the `UseMyDomain` component.
	- We've also partially tested the fourth implementation of the refactor, from `get-domain-inbound-transfer-info.js`
- Click the blue 'Select' button to transfer your domain
- Click 'Start setup', 'I found the domain's settings page', and then 'I've unlocked my domain'
- Confirm that the UI reflects an accurate locked/unlocked status (for thorough testing, you can try unlocking an actual domain name if you have one to test with and confirm that it picks up on the changed lock status
	- We've now tested the third implementation of the refactor, this one in `transfer-domain-step-unlock.jsx`

**Third flow:**
- Start at `/start/domains/use-your-domain?step=domain-input`
- Enter a domain name and click 'Next'
- Confirm that on the next page your domain name is properly shown, then click the blue 'select' button to transfer your domain. You should then be taken on to the Choose a plan step.
	- This completed testing the fourth implementation of the refactor, from `get-domain-inbound-transfer-info.js`
