### PR TITLE
Post Editor: Cleanup obsolete section references

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -30,5 +30,4 @@ These represent the top section in the masterbar as well as other significant ar
 - `my-sites`: the site related admin functionality. Akin to wp-admin.
 - `reader`: the home of all Reader sections.
 - `me`: the sections under the `/me` route.
-- `post-editor`: the editor.
 - `signup`: the signup flows.

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -260,8 +260,8 @@
 	}
 
 	@media only screen and ( max-width: 660px ) {
-		.layout.focus-sites:not( .is-section-post-editor ) .layout__primary .main,
-		.layout.focus-sidebar:not( .is-section-post-editor ) .layout__primary .main {
+		.layout.focus-sites .layout__primary .main,
+		.layout.focus-sidebar .layout__primary .main {
 			transform: translateX( 100% );
 		}
 	}

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -24,7 +24,6 @@ import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-dis
 import { getSectionName, appBannerIsEnabled } from 'calypso/state/ui/selectors';
 import {
 	ALLOWED_SECTIONS,
-	EDITOR,
 	GUTENBERG,
 	NOTES,
 	READER,
@@ -103,7 +102,7 @@ export class AppBanner extends Component {
 
 		// Inside page/post editor, hide the banner until we know that welcome tour has been dimissed to avoid overlapping.
 		if (
-			[ EDITOR, GUTENBERG ].includes( currentSection ) &&
+			currentSection === GUTENBERG &&
 			( ! blockEditorNuxStatus || blockEditorNuxStatus.show_welcome_guide )
 		) {
 			return false;
@@ -144,7 +143,6 @@ export class AppBanner extends Component {
 		if ( this.isAndroid() ) {
 			//TODO: update when section deep links are available.
 			switch ( currentSection ) {
-				case EDITOR:
 				case GUTENBERG:
 					return 'intent://post/#Intent;scheme=wordpress;package=org.wordpress.android;end';
 				case NOTES:
@@ -234,7 +232,6 @@ export function buildDeepLinkFragment( currentRoute, currentSection ) {
 
 	const getFragment = () => {
 		switch ( currentSection ) {
-			case EDITOR:
 			case GUTENBERG:
 				return '/post';
 			case NOTES:

--- a/client/blocks/app-banner/test/__snapshots__/app-banner.jsx.snap
+++ b/client/blocks/app-banner/test/__snapshots__/app-banner.jsx.snap
@@ -4,14 +4,10 @@ exports[`iOS deep link fragments returns a fragment for each section 1`] = `"%2F
 
 exports[`iOS deep link fragments returns a fragment for each section 2`] = `"%2Ftest"`;
 
-exports[`iOS deep link fragments returns a fragment for each section 3`] = `"%2Fpost"`;
-
-exports[`iOS deep link fragments returns a fragment for each section 4`] = `"%2Fnotifications"`;
+exports[`iOS deep link fragments returns a fragment for each section 3`] = `"%2Fnotifications"`;
 
 exports[`iOS deep links returns URIs for each path 1`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Ftest"`;
 
 exports[`iOS deep links returns URIs for each path 2`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Ftest"`;
 
-exports[`iOS deep links returns URIs for each path 3`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Fpost"`;
-
-exports[`iOS deep links returns URIs for each path 4`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Fnotifications"`;
+exports[`iOS deep links returns URIs for each path 3`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Fnotifications"`;

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -3,7 +3,7 @@
  */
 
 import { getiOSDeepLink, buildDeepLinkFragment } from 'calypso/blocks/app-banner';
-import { EDITOR, NOTES, READER, STATS, getCurrentSection } from 'calypso/blocks/app-banner/utils';
+import { NOTES, READER, STATS, getCurrentSection } from 'calypso/blocks/app-banner/utils';
 
 describe( 'iOS deep link fragments', () => {
 	test( 'properly encodes tricky fragments', () => {
@@ -18,7 +18,7 @@ describe( 'iOS deep link fragments', () => {
 	} );
 
 	test( 'returns a fragment for each section', () => {
-		[ STATS, READER, EDITOR, NOTES ].forEach( ( section ) =>
+		[ STATS, READER, NOTES ].forEach( ( section ) =>
 			expect( buildDeepLinkFragment( '/test', section ) ).toMatchSnapshot()
 		);
 	} );
@@ -48,7 +48,7 @@ describe( 'iOS deep links', () => {
 	} );
 
 	test( 'returns URIs for each path', () => {
-		[ STATS, READER, EDITOR, NOTES ].forEach( ( section ) =>
+		[ STATS, READER, NOTES ].forEach( ( section ) =>
 			expect( getiOSDeepLink( '/test', section ) ).toMatchSnapshot()
 		);
 	} );
@@ -70,10 +70,6 @@ describe( 'getCurrentSection', () => {
 
 	test( 'returns reader if in reader section', () => {
 		expect( getCurrentSection( READER, false, '/' ) ).toBe( READER );
-	} );
-
-	test( 'returns editor if in editor section', () => {
-		expect( getCurrentSection( EDITOR, false, '/post/123' ) ).toBe( EDITOR );
 	} );
 
 	test( 'returns null if in a disallowed section', () => {

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -1,18 +1,16 @@
 import { get, includes, reduce } from 'lodash';
 
 export const APP_BANNER_DISMISS_TIMES_PREFERENCE = 'appBannerDismissTimes';
-export const EDITOR = 'post-editor';
 export const GUTENBERG = 'gutenberg-editor';
 export const NOTES = 'notifications';
 export const READER = 'reader';
 export const STATS = 'stats';
-export const ALLOWED_SECTIONS = [ EDITOR, GUTENBERG, NOTES, READER, STATS ];
+export const ALLOWED_SECTIONS = [ GUTENBERG, NOTES, READER, STATS ];
 export const ONE_WEEK_IN_MILLISECONDS = 604800000;
 export const ONE_MONTH_IN_MILLISECONDS = 2419200000; // 28 days
 
 export function getAppBannerData( translate, sectionName ) {
 	switch ( sectionName ) {
-		case EDITOR:
 		case GUTENBERG:
 			return {
 				title: translate( 'Rich mobile publishing.' ),

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1243,66 +1243,6 @@ const contextLinksForSection = {
 			},
 		},
 	],
-	'post-editor': [
-		{
-			get link() {
-				return localizeUrl( 'https://wordpress.com/support/editors/' );
-			},
-			post_id: 3347,
-			get title() {
-				return translate( 'The Visual Editor and the HTML Editor' );
-			},
-			get description() {
-				return translate(
-					'When creating a post or page on your WordPress.com blog, you have two editing modes ' +
-						'available to you: the Visual Editor and the HTML Editor.'
-				);
-			},
-		},
-		{
-			get link() {
-				return localizeUrl( 'https://wordpress.com/support/visual-editor/' );
-			},
-			post_id: 3644,
-			get title() {
-				return translate( 'The Visual Editor' );
-			},
-			get description() {
-				return translate(
-					'The visual editor provides a semi-WYSIWYG (What You See is What You Get) content editor that ' +
-						'allows you to easily create, edit, and format your content in a view similar to that of a word processor.'
-				);
-			},
-		},
-		{
-			get link() {
-				return localizeUrl( 'https://wordpress.com/support/xml-rpc/' );
-			},
-			post_id: 3595,
-			get title() {
-				return translate( 'Offline Editing' );
-			},
-			get description() {
-				return translate(
-					'Learn how to create and edit content for your WordPress.com site even without being connected to the internet!'
-				);
-			},
-		},
-		{
-			get link() {
-				return localizeUrl( 'https://wordpress.com/support/adding-users/' );
-			},
-			post_id: 2160,
-			get title() {
-				return translate( 'Inviting Contributors, Followers, and Viewers' );
-			},
-			get description() {
-				return translate(
-					'Invite contributors, followers, and viewers to collaborate with others and grow your audience!'
-				);
-			},
-		},
-	],
 	'gutenberg-editor': [
 		{
 			get link() {
@@ -1956,65 +1896,6 @@ const videosForSection = {
 				return translate(
 					'Find out how to activate free email forwarding from an address using a custom domain registered through WordPress.com.'
 				);
-			},
-		},
-	],
-	'post-editor': [
-		{
-			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/watch?v=hNg1rrkiAjg',
-			get title() {
-				return translate( 'Set a Featured Image for a Post or Page' );
-			},
-			get description() {
-				return translate(
-					'Find out how to add a featured image where available on your WordPress.com or Jetpack-enabled WordPress site.'
-				);
-			},
-		},
-		{
-			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/watch?v=dAcEBKXPlyA',
-			get title() {
-				return translate( 'Add a Contact Form to Your Website' );
-			},
-			get description() {
-				return translate( 'Find out how to add a contact form to your WordPress.com site.' );
-			},
-		},
-		{
-			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/watch?v=ssfHW5lwFZg',
-			get title() {
-				return translate( 'Embed a YouTube Video in Your Website' );
-			},
-			get description() {
-				return translate(
-					'Find out how to embed a YouTube video in your content (including posts, pages, and even comments) ' +
-						'on your WordPress.com or Jetpack-enabled WordPress website or blog.'
-				);
-			},
-		},
-		{
-			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/watch?v=_tpcHN6ZtKM',
-			get title() {
-				return translate( 'Schedule a Post' );
-			},
-			get description() {
-				return translate(
-					'Find out how to schedule a post on your WordPress.com website or blog.'
-				);
-			},
-		},
-		{
-			type: RESULT_VIDEO,
-			link: 'https://www.youtube.com/watch?v=V8UToJoSf4Q',
-			get title() {
-				return translate( 'Add a Pay with PayPal button' );
-			},
-			get description() {
-				return translate( 'Find out how to add a payment button to your WordPress.com website.' );
 			},
 		},
 	],

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -249,7 +249,7 @@ export class SeoPreviewPane extends PureComponent {
 const mapStateToProps = ( state, { overridePost } ) => {
 	const site = getSelectedSite( state );
 	const post = overridePost || getSitePost( state, site.ID, getEditorPostId( state ) );
-	const isEditorShowing = [ 'gutenberg-editor', 'post-editor' ].includes( getSectionName( state ) );
+	const isEditorShowing = getSectionName( state ) === 'gutenberg-editor';
 
 	return {
 		site: {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -37,7 +37,6 @@ function determinePostType( context ) {
 	return context.params.customPostType;
 }
 
-//duplicated from post-editor/controller.js. We should import it from there instead
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
 		return null;
@@ -226,8 +225,6 @@ function showDraftPostModal() {
 }
 
 export const post = ( context, next ) => {
-	// See post-editor/controller.js for reference.
-
 	const postId = getPostID( context );
 	const postType = determinePostType( context );
 	const jetpackCopy = parseInt( get( context, 'query.jetpack-copy', null ) );

--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -249,7 +249,6 @@ If neither the code chunk nor the site data required for `/settings` are availab
 _The [fix][pr-10521]:_ We make Guided Tours "subscribe" to the corresponding data requests using its all-purpose [`actionLog`][action-log]: simply add the action type signaling the satisfaction of a data need — _e.g._, `RECEIVE_FOOS` or `REQUEST_FOOS_SUCCESS` — to the log's [white list][relevant-types]. Any change to `actionLog` triggers all of Guided Tours' view layer to update, thereby allowing a correct and timely positioning of steps.
 
 [async-load]: https://github.com/Automattic/wp-calypso/blob/HEAD/client/components/async-load/README.md
-[async-load-usage]: https://github.com/Automattic/wp-calypso/blob/791003963e72c39589073b4de634bf946d1d288f/client/post-editor/editor-sidebar/index.jsx#L43
 [pr-10521]: https://github.com/Automattic/wp-calypso/pull/10521
 [action-log]: https://github.com/Automattic/wp-calypso/tree/791003963e72c39589073b4de634bf946d1d288f/client/state/ui/action-log
 [relevant-types]: https://github.com/Automattic/wp-calypso/blob/791003963e72c39589073b4de634bf946d1d288f/client/state/ui/action-log/reducer.js#L18-L25

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -121,7 +121,6 @@
 
 	// The editor has its own sidebar which doesnt
 	// use the secondary element.
-	.is-section-post-editor &,
 	.is-section-gutenberg-editor &,
 	// Some screens (like /theme/) simply dont have
 	// a sidebar.
@@ -227,10 +226,9 @@
 	Content - The content is the furrent focus
 */
 
-// Adjust the content as needed when focused on the site selector
-// or sidebar, but never in the editor.
-.layout.focus-sites:not( .is-section-post-editor ),
-.layout.focus-sidebar:not( .is-section-post-editor ) {
+// Adjust the content as needed when focused on the site selector or sidebar.
+.layout.focus-sites,
+.layout.focus-sidebar {
 	.layout__primary .main {
 		@include breakpoint-deprecated( '<660px' ) {
 			pointer-events: none;

--- a/client/my-sites/resume-editing/index.jsx
+++ b/client/my-sites/resume-editing/index.jsx
@@ -17,7 +17,6 @@ import {
 } from 'calypso/state/editor/last-draft/selectors';
 import { getEditorPath } from 'calypso/state/editor/selectors';
 import { isRequestingSitePost } from 'calypso/state/posts/selectors';
-import { getSectionName } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -28,7 +27,6 @@ class ResumeEditing extends Component {
 		requesting: PropTypes.bool,
 		draft: PropTypes.object,
 		editPath: PropTypes.string,
-		section: PropTypes.string,
 		translate: PropTypes.func,
 	};
 
@@ -46,8 +44,8 @@ class ResumeEditing extends Component {
 	};
 
 	render() {
-		const { siteId, postId, requesting, draft, editPath, section, translate } = this.props;
-		if ( ! draft || 'post-editor' === section ) {
+		const { siteId, postId, requesting, draft, editPath, translate } = this.props;
+		if ( ! draft ) {
 			return null;
 		}
 
@@ -79,7 +77,6 @@ export default connect(
 			requesting: siteId && postId && isRequestingSitePost( state, siteId, postId ),
 			draft: getEditorLastDraftPost( state ),
 			editPath: getEditorPath( state, siteId, postId ),
-			section: getSectionName( state ),
 		};
 	},
 	{ resetEditorLastDraft }

--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -19,7 +19,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 class PostRevisionsDialog extends PureComponent {
 	static propTypes = {
 		/**
-		 * loadRevision is passed through from `post-editor/post-editor.jsx`
+		 * loadRevision is passed through from `gutenberg/editor/calypsoify-iframe.tsx`
 		 *
 		 * TODO untangle & reduxify
 		 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A while ago, we removed the classic editor section, along with a bunch of components, libraries and logic that was unused anymore.

This PR cleans up a bit of that era - code that relies on the current section to be `post-editor`, which will no longer happen.

#### Testing instructions

None of this is testable - just verify that removed code makes sense to be removed as it would only work if the current section is `post-editor`.