### PR TITLE
Videos UI - Refactor footer and header for better maintainability

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -8,7 +8,7 @@ import VideoHeaderBar from './video-header-bar';
 import VideoPlayer from './video-player';
 import './style.scss';
 
-const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) => {
+const VideosUi = ( { onBackClick = () => {} } ) => {
 	const translate = useTranslate();
 	const { data: course } = useCourseQuery( 'blogging-quick-start', { retry: false } );
 	const [ selectedVideoIndex, setSelectedVideoIndex ] = useState( null );
@@ -17,6 +17,17 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 	const [ currentVideo, setCurrentVideo ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
 	const videoRef = useRef( null );
+
+	const [ isMobile, setIsMobile ] = useState( window.innerWidth < 600 );
+	useEffect( () => {
+		window.addEventListener(
+			'resize',
+			() => {
+				setIsMobile( window.innerWidth < 600 );
+			},
+			false
+		);
+	}, [ isMobile ] );
 
 	const onVideoPlayClick = ( videoSlug, videoInfo ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
@@ -85,11 +96,7 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 		<div className="videos-ui">
 			<div className="videos-ui__header">
 				<VideoHeaderBar
-					displayIcon={ true }
-					displayLinks={ shouldDisplayTopLinks }
-					displaySkipLink={ false }
-					displayBackLink={ false }
-					displayCloseLink={ true }
+					context={ 'modal' }
 					onBackClick={ onBackClick }
 					skipClickHandler={ skipClickHandler }
 				/>
@@ -199,8 +206,8 @@ const VideosUi = ( { shouldDisplayTopLinks = false, onBackClick = () => {} } ) =
 			</div>
 			{ course && (
 				<VideoFooterBar
-					displayBackButton={ true }
-					displaySkipLink={ true }
+					context={ 'modal' }
+					isMobile={ isMobile }
 					displayCTA={ false }
 					descriptionCTA={ course.cta.description }
 					buttonTextCTA={ course.cta.action }

--- a/client/components/videos-ui/style-video-bar.scss
+++ b/client/components/videos-ui/style-video-bar.scss
@@ -37,10 +37,6 @@
         }
     }
 
-    .videos-ui__desktop {
-        display: none;
-    }
-
     .videos-ui__cta {
         display: flex;
         justify-content: flex-end;
@@ -65,18 +61,6 @@
     }
 
 	@include break-small {
-        .videos-ui__desktop {
-            display: block;
-        }
-        .videos-ui__mobile {
-            display: none;
-        }
-
-        .videos-ui__bar-content {
-            &.videos-ui__desktop {
-                display: flex;
-            }
-        }
         .videos-ui__cta {
             justify-content: space-between;
         }

--- a/client/components/videos-ui/video-footer-bar.jsx
+++ b/client/components/videos-ui/video-footer-bar.jsx
@@ -26,6 +26,11 @@ const VideoFooterBar = ( {
 		} );
 	};
 
+	const shouldDisplayFooter = displayBackButton || displaySkipLink | displayCTA;
+	if ( ! shouldDisplayFooter ) {
+		return null;
+	}
+
 	return (
 		<div className={ 'videos-ui__bar videos-ui__is-footer' }>
 			<div

--- a/client/components/videos-ui/video-footer-bar.jsx
+++ b/client/components/videos-ui/video-footer-bar.jsx
@@ -1,5 +1,4 @@
 import { Button, Gridicon } from '@automattic/components';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -8,8 +7,8 @@ import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-sl
 import './style-video-bar.scss';
 
 const VideoFooterBar = ( {
-	displayBackButton,
-	displaySkipLink,
+	context,
+	isMobile,
 	displayCTA,
 	descriptionCTA = '',
 	buttonTextCTA = '',
@@ -26,20 +25,21 @@ const VideoFooterBar = ( {
 		} );
 	};
 
-	const shouldDisplayFooter = displayBackButton || displaySkipLink | displayCTA;
-	if ( ! shouldDisplayFooter ) {
+	let displayBackButton = false;
+	const displaySkipLink = false;
+	if ( context === 'modal' && isMobile ) {
+		displayBackButton = true;
+	}
+
+	if ( ! displayBackButton && ! displaySkipLink && ! displayCTA ) {
 		return null;
 	}
 
 	return (
 		<div className={ 'videos-ui__bar videos-ui__is-footer' }>
-			<div
-				className={ classNames( 'videos-ui__bar-content', {
-					mobile: ! displayCTA,
-				} ) }
-			>
+			<div className={ 'videos-ui__bar-content' }>
 				{ displayBackButton && (
-					<div className={ 'videos-ui__mobile' }>
+					<div className={ 'videos-ui__back' }>
 						<a href="/" onClick={ onBackClick }>
 							<Gridicon icon="chevron-left" size={ 24 } />
 							<span>{ translate( 'Back' ) }</span>
@@ -48,14 +48,14 @@ const VideoFooterBar = ( {
 				) }
 				{ displayCTA && (
 					<div className={ 'videos-ui__cta' }>
-						<div className={ 'videos-ui__desktop' }>{ descriptionCTA }</div>
+						<div>{ descriptionCTA }</div>
 						<Button onClick={ onCTAButtonClick } className="videos-ui__button" href={ hrefCTA }>
 							<span>{ buttonTextCTA }</span>
 						</Button>
 					</div>
 				) }
 				{ displaySkipLink && (
-					<div className="videos-ui__bar-skip-link videos-ui__mobile">
+					<div className="videos-ui__bar-skip-link">
 						<a href={ `/post/${ siteSlug }` } onClick={ skipClickHandler }>
 							{ translate( 'Draft your first post' ) }
 						</a>

--- a/client/components/videos-ui/video-header-bar.jsx
+++ b/client/components/videos-ui/video-header-bar.jsx
@@ -6,51 +6,51 @@ import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-sl
 
 import './style-video-bar.scss';
 
-const VideoHeaderBar = ( {
-	displayIcon,
-	displayLinks,
-	displayBackLink = false,
-	displaySkipLink = false,
-	displayCloseLink = false,
-	onBackClick = () => {},
-	skipClickHandler = () => {},
-} ) => {
+const VideoHeaderBar = ( { context, onBackClick = () => {}, skipClickHandler = () => {} } ) => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	let displayIcon = false;
+	const displayBackLink = false;
+	const displaySkipLink = false;
+	let displayCloseLink = false;
+
+	if ( context === 'modal' ) {
+		displayIcon = true;
+		displayCloseLink = true;
+	}
 
 	return (
 		<div className={ 'videos-ui__bar' }>
 			{ displayIcon && <Gridicon icon="my-sites" size={ 24 } /> }
-			{ displayLinks && (
-				<div className={ classNames( 'videos-ui__bar-content', 'videos-ui__desktop' ) }>
-					<div>
-						{ displayBackLink && (
-							<a
-								href="/"
-								className={ classNames( {
-									'videos-ui__back-link': displayIcon,
-								} ) }
-								onClick={ onBackClick }
-							>
-								<Gridicon icon="chevron-left" size={ 24 } />
-								<span>{ translate( 'Back' ) }</span>
-							</a>
-						) }
-					</div>
-					<div className="videos-ui__bar-skip-link">
-						{ displaySkipLink && (
-							<a href={ `/post/${ siteSlug }` } onClick={ skipClickHandler }>
-								{ translate( 'Draft your first post' ) }
-							</a>
-						) }
-						{ displayCloseLink && (
-							<span role="button" onKeyDown={ onBackClick } tabIndex={ 0 } onClick={ onBackClick }>
-								<Gridicon icon="cross" size={ 24 } />
-							</span>
-						) }
-					</div>
+			<div className={ classNames( 'videos-ui__bar-content', 'videos-ui__desktop' ) }>
+				<div>
+					{ displayBackLink && (
+						<a
+							href="/"
+							className={ classNames( {
+								'videos-ui__back-link': displayIcon,
+							} ) }
+							onClick={ onBackClick }
+						>
+							<Gridicon icon="chevron-left" size={ 24 } />
+							<span>{ translate( 'Back' ) }</span>
+						</a>
+					) }
 				</div>
-			) }
+				<div className="videos-ui__bar-skip-link">
+					{ displaySkipLink && (
+						<a href={ `/post/${ siteSlug }` } onClick={ skipClickHandler }>
+							{ translate( 'Draft your first post' ) }
+						</a>
+					) }
+					{ displayCloseLink && (
+						<span role="button" onKeyDown={ onBackClick } tabIndex={ 0 } onClick={ onBackClick }>
+							<Gridicon icon="cross" size={ 24 } />
+						</span>
+					) }
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
@@ -10,7 +10,7 @@ const BloggingQuickStartModal = ( props ) => {
 		isVisible && (
 			<BlankCanvas className={ 'blogging-quick-start-modal' }>
 				<BlankCanvas.Content>
-					<VideosUi shouldDisplayTopLinks={ true } onBackClick={ onClose } />
+					<VideosUi onBackClick={ onClose } />
 				</BlankCanvas.Content>
 			</BlankCanvas>
 		)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR refactors the Videos UI footer and header to be more flexible to different contexts in the long-term. In so doing, it also fixes an issue where the footer border was being displayed even when no content was present, as well as an issue causing the "Draft your first post" link to incorrectly display on mobile in the modal context.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this diff locally. 
* Verify appearance of Videos UI modal above and below 600px breakpoint.
* Below 600px wide, footer should display a "Back" button and header should display Wordpress logo and X to close.
* Above 600px wide, footer should be empty with no border, and header should still display logo and X.
* In `client/components/videos-ui/index.jsx`, set `displayCTA` to `true` on the `VideoFooterBar` component.
* Verify that the CTA footer bar still displays correctly both above and below the breakpoint.

Above 600px:

![image](https://user-images.githubusercontent.com/13437011/142938753-849afe8f-26c5-49e4-9fcd-afbe5b5f28fe.png)

Below 600px:

<img width="440" alt="CleanShot 2021-11-22 at 15 37 45@2x" src="https://user-images.githubusercontent.com/13437011/142938838-f73ad907-475d-4c69-a7ac-b9436a64f0d9.png">


CTA:

![image](https://user-images.githubusercontent.com/13437011/142938686-b336d5dd-ee73-43ef-9191-8411bb70b5a1.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58207
Fixes #58184
