### PR TITLE
WIP: Move `recordSignupComplete` to response handler of `/sites/new`

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -93,6 +93,21 @@ export function recordSignupComplete(
 	} );
 }
 
+export function recordNewUserSiteCreated( flow, isNew7DUserSite ) {
+	if ( !isNew7DUserSite ) {
+		return;
+	}	
+
+	const device = resolveDeviceTypeByViewPort();
+
+	// Tracks
+	recordTracksEvent( 'calypso_new_user_site_creation', { flow, device } );
+	// Google Analytics
+	gaRecordEvent( 'Signup', 'calypso_new_user_site_creation' );
+	// FullStory
+	recordFullStoryEvent( 'calypso_new_user_site_creation', { flow, device } );
+}
+
 export function recordSignupStep( flow, step, optionalProps ) {
 	const device = resolveDeviceTypeByViewPort();
 	const props = {

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -65,18 +65,6 @@ export function recordSignupComplete(
 	// Google Analytics
 	gaRecordEvent( 'Signup', 'calypso_signup_complete:' + flags.join( ',' ) );
 
-	// Tracks, Google Analytics, FullStory
-	if ( isNew7DUserSite ) {
-		const device = resolveDeviceTypeByViewPort();
-
-		// Tracks
-		recordTracksEvent( 'calypso_new_user_site_creation', { flow, device } );
-		// Google Analytics
-		gaRecordEvent( 'Signup', 'calypso_new_user_site_creation' );
-		// FullStory
-		recordFullStoryEvent( 'calypso_new_user_site_creation', { flow, device } );
-	}
-
 	// Marketing
 	adTrackSignupComplete( { isNewUserSite: isNewUser && isNewSite } );
 
@@ -93,17 +81,19 @@ export function recordSignupComplete(
 	} );
 }
 
-export function recordNewUserSiteCreated( flow, isNew7DUserSite ) {
-	if ( !isNew7DUserSite ) {
+export function recordNewUserSiteCreated( flow, isNewUser ) {
+	if ( ! isNewUser ) {
 		return;
-	}	
+	}
 
 	const device = resolveDeviceTypeByViewPort();
 
 	// Tracks
 	recordTracksEvent( 'calypso_new_user_site_creation', { flow, device } );
+
 	// Google Analytics
 	gaRecordEvent( 'Signup', 'calypso_new_user_site_creation' );
+
 	// FullStory
 	recordFullStoryEvent( 'calypso_new_user_site_creation', { flow, device } );
 }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -4,7 +4,7 @@ import { Site } from '@automattic/data-stores';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import debugFactory from 'debug';
 import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
-import { recordRegistration } from 'calypso/lib/analytics/signup';
+import { recordRegistration, recordNewUserSiteCreated } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	updatePrivacyForDomain,
@@ -290,6 +290,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	}
 
 	const locale = getLocaleSlug();
+	const isNewUser = !! ( reduxStore.getState().currentUser.user.site_count <= 1 || 0 );
 
 	wpcom.req.post(
 		'/sites/new',
@@ -325,6 +326,9 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				isFreeThemePreselected,
 				themeSlugWithRepo
 			);
+
+			// Record calypso_new_user_site_creation
+			recordNewUserSiteCreated( flowToCheck, isNewUser );
 		}
 	);
 }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -20,7 +20,11 @@ import wpcom from 'calypso/lib/wp';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import flows from 'calypso/signup/config/flows';
 import steps from 'calypso/signup/config/steps';
-import { getCurrentUserName, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserName,
+	isUserLoggedIn,
+	getCurrentUserSiteCount,
+} from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
@@ -288,9 +292,8 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		saveToLocalStorageAndProceed( state, domainItem, themeItem, newSiteParams, callback );
 		return;
 	}
-
 	const locale = getLocaleSlug();
-	const isNewUser = !! ( reduxStore.getState().currentUser.user.site_count <= 1 || 0 );
+	const isNewUser = getCurrentUserSiteCount( state ) <= 1;
 
 	wpcom.req.post(
 		'/sites/new',

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -27,6 +27,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
@@ -293,7 +294,9 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		return;
 	}
 	const locale = getLocaleSlug();
-	const isNewUser = getCurrentUserSiteCount( state ) <= 1;
+	const isNew7dUser = !! (
+		getCurrentUserSiteCount( state ) <= 1 && isUserRegistrationDaysWithinRange( state, null, 0, 7 )
+	);
 
 	wpcom.req.post(
 		'/sites/new',
@@ -331,7 +334,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			);
 
 			// Record calypso_new_user_site_creation
-			recordNewUserSiteCreated( flowToCheck, isNewUser );
+			recordNewUserSiteCreated( flowToCheck, isNew7dUser );
 		}
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ref pau2Xa-3E9-p2 the event `calypso_new_user_site_creation` fires in some flows that do not create a new site. 
* This PR attempts to fix this, by moving the call to `recordSignupComplete` inside the response handler of `/sites/new/` (where we know a new site has been created). This is similar to how `recordRegistration` is called when a new user is created.
* I've also added a check to see if current sites <= 1, to prevent this event from firing on any subsequent site creations from the same user.

#### Testing instructions
TBD, but basic manual testing flow:
* Create a new user via /start/ 
* Create a new site by following the signup flow
* **Expected**: `calypso_new_user_site_creation` should fire
* Create a new site under the same account
* **Expected**: `calypso_new_user_site_creation` should not fire
* Create a new user via https://wordpress.com/start/domain
* **Expected**: `calypso_new_user_site_creation` should not fire
