### PR TITLE
Fix domain list header option button styles

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -686,12 +686,12 @@ class AllDomains extends Component {
 		const buttons = [
 			this.renderDomainTableFilterButton(),
 			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton />,
+			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
 		];
 
 		const mobileButtons = [
 			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton />,
+			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
 		];
 
 		return (

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -14,10 +14,6 @@
 
 	button.options-domain-button.ellipsis {
 		padding: 4px 0;
-
-		@include break-mobile {
-			padding: 7px;
-		}
 	}
 
 	svg.options-domain-button__ellipsis {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The option button needs to have the padding removed and should also be borderless to match the updated design.

#### Testing instructions

View the all domains list at http://calypso.localhost:3000/domains/manage?flags=domains/management-list-redesign

Make sure that the options button in the top right corner is borderless and is aligned with the other option buttons in the list below.

Before the patch:
<img width="1103" alt="Screen Shot 2021-11-22 at 11 39 00 AM" src="https://user-images.githubusercontent.com/1379730/142900539-c7dfbab6-6c6d-4a89-81e9-408297caa620.png">

After the patch:
<img width="1103" alt="Screen Shot 2021-11-22 at 11 39 16 AM" src="https://user-images.githubusercontent.com/1379730/142900565-d0a215c5-8c0f-4366-8d4b-4bb0eae441c1.png">


