### PR TITLE
Prevent JS error in Jetpack connection flow

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -105,6 +105,7 @@ export function partnerCouponRedirects( context, next ) {
 
 	if ( ! partnerCoupon || ! partnerCoupon.includes( '_' ) ) {
 		next();
+		return;
 	}
 
 	// All partner coupons assumes a logic like {PARTNER}_{PRESET}_abc123.
@@ -122,6 +123,7 @@ export function partnerCouponRedirects( context, next ) {
 		! JETPACK_COUPON_PRESET_MAPPING.hasOwnProperty( splitCoupon[ 1 ] )
 	) {
 		next();
+		return;
 	}
 
 	const state = context.store.getState();


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes a bug that prevented from completing the Jetpack connection flow.

The issue was introduced in this #58177.

### Testing instructions

- Download the PR and run Calypso
- Select a self-hosted site that is not connected to Jetpack yet
- Open the browser console
- From the site WP admin, start the connection process, and stop at the authorization screen
- Copy the URL, and replace `wordpress.com` with `calypso.localhost:3000`
- Verify that you can complete the connection flow, including choosing a plan in the pricing page
- Check that no exception was raised in the console in the pricing page

