### PR TITLE
Fix: Theme search on mobile

### DIFF
--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -92,7 +92,12 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	};
 
 	return (
-		<div className="screen-options-tab" ref={ ref } data-testid="screen-options-tab">
+		<div
+			className="screen-options-tab"
+			id="screen-options-tab-id"
+			ref={ ref }
+			data-testid="screen-options-tab"
+		>
 			<button className="screen-options-tab__button" onClick={ handleToggle }>
 				<span className="screen-options-tab__label">{ __( 'Screen Options' ) }</span>
 				<span

--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -92,12 +92,7 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	};
 
 	return (
-		<div
-			className="screen-options-tab"
-			id="screen-options-tab-id"
-			ref={ ref }
-			data-testid="screen-options-tab"
-		>
+		<div className="screen-options-tab" ref={ ref } data-testid="screen-options-tab">
 			<button className="screen-options-tab__button" onClick={ handleToggle }>
 				<span className="screen-options-tab__label">{ __( 'Screen Options' ) }</span>
 				<span

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -159,7 +159,7 @@ class ThemeShowcase extends Component {
 
 	scrollToSearchInput = () => {
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
-			const yOffset = -55;
+			const yOffset = -55; // A number that takes the Adminbar as well as the screen options into account on mobile view ports.
 			this.scrollRef.current.scrollIntoView();
 			const y = this.scrollRef.current.getBoundingClientRect().top + window.pageYOffset + yOffset;
 			window.scrollTo( { top: y } );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,3 +1,4 @@
+import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
@@ -158,7 +159,12 @@ class ThemeShowcase extends Component {
 	}
 
 	scrollToSearchInput = () => {
-		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
+		if (
+			! this.props.loggedOutComponent &&
+			this.scrollRef &&
+			this.scrollRef.current &&
+			! isMobile()
+		) {
 			this.scrollRef.current.scrollIntoView();
 		}
 	};
@@ -176,7 +182,8 @@ class ThemeShowcase extends Component {
 			searchString: searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim(),
 		} );
 		this.setState( { tabFilter: this.tabFilters.ALL } );
-		page( url );
+		// Update the url without moving the window around.
+		window.history.pushState( { path: url }, '', url );
 		this.scrollToSearchInput();
 	};
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -168,7 +168,7 @@ class ThemeShowcase extends Component {
 				.getElementById( 'screen-options-tab-id' )
 				?.getBoundingClientRect().height;
 
-			const yOffset = -( headerHeight + screenOptionTab ); // A number that takes the Adminbar as well as the screen options into account on mobile view ports.
+			const yOffset = -( headerHeight + screenOptionTab ); // Total height of admin bar and screen options on mobile.
 			const elementBoundary = this.scrollRef.current.getBoundingClientRect();
 
 			const y = elementBoundary.top + window.pageYOffset + yOffset;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,4 +1,3 @@
-import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
@@ -159,13 +158,11 @@ class ThemeShowcase extends Component {
 	}
 
 	scrollToSearchInput = () => {
-		if (
-			! this.props.loggedOutComponent &&
-			this.scrollRef &&
-			this.scrollRef.current &&
-			! isMobile()
-		) {
+		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
+			const yOffset = -55;
 			this.scrollRef.current.scrollIntoView();
+			const y = this.scrollRef.current.getBoundingClientRect().top + window.pageYOffset + yOffset;
+			window.scrollTo( { top: y } );
 		}
 	};
 
@@ -182,8 +179,7 @@ class ThemeShowcase extends Component {
 			searchString: searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim(),
 		} );
 		this.setState( { tabFilter: this.tabFilters.ALL } );
-		// Update the url without moving the window around.
-		window.history.pushState( { path: url }, '', url );
+		page( url );
 		this.scrollToSearchInput();
 	};
 
@@ -383,7 +379,7 @@ class ThemeShowcase extends Component {
 						uri={ this.constructUrl() }
 					/>
 				) }
-				<div className="themes__content">
+				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />
 					<ThemesSearchCard
 						onSearch={ this.doSearch }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -159,9 +159,19 @@ class ThemeShowcase extends Component {
 
 	scrollToSearchInput = () => {
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
-			const yOffset = -55; // A number that takes the Adminbar as well as the screen options into account on mobile view ports.
-			this.scrollRef.current.scrollIntoView();
-			const y = this.scrollRef.current.getBoundingClientRect().top + window.pageYOffset + yOffset;
+			// If you are a larger screen where the theme info is displayed horizontally.
+			if ( window.innerWidth > 600 ) {
+				return;
+			}
+			const headerHeight = document.getElementById( 'header' )?.getBoundingClientRect().height;
+			const screenOptionTab = document
+				.getElementById( 'screen-options-tab-id' )
+				?.getBoundingClientRect().height;
+
+			const yOffset = -( headerHeight + screenOptionTab ); // A number that takes the Adminbar as well as the screen options into account on mobile view ports.
+			const elementBoundary = this.scrollRef.current.getBoundingClientRect();
+
+			const y = elementBoundary.top + window.pageYOffset + yOffset;
 			window.scrollTo( { top: y } );
 		}
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -163,9 +163,11 @@ class ThemeShowcase extends Component {
 			if ( window.innerWidth > 600 ) {
 				return;
 			}
-			const headerHeight = document.getElementById( 'header' )?.getBoundingClientRect().height;
+			const headerHeight = document
+				.getElementsByClassName( 'masterbar' )[ 0 ]
+				?.getBoundingClientRect().height;
 			const screenOptionTab = document
-				.getElementById( 'screen-options-tab-id' )
+				.getElementsByClassName( 'screen-options-tab__button' )[ 0 ]
 				?.getBoundingClientRect().height;
 
 			const yOffset = -( headerHeight + screenOptionTab ); // Total height of admin bar and screen options on mobile.

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -23,6 +23,10 @@
 	}
 }
 
+.themes__content {
+	min-height: 100vh;
+}
+
 .is-section-themes.has-no-sidebar .themes__content {
 	padding: 0 0 32px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Do not attempt to scroll to the top on mobile only. 
* Do not use page() call since it also moves the page to the top when there is no search

#### Testing instructions
Go to http://calypso.localhost:3000/themes/example.com

* Use the search bar. On mobile and desktop) Notice that it works as expected. 
* Scrolls to the top on search typing. The search bar doesn't move around as you type. 

Fixes https://github.com/Automattic/wp-calypso/issues/58149


Before:

https://user-images.githubusercontent.com/115071/143321584-d2b31dee-78ac-4a9e-af5e-74a287ffa0e7.mp4

https://user-images.githubusercontent.com/115071/143321593-61bd16eb-592e-4f76-8d96-6ff5c54ebb4e.mp4


After:

https://user-images.githubusercontent.com/115071/143321574-f187c24d-1491-4dc3-b421-750e945e88d5.mp4


https://user-images.githubusercontent.com/115071/143321599-7a53090e-add3-4b7c-b1cc-906e55e023b5.mp4


