### PR TITLE
Domains: Remove `redux-bridge` from domain management

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -32,6 +32,10 @@ import {
 } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
+import {
+	showUpdatePrimaryDomainSuccessNotice,
+	showUpdatePrimaryDomainErrorNotice,
+} from 'calypso/state/domains/management/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -46,12 +50,7 @@ import DomainItem from './domain-item';
 import DomainOnly from './domain-only';
 import ListItemPlaceholder from './item-placeholder';
 import ListHeader from './list-header';
-import {
-	filterOutWpcomDomains,
-	getDomainManagementPath,
-	showUpdatePrimaryDomainSuccessNotice,
-	showUpdatePrimaryDomainErrorNotice,
-} from './utils';
+import { filterOutWpcomDomains, getDomainManagementPath } from './utils';
 
 import './style.scss';
 import 'calypso/my-sites/domains/style.scss';
@@ -293,10 +292,10 @@ export class List extends Component {
 			.then(
 				() => {
 					this.setState( { primaryDomainIndex: -1 } );
-					showUpdatePrimaryDomainSuccessNotice( domainName );
+					this.props.showUpdatePrimaryDomainSuccessNotice( domainName );
 				},
 				( error ) => {
-					showUpdatePrimaryDomainErrorNotice( error.message );
+					this.props.showUpdatePrimaryDomainErrorNotice( error.message );
 					this.setState( { primaryDomainIndex: currentPrimaryIndex } );
 				}
 			)
@@ -332,14 +331,14 @@ export class List extends Component {
 					settingPrimaryDomain: false,
 				} );
 
-				showUpdatePrimaryDomainSuccessNotice( domain.name );
+				this.props.showUpdatePrimaryDomainSuccessNotice( domain.name );
 			},
 			( error ) => {
 				this.setState( {
 					settingPrimaryDomain: false,
 					primaryDomainIndex: currentPrimaryIndex,
 				} );
-				showUpdatePrimaryDomainErrorNotice( error.message );
+				this.props.showUpdatePrimaryDomainErrorNotice( error.message );
 			}
 		);
 	};
@@ -449,12 +448,12 @@ export default connect(
 			canSetPrimaryDomain: hasActiveSiteFeature( state, siteId, FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ),
 		};
 	},
-	( dispatch ) => {
-		return {
-			setPrimaryDomain: ( ...props ) => setPrimaryDomain( ...props )( dispatch ),
-			changePrimary: ( domain, mode ) => dispatch( changePrimary( domain, mode ) ),
-			successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
-			errorNotice: ( text, options ) => dispatch( errorNotice( text, options ) ),
-		};
+	{
+		changePrimary,
+		errorNotice,
+		setPrimaryDomain,
+		showUpdatePrimaryDomainErrorNotice,
+		showUpdatePrimaryDomainSuccessNotice,
+		successNotice,
 	}
 )( localize( withLocalizedMoment( List ) ) );

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -36,6 +36,10 @@ import {
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
+import {
+	showUpdatePrimaryDomainSuccessNotice,
+	showUpdatePrimaryDomainErrorNotice,
+} from 'calypso/state/domains/management/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
 import { getPurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
@@ -54,8 +58,6 @@ import { filterDomainsByOwner } from './helpers';
 import {
 	filterOutWpcomDomains,
 	getDomainManagementPath,
-	showUpdatePrimaryDomainSuccessNotice,
-	showUpdatePrimaryDomainErrorNotice,
 	getSimpleSortFunctionBy,
 	getReverseSimpleSortFunctionBy,
 } from './utils';
@@ -408,10 +410,10 @@ export class SiteDomains extends Component {
 			.then(
 				() => {
 					this.setState( { primaryDomainIndex: -1 } );
-					showUpdatePrimaryDomainSuccessNotice( domainName );
+					this.props.showUpdatePrimaryDomainSuccessNotice( domainName );
 				},
 				( error ) => {
-					showUpdatePrimaryDomainErrorNotice( error.message );
+					this.props.showUpdatePrimaryDomainErrorNotice( error.message );
 					this.setState( { primaryDomainIndex: currentPrimaryIndex } );
 				}
 			)
@@ -447,14 +449,14 @@ export class SiteDomains extends Component {
 					settingPrimaryDomain: false,
 				} );
 
-				showUpdatePrimaryDomainSuccessNotice( domain.name );
+				this.props.showUpdatePrimaryDomainSuccessNotice( domain.name );
 			},
 			( error ) => {
 				this.setState( {
 					settingPrimaryDomain: false,
 					primaryDomainIndex: currentPrimaryIndex,
 				} );
-				showUpdatePrimaryDomainErrorNotice( error.message );
+				this.props.showUpdatePrimaryDomainErrorNotice( error.message );
 			}
 		);
 	};
@@ -528,12 +530,12 @@ export default connect(
 			isFetchingPurchases: isFetchingSitePurchases( state ),
 		};
 	},
-	( dispatch ) => {
-		return {
-			setPrimaryDomain: ( ...props ) => setPrimaryDomain( ...props )( dispatch ),
-			changePrimary: ( domain, mode ) => dispatch( changePrimary( domain, mode ) ),
-			successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
-			errorNotice: ( text, options ) => dispatch( errorNotice( text, options ) ),
-		};
+	{
+		changePrimary,
+		errorNotice,
+		setPrimaryDomain,
+		showUpdatePrimaryDomainErrorNotice,
+		showUpdatePrimaryDomainSuccessNotice,
+		successNotice,
 	}
 )( localize( withLocalizedMoment( SiteDomains ) ) );

--- a/client/my-sites/domains/domain-management/list/utils.js
+++ b/client/my-sites/domains/domain-management/list/utils.js
@@ -1,12 +1,9 @@
-import { translate } from 'i18n-calypso';
 import { type } from 'calypso/lib/domains/constants';
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import {
 	domainManagementEdit,
 	domainManagementSiteRedirect,
 	domainManagementTransferIn,
 } from 'calypso/my-sites/domains/paths';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 export const getDomainManagementPath = ( domainName, domainType, siteSlug, currentRoute ) => {
 	switch ( domainType ) {
@@ -24,28 +21,6 @@ export const getDomainManagementPath = ( domainName, domainType, siteSlug, curre
 export const ListAllActions = {
 	editContactInfo: 'edit-contact-info',
 	editContactEmail: 'edit-contact-email',
-};
-
-export const showUpdatePrimaryDomainSuccessNotice = ( domainName ) => {
-	reduxDispatch(
-		successNotice(
-			translate(
-				'Primary domain changed: all domains will redirect to {{em}}%(domainName)s{{/em}}.',
-				{ args: { domainName }, components: { em: <em /> } }
-			),
-			{ duration: 10000, isPersistent: true }
-		)
-	);
-};
-
-export const showUpdatePrimaryDomainErrorNotice = ( errorMessage ) => {
-	reduxDispatch(
-		errorNotice(
-			errorMessage ||
-				translate( "Something went wrong and we couldn't change your primary domain." ),
-			{ duration: 10000, isPersistent: true }
-		)
-	);
 };
 
 export const filterOutWpcomDomains = ( domains ) => {

--- a/client/state/domains/management/actions.js
+++ b/client/state/domains/management/actions.js
@@ -1,4 +1,5 @@
 import { mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
+import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
 	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
@@ -15,6 +16,7 @@ import {
 	DOMAIN_MANAGEMENT_WHOIS_SAVE_SUCCESS,
 	DOMAIN_MANAGEMENT_WHOIS_UPDATE,
 } from 'calypso/state/action-types';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/domains/init';
 
@@ -164,3 +166,29 @@ export function updateWhois( domain, whoisData ) {
 		whoisData,
 	};
 }
+
+export const showUpdatePrimaryDomainSuccessNotice = ( domainName ) => {
+	return ( dispatch ) => {
+		dispatch(
+			successNotice(
+				translate(
+					'Primary domain changed: all domains will redirect to {{em}}%(domainName)s{{/em}}.',
+					{ args: { domainName }, components: { em: <em /> } }
+				),
+				{ duration: 10000, isPersistent: true }
+			)
+		);
+	};
+};
+
+export const showUpdatePrimaryDomainErrorNotice = ( errorMessage ) => {
+	return ( dispatch ) => {
+		dispatch(
+			errorNotice(
+				errorMessage ||
+					translate( "Something went wrong and we couldn't change your primary domain." ),
+				{ duration: 10000, isPersistent: true }
+			)
+		);
+	};
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We've been removing the remaining instances of `redux-bridge` recently.

This PR removes one of them in the notices of the domain management - where we set the primary domain of a site.

Essentially, we're refactoring the functions that create the notices to thunks and move them where they belong. We also change the consumer components to dispatch them as redux actions.

#### Testing instructions

* Go to the domain management page of a site with a custom domain.
* You should see a **"Your free WordPress.com address is ...."** section - click on the ellipsis on the right side of it.
* Click the button to make it a primary domain.
* Verify you can see a success notice with the right domain name in it.
* Once done, click on the ellipsis on the original domain. Click to make it back primary.
* Verify you can see a success notice with the right domain name in it.
* Block the network request to `/rest/v1.1/sites/12345678/domains/primary?http_envelope=1` where `12345678` is your site ID.
* Try setting the primary domain again.
* Verify you get an error notice, saying **"Something went wrong and we couldn't change your primary domain."**.