### PR TITLE
CI: Enable per-checkin trigger for Pre-Release Test.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -726,7 +726,11 @@ object PreReleaseE2ETests : BuildType({
 		}
 	}
 
-	triggers {}
+	triggers {
+		vcs {
+            perCheckinTriggering = true
+        }
+	}
 
 	failureConditions {
 		executionTimeoutMin = 20


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR seeks to enforce TeamCity to run a build per `trunk` check-in.

According to the [documentation](https://teamcity.jetbrains.com/app/dsl-documentation/jetbrains.build-server.configs.kotlin.v2019_2.triggers/-vcs-trigger/per-checkin-triggering.html), this forces each check-in to have their own build. Which is what we're aiming for.

Context: p4TIVU-9Sa-p2

Related to https://github.com/Automattic/wp-calypso/issues/55727.