### PR TITLE
Update the TOS text on Plugin Details page.

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -270,7 +270,18 @@ function PluginDetails( props ) {
 							</div>
 							<div className="plugin-details__t-and-c">
 								{ translate(
-									'By installing, you agree to WordPress.com’s Terms of Service and the Third-Party plug-in Terms.'
+									'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the Third-Party plugin Terms.',
+									{
+										components: {
+											a: (
+												<a
+													target="_blank"
+													rel="noopener noreferrer"
+													href="https://wordpress.com/tos/"
+												/>
+											),
+										},
+									}
 								) }
 							</div>
 						</div>


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Add a link to WordPress.com’s Terms of Service.
* Use the word "plugin" instead of "plug-in".

#### Testing instructions

* Go to `/plugins` page with a selected site
* Click in a not installed plugin to go to Plugin Details page.
* Verify if the text below the CTA shows a link to WordPress.com TOS.
* Click on the link and check if it opens a new tab on https://wordpress.com/tos/
![Screen Shot 2021-11-23 at 14 34 03](https://user-images.githubusercontent.com/5039531/143083980-842fb66e-f8c8-4620-a0d3-0151d02e6f34.png)



---

Fixes #58287
