### PR TITLE
use-external-contributors: Add staleTime to prevent API spam

### DIFF
--- a/client/data/external-contributors/use-external-contributors.js
+++ b/client/data/external-contributors/use-external-contributors.js
@@ -10,11 +10,12 @@ const useExternalContributorsQuery = ( siteId, queryOptions = {} ) => {
 				apiNamespace: 'wpcom/v2',
 			} ),
 		{
-			...queryOptions,
 			enabled: !! siteId,
 			// The external contributors endpoint can be a little slow, so don't
 			// retry too soon if it is taking a while.
 			retryDelay: 2000,
+			staleTime: 1000 * 60 * 3, // 3 minutes
+			...queryOptions,
 		}
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When scrolling down the infinite list of users on a `/people/team/<P2URL>` page, stop the application from making duplicate requests to the `/sites/${ siteId }/external-contributors` endpoint.

#### Testing instructions

* Visit `/people/team/<P2URL>` on a site without this branch. It should be a P2 with 100+ members.
* You should see the list of users. Open the network tab in devtools, and set filtering to `Fetch/XHR` and the string `external`.
* Scroll down through the list of users. Infinite scroll should kick in as you scroll downward.
* As you scroll, you should see the application making constant requests to the `external-contributors` endpoint. As soon as one request finishes, it makes another.

https://user-images.githubusercontent.com/937354/143067751-191ecb85-a202-483b-a960-56735d2c62e1.mp4

* Apply the PR and take the same steps.
* You should only see 1 or 2 requests to the `external-contributors` endpoint, instead of endless requests as you scroll.

#### Explanation

* Each site has a list of "external-contributors", which is users that have the "Is a Contractor" checkbox checked.
* The PeopleProfile uses a hook using react-query to pull this information in: https://github.com/Automattic/wp-calypso/blob/427fb827098f09535bbc81198bb3eb0f1596f988/client/my-sites/people/people-profile/index.jsx#L22
* The react-query has a cacheKey including the siteId, which makes you think it would only fetch once for each site: https://github.com/Automattic/wp-calypso/blob/427fb827098f09535bbc81198bb3eb0f1596f988/client/data/external-contributors/use-external-contributors.js#L6
* However, it's clearly fetching for each user as you scroll down the list. Why?
  * Checking the [useQuery reference](https://react-query.tanstack.com/reference/useQuery), `staleTime` defaults to `0` which means all data is considered stale after fetching. Which is usually not a big deal, but `refetchOnMount` defaults to `true`, which means `the query will refetch on mount if the data is stale`. As we scroll down the infinite list, we are constantly mounting new dom elements representing users, which is refetching the stale data.
  * My solution here is to make the data stay fresh for a few minutes, so it won't be refreshed as we scroll down the list.
  * The other parts of the system used for managing this status don't currently use the react-query hook, so they won't be affected by this.
* I also moved `...queryOptions` to the bottom of the options, allowing options specified at the callsite to override the default options in the query file.

I noticed this while investigating #58088.
