### PR TITLE
Fix target path for domain registration thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -1,7 +1,7 @@
 import { translate } from 'i18n-calypso';
 import domainRegisteredSuccess from 'calypso/assets/images/illustrations/domain-registration-success.svg';
 import { buildDomainStepForProfessionalEmail } from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
-import { domainMappingSetup } from 'calypso/my-sites/domains/paths';
+import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import type {
 	DomainThankYouParams,
@@ -41,7 +41,7 @@ const DomainRegistrationThankYouProps = ( {
 						),
 						stepCta: (
 							<FullWidthButton
-								href={ domainMappingSetup( selectedSiteSlug, domain ) }
+								href={ domainManagementEdit( selectedSiteSlug, domain, null ) }
 								primary
 								busy={ false }
 								disabled={ false }

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -1,7 +1,7 @@
 import { translate } from 'i18n-calypso';
 import domainRegisteredSuccess from 'calypso/assets/images/illustrations/domain-registration-success.svg';
 import { buildDomainStepForProfessionalEmail } from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
-import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import type {
 	DomainThankYouParams,
@@ -41,7 +41,7 @@ const DomainRegistrationThankYouProps = ( {
 						),
 						stepCta: (
 							<FullWidthButton
-								href={ domainManagementEdit( selectedSiteSlug, domain, null ) }
+								href={ domainManagementList( selectedSiteSlug, null ) }
 								primary
 								busy={ false }
 								disabled={ false }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the link we show for domain registration purchases to point at the primary domain management page instead of the domain mapping configuration page

@Automattic/nomado, could you comment on whether you want the wording here to be updated? It feels a bit awkward in that the content refers to managing and organising multiple domains.

#### Testing instructions

* Run this branch locally or via the live branch
* Purchase a new domain registration
* Confirm that you see a "Manage domains" button
* Click on the button
* Verify that you are taken to the main domain management screen

#### Screenshot

<img width="934" alt="Screenshot 2021-11-23 at 14 46 58" src="https://user-images.githubusercontent.com/3376401/143026659-72e30110-ff35-4b58-bf62-3d51dc280d3d.png">