### PR TITLE
Fix how the domains lists are filtered so we're using the correct property form the domains list

### DIFF
--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -58,6 +58,7 @@ export type ResponseDomain = {
 	currentUserCanCreateSiteFromDomainOnly: boolean;
 	currentUserCanManage: boolean;
 	currentUserCannotAddEmailReason: CannotAddEmailReason | null;
+	currentUserIsOwner: boolean;
 	domain: string;
 	domainLockingAvailable: boolean;
 	domainRegistrationAgreementUrl: string | null;

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -50,10 +50,10 @@ import BulkEditContactInfo from './bulk-edit-contact-info';
 import DomainItem from './domain-item';
 import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
+import { filterDomainsByOwner } from './helpers';
 import ListItemPlaceholder from './item-placeholder';
 import ListHeader from './list-header';
 import {
-	filterDomainsByOwner,
 	getDomainManagementPath,
 	getSimpleSortFunctionBy,
 	getReverseSimpleSortFunctionBy,

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -53,6 +53,7 @@ import DomainsTableFilterButton from './domains-table-filter-button';
 import ListItemPlaceholder from './item-placeholder';
 import ListHeader from './list-header';
 import {
+	filterDomainsByOwner,
 	getDomainManagementPath,
 	getSimpleSortFunctionBy,
 	getReverseSimpleSortFunctionBy,
@@ -460,7 +461,7 @@ class AllDomains extends Component {
 				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
 				<DomainsTable
 					currentRoute={ currentRoute }
-					domains={ this.filterDomains(
+					domains={ filterDomainsByOwner(
 						this.mergeFilteredDomainsWithDomainsDetails(),
 						selectedFilter
 					) }
@@ -619,17 +620,6 @@ class AllDomains extends Component {
 		);
 	}
 
-	filterDomains( domains, filter ) {
-		return domains.filter( ( domain ) => {
-			if ( 'owned-by-me' === filter ) {
-				return domain.currentUserCanManage;
-			} else if ( 'owned-by-others' === filter ) {
-				return ! domain.currentUserCanManage;
-			}
-			return true;
-		} );
-	}
-
 	renderDomainTableFilterButton() {
 		const { context } = this.props;
 
@@ -647,13 +637,13 @@ class AllDomains extends Component {
 				label: 'Owned by me',
 				value: 'owned-by-me',
 				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-me' } ),
-				count: this.filterDomains( nonWpcomDomains, 'owned-by-me' )?.length,
+				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-me' )?.length,
 			},
 			{
 				label: 'Owned by others',
 				value: 'owned-by-others',
 				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-others' } ),
-				count: this.filterDomains( nonWpcomDomains, 'owned-by-others' )?.length,
+				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-others' )?.length,
 			},
 		];
 

--- a/client/my-sites/domains/domain-management/list/helpers.ts
+++ b/client/my-sites/domains/domain-management/list/helpers.ts
@@ -1,0 +1,17 @@
+import { ResponseDomain } from 'calypso/lib/domains/types';
+
+type FilterDomainsByOwnerType = (
+	domains: Array< ResponseDomain >,
+	filter: 'owned-by-me' | 'owned-by-others' | undefined
+) => Array< ResponseDomain >;
+
+export const filterDomainsByOwner: FilterDomainsByOwnerType = ( domains, filter ) => {
+	return domains.filter( ( domain: ResponseDomain ) => {
+		if ( 'owned-by-me' === filter ) {
+			return domain.currentUserIsOwner;
+		} else if ( 'owned-by-others' === filter ) {
+			return ! domain.currentUserIsOwner;
+		}
+		return true;
+	} );
+};

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -52,6 +52,7 @@ import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
 import {
 	filterOutWpcomDomains,
+	filterDomainsByOwner,
 	getDomainManagementPath,
 	showUpdatePrimaryDomainSuccessNotice,
 	showUpdatePrimaryDomainErrorNotice,
@@ -87,17 +88,6 @@ export class SiteDomains extends Component {
 		return this.props.isRequestingSiteDomains && this.props.domains.length === 0;
 	}
 
-	filterDomains( domains, filter ) {
-		return domains.filter( ( domain ) => {
-			if ( 'owned-by-me' === filter ) {
-				return domain.currentUserIsOwner;
-			} else if ( 'owned-by-others' === filter ) {
-				return ! domain.currentUserIsOwner;
-			}
-			return true;
-		} );
-	}
-
 	renderNewDesign() {
 		const {
 			currentRoute,
@@ -114,7 +104,10 @@ export class SiteDomains extends Component {
 
 		const selectedFilter = context?.query?.filter;
 
-		const nonWpcomDomains = this.filterDomains( filterOutWpcomDomains( domains ), selectedFilter );
+		const nonWpcomDomains = filterDomainsByOwner(
+			filterOutWpcomDomains( domains ),
+			selectedFilter
+		);
 		const wpcomDomain = domains.find(
 			( domain ) => domain.type === type.WPCOM || domain.isWpcomStagingDomain
 		);
@@ -238,7 +231,7 @@ export class SiteDomains extends Component {
 				value: 'owned-by-me',
 				path:
 					domainManagementList( selectedSite?.slug ) + '?' + stringify( { filter: 'owned-by-me' } ),
-				count: this.filterDomains( nonWpcomDomains, 'owned-by-me' )?.length,
+				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-me' )?.length,
 			},
 			{
 				label: 'Owned by others',
@@ -247,7 +240,7 @@ export class SiteDomains extends Component {
 					domainManagementList( selectedSite?.slug ) +
 					'?' +
 					stringify( { filter: 'owned-by-others' } ),
-				count: this.filterDomains( nonWpcomDomains, 'owned-by-others' )?.length,
+				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-others' )?.length,
 			},
 			null,
 			{

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -50,9 +50,9 @@ import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import DomainOnly from './domain-only';
 import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
+import { filterDomainsByOwner } from './helpers';
 import {
 	filterOutWpcomDomains,
-	filterDomainsByOwner,
 	getDomainManagementPath,
 	showUpdatePrimaryDomainSuccessNotice,
 	showUpdatePrimaryDomainErrorNotice,

--- a/client/my-sites/domains/domain-management/list/utils.js
+++ b/client/my-sites/domains/domain-management/list/utils.js
@@ -76,3 +76,14 @@ export const getSimpleSortFunctionBy = ( column ) => ( first, second, sortOrder 
 
 export const getReverseSimpleSortFunctionBy = ( column ) => ( first, second, sortOrder ) =>
 	getSimpleSortFunctionBy( column )( first, second, sortOrder ) * -1;
+
+export const filterDomainsByOwner = ( domains, filter ) => {
+	return domains.filter( ( domain ) => {
+		if ( 'owned-by-me' === filter ) {
+			return domain.currentUserIsOwner;
+		} else if ( 'owned-by-others' === filter ) {
+			return ! domain.currentUserIsOwner;
+		}
+		return true;
+	} );
+};

--- a/client/my-sites/domains/domain-management/list/utils.js
+++ b/client/my-sites/domains/domain-management/list/utils.js
@@ -76,14 +76,3 @@ export const getSimpleSortFunctionBy = ( column ) => ( first, second, sortOrder 
 
 export const getReverseSimpleSortFunctionBy = ( column ) => ( first, second, sortOrder ) =>
 	getSimpleSortFunctionBy( column )( first, second, sortOrder ) * -1;
-
-export const filterDomainsByOwner = ( domains, filter ) => {
-	return domains.filter( ( domain ) => {
-		if ( 'owned-by-me' === filter ) {
-			return domain.currentUserIsOwner;
-		} else if ( 'owned-by-others' === filter ) {
-			return ! domain.currentUserIsOwner;
-		}
-		return true;
-	} );
-};


### PR DESCRIPTION
Apparently we're not using the same function to filter domains by owner in the new designs. Let's fix that 

#### Changes proposed in this Pull Request

* Fix the domain list filter on both site domains and all domains list to use the new `currentUserIsOwner` property

#### Testing instructions

* Open up a site domains list and make sure that the filtering works
* Open up an all domains list and make sure that the filtering works in there too
