### PR TITLE
Reader: Remove `redux-bridge` from `expandCard`

### DIFF
--- a/client/state/reader-ui/card-expansions/actions.js
+++ b/client/state/reader-ui/card-expansions/actions.js
@@ -1,4 +1,3 @@
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import * as stats from 'calypso/reader/stats';
 import {
 	READER_EXPAND_CARD,
@@ -10,18 +9,20 @@ import DISPLAY_TYPES from 'calypso/state/reader/posts/display-types';
 import 'calypso/state/reader-ui/init';
 
 export const expandCard = ( { postKey, post, site } ) => {
-	if ( post.display_type & DISPLAY_TYPES.PHOTO_ONLY ) {
-		stats.recordTrackForPost( 'calypso_reader_photo_expanded', post );
-	} else if ( post.display_type & DISPLAY_TYPES.FEATURED_VIDEO ) {
-		stats.recordTrackForPost( 'calypso_reader_video_expanded', post );
-	}
-	stats.recordTrackForPost( 'calypso_reader_article_opened', post );
+	return ( dispatch ) => {
+		if ( post.display_type & DISPLAY_TYPES.PHOTO_ONLY ) {
+			stats.recordTrackForPost( 'calypso_reader_photo_expanded', post );
+		} else if ( post.display_type & DISPLAY_TYPES.FEATURED_VIDEO ) {
+			stats.recordTrackForPost( 'calypso_reader_video_expanded', post );
+		}
+		stats.recordTrackForPost( 'calypso_reader_article_opened', post );
 
-	// Record page view
-	reduxDispatch( markPostSeen( post, site ) );
-	return {
-		type: READER_EXPAND_CARD,
-		payload: { postKey },
+		// Record page view
+		dispatch( markPostSeen( post, site ) );
+		dispatch( {
+			type: READER_EXPAND_CARD,
+			payload: { postKey },
+		} );
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We've been removing the remaining instances of `redux-bridge` recently.

This PR removes it from the `expandCard` action creator, part of the Reader. It basically converts `expandCard` from an action creator to an action thunk. That allows us to use `dispatch` over the `markPostSeen()` action directly, rather than unnecessarily include it from `redux-bridge`.

#### Testing instructions

* Go to `/read/list/automattic/a12s`
* Find a post that consists only of the image. 
* Click on the image and verify it enlarges.