### PR TITLE
Add sign in with different user feature in Jetpack connection flow

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -702,6 +702,7 @@ export class JetpackAuthorize extends Component {
 		const { translate } = this.props;
 		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
 		const { from } = this.props.authQuery;
+		const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
 
 		if ( this.retryingAuth || isAuthorizing || authorizeSuccess || this.redirecting ) {
 			return null;
@@ -714,19 +715,23 @@ export class JetpackAuthorize extends Component {
 
 		return (
 			<LoggedOutFormLinks>
-				{ this.renderBackToWpAdminLink() }
+				{ ! isJetpackMagicLinkSignUpFlow && this.renderBackToWpAdminLink() }
 				<LoggedOutFormLinkItem
 					href={ login( { isJetpack: true, redirectTo: window.location.href, from } ) }
 					onClick={ this.handleSignIn }
 				>
 					{ translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
-				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
-					{ translate( 'Create a new account' ) }
-				</LoggedOutFormLinkItem>
-				<JetpackConnectHappychatButton eventName="calypso_jpc_authorize_chat_initiated">
-					<HelpButton />
-				</JetpackConnectHappychatButton>
+				{ ! isJetpackMagicLinkSignUpFlow && (
+					<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
+						{ translate( 'Create a new account' ) }
+					</LoggedOutFormLinkItem>
+				) }
+				{ ! isJetpackMagicLinkSignUpFlow && (
+					<JetpackConnectHappychatButton eventName="calypso_jpc_authorize_chat_initiated">
+						<HelpButton />
+					</JetpackConnectHappychatButton>
+				) }
 			</LoggedOutFormLinks>
 		);
 	}
@@ -820,9 +825,6 @@ export class JetpackAuthorize extends Component {
 	render() {
 		const { translate } = this.props;
 		const wooDna = this.getWooDnaConfig();
-
-		const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
-
 		const authSiteId = this.props.authQuery.clientId;
 
 		return (
@@ -852,7 +854,7 @@ export class JetpackAuthorize extends Component {
 							{ this.renderNotices() }
 							{ this.renderStateAction() }
 						</Card>
-						{ ! isJetpackMagicLinkSignUpFlow && this.renderFooterLinks() }
+						{ this.renderFooterLinks() }
 					</div>
 				</div>
 			</MainWrapper>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds back the ability to sign in with a different account when connecting a Jetpack site.

Fixes 1164141197617539-as-1201318004834207

### Testing instructions

- Download the PR and run Calypso
- Select a self-hosted site that is not connected to Jetpack yet
- From the WP admin, start the connection process, and stop at the authorization screen (see below)
- Copy the URL, and replace `wordpress.com` with `calypso.localhost:3000`
- Check that you see the option to sign in with a different user

### Screenshots
<img width="493" alt="Screen Shot 2021-11-23 at 11 19 03 AM" src="https://user-images.githubusercontent.com/1620183/143063317-c97ca174-e236-4cb7-9b39-22c2ed690a3f.png">



