### PR TITLE
Restrict domain transfer actions to the domain owner

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
@@ -33,25 +33,37 @@ class TransferInDomainType extends Component {
 
 	renderPendingStart() {
 		const { domain, translate } = this.props;
+		const { currentUserIsOwner } = domain;
 
 		return (
 			<>
 				<p>
-					{ translate(
-						'We need you to complete a couple of steps before we can transfer %(domain)s from your ' +
-							'current domain provider to WordPress.com. Your domain will stay at your current provider ' +
-							'until the transfer is completed.',
-						{
-							args: {
-								domain: domain.name,
-							},
-						}
-					) }
+					{ currentUserIsOwner
+						? translate(
+								'We need you to complete a couple of steps before we can transfer %(domain)s from your ' +
+									'current domain provider to WordPress.com. Your domain will stay at your current provider ' +
+									'until the transfer is completed.',
+								{
+									args: {
+										domain: domain.name,
+									},
+								}
+						  )
+						: translate(
+								'This domain transfer is waiting to be initiated. Please contact the domain owner to start it.',
+								{
+									args: {
+										domain: domain.name,
+									},
+								}
+						  ) }
 				</p>
 
-				<Button primary onClick={ this.startTransfer }>
-					{ translate( 'Start transfer' ) }
-				</Button>
+				{ currentUserIsOwner && (
+					<Button primary onClick={ this.startTransfer }>
+						{ translate( 'Start transfer' ) }
+					</Button>
+				) }
 			</>
 		);
 	}
@@ -72,33 +84,45 @@ class TransferInDomainType extends Component {
 
 	renderTransferFailed() {
 		const { domain, translate } = this.props;
+		const { currentUserIsOwner } = domain;
 
 		return (
 			<>
 				<p>
-					{ translate(
-						'We were unable to complete the transfer of {{strong}}%(domain)s{{/strong}}. ' +
-							'You can remove the transfer from your account or try to start the transfer again. ' +
-							'{{a}}Learn more{{/a}}',
-						{
-							args: {
-								domain: domain.name,
-							},
-							components: {
-								strong: <strong />,
-								a: (
-									<a
-										href={ INCOMING_DOMAIN_TRANSFER_STATUSES }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
+					{ currentUserIsOwner
+						? translate(
+								'We were unable to complete the transfer of {{strong}}%(domain)s{{/strong}}. ' +
+									'You can remove the transfer from your account or try to start the transfer again. ' +
+									'{{a}}Learn more{{/a}}',
+								{
+									args: {
+										domain: domain.name,
+									},
+									components: {
+										strong: <strong />,
+										a: (
+											<a
+												href={ INCOMING_DOMAIN_TRANSFER_STATUSES }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+						  )
+						: translate(
+								'This domain transfer failed to complete. Please contact the domain owner to restart it.',
+								{
+									args: {
+										domain: domain.name,
+									},
+								}
+						  ) }
 				</p>
 
-				<Button onClick={ this.startTransfer }>{ translate( 'Start transfer again' ) }</Button>
+				{ currentUserIsOwner && (
+					<Button onClick={ this.startTransfer }>{ translate( 'Start transfer again' ) }</Button>
+				) }
 			</>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
@@ -50,20 +50,21 @@ class TransferInDomainType extends Component {
 								}
 						  )
 						: translate(
-								'This domain transfer is waiting to be initiated. Please contact the domain owner to start it.',
+								'This domain transfer is waiting to be initiated. Please contact the domain owner, {{strong}}%(owner)s{{/strong}}, to start it.',
 								{
 									args: {
-										domain: domain.name,
+										owner: domain.owner,
+									},
+									components: {
+										strong: <strong />,
 									},
 								}
 						  ) }
 				</p>
 
-				{ currentUserIsOwner && (
-					<Button primary onClick={ this.startTransfer }>
-						{ translate( 'Start transfer' ) }
-					</Button>
-				) }
+				<Button disabled={ ! currentUserIsOwner } primary onClick={ this.startTransfer }>
+					{ translate( 'Start transfer' ) }
+				</Button>
 			</>
 		);
 	}
@@ -111,18 +112,21 @@ class TransferInDomainType extends Component {
 								}
 						  )
 						: translate(
-								'This domain transfer failed to complete. Please contact the domain owner to restart it.',
+								'The domain transfer failed to complete. Please contact the domain owner, {{strong}}%(owner)s{{/strong}}, to restart it.',
 								{
 									args: {
-										domain: domain.name,
+										owner: domain.owner,
+									},
+									components: {
+										strong: <strong />,
 									},
 								}
 						  ) }
 				</p>
 
-				{ currentUserIsOwner && (
-					<Button onClick={ this.startTransfer }>{ translate( 'Start transfer again' ) }</Button>
-				) }
+				<Button disabled={ ! currentUserIsOwner } onClick={ this.startTransfer }>
+					{ translate( 'Start transfer again' ) }
+				</Button>
 			</>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -476,29 +476,33 @@ class DomainManagementNavigationEnhanced extends Component {
 	getDeleteDomain() {
 		const { domain, isLoadingPurchase, purchase, selectedSite, translate } = this.props;
 		const domainType = domain && domain.type;
+		const currentUserIsOwner = domain.currentUserIsOwner;
 
 		if ( ! domain.currentUserCanManage ) {
 			return null;
 		}
 
 		let title;
+		let description;
 
 		if ( domainTypes.TRANSFER === domainType ) {
 			const status = domain.transferStatus;
-			const currentUserIsOwner = domain.currentUserIsOwner;
 
-			if (
-				transferStatus.PENDING_OWNER === status ||
-				transferStatus.PENDING_REGISTRY === status ||
-				! currentUserIsOwner
-			) {
+			if ( transferStatus.PENDING_OWNER === status || transferStatus.PENDING_REGISTRY === status ) {
 				return null;
 			}
 
 			if ( status === transferStatus.CANCELLED ) {
 				title = translate( 'Remove transfer from your account' );
+				if ( ! currentUserIsOwner ) {
+					title = translate( 'Remove transfer' );
+					description = translate( 'Only the domain owner can remove the transfer' );
+				}
 			} else {
 				title = translate( 'Cancel transfer' );
+				if ( ! currentUserIsOwner ) {
+					description = translate( 'Only the domain owner can cancel the transfer' );
+				}
 			}
 		} else if ( domainTypes.MAPPED === domainType ) {
 			title = translate( 'Delete domain mapping' );
@@ -514,6 +518,12 @@ class DomainManagementNavigationEnhanced extends Component {
 
 		if ( ! selectedSite || ! purchase ) {
 			return null;
+		}
+
+		if ( ! currentUserIsOwner ) {
+			return (
+				<VerticalNavItemEnhanced materialIcon="delete" text={ title } description={ description } />
+			);
 		}
 
 		if ( isCancelable( purchase ) ) {

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -485,8 +485,13 @@ class DomainManagementNavigationEnhanced extends Component {
 
 		if ( domainTypes.TRANSFER === domainType ) {
 			const status = domain.transferStatus;
+			const currentUserIsOwner = domain.currentUserIsOwner;
 
-			if ( transferStatus.PENDING_OWNER === status || transferStatus.PENDING_REGISTRY === status ) {
+			if (
+				transferStatus.PENDING_OWNER === status ||
+				transferStatus.PENDING_REGISTRY === status ||
+				! currentUserIsOwner
+			) {
 				return null;
 			}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

When a transfer sub is `PENDING_START` (or `CANCELLED`), we should only show the **Start Transfer** (or **Start Transfer Again**) button for domain owners. Non-owners won't actually be able to start the transfer anyway, so we shouldn't let them even try.

I disabled  **cancel**/**start**/**restart** actions for a domain transfer when the user doesn't own the domain.

## Testing instructions

This PR depends on D70570-code

In order to test this PR, you will need to have two domains in state `PENDING_START` and state `CANCELLED` respectively, and you must not be the domains owner.

* for the `PENDING_START` domain, verify that **Start transfer** button and **Cancel transfer** link are disabled
* for the `CANCELLED` domain, verify that **Start transfer again** button and **Remove transfer** link are disabled
* please verify also that copy matches the one showed in the screenshots.
 
![transfer-pending-start-before](https://user-images.githubusercontent.com/2797601/143050565-256bd0c5-9a75-44d8-964c-26b9b2400a4a.png)

![transfer-pending-start-after](https://user-images.githubusercontent.com/2797601/143247245-90ab2371-5eb3-4727-a2f8-de91aa882a9d.png)

![transfer-cancelled-before](https://user-images.githubusercontent.com/2797601/143048858-fd8c340c-209a-423c-b3f5-85eced015957.png)

![transfer-cancelled-after](https://user-images.githubusercontent.com/2797601/143247798-0bb01dd4-3216-4a2b-8ac4-682b2eb7b0ca.png)