### PR TITLE
Restore: Hide Intro Banner on Pricing Page During Sale

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -1,19 +1,16 @@
 import { useTranslate } from 'i18n-calypso';
+import * as React from 'react';
+import { useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
-import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
+import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 
 import './style.scss';
 
 const Header: React.FC< Props > = () => {
 	const translate = useTranslate();
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_jetpack_pricing_page_without_money_back_banner'
-	);
-
-	const suppressIntroBanner =
-		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'treatment';
+	const hasJetpackSaleCoupon = useSelector( getJetpackSaleCoupon );
 
 	return (
 		<>
@@ -27,7 +24,7 @@ const Header: React.FC< Props > = () => {
 				/>
 			</div>
 
-			{ ! suppressIntroBanner && <IntroPricingBanner /> }
+			{ ! hasJetpackSaleCoupon && <IntroPricingBanner /> }
 		</>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restore hiding the "introductory offer" during a sale on the Jetpack Pricing Page

| **Before**  | **After** |
| ------------- | ------------- |
| ![Screen Shot 2021-11-23 at 08 45 17](https://user-images.githubusercontent.com/2810519/143067270-e69bef10-3298-4a2a-8021-509b17da89cb.png)  |  ![Screen Shot 2021-11-23 at 08 44 28](https://user-images.githubusercontent.com/2810519/143067344-16a92e77-fad9-4041-bcb9-5a9c89006f24.png)  |

#### Testing instructions

1. Boot branch on Calypso Green
2. Navigate to the Pricing Page
3. Verify that the introductory banner is hidden as in the "After" screenshot above
