### PR TITLE
Emails: Add feature flag: "emails/new-email-comparison" in Upgrades -> Emails

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -1,3 +1,4 @@
+import { isEnabled as isConfigEnabled } from '@automattic/calypso-config';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailForwarding from 'calypso/my-sites/email/email-forwarding';
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
@@ -77,14 +78,18 @@ export default {
 	},
 
 	emailManagementPurchaseNewEmailAccount( pageContext, next ) {
+		const comparisonComponent = ! isConfigEnabled( 'emails/new-email-comparison' ) ? (
+			<EmailProvidersComparison
+				comparisonContext="email-purchase"
+				selectedDomainName={ pageContext.params.domain }
+				source={ pageContext.query.source }
+			/>
+		) : (
+			<h1> Placeholder </h1>
+		);
+
 		pageContext.primary = (
-			<CalypsoShoppingCartProvider>
-				<EmailProvidersComparison
-					comparisonContext="email-purchase"
-					selectedDomainName={ pageContext.params.domain }
-					source={ pageContext.query.source }
-				/>
-			</CalypsoShoppingCartProvider>
+			<CalypsoShoppingCartProvider>{ comparisonComponent }</CalypsoShoppingCartProvider>
 		);
 
 		next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds an initial placeholder to show the new comparison stacked page for emails

#### Testing instructions

- Go to Upgrades -> Emails
- Check that you see the traditional emails provider comparison page
- Add the following flag to the url: `?flags=emails/new-email-comparison`
- Assert that you no longer see the emails provider comparison page an you see "Placeholder" instead

_This Pull Requests assumes that we are going to create a new email comparison component._

Related to 1200182182542585-as-1201414571816235
