### PR TITLE
Domains: Update bulk contact information editing to use the new components

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -24,6 +24,7 @@ class AutoRenewToggle extends Component {
 		siteDomain: PropTypes.string.isRequired,
 		planName: PropTypes.string.isRequired,
 		isEnabled: PropTypes.bool.isRequired,
+		shouldDisable: PropTypes.bool,
 		isAtomicSite: PropTypes.bool.isRequired,
 		fetchingUserPurchases: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
@@ -35,6 +36,7 @@ class AutoRenewToggle extends Component {
 	};
 
 	static defaultProps = {
+		shouldDisable: false,
 		fetchingUserPurchases: false,
 		getChangePaymentMethodUrlFor: getChangePaymentMethodPath,
 	};
@@ -203,7 +205,7 @@ class AutoRenewToggle extends Component {
 	}
 
 	render() {
-		const { planName, siteDomain, purchase, withTextStatus } = this.props;
+		const { planName, siteDomain, purchase, withTextStatus, shouldDisable } = this.props;
 
 		if ( ! this.shouldRender( purchase ) ) {
 			return null;
@@ -213,7 +215,7 @@ class AutoRenewToggle extends Component {
 			<>
 				<ToggleControl
 					checked={ this.getToggleUiStatus() }
-					disabled={ this.isUpdatingAutoRenew() }
+					disabled={ this.isUpdatingAutoRenew() || shouldDisable }
 					onChange={ this.onToggleAutoRenew }
 					label={ withTextStatus && this.renderTextStatus() }
 				/>

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -384,6 +384,8 @@ class AllDomains extends Component {
 			isContactEmailEditContext,
 		} = this.props;
 
+		const { isSavingContactInfo } = this.state;
+
 		const selectedFilter = context?.query?.filter;
 
 		const domainsTableColumns = [
@@ -474,6 +476,7 @@ class AllDomains extends Component {
 						className="list__checkbox"
 						onChange={ this.handleSelectAllDomains }
 						checked={ areAllCheckboxesChecked }
+						disabled={ this.state.isSavingContactInfo }
 					/>
 				),
 			} );
@@ -498,6 +501,7 @@ class AllDomains extends Component {
 					sites={ sites }
 					requestingSiteDomains={ requestingSiteDomains }
 					hasLoadedPurchases={ hasLoadedUserPurchases }
+					isSavingContactInfo={ isSavingContactInfo }
 				/>
 			</>
 		);

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -477,6 +477,7 @@ class AllDomains extends Component {
 					) }
 					domainsTableColumns={ domainsTableColumns }
 					isManagingAllSites={ true }
+					isContactEmailEditContext={ isContactEmailEditContext }
 					goToEditDomainRoot={ this.handleDomainItemClick }
 					isLoading={ this.isLoading() }
 					purchases={ purchases }

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -12,6 +12,7 @@ import QueryAllDomains from 'calypso/components/data/query-all-domains';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EmptyContent from 'calypso/components/empty-content';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -374,6 +375,7 @@ class AllDomains extends Component {
 			requestingSiteDomains,
 			hasLoadedUserPurchases,
 			translate,
+			isContactEmailEditContext,
 		} = this.props;
 
 		const selectedFilter = context?.query?.filter;
@@ -454,6 +456,15 @@ class AllDomains extends Component {
 			{ name: 'auto-renew', label: translate( 'Auto-renew' ) },
 			{ name: 'action', label: null },
 		];
+
+		if ( isContactEmailEditContext ) {
+			domainsTableColumns.unshift( {
+				name: 'select-domain',
+				label: (
+					<FormCheckbox className="list__checkbox" onChange={ () => {} } onClick={ () => {} } />
+				),
+			} );
+		}
 
 		return (
 			<>

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -245,11 +245,17 @@ class AllDomains extends Component {
 		);
 	}
 
+	handleSelectAllDomains = ( event ) => {
+		return this.handleDomainListHeaderToggle( event.target.checked );
+	};
+
 	mergeFilteredDomainsWithDomainsDetails() {
 		const { domainsDetails } = this.props;
-		return this.filteredDomains().map(
-			( domain ) => this.findDomainDetails( domainsDetails, domain ) || domain
-		);
+		const { selectedDomains } = this.state;
+		return this.filteredDomains().map( ( domain ) => ( {
+			...( this.findDomainDetails( domainsDetails, domain ) || domain ),
+			selected: selectedDomains[ domain.name ],
+		} ) );
 	}
 
 	renderQuerySiteDomainsOnce( blogId ) {
@@ -460,9 +466,7 @@ class AllDomains extends Component {
 		if ( isContactEmailEditContext ) {
 			domainsTableColumns.unshift( {
 				name: 'select-domain',
-				label: (
-					<FormCheckbox className="list__checkbox" onChange={ () => {} } onClick={ () => {} } />
-				),
+				label: <FormCheckbox className="list__checkbox" onChange={ this.handleSelectAllDomains } />,
 			} );
 		}
 
@@ -475,6 +479,7 @@ class AllDomains extends Component {
 						this.mergeFilteredDomainsWithDomainsDetails(),
 						selectedFilter
 					) }
+					handleDomainItemToggle={ this.handleDomainItemToggle }
 					domainsTableColumns={ domainsTableColumns }
 					isManagingAllSites={ true }
 					isContactEmailEditContext={ isContactEmailEditContext }
@@ -620,9 +625,18 @@ class AllDomains extends Component {
 	}
 
 	filteredDomains() {
-		const { domainsList, canManageSitesMap } = this.props;
+		const {
+			filteredDomainsList,
+			domainsList,
+			canManageSitesMap,
+			isContactEmailEditContext,
+		} = this.props;
 		if ( ! domainsList ) {
 			return [];
+		}
+
+		if ( isContactEmailEditContext ) {
+			return filteredDomainsList;
 		}
 
 		// filter on sites we can manage, that aren't `wpcom` type

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -464,9 +464,18 @@ class AllDomains extends Component {
 		];
 
 		if ( isContactEmailEditContext ) {
+			const areAllCheckboxesChecked = Object.entries( this.state.selectedDomains ).every(
+				( [ , selected ] ) => selected
+			);
 			domainsTableColumns.unshift( {
 				name: 'select-domain',
-				label: <FormCheckbox className="list__checkbox" onChange={ this.handleSelectAllDomains } />,
+				label: (
+					<FormCheckbox
+						className="list__checkbox"
+						onChange={ this.handleSelectAllDomains }
+						checked={ areAllCheckboxesChecked }
+					/>
+				),
 			} );
 		}
 

--- a/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
+++ b/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
@@ -115,7 +115,7 @@ class BulkEditContactInfo extends Component {
 	};
 
 	onTransferLockOptOutChange = ( event ) => {
-		this.props.onTransferLockOptOutChange( event.target.checked );
+		this.props.onTransferLockOptOutChange( ! event.target.checked );
 	};
 
 	validateContactDetails = ( contactDetails ) => {

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -167,7 +167,7 @@ class DomainRow extends PureComponent {
 	}
 
 	renderAutoRenew() {
-		const { site, hasLoadedPurchases, purchase } = this.props;
+		const { site, hasLoadedPurchases, purchase, isManagingAllSites, showCheckbox } = this.props;
 
 		if ( ! this.shouldShowAutoRenewStatus() || ( hasLoadedPurchases && ! purchase ) ) {
 			return <span className="domain-row__auto-renew-cell">-</span>;
@@ -188,6 +188,7 @@ class DomainRow extends PureComponent {
 					planName={ site.plan.product_name_short }
 					siteDomain={ site.domain }
 					purchase={ purchase }
+					shouldDisable={ isManagingAllSites && showCheckbox }
 					withTextStatus={ false }
 					toggleSource="registered-domain-status"
 				/>
@@ -381,10 +382,15 @@ class DomainRow extends PureComponent {
 		);
 	}
 
+	handleDomainSelection = ( event ) => {
+		const { domain } = this.props;
+		return this.props.handleDomainItemToggle( domain, event.target.checked );
+	};
+
 	renderDomainCheckbox() {
 		return (
 			<div className="domain-row__checkbox-cell">
-				<FormCheckbox className="domain-row__checkbox" onChange={ () => {} } onClick={ () => {} } />
+				<FormCheckbox className="domain-row__checkbox" onChange={ this.handleDomainSelection } />
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -39,6 +39,7 @@ class DomainRow extends PureComponent {
 		isBusy: PropTypes.bool,
 		isLoadingDomainDetails: PropTypes.bool,
 		isManagingAllSites: PropTypes.bool,
+		isSavingContactInfo: PropTypes.bool,
 		onClick: PropTypes.func.isRequired,
 		onMakePrimaryClick: PropTypes.func,
 		purchase: PropTypes.object,
@@ -51,6 +52,7 @@ class DomainRow extends PureComponent {
 	static defaultProps = {
 		disabled: false,
 		isManagingAllSites: false,
+		isSavingContactInfo: false,
 		isLoadingDomainDetails: false,
 		isBusy: false,
 		showDomainDetails: true,
@@ -388,13 +390,14 @@ class DomainRow extends PureComponent {
 	};
 
 	renderDomainCheckbox() {
-		const { domain } = this.props;
+		const { domain, isSavingContactInfo } = this.props;
 		return (
 			<div className="domain-row__checkbox-cell">
 				<FormCheckbox
 					className="domain-row__checkbox"
 					onChange={ this.handleDomainSelection }
 					checked={ domain.selected }
+					disabled={ isSavingContactInfo }
 				/>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -9,6 +9,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import MaterialIcon from 'calypso/components/material-icon';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import Spinner from 'calypso/components/spinner';
@@ -380,6 +381,14 @@ class DomainRow extends PureComponent {
 		);
 	}
 
+	renderDomainCheckbox() {
+		return (
+			<div className="domain-row__checkbox-cell">
+				<FormCheckbox className="domain-row__checkbox" onChange={ () => {} } onClick={ () => {} } />
+			</div>
+		);
+	}
+
 	busyMessage() {
 		if ( this.props.isBusy && this.props.busyMessage ) {
 			return <div className="domain-row__busy-message">{ this.props.busyMessage }</div>;
@@ -387,13 +396,14 @@ class DomainRow extends PureComponent {
 	}
 
 	render() {
-		const { domain, isManagingAllSites, translate } = this.props;
+		const { domain, isManagingAllSites, showCheckbox, translate } = this.props;
 		const domainTypeText = getDomainTypeText( domain, translate, domainInfoContext.DOMAIN_ROW );
 		const expiryDate = domain?.expiry ? moment.utc( domain?.expiry ) : null;
 
 		return (
 			<div className="domain-row">
 				<div className="domain-row__mobile-container">
+					{ isManagingAllSites && showCheckbox && this.renderDomainCheckbox() }
 					{ this.renderDomainName( domainTypeText ) }
 					{ isManagingAllSites && this.renderSite() }
 					{ this.renderDomainStatus() }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -384,13 +384,18 @@ class DomainRow extends PureComponent {
 
 	handleDomainSelection = ( event ) => {
 		const { domain } = this.props;
-		return this.props.handleDomainItemToggle( domain, event.target.checked );
+		return this.props.handleDomainItemToggle( domain.name, event.target.checked );
 	};
 
 	renderDomainCheckbox() {
+		const { domain } = this.props;
 		return (
 			<div className="domain-row__checkbox-cell">
-				<FormCheckbox className="domain-row__checkbox" onChange={ this.handleDomainSelection } />
+				<FormCheckbox
+					className="domain-row__checkbox"
+					onChange={ this.handleDomainSelection }
+					checked={ domain.selected }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -115,6 +115,18 @@
 	}
 }
 
+.domain-row__checkbox-cell {
+	overflow: hidden;
+	flex: 1;
+
+	@include break-mobile {
+		flex: 10 10 0;
+		align-self: center;
+		font-size: $font-body-small;
+		padding-top: 2px;
+	}
+}
+
 .domain-row__domain-cell {
 	overflow: hidden;
 	flex: 1;

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -162,7 +162,8 @@ class DomainsTable extends PureComponent {
 						busyMessage={ translate( 'Setting primary site address…', {
 							context: 'Shows up when the primary domain is changing and the user is waiting',
 						} ) }
-						disabled={ settingPrimaryDomain }
+						disabled={ settingPrimaryDomain || isContactEmailEditContext }
+						showDomainDetails={ ! isContactEmailEditContext }
 						selectionIndex={ index }
 						onMakePrimaryClick={ handleUpdatePrimaryDomainOptionClick }
 						shouldUpgradeToMakePrimary={

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -100,6 +100,7 @@ class DomainsTable extends PureComponent {
 			shouldUpgradeToMakeDomainPrimary,
 			requestingSiteDomains,
 			sites,
+			isContactEmailEditContext,
 			translate,
 		} = this.props;
 
@@ -149,6 +150,7 @@ class DomainsTable extends PureComponent {
 					<DomainRow
 						key={ `${ domain.name }-${ index }` }
 						currentRoute={ currentRoute }
+						showCheckbox={ isContactEmailEditContext }
 						domain={ domain }
 						site={ selectedSite }
 						isManagingAllSites={ isManagingAllSites }

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -101,6 +101,7 @@ class DomainsTable extends PureComponent {
 			requestingSiteDomains,
 			sites,
 			isContactEmailEditContext,
+			handleDomainItemToggle,
 			translate,
 		} = this.props;
 
@@ -155,6 +156,7 @@ class DomainsTable extends PureComponent {
 						site={ selectedSite }
 						isManagingAllSites={ isManagingAllSites }
 						isLoadingDomainDetails={ isLoadingDomainDetails }
+						handleDomainItemToggle={ handleDomainItemToggle }
 						onClick={ settingPrimaryDomain ? noop : goToEditDomainRoot }
 						isBusy={ settingPrimaryDomain && index === primaryDomainIndex }
 						busyMessage={ translate( 'Setting primary site address…', {

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -20,6 +20,7 @@ class DomainsTable extends PureComponent {
 		hasLoadedPurchases: PropTypes.bool,
 		isLoading: PropTypes.bool,
 		isManagingAllSites: PropTypes.bool,
+		isSavingContactInfo: PropTypes.bool,
 		primaryDomainIndex: PropTypes.number,
 		purchases: PropTypes.array,
 		settingPrimaryDomain: PropTypes.bool,
@@ -101,6 +102,7 @@ class DomainsTable extends PureComponent {
 			requestingSiteDomains,
 			sites,
 			isContactEmailEditContext,
+			isSavingContactInfo,
 			handleDomainItemToggle,
 			translate,
 		} = this.props;
@@ -152,6 +154,7 @@ class DomainsTable extends PureComponent {
 						key={ `${ domain.name }-${ index }` }
 						currentRoute={ currentRoute }
 						showCheckbox={ isContactEmailEditContext }
+						isSavingContactInfo={ isSavingContactInfo }
 						domain={ domain }
 						site={ selectedSite }
 						isManagingAllSites={ isManagingAllSites }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -453,6 +453,9 @@
 	}
 }
 
+.list__select-domain-cell {
+	flex: 10 10 0;
+}
 .list__domain-cell {
 	flex: 83 83 0;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds some logic to the existing components so the bulk contact information editing works with them as well. 

#### Preview
![image](https://user-images.githubusercontent.com/18705930/143037739-9eda2c71-dc76-41d6-a082-8c82bfe195e7.png)

#### Testing instructions
- Go to `/domains/manage?site=all&action=edit-contact-email`
- Check that the page looks like the screenshot above and that everything is working as intended:
  - Adding an email and clicking the confirmation button should change the contact information email for all the selected domains;
  - Unselected domains should not be affected;
  - The ordering should be working properly;
  - The header's checkbox should select/unselect all domains.