### PR TITLE
Explicitly list unsupported browsers.

### DIFF
--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -25,11 +25,11 @@ import analytics from 'calypso/server/lib/analytics';
  */
 const UNSUPPORTED_BROWSERS = [
 	'ie <= 11',
-	'edge <= 80',
-	'firefox <= 74',
-	'chrome <= 80',
+	'edge <= 79',
+	'firefox <= 73',
+	'chrome <= 79',
 	'safari <= 13', // Note: 13.1 IS supported. Browserslist considers Safari point releases as new versions.
-	'opera <= 67',
+	'opera <= 66',
 	'ios <= 13.3',
 ];
 

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -44,8 +44,7 @@ function isUnsupportedBrowser( req ) {
 }
 
 /**
- * These public pages will likely work even in unsupported browsers, so we will
- * not redirect them.
+ * These public pages work even in unsupported browsers, so we do not redirect them.
  */
 function allowPath( path ) {
 	const locales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -40,13 +40,7 @@ function isUnsupportedBrowser( req ) {
 	// based on the chrome version.
 	const userAgentString = req.useragent.source;
 	const sanitizedUA = userAgentString.replace( / (WordPressDesktop|Electron)\/[.\d]+/g, '' );
-	return matchesUA( sanitizedUA, {
-		env: 'evergreen',
-		ignorePatch: true,
-		ignoreMinor: true,
-		allowHigherVersions: true,
-		browsers: UNSUPPORTED_BROWSERS,
-	} );
+	return matchesUA( sanitizedUA, { ignoreMinor: true, browsers: UNSUPPORTED_BROWSERS } );
 }
 
 // We don't want to redirect some of our public landing pages, so we include them here.

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -43,7 +43,10 @@ function isUnsupportedBrowser( req ) {
 	return matchesUA( sanitizedUA, { ignoreMinor: true, browsers: UNSUPPORTED_BROWSERS } );
 }
 
-// We don't want to redirect some of our public landing pages, so we include them here.
+/**
+ * These public pages will likely work even in unsupported browsers, so we will
+ * not redirect them.
+ */
 function allowPath( path ) {
 	const locales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
 	const prefixedLocale = locales.find( ( locale ) => path.startsWith( `/${ locale }/` ) );
@@ -53,15 +56,7 @@ function allowPath( path ) {
 		? path.replace( new RegExp( `^/${ prefixedLocale }` ), '' )
 		: path;
 
-	const allowedPaths = [
-		'/browsehappy',
-		'/log-in',
-		'/start',
-		'/new',
-		'/themes',
-		'/theme',
-		'/domains',
-	];
+	const allowedPaths = [ '/browsehappy', '/themes', '/theme' ];
 	// For example, match either exactly "/themes" or "/themes/*"
 	return allowedPaths.some( ( p ) => parsedPath === p || parsedPath.startsWith( p + '/' ) );
 }

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -3,7 +3,37 @@ import { matchesUA } from 'browserslist-useragent';
 import { addQueryArgs } from 'calypso/lib/url';
 import analytics from 'calypso/server/lib/analytics';
 
-function isSupportedBrowser( req ) {
+/**
+ * This is a list of browsers which DEFINITELY do not work on WordPress.com.
+ *
+ * I created this list by finding the oldest version of Chrome which supports the
+ * log-in page, and then finding which language feature was added in that release.
+ *
+ * In this case, the feature was optional chaining, which we use in our bundle,
+ * but is not supported by these browsers. As a result, these browsers do not
+ * work with the WordPress.com login page. See https://caniuse.com/?search=optional%20chaining.
+ *
+ * In other words, if you use Chrome v79, you won't be able to log in. But if you
+ * use v80, the form works.
+ *
+ * For browsers not listed, we have not tested whether they work.
+ *
+ * Importantly, browsers are only completely supported if they fall within the range
+ * listed in package.json. This list only serves as a way to assist users who are
+ * using a browser which is definitely broken. It is not a guarantee that things
+ * will work flawlessly on newer versions.
+ */
+const UNSUPPORTED_BROWSERS = [
+	'ie <= 11',
+	'edge <= 80',
+	'firefox <= 74',
+	'chrome <= 80',
+	'safari <= 13', // Note: 13.1 IS supported. Browserslist considers Safari point releases as new versions.
+	'opera <= 67',
+	'ios <= 13.3',
+];
+
+function isUnsupportedBrowser( req ) {
 	// The desktop app sends a UserAgent including WordPress, Electron and Chrome.
 	// We need to check if the chrome portion is supported, but the UA library
 	// will select WordPress and Electron before Chrome, giving a result not
@@ -15,6 +45,7 @@ function isSupportedBrowser( req ) {
 		ignorePatch: true,
 		ignoreMinor: true,
 		allowHigherVersions: true,
+		browsers: UNSUPPORTED_BROWSERS,
 	} );
 }
 
@@ -69,7 +100,7 @@ export default () => ( req, res, next ) => {
 	}
 
 	const forceRedirect = config.isEnabled( 'redirect-fallback-browsers/test' );
-	if ( ! forceRedirect && isSupportedBrowser( req ) ) {
+	if ( ! forceRedirect && ! isUnsupportedBrowser( req ) ) {
 		next();
 		return;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request
Follow up to #58218, we explicitly list unsupported browsers. These browsers will see the unsupported browser messaging. See reasoning in #58218. Importantly, the listed browsers cannot use the login form or get a WSOD upon login. (So it's not an arbitrary list.)

Another benefit of this approach is that if we don't know" whether a browser is supported, we'll allow them to try to access Calypso.

I also adjusted the "allow path" code. Since we know for certain that the pages I removed (log-in, start, new, domains) do not work at all with these browsers, we should show the message before trying to access them. Otherwise, the user won't have any path forward.

The only reason we added that code was to handle bots like the googlebot. Since the google bot isn't in our "unsupported browser list," it should never be redirected. As a result, it's not as important to completely allow these unauthenticated pages.

Resolves #58352
### Testing instructions

Access the calypso.live link using Firefox 74, then using Firefox 73. The former will not get an unsupported browser message. The latter will.
