### PR TITLE
E2E: update Editor: Basic Post Flow spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -251,8 +251,11 @@ export class GutenbergEditorPage {
 	}
 
 	/**
+	 * Remove the block from the editor.
 	 *
-	 * @param blockEditorSelector
+	 * This method requires the handle to the block in question to be passed in as parameter.
+	 *
+	 * @param {ElementHandle} blockHandle ElementHandle of the block to be removed.
 	 */
 	async removeBlock( blockHandle: ElementHandle ): Promise< void > {
 		await blockHandle.click();

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -251,6 +251,15 @@ export class GutenbergEditorPage {
 	}
 
 	/**
+	 *
+	 * @param blockEditorSelector
+	 */
+	async removeBlock( blockHandle: ElementHandle ): Promise< void > {
+		await blockHandle.click();
+		await this.page.keyboard.press( 'Backspace' );
+	}
+
+	/**
 	 * Open the block inserter panel.
 	 *
 	 * @returns {Promise<void>} No return value.
@@ -465,8 +474,11 @@ export class GutenbergEditorPage {
 	 * Click on the `Preview` button on the editor toolbar, then select requested the preview option.
 	 *
 	 * This method interacts with the non-mobile implementation of the editor preview,
-	 * which applies an attribute to the editor to simulate target device.
+	 * which applies an attribute to the editor to simulate the preview environment.
 	 *
+	 * Additionally, this method only works in the desktop browser environment; in a mobile
+	 * environment, the Preview button will launch a new page. For mobile, use
+	 * `GutenbergEditorPage.openPreviewAsMobile` instead.
 	 *
 	 * @param {PreviewOptions} target Preview option to be selected.
 	 * @throws {Error} If environment is 'mobile'.
@@ -478,7 +490,8 @@ export class GutenbergEditorPage {
 		const frame = await this.getEditorFrame();
 		await frame.click( selectors.previewButton );
 		await frame.click( selectors.previewMenuItem( target ) );
-		await frame.waitForSelector( selectors.previewPane( target ) );
+		const handle = await frame.waitForSelector( selectors.previewPane( target ) );
+		await handle.waitForElementState( 'stable' );
 	}
 
 	/**
@@ -486,6 +499,10 @@ export class GutenbergEditorPage {
 	 *
 	 * This method will click on the Preview button if required, then select the `Desktop` entry,
 	 * which is the default view setting when the editor is opened initially.
+	 *
+	 * Additionally, this method only works in the desktop browser environment; in a mobile
+	 * environment, the Preview button would have launched a new page. For mobile, close
+	 * the new page instead.
 	 *
 	 * @throws {Error} If environment is 'mobile'.
 	 */
@@ -495,19 +512,11 @@ export class GutenbergEditorPage {
 		}
 		const frame = await this.getEditorFrame();
 
-		const previewButtonHandle = await frame.waitForSelector( selectors.previewButton );
-		// Check if the Preview button has been clicked and that menu options are showing.
-		// If required, click and show the menu items so that 'Desktop' can be clicked.
-		if ( ( await previewButtonHandle.getAttribute( 'aria-expanded' ) ) === 'false' ) {
-			await frame.click( selectors.previewButton );
-		}
-		// Select 'Desktop'.
-		await frame.click( selectors.previewMenuItem( 'Desktop' ) );
-		// Dismiss the Preview button.
-		await previewButtonHandle.click();
+		// Restore the editor view to Desktop size.
+		await this.openPreviewAsDesktop( 'Desktop' );
 
-		// Ensure the preview menu is closed and that preview settings are back to default.
-		await frame.waitForSelector( 'button[aria-expanded=false]' );
+		// Ensure the preview menu is closed and that preview settings are back to default (Desktop).
+		await frame.waitForSelector( `${ selectors.previewButton }[aria-expanded=false]` );
 		await frame.waitForSelector( selectors.previewPane( 'Desktop' ) );
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -13,9 +13,10 @@ import {
 	NewPostFlow,
 	setupHooks,
 	PublishedPostPage,
+	ImageBlock,
 	skipItIf,
 } from '@automattic/calypso-e2e';
-import { Page } from 'playwright';
+import { Page, ElementHandle } from 'playwright';
 
 const quote =
 	'The problem with quotes on the Internet is that it is hard to verify their authenticity. \n— Abraham Lincoln';
@@ -36,7 +37,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		page = args.page;
 	} );
 
-	describe( 'Starting and populating post data', function () {
+	describe( 'Block editor', function () {
+		let blockHandle: ElementHandle;
+
 		it( 'Log in', async function () {
 			const loginPage = new LoginPage( page );
 			await loginPage.login( { account: user } );
@@ -54,6 +57,17 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		it( 'Enter post text', async function () {
 			await gutenbergEditorPage.enterText( quote );
+		} );
+
+		it( 'Add image block', async function () {
+			blockHandle = await gutenbergEditorPage.addBlock(
+				ImageBlock.blockName,
+				ImageBlock.blockEditorSelector
+			);
+		} );
+
+		it( 'Remove image block', async function () {
+			await gutenbergEditorPage.removeBlock( blockHandle );
 		} );
 
 		it( 'Open editor settings sidebar for post', async function () {
@@ -87,9 +101,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		// Editor Preview behaves depends on the device type.
 		// On desktop and tablet, preview applies CSS attributes to modify the preview in-editor.
 		// On mobile web, preview button opens a new tab.
-
-		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
-		skipItIf( targetDevice !== 'mobile' )( 'Launch preview', async function () {
+		it( 'Launch preview', async function () {
 			if ( BrowserHelper.getTargetDeviceName() === 'mobile' ) {
 				previewPage = await gutenbergEditorPage.openPreviewAsMobile();
 			} else {
@@ -97,8 +109,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			}
 		} );
 
-		// TODO: step skipped for non-mobile due to https://github.com/Automattic/wp-calypso/issues/57128.
-		skipItIf( targetDevice !== 'mobile' )( 'Close preview', async function () {
+		it( 'Close preview', async function () {
 			// Mobile path.
 			if ( previewPage ) {
 				await previewPage.close();
@@ -108,7 +119,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			}
 		} );
 
-		// TODO: step skipped for mobile, since previewing naturally saves the post, rendering this step unnecessary.
+		// Step skipped for mobile, since previewing naturally saves the post, rendering this step unnecessary.
 		skipItIf( targetDevice === 'mobile' )( 'Save draft', async function () {
 			await gutenbergEditorPage.saveDraft();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new test step to the Editor: Basic Post Flow spec and re-enables the Preview steps.

Key changes:
- implement method in `GutenbergEditorPage` to remove a block.
- add new steps to test removal of a block from the editor to fulfill https://github.com/Automattic/wp-calypso/issues/55642.
- re-enable the Preview steps as https://github.com/Automattic/wp-calypso/issues/57128 has been fixed.
- refactor the preview-related methods.

#### Testing instructions

- [x] normal tests
  - [x] desktop
  - [x] mobile

Closes #55642
