### PR TITLE
Products: Convert main calypso products functions to TypeScript

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -145,7 +145,7 @@ export class CheckoutThankYou extends Component {
 
 		if ( selectedSite && receipt.hasLoadedFromServer && this.hasPlanOrDomainProduct() ) {
 			this.props.refreshSitePlans( selectedSite.ID );
-		} else if ( shouldFetchSitePlans( sitePlans, selectedSite ) ) {
+		} else if ( selectedSite && shouldFetchSitePlans( sitePlans ) ) {
 			this.props.fetchSitePlans( selectedSite.ID );
 		}
 

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -38,13 +38,15 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/calypso-products#readme",
 	"dependencies": {
 		"@automattic/calypso-config": "workspace:^",
-		"i18n-calypso": "workspace:^",
-		"react": "^17.0.2"
+		"i18n-calypso": "workspace:^"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"chai": "^4.3.4",
 		"typescript": "^4.4.4"
+	},
+	"peerDependencies": {
+		"react": "^17.0.2"
 	},
 	"private": true
 }

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -38,7 +38,6 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/calypso-products#readme",
 	"dependencies": {
 		"@automattic/calypso-config": "workspace:^",
-		"@automattic/calypso-url": "workspace:^",
 		"i18n-calypso": "workspace:^",
 		"react": "^17.0.2"
 	},

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -1,11 +1,4 @@
 import {
-	format as formatUrl,
-	getUrlParts,
-	getUrlFromParts,
-	determineUrlType,
-	URL_TYPE,
-} from '@automattic/calypso-url';
-import {
 	TERM_MONTHLY,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
@@ -441,35 +434,22 @@ export function getBillingMonthsForTerm( term: string ): number {
 }
 
 export function plansLink(
-	url: string,
+	urlString: string,
 	siteSlug: string,
 	intervalType: string,
 	forceIntervalType = false
 ): string {
-	const originalUrlType = determineUrlType( url );
-	const resultUrl = getUrlParts( url );
-
-	if ( originalUrlType === URL_TYPE.INVALID ) {
-		throw new Error( 'Cannot format an invalid URL.' );
-	}
-
-	if ( originalUrlType === URL_TYPE.PATH_RELATIVE ) {
-		throw new Error( 'Cannot format path-relative URLs.' );
-	}
+	const url = new URL( urlString, window.location.origin );
 
 	if ( 'monthly' === intervalType || forceIntervalType ) {
-		resultUrl.pathname += '/' + intervalType;
+		url.pathname += '/' + intervalType;
 	}
 
 	if ( siteSlug ) {
-		resultUrl.pathname += '/' + siteSlug;
+		url.pathname += '/' + siteSlug;
 	}
 
-	// getUrlFromParts only works with absolute URLs, so add some dummy data if
-	// needed, and format down to the type of the original url.
-	resultUrl.protocol = resultUrl.protocol || 'https:';
-	resultUrl.hostname = resultUrl.hostname || '__hostname__.invalid';
-	return formatUrl( getUrlFromParts( resultUrl ), originalUrlType );
+	return url.toString();
 }
 
 export function applyTestFiltersToPlansList(

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -396,21 +396,16 @@ export function planMatches( planKey: string | Plan, query: PlanMatchesQuery = {
 	// @TODO: make getPlan() throw an error on failure. This is going to be a larger change with a separate PR.
 	const plan = getPlan( planKey );
 	if ( ! plan ) {
+		return false;
+	}
+	if (
+		( ! ( 'type' in query ) || plan.type === query.type ) &&
+		( ! ( 'group' in query ) || plan.group === query.group ) &&
+		( ! ( 'term' in query ) || plan.term === query.term )
+	) {
 		return true;
 	}
-	if ( ! plan.type || ! plan.group || ! plan.term ) {
-		return true;
-	}
-	if ( plan.type !== query.type ) {
-		return false;
-	}
-	if ( plan.group !== query.group ) {
-		return false;
-	}
-	if ( plan.term !== query.term ) {
-		return false;
-	}
-	return true;
+	return false;
 }
 
 export function calculateMonthlyPriceForPlan( planSlug: string, termPrice: number ): number {
@@ -612,6 +607,10 @@ export const getPopularPlanSpec = ( {
 	};
 };
 
+function isValueTruthy< T >( value: T ): value is Exclude< T, null | undefined | false | 0 | '' > {
+	return !! value;
+}
+
 export const chooseDefaultCustomerType = ( {
 	currentCustomerType,
 	selectedPlan,
@@ -635,7 +634,8 @@ export const chooseDefaultCustomerType = ( {
 		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_ECOMMERCE } )[ 0 ],
 	]
 		.map( ( planKey ) => getPlan( planKey ) )
-		.map( ( plan ) => plan?.getStoreSlug() ?? '' );
+		.filter( isValueTruthy )
+		.map( ( plan ) => plan.getStoreSlug() );
 
 	if ( selectedPlan ) {
 		return businessPlanSlugs.includes( selectedPlan as PlanSlug ) ? 'business' : 'personal';

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -449,6 +449,9 @@ export function plansLink(
 		url.pathname += '/' + siteSlug;
 	}
 
+	if ( urlString.startsWith( '/' ) ) {
+		return url.pathname + url.search;
+	}
 	return url.toString();
 }
 

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -45,6 +45,7 @@ import type {
 	WithCamelCaseSlug,
 	WithSnakeCaseSlug,
 } from './types';
+import type { TranslateResult } from 'i18n-calypso';
 
 export function getPlans(): Record< string, Plan > {
 	return PLANS_LIST;
@@ -141,26 +142,31 @@ export function planHasAtLeastOneFeature( plan: string | Plan, features: string[
  *
  * Returns an array of all the plan features (may have duplicates)
  */
-export function getAllFeaturesForPlan( plan: Plan | string ): string[] {
-	const planConstantObj = getPlan( plan );
-	if ( ! planConstantObj ) {
+export function getAllFeaturesForPlan( plan: Plan | string ): TranslateResult[] {
+	const planObj = getPlan( plan );
+	if ( ! planObj ) {
 		return [];
 	}
-
 	return [
-		'getPlanCompareFeatures',
-		'getPromotedFeatures',
-		'getSignupFeatures',
-		'getBlogSignupFeatures',
-		'getPortfolioSignupFeatures',
-		'getIncludedFeatures',
-	].reduce(
-		( featuresArray: string[], featureMethodName: string ) => [
-			...( planConstantObj?.[ featureMethodName ]?.() ?? [] ),
-			...featuresArray,
-		],
-		[]
-	);
+		...( 'getPlanCompareFeatures' in planObj && planObj.getPlanCompareFeatures
+			? planObj.getPlanCompareFeatures()
+			: [] ),
+		...( 'getPromotedFeatures' in planObj && planObj.getPromotedFeatures
+			? planObj.getPromotedFeatures()
+			: [] ),
+		...( 'getSignupFeatures' in planObj && planObj.getSignupFeatures
+			? planObj.getSignupFeatures()
+			: [] ),
+		...( 'getBlogSignupFeatures' in planObj && planObj.getBlogSignupFeatures
+			? planObj.getBlogSignupFeatures()
+			: [] ),
+		...( 'getPortfolioSignupFeatures' in planObj && planObj.getPortfolioSignupFeatures
+			? planObj.getPortfolioSignupFeatures()
+			: [] ),
+		...( 'getIncludedFeatures' in planObj && planObj.getIncludedFeatures
+			? planObj.getIncludedFeatures()
+			: [] ),
+	];
 }
 
 /**
@@ -490,9 +496,7 @@ export function applyTestFiltersToPlansList(
 
 	return {
 		...filteredPlanConstantObj,
-		/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-		getPlanCompareFeatures: ( experiment: string, options: Record< string, unknown > ) =>
-			filteredPlanFeaturesConstantList,
+		getPlanCompareFeatures: () => filteredPlanFeaturesConstantList,
 	};
 }
 
@@ -523,8 +527,7 @@ export function applyTestFiltersToProductsList(
 
 	return {
 		...filteredProductConstantObj,
-		/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-		getPlanCompareFeatures: ( experiment: string, options: Record< string, unknown > ) => [],
+		getPlanCompareFeatures: () => [],
 	};
 }
 

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -394,9 +394,23 @@ export function planMatches( planKey: string | Plan, query: PlanMatchesQuery = {
 	}
 
 	// @TODO: make getPlan() throw an error on failure. This is going to be a larger change with a separate PR.
-	const plan = getPlan( planKey ) || {};
-	const match = ( key ) => ! ( key in query ) || plan[ key ] === query[ key ];
-	return match( 'type' ) && match( 'group' ) && match( 'term' );
+	const plan = getPlan( planKey );
+	if ( ! plan ) {
+		return true;
+	}
+	if ( ! plan.type || ! plan.group || ! plan.term ) {
+		return true;
+	}
+	if ( plan.type !== query.type ) {
+		return false;
+	}
+	if ( plan.group !== query.group ) {
+		return false;
+	}
+	if ( plan.term !== query.term ) {
+		return false;
+	}
+	return true;
 }
 
 export function calculateMonthlyPriceForPlan( planSlug: string, termPrice: number ): number {

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -991,7 +991,8 @@ const getPlanJetpackCompleteDetails = () => ( {
 /**
  * @typedef {import( "./types").Plan} Plan
  * @typedef {import( "./types").JetpackPlan} JetpackPlan
- * @type	{Object.<string, Plan|JetpackPlan>}
+ * @typedef {import( "./types").WPComPlan} WPComPlan
+ * @type	{Object.<string, Plan|JetpackPlan|WPComPlan>}
  */
 export const PLANS_LIST = {
 	[ PLAN_FREE ]: {

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -990,7 +990,8 @@ const getPlanJetpackCompleteDetails = () => ( {
 // DO NOT import. Use `getPlan` instead.
 /**
  * @typedef {import( "./types").Plan} Plan
- * @type	{Object.<string, Plan>}
+ * @typedef {import( "./types").JetpackPlan} JetpackPlan
+ * @type	{Object.<string, Plan|JetpackPlan>}
  */
 export const PLANS_LIST = {
 	[ PLAN_FREE ]: {

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -29,12 +29,13 @@ export interface WPComPlan extends Plan {
 	getPortfolioAudience?: () => TranslateResult;
 	getStoreAudience?: () => TranslateResult;
 	getPlanCompareFeatures?: (
-		experiment: string,
-		options: Record< string, unknown >
+		experiment?: string,
+		options?: Record< string, unknown >
 	) => TranslateResult[];
 	getSignupFeatures?: () => Feature[];
 	getBlogSignupFeatures?: () => Feature[];
 	getPortfolioSignupFeatures?: () => Feature[];
+	getPromotedFeatures?: () => Feature[];
 }
 
 // Jetpack

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -104,3 +104,9 @@ export interface Plan {
 
 export type WithSnakeCaseSlug = { product_slug: string };
 export type WithCamelCaseSlug = { productSlug: string };
+
+export interface PlanMatchesQuery {
+	term?: string;
+	group?: string;
+	type?: string;
+}

--- a/packages/calypso-products/test/plans-link.js
+++ b/packages/calypso-products/test/plans-link.js
@@ -1,8 +1,12 @@
 import { plansLink } from '../src';
 
 describe( 'plansLink', () => {
-	test( 'should return url unchanged for yearly no-site', () => {
+	test( 'should return relative url unchanged for yearly no-site', () => {
 		expect( plansLink( '/plans' ) ).toBe( '/plans' );
+	} );
+
+	test( 'should return absolute url unchanged for yearly no-site', () => {
+		expect( plansLink( 'https://example.com/plans' ) ).toBe( 'https://example.com/plans' );
 	} );
 
 	test( 'should append monthly to url when required', () => {

--- a/packages/calypso-products/tsconfig.json
+++ b/packages/calypso-products/tsconfig.json
@@ -6,5 +6,6 @@
 		"declarationDir": "dist/types",
 		"rootDir": "src"
 	},
-	"include": [ "src" ]
+	"include": [ "src" ],
+	"references": [ { "path": "../calypso-config" }, { "path": "../i18n-calypso" } ]
 }

--- a/packages/calypso-products/tsconfig.json
+++ b/packages/calypso-products/tsconfig.json
@@ -7,5 +7,5 @@
 		"rootDir": "src"
 	},
 	"include": [ "src" ],
-	"references": [ { "path": "../calypso-config" }, { "path": "../i18n-calypso" } ]
+	"references": [ { "path": "../calypso-config" } ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,7 +250,6 @@ __metadata:
   dependencies:
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/calypso-url": "workspace:^"
     chai: ^4.3.4
     i18n-calypso: "workspace:^"
     react: ^17.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,8 +252,9 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     chai: ^4.3.4
     i18n-calypso: "workspace:^"
-    react: ^17.0.2
     typescript: ^4.4.4
+  peerDependencies:
+    react: ^17.0.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This converts the main functions in the `calypso-products` package to TypeScript. For the most part, this does not change any of the functions' behavior, but in some cases we had to add new guards to prevent fatal errors and satisfy the type checker.

#### Testing instructions

It's hard to test this entire change since it touches so much of calypso, so the best thing to do is probably to review the significant changes in the diff and make sure that they look correct.

The good news is that these functions are so central to most of calypso's functionality that most of them are covered directly or indirectly by tests in various places.