### PR TITLE
Assorted ESLint fixes

### DIFF
--- a/apps/notifications/src/panel/templates/actions.jsx
+++ b/apps/notifications/src/panel/templates/actions.jsx
@@ -28,14 +28,14 @@ const getInitialReplyValue = ( note, translate ) => {
 	}
 
 	if ( username ) {
-		return translate( 'Reply to %(username)s...', {
+		return translate( 'Reply to %(username)s…', {
 			args: { username },
 		} );
 	}
 
 	return getType( note ) === 'post'
-		? translate( 'Reply to post...' )
-		: translate( 'Reply to comment...' );
+		? translate( 'Reply to post…' )
+		: translate( 'Reply to comment…' );
 };
 
 const ActionsPane = ( { global, isApproved, isLiked, note, translate } ) => {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -579,7 +579,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the Popover component
 	 *
-	 * @returns {React.Element} the Popover component
+	 * @returns {import('react').Element} the Popover component
 	 */
 	renderPopover() {
 		const headerProps = {
@@ -618,7 +618,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the DatePicker component
 	 *
-	 * @returns {React.Element} the DatePicker component
+	 * @returns {import('react').Element} the DatePicker component
 	 */
 	renderDatePicker() {
 		const fromDate = this.momentDateToJsDate( this.state.startDate );
@@ -670,7 +670,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the component
 	 *
-	 * @returns {React.Element} the DateRange component
+	 * @returns {import('react').Element} the DateRange component
 	 */
 	render() {
 		const rootClassNames = classNames( {

--- a/client/components/fixed-navigation-header/README.md
+++ b/client/components/fixed-navigation-header/README.md
@@ -1,6 +1,6 @@
 # FixedNavigationHeader (TSX)
 
-This component displays a header with a breadcrumb. 
+This component displays a header with a breadcrumb.
 It can also include children items which will be positioned to the far right.
 
 ## How to use
@@ -14,7 +14,9 @@ const navigationItems = [
 ];
 
 function render() {
-	return <FixedNavigationHeader navigationItems={ navigationItems }>Children Item</FixedNavigationHeader>;
+	return (
+		<FixedNavigationHeader navigationItems={ navigationItems }>Children Item</FixedNavigationHeader>
+	);
 }
 ```
 

--- a/client/components/marked-lines/README.md
+++ b/client/components/marked-lines/README.md
@@ -8,29 +8,27 @@ optional highlighting or marks to point out specific parts of one or more lines.
 ```jsx
 import MarkedLines from 'calypso/components/marked-lines';
 
-return (
-	<MarkedLines
-		context={ {
-			10: 'add :: Num a => a -> a -> a',
-			11: 'add = (+)',
-			15: 'solve a b = solution',
-			16: '	where',
-			17: '		solution = sum parts',
-			18: '		{- 💩 indices are in UCS-2 code units -}',
-			19: '		sum = foldl add 0',
-			20: '		parts = foo a b',
-			58: '{- lines need not be contiguous -}',
-			marks: {
-				11: [ [ 6, 9 ] ],
-				18: [ [ 23, 28 ] ],
-				19: [
-					[ 2, 5 ],
-					[ 14, 17 ],
-				],
-			},
-		} }
-	/>
-);
+<MarkedLines
+	context={ {
+		10: 'add :: Num a => a -> a -> a',
+		11: 'add = (+)',
+		15: 'solve a b = solution',
+		16: '	where',
+		17: '		solution = sum parts',
+		18: '		{- 💩 indices are in UCS-2 code units -}',
+		19: '		sum = foldl add 0',
+		20: '		parts = foo a b',
+		58: '{- lines need not be contiguous -}',
+		marks: {
+			11: [ [ 6, 9 ] ],
+			18: [ [ 23, 28 ] ],
+			19: [
+				[ 2, 5 ],
+				[ 14, 17 ],
+			],
+		},
+	} }
+/>;
 ```
 
 ### Props

--- a/client/components/marked-lines/index.jsx
+++ b/client/components/marked-lines/index.jsx
@@ -11,9 +11,8 @@ import './style.scss';
  * @example
  * mark( 'be kind' ) =>
  *   <mark key="be kind" className="marked-lines__mark">be kind</mark>
- *
  * @param {string} text the string to mark
- * @returns {React.Element} React <mark> Element
+ * @returns {import('react').Element} React <mark> Element
  */
 const mark = ( text ) => (
 	<mark key={ text } className="marked-lines__mark">
@@ -29,7 +28,6 @@ const mark = ( text ) => (
  * const marks = [ [ 2, 4 ], [ 5, 9 ] ]
  * const content = '->^^-_____<--'
  * markup( marks, content ) === [ '->', <mark>{ '^^' }</mark>, '-', <mark>{ '_____' }</mark>, '<--' ]
- *
  * @param {Array<Array<number>>} marks spanning indices of text to mark, values in UCS-2 code units
  * @param {string} content the plaintext content to mark
  * @returns {Array|string} list of output text nodes and mark elements or plain string output

--- a/client/components/pagination/README.md
+++ b/client/components/pagination/README.md
@@ -14,16 +14,16 @@ function render() {
 
 ### Props
 
-| Name          | Type                    | Default  | Description                                                                                      |
-| ------------- | ----------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `page`\*      | `integer`               | null     | The current active page number.                                                                  |
-| `perPage`\*   | `integer`               | null     | Number of records shown per page.                                                                |
-| `total`\*     | `integer`               | null     | Total number of records.                                                                         |
-| `pageClick`\* | `function`              | null     | Function called when a pagination item is clicked - the page clicked is provided as an argument. |
-| `compact`     | `bool`                  | false    | Render a smaller version.                                                                        |
-| `nextLabel`   | `string`                | null     | Overrides the "Next" button label.                                                               |
-| `prevLabel`   | `string`                | null     | Overrides the "Previous" button label.                                                           |
-| `variant`     | `PaginationVariant`     | outlined | Sets the style of the component                                                                  |
+| Name          | Type                | Default  | Description                                                                                      |
+| ------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `page`\*      | `integer`           | null     | The current active page number.                                                                  |
+| `perPage`\*   | `integer`           | null     | Number of records shown per page.                                                                |
+| `total`\*     | `integer`           | null     | Total number of records.                                                                         |
+| `pageClick`\* | `function`          | null     | Function called when a pagination item is clicked - the page clicked is provided as an argument. |
+| `compact`     | `bool`              | false    | Render a smaller version.                                                                        |
+| `nextLabel`   | `string`            | null     | Overrides the "Next" button label.                                                               |
+| `prevLabel`   | `string`            | null     | Overrides the "Previous" button label.                                                           |
+| `variant`     | `PaginationVariant` | outlined | Sets the style of the component                                                                  |
 
 ### General guidelines
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -102,7 +102,7 @@ class PurchaseNotice extends Component {
 	 * Returns appropriate warning text for a purchase that is expiring but where the expiration is not imminent.
 	 *
 	 * @param  {object} purchase  The purchase object
-	 * @param  {React.Component} autoRenewingUpgradesLink  An optional link component, for linking to other purchases on the site that are auto-renewing rather than expiring
+	 * @param  {Component} autoRenewingUpgradesLink  An optional link component, for linking to other purchases on the site that are auto-renewing rather than expiring
 	 * @returns  {string}  Translated text for the warning message.
 	 */
 	getExpiringLaterText( purchase, autoRenewingUpgradesLink = null ) {

--- a/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
@@ -1,6 +1,42 @@
 import styled from '@emotion/styled';
 import { FunctionComponent } from 'react';
 
+type FormFieldWrapperProps = {
+	isError: boolean;
+	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+};
+
+const FormFieldWrapper = styled.div< FormFieldWrapperProps >`
+	select {
+		width: 100%;
+	}
+`;
+
+type LabelProps = {
+	isDisabled: boolean;
+	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+};
+
+const Label = styled.label< LabelProps >`
+	display: block;
+	color: ${ ( props ) => props.theme.colors.textColor };
+	font-weight: ${ ( props ) => props.theme.weights.bold };
+	font-size: 14px;
+	margin-bottom: 8px;
+
+	:hover {
+		cursor: ${ ( props ) => ( props.isDisabled ? 'default' : 'pointer' ) };
+	}
+`;
+
+const Description = styled.p< DescriptionProps >`
+	margin: 8px 0 0;
+	color: ${ ( props ) =>
+		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight };
+	font-style: italic;
+	font-size: 14px;
+`;
+
 /**
  * Annotate a form field element with a label, description, and an optional
  * colored error border with error text.
@@ -59,34 +95,6 @@ const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > = ( {
 	);
 };
 
-type LabelProps = {
-	isDisabled: boolean;
-	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-};
-
-const Label = styled.label< LabelProps >`
-	display: block;
-	color: ${ ( props ) => props.theme.colors.textColor };
-	font-weight: ${ ( props ) => props.theme.weights.bold };
-	font-size: 14px;
-	margin-bottom: 8px;
-
-	:hover {
-		cursor: ${ ( props ) => ( props.isDisabled ? 'default' : 'pointer' ) };
-	}
-`;
-
-type FormFieldWrapperProps = {
-	isError: boolean;
-	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-};
-
-const FormFieldWrapper = styled.div< FormFieldWrapperProps >`
-	select {
-		width: 100%;
-	}
-`;
-
 function RenderedDescription( {
 	descriptionText,
 	descriptionId,
@@ -114,13 +122,5 @@ type DescriptionProps = {
 	isError?: boolean;
 	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
-
-const Description = styled.p< DescriptionProps >`
-	margin: 8px 0 0;
-	color: ${ ( props ) =>
-		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight };
-	font-style: italic;
-	font-size: 14px;
-`;
 
 export default FormFieldAnnotation;

--- a/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { FunctionComponent } from 'react';
+import type { FunctionComponent } from 'react';
 
 type FormFieldWrapperProps = {
 	isError: boolean;

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -74,7 +74,7 @@ class AddDnsRecord extends Component {
 		return (
 			<Breadcrumbs items={ items } mobileItem={ mobileItem } buttons={ [] } mobileButtons={ [] } />
 		);
-	};
+	}
 
 	goBack = () => {
 		const { selectedSite, selectedDomainName } = this.props;

--- a/client/my-sites/plugins/plugin-site-list/README.md
+++ b/client/my-sites/plugins/plugin-site-list/README.md
@@ -7,14 +7,12 @@ This component is used to represent a list of `Plugin-Site`, with a `Section-Hea
 ```jsx
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
 
-return (
-	<PluginSiteList
-		sites={ sites }
-		plugin={ this.state.plugin }
-		notices={ this.state.notices }
-		title={ title }
-	/>
-);
+<PluginSiteList
+	sites={ sites }
+	plugin={ this.state.plugin }
+	notices={ this.state.notices }
+	title={ title }
+/>;
 ```
 
 ## Props

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -28,7 +28,7 @@ function render() {
 - `iconSize`: number with the size of the icon. Defaulted to 40, since all the intertal css are adjusted around that value, it would be better to not change the default
 - `variant`: the component can be used in compact or extended view. Defaults to `Compact`.
 
-  | variant        | displays                                                                  |
-  | -------------- | ------------------------------------------------------------------------- |
-  | Compact        | Icon, Name, Short Description                                             |
-  | Extended       | Icon, Name, Author, Short Description, Pricing Info                       |
+  | variant  | displays                                            |
+  | -------- | --------------------------------------------------- |
+  | Compact  | Icon, Name, Short Description                       |
+  | Extended | Icon, Name, Author, Short Description, Pricing Info |

--- a/client/my-sites/plugins/plugins-list/README.md
+++ b/client/my-sites/plugins/plugins-list/README.md
@@ -7,15 +7,13 @@ This component is used to represent a list `PluginItem`s, with a `PluginsListHea
 ```jsx
 import PluginsList from 'calypso/my-sites/plugins/plugins-list';
 
-return (
-	<PluginsList
-		header={ this.props.translate( 'Plugins' ) }
-		plugins={ this.getPlugins() }
-		sites={ this.props.sites }
-		selectedSite={ this.props.selectedSite }
-		isPlaceholder={ this.showPluginListPlaceholders( true ) }
-	/>
-);
+<PluginsList
+	header={ this.props.translate( 'Plugins' ) }
+	plugins={ this.getPlugins() }
+	sites={ this.props.sites }
+	selectedSite={ this.props.selectedSite }
+	isPlaceholder={ this.showPluginListPlaceholders( true ) }
+/>;
 ```
 
 ## Props

--- a/docs/data-persistence.md
+++ b/docs/data-persistence.md
@@ -31,7 +31,7 @@ The custom `combineReducers` handles persistence for the reducers it's combining
 To opt-out of persistence we simply combine reducers without any attached schema.
 
 ```javascript
-return combineReducers( {
+combineReducers( {
 	age,
 	height,
 } );
@@ -40,7 +40,7 @@ return combineReducers( {
 To persist, we add the schema by wrapping the reducer with the `withSchemaValidation` util:
 
 ```javascript
-return combineReducers( {
+combineReducers( {
 	age: withSchemaValidation( ageSchema, age ),
 	height,
 } );

--- a/packages/i18n-calypso/src/localize.js
+++ b/packages/i18n-calypso/src/localize.js
@@ -15,8 +15,8 @@ export default function ( i18n ) {
 	/**
 	 * Localize a React component
 	 *
-	 * @param  {React.Component} ComposedComponent React component to localize
-	 * @returns {React.Component}                   The localized component
+	 * @param  {Component} ComposedComponent React component to localize
+	 * @returns {Component}                   The localized component
 	 */
 	return function ( ComposedComponent ) {
 		const componentName = ComposedComponent.displayName || ComposedComponent.name || '';

--- a/packages/social-previews/src/twitter-preview/tweet.jsx
+++ b/packages/social-previews/src/twitter-preview/tweet.jsx
@@ -26,8 +26,7 @@ export class Tweet extends PureComponent {
 	 *
 	 * @param {string} profileImage URL of the Twitter profile image.
 	 * @param {boolean} isLast Whether or not this is the last tweet in the in a thread.
-	 *
-	 * @returns {React.Element} The sidebar.
+	 * @returns {import('react').Element} The sidebar.
 	 */
 	renderSidebar( profileImage, isLast ) {
 		return (
@@ -46,8 +45,7 @@ export class Tweet extends PureComponent {
 	 * @param {string} name The display name of the Twitter account.
 	 * @param {string} screenName The at-name of the Twitter account.
 	 * @param {Date} date The date to be shown for this preview.
-	 *
-	 * @returns {React.Element} The header.
+	 * @returns {import('react').Element} The header.
 	 */
 	renderHeader( name, screenName, date ) {
 		return (
@@ -65,8 +63,7 @@ export class Tweet extends PureComponent {
 	 * @param {string} text The text of the tweet.
 	 * @param {Array} urls Optional. An array of URLs that are in the text.
 	 * @param {object} card Optional. The card data for this tweet.
-	 *
-	 * @returns {React.Element} The text section.
+	 * @returns {import('react').Element} The text section.
 	 */
 	renderText( text, urls = [], card = {} ) {
 		// If the text ends with the card URL, remove it.
@@ -93,8 +90,7 @@ export class Tweet extends PureComponent {
 	 * GIF, or a single video. Any media beyond these limits will be discarded.
 	 *
 	 * @param {Array} media The media to include in this tweet.
-	 *
-	 * @returns {React.Element} The media section.
+	 * @returns {import('react').Element} The media section.
 	 */
 	renderMedia( media ) {
 		if ( ! media ) {
@@ -168,8 +164,7 @@ export class Tweet extends PureComponent {
 	 * Given a tweet URL, renders it as a quoted tweet.
 	 *
 	 * @param {string} tweet The tweet URL.
-	 *
-	 * @returns {React.Element} The quoted tweet.
+	 * @returns {import('react').Element} The quoted tweet.
 	 */
 	renderQuoteTweet( tweet ) {
 		if ( ! tweet ) {
@@ -193,8 +188,7 @@ export class Tweet extends PureComponent {
 	 * Given card data, renders the Twitter-style card.
 	 *
 	 * @param {object} card The card data.
-	 *
-	 * @returns {React.Element} The card tweet.
+	 * @returns {import('react').Element} The card tweet.
 	 */
 	renderCard( card ) {
 		if ( ! card ) {
@@ -233,7 +227,7 @@ export class Tweet extends PureComponent {
 	/**
 	 * Renders the footer section of a single tweet, showing (non-functioning) reply, retweet, etc buttons.
 	 *
-	 * @returns {React.Element} The footer.
+	 * @returns {import('react').Element} The footer.
 	 */
 	renderFooter() {
 		return (

--- a/packages/viewport-react/src/index.js
+++ b/packages/viewport-react/src/index.js
@@ -11,7 +11,6 @@ import { forwardRef, useState, useEffect } from 'react';
  * React hook for getting the status for a breakpoint and keeping it updated.
  *
  * @param {string} breakpoint The breakpoint to consider.
- *
  * @returns {boolean} The current status for the breakpoint.
  */
 export function useBreakpoint( breakpoint ) {
@@ -64,7 +63,6 @@ export function useDesktopBreakpoint() {
  * keeping it updated.
  *
  * @param {string} breakpoint The breakpoint to consider.
- *
  * @returns {Function} A function that given a component returns the
  * wrapped component.
  */
@@ -82,8 +80,7 @@ export const withBreakpoint = ( breakpoint ) =>
  * React higher order component for getting the status for the mobile
  * breakpoint and keeping it updated.
  *
- * @param {React.Component|Function} Wrapped The component to wrap.
- *
+ * @param {import('react').Component|Function} Wrapped The component to wrap.
  * @returns {Function} The wrapped component.
  */
 export const withMobileBreakpoint = createHigherOrderComponent(
@@ -99,8 +96,7 @@ export const withMobileBreakpoint = createHigherOrderComponent(
  * React higher order component for getting the status for the desktop
  * breakpoint and keeping it updated.
  *
- * @param {React.Component|Function} Wrapped The component to wrap.
- *
+ * @param {import('react').Component|Function} Wrapped The component to wrap.
  * @returns {Function} The wrapped component.
  */
 export const withDesktopBreakpoint = createHigherOrderComponent(

--- a/packages/wpcom.js/src/lib/site.taxonomy.js
+++ b/packages/wpcom.js/src/lib/site.taxonomy.js
@@ -48,7 +48,7 @@ class SiteTaxonomy {
 	 * Return `Term` instance
 	 *
 	 * @param {string} [term] - term slug
-	 * @returns {Term} Term instance
+	 * @returns {SiteTaxonomyTerm} Term instance
 	 */
 	term( term ) {
 		return new SiteTaxonomyTerm( term, this._taxonomy, this._siteId, this.wpcom );


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fixes a bunch of ESLint errors:

* Parsing error: 'return' outside of function.
* @typescript-eslint/no-use-before-define
* jsdoc/no-undefined-types
* prettier/prettier
* wpcalypso/i18n-ellipsis
