### PR TITLE
I18n: reorganize the setLocale, setLocaleRawData and switchLocale actions

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -1,12 +1,13 @@
 import config from '@automattic/calypso-config';
+import i18n from 'i18n-calypso';
 import {
 	getLanguageSlugs,
 	isDefaultLocale,
 	isTranslatedIncompletely,
 } from 'calypso/lib/i18n-utils';
 import { initLanguageEmpathyMode } from 'calypso/lib/i18n-utils/empathy-mode';
-import { loadUserUndeployedTranslations } from 'calypso/lib/i18n-utils/switch-locale';
-import { setLocale, setLocaleRawData } from 'calypso/state/ui/language/actions';
+import { loadUserUndeployedTranslations, switchLocale } from 'calypso/lib/i18n-utils/switch-locale';
+import { setLocale } from 'calypso/state/ui/language/actions';
 
 function getLocaleFromPathname() {
 	const pathname = window.location.pathname.replace( /\/$/, '' );
@@ -38,7 +39,9 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		// Use the locale translation data that were boostrapped by the server
 		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
 
-		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
+		i18n.setLocale( i18nLocaleStringsObject );
+		const { localeSlug, localeVariant } = i18nLocaleStringsObject[ '' ];
+		reduxStore.dispatch( setLocale( localeSlug, localeVariant ) );
 
 		// The empty string key [ '' ] where metadata about the translation file
 		// (e.g., the locale name, plurals definitions, etc.) are stored.
@@ -49,19 +52,19 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 	} else if ( currentUser && currentUser.localeSlug ) {
 		if ( shouldUseFallbackLocale ) {
 			// Use user locale fallback slug
-			reduxStore.dispatch( setLocale( userLocaleSlug ) );
+			reduxStore.dispatch( switchLocale( userLocaleSlug ) );
 		} else {
-			// Use the current user's and load traslation data with a fetch request
-			reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
+			// Use the current user's and load translation data with a fetch request
+			reduxStore.dispatch( switchLocale( currentUser.localeSlug, currentUser.localeVariant ) );
 		}
 	} else if ( bootstrappedLocaleSlug ) {
 		// Use locale slug from bootstrapped language manifest object
-		reduxStore.dispatch( setLocale( bootstrappedLocaleSlug ) );
+		reduxStore.dispatch( switchLocale( bootstrappedLocaleSlug ) );
 	} else {
 		// For logged out Calypso pages, set the locale from slug
 		const pathLocaleSlug = getLocaleFromPathname();
-		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
+		pathLocaleSlug && reduxStore.dispatch( switchLocale( pathLocaleSlug, '' ) );
 	}
 
-	// If user is logged out and translations are not boostrapped, we assume default locale
+	// If user is logged out and translations are not bootstrapped, we assume default locale
 };

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 import QueryLocaleSuggestions from 'calypso/components/data/query-locale-suggestions';
 import Notice from 'calypso/components/notice';
 import { addLocaleToPath, getLanguage } from 'calypso/lib/i18n-utils';
+import { switchLocale } from 'calypso/lib/i18n-utils/switch-locale';
 import getLocaleSuggestions from 'calypso/state/selectors/get-locale-suggestions';
-import { setLocale } from 'calypso/state/ui/language/actions';
 import LocaleSuggestionsListItem from './list-item';
 
 import './style.scss';
@@ -28,7 +28,7 @@ export class LocaleSuggestions extends Component {
 		dismissed: false,
 	};
 
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		let { locale } = this.props;
 
 		if ( ! locale && typeof navigator === 'object' && 'languages' in navigator ) {
@@ -41,12 +41,12 @@ export class LocaleSuggestions extends Component {
 			}
 		}
 
-		this.props.setLocale( locale );
+		this.props.switchLocale( locale );
 	}
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.locale !== nextProps.locale ) {
-			this.props.setLocale( nextProps.locale );
+	componentDidUpdate( prevProps ) {
+		if ( this.props.locale !== prevProps.locale ) {
+			this.props.switchLocale( this.props.locale );
 		}
 	}
 
@@ -98,5 +98,5 @@ export default connect(
 	( state ) => ( {
 		localeSuggestions: getLocaleSuggestions( state ),
 	} ),
-	{ setLocale }
+	{ switchLocale }
 )( LocaleSuggestions );

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -20,11 +20,11 @@ describe( 'LocaleSuggestions', () => {
 			{ locale: 'fr', name: 'Français', availability_text: 'Également disponible en' },
 			{ locale: 'en', name: 'English', availability_text: 'Also available in' },
 		],
-		setLocale: jest.fn(),
+		switchLocale: jest.fn(),
 	};
 
 	test( 'should not render without suggestions', () => {
-		const wrapper = shallow( <LocaleSuggestions path="" locale="x" setLocale={ () => {} } /> );
+		const wrapper = shallow( <LocaleSuggestions path="" locale="x" switchLocale={ () => {} } /> );
 		expect( wrapper.type() ).toBe( null );
 	} );
 

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -1,8 +1,8 @@
 import config from '@automattic/calypso-config';
+import { switchLocale } from 'calypso/lib/i18n-utils/switch-locale';
 import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setSection } from 'calypso/state/ui/actions';
-import { setLocale } from 'calypso/state/ui/language/actions';
 
 const noop = () => {};
 
@@ -55,7 +55,7 @@ export function setLocaleMiddleware( context, next ) {
 			: currentUser.localeSlug;
 	}
 
-	context.store.dispatch( setLocale( context.lang || config( 'i18n_default_locale_slug' ) ) );
+	context.store.dispatch( switchLocale( context.lang || config( 'i18n_default_locale_slug' ) ) );
 	next();
 }
 

--- a/client/controller/ssr-setup-locale.js
+++ b/client/controller/ssr-setup-locale.js
@@ -1,22 +1,29 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import { readFile } from 'fs/promises';
+import i18n from 'i18n-calypso';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import { getLanguage } from 'calypso/lib/i18n-utils';
 import config from 'calypso/server/config';
-import { setLocaleRawData } from 'calypso/state/ui/language/actions';
+import { setLocale } from 'calypso/state/ui/language/actions';
 
 export function ssrSetupLocaleMiddleware() {
 	const translationsCache = {};
 
 	return function ssrSetupLocale( context, next ) {
 		function resetLocaleData() {
-			const localeDataPlaceholder = { '': {} };
-			context.store.dispatch( setLocaleRawData( localeDataPlaceholder ) );
-			next();
+			i18n.setLocale( null );
+			context.store.dispatch( setLocale( i18n.getLocaleSlug() ) );
+		}
+
+		function setLocaleData( localeData ) {
+			i18n.setLocale( localeData );
+			const { localeSlug, localeVariant } = localeData[ '' ];
+			context.store.dispatch( setLocale( localeSlug, localeVariant ) );
 		}
 
 		if ( ! context.params.lang ) {
 			resetLocaleData();
+			next();
 			return;
 		}
 
@@ -27,7 +34,9 @@ export function ssrSetupLocaleMiddleware() {
 
 		const language = getLanguage( context.params.lang );
 		if ( ! language ) {
+			resetLocaleData();
 			next();
+			return;
 		}
 
 		context.lang = language.langSlug;
@@ -35,18 +44,20 @@ export function ssrSetupLocaleMiddleware() {
 
 		const cachedTranslations = translationsCache[ context.lang ];
 		if ( typeof cachedTranslations !== 'undefined' ) {
-			context.store.dispatch( setLocaleRawData( cachedTranslations ) );
+			setLocaleData( cachedTranslations );
 			next();
 		} else {
 			readFile( getAssetFilePath( `languages/${ context.lang }-v1.1.json` ), 'utf-8' )
 				.then( ( data ) => {
 					const translations = JSON.parse( data );
-
-					context.store.dispatch( setLocaleRawData( translations ) );
 					translationsCache[ context.lang ] = translations;
+					setLocaleData( translations );
 					next();
 				} )
-				.catch( resetLocaleData );
+				.catch( () => {
+					resetLocaleData();
+					next();
+				} );
 		}
 	};
 }

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -1,7 +1,7 @@
 import page from 'page';
+import { switchLocale } from 'calypso/lib/i18n-utils/switch-locale';
 import { addQueryArgs } from 'calypso/lib/route';
 import { hideMasterbar } from 'calypso/state/ui/actions';
-import { setLocale } from 'calypso/state/ui/language/actions';
 import Header from './header';
 import JetpackComFooter from './jpcom-footer';
 import JetpackComMasterbar from './jpcom-masterbar';
@@ -11,7 +11,7 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 	const { locale, site } = context.params;
 
 	if ( locale ) {
-		context.store.dispatch( setLocale( locale ) );
+		context.store.dispatch( switchLocale( locale ) );
 
 		if ( context.pathname.includes( '/pricing/storage' ) ) {
 			page.redirect(

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -17,13 +17,13 @@ import {
 	getLanguageEmpathyModeActive,
 	toggleLanguageEmpathyMode,
 } from 'calypso/lib/i18n-utils/empathy-mode';
+import { switchLocale } from 'calypso/lib/i18n-utils/switch-locale';
 import { TranslationScanner } from 'calypso/lib/i18n-utils/translation-scanner';
 import translator, { trackTranslatorStatus } from 'calypso/lib/translator-jumpstart';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getOriginalUserSetting from 'calypso/state/selectors/get-original-user-setting';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import { setLocale } from 'calypso/state/ui/language/actions';
 import './style.scss';
 
 class TranslatorLauncher extends Component {
@@ -246,11 +246,11 @@ class TranslatorLauncher extends Component {
 					this.selectedLanguageSlug = this.props.selectedLanguageSlug;
 
 					const DEFAULT_LANGUAGE = 'en';
-					setLocale( DEFAULT_LANGUAGE );
+					this.props.switchLocale( DEFAULT_LANGUAGE );
 				} else {
 					window.removeEventListener( 'scroll', this.handleWindowScroll );
 
-					this.selectedLanguageSlug && this.props.setLocale( this.selectedLanguageSlug );
+					this.selectedLanguageSlug && this.props.switchLocale( this.selectedLanguageSlug );
 				}
 			}
 		);
@@ -407,5 +407,5 @@ export default connect(
 			getOriginalUserSetting( state, 'i18n_empathy_mode' ),
 		selectedLanguageSlug: getCurrentLocaleSlug( state ),
 	} ),
-	{ setLocale }
+	{ switchLocale }
 )( localize( TranslatorLauncher ) );

--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -1,21 +1,25 @@
 import config from '@automattic/calypso-config';
 import languages from '@automattic/languages';
 import { Fragment, useReducer } from 'react';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import LanguagePickerModal from 'calypso/components/language-picker/modal';
 import {
 	getLanguageEmpathyModeActive,
 	toggleLanguageEmpathyMode,
 } from 'calypso/lib/i18n-utils/empathy-mode';
+import { switchLocale } from 'calypso/lib/i18n-utils/switch-locale';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import { setLocale } from 'calypso/state/ui/language/actions';
 import MasterbarItem from './item';
 
-function QuickLanguageSwitcher( props ) {
+export default function QuickLanguageSwitcher() {
+	const dispatch = useDispatch();
+	const selectedLanguageSlug = useSelector( getCurrentLocaleSlug );
 	const [ isShowingModal, toggleLanguagesModal ] = useReducer( ( toggled ) => ! toggled, false );
 	const onSelected = ( language, { empathyMode, useFallbackForIncompleteLanguages } ) => {
-		props.setLocale(
-			useFallbackForIncompleteLanguages ? config( 'i18n_default_locale_slug' ) : language.langSlug
+		dispatch(
+			switchLocale(
+				useFallbackForIncompleteLanguages ? config( 'i18n_default_locale_slug' ) : language.langSlug
+			)
 		);
 		toggleLanguageEmpathyMode( empathyMode );
 	};
@@ -27,12 +31,12 @@ function QuickLanguageSwitcher( props ) {
 				className="masterbar__quick-language-switcher"
 				onClick={ toggleLanguagesModal }
 			>
-				{ props.selectedLanguageSlug }
+				{ selectedLanguageSlug }
 			</MasterbarItem>
 			{ isShowingModal && (
 				<LanguagePickerModal
 					languages={ languages }
-					selectedLanguageSlug={ props.selectedLanguageSlug }
+					selectedLanguageSlug={ selectedLanguageSlug }
 					empathyMode={ getLanguageEmpathyModeActive() }
 					showEmpathyModeControl
 					onSelectLanguage={ onSelected }
@@ -42,10 +46,3 @@ function QuickLanguageSwitcher( props ) {
 		</Fragment>
 	);
 }
-
-export default connect(
-	( state ) => ( {
-		selectedLanguageSlug: getCurrentLocaleSlug( state ),
-	} ),
-	{ setLocale }
-)( QuickLanguageSwitcher );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -3,6 +3,7 @@ import { getUrlFromParts, getUrlParts } from '@automattic/calypso-url';
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 import { forEach, throttle } from 'lodash';
+import { setLocale } from 'calypso/state/ui/language/actions';
 import { isDefaultLocale, getLanguage } from './utils';
 
 const debug = debugFactory( 'calypso:i18n' );
@@ -305,17 +306,11 @@ function removeRequireChunkTranslationsHandler() {
 }
 
 let lastRequestedLocale = null;
-export default async function switchLocale( localeSlug ) {
+async function doSwitchLocale( localeSlug ) {
 	// check if the language exists in config.languages
 	const language = getLanguage( localeSlug );
 
 	if ( ! language ) {
-		return;
-	}
-
-	// Note: i18n is a singleton that will be shared between all server requests!
-	// Disable switching locale on the server
-	if ( typeof document === 'undefined' ) {
 		return;
 	}
 
@@ -423,6 +418,13 @@ export default async function switchLocale( localeSlug ) {
 			}
 		);
 	}
+}
+
+export function switchLocale( localeSlug, localeVariant = null ) {
+	return ( dispatch ) => {
+		doSwitchLocale( localeVariant || localeSlug );
+		dispatch( setLocale( localeSlug, localeVariant ) );
+	};
 }
 
 export function loadUserUndeployedTranslations( currentLocaleSlug ) {

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -1,5 +1,3 @@
-import i18n from 'i18n-calypso';
-import switchLocale from 'calypso/lib/i18n-utils/switch-locale';
 import { LOCALE_SET } from 'calypso/state/action-types';
 
 import 'calypso/state/ui/init';
@@ -12,25 +10,6 @@ import 'calypso/state/ui/init';
  * @returns {object} Action
  */
 export const setLocale = ( localeSlug, localeVariant = null ) => {
-	switchLocale( localeVariant || localeSlug );
-	return {
-		type: LOCALE_SET,
-		localeSlug,
-		localeVariant,
-	};
-};
-
-/**
- * Set the ui locale using a raw (jed) translation object
- *
- * @param   {object} localeData the locale data to be set
- * @returns {object} Action
- */
-export const setLocaleRawData = ( localeData ) => {
-	i18n.setLocale( localeData );
-
-	const { localeSlug, localeVariant = null } = localeData[ '' ];
-
 	return {
 		type: LOCALE_SET,
 		localeSlug,

--- a/client/state/ui/language/test/actions.js
+++ b/client/state/ui/language/test/actions.js
@@ -1,5 +1,5 @@
 import { LOCALE_SET } from 'calypso/state/action-types';
-import { setLocale, setLocaleRawData } from '../actions';
+import { setLocale } from '../actions';
 
 describe( 'actions', () => {
 	describe( 'setLocale', () => {
@@ -13,37 +13,6 @@ describe( 'actions', () => {
 
 		test( 'returns an action with localeVariant set', () => {
 			expect( setLocale( 'he', 'he_formal' ) ).toEqual( {
-				type: LOCALE_SET,
-				localeSlug: 'he',
-				localeVariant: 'he_formal',
-			} );
-		} );
-	} );
-
-	describe( 'setLocaleRawData', () => {
-		test( 'returns an appropriate action', () => {
-			expect(
-				setLocaleRawData( {
-					'': {
-						localeSlug: 'he',
-					},
-				} )
-			).toEqual( {
-				type: LOCALE_SET,
-				localeSlug: 'he',
-				localeVariant: null,
-			} );
-		} );
-
-		test( 'returns an action with localeVariant set', () => {
-			expect(
-				setLocaleRawData( {
-					'': {
-						localeSlug: 'he',
-						localeVariant: 'he_formal',
-					},
-				} )
-			).toEqual( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
 				localeVariant: 'he_formal',


### PR DESCRIPTION
Here I'm trying to clean up the `setLocale` and `setLocaleRawData` Redux action creators. They are not correct Redux action creators, because they also call `switchLocale` and `i18n.setLocale` instead of just returning a Redux action to be dispatched.

The new setup is:
- the `setLocale` action merely updates the state in Redux and nothing else. There are no side effects.
- the `setLocaleRawData` action disappears. I'm replacing it with calling `i18n.setLocale` and `dispatch( setLocale )` manually. There are two places where this action was used.
- there is a new `switchLocale` thunk that does the very complex logic for actually switching a locale (loading translations from server, changing stuff in DOM and Redux etc.) I'm replacing many usages of `setLocale` with the new `switchLocale`.

One good thing about `switchLocale` is that it's guaranteed to be called only in browser, never in SSR (please verify that during review!). React components are calling it only in effects, DOM event callbacks and lifecycle methods.

Let me know what you think.