### PR TITLE
Signup: Do not continue to checkout if there are errors when adding cart products

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -469,8 +469,8 @@ function processItemCart(
 				} )
 				.catch( ( error ) => {
 					debug( 'product add request had an error', error );
-					reduxStore.dispatch( errorNotice( error.message, { isPersistent: true } ) );
-					callback( error.message, providedDependencies );
+					reduxStore.dispatch( errorNotice( error.message ) );
+					callback( error, providedDependencies );
 				} );
 		} else {
 			debug( 'no cart items to add' );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -458,6 +458,11 @@ function processItemCart(
 						callback( updatedCart.messages.errors[ 0 ].message, providedDependencies );
 						return;
 					}
+					const error = cartManagerClient.forCartKey( siteSlug ).getState().loadingError;
+					if ( error ) {
+						callback( error, providedDependencies );
+						return;
+					}
 					callback( undefined, providedDependencies );
 				} )
 				.catch( ( error ) => callback( error, providedDependencies ) );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -452,7 +452,14 @@ function processItemCart(
 			cartManagerClient
 				.forCartKey( siteSlug )
 				.actions.addProductsToCart( newCartItemsToAdd )
-				.then( () => callback( undefined, providedDependencies ) )
+				.then( ( updatedCart ) => {
+					// Even if the cart request succeeds, there may be errors
+					if ( updatedCart.messages?.errors && updatedCart.messages.errors.length > 0 ) {
+						callback( updatedCart.messages.errors[ 0 ].message, providedDependencies );
+						return;
+					}
+					callback( undefined, providedDependencies );
+				} )
 				.catch( ( error ) => callback( error, providedDependencies ) );
 		} else {
 			callback( undefined, providedDependencies );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -26,6 +26,7 @@ import {
 	getSelectedImportEngine,
 	getNuxUrlInputValue,
 } from 'calypso/state/importer-nux/temp-selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
@@ -468,7 +469,8 @@ function processItemCart(
 				} )
 				.catch( ( error ) => {
 					debug( 'product add request had an error', error );
-					callback( error, providedDependencies );
+					reduxStore.dispatch( errorNotice( error.message, { isPersistent: true } ) );
+					callback( error.message, providedDependencies );
 				} );
 		} else {
 			debug( 'no cart items to add' );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -11,6 +11,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import MarketingMessage from 'calypso/components/marketing-message';
+import Notice from 'calypso/components/notice';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
@@ -136,8 +137,20 @@ export class PlansStep extends Component {
 			isReskinned,
 		} = this.props;
 
+		let errorDisplay;
+		if ( 'invalid' === this.props.step?.status ) {
+			errorDisplay = (
+				<div>
+					<Notice status="is-error" showDismiss={ false }>
+						{ this.props.step.errors.message }
+					</Notice>
+				</div>
+			);
+		}
+
 		return (
 			<div>
+				{ errorDisplay }
 				<QueryPlans />
 				<PlansFeaturesMain
 					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -34,6 +34,8 @@ The `UseShoppingCart` object contains the following properties. Note that the ac
 
 The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
 
+**Note that the Promise returned by cart actions will never be rejected.** If there are errors returned by the shopping-cart response, they will be in the `messages.errors` property of the returned `ResponseCart`. If the cart request itself fails, the `loadingError` property will be set on the cart manager.
+
 - `addProductsToCart: ( products: RequestCartProduct[] ) => Promise<ResponseCart>`. A function that requests adding new products to the cart. May cause the cart to be replaced instead, depending on the RequestCartProducts (mostly renewals and non-renewals cannot co-exist in the cart at the same time).
 - `removeProductFromCart: ( uuidToRemove: string ) => Promise<ResponseCart>`. A function that requests removing a product from the cart.
 - `applyCoupon: ( couponId: string ) => Promise<ResponseCart>`. A function that requests applying a coupon to the cart (only one coupon can be applied at a time).


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When using the cart manager package to add products to the cart during signup, if there are any errors, they will currently be ignored because errors are reported on the `messages.errors` property of a shopping-cart endpoint response, rather than as a Promise rejection.

This PR reports any such error to the signup framework instead so that it will return to the previous step. It also explicitly displays the error as a notice so that it will be visible to the user.

Note that with these changes, sometimes the error will be displayed twice on the page. This is because the steps themselves have their own error handling functionality which displays an error inline if the error is attached to the step itself. However, there are cases where the displayed step may not be the step with the error. For example, if you select a domain, then select a plan, then signup tries to add both, it will return you to the plans page even if the first error is for the domains step; in that case the inline error would only be displayed if the user clicks to go back to the domains step, which is not guaranteed.

It would be nice if signup returned the user to the first step with an error, but I don't know how to make it do that, so by displaying the error as a global notice we avoid the risk that it won't be displayed at all. Future PRs could improve on this.

An example of the plans page showing an error:

<img width="663" alt="Screen Shot 2021-11-23 at 7 05 01 PM" src="https://user-images.githubusercontent.com/2036909/143147914-4808e732-0d06-4d29-8c3b-91c1de899f70.png">

An example of the domains page showing an error (twice, explained above):

<img width="659" alt="Screen Shot 2021-11-23 at 7 33 55 PM" src="https://user-images.githubusercontent.com/2036909/143150069-b5710849-d780-4a72-abf1-5525b56a06e3.png">

This will not resolve https://github.com/Automattic/wp-calypso/issues/57960 / https://github.com/Automattic/wp-calypso/issues/57958 but it should help to determine the actual error that's happening there. 

#### Testing instructions

- To test this you'll need to modify the shopping-cart endpoint to always return an error; D70551-code should do it.
- Visit `/start` and proceed through the signup flow, adding a paid plan to the cart.
- Verify that you are returned to the plan step.
- Verify that you see an error message displayed.