### PR TITLE
Docs: Remove unnecessary React import from READMEs

### DIFF
--- a/client/blocks/product-plan-overlap-notices/README.md
+++ b/client/blocks/product-plan-overlap-notices/README.md
@@ -8,13 +8,10 @@ Those notices will appear when there is a feature overlap between the current pl
 
 ```jsx
 import { JETPACK_PRODUCTS_LIST, JETPACK_PLANS } from '@automattic/calypso-products';
-import React from 'react';
 import ProductPlanOverlapNotices from 'calypso/blocks/product-plan-overlap-notices';
 
-export default class extends React.Component {
-	render() {
-		return <ProductPlanOverlapNotices plans={ JETPACK_PLANS } products={ JETPACK_PRODUCTS_LIST } />;
-	}
+export default function MyComponent() {
+	return <ProductPlanOverlapNotices plans={ JETPACK_PLANS } products={ JETPACK_PRODUCTS_LIST } />;
 }
 ```
 

--- a/client/blocks/shortcode/README.md
+++ b/client/blocks/shortcode/README.md
@@ -9,15 +9,10 @@ Shortcode is a React component enabling sandboxed rendering of a shortcode strin
 Simply pass a site ID and a shortcode string child. The component will automatically trigger a network request to retrieve the rendered shortcode.
 
 ```jsx
-import React from 'react';
 import Shortcode from 'calypso/blocks/shortcode';
 
-export default class extends React.Component {
-	static displayName = 'MyComponent';
-
-	render() {
-		return <Shortcode siteId={ 6393289 }>[gallery ids="31860,31856"]</Shortcode>;
-	}
+export default function MyComponent() {
+	return <Shortcode siteId={ 6393289 }>[gallery ids="31860,31856"]</Shortcode>;
 }
 ```
 

--- a/client/components/badge/README.md
+++ b/client/components/badge/README.md
@@ -6,13 +6,10 @@ should stand out from the rest.
 ## Usage
 
 ```jsx
-import React from 'react';
 import Badge from 'calypso/components/badge';
 
-class MyComponent extends React.Component {
-	render() {
-		return <Badge type="warning">Only 6MB left!</Badge>;
-	}
+function MyComponent() {
+	return <Badge type="warning">Only 6MB left!</Badge>;
 }
 ```
 

--- a/client/components/clipboard-button-input/README.md
+++ b/client/components/clipboard-button-input/README.md
@@ -7,7 +7,6 @@ Clipboard Button Input is a React component used to display a text input field c
 In most cases, the component can be treated much like any other text input element. Pass a `value` to be used as the input text to be copied.
 
 ```jsx
-import React from 'react';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 
 export default function MyComponent() {

--- a/client/components/data/document-head/README.md
+++ b/client/components/data/document-head/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `title`, `skipTitleFormatting`, `unreadCount`, `link` or `meta`. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 
 export default function HomeSection() {

--- a/client/components/data/domain-management/README.md
+++ b/client/components/data/domain-management/README.md
@@ -8,7 +8,6 @@ Pass a component as a child of `<DomainManagementData />`. `DomainManagementData
 It will handle the data itself thus helping us to decouple concerns: i.e. fetching and displaying data. This pattern is also called [container components](https://medium.com/@learnreact/container-components-c0e67432e005).
 
 ```js
-import React from 'react';
 import DomainManagementData from 'calypso/components/data/domain-management';
 import MyChildComponent from 'calypso/components/my-child-component';
 

--- a/client/components/data/media-list-data/README.md
+++ b/client/components/data/media-list-data/README.md
@@ -7,7 +7,6 @@ MediaListData is a React component intended to be used as a controller-view to s
 Wrap a child component with `<MediaListData />`, passing a `siteId` and optional `filter`, `postId` and `search` values. [As a controller-view](https://facebook.github.io/flux/docs/overview.html#views-and-controller-views), MediaListData does not render any content of its own; instead, it simply renders the child component.
 
 ```jsx
-import React from 'react';
 import MediaListData from 'calypso/components/data/media-list-data';
 import MyChildComponent from './my-child-component';
 

--- a/client/components/data/query-active-theme/README.md
+++ b/client/components/data/query-active-theme/README.md
@@ -7,7 +7,6 @@ Query Active Theme is a React component used in managing fetching of a given sit
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import { connect } from 'react-redux';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import { getActiveTheme } from 'calypso/state/themes/selectors';

--- a/client/components/data/query-atat-eligibility/README.md
+++ b/client/components/data/query-atat-eligibility/README.md
@@ -8,7 +8,6 @@ Render the component, passing a `siteId`. It does not accept any children nor do
 You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```js
-import React from 'react';
 import { connect } from 'react-redux';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 

--- a/client/components/data/query-billing-transaction/README.md
+++ b/client/components/data/query-billing-transaction/README.md
@@ -7,7 +7,6 @@
 Render the component and pass `transactionId` as a prop. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
 import Receipt from './receipt';
 

--- a/client/components/data/query-billing-transactions/README.md
+++ b/client/components/data/query-billing-transactions/README.md
@@ -7,7 +7,6 @@
 Render the component as a child in any component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 import MyBillingTransactionsList from './list';
 

--- a/client/components/data/query-canonical-theme/README.md
+++ b/client/components/data/query-canonical-theme/README.md
@@ -7,7 +7,6 @@ Query Canonical Theme is a React component used in managing the fetching of indi
 Render the component, passing `siteId` and `themeId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import { connect } from 'react-redux';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import Theme from 'calypso/components/theme';

--- a/client/components/data/query-countries/README.md
+++ b/client/components/data/query-countries/README.md
@@ -7,7 +7,6 @@
 Render the component without props. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryDomainCountries from 'calypso/components/data/query-countries/domains';
 
 export default function CountriesList( { countries } ) {

--- a/client/components/data/query-country-states/README.md
+++ b/client/components/data/query-country-states/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `countryCode`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryCountryStates from 'calypso/components/data/query-country-states';
 
 export default function MyStatesList( { countryStates } ) {

--- a/client/components/data/query-domain-info/README.md
+++ b/client/components/data/query-domain-info/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `domainName`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import { useSelector } from 'react-redux';
 import QueryDomainInfo from 'calypso/components/data/query-domain-info';
 import { getDomainWapiInfoByDomainName } from 'calypso/state/domains/transfer/selectors';

--- a/client/components/data/query-jetpack-connection/README.md
+++ b/client/components/data/query-jetpack-connection/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
 import MyJetpackConnectionStatusBlock from './status-block';
 

--- a/client/components/data/query-jetpack-modules/README.md
+++ b/client/components/data/query-jetpack-modules/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import MyJetpackModulesListItem from './list-item';
 

--- a/client/components/data/query-jetpack-scan-history/README.md
+++ b/client/components/data/query-jetpack-scan-history/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryJetpackScanHistory from 'calypso/components/data/query-jetpack-scan-history';
 import Scan from './scan';
 

--- a/client/components/data/query-jetpack-scan-threat-counts/README.md
+++ b/client/components/data/query-jetpack-scan-threat-counts/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryJetpackScanThreatCounts from 'calypso/components/data/query-jetpack-scan-threat-counts';
 import Scan from './scan';
 

--- a/client/components/data/query-jetpack-scan/README.md
+++ b/client/components/data/query-jetpack-scan/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import Scan from './scan';
 

--- a/client/components/data/query-jetpack-settings/README.md
+++ b/client/components/data/query-jetpack-settings/README.md
@@ -8,7 +8,6 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import { map } from 'lodash';
-import React from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackSettings from 'calypso/components/data/query-jetpack-settings';
 import getJetpackSettings from 'calypso/state/selectors/get-jetpack-settings';

--- a/client/components/data/query-jetpack-user-connection/README.md
+++ b/client/components/data/query-jetpack-user-connection/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackUserConnection from 'calypso/components/data/query-jetpack-user-connection';
 import getJetpackUserConnection from 'calypso/state/selectors/get-jetpack-user-connection';

--- a/client/components/data/query-jitm/README.md
+++ b/client/components/data/query-jitm/README.md
@@ -6,10 +6,6 @@
 
 Render the component, passing `siteId`, `messagePath` and optional `sectionName`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
-```jsx
-import React from 'react';
-```
-
 ## Props
 
 ### `siteId`

--- a/client/components/data/query-keyring-connections/README.md
+++ b/client/components/data/query-keyring-connections/README.md
@@ -7,7 +7,6 @@
 Render the component without props. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import React from 'react';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 
 export default function MyConnectionsList( { connections } ) {

--- a/client/components/data/query-keyring-services/README.md
+++ b/client/components/data/query-keyring-services/README.md
@@ -7,7 +7,6 @@
 Render the component without props. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import React from 'react';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 
 export default function MyServicesList( { services } ) {

--- a/client/components/data/query-media/README.md
+++ b/client/components/data/query-media/README.md
@@ -7,7 +7,6 @@ Query Media is a React component used in managing the fetching of media queries.
 Render the component, passing `siteId` and `query` or a `siteId` and `mediaId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryMedia from 'calypso/components/data/query-media';
 import MyMediaListItem from './list-item';
 

--- a/client/components/data/query-post-counts/README.md
+++ b/client/components/data/query-post-counts/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `type`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryPostCounts from 'calypso/components/data/query-post-counts';
 
 export default function PostCount( { count } ) {

--- a/client/components/data/query-post-likes/README.md
+++ b/client/components/data/query-post-likes/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `postId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryPostLikes from 'calypso/components/data/query-post-likes';
 import MyPostLikesListItem from './list-item';
 

--- a/client/components/data/query-post-revision-authors/README.md
+++ b/client/components/data/query-post-revision-authors/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `userIds`. It does not accept any children, nor does it render any element to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryUsers from 'calypso/components/data/query-users';
 
 export default function PostRevisionAuthors( { authors } ) {

--- a/client/components/data/query-post-revisions/README.md
+++ b/client/components/data/query-post-revisions/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `postId`. It does not accept any children, nor does it render any element to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryPostRevisions from 'calypso/components/data/query-post-revisions';
 
 export default function PostRevisions( { revisions } ) {

--- a/client/components/data/query-post-stats/README.md
+++ b/client/components/data/query-post-stats/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`, `postId` and `fields`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 
 export default function Component( { statValue } ) {

--- a/client/components/data/query-post-types/README.md
+++ b/client/components/data/query-post-types/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryPostTypes from 'calypso/components/data/query-post-types';
 import MyPostTypesListItem from './list-item';
 

--- a/client/components/data/query-posts/README.md
+++ b/client/components/data/query-posts/README.md
@@ -7,7 +7,6 @@ Query Posts is a React component used in managing the fetching of posts queries.
 Render the component, passing `siteId` and `query`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryPosts from 'calypso/components/data/query-posts';
 import MyPostsListItem from './list-item';
 

--- a/client/components/data/query-publicize-connections/README.md
+++ b/client/components/data/query-publicize-connections/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` or the boolean attribute `selectedSite`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connetions';
 import MyConnectionsListItem from './list-item';
 

--- a/client/components/data/query-reader-list/README.md
+++ b/client/components/data/query-reader-list/README.md
@@ -7,7 +7,6 @@
 Render the component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryReaderList from 'calypso/components/data/query-reader-list';
 import MyListItem from './list-item';
 

--- a/client/components/data/query-reader-lists/README.md
+++ b/client/components/data/query-reader-lists/README.md
@@ -7,7 +7,6 @@
 Render the component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryReaderLists from 'calypso/components/data/query-reader-lists';
 import MyListItem from './list-item';
 

--- a/client/components/data/query-reader-tag-images/README.md
+++ b/client/components/data/query-reader-tag-images/README.md
@@ -7,7 +7,6 @@
 Render the component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryReaderTagImages from 'calypso/components/data/query-reader-tag-images';
 import MyListItem from './list-item';
 

--- a/client/components/data/query-reader-thumbnails/README.md
+++ b/client/components/data/query-reader-thumbnails/README.md
@@ -7,7 +7,6 @@
 Render the component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryReaderThumbnails from 'calypso/components/data/query-reader-thumbnail';
 import { getThumbnailForIframe } from 'calypso/state/reader/thumbnails/selectors';
 

--- a/client/components/data/query-rewind-backup-status/README.md
+++ b/client/components/data/query-rewind-backup-status/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `backupId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryBackupRestoreStatus from 'calypso/components/data/query-backup-backup-status';
 
 export default function MyComponent( props ) {

--- a/client/components/data/query-rewind-backups/README.md
+++ b/client/components/data/query-rewind-backups/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import { useSelector } from 'react-redux';
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';

--- a/client/components/data/query-rewind-restore-status/README.md
+++ b/client/components/data/query-rewind-restore-status/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `restoreId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 
 export default function MyComponent( props ) {

--- a/client/components/data/query-site-connection-status/README.md
+++ b/client/components/data/query-site-connection-status/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QuerySiteConnectionStatus from 'calypso/components/data/query-site-connection-status';
 
 export default function ExampleSiteComponent( { siteConnectionStatus, translate } ) {

--- a/client/components/data/query-site-credentials/README.md
+++ b/client/components/data/query-site-credentials/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
 
 export default function ExampleSiteComponent( { siteCredentials, translate } ) {

--- a/client/components/data/query-site-invites/README.md
+++ b/client/components/data/query-site-invites/README.md
@@ -11,7 +11,6 @@ sibling components which make use of the fetched data made available through
 the global application state.
 
 ```jsx
-import React from 'react';
 import { connect } from 'react-redux';
 import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 

--- a/client/components/data/query-site-keyrings/README.md
+++ b/client/components/data/query-site-keyrings/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 
 export default function MyKeyringsPage( { keyrings } ) {

--- a/client/components/data/query-site-monitor-settings/README.md
+++ b/client/components/data/query-site-monitor-settings/README.md
@@ -8,7 +8,6 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import { connect } from 'react-redux';
 import QuerySiteMonitorSettings from 'calypso/components/data/query-site-monitor-settings';
 import getSiteMonitorSettings from 'calypso/state/selectors/get-site-monitor-settings';

--- a/client/components/data/query-site-settings/README.md
+++ b/client/components/data/query-site-settings/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 
 export default function MySettingsPage( { settings } ) {

--- a/client/components/data/query-site-stats/README.md
+++ b/client/components/data/query-site-stats/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `statType`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 
 export default function AmazingVisualizationOfStats( { stats } ) {

--- a/client/components/data/query-stats-recent-post-views/README.md
+++ b/client/components/data/query-stats-recent-post-views/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `postIds`. It does not accept any children, nor does it render any element to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryRecentPostViews from 'calypso/components/data/query-stats-recent-post-views';
 
 export default function ViewCount( { viewCount } ) {

--- a/client/components/data/query-taxonomies/README.md
+++ b/client/components/data/query-taxonomies/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `postType`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryTaxonomies from 'calypso/components/data/query-taxonomies';
 
 export default function MyTaxonomiesList( { taxonomies } ) {

--- a/client/components/data/query-terms/README.md
+++ b/client/components/data/query-terms/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId` and `taxonomy`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryTerms from 'calypso/components/data/query-terms';
 
 export default function AmazingListOfTerms( { terms } ) {

--- a/client/components/data/query-theme/README.md
+++ b/client/components/data/query-theme/README.md
@@ -7,7 +7,6 @@ Query Theme is a React component used in managing the fetching of individual the
 Render the component, passing `siteId` and `themeId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import { connect } from 'react-redux';
 import QueryTheme from 'calypso/components/data/query-theme';
 import Theme from 'calypso/components/theme';

--- a/client/components/data/query-themes/README.md
+++ b/client/components/data/query-themes/README.md
@@ -7,7 +7,6 @@ Query Themes is a React component used in managing the fetching of themes querie
 Render the component, passing `siteId` and `query`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import { connect } from 'react-redux';
 import QueryThemes from 'calypso/components/data/query-themes';
 import Theme from 'calypso/components/theme';

--- a/client/components/data/query-user-settings/README.md
+++ b/client/components/data/query-user-settings/README.md
@@ -7,7 +7,6 @@
 Render the component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import { useSelector } from 'react-redux';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import { default as getUserSettings } from 'calypso/state/selectors/get-user-settings';

--- a/client/components/data/query-wordads-settings/README.md
+++ b/client/components/data/query-wordads-settings/README.md
@@ -7,7 +7,6 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryWordadsSettings from 'calypso/components/data/query-wordads-settings';
 
 export default function MySettings( { settings } ) {

--- a/client/components/data/query-wporg-plugins/README.md
+++ b/client/components/data/query-wporg-plugins/README.md
@@ -12,7 +12,6 @@ Pagination is currently supported only for category queries in the API, so you c
 It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
-import React from 'react';
 import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
 import { getPluginsListByCategory } from 'calypso/state/plugins/wporg/selectors';
 

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -6,11 +6,11 @@ React component used to display a Date Picker.
 
 ## Example Usage
 
-```js
-import React from 'react';
+```jsx
+import { Component } from 'react';
 import DatePicker from 'calypso/components/date-picker';
 
-export default class extends React.Component {
+export default class extends Component {
 	// ...
 
 	onSelectDay( date ) {

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -7,17 +7,14 @@ External Link is a React component for rendering an external link.
 ### Usage
 
 ```jsx
-import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 
-class MyComponent extends React.Component {
-	render() {
-		return (
-			<ExternalLink icon href="https://wordpress.org" onClick={ () => {} }>
-				WordPress.org
-			</ExternalLink>
-		);
-	}
+function MyComponent() {
+	return (
+		<ExternalLink icon href="https://wordpress.org" onClick={ () => {} }>
+			WordPress.org
+		</ExternalLink>
+	);
 }
 ```
 
@@ -42,23 +39,20 @@ and is capable of recording Tracks events.
 ### Usage
 
 ```jsx
-import React from 'react';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 
-class MyComponent extends React.Component {
-	render() {
-		return (
-			<ExternalLinkWithTracking
-				icon
-				href="https://wordpress.org"
-				onClick={ () => {} }
-				tracksEventName="tracks_event_name"
-				tracksEventProps={ { foo: 'baz' } }
-			>
-				WordPress.org
-			</ExternalLinkWithTracking>
-		);
-	}
+function MyComponent() {
+	return (
+		<ExternalLinkWithTracking
+			icon
+			href="https://wordpress.org"
+			onClick={ () => {} }
+			tracksEventName="tracks_event_name"
+			tracksEventProps={ { foo: 'baz' } }
+		>
+			WordPress.org
+		</ExternalLinkWithTracking>
+	);
 }
 ```
 

--- a/client/components/feature-example/README.md
+++ b/client/components/feature-example/README.md
@@ -5,17 +5,14 @@ Feature Example is a component used to render an mocked example of any feature. 
 ## Usage
 
 ```jsx
-import React from 'react';
 import EmptyContent from 'calypso/components/empty-content';
 import FeatureExample from 'calypso/components/feature-example';
 
-class MyComponent extends React.Component {
-	render() {
-		return (
-			<FeatureExample>
-				<EmptyContent />
-			</FeatureExample>
-		);
-	}
+function MyComponent() {
+	return (
+		<FeatureExample>
+			<EmptyContent />
+		</FeatureExample>
+	);
 }
 ```

--- a/client/components/forms/counted-textarea/README.md
+++ b/client/components/forms/counted-textarea/README.md
@@ -9,7 +9,7 @@ Counted Textarea is a React form component which renders a `<textarea />` accomp
 `<CountedTextarea />` expects to be rendered as a [controlled component](https://facebook.github.io/react/docs/forms.html#controlled-components), meaning that it will only behave as expected if passed a `value` prop. The textarea will automatically keep the character count in sync as the value prop is changed. With the exception of `className`, all props will be transferred to the child `<textarea />`. If a `className` prop is passed, it will be applied to the wrapper node.
 
 ```jsx
-import React from 'react';
+import { Component } from 'react';
 import CountedTextarea from 'calypso/components/forms/counted-textarea';
 
 class MyComponent extends Component {

--- a/client/components/gallery-shortcode/README.md
+++ b/client/components/gallery-shortcode/README.md
@@ -7,21 +7,16 @@ Gallery Shortcode is a React component used in displaying galleries. It makes us
 Simply pass a site ID and an array of media items.
 
 ```jsx
-import React from 'react';
 import GalleryShortcode from 'calypso/components/gallery-shortcode';
 
-export default class extends React.Component {
-	static displayName = 'MyComponent';
-
-	render() {
-		return (
-			<GalleryShortcode
-				siteId={ 6393289 }
-				items={ [ { ID: 31860 }, { ID: 31856 } ] }
-				className="my-component"
-			/>
-		);
-	}
+export default function MyComponent() {
+	return (
+		<GalleryShortcode
+			siteId={ 6393289 }
+			items={ [ { ID: 31860 }, { ID: 31856 } ] }
+			className="my-component"
+		/>
+	);
 }
 ```
 

--- a/client/components/happiness-support/README.md
+++ b/client/components/happiness-support/README.md
@@ -5,7 +5,6 @@ This component renders a card presenting our support resources, including links 
 ## Usage
 
 ```js
-import React from 'react';
 import HappinessSupport from 'calypso/components/happiness-support';
 
 export default () => {

--- a/client/components/image-preloader/README.md
+++ b/client/components/image-preloader/README.md
@@ -7,15 +7,12 @@ Image Preloader is a React component to display a placeholder element until the 
 ## Usage
 
 ```jsx
-import React from 'react';
 import ImagePreloader from 'calypso/components/image-preloader';
 
-export default class extends React.Component {
-	render() {
-		return (
-			<ImagePreloader placeholder={ <div>Loading...</div> } src="http://lorempixel.com/200/200" />
-		);
-	}
+export default function MyComponent() {
+	return (
+		<ImagePreloader placeholder={ <div>Loading...</div> } src="http://lorempixel.com/200/200" />
+	);
 }
 ```
 

--- a/client/components/image/README.md
+++ b/client/components/image/README.md
@@ -6,7 +6,6 @@ to the image element if the image fails to load.
 ## Usage
 
 ```jsx
-import React from 'react';
 import Image from 'calypso/components/image';
 
 const MyComponent = () => <Image src="http://example.com/fails" className="my-image" />;

--- a/client/components/localized-moment/README.md
+++ b/client/components/localized-moment/README.md
@@ -12,14 +12,11 @@ Is a higher-order component (HOC) that provides two props to the wrapped child:
 ### Usage
 
 ```jsx
-import React from 'react';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
-class Label extends React.Component {
-	render() {
-		const { moment, date } = this.props;
-		return <span>{ moment( date ).format( 'LLLL' ) }</span>;
-	}
+function Label() {
+	const { moment, date } = this.props;
+	return <span>{ moment( date ).format( 'LLLL' ) }</span>;
 }
 
 export default withLocalizedMoment( Label );
@@ -38,7 +35,6 @@ in `withLocalizedMoment`. It's just a different implementation of the same conce
 ### Usage
 
 ```jsx
-import React from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 export default function Label( { date } ) {
@@ -62,7 +58,6 @@ locale slug.
 ### Usage
 
 ```jsx
-import React from 'react';
 import ReactDom from 'react-dom';
 import MomentProvider from 'calypso/components/localized-moment/provider';
 

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -193,7 +193,6 @@ text (optional) and a button.
 ### How to use the `<ProductCardAction />`
 
 ```jsx
-import React from 'react';
 import ProductCard from 'calypso/components/product-card';
 import ProductCardAction from 'calypso/components/product-card/action';
 

--- a/client/components/purchase-detail/README.md
+++ b/client/components/purchase-detail/README.md
@@ -6,7 +6,6 @@ This component renders a box with a title, description, button, and icon, based 
 
 ```js
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 
 const MyComponent = ( { translate } ) => (

--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -8,7 +8,6 @@ and optional actions buttons.
 ```js
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import SectionHeader from 'calypso/components/section-header';
 
 const MyHeader = ( { translate } ) => (

--- a/client/components/segmented-control/README.md
+++ b/client/components/segmented-control/README.md
@@ -13,10 +13,10 @@ The children technique is appropriate when you'd like to define the "selection" 
 A good example for this case is navigation. Sometimes the option that is selected is defined by the route, other times it's a state value, external prop, etc.
 
 ```jsx
-import React from 'react';
+import { Component } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
 
-export default class extends React.Component {
+export default class extends Component {
 	// ...
 
 	render() {
@@ -103,7 +103,6 @@ A good example for this case is a form element. You don't want to have to write 
 **NOTE**: _there is still more work here in order to be fully functional as a form element. This is currently experimental._
 
 ```jsx
-import React from 'react';
 import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 
 const options = [

--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -12,25 +12,20 @@ The children technique is appropriate when you'd like to define the "selection" 
 
 A good example for this case is navigation. Sometimes the option that is selected is defined by the route, other times it's a state value, external prop, etc.
 
-```js
-import React from 'react';
+```jsx
 import SelectDropdown from 'calypso/components/select-dropdown';
 
-export default class extends React.Component {
-	// ...
-
-	render() {
-		return (
-			<SelectDropdown selectedText="Published">
-				<SelectDropdown.Item selected path="/published">
-					Published
-				</SelectDropdown.Item>
-				<SelectDropdown.Item path="/scheduled">Scheduled</SelectDropdown.Item>
-				<SelectDropdown.Item path="/drafts">Drafts</SelectDropdown.Item>
-				<SelectDropdown.Item path="/trashed">Trashed</SelectDropdown.Item>
-			</SelectDropdown>
-		);
-	}
+export default function MyComponent() {
+	return (
+		<SelectDropdown selectedText="Published">
+			<SelectDropdown.Item selected path="/published">
+				Published
+			</SelectDropdown.Item>
+			<SelectDropdown.Item path="/scheduled">Scheduled</SelectDropdown.Item>
+			<SelectDropdown.Item path="/drafts">Drafts</SelectDropdown.Item>
+			<SelectDropdown.Item path="/trashed">Trashed</SelectDropdown.Item>
+		</SelectDropdown>
+	);
 }
 ```
 

--- a/client/components/site-offset/README.md
+++ b/client/components/site-offset/README.md
@@ -11,15 +11,12 @@ Is a higher-order component (HOC) that provides one prop to the wrapped child:
 ### Usage
 
 ```jsx
-import React from 'react';
 import { withApplySiteOffset } from 'calypso/components/site-offset';
 
-class Label extends React.Component {
-	render() {
-		const { moment, date } = this.props;
-		const displayDate = applySiteOffset( date )?.format( 'LLLL' );
-		return <span>{ displayDate ? displayDate : 'Loading...' }</span>;
-	}
+function Label() {
+	const { moment, date } = this.props;
+	const displayDate = applySiteOffset( date )?.format( 'LLLL' );
+	return <span>{ displayDate ? displayDate : 'Loading...' }</span>;
 }
 
 export default withApplySiteOffset( Label );
@@ -38,7 +35,6 @@ in `withApplySiteOffset`. It's just a different implementation of the same conce
 ### Usage
 
 ```jsx
-import React from 'react';
 import { useApplySiteOffset } from 'calypso/components/site-offset';
 
 export default function Label( { date } ) {
@@ -62,7 +58,6 @@ The `SiteOffsetProvider` component takes one prop: `site`. It is a string that i
 ### Usage
 
 ```jsx
-import React from 'react';
 import ReactDom from 'react-dom';
 import { SiteOffsetProvider } from 'calypso/components/site-offset/context';
 

--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -7,13 +7,10 @@ Spinner is a React component for rendering a loading indicator.
 ## Usage
 
 ```jsx
-import React from 'react';
 import Spinner from 'calypso/components/spinner';
 
-export default class extends React.Component {
-	render() {
-		return <Spinner />;
-	}
+export default function MyComponent() {
+	return <Spinner />;
 }
 ```
 

--- a/client/components/upgrades/credit-card-number-input/README.md
+++ b/client/components/upgrades/credit-card-number-input/README.md
@@ -5,13 +5,10 @@
 ## Usage
 
 ```jsx
-import React from 'react';
 import CreditCardNumberInput from 'calypso/components/upgrades/credit-card-number-input';
 
-class MyComponent extends React.Component {
-	render() {
-		return <CreditCardNumberInput value={ this.state.card.number } />;
-	}
+function MyComponent() {
+	return <CreditCardNumberInput value={ this.state.card.number } />;
 }
 ```
 

--- a/client/components/version/README.md
+++ b/client/components/version/README.md
@@ -5,13 +5,10 @@ Version is a React component for rendering a version number
 ## Usage
 
 ```jsx
-import React from 'react';
 import Version from 'calypso/components/version';
 
-class MyComponent extends React.Component {
-	render() {
-		return <Version version={ 123 } icon="plugins" />;
-	}
+function MyComponent() {
+	return <Version version={ 123 } icon="plugins" />;
 }
 ```
 

--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -66,7 +66,6 @@ export default {};
 For `index.js`, this is the essential boilerplate, which comprises the imports and the `makeTour` wrapping:
 
 ```javascript
-import React from 'react';
 import {
 	makeTour,
 	Tour,

--- a/client/lib/react-pass-to-children/README.md
+++ b/client/lib/react-pass-to-children/README.md
@@ -7,10 +7,10 @@ Pass to Children is a utility method to assist in creating a React pass-through 
 The exposed method expects to receive the current react element instance, and an object of props to pass to the child in addition to the props of the instance itself.
 
 ```js
-import React from 'react';
+import { Component } from 'react';
 import passToChildren from 'calypso/lib/react-pass-to-children';
 
-export default class extends React.Component {
+export default class extends Component {
 	render() {
 		return passToChildren( this, {
 			data: [ 1, 2, 3 ],

--- a/client/me/purchases/components/loading-placeholder/README.md
+++ b/client/me/purchases/components/loading-placeholder/README.md
@@ -5,7 +5,6 @@
 ```js
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
 
 const MyComponentLoadingPlaceholder = ( { translate } ) => (

--- a/client/my-sites/plans/current-plan/my-plan-card/README.md
+++ b/client/my-sites/plans/current-plan/my-plan-card/README.md
@@ -11,21 +11,18 @@ See p1HpG7-7ET-p2 for more details.
 
 ```jsx
 import { Button } from '@automattic/components';
-import React from 'react';
 import MyPlanCard from 'calypso/components/my-plan-card';
 
-export default class extends React.Component {
-	render() {
-		return (
-			<MyPlanCard
-				action={ <Button compact>Manage Payment</Button> }
-				details="Expires on October 27, 2020"
-				product="jetpack_personal"
-				tagline="Your data is being securely backed up and you have access to priority support."
-				title="Jetpack Personal"
-			/>
-		);
-	}
+export default function MyComponent() {
+	return (
+		<MyPlanCard
+			action={ <Button compact>Manage Payment</Button> }
+			details="Expires on October 27, 2020"
+			product="jetpack_personal"
+			tagline="Your data is being securely backed up and you have access to priority support."
+			title="Jetpack Personal"
+		/>
+	);
 }
 ```
 

--- a/client/my-sites/plugins/plugins-browser-list/README.md
+++ b/client/my-sites/plugins/plugins-browser-list/README.md
@@ -6,7 +6,6 @@ This component is used to display a list with the a parametrizable number of plu
 
 ```js
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import PluginsList from 'calypso/my-sites/plugins/plugins-browser-list';
 
 const MyPluginsList = ( { pluginsData, translate } ) => (

--- a/client/my-sites/post-type-list/README.md
+++ b/client/my-sites/post-type-list/README.md
@@ -9,7 +9,6 @@
 Render the component, passing props to describe your query.
 
 ```jsx
-import React from 'react';
 import PostTypeList from 'calypso/my-sites/post-type-list';
 
 export default function MyComponent() {

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -120,15 +120,9 @@ The steps below guide you through creating a new flow and step:
 
 3 - add a simple React component to `index.jsx`:
 
-```javascript
-import React from 'react';
-
-export default class extends React.Component {
-	static displayName = 'HelloWorld';
-
-	render() {
-		return <span>Hello world</span>;
-	}
+```jsx
+export default function HelloWorld() {
+	return <span>Hello world</span>;
 }
 ```
 
@@ -167,7 +161,7 @@ the first step of the flow at `/start/hello/hello-world`, where you should see y
 
 8 - now we need a way for users to move to the next step of the flow. Let's add a button and a form to the step's `render` method:
 
-```javascript
+```jsx
 function render() {
 	return (
 		<form onSubmit={ this.handleSubmit }>

--- a/client/state/push-notifications/README.md
+++ b/client/state/push-notifications/README.md
@@ -20,7 +20,6 @@ A module for managing push notification state & communicating with the service w
 ### How to use
 
 ```js
-import React from 'react';
 import { connect } from 'react-redux';
 
 function mapStateToProps( state ) {

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -147,16 +147,18 @@ touch client/my-sites/hello-world/main.jsx
 Start by importing React as an external dependency at the top, then import the internal "Main" UI component from `components/main`. We'll use it to set up our view tree. Finally, create and export a new React Component.
 
 ```javascript
-import React from 'react';
+import { Component } from 'react';
 import Main from 'calypso/components/main';
 
-export default class HelloWorld extends React.Component {}
+export default class HelloWorld extends Component {}
 ```
 
 Cool. Let's make the React component render something for us. We'll do that by adding a `render()` method that uses the "Main" component and outputs some markup. Let's add the `render()` method inside of the `React.Component` extension like so:
 
 ```jsx
-export default class HelloWorld extends React.Component {
+import { Component } from 'react';
+
+export default class HelloWorld extends Component {
 	render() {
 		return (
 			<Main>
@@ -195,7 +197,9 @@ Then add some styles for our `HelloWorld` component:
 Let's update the component we wrote above to include our new styles:
 
 ```jsx
-export default class HelloWorld extends React.Component {
+import { Component } from 'react';
+
+export default class HelloWorld extends Component {
 	render() {
 		return (
 			<Main className="hello-world">
@@ -220,7 +224,6 @@ Time to hook this up with our controller function. Open `/hello-world/controller
 Import React and your new component at the top of the file:
 
 ```javascript
-import React from 'react';
 import HelloWorld from 'calypso/my-sites/hello-world/main';
 ```
 

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -234,7 +234,6 @@ In the example above we only pass the first argument, `mapStateToProps`. As anot
 
 ```jsx
 import { localize } from 'i18n-calypso';
-import React from 'react';
 
 const PostDeleteButton = ( { deleteHandler, label, translate } ) => (
 	<button onClick={ deleteHandler }>

--- a/docs/testing/snapshot-testing.md
+++ b/docs/testing/snapshot-testing.md
@@ -70,7 +70,6 @@ structure. Pretty cool 😎
 
 ```js
 import { shallow } from 'enzyme';
-import React from 'react';
 import LocaleSuggestions from '../locale-suggestions';
 import MyComponent from '../my-component';
 

--- a/packages/components/src/root-child/README.md
+++ b/packages/components/src/root-child/README.md
@@ -9,19 +9,16 @@ positioning may impact the child's style.
 
 ```jsx
 import { RootChild } from '@automattic/components';
-import React from 'react';
 
-export default class extends React.Component {
-	render() {
-		return (
-			<div className="my-component">
-				<span>This text will be a child of MyComponent</span>
-				<RootChild>
-					<span>This text will be a child of the root element, not of MyComponent</span>
-				</RootChild>
-			</div>
-		);
-	}
+export default function MyComponent() {
+	return (
+		<div className="my-component">
+			<span>This text will be a child of MyComponent</span>
+			<RootChild>
+				<span>This text will be a child of the root element, not of MyComponent</span>
+			</RootChild>
+		</div>
+	);
 }
 ```
 

--- a/packages/data-stores/README.md
+++ b/packages/data-stores/README.md
@@ -11,7 +11,6 @@ To use stores from the package, import and register the relevant store to obtain
 ```tsx
 import { Verticals } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
-import React from 'react';
 
 const VERTICALS_STORE = Verticals.register();
 

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -247,7 +247,6 @@ Typically, you'd wrap your exported function with `localize`:
 ```jsx
 // greeting.jsx
 import { localize } from 'i18n-calypso';
-import React from 'react';
 
 function Greeting( { translate, className } ) {
 	return <h1 className={ className }>{ translate( 'Hello!' ) }</h1>;
@@ -260,7 +259,6 @@ When the wrapped component is rendered, the render behavior of the original comp
 
 ```jsx
 // index.jsx
-import React from 'react';
 import { render } from 'react-dom';
 import Greeting from './greeting';
 
@@ -289,7 +287,6 @@ The function can be called to return a localized value of a string, and it also 
 
 ```jsx
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
 
 function Greeting( { className } ) {
 	const translate = useTranslate();
@@ -318,7 +315,6 @@ Example:
 ```jsx
 import { Gridicon } from '@automattic/components';
 import { useRtl } from 'i18n-calypso';
-import React from 'react';
 
 export default function Header() {
 	const isRtl = useRtl();
@@ -341,7 +337,6 @@ Example:
 ```jsx
 import { Gridicon } from '@automattic/components';
 import { withRtl } from 'i18n-calypso';
-import React from 'react';
 
 function Header( { isRtl } ) {
 	const icon = isRtl ? 'arrow-left' : 'arrow-right';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #56451 importing `React` has been unnecessary when it was done solely to be able to use JSX. We removed most of the occurrences of that import, but didn't remove them from the READMEs. 

This PR removes the unnecessary `React` import from READMEs throughout Calypso.

#### Testing instructions

Not needed, this affects only documentation.