### PR TITLE
[o2-blocks] Add paste-handler to auto-infer spoiler content from HTML

### DIFF
--- a/apps/o2-blocks/src/spoiler/editor.jsx
+++ b/apps/o2-blocks/src/spoiler/editor.jsx
@@ -2,6 +2,7 @@ import { RichText } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+import { transforms } from './transform';
 
 const blockAttributes = {
 	summary: {
@@ -90,6 +91,7 @@ registerBlockType( 'a8c/spoiler', {
 	attributes: blockAttributes,
 	edit,
 	save,
+	transforms,
 	deprecated: [
 		{
 			attributes: blockAttributes_v1,

--- a/apps/o2-blocks/src/spoiler/transform.js
+++ b/apps/o2-blocks/src/spoiler/transform.js
@@ -1,0 +1,30 @@
+import { createBlock, rawHandler } from '@wordpress/blocks';
+
+export const transforms = {
+	from: [
+		{
+			type: 'raw',
+			isMatch: ( node ) => node.nodeName === 'DETAILS' && node.querySelector( 'summary' ) !== null,
+			schema: ( { phrasingContentSchema } ) => ( {
+				details: {
+					children: {
+						...phrasingContentSchema,
+						summary: { children: phrasingContentSchema },
+					},
+				},
+			} ),
+			transform( node ) {
+				const summary = node.querySelector( 'summary' );
+				node.removeChild( summary );
+
+				return createBlock(
+					'a8c/spoiler',
+					{
+						summary: summary.innerHTML,
+					},
+					rawHandler( { HTML: node.innerHTML } )
+				);
+			},
+		},
+	],
+};


### PR DESCRIPTION
Resolves #58144

Previously the only way to create a spoiler block was to manually create
one through the block inserter or slash-code.

In this patch we're introducing a new `raw` transform to the block which
will infer the spoiler block when pasting or performing "Convert to Blocks"
on a classic block or raw HTML. To infer the struture it looks for
the `<details><summary>Click to reveal!</summary>Spoiler alert!</details>`
pattern as evident in the new `transform`.

![spoilerBlockPasteHandling mov](https://user-images.githubusercontent.com/5431237/143086361-0c5e471b-8ce1-4aa4-9a06-072ccc1cd441.gif)

### Testing

You'll need to test the build of these blocks on your local dev sandbox.
Reach out to me in Slack if you want help figuring out how to do this.

**Note** Gutenberg has two separate modes for paste handling. One is
"inline" and the other isn't, and this is based on whether there's a newline
in the pasted text and if there's no `html` MIME type. I've had quite a hassle
testing this locally because I was confused by the different ways to paste.

Here is a test string that should produce a spoiler block:
```html
<details><summary>Title here</summary> content here</details>

```

Here is another:
```html
<details>
    <summary>Title again</summary>
    <strong>Wow!</strong> What a spoiler…
</details>
```

Here is one that shouldn't:
`<details><summary>Title here</summary> content here</details>`

For either case, if you end up with a classic block or raw HTML you should
be able to successfully create a spoiler block by clicking on `Convert to Blocks`

#### How to infer spoilers:
 - Paste the HTML with the newline
 - Paste the HTML without any newlines, then convert the created classic block to blocks
 - Paste ay of the HTML snippets into the code editor, flip back to the visual editor, convert as needed

We're looking to stress the system but don't need to worry too much about perfection.
This shouldn't crash and it should make the spoiler block for common situations.

Thanks for the reviews!