### PR TITLE
Import: cancel non started imports

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -24,7 +24,7 @@ import WordPressImporter from 'calypso/my-sites/importer/importer-wordpress';
 import JetpackImporter from 'calypso/my-sites/importer/jetpack-importer';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { fetchImporterState, startImport } from 'calypso/state/imports/actions';
+import { fetchImporterState, startImport, cancelImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import {
 	getImporterStatusForSiteId,
@@ -93,6 +93,12 @@ class SectionImport extends Component {
 		} );
 	};
 
+	cancelNonStartedImports = () => {
+		this.props.siteImports
+			.filter( ( x ) => x.importerState === appStates.READY_FOR_UPLOAD )
+			.forEach( ( x ) => this.props.cancelImport( x.site.ID, x.importerId ) );
+	};
+
 	trackImporterStateChange = memoizeLast( ( importerState, importerId ) => {
 		const stateToEventNameMap = {
 			[ appStates.READY_FOR_UPLOAD ]: 'calypso_importer_view',
@@ -124,6 +130,10 @@ class SectionImport extends Component {
 		}
 
 		this.handleStateChanges();
+	}
+
+	componentWillUnmount() {
+		this.cancelNonStartedImports();
 	}
 
 	/**
@@ -320,5 +330,5 @@ export default connect(
 			isImporterStatusHydrated: isImporterStatusHydrated( state ),
 		};
 	},
-	{ recordTracksEvent, startImport, fetchImporterState }
+	{ recordTracksEvent, startImport, fetchImporterState, cancelImport }
 )( localize( SectionImport ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The change fixes a case when the wrong importer is presented. The wrong importer means importer selected in the previous step.

So, the fix is clearing the non-started import array on the component unmount hook.

#### Testing instructions

1. go to `/start/importer?siteSlug=<YOUR_SLUG.wordpress.com>
2. click on the `I don't have a site address` link
3. select `Blogger` importer
4. click on `Import your content` button
5. click on the browser back button
6. the same as step 2
7. select `Medium` importer
8. the same as step 4
9. check if the `Medium` importer is presented


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58286
