### PR TITLE
Notification: Make text be left-aligned

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -786,7 +786,6 @@
 	}
 
 	.wpnc__single-view .wpnc__badge .wpnc__body .wpnc__body-content .wpnc__paragraph {
-		text-align: center;
 		font-family: $sans;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove center alignment of notification due to badge image

**Examples**

![image](https://user-images.githubusercontent.com/13596067/142979050-86eba549-e087-42ee-898d-51748bc1167f.png)

![image](https://user-images.githubusercontent.com/13596067/142979851-120860a7-4bd0-4ff5-b11e-539dfedef287.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click the notification icon at the top-right corner
* Click each notification to see the detail
* Check every notification looks good with left alignment

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56252, p1631653453409800-slack-C029SB8JT8S
