### PR TITLE
CI: Exclude non-trunk branches from auto triggering Pre-Release tests.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -726,7 +726,14 @@ object PreReleaseE2ETests : BuildType({
 		}
 	}
 
-	triggers {}
+	triggers {
+		vcs {
+			branchFilter = """
+					-:*
+				""".trimIndent()
+            perCheckinTriggering = true
+        }
+	}
 
 	failureConditions {
 		executionTimeoutMin = 20


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/58435, which enabled build per check-in.

The changes there had the unintentional side effect of running Pre-Release tests for every commit in branches as well.

Key changes:
- exclude all branches from automatically triggering the Pre-Release tests, **except for** `trunk` branch.

Related to https://github.com/Automattic/wp-calypso/pull/58435, https://github.com/Automattic/wp-calypso/issues/55727.
