### PR TITLE
Hero Flow: Fix sending incorrect design to tracks event

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -133,7 +133,7 @@ export default function DesignPickerStep( props ) {
 			)
 		);
 
-		submitDesign( selectedDesign );
+		submitDesign( _selectedDesign );
 	}
 
 	function previewDesign( _selectedDesign ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the user chooses the design directly, the design props would be `null` because we use an incorrect variable after [refactoring](https://github.com/Automattic/wp-calypso/pull/57986)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?siteSlug=<your_site>`
* Select build intent
* Select design directly
* Check the tracks event is correct or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1637663985107400-slack-C029SB8JT8S, https://github.com/Automattic/wp-calypso/pull/57986