### PR TITLE
Layout: Remove unused CSS classes

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -219,8 +219,6 @@ class Layout extends Component {
 			[ 'is-section-' + this.props.sectionName ]: this.props.sectionName,
 			'is-support-session': this.props.isSupportSession,
 			'has-no-sidebar': this.props.sidebarIsHidden,
-			'is-inline-help-showing': this.shouldLoadInlineHelp(),
-			'is-happychat-button-showing': this.shouldShowHappyChatButton(),
 			'has-docked-chat': this.props.chatIsOpen && this.props.chatIsDocked,
 			'has-no-masterbar': this.props.masterbarIsHidden,
 			'is-jetpack-login': this.props.isJetpackLogin,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up a couple of CSS classnames that are not in use but are being added to each Calypso render that uses the primary layout.

#### Testing instructions

Verify the removed classnames are not in use.