### PR TITLE
Site Editor e2e - dismiss new welcome guide where necessary (fix failures for Gutenberg 12.0).

### DIFF
--- a/test/e2e/lib/components/guide-component.js
+++ b/test/e2e/lib/components/guide-component.js
@@ -15,6 +15,15 @@ export default class GuideComponent extends AsyncBaseContainer {
 				waitOverride
 			)
 		) {
+			// If the guide has a close button, use this to dismiss.
+			const closeButtonSelector = By.css(
+				'.components-guide .components-button[aria-label="Close dialog"]'
+			);
+			if ( await driverHelper.isElementLocated( this.driver, closeButtonSelector ) ) {
+				return await driverHelper.clickWhenClickable( this.driver, closeButtonSelector );
+			}
+
+			// For when there is no close button present.
 			try {
 				// Easiest way to dismiss it, but it might not work in IE.
 				await this.driver.findElement( By.css( selector ) ).sendKeys( Key.ESCAPE );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -7,6 +7,7 @@ import { By, Key } from 'selenium-webdriver';
 /**
  * Internal dependencies
  */
+import GuideComponent from '../../lib/components/guide-component.js';
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import SiteEditorComponent from '../../lib/components/site-editor-component.js';
 import * as dataHelper from '../../lib/data-helper.js';
@@ -344,6 +345,9 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			await editor.waitForTemplateToLoad();
 			await editor.waitForTemplatePartsToLoad();
 			await deleteTemplatesAndTemplateParts( this.driver );
+
+			const welcomeGuide = new GuideComponent( this.driver );
+			await welcomeGuide.dismiss( 4000 );
 		} );
 
 		it( 'should skip tracking "wpcom_block_editor_nav_sidebar_item_edit" when editor just loaded (no query params)', async function () {
@@ -366,6 +370,10 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 					assert.strictEqual( globalStylesToggleEvents.length, 1 );
 					const [ , eventData ] = globalStylesToggleEvents[ 0 ];
 					assert.strictEqual( eventData.open, true );
+
+					// Dismiss the Global Styles welcome guide if present.
+					const welcomeGuide = new GuideComponent( this.driver );
+					await welcomeGuide.dismiss( 4000 );
 				} );
 
 				it( 'when Global Styles sidebar is closed', async function () {


### PR DESCRIPTION
To unblock failing tests for the next Gutenberg release cycle for 12.0 (related issue #58280), this PR dismisses the new core welcome guide where appropriate so that tests no longer fail due to clicks being intercepted by the modal.

* The `GuideComponent` is updated to allow more simple dismissing of the guide when a close button is available.  Previous guides did not have close buttons on the front page, and the component falls back to its previous functionality when the close button is not present.
* The Site editor tracking test is updated to dismiss the guides when they appear (when the editor is first loaded and when the global styles panel is first opened).

#### Testing
* The`wp-calypso-gutenberg-site-editor-tracking-spec.js` should no longer fail due to the modal intercepting clicks.
* Post/page editor specs are unaffected.