### PR TITLE
E2E: fix timeout value for Signup: Paid > Make purchase step.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-signup__paid.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__paid.ts
@@ -122,7 +122,7 @@ skipDescribeIf( isStagingOrProd )(
 			} );
 
 			it( 'Make purchase', async function () {
-				await cartCheckoutPage.purchase( { timeout: 90 * 100 } );
+				await cartCheckoutPage.purchase( { timeout: 90 * 1000 } );
 			} );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In reviewing #57862 I missed the wrong timeout value being passed into {timeout} value for `purchase` - it is set to 9 seconds instead of 90 seconds.

#### Testing instructions

Related to #57862.
Closes #58380.
