### PR TITLE
Framework: Refactor away from `_.words()`

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -1,6 +1,6 @@
 import { createSelector } from '@automattic/state-utils';
 import { translate } from 'i18n-calypso';
-import { intersection, words } from 'lodash';
+import { intersection } from 'lodash';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
@@ -416,7 +416,13 @@ export function filterListBySearchTerm( searchTerm = '', collection = [], limit 
 		return [];
 	}
 
-	const searchTermWords = words( searchTerm ).map( ( word ) => word.toLowerCase() );
+	const searchTermWords = searchTerm
+		// Split to words.
+		.split( /[\W_]+/g )
+		// Eliminate any empty string results.
+		.filter( Boolean )
+		// Lowercase all words.
+		.map( ( word ) => word.toLowerCase() );
 	if ( ! searchTermWords.length ) {
 		return [];
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lodash's `words()` is used a single time in the entire codebase, and it's pretty straightforward to replace with a simple implementation.

If you want to find out why we're moving away from Lodash, see https://github.com/Automattic/wp-calypso/pull/50368 and p4TIVU-9Bf-p2.

#### Testing instructions

* Verify inline help search still works well.
* Verify all tests pass: `yarn run test-client client/blocks/inline-help/`.