### PR TITLE
Test passwordless signup for new users, take 2

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -51,6 +51,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import { getSectionName } from 'calypso/state/ui/selectors';
 import CrowdsignalSignupForm from './crowdsignal';
 import P2SignupForm from './p2';
+import PasswordlessSignupForm from './passwordless';
 import SocialSignupForm from './social';
 
 import './style.scss';
@@ -85,6 +86,7 @@ class SignupForm extends Component {
 		goToNextStep: PropTypes.func,
 		handleLogin: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
+		isPasswordlessExperiment: PropTypes.bool,
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
@@ -108,6 +110,7 @@ class SignupForm extends Component {
 		displayNameInput: false,
 		displayUsernameInput: true,
 		flowName: '',
+		isPasswordlessExperiment: false,
 		isSocialSignupEnabled: false,
 		showRecaptchaToS: false,
 		horizontal: false,
@@ -1031,6 +1034,49 @@ class SignupForm extends Component {
 			);
 		}
 
+		/*
+			AB Test: passwordlessSignup
+			`<PasswordlessSignupForm />` is for the `onboarding` flow.
+			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
+		*/
+		if (
+			( this.props.flowName === 'onboarding' || this.props.flowName === 'test-fse' ) &&
+			this.props.isPasswordlessExperiment
+		) {
+			const logInUrl = config.isEnabled( 'login/native-login-links' )
+				? this.getLoginLink()
+				: localizeUrl( config( 'login_url' ), this.props.locale );
+
+			return (
+				<div
+					className={ classNames( 'signup-form', this.props.className, {
+						'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+					} ) }
+				>
+					{ this.getNotice() }
+					<PasswordlessSignupForm
+						step={ this.props.step }
+						stepName={ this.props.stepName }
+						flowName={ this.props.flowName }
+						goToNextStep={ this.props.goToNextStep }
+						renderTerms={ this.termsOfServiceLink }
+						logInUrl={ logInUrl }
+						disabled={ this.props.disabled }
+						disableSubmitButton={ this.props.disableSubmitButton }
+						recaptchaClientId={ this.props.recaptchaClientId }
+					/>
+					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+						<SocialSignupForm
+							handleResponse={ this.props.handleSocialResponse }
+							socialService={ this.props.socialService }
+							socialServiceResponse={ this.props.socialServiceResponse }
+						/>
+					) }
+
+					{ this.props.footerLink || this.footerLink() }
+				</div>
+			);
+		}
 		return (
 			<div
 				className={ classNames( 'signup-form', this.props.className, {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1017,10 +1017,7 @@ class SignupForm extends Component {
 			`<PasswordlessSignupForm />` is for the `onboarding` flow.
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		if (
-			( this.props.flowName === 'onboarding' || this.props.flowName === 'test-fse' ) &&
-			this.props.isPasswordlessExperiment
-		) {
+		if ( this.props.flowName === 'onboarding' && this.props.isPasswordlessExperiment ) {
 			const logInUrl = this.getLoginLink();
 
 			return (

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -90,7 +90,6 @@ class SignupForm extends Component {
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
-		recaptchaClientId: PropTypes.number,
 		save: PropTypes.func,
 		signupDependencies: PropTypes.object,
 		step: PropTypes.object,
@@ -98,7 +97,6 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
-		showRecaptchaToS: PropTypes.bool,
 		horizontal: PropTypes.bool,
 
 		// Connected props
@@ -112,7 +110,6 @@ class SignupForm extends Component {
 		flowName: '',
 		isPasswordlessExperiment: false,
 		isSocialSignupEnabled: false,
-		showRecaptchaToS: false,
 		horizontal: false,
 	};
 
@@ -893,7 +890,7 @@ class SignupForm extends Component {
 	}
 
 	footerLink() {
-		const { flowName, showRecaptchaToS, translate } = this.props;
+		const { flowName, translate } = this.props;
 
 		if ( this.props.isP2Flow ) {
 			return (
@@ -924,25 +921,6 @@ class SignupForm extends Component {
 							/>
 						) }
 					</LoggedOutFormLinks>
-				) }
-				{ showRecaptchaToS && (
-					<div className="signup-form__recaptcha-tos">
-						<LoggedOutFormLinks>
-							<p>
-								{ translate(
-									'This site is protected by reCAPTCHA and the Google {{a1}}Privacy Policy{{/a1}} and {{a2}}Terms of Service{{/a2}} apply.',
-									{
-										components: {
-											a1: <a href="https://policies.google.com/privacy" />,
-											a2: <a href="https://policies.google.com/terms" />,
-										},
-										comment:
-											'English wording comes from Google: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed',
-									}
-								) }
-							</p>
-						</LoggedOutFormLinks>
-					</div>
 				) }
 			</>
 		);
@@ -1043,14 +1021,11 @@ class SignupForm extends Component {
 			( this.props.flowName === 'onboarding' || this.props.flowName === 'test-fse' ) &&
 			this.props.isPasswordlessExperiment
 		) {
-			const logInUrl = config.isEnabled( 'login/native-login-links' )
-				? this.getLoginLink()
-				: localizeUrl( config( 'login_url' ), this.props.locale );
+			const logInUrl = this.getLoginLink();
 
 			return (
 				<div
 					className={ classNames( 'signup-form', this.props.className, {
-						'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
 						'is-horizontal': this.props.horizontal,
 					} ) }
 				>
@@ -1064,7 +1039,6 @@ class SignupForm extends Component {
 						logInUrl={ logInUrl }
 						disabled={ this.props.disabled }
 						disableSubmitButton={ this.props.disableSubmitButton }
-						recaptchaClientId={ this.props.recaptchaClientId }
 					/>
 
 					{ ! config.isEnabled( 'desktop' ) &&
@@ -1090,7 +1064,6 @@ class SignupForm extends Component {
 		return (
 			<div
 				className={ classNames( 'signup-form', this.props.className, {
-					'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
 					'is-horizontal': this.props.horizontal,
 				} ) }
 			>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1051,6 +1051,7 @@ class SignupForm extends Component {
 				<div
 					className={ classNames( 'signup-form', this.props.className, {
 						'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+						'is-horizontal': this.props.horizontal,
 					} ) }
 				>
 					{ this.getNotice() }
@@ -1065,14 +1066,23 @@ class SignupForm extends Component {
 						disableSubmitButton={ this.props.disableSubmitButton }
 						recaptchaClientId={ this.props.recaptchaClientId }
 					/>
+
+					{ ! config.isEnabled( 'desktop' ) &&
+						this.props.horizontal &&
+						! this.userCreationComplete() && (
+							<div className="signup-form__separator">
+								<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
+							</div>
+						) }
+
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 						<SocialSignupForm
 							handleResponse={ this.props.handleSocialResponse }
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
+							isReskinned={ this.props.isReskinned }
 						/>
 					) }
-
 					{ this.props.footerLink || this.footerLink() }
 				</div>
 			);

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1017,7 +1017,7 @@ class SignupForm extends Component {
 			`<PasswordlessSignupForm />` is for the `onboarding` flow.
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		if ( this.props.flowName === 'onboarding' && this.props.isPasswordlessExperiment ) {
+		if ( this.props.isPasswordlessExperiment ) {
 			const logInUrl = this.getLoginLink();
 
 			return (

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -76,7 +76,6 @@ class PasswordlessSignupForm extends Component {
 					is_passwordless: true,
 					signup_flow_name: this.props.flowName,
 					validate: false,
-					// ab_test_variations: getSavedVariations(),
 				},
 				null
 			);
@@ -140,7 +139,7 @@ class PasswordlessSignupForm extends Component {
 					<>
 						{ translate( 'An account with this email address already exists.' ) }
 						&nbsp;
-						{ translate( 'If this is you {{a}}log in now{{/a}}.', {
+						{ translate( '{{a}}Log in now{{/a}} to finish signing up.', {
 							components: {
 								a: (
 									<a

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -138,6 +138,8 @@ class PasswordlessSignupForm extends Component {
 			email: this.state.email,
 		};
 
+		const marketing_price_group = response?.marketing_price_group ?? '';
+
 		recordRegistration( {
 			userData,
 			flow: this.props.flowName,
@@ -146,6 +148,7 @@ class PasswordlessSignupForm extends Component {
 
 		this.submitStep( {
 			username,
+			marketing_price_group,
 			bearer_token: response.bearer_token,
 		} );
 	};
@@ -220,7 +223,7 @@ class PasswordlessSignupForm extends Component {
 	}
 
 	formFooter() {
-		const { isSubmitting, isEmailAddressValid } = this.state;
+		const { isSubmitting } = this.state;
 		if ( this.userCreationComplete() ) {
 			return (
 				<LoggedOutFormFooter>
@@ -239,12 +242,7 @@ class PasswordlessSignupForm extends Component {
 					type="submit"
 					primary
 					busy={ isSubmitting }
-					disabled={
-						isSubmitting ||
-						! isEmailAddressValid ||
-						!! this.props.disabled ||
-						!! this.props.disableSubmitButton
-					}
+					disabled={ isSubmitting || !! this.props.disabled || !! this.props.disableSubmitButton }
 				>
 					{ submitButtonText }
 				</Button>

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
@@ -10,6 +11,7 @@ import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import Notice from 'calypso/components/notice';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wpcom from 'calypso/lib/wp';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -70,15 +72,15 @@ class PasswordlessSignupForm extends Component {
 		} );
 
 		try {
-			const response = await wpcom.undocumented().usersNew(
-				{
-					email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
-					is_passwordless: true,
-					signup_flow_name: this.props.flowName,
-					validate: false,
-				},
-				null
-			);
+			const response = await wpcom.req.post( '/users/new', {
+				email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
+				is_passwordless: true,
+				signup_flow_name: this.props.flowName,
+				validate: false,
+				locale: getLocaleSlug(),
+				client_id: config( 'wpcom_signup_id' ),
+				client_secret: config( 'wpcom_signup_key' ),
+			} );
 			this.createAccountCallback( null, response );
 		} catch ( err ) {
 			this.createAccountCallback( err );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -1,0 +1,285 @@
+import { Button } from '@automattic/components';
+import emailValidator from 'email-validator';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
+import Notice from 'calypso/components/notice';
+import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
+import { recordRegistration } from 'calypso/lib/analytics/signup';
+import wpcom from 'calypso/lib/wp';
+import flows from 'calypso/signup/config/flows';
+import ValidationFieldset from 'calypso/signup/validation-fieldset';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+
+class PasswordlessSignupForm extends Component {
+	static propTypes = {
+		locale: PropTypes.string,
+	};
+
+	static defaultProps = {
+		locale: 'en',
+	};
+
+	state = {
+		isSubmitting: false,
+		email: this.props.step && this.props.step.form ? this.props.step.form.email : '',
+		errorMessages: null,
+	};
+
+	submitTracksEvent = ( isSuccessful, props ) => {
+		const tracksEventName = isSuccessful
+			? 'calypso_signup_actions_onboarding_passwordless_login_success'
+			: 'calypso_signup_actions_onboarding_passwordless_login_error';
+		this.props.recordTracksEvent( tracksEventName, {
+			...props,
+		} );
+	};
+
+	onFormSubmit = async ( event ) => {
+		event.preventDefault();
+
+		if ( ! this.state.email || ! emailValidator.validate( this.state.email ) ) {
+			this.setState( {
+				errorMessages: [ this.props.translate( 'Please provide a valid email address.' ) ],
+				isSubmitting: false,
+			} );
+			this.submitTracksEvent( false, { action_message: 'Please provide a valid email address.' } );
+			return;
+		}
+
+		this.setState( {
+			isSubmitting: true,
+		} );
+
+		// Save form state in a format that is compatible with the standard SignupForm used in the user step.
+		const form = {
+			firstName: '',
+			lastName: '',
+			email: this.state.email,
+			username: '',
+			password: '',
+		};
+
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			form,
+		} );
+
+		const isRecaptchaLoaded = typeof this.props.recaptchaClientId === 'number';
+
+		let recaptchaToken = undefined;
+		let recaptchaError = undefined;
+
+		if ( flows.getFlow( this.props.flowName )?.showRecaptcha ) {
+			if ( isRecaptchaLoaded ) {
+				recaptchaToken = await recordGoogleRecaptchaAction(
+					this.props.recaptchaClientId,
+					'calypso/signup/formSubmit'
+				);
+
+				if ( ! recaptchaToken ) {
+					recaptchaError = 'recaptcha_failed';
+				}
+			} else {
+				recaptchaError = 'recaptcha_didnt_load';
+			}
+		}
+
+		try {
+			const response = await wpcom.undocumented().usersNew(
+				{
+					email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
+					'g-recaptcha-error': recaptchaError,
+					'g-recaptcha-response': recaptchaToken || undefined,
+					is_passwordless: true,
+					signup_flow_name: this.props.flowName,
+					validate: false,
+					// ab_test_variations: getSavedVariations(),
+				},
+				null
+			);
+			this.createAccountCallback( null, response );
+		} catch ( err ) {
+			this.createAccountCallback( err );
+		}
+	};
+
+	createAccountCallback = ( error, response ) => {
+		if ( error ) {
+			const errorMessage = this.getErrorMessage( error );
+			this.setState( {
+				errorMessages: [ errorMessage ],
+				isSubmitting: false,
+			} );
+			this.submitTracksEvent( false, { action_message: error.message } );
+			return;
+		}
+
+		this.setState( {
+			errorMessages: null,
+			isSubmitting: false,
+		} );
+
+		const username =
+			( response && response.signup_sandbox_username ) || ( response && response.username );
+
+		const userId =
+			( response && response.signup_sandbox_user_id ) || ( response && response.user_id );
+
+		const userData = {
+			ID: userId,
+			username: username,
+			email: this.state.email,
+		};
+
+		recordRegistration( {
+			userData,
+			flow: this.props.flowName,
+			type: 'passwordless',
+		} );
+
+		this.submitStep( {
+			username,
+			bearer_token: response.bearer_token,
+		} );
+	};
+
+	getErrorMessage( errorObj = { error: null, message: null } ) {
+		const { translate } = this.props;
+
+		switch ( errorObj.error ) {
+			case 'already_taken':
+			case 'already_active':
+			case 'email_exists':
+				return (
+					<>
+						{ translate( 'An account with this email address already exists.' ) }
+						&nbsp;
+						{ translate( 'If this is you {{a}}log in now{{/a}}.', {
+							components: {
+								a: (
+									<a
+										href={ `${ this.props.logInUrl }&email_address=${ encodeURIComponent(
+											this.state.email
+										) }` }
+									/>
+								),
+							},
+						} ) }
+					</>
+				);
+			default:
+				return translate(
+					'Sorry, something went wrong when trying to create your account. Please try again.'
+				);
+		}
+	}
+
+	submitStep = ( data ) => {
+		const { flowName, stepName, goToNextStep, submitCreateAccountStep } = this.props;
+		submitCreateAccountStep(
+			{
+				flowName,
+				stepName,
+				// We use this flag in the flow controller to communicate to the flow controller that we're
+				// dealing with passwordless signup, and therefore don't need to call the apiFunction
+				// normally associated with the user step.
+				isPasswordlessSignupForm: true,
+			},
+			data
+		);
+		this.submitTracksEvent( true, { action_message: 'Successful login', username: data.username } );
+		goToNextStep();
+	};
+
+	onInputChange = ( { target: { value } } ) =>
+		this.setState( {
+			email: value,
+			errorMessages: null,
+			isEmailAddressValid: emailValidator.validate( value ),
+		} );
+
+	renderNotice() {
+		return (
+			<Notice showDismiss={ false } status="is-error">
+				{ this.props.translate(
+					'Your account has already been created. You can change your email, username, and password later.'
+				) }
+			</Notice>
+		);
+	}
+
+	userCreationComplete() {
+		return this.props.step && 'completed' === this.props.step.status;
+	}
+
+	formFooter() {
+		const { isSubmitting, isEmailAddressValid } = this.state;
+		if ( this.userCreationComplete() ) {
+			return (
+				<LoggedOutFormFooter>
+					<Button primary onClick={ () => this.props.goToNextStep() }>
+						{ this.props.translate( 'Continue' ) }
+					</Button>
+				</LoggedOutFormFooter>
+			);
+		}
+		const submitButtonText = isSubmitting
+			? this.props.translate( 'Creating Your Account…' )
+			: this.props.translate( 'Create your account' );
+		return (
+			<LoggedOutFormFooter>
+				<Button
+					type="submit"
+					primary
+					busy={ isSubmitting }
+					disabled={
+						isSubmitting ||
+						! isEmailAddressValid ||
+						!! this.props.disabled ||
+						!! this.props.disableSubmitButton
+					}
+				>
+					{ submitButtonText }
+				</Button>
+			</LoggedOutFormFooter>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+		const { errorMessages, isSubmitting } = this.state;
+
+		return (
+			<div className="signup-form__passwordless-form-wrapper">
+				<LoggedOutForm onSubmit={ this.onFormSubmit } noValidate>
+					<ValidationFieldset errorMessages={ errorMessages }>
+						<FormLabel htmlFor="email">{ translate( 'Enter your email address' ) }</FormLabel>
+						<FormTextInput
+							autoCapitalize={ 'off' }
+							className="signup-form__passwordless-email"
+							type="email"
+							name="email"
+							value={ this.state.email }
+							onChange={ this.onInputChange }
+							disabled={ isSubmitting || !! this.props.disabled }
+						/>
+					</ValidationFieldset>
+					{ this.props.renderTerms() }
+					{ this.formFooter() }
+				</LoggedOutForm>
+			</div>
+		);
+	}
+}
+export default connect( null, {
+	recordTracksEvent,
+	saveSignupStep,
+	submitCreateAccountStep: submitSignupStep,
+} )( localize( PasswordlessSignupForm ) );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -9,10 +9,8 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import Notice from 'calypso/components/notice';
-import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import wpcom from 'calypso/lib/wp';
-import flows from 'calypso/signup/config/flows';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -71,32 +69,10 @@ class PasswordlessSignupForm extends Component {
 			form,
 		} );
 
-		const isRecaptchaLoaded = typeof this.props.recaptchaClientId === 'number';
-
-		let recaptchaToken = undefined;
-		let recaptchaError = undefined;
-
-		if ( flows.getFlow( this.props.flowName )?.showRecaptcha ) {
-			if ( isRecaptchaLoaded ) {
-				recaptchaToken = await recordGoogleRecaptchaAction(
-					this.props.recaptchaClientId,
-					'calypso/signup/formSubmit'
-				);
-
-				if ( ! recaptchaToken ) {
-					recaptchaError = 'recaptcha_failed';
-				}
-			} else {
-				recaptchaError = 'recaptcha_didnt_load';
-			}
-		}
-
 		try {
 			const response = await wpcom.undocumented().usersNew(
 				{
 					email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
-					'g-recaptcha-error': recaptchaError,
-					'g-recaptcha-response': recaptchaToken || undefined,
 					is_passwordless: true,
 					signup_flow_name: this.props.flowName,
 					validate: false,

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -66,6 +66,20 @@
 	text-decoration: underline;
 }
 
+.signup-form__passwordless-form-wrapper {
+	.signup-form__terms-of-service-link {
+		margin: 4px 0;
+	}
+
+	.logged-out-form__footer {
+		margin-top: 0;
+	}
+
+	.validation-fieldset__validation-message {
+		min-height: auto;
+	}
+}
+
 .signup-form__recaptcha-tos {
 	display: none;
 	padding: 20px 10px 10px;

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -56,6 +56,7 @@ interface Step {
 	providesToken?: boolean;
 	stepName: string;
 	allowUnauthenticated?: boolean;
+	isPasswordlessSignupForm?: boolean;
 }
 
 const steps: Record< string, Step > = untypedSteps;
@@ -369,6 +370,21 @@ export default class SignupFlowController {
 			step.stepName,
 			'optionalDependencies'
 		);
+
+		/*
+			AB Test: passwordlessSignup
+			`isPasswordlessSignupForm` is set by the PasswordlessSignupForm.
+			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow.
+			For passwordless signups, the API call has already occurred in the PasswordlessSignupForm, so here it is skipped.
+		*/
+		if ( step?.isPasswordlessSignupForm ) {
+			this._processingSteps.delete( step.stepName );
+			recordTracksEvent( 'calypso_signup_actions_complete_step', {
+				step: step.stepName,
+			} );
+			this._reduxStore.dispatch( completeSignupStep( step, dependenciesFound ) );
+			return;
+		}
 
 		// deferred because a step can be processed as soon as it is submitted
 		defer( () => {

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -32,7 +32,13 @@ class EmailedLoginLinkSuccessfully extends Component {
 
 		this.props.hideMagicLoginRequestForm();
 
-		page( login( { isJetpack: this.props.isJetpackLogin, locale: this.props.locale } ) );
+		page(
+			login( {
+				isJetpack: this.props.isJetpackLogin,
+				isWhiteLogin: this.props.isWhiteLogin,
+				locale: this.props.locale,
+			} )
+		);
 	};
 
 	render() {
@@ -68,7 +74,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 					<a
 						href={ login( {
 							isJetpack: this.props.isJetpackLogin,
-							isGutenboarding: this.props.isGutenboardingLogin,
+							isWhiteLogin: this.props.isWhiteLogin,
 							locale: this.props.locale,
 						} ) }
 						onClick={ this.onClickBackLink }
@@ -85,7 +91,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 const mapState = ( state ) => ( {
 	locale: getCurrentLocaleSlug( state ),
 	isJetpackLogin: getCurrentRoute( state ) === '/log-in/jetpack/link',
-	isGutenboardingLogin: getCurrentRoute( state )?.startsWith( '/log-in/gutenboarding/link' ),
+	isWhiteLogin: getCurrentRoute( state )?.startsWith( '/log-in/new/link' ),
 } );
 
 const mapDispatch = {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -115,7 +115,8 @@ export class UserStep extends Component {
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
-		const { oauth2Signup, initialContext } = this.props;
+		const { oauth2Signup, initialContext, flowName } = this.props;
+
 		const clientId = get( initialContext, 'query.oauth2_client_id', null );
 
 		this.setSubHeaderText( this.props );
@@ -123,13 +124,15 @@ export class UserStep extends Component {
 		if ( oauth2Signup && clientId ) {
 			this.props.fetchOAuth2ClientData( clientId );
 		}
-		const experimentCheck = this.state.isDesktop
-			? 'registration_email_only_desktop'
-			: 'registration_email_only_mobile';
+		if ( flowName === 'onboarding' ) {
+			const experimentCheck = this.state.isDesktop
+				? 'registration_email_only_desktop'
+				: 'registration_email_only_mobile';
 
-		loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
-			this.setState( { experiment: experimentName } );
-		} );
+			loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
+				this.setState( { experiment: experimentName } );
+			} );
+		}
 	}
 
 	componentDidMount() {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -476,9 +476,6 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
-					showRecaptchaToS={
-						flows.getFlow( this.props.flowName, this.props.userLoggedIn )?.showRecaptcha
-					}
 					horizontal={ isReskinned }
 					isReskinned={ isReskinned }
 				/>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
 import { isEmpty, omit, get } from 'lodash';
@@ -98,6 +99,7 @@ export class UserStep extends Component {
 		subHeaderText: '',
 		recaptchaClientId: null,
 		experiment: null,
+		isDesktop: isDesktop(),
 	};
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -121,7 +123,11 @@ export class UserStep extends Component {
 		if ( oauth2Signup && clientId ) {
 			this.props.fetchOAuth2ClientData( clientId );
 		}
-		loadExperimentAssignment( 'registration_remove_username' ).then( ( experimentName ) => {
+		const experimentCheck = this.state.isDesktop
+			? 'registration_email_only_desktop'
+			: 'registration_email_only_mobile';
+
+		loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
 			this.setState( { experiment: experimentName } );
 		} );
 	}
@@ -472,6 +478,7 @@ export class UserStep extends Component {
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
 					isPasswordlessExperiment={ this.isPasswordlessExperiment() }
+					experimentName={ this.state.experiment }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -126,8 +126,8 @@ export class UserStep extends Component {
 		}
 		if ( flowName === 'onboarding' ) {
 			const experimentCheck = this.state.isDesktop
-				? 'registration_email_only_desktop'
-				: 'registration_email_only_mobile';
+				? 'registration_email_only_desktop_relaunch'
+				: 'registration_email_only_mobile_relaunch';
 
 			loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
 				this.setState( { experiment: experimentName } );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -519,17 +519,15 @@ export class UserStep extends Component {
 		}
 
 		return (
-			this.state.experiment?.variationName !== undefined && (
-				<StepWrapper
-					flowName={ this.props.flowName }
-					stepName={ this.props.stepName }
-					headerText={ this.getHeaderText() }
-					subHeaderText={ this.state.subHeaderText }
-					positionInFlow={ this.props.positionInFlow }
-					fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
-					stepContent={ this.renderSignupForm() }
-				/>
-			)
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				headerText={ this.getHeaderText() }
+				subHeaderText={ this.state.subHeaderText }
+				positionInFlow={ this.props.positionInFlow }
+				fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
+				stepContent={ this.renderSignupForm() }
+			/>
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Note: This PR is a follow-up to #57846, which was merged and then reverted by #57846, due to a bug that broke non-onboarding signup flows. This PR removes the line that caused that issue.

This PR re-implements the passwordless signup, which will run as a test again the control experience. The test is configured to run via two Explat tests, one each for mobile and desktop viewports. Those test names are:

Desktop: `registration_email_only_desktop_relaunch`
Mobile: `registration_email_only_mobile_relaunch`

Context behind this test is at p58i-boI-p2#comment-52280.

Before:
<img width="894" alt="CleanShot 2021-11-10 at 16 27 04@2x" src="https://user-images.githubusercontent.com/35781181/141319021-5379680c-11db-4e3e-88b2-177140cef5c5.png">

After:
<img width="956" alt="CleanShot 2021-11-10 at 11 12 08@2x" src="https://user-images.githubusercontent.com/35781181/141319035-8bf718b8-ded3-4cbf-83ae-71ccc9048111.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso.
* Navigate to both tests in Explat.
* Add the `control` and `treatment` variation bookmarklets to your nav bar.
* Navigate to `/start/new` on your Calypso instance and assign yourself to the `treatment` variation.
* Repeat the tests for both desktop and mobile viewports.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57846 #58359
