### PR TITLE
ESLint: allow loops with constant conditions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -206,6 +206,8 @@ module.exports = {
 		// REST API objects include underscores
 		camelcase: 'off',
 
+		'no-constant-condition': [ 'error', { checkLoops: false } ],
+
 		'no-path-concat': 'error',
 
 		'one-var': [ 'error', 'never' ],

--- a/client/lib/highlight/index.js
+++ b/client/lib/highlight/index.js
@@ -38,7 +38,6 @@ function highlightNode( node, term, wrapperNode ) {
 		remainingText = node.nodeValue;
 	}
 
-	// eslint-disable-next-line no-constant-condition
 	while ( true ) {
 		pos = remainingText.toLowerCase().indexOf( term.toLowerCase() );
 		if ( ! remainingText || pos === -1 ) {

--- a/packages/wpcom-xhr-request/src/index.js
+++ b/packages/wpcom-xhr-request/src/index.js
@@ -153,7 +153,7 @@ function enableStreamModeProcessing( req, onStreamRecord ) {
 		// while we’re working with text that has already been decoded from UTF-8 into a string
 		// that can only be indexed in UTF-16 code units. Reconciling this difference is not
 		// worth the effort, and might even be impossible if there were encoding errors.
-		for (;;) {
+		while ( true ) {
 			const stop = target.response.indexOf( '\n', start );
 
 			if ( stop < 0 ) {

--- a/test/e2e/lib/hooks/video/framebuffer.js
+++ b/test/e2e/lib/hooks/video/framebuffer.js
@@ -5,7 +5,6 @@ import path from 'path';
 import { getTestNameWithTime } from '../../test-utils';
 
 export const getFreeDisplay = () => {
-	// eslint-disable-next-line no-constant-condition
 	while ( true ) {
 		const i = 99 + Math.round( Math.random() * 100 );
 		try {


### PR DESCRIPTION
Configures the `no-constant-condition` ESLint rule so that I can legally write infinite loops like:
```js
while ( true ) {
  if ( condition() ) {
    break; // or return
  }

  /* ... */
}
```

Currently the rule prohibits such loops, or more precisely, forces me to write them as `for (;;) {`. I don't think that's a valuable suggestion. Why would it be better than `while ( true )` in any sense?

The rule continues to prohibit constant conditions like:
```js
if ( false ) {
  /* ... */
}
```
and I like that because that's often some debugging artifact where I commented out a complex condition:
```js
if ( true /* originalConditionThatIsHardToMakeTrueOtherwise */ ) {
  /* ... */
}
```
and forgot to comment it back in.