### PR TITLE
State: Refactor away from Lodash in Jetpack state

### DIFF
--- a/client/state/jetpack/modules/actions.js
+++ b/client/state/jetpack/modules/actions.js
@@ -1,5 +1,4 @@
 import { translate } from 'i18n-calypso';
-import { omit, mapValues } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import {
 	JETPACK_MODULE_ACTIVATE,
@@ -145,10 +144,16 @@ export const fetchModuleList = ( siteId ) => {
 				path: '/jetpack/v4/module/all/',
 			} )
 			.then( ( { data } ) => {
-				const modules = mapValues( data, ( module ) => ( {
-					active: module.activated,
-					...omit( module, 'activated' ),
-				} ) );
+				const modules = Object.entries( data ).reduce(
+					( acc, [ key, { activated: active, ...module } ] ) => {
+						acc[ key ] = {
+							active,
+							...module,
+						};
+						return acc;
+					},
+					{}
+				);
 
 				dispatch( receiveJetpackModules( siteId, modules ) );
 				dispatch( {

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -1,4 +1,4 @@
-import { forEach, pickBy } from 'lodash';
+import { forEach } from 'lodash';
 import {
 	JETPACK_MODULE_ACTIVATE,
 	JETPACK_MODULE_ACTIVATE_FAILURE,
@@ -57,9 +57,12 @@ const createModuleListRequestReducer = ( fetchingModules ) => {
 const createSettingsItemsReducer = () => {
 	return ( state, { siteId, settings } ) => {
 		let updatedState = state;
-		const moduleActivationState = pickBy( settings, ( settingValue, settingName ) => {
-			return state[ siteId ]?.[ settingName ] !== undefined;
-		} );
+
+		const moduleActivationState = Object.fromEntries(
+			Object.entries( settings ).filter(
+				( [ settingName ] ) => state[ siteId ]?.[ settingName ] !== undefined
+			)
+		);
 
 		forEach( moduleActivationState, ( active, moduleSlug ) => {
 			updatedState = Object.assign( {}, updatedState, {

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -1,4 +1,4 @@
-import { forEach, get, merge, pickBy } from 'lodash';
+import { forEach, get, pickBy } from 'lodash';
 import {
 	JETPACK_MODULE_ACTIVATE,
 	JETPACK_MODULE_ACTIVATE_FAILURE,
@@ -16,43 +16,42 @@ import {
 import { combineReducers } from 'calypso/state/utils';
 
 const createItemsReducer = ( active ) => {
-	return ( state, { siteId, moduleSlug } ) => {
-		return merge( {}, state, {
-			[ siteId ]: {
-				[ moduleSlug ]: {
-					active,
-				},
+	return ( state, { siteId, moduleSlug } ) => ( {
+		...state,
+		[ siteId ]: {
+			...state?.[ siteId ],
+			[ moduleSlug ]: {
+				...state?.[ siteId ]?.[ moduleSlug ],
+				active,
 			},
-		} );
-	};
+		},
+	} );
 };
 
 const createItemsListReducer = () => {
-	return ( state, { siteId, modules } ) => {
-		return merge( {}, state, {
-			[ siteId ]: modules,
-		} );
-	};
+	return ( state, { siteId, modules } ) => ( {
+		...state,
+		[ siteId ]: modules,
+	} );
 };
 
 const createRequestsReducer = ( data ) => {
-	return ( state, { siteId, moduleSlug } ) => {
-		return merge( {}, state, {
-			[ siteId ]: {
-				[ moduleSlug ]: data,
-			},
-		} );
-	};
+	return ( state, { siteId, moduleSlug } ) => ( {
+		...state,
+		[ siteId ]: {
+			...state?.[ siteId ],
+			[ moduleSlug ]: data,
+		},
+	} );
 };
 
 const createModuleListRequestReducer = ( fetchingModules ) => {
-	return ( state, { siteId } ) => {
-		return merge( {}, state, {
-			[ siteId ]: {
-				fetchingModules,
-			},
-		} );
-	};
+	return ( state, { siteId } ) => ( {
+		...state,
+		[ siteId ]: {
+			fetchingModules,
+		},
+	} );
 };
 
 const createSettingsItemsReducer = () => {

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -1,4 +1,4 @@
-import { forEach, get, pickBy } from 'lodash';
+import { forEach, pickBy } from 'lodash';
 import {
 	JETPACK_MODULE_ACTIVATE,
 	JETPACK_MODULE_ACTIVATE_FAILURE,
@@ -19,9 +19,9 @@ const createItemsReducer = ( active ) => {
 	return ( state, { siteId, moduleSlug } ) => ( {
 		...state,
 		[ siteId ]: {
-			...state?.[ siteId ],
+			...state[ siteId ],
 			[ moduleSlug ]: {
-				...state?.[ siteId ]?.[ moduleSlug ],
+				...state[ siteId ]?.[ moduleSlug ],
 				active,
 			},
 		},
@@ -39,7 +39,7 @@ const createRequestsReducer = ( data ) => {
 	return ( state, { siteId, moduleSlug } ) => ( {
 		...state,
 		[ siteId ]: {
-			...state?.[ siteId ],
+			...state[ siteId ],
 			[ moduleSlug ]: data,
 		},
 	} );
@@ -58,7 +58,7 @@ const createSettingsItemsReducer = () => {
 	return ( state, { siteId, settings } ) => {
 		let updatedState = state;
 		const moduleActivationState = pickBy( settings, ( settingValue, settingName ) => {
-			return get( state, [ siteId, settingName ] ) !== undefined;
+			return state[ siteId ]?.[ settingName ] !== undefined;
 		} );
 
 		forEach( moduleActivationState, ( active, moduleSlug ) => {

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -1,4 +1,3 @@
-import { forEach } from 'lodash';
 import {
 	JETPACK_MODULE_ACTIVATE,
 	JETPACK_MODULE_ACTIVATE_FAILURE,
@@ -58,13 +57,11 @@ const createSettingsItemsReducer = () => {
 	return ( state, { siteId, settings } ) => {
 		let updatedState = state;
 
-		const moduleActivationState = Object.fromEntries(
-			Object.entries( settings ).filter(
-				( [ settingName ] ) => state[ siteId ]?.[ settingName ] !== undefined
-			)
+		const moduleActivationState = Object.entries( settings ).filter(
+			( [ settingName ] ) => state[ siteId ]?.[ settingName ] !== undefined
 		);
 
-		forEach( moduleActivationState, ( active, moduleSlug ) => {
+		moduleActivationState.forEach( ( [ moduleSlug, active ] ) => {
 			updatedState = Object.assign( {}, updatedState, {
 				[ siteId ]: {
 					...updatedState[ siteId ],

--- a/client/state/jetpack/modules/test/actions.js
+++ b/client/state/jetpack/modules/test/actions.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { omit, mapValues } from 'lodash';
 import sinon from 'sinon';
 import {
 	JETPACK_MODULE_ACTIVATE,
@@ -191,14 +190,26 @@ describe( 'actions', () => {
 
 			test( 'should dispatch JETPACK_MODULES_RECEIVE when we get the response from the API', () => {
 				const result = fetchModuleList( siteId )( spy );
+				const modules = {
+					'module-a': {
+						module: 'module-a',
+						active: false,
+					},
+					'module-b': {
+						module: 'module-b',
+						active: true,
+						options: {
+							c: {
+								currentValue: 2,
+							},
+						},
+					},
+				};
 				return result.then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_MODULES_RECEIVE,
 						siteId,
-						modules: mapValues( API_MODULE_LIST_RESPONSE_FIXTURE.data, ( module ) => ( {
-							active: module.activated,
-							...omit( module, 'activated' ),
-						} ) ),
+						modules,
 					} );
 				} );
 			} );

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -1,4 +1,3 @@
-import { mapValues, merge } from 'lodash';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	JETPACK_MODULE_DEACTIVATE_SUCCESS,
@@ -32,14 +31,21 @@ export const settingsReducer = keyedReducer(
 			}
 			case JETPACK_MODULES_RECEIVE: {
 				const { modules } = action;
-				const modulesActivationState = mapValues( modules, ( module ) => module.active );
+				const modulesActivationState = Object.fromEntries(
+					Object.entries( modules ).map( ( [ key, module ] ) => [ key, module.active ] )
+				);
 				// The need for flattening module options into this moduleSettings is temporary.
 				// Once https://github.com/Automattic/jetpack/pull/6002 is released,
 				// the flattening will be done on the server side for the /jetpack/v4/settings/ endpoint
 				const moduleSettings = Object.keys( modules ).reduce( ( allTheSettings, slug ) => {
 					return {
 						...allTheSettings,
-						...mapValues( modules[ slug ].options, ( option ) => option.current_value ),
+						...Object.fromEntries(
+							Object.entries( modules[ slug ]?.options ?? {} ).map( ( [ key, option ] ) => [
+								key,
+								option.current_value,
+							] )
+						),
 					};
 				}, {} );
 				return {
@@ -58,8 +64,10 @@ export const settingsReducer = keyedReducer(
 				return state;
 			}
 			case JETPACK_SETTINGS_UPDATE: {
-				const { settings } = action;
-				return merge( {}, state, settings );
+				return {
+					...state,
+					...action.settings,
+				};
 			}
 		}
 

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -96,6 +96,11 @@ describe( 'reducer', () => {
 					},
 					'module-b': {
 						active: true,
+						options: {
+							some_option: {
+								current_value: 'test',
+							},
+						},
 					},
 				},
 			};
@@ -105,6 +110,7 @@ describe( 'reducer', () => {
 					setting_123: 'test',
 					'module-a': false,
 					'module-b': true,
+					some_option: 'test',
 				},
 			} );
 		} );

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -1,5 +1,3 @@
-import { forEach, get, omit } from 'lodash';
-
 /**
  * Normalize settings for use in Redux.
  *
@@ -19,7 +17,7 @@ export const normalizeSettings = ( settings ) => {
 			case 'jetpack_portfolio_posts_per_page':
 				break;
 			case 'jetpack_protect_global_whitelist': {
-				const explicitlyAllowedIps = get( settings[ key ], [ 'local' ], [] );
+				const explicitlyAllowedIps = settings[ key ]?.local ?? [];
 				memo[ key ] = explicitlyAllowedIps.join( '\n' );
 				break;
 			}
@@ -104,11 +102,17 @@ export const filterSettingsByActiveModules = ( settings ) => {
 	};
 	let filteredSettings = { ...settings };
 
-	forEach( moduleSettingsList, ( moduleSettings, moduleSlug ) => {
+	Object.entries( moduleSettingsList ).forEach( ( [ moduleSlug, moduleSettings ] ) => {
 		if ( ! settings[ moduleSlug ] ) {
-			filteredSettings = omit( filteredSettings, moduleSettings );
+			filteredSettings = Object.fromEntries(
+				Object.entries( filteredSettings ).filter(
+					( [ settingName ] ) => ! moduleSettings.includes( settingName )
+				)
+			);
 		}
-		filteredSettings = omit( filteredSettings, moduleSlug );
+		filteredSettings = Object.fromEntries(
+			Object.entries( filteredSettings ).filter( ( [ settingName ] ) => settingName !== moduleSlug )
+		);
 	} );
 
 	return filteredSettings;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors away from any Lodash used inside the Jetpack state - modules and settings.

The area is very well covered by automated tests, which helps us to migrate away from Lodash safely.

#### Testing instructions

* Go to `/settings/general/:site` where `:site` is a Jetpack site on a paid plan.
* Play with all the settings and verify they are saved and retrieved well like before.
* Test all the other settings subpages.
* Verify all tests pass: `yarn run test-client client/state/jetpack`.