### PR TITLE
Fix the "tested up to" field value on Plugin Details page.

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -90,6 +90,7 @@ export function getAllowedPluginData( plugin ) {
 		'slug',
 		'support_URL',
 		'tags',
+		'tested',
 		'update',
 		'updating',
 		'version',

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -328,7 +328,7 @@ function PluginDetails( props ) {
 								<div className="plugin-details__tested-text title">
 									{ translate( 'Tested up to' ) }
 								</div>
-								<div className="plugin-details__tested-value value">{ fullPlugin.version }</div>
+								<div className="plugin-details__tested-value value">{ fullPlugin.tested }</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the `tested` field on the allowed plugin data to be read.
* Show the `tested` value on the `Tested up to` field.

#### Testing instructions

* Go to `/plugins` page
* Click in one plugin to go to Plugin Details page.
* Check if the value of the  `Tested up to` field differs from the `version` field.

![Screen Shot 2021-11-23 at 13 41 12](https://user-images.githubusercontent.com/5039531/143077383-abce6b8a-ade9-4683-ad8b-4850e0aa5578.png)

---

Fixes #58283
