### PR TITLE
On localized routes, set locale in page.js handler instead of LocaleSuggestions didMount

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -25,15 +25,6 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		initLanguageEmpathyMode();
 	}
 
-	let userLocaleSlug = currentUser.localeVariant || currentUser.localeSlug;
-	const shouldUseFallbackLocale =
-		currentUser?.use_fallback_for_incomplete_languages &&
-		isTranslatedIncompletely( userLocaleSlug );
-
-	if ( shouldUseFallbackLocale ) {
-		userLocaleSlug = config( 'i18n_default_locale_slug' );
-	}
-
 	const bootstrappedLocaleSlug = window?.i18nLanguageManifest?.locale?.[ '' ]?.localeSlug;
 
 	if ( window.i18nLocaleStrings ) {
@@ -49,11 +40,14 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 			loadUserUndeployedTranslations( localeSlug );
 		}
 	} else if ( currentUser && currentUser.localeSlug ) {
-		if ( shouldUseFallbackLocale ) {
+		if (
+			currentUser.use_fallback_for_incomplete_languages &&
+			isTranslatedIncompletely( currentUser.localeVariant || currentUser.localeSlug )
+		) {
 			// Use user locale fallback slug
-			reduxStore.dispatch( setLocale( userLocaleSlug ) );
+			reduxStore.dispatch( setLocale( config( 'i18n_default_locale_slug' ) ) );
 		} else {
-			// Use the current user's and load traslation data with a fetch request
+			// Use the current user's and load translation data with a fetch request
 			reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
 		}
 	} else if ( bootstrappedLocaleSlug ) {

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -1,102 +1,60 @@
 import { getLocaleSlug } from 'i18n-calypso';
-import startsWith from 'lodash/startsWith';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import QueryLocaleSuggestions from 'calypso/components/data/query-locale-suggestions';
 import Notice from 'calypso/components/notice';
-import { addLocaleToPath, getLanguage } from 'calypso/lib/i18n-utils';
+import { addLocaleToPath } from 'calypso/lib/i18n-utils';
 import getLocaleSuggestions from 'calypso/state/selectors/get-locale-suggestions';
-import { setLocale } from 'calypso/state/ui/language/actions';
 import LocaleSuggestionsListItem from './list-item';
 
 import './style.scss';
 
-export class LocaleSuggestions extends Component {
-	static propTypes = {
-		locale: PropTypes.string,
-		path: PropTypes.string.isRequired,
-		localeSuggestions: PropTypes.array,
-	};
+export function LocaleSuggestions( { path, localeSuggestions } ) {
+	const [ dismissed, setDismissed ] = useState( false );
 
-	static defaultProps = {
-		locale: '',
-		localeSuggestions: [],
-	};
-
-	state = {
-		dismissed: false,
-	};
-
-	componentDidMount() {
-		let { locale } = this.props;
-
-		if ( ! locale && typeof navigator === 'object' && 'languages' in navigator ) {
-			for ( const langSlug of navigator.languages ) {
-				const language = getLanguage( langSlug.toLowerCase() );
-				if ( language ) {
-					locale = language.langSlug;
-					break;
-				}
-			}
-		}
-
-		this.props.setLocale( locale );
+	if ( dismissed ) {
+		return null;
 	}
 
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.locale !== this.props.locale ) {
-			this.props.setLocale( this.props.locale );
-		}
+	if ( ! localeSuggestions ) {
+		return <QueryLocaleSuggestions />;
 	}
 
-	dismiss = () => this.setState( { dismissed: true } );
+	const localeSlug = getLocaleSlug();
+	const usersOtherLocales = localeSuggestions.filter(
+		( locale ) => ! ( localeSlug && localeSlug.startsWith( locale.locale ) )
+	);
 
-	getPathWithLocale = ( locale ) => addLocaleToPath( this.props.path, locale );
-
-	render() {
-		if ( this.state.dismissed ) {
-			return null;
-		}
-
-		const { localeSuggestions } = this.props;
-
-		if ( ! localeSuggestions ) {
-			return <QueryLocaleSuggestions />;
-		}
-
-		const usersOtherLocales = localeSuggestions.filter( function ( locale ) {
-			return ! startsWith( getLocaleSlug(), locale.locale );
-		} );
-
-		if ( usersOtherLocales.length === 0 ) {
-			return null;
-		}
-
-		const localeMarkup = usersOtherLocales.map( ( locale ) => {
-			return (
-				<LocaleSuggestionsListItem
-					key={ 'locale-' + locale.locale }
-					locale={ locale }
-					onLocaleSuggestionClick={ this.dismiss }
-					path={ this.getPathWithLocale( locale.locale ) }
-				/>
-			);
-		} );
-
-		return (
-			<div className="locale-suggestions">
-				<Notice icon="globe" showDismiss={ true } onDismissClick={ this.dismiss }>
-					<div className="locale-suggestions__list">{ localeMarkup }</div>
-				</Notice>
-			</div>
-		);
+	if ( usersOtherLocales.length === 0 ) {
+		return null;
 	}
+
+	const dismiss = () => setDismissed( true );
+
+	return (
+		<div className="locale-suggestions">
+			<Notice icon="globe" showDismiss onDismissClick={ dismiss }>
+				<div className="locale-suggestions__list">
+					{ usersOtherLocales.map( ( locale ) => (
+						<LocaleSuggestionsListItem
+							key={ locale.locale }
+							locale={ locale }
+							onLocaleSuggestionClick={ dismiss }
+							path={ addLocaleToPath( path, locale.locale ) }
+						/>
+					) ) }
+				</div>
+			</Notice>
+		</div>
+	);
 }
 
-export default connect(
-	( state ) => ( {
-		localeSuggestions: getLocaleSuggestions( state ),
-	} ),
-	{ setLocale }
-)( LocaleSuggestions );
+LocaleSuggestions.propTypes = {
+	path: PropTypes.string.isRequired,
+	localeSuggestions: PropTypes.array,
+};
+
+export default connect( ( state ) => ( { localeSuggestions: getLocaleSuggestions( state ) } ) )(
+	LocaleSuggestions
+);

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -4,7 +4,8 @@
 
 import { shallow } from 'enzyme';
 import { getLocaleSlug } from 'i18n-calypso';
-import { LocaleSuggestions } from '../';
+import QueryLocaleSuggestions from 'calypso/components/data/query-locale-suggestions';
+import { LocaleSuggestions } from '..';
 
 jest.mock( 'calypso/lib/i18n-utils', () => ( { addLocaleToPath: ( locale ) => locale } ) );
 jest.mock( 'i18n-calypso', () => ( { getLocaleSlug: jest.fn( () => '' ) } ) );
@@ -14,18 +15,16 @@ jest.mock( 'calypso/components/notice', () => ( props ) => [ ...props.children ]
 describe( 'LocaleSuggestions', () => {
 	const defaultProps = {
 		path: '',
-		locale: 'x',
 		localeSuggestions: [
 			{ locale: 'es', name: 'Español', availability_text: 'También disponible en' },
 			{ locale: 'fr', name: 'Français', availability_text: 'Également disponible en' },
 			{ locale: 'en', name: 'English', availability_text: 'Also available in' },
 		],
-		setLocale: jest.fn(),
 	};
 
 	test( 'should not render without suggestions', () => {
-		const wrapper = shallow( <LocaleSuggestions path="" locale="x" setLocale={ () => {} } /> );
-		expect( wrapper.type() ).toBe( null );
+		const wrapper = shallow( <LocaleSuggestions path="" /> );
+		expect( wrapper.type() ).toBe( QueryLocaleSuggestions );
 	} );
 
 	test( 'should have `locale-suggestions` class', () => {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -363,7 +363,7 @@ export function instructions( context, next ) {
 	next();
 }
 
-export function signupForm( context, next ) {
+function signupForm( context, next ) {
 	recordPageView(
 		'jetpack/connect/authorize',
 		'Jetpack Authorize',
@@ -400,7 +400,7 @@ export function credsForm( context, next ) {
 	next();
 }
 
-export function authorizeForm( context, next ) {
+function authorizeForm( context, next ) {
 	recordPageView(
 		'jetpack/connect/authorize',
 		'Jetpack Authorize',

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -240,12 +240,8 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 };
 
 export function redirectWithoutLocaleIfLoggedIn( context, next ) {
-	debug( 'controller: redirectWithoutLocaleIfLoggedIn', context.params );
-	const isLoggedIn = isUserLoggedIn( context.store.getState() );
-	if ( isLoggedIn && getLocaleFromPath( context.path ) ) {
-		const urlWithoutLocale = removeLocaleFromPath( context.path );
-		debug( 'redirectWithoutLocaleIfLoggedIn to %s', urlWithoutLocale );
-		return page.redirect( urlWithoutLocale );
+	if ( isUserLoggedIn( context.store.getState() ) && getLocaleFromPath( context.path ) ) {
+		return page.redirect( removeLocaleFromPath( context.path ) );
 	}
 
 	next();

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -328,7 +328,6 @@ export function connect( context, next ) {
 			<JetpackConnect
 				ctaFrom={ query.cta_from /* origin tracking params */ }
 				ctaId={ query.cta_id /* origin tracking params */ }
-				locale={ params.locale }
 				path={ path }
 				type={ type }
 				url={ query.url }

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, setLocaleMiddleware } from 'calypso/controller';
 import { OFFER_RESET_FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -30,6 +30,7 @@ export default function () {
 		`/jetpack/connect/:type(${ planTypeString })/:interval(yearly|monthly)?/${ locale }`,
 		controller.redirectToSiteLessCheckout,
 		controller.redirectWithoutLocaleIfLoggedIn,
+		setLocaleMiddleware( 'locale' ),
 		controller.loginBeforeJetpackSearch,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,
@@ -58,6 +59,7 @@ export default function () {
 	page(
 		`/jetpack/connect/authorize/${ locale }`,
 		controller.redirectWithoutLocaleIfLoggedIn,
+		setLocaleMiddleware( 'locale' ),
 		controller.setMasterbar,
 		controller.authorizeOrSignup,
 		makeLayout,

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -19,7 +19,6 @@ import { cleanUrl } from './utils';
 
 export class JetpackConnectMain extends Component {
 	static propTypes = {
-		locale: PropTypes.string,
 		path: PropTypes.string,
 		type: PropTypes.oneOf( [ ...FLOW_TYPES, false ] ),
 		url: PropTypes.string,
@@ -112,19 +111,11 @@ export class JetpackConnectMain extends Component {
 		);
 	}
 
-	renderLocaleSuggestions() {
-		if ( this.props.isLoggedIn || ! this.props.locale ) {
-			return;
-		}
-
-		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
-	}
-
 	render() {
-		const { renderFooter, status, type } = this.props;
+		const { renderFooter, status, type, isLoggedIn, path } = this.props;
 		return (
 			<MainWrapper>
-				{ this.renderLocaleSuggestions() }
+				{ ! isLoggedIn && <LocaleSuggestions path={ path } /> }
 				<div className="jetpack-connect__site-url-entry-container">
 					<MainHeader type={ type } />
 					{ this.renderSiteInput( status ) }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -256,12 +256,6 @@ export class JetpackSignup extends Component {
 		);
 	}
 
-	renderLocaleSuggestions() {
-		return this.props.locale ? (
-			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-		) : null;
-	}
-
 	renderFooterLink() {
 		const { authQuery } = this.props;
 
@@ -439,7 +433,7 @@ export class JetpackSignup extends Component {
 				pageTitle={ wooDna.getServiceName() + ' — ' + pageTitle }
 			>
 				<div className="jetpack-connect__authorize-form">
-					{ this.renderLocaleSuggestions() }
+					{ this.props.locale && <LocaleSuggestions path={ this.props.path } /> }
 					<FormattedHeader headerText={ header } subHeaderText={ subHeader } />
 					{ content }
 					{ this.renderLoginUser() }
@@ -456,7 +450,7 @@ export class JetpackSignup extends Component {
 		return (
 			<MainWrapper isWoo={ this.isWoo() }>
 				<div className="jetpack-connect__authorize-form">
-					{ this.renderLocaleSuggestions() }
+					{ this.props.locale && <LocaleSuggestions path={ this.props.path } /> }
 					<AuthFormHeader authQuery={ this.props.authQuery } isWoo={ this.isWoo() } />
 					<SignupForm
 						disabled={ isCreatingAccount }

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -63,7 +63,6 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
     className="jetpack-connect__authorize-form"
   >
     <Connect(LocaleSuggestions)
-      locale="es"
       path="/jetpack/connect/authorize/es"
     />
     <Connect(Localized(AuthFormHeader))

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -66,17 +66,7 @@ class MagicLogin extends Component {
 	};
 
 	renderLinks() {
-		const {
-			isJetpackLogin,
-			isGutenboardingLogin,
-			locale,
-			showCheckYourEmail,
-			translate,
-		} = this.props;
-
-		if ( showCheckYourEmail ) {
-			return null;
-		}
+		const { isJetpackLogin, isGutenboardingLogin, locale, translate } = this.props;
 
 		// The email address from the URL (if present) is added to the login
 		// parameters in this.onClickEnterPasswordInstead(). But it's left out
@@ -97,16 +87,6 @@ class MagicLogin extends Component {
 				</a>
 			</div>
 		);
-	}
-
-	renderLocaleSuggestions() {
-		const { locale, path, showCheckYourEmail } = this.props;
-
-		if ( showCheckYourEmail ) {
-			return null;
-		}
-
-		return <LocaleSuggestions locale={ locale } path={ path } />;
 	}
 
 	renderGutenboardingLogo() {
@@ -146,13 +126,13 @@ class MagicLogin extends Component {
 				{ this.props.isJetpackLogin && <JetpackHeader /> }
 				{ this.props.isGutenboardingLogin && this.renderGutenboardingLogo() }
 
-				{ this.renderLocaleSuggestions() }
+				{ ! this.props.showCheckYourEmail && <LocaleSuggestions path={ this.props.path } /> }
 
 				<GlobalNotices id="notices" />
 
 				<RequestLoginEmailForm { ...requestLoginEmailFormProps } />
 
-				{ this.renderLinks() }
+				{ ! this.props.showCheckYourEmail && this.renderLinks() }
 			</Main>
 		);
 	}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -128,16 +128,6 @@ export class Login extends Component {
 		);
 	}
 
-	renderI18nSuggestions() {
-		const { locale, path, isLoginView } = this.props;
-
-		if ( ! isLoginView ) {
-			return null;
-		}
-
-		return <LocaleSuggestions locale={ locale } path={ path } />;
-	}
-
 	renderFooter() {
 		const { isJetpack, isGutenboarding, isP2Login, translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2Client;
@@ -283,20 +273,18 @@ export class Login extends Component {
 	}
 
 	render() {
-		const { locale, translate } = this.props;
+		const { locale, translate, isLoginView, path } = this.props;
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 		return (
 			<div>
 				{ this.props.isP2Login && this.renderP2Logo() }
 				<Main className="wp-login__main">
-					{ this.renderI18nSuggestions() }
-
 					<DocumentHead
 						title={ translate( 'Log In' ) }
 						link={ [ { rel: 'canonical', href: canonicalUrl } ] }
 						meta={ [ { name: 'description', content: 'Log in to WordPress.com' } ] }
 					/>
-
+					{ isLoginView && <LocaleSuggestions path={ path } /> }
 					<div className="wp-login__container">{ this.renderContent() }</div>
 				</Main>
 

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -1,7 +1,6 @@
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
 import page from 'page';
-import { createElement } from 'react';
 import store from 'store';
 import { getLocaleFromPath, removeLocaleFromPath } from 'calypso/lib/i18n-utils';
 import { navigate } from 'calypso/lib/navigate';
@@ -17,7 +16,7 @@ import { acceptInvite as acceptInviteAction } from 'calypso/state/invites/action
  */
 const debug = debugModule( 'calypso:invite-accept:controller' );
 
-export function redirectWithoutLocaleifLoggedIn( context, next ) {
+export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 	if ( isUserLoggedIn( context.store.getState() ) && getLocaleFromPath( context.path ) ) {
 		return page.redirect( removeLocaleFromPath( context.path ) );
 	}
@@ -52,13 +51,15 @@ export function acceptInvite( context, next ) {
 		return;
 	}
 
-	context.primary = createElement( InviteAccept, {
-		siteId: context.params.site_id,
-		inviteKey: context.params.invitation_key,
-		activationKey: context.params.activation_key,
-		authKey: context.params.auth_key,
-		locale: context.params.locale,
-		path: context.path,
-	} );
+	context.primary = (
+		<InviteAccept
+			siteId={ context.params.site_id }
+			inviteKey={ context.params.invitation_key }
+			activationKey={ context.params.activation_key }
+			authKey={ context.params.auth_key }
+			path={ context.path }
+		/>
+	);
+
 	next();
 }

--- a/client/my-sites/invites/index.js
+++ b/client/my-sites/invites/index.js
@@ -1,7 +1,7 @@
 import page from 'page';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, setLocaleMiddleware } from 'calypso/controller';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
-import { acceptInvite, redirectWithoutLocaleifLoggedIn } from './controller';
+import { acceptInvite, redirectWithoutLocaleIfLoggedIn } from './controller';
 
 export default () => {
 	const locale = getLanguageRouteParam( 'locale' );
@@ -12,7 +12,8 @@ export default () => {
 			`/accept-invite/:site_id/:invitation_key/:activation_key/${ locale }`,
 			`/accept-invite/:site_id/:invitation_key/:activation_key/:auth_key/${ locale }`,
 		],
-		redirectWithoutLocaleifLoggedIn,
+		redirectWithoutLocaleIfLoggedIn,
+		setLocaleMiddleware( 'locale' ),
 		acceptInvite,
 		makeLayout,
 		clientRender

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -121,14 +121,6 @@ class InviteAccept extends Component {
 		await this.props.redirectToLogout( window.location.href );
 	};
 
-	localeSuggestions = () => {
-		if ( this.props.user || ! this.props.locale ) {
-			return;
-		}
-
-		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
-	};
-
 	renderForm = () => {
 		const { invite } = this.state;
 
@@ -224,7 +216,7 @@ class InviteAccept extends Component {
 
 	render() {
 		const { invite } = this.state;
-		const { user } = this.props;
+		const { user, path } = this.props;
 
 		const containerClasses = classNames( 'invite-accept', {
 			'is-p2-invite': !! invite?.site?.is_wpforteams_site,
@@ -236,7 +228,7 @@ class InviteAccept extends Component {
 
 		return (
 			<div className={ containerClasses }>
-				{ this.localeSuggestions() }
+				{ ! user && <LocaleSuggestions path={ path } /> }
 				<div className={ formClasses }>
 					{ this.isMatchEmailError() && user && (
 						<Notice

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -312,7 +312,7 @@ function setUpLoggedInRoute( req, res, next ) {
 						isTranslatedIncompletely( data.localeVariant || data.localeSlug )
 					)
 				) {
-					req.context.lang = data.localeSlug;
+					req.context.lang = data.localeVariant || data.localeSlug;
 					req.context.store.dispatch( {
 						type: LOCALE_SET,
 						localeSlug: data.localeSlug,

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -902,17 +902,17 @@ const assertSection = ( { url, entry, sectionName, sectionGroup } ) => {
 		it( 'sets the locale in the store', async () => {
 			const theUser = {
 				localeSlug: 'es',
-				localeVariant: 'ES',
+				localeVariant: 'es_ES',
 			};
 			app.withBootstrapUser( theUser );
 
 			const { request } = await app.run();
 
-			expect( request.context.lang ).toEqual( 'es' );
+			expect( request.context.lang ).toEqual( 'es_ES' );
 			expect( theStore.dispatch ).toHaveBeenCalledWith( {
 				type: 'LOCALE_SET',
 				localeSlug: 'es',
-				localeVariant: 'ES',
+				localeVariant: 'es_ES',
 			} );
 		} );
 

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -1,4 +1,5 @@
-import { getLanguage, getLanguageRouteParam } from 'calypso/lib/i18n-utils';
+import { setLocaleMiddleware } from 'calypso/controller';
+import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 
 export default function ( router ) {
 	const lang = getLanguageRouteParam();
@@ -10,16 +11,6 @@ export default function ( router ) {
 			`/start/:flowName/:stepName/${ lang }`,
 			`/start/:flowName/:stepName/:stepSectionName/${ lang }`,
 		],
-		setUpLocale
+		setLocaleMiddleware()
 	);
-}
-
-// Set up the locale if there is one
-function setUpLocale( context, next ) {
-	const language = getLanguage( context.params.lang );
-	if ( language ) {
-		context.lang = context.params.lang;
-	}
-
-	next();
 }

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -1,5 +1,5 @@
 import page from 'page';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, setLocaleMiddleware } from 'calypso/controller';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import controller from './controller';
 
@@ -13,9 +13,10 @@ export default function () {
 			`/start/:flowName/:stepName/${ lang }`,
 			`/start/:flowName/:stepName/:stepSectionName/${ lang }`,
 		],
+		controller.redirectWithoutLocaleIfLoggedIn,
+		setLocaleMiddleware(),
 		controller.redirectTests,
 		controller.saveInitialContext,
-		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
 		controller.setSelectedSiteForSignup,
 		controller.start,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -642,9 +642,7 @@ class Signup extends Component {
 		return (
 			<div className="signup__step" key={ stepKey }>
 				<div className={ `signup__step is-${ kebabCase( this.props.stepName ) }` }>
-					{ shouldRenderLocaleSuggestions && (
-						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-					) }
+					{ shouldRenderLocaleSuggestions && <LocaleSuggestions path={ this.props.path } /> }
 					{ this.state.shouldShowLoadingScreen ? (
 						this.renderProcessingScreen( isReskinned )
 					) : (


### PR DESCRIPTION
The `<LocaleSuggestions>` component not only loads and displays locale suggestions, but also sets the language on routes with a `:locale` param.

This PR moves that responsibility out of the `LocaleSuggestions` component, into a page.js handler.