### PR TITLE
Settings: Cleanup unused publish confirmation code

### DIFF
--- a/client/my-sites/site-settings/composing/publish-confirmation.jsx
+++ b/client/my-sites/site-settings/composing/publish-confirmation.jsx
@@ -12,7 +12,7 @@ export default function PublishConfirmation() {
 			<FormSettingExplanation>
 				{ translate(
 					'The Block Editor handles the Publish confirmation setting. ' +
-						'To enable it, go to Options under the Ellipses menu in the Editor ' +
+						'To enable it, go to Options under the Ellipsis menu in the Editor ' +
 						'and check "Enable Pre-publish checks."'
 				) }
 			</FormSettingExplanation>

--- a/client/my-sites/site-settings/composing/publish-confirmation.jsx
+++ b/client/my-sites/site-settings/composing/publish-confirmation.jsx
@@ -1,82 +1,21 @@
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { useTranslate } from 'i18n-calypso';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import { saveConfirmationSidebarPreference } from 'calypso/state/editor/actions';
-import { isConfirmationSidebarEnabled } from 'calypso/state/editor/selectors';
-import { isFetchingPreferences } from 'calypso/state/preferences/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-class PublishConfirmation extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = { isToggleOn: props.publishConfirmationEnabled };
-		this.handleToggle = this.handleToggle.bind( this );
-	}
+export default function PublishConfirmation() {
+	const translate = useTranslate();
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.publishConfirmationEnabled !== this.state.isToggleOn ) {
-			this.setState( { isToggleOn: nextProps.publishConfirmationEnabled } );
-		}
-	}
-
-	handleToggle() {
-		const { siteId, savePublishConfirmationPreference } = this.props;
-		const isToggleOn = ! this.state.isToggleOn;
-		this.setState( { isToggleOn: isToggleOn } );
-		savePublishConfirmationPreference( siteId, isToggleOn );
-	}
-
-	render() {
-		const { translate } = this.props;
-
-		return (
-			<FormFieldset>
-				<FormLabel>{ translate( 'Show publish confirmation' ) }</FormLabel>
-				<FormSettingExplanation>
-					{ translate(
-						'The Block Editor handles the Publish confirmation setting. ' +
-							'To enable it, go to Options under the Ellipses menu in the Editor ' +
-							'and check "Enable Pre-publish checks."'
-					) }
-				</FormSettingExplanation>
-			</FormFieldset>
-		);
-	}
+	return (
+		<FormFieldset>
+			<FormLabel>{ translate( 'Show publish confirmation' ) }</FormLabel>
+			<FormSettingExplanation>
+				{ translate(
+					'The Block Editor handles the Publish confirmation setting. ' +
+						'To enable it, go to Options under the Ellipses menu in the Editor ' +
+						'and check "Enable Pre-publish checks."'
+				) }
+			</FormSettingExplanation>
+		</FormFieldset>
+	);
 }
-
-PublishConfirmation.defaultProps = {
-	publishConfirmationEnabled: true,
-};
-
-PublishConfirmation.propTypes = {
-	siteId: PropTypes.number,
-	fetchingPreferences: PropTypes.bool,
-	publishConfirmationEnabled: PropTypes.bool,
-	savePublishConfirmationPreference: PropTypes.func,
-	translate: PropTypes.func,
-};
-
-export default connect(
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
-
-		return {
-			siteId,
-			fetchingPreferences: isFetchingPreferences( state ),
-			publishConfirmationEnabled: isConfirmationSidebarEnabled( state, siteId ),
-		};
-	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				savePublishConfirmationPreference: saveConfirmationSidebarPreference,
-			},
-			dispatch
-		);
-	}
-)( localize( PublishConfirmation ) );

--- a/client/state/editor/actions.js
+++ b/client/state/editor/actions.js
@@ -1,8 +1,5 @@
-import { filter } from 'lodash';
 import { EDITOR_IFRAME_LOADED, EDITOR_START, EDITOR_STOP } from 'calypso/state/action-types';
-import { withAnalytics, bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { getPreference } from 'calypso/state/preferences/selectors';
+import { withAnalytics, bumpStat } from 'calypso/state/analytics/actions';
 import { setMediaModalView } from 'calypso/state/ui/media-modal/actions';
 import { ModalViews } from 'calypso/state/ui/media-modal/constants';
 
@@ -68,41 +65,6 @@ export function setEditorMediaModalView( view ) {
 	}
 
 	return action;
-}
-
-/**
- * Returns an action object used in signalling that the confirmation sidebar
- * preference has changed.
- *
- * @param  {number}  siteId    Site ID
- * @param  {?boolean}   isEnabled Whether or not the sidebar should be shown
- * @returns {object}            Action object
- */
-export function saveConfirmationSidebarPreference( siteId, isEnabled = true ) {
-	return ( dispatch, getState ) => {
-		const disabledSites = getPreference( getState(), 'editorConfirmationDisabledSites' );
-
-		if ( isEnabled ) {
-			dispatch(
-				savePreference(
-					'editorConfirmationDisabledSites',
-					filter( disabledSites, ( _siteId ) => siteId !== _siteId )
-				)
-			);
-		} else {
-			dispatch( savePreference( 'editorConfirmationDisabledSites', [ ...disabledSites, siteId ] ) );
-		}
-
-		dispatch(
-			recordTracksEvent(
-				isEnabled
-					? 'calypso_publish_confirmation_preference_enable'
-					: 'calypso_publish_confirmation_preference_disable'
-			)
-		);
-
-		dispatch( bumpStat( 'calypso_publish_confirmation', isEnabled ? 'enabled' : 'disabled' ) );
-	};
 }
 
 export const setEditorIframeLoaded = ( isIframeLoaded = true, iframePort = null ) => ( {

--- a/client/state/editor/selectors.js
+++ b/client/state/editor/selectors.js
@@ -1,7 +1,6 @@
 import { get } from 'lodash';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getEditedPost } from 'calypso/state/posts/selectors';
-import { getPreference } from 'calypso/state/preferences/selectors';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
@@ -99,17 +98,6 @@ export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
 	}
 
 	return path;
-}
-
-/**
- * Returns whether the confirmation sidebar is enabled for the given siteId
- *
- * @param  {object}  state     Global state tree
- * @param  {number}  siteId    Site ID
- * @returns {boolean}           Whether or not the sidebar is enabled
- */
-export function isConfirmationSidebarEnabled( state, siteId ) {
-	return getPreference( state, 'editorConfirmationDisabledSites' ).indexOf( siteId ) === -1;
 }
 
 export function isEditorIframeLoaded( state ) {

--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -4,7 +4,6 @@ export const DEFAULT_PREFERENCE_VALUES = {
 	'guided-tours-history': [],
 	recentSites: [],
 	mediaScale: 0.157,
-	editorConfirmationDisabledSites: [],
 	colorScheme: 'default',
 	homeQuickLinksToggleStatus: 'expanded',
 };

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -33,10 +33,6 @@ export const remoteValuesSchema = {
 			minimum: 0,
 			maximum: 1,
 		},
-		editorConfirmationDisabledSites: {
-			type: 'array',
-			items: { type: 'number' },
-		},
 		colorScheme: {
 			type: 'string',
 			enum: [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #45938, the publish confirmation is controlled from inside the block editor settings. This means we can clean up the dead code that was concealed inside the `PublishConfirmation` component, and that includes some unused state and a user preference that's no longer used. I'm also using the opportunity to refactor the component to a functional component.

#### Testing instructions

* Go to `/settings/writing/:site`
* Verify the `Show publish confirmation` component looks the same way.
* Verify none of the removed code is used.
* Verify tests still pass.