### PR TITLE
Mobile web: Fix Dot pager for single pages

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -90,22 +90,29 @@ export const DotPager = ( {
 		if ( ! hasDynamicHeight ) {
 			return;
 		}
+		if ( 1 === numPages ) {
+			return;
+		}
 
 		const targetHeight = pagesRef.current?.querySelector( '.is-current' )?.offsetHeight;
+
 		setPagesStyle( targetHeight ? { height: targetHeight } : undefined );
-	}, [ hasDynamicHeight, setPagesStyle ] );
+	}, [ hasDynamicHeight, setPagesStyle, numPages ] );
 
 	useEffect( () => {
 		updateLayout();
 	}, [ currentPage, updateLayout ] );
 
 	useEffect( () => {
+		if ( 1 === numPages ) {
+			return;
+		}
 		window.addEventListener( 'resize', updateLayout );
 
 		return () => {
 			window.removeEventListener( 'resize', updateLayout );
 		};
-	}, [ updateLayout ] );
+	}, [ updateLayout, numPages ] );
 
 	useEffect( () => {
 		if ( currentPage >= numPages ) {

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -2,7 +2,7 @@ import { Icon, arrowRight } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import { times } from 'lodash';
-import { Children, useState, useEffect, useRef, useCallback } from 'react';
+import { Children, useState, useEffect, useRef } from 'react';
 
 import './style.scss';
 
@@ -86,33 +86,41 @@ export const DotPager = ( {
 	const [ pagesStyle, setPagesStyle ] = useState();
 	const pagesRef = useRef();
 	const numPages = Children.count( children );
-	const updateLayout = useCallback( () => {
-		if ( ! hasDynamicHeight ) {
-			return;
-		}
-		if ( 1 === numPages ) {
-			return;
-		}
 
+	function useUpdateLayout( enabled, currentPageIndex, updateLayout ) {
+		// save callback to a ref so that it doesn't need to be a dependency of other hooks
+		const savedUpdateLayout = useRef();
+		useEffect( () => {
+			savedUpdateLayout.current = updateLayout;
+		}, [ updateLayout ] );
+
+		// fire when the `currentPageIndex` parameter changes
+		useEffect( () => {
+			if ( ! enabled ) {
+				return;
+			}
+
+			savedUpdateLayout.current();
+		}, [ enabled, currentPageIndex ] );
+
+		// fire when the window resizes
+		useEffect( () => {
+			if ( ! enabled ) {
+				return;
+			}
+
+			const onResize = () => savedUpdateLayout.current();
+			window.addEventListener( 'resize', onResize );
+			return () => window.removeEventListener( 'resize', onResize );
+		}, [ enabled ] );
+	}
+
+	const updateEnabled = hasDynamicHeight && numPages > 1;
+
+	useUpdateLayout( updateEnabled, currentPage, () => {
 		const targetHeight = pagesRef.current?.querySelector( '.is-current' )?.offsetHeight;
-
 		setPagesStyle( targetHeight ? { height: targetHeight } : undefined );
-	}, [ hasDynamicHeight, setPagesStyle, numPages ] );
-
-	useEffect( () => {
-		updateLayout();
-	}, [ currentPage, updateLayout ] );
-
-	useEffect( () => {
-		if ( 1 === numPages ) {
-			return;
-		}
-		window.addEventListener( 'resize', updateLayout );
-
-		return () => {
-			window.removeEventListener( 'resize', updateLayout );
-		};
-	}, [ updateLayout, numPages ] );
+	} );
 
 	useEffect( () => {
 		if ( currentPage >= numPages ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes any resize as well as height setting from dot pager element when there is only one element.

#### Testing instructions

* Visit home on a site that still has a site setup component.
* Resize the window. Notice that we never have a cut off list of site setup tasks.
 
Before:

<img width="300" src="https://user-images.githubusercontent.com/115071/142951759-598a20ec-18a3-4a2a-af03-3ecf3b5405e1.png" />

After:

<img width="300" src="https://user-images.githubusercontent.com/115071/142951711-7f3afdf2-338a-47a8-b926-4eb40096249b.png" />


