### PR TITLE
Products: Remove formatProduct from cart-items

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1,5 +1,5 @@
 import {
-	formatProduct,
+	camelOrSnakeSlug,
 	isCustomDesign,
 	isDomainMapping,
 	isDomainProduct,
@@ -565,21 +565,20 @@ export function getDomainMappings( cart ) {
 /**
  * Returns a renewal CartItem object with the given properties and product slug.
  *
- * @param {string|object} product - the product object
- * @param {object} [properties] - properties to be included in the new CartItem object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} a CartItem object
+ * @param {(import('@automattic/calypso-products').WithCamelCaseSlug|import('@automattic/calypso-products').WithSnakeCaseSlug) & ({is_domain_registration?: boolean; isDomainRegistration?: boolean})} product - the product object
+ * @param {{domain?: string}} properties - properties to be included in the new CartItem object
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} a CartItem object
  */
 export function getRenewalItemFromProduct( product, properties ) {
-	product = formatProduct( product );
-
+	const slug = camelOrSnakeSlug( product );
 	let cartItem;
 
 	if ( isDomainProduct( product ) ) {
-		cartItem = domainItem( product.product_slug, properties.domain, properties.source );
+		cartItem = domainItem( slug, properties.domain ?? '' );
 	}
 
 	if ( isPlan( product ) ) {
-		cartItem = planItem( product.product_slug );
+		cartItem = planItem( slug );
 	}
 
 	if ( isGSuiteOrGoogleWorkspace( product ) ) {
@@ -615,11 +614,11 @@ export function getRenewalItemFromProduct( product, properties ) {
 	}
 
 	if ( isJetpackProduct( product ) ) {
-		cartItem = jetpackProductItem( product.product_slug );
+		cartItem = jetpackProductItem( slug );
 	}
 
 	if ( isSpaceUpgrade( product ) ) {
-		cartItem = spaceUpgradeItem( product.product_slug );
+		cartItem = spaceUpgradeItem( slug );
 	}
 
 	if ( ! cartItem ) {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -310,20 +310,16 @@ export function hasRenewableSubscription( cart ) {
  * Creates a new shopping cart item for a plan.
  *
  * @param {string} productSlug - the unique string that identifies the product
- * @param {object} [properties] - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct | null} the new item
+ * @returns {{product_slug: string} | null} the new item
  */
-export function planItem( productSlug, properties ) {
+export function planItem( productSlug ) {
 	// Free plan doesn't have shopping cart.
 	if ( isWpComFreePlan( productSlug ) ) {
 		return null;
 	}
 
-	const domainToBundle = properties?.domainToBundle ?? '';
-
 	return {
 		product_slug: productSlug,
-		...( domainToBundle ? { extra: { domain_to_bundle: domainToBundle } } : {} ),
 	};
 }
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -697,8 +697,13 @@ export function isNextDomainFree( cart, domain = '' ) {
 	return true;
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart Cart
+ * @param {string} domain Domain
+ * @returns {boolean}
+ */
 export function isDomainBundledWithPlan( cart, domain ) {
-	const bundledDomain = cart?.bundledDomain ?? '';
+	const bundledDomain = cart?.bundled_domain ?? '';
 	return '' !== bundledDomain && ( domain ?? '' ).toLowerCase() === bundledDomain.toLowerCase();
 }
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -58,7 +58,7 @@ export function getAllCartItems( cart ) {
  * Gets the renewal items from the specified shopping cart.
  *
  * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
- * @returns {Array} an array of renewal items
+ * @returns {import('@automattic/shopping-cart').ResponseCartProduct[]} an array of renewal items
  */
 export function getRenewalItems( cart ) {
 	return getAllCartItems( cart ).filter( isRenewal );
@@ -114,30 +114,58 @@ export function hasEcommercePlan( cart ) {
 	return cart && getAllCartItems( cart ).some( isEcommerce );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasBloggerPlan( cart ) {
 	return getAllCartItems( cart ).some( isBlogger );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasPersonalPlan( cart ) {
 	return getAllCartItems( cart ).some( isPersonal );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasPremiumPlan( cart ) {
 	return getAllCartItems( cart ).some( isPremium );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasBusinessPlan( cart ) {
 	return getAllCartItems( cart ).some( isBusiness );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasDomainCredit( cart ) {
 	return cart.has_bundle_credit || hasPlan( cart );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasMonthlyCartItem( cart ) {
 	return getAllCartItems( cart ).some( isMonthlyProduct );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasBiennialCartItem( cart ) {
 	return getAllCartItems( cart ).some( isBiennially );
 }
@@ -205,6 +233,10 @@ function isDomainRenewal( cartItem ) {
 	return isRenewal( cartItem ) && isDomainRegistration( cartItem );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasDomainBeingUsedForPlan( cart ) {
 	return getDomainRegistrations( cart ).some( ( registration ) =>
 		isDomainBeingUsedForPlan( cart, registration.meta )
@@ -278,15 +310,15 @@ export function hasTrafficGuide( cart ) {
 /**
  * Returns a bill period of given cartItem
  *
- * @param {object} cartItem - cartItem
- * @returns {number|null} bill period of given cartItem
+ * @param {import('@automattic/shopping-cart').ResponseCartProduct} cartItem The product
+ * @returns {number} bill period of given cartItem
  */
 export function getCartItemBillPeriod( cartItem ) {
-	let billPeriod = cartItem.bill_period;
+	const billPeriod = parseInt( cartItem.bill_period, 10 ) || 0;
 	if ( ! Number.isInteger( billPeriod ) ) {
 		const plan = getPlan( cartItem.product_slug );
 		if ( plan ) {
-			billPeriod = getTermDuration( plan.term );
+			return getTermDuration( plan.term ) ?? 0;
 		}
 	}
 	return billPeriod;
@@ -341,8 +373,8 @@ export function supportsPrivacyProtectionPurchase( productSlug, productsList ) {
  *
  * @param {string} productSlug - the unique string that identifies the product
  * @param {string} domain - domain name
- * @param {string} source - optional source for the domain item, e.g. `getdotblog`.
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @param {string|undefined} [source] - optional source for the domain item, e.g. `getdotblog`.
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function domainItem( productSlug, domain, source ) {
 	const extra = source ? { extra: { source: source } } : undefined;
@@ -361,7 +393,7 @@ export function domainItem( productSlug, domain, source ) {
  *
  * @param {string} themeSlug - the unique string that identifies the product
  * @param {string} [source] - optional source for the domain item, e.g. `getdotblog`.
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function themeItem( themeSlug, source ) {
 	return {
@@ -377,7 +409,7 @@ export function themeItem( themeSlug, source ) {
  * Creates a new shopping cart item for a domain registration.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function domainRegistration( properties ) {
 	return {
@@ -391,7 +423,7 @@ export function domainRegistration( properties ) {
  * Creates a new shopping cart item for a domain mapping.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function domainMapping( properties ) {
 	return domainItem( 'domain_map', properties.domain, properties.source );
@@ -401,7 +433,7 @@ export function domainMapping( properties ) {
  * Creates a new shopping cart item for Site Redirect.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function siteRedirect( properties ) {
 	return domainItem( 'offsite_redirect', properties.domain, properties.source );
@@ -411,7 +443,7 @@ export function siteRedirect( properties ) {
  * Creates a new shopping cart item for an incoming domain transfer.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function domainTransfer( properties ) {
 	return {
@@ -434,7 +466,7 @@ export function getGoogleApps( cart ) {
  * Creates a new shopping cart item for G Suite or Google Workspace.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function googleApps( properties ) {
 	const { domain, meta, product_slug, quantity, new_quantity, users } = properties;
@@ -468,7 +500,7 @@ export function googleAppsExtraLicenses( properties ) {
  * Creates a new shopping cart item for Titan Mail Monthly.
  *
  * @param {object} properties - list of properties
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function titanMailMonthly( properties ) {
 	return {
@@ -482,10 +514,18 @@ export function titanMailMonthly( properties ) {
 	};
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasGoogleApps( cart ) {
 	return getAllCartItems( cart ).some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasTitanMail( cart ) {
 	return getAllCartItems( cart ).some( isTitanMail );
 }
@@ -530,7 +570,7 @@ export function spaceUpgradeItem( slug ) {
  * Creates a new shopping cart item for a jetpack product.
  *
  * @param {string} slug - the slug for the product
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new item
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function jetpackProductItem( slug ) {
 	return {
@@ -627,9 +667,9 @@ export function getRenewalItemFromProduct( product, properties ) {
 /**
  * Returns a renewal CartItem object from the given cartItem and properties.
  *
- * @param {import('@automattic/shopping-cart').ResponseCartProduct} cartItem - item
- * @param {object} properties - properties to be included in the new CartItem object
- * @returns {import('@automattic/shopping-cart').ResponseCartProduct} a CartItem object
+ * @param {import('@automattic/shopping-cart').RequestCartProduct} cartItem - item
+ * @param {{id: string}} properties - properties to be included in the new CartItem object
+ * @returns {import('@automattic/shopping-cart').RequestCartProduct} a CartItem object
  */
 export function getRenewalItemFromCartItem( cartItem, properties ) {
 	return {
@@ -642,6 +682,11 @@ export function getRenewalItemFromCartItem( cartItem, properties ) {
 	};
 }
 
+/**
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart - cart as `ResponseCart` object
+ * @param {string} domain - the domain
+ * @returns {boolean} true if there is at least one of the matching products in the cart
+ */
 export function hasDomainInCart( cart, domain ) {
 	return getAllCartItems( cart ).some( ( product ) => {
 		return product.is_domain_registration === true && product.meta === domain;
@@ -653,7 +698,6 @@ export function hasDomainInCart( cart, domain ) {
  *
  * @param {import('@automattic/shopping-cart').ResponseCartProduct} item - the object for domain registrations
  * @param {boolean} value - whether privacy is on or off
- *
  * @returns {import('@automattic/shopping-cart').ResponseCartProduct} the new ResponseCartProduct with added/removed privacy
  */
 export function updatePrivacyForDomain( item, value ) {
@@ -679,7 +723,7 @@ function isPartialCredits( cartItem ) {
 /**
  * Returns true if, according to cart attributes, a `domain` should be free
  *
- * @param {object} cart Cart
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart Cart
  * @param {string} domain Domain
  * @returns {boolean} See description
  */
@@ -710,7 +754,7 @@ export function isDomainBundledWithPlan( cart, domain ) {
 /**
  * Returns true if cart contains a plan and also a domain that comes for free with that plan
  *
- * @param {object} cart Cart
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart Cart
  * @param {string} domain Domain
  * @returns {boolean} see description
  */
@@ -765,7 +809,7 @@ export function shouldBundleDomainWithPlan(
  * This function checks tells if user has to upgrade just to be able to pay for a domain.
  *
  * @param {object} selectedSite Site
- * @param {object} cart Cart
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart Cart
  * @param {string} domain Domain name
  * @returns {boolean} See description
  */
@@ -792,20 +836,28 @@ export function isDomainMappingFree( selectedSite ) {
 	return selectedSite && isPlan( selectedSite.plan ) && ! isBloggerPlan( selectedSite.plan );
 }
 
+/**
+ * @param {string} domainPriceRule
+ * @returns {boolean}
+ */
 export function isPaidDomain( domainPriceRule ) {
 	return 'PRICE' === domainPriceRule;
 }
 
+/**
+ * @param {string|undefined} flowName
+ * @returns {boolean}
+ */
 const isMonthlyOrFreeFlow = ( flowName ) => {
-	return (
+	return Boolean(
 		flowName &&
-		[
-			'free',
-			'personal-monthly',
-			'premium-monthly',
-			'business-monthly',
-			'ecommerce-monthly',
-		].includes( flowName )
+			[
+				'free',
+				'personal-monthly',
+				'premium-monthly',
+				'business-monthly',
+				'ecommerce-monthly',
+			].includes( flowName )
 	);
 };
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -314,14 +314,14 @@ export function hasTrafficGuide( cart ) {
  * @returns {number} bill period of given cartItem
  */
 export function getCartItemBillPeriod( cartItem ) {
-	const billPeriod = parseInt( cartItem.bill_period, 10 ) || 0;
+	const billPeriod = cartItem.bill_period ? parseInt( cartItem.bill_period, 10 ) : undefined;
 	if ( ! Number.isInteger( billPeriod ) ) {
 		const plan = getPlan( cartItem.product_slug );
 		if ( plan ) {
 			return getTermDuration( plan.term ) ?? 0;
 		}
 	}
-	return billPeriod;
+	return billPeriod ?? 0;
 }
 
 /**

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -631,7 +631,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 	} );
 	const properties = {
 		domain: 'purchased.com',
-		source: 'source',
 	};
 	describe( 'isDomainProduct', () => {
 		test( 'should return the corresponding renewal item', () => {
@@ -641,7 +640,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				extra: {
 					purchaseId: 123,
 					purchaseType: 'renewal',
-					source: 'source',
 				},
 				meta: 'purchased.com',
 				product_slug: 'domain_map',
@@ -690,7 +688,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 				extra: {
 					purchaseId: 123,
 					purchaseType: 'renewal',
-					source: 'source',
 				},
 				meta: 'purchased.com',
 				product_slug: 'offsite_redirect',

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -12,7 +12,7 @@ describe( 'index', () => {
 			productSlug: 'dotcom_domain',
 			domain: 'testdomain.com',
 		} );
-		PREMIUM_PRODUCT = cartItems.planItem( 'value_bundle', { isFreeTrial: false } );
+		PREMIUM_PRODUCT = cartItems.planItem( 'value_bundle' );
 	} );
 
 	describe( 'cartItems.hasProduct( cart, productSlug )', () => {

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -125,7 +125,7 @@ class CartFreeUserPlanUpsell extends Component {
 	}
 
 	addPlanToCart = () => {
-		const planCartItem = planItem( PLAN_PERSONAL, {} );
+		const planCartItem = planItem( PLAN_PERSONAL );
 		if ( planCartItem ) {
 			this.props.addItemToCart( planCartItem );
 			this.props.clickUpsellAddToCart();

--- a/packages/calypso-products/src/is-custom-design.ts
+++ b/packages/calypso-products/src/is-custom-design.ts
@@ -1,3 +1,6 @@
-export function isCustomDesign( product: { product_slug: string } ): boolean {
-	return 'custom-design' === product.product_slug;
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
+
+export function isCustomDesign( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
+	return 'custom-design' === camelOrSnakeSlug( product );
 }

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -33,6 +33,7 @@ export function getEmptyResponseCart(): ResponseCart {
 		tax: { location: {}, display_taxes: false },
 		is_signup: false,
 		next_domain_is_free: false,
+		next_domain_condition: '',
 	};
 }
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -232,6 +232,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	next_domain_is_free: boolean;
 	next_domain_condition: '' | 'blog';
 	bundled_domain?: string;
+	has_bundle_credit?: boolean;
 	terms_of_service?: TermsOfServiceRecord[];
 }
 
@@ -277,7 +278,6 @@ export interface ResponseCartProduct {
 	currency: string;
 	product_cost_integer: number;
 	product_cost_display: string;
-	has_bundle_credit?: boolean;
 	item_original_cost_integer: number; // without discounts or volume, with quantity
 	item_original_cost_display: string; // without discounts or volume, with quantity
 	item_subtotal_monthly_cost_display: string;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -230,6 +230,8 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	cart_generated_at_timestamp: number;
 	tax: ResponseCartTaxData;
 	next_domain_is_free: boolean;
+	next_domain_condition: '' | 'blog';
+	bundled_domain?: string;
 	terms_of_service?: TermsOfServiceRecord[];
 }
 
@@ -275,6 +277,7 @@ export interface ResponseCartProduct {
 	currency: string;
 	product_cost_integer: number;
 	product_cost_display: string;
+	has_bundle_credit?: boolean;
 	item_original_cost_integer: number; // without discounts or volume, with quantity
 	item_original_cost_display: string; // without discounts or volume, with quantity
 	item_subtotal_monthly_cost_display: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the vein of https://github.com/Automattic/wp-calypso/pull/58320, https://github.com/Automattic/wp-calypso/pull/58270, https://github.com/Automattic/wp-calypso/pull/58197, https://github.com/Automattic/wp-calypso/pull/58136, #58080, and #58086, this PR removes more uses of the `formatProduct` function in the `calypso-products` package because it makes it difficult to determine types and in some cases is unnecessary.

In this PR specifically, we change the function `getRenewalItemFromProduct`. This change attempts to not modify the logic of this function, except that it now always requires an object (where it previously would accept anything). 

Additionally, the function used to accept any properties as its second argument, and I've narrowed that down to just a `domain` property because the other possible properties are not passed in anywhere apart from tests.

#### Testing instructions

No specific testing should be necessary, other than making sure that all the call-sites pass in an object as the first argument and never pass in anything other than `{domain?: string}` for the second argument.