### PR TITLE
Revert "CI: Enable per-checkin trigger for Pre-Release Test."

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -726,11 +726,7 @@ object PreReleaseE2ETests : BuildType({
 		}
 	}
 
-	triggers {
-		vcs {
-            perCheckinTriggering = true
-        }
-	}
+	triggers {}
 
 	failureConditions {
 		executionTimeoutMin = 20


### PR DESCRIPTION
Reverts Automattic/wp-calypso#58435

It was creating builds for all PRs in the repo, including external forks.