### PR TITLE
Update outdated packages

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -128,6 +128,7 @@ RUN apt update &&\
 	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg &&\
 	echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php-sury.list &&\
 	apt update &&\
+ 	apt-get upgrade -y &&\
 	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose &&\
 	composer install
 


### PR DESCRIPTION
## Background

Our docker image is failing to build with the error

```
12:06:52   #19 23.19 Fatal error: Uncaught ErrorException: preg_match_all(): Compilation failed: unrecognised compile-time option bit(s) at offset 0 in phar:///usr/local/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php:137
12:06:52   #19 23.19 Stack trace:
12:06:52   #19 23.19 #0 [internal function]: Composer\Util\ErrorHandler::handle()
12:06:52   #19 23.19 #1 phar:///usr/local/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php(137): preg_match_all()
12:06:52   #19 23.19 #2 phar:///usr/local/bin/composer/vendor/symfony/console/Output/Output.php(155): Symfony\Component\Console\Formatter\OutputFormatter->format()
12:06:52   #19 23.19 #3 phar:///usr/local/bin/composer/vendor/symfony/console/Output/Output.php(132): Symfony\Component\Console\Output\Output->write()
12:06:52   #19 23.19 #4 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(641): Symfony\Component\Console\Output\Output->writeln()
12:06:52   #19 23.19 #5 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(127): Symfony\Component\Console\Application->renderException()
12:06:52   #19 23.19 #6 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(122): Symfony\Component\ in phar:///usr/local/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php on line 137
12:06:52   #19 23.19 PHP Fatal error:  Uncaught ErrorException: preg_match_all(): Compilation failed: unrecognised compile-time option bit(s) at offset 0 in phar:///usr/local/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php:137
12:06:52   #19 23.19 Stack trace:
12:06:52   #19 23.19 #0 [internal function]: Composer\Util\ErrorHandler::handle()
12:06:52   #19 23.19 #1 phar:///usr/local/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php(137): preg_match_all()
12:06:52   #19 23.19 #2 phar:///usr/local/bin/composer/vendor/symfony/console/Output/Output.php(155): Symfony\Component\Console\Formatter\OutputFormatter->format()
12:06:52   #19 23.19 #3 phar:///usr/local/bin/composer/vendor/symfony/console/Output/Output.php(132): Symfony\Component\Console\Output\Output->write()
12:06:52   #19 23.19 #4 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(641): Symfony\Component\Console\Output\Output->writeln()
12:06:52   #19 23.19 #5 phar:///usr/local/bin/composer/vendor/symfony/console/Application.php(127): Symfony\Component\Console\Application->renderException()
12:06:52   #19 23.19 #6 phar:///usr/local/bin/composer/src/Composer/Console/Application.php(122): Symfony\Component\ in phar:///usr/local/bin/composer/vendor/symfony/console/Formatter/OutputFormatter.php on line 137
```

This seems to come from running `composer install`.

[This issue](https://github.com/oerdnj/deb.sury.org/issues/1674) suggests it is reltaed to outdated system libraries, `pcre` specifically.

## Changes

Update outadated system libraries before runnign `composer install`.

