### PR TITLE
Remove defunct minify option from WebpackRTLPlugin

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -273,7 +273,6 @@ const webpackConfig = {
 		...SassConfig.plugins( {
 			chunkFilename: cssChunkFilename,
 			filename: cssFilename,
-			minify: ! isDevelopment,
 		} ),
 		new AssetsWriter( {
 			filename: `assets.json`,

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -51,10 +51,9 @@ module.exports.loader = ( { includePaths, prelude, postCssOptions } ) => ( {
  * @param  {object}   _                Options
  * @param  {string}   _.chunkFilename  filename pattern to use for CSS files
  * @param  {string}   _.filename       filename pattern to use for CSS chunk files
- * @param  {boolean}  _.minify         whether to minify CSS
  * @returns {object[]}                 styling relevant webpack plugin objects
  */
-module.exports.plugins = ( { chunkFilename, filename, minify } ) => [
+module.exports.plugins = ( { chunkFilename, filename } ) => [
 	new MiniCssExtractPlugin( {
 		chunkFilename,
 		filename,
@@ -64,7 +63,5 @@ module.exports.plugins = ( { chunkFilename, filename, minify } ) => [
 		},
 	} ),
 	new MiniCSSWithRTLPlugin(),
-	new WebpackRTLPlugin( {
-		minify,
-	} ),
+	new WebpackRTLPlugin(),
 ];


### PR DESCRIPTION
Removes a defunct `minify` option from the `calypso-build`'s `SassConfig`, which further passed it to the `WebpackRTLPlugin`. That used to work when the CSS minification was done inside the RTL plugin with `cssnano`, but that's long gone. Nowadays, the minification is done by `dart-sass` and is configurable wit its `outputStyle` option.

By default, `sass-loader` sets `outputStyle` according to `process.env.NODE_ENV`, and if we wanted to manually override it, it would need to be a `{ sassOptions: { outputStyle }` option of the `sass-loader`.

And to make it configurable in the `calypso-build` presets, we'd have to add a new `minify` option to `SassConfig.loader`, as opposed to the `SassConfig.plugins` where it was until now.