### PR TITLE
Update the last updated date format on Plugin Details page.

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -229,9 +229,7 @@ function PluginDetails( props ) {
 								<div className="plugin-details__info">
 									<div className="plugin-details__info-title">{ translate( 'Last updated' ) }</div>
 									<div className="plugin-details__info-value">
-										{ moment
-											.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' )
-											.format( 'YYYY-MM-DD' ) }
+										{ moment.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' ).format( 'LL' ) }
 									</div>
 								</div>
 								<div className="plugin-details__info">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the date format from `YYYY-MM-DD` to `LL`  that displays as `month name, day of month, year`

#### Testing instructions


* Go to `/plugins` page
* Click in one plugin to go to Plugin Details page.
* Verify if the date is displayed as the `after` section below

|Before | After|
|-------|------|
|![Screen Shot 2021-11-23 at 14 58 39](https://user-images.githubusercontent.com/5039531/143088845-7b8d6a86-17b2-4376-846d-48dc008c3954.png)|![Screen Shot 2021-11-23 at 14 58 07](https://user-images.githubusercontent.com/5039531/143088862-67264035-3026-496e-8489-3292f9c8615e.png)|

---

Fixes #58285