### PR TITLE
Fix alignment of site pop-up list of write button

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -108,6 +108,7 @@
 .site__info {
 	width: 0; // Firefox needs explicit width (even 0)
 	flex: 1 0 auto;
+	text-align: initial;
 }
 
 .site__title {
@@ -190,7 +191,7 @@
 	}
 
 	.site__badge {
-		background: var(--color-sidebar-menu-hover-background);
-    	color: var(--color-sidebar-menu-hover-text);
+		background: var( --color-sidebar-menu-hover-background );
+		color: var( --color-sidebar-menu-hover-text );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As the class `.popover__inner` specifies the value of `text-align` to center, it leads to the wrong alignment of the site popup-list. Thus, setting the value of `text-align` to `initial` to make sure the alignment is correct.

| LTR | RTL (ex. AR) |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/142835691-5339896a-ba3b-4024-8139-794c5d010b16.png) | ![image](https://user-images.githubusercontent.com/13596067/142835521-1cf29475-28a4-490c-bdc0-d39ea77134b7.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/home
* Click on write
* See pop up list of sites that are aligned correctly no matter the direction is ltr or rtl

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56114
