### PR TITLE
Fix/bugs in email forward form

### DIFF
--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.jsx
@@ -88,14 +88,14 @@ class EmailForwardingAddNewCompactList extends Component {
 	}
 
 	onRemoveEmailForward = ( index ) => {
-		const { emailForwards } = this.state;
+		const emailForwards = [ ...this.state.emailForwards ];
 		emailForwards.splice( index, 1 );
 		this.setState( { emailForwards } );
 	};
 
 	onUpdateEmailForward = ( index, name, value ) => {
 		// eslint-disable-next-line prefer-const
-		let emailForwards = { ...this.state.emailForwards };
+		let emailForwards = [ ...this.state.emailForwards ];
 		emailForwards[ index ][ name ] = value;
 
 		const validEmailForward = validateAllFields( emailForwards[ index ] );
@@ -123,13 +123,15 @@ class EmailForwardingAddNewCompactList extends Component {
 	render() {
 		const { selectedDomainName } = this.props;
 
+		const { emailForwards } = this.state;
+
 		return (
 			<>
-				{ this.state.emailForwards?.map( ( fields, index ) => (
+				{ emailForwards.map( ( fields, index ) => (
 					<Fragment key={ `email-forwarding__add-new_fragment__card-${ index }` }>
 						<form className="email-forwarding__add-new">
 							<EmailForwardingAddNewCompact
-								emailForwards={ this.state.emailForwards }
+								emailForwards={ emailForwards }
 								fields={ fields }
 								index={ index }
 								onAddEmailForward={ this.onAddNewEmailForward }

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.jsx
@@ -7,20 +7,15 @@ import { validateAllFields } from 'calypso/lib/domains/email-forwarding';
 import EmailForwardingAddNewCompact from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact';
 import { composeAnalytics, withAnalytics } from 'calypso/state/analytics/actions';
 import { addEmailForward } from 'calypso/state/email-forwarding/actions';
-import getEmailForwardingLimit from 'calypso/state/selectors/get-email-forwarding-limit';
 import {
 	addEmailForwardSuccess,
-	getEmailForwards,
 	isAddingEmailForward,
 } from 'calypso/state/selectors/get-email-forwards';
-import { isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class EmailForwardingAddNewCompactList extends Component {
 	static propTypes = {
-		emailForwards: PropTypes.array,
-		emailForwardingLimit: PropTypes.number,
 		onConfirmEmailForwarding: PropTypes.func.isRequired,
 		onAddEmailForwardSuccess: PropTypes.func,
 		selectedDomainName: PropTypes.string.isRequired,
@@ -157,15 +152,10 @@ class EmailForwardingAddNewCompactList extends Component {
 
 export default connect(
 	( state, ownProps ) => {
-		const siteId = getSelectedSiteId( state );
 		return {
 			emailForwardSuccess: addEmailForwardSuccess( state, ownProps.selectedDomainName ),
 			selectedSiteSlug: getSiteSlug( state, getSelectedSiteId( state ) ),
 			isSubmittingEmailForward: isAddingEmailForward( state, ownProps.selectedDomainName ),
-			isRequestingDomains: isRequestingSiteDomains( state, siteId ),
-			emailForwards: getEmailForwards( state, ownProps.selectedDomainName ),
-			emailForwardingLimit: getEmailForwardingLimit( state, siteId ),
-			siteId,
 		};
 	},
 	{ addEmailForward }

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.jsx
@@ -30,7 +30,6 @@ class EmailForwardingAddNewCompactList extends Component {
 		super( props );
 		this.state = {
 			emailForwards: [ { destination: '', mailbox: '', isValid: false } ],
-			isRedirecting: false,
 			newEmailForwardAdded: false,
 		};
 	}
@@ -71,8 +70,10 @@ class EmailForwardingAddNewCompactList extends Component {
 	};
 
 	onAddNewEmailForward = () => {
-		this.setState( {
-			emailForwards: [ ...this.state.emailForwards, { destination: '', mailbox: '' } ],
+		this.setState( ( currentState ) => {
+			return {
+				emailForwards: [ ...currentState.emailForwards, { destination: '', mailbox: '' } ],
+			};
 		} );
 	};
 
@@ -92,14 +93,14 @@ class EmailForwardingAddNewCompactList extends Component {
 	}
 
 	onRemoveEmailForward = ( index ) => {
-		const [ emailForwards ] = this.state;
+		const { emailForwards } = this.state;
 		emailForwards.splice( index, 1 );
 		this.setState( { emailForwards } );
 	};
 
 	onUpdateEmailForward = ( index, name, value ) => {
 		// eslint-disable-next-line prefer-const
-		let emailForwards = this.state.emailForwards;
+		let emailForwards = { ...this.state.emailForwards };
 		emailForwards[ index ][ name ] = value;
 
 		const validEmailForward = validateAllFields( emailForwards[ index ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR addresses some issues flagged in [this review](https://github.com/Automattic/wp-calypso/pull/57492#pullrequestreview-812352268) of #57492, which were mainly to do with bad state manipulation.
* The PR also removes some unused data that was wired into the same component.

#### Testing instructions

* Run this branch locally, or access the live branch.
* For a site that has a domain without email for the domain, navigate to Upgrades -> Emails.
* If this is the only domain on the site, you should see the email comparison page appear.
* If this is not the only domain on the site, click on "Add Email" for your domain in the list of domains that don't have email. This should display the email comparison page.
* Click on the "Add email forwarding" button in the bottom card on the screen
* Type in an email forward and a receiving email address (feel free to enter some bad data!)
   - If you enter incomplete or invalid data, verify that you see a validation error for the relevant field(s)
* Once you have addressed any data validation issues, click on the "Add" button
* Verify that you're redirected to the management screen for your email forward and that your newly-created email forward is listed

Related to #57492