### PR TITLE
Design Picker: Adjust styles

### DIFF
--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -89,8 +89,15 @@
 	padding-bottom: 30px;
 
 	.step-wrapper__content {
-		height: calc( 100vh - 256px );
-		max-height: 540px;
+		height: calc( 100vh - 245px );
+
+		@include break-mobile {
+			height: calc( 100vh - 225px );
+		}
+
+		@include break-small {
+			height: calc( 100vh - 128px );
+		}
 	}
 
 	@include break-small {
@@ -100,7 +107,7 @@
 		}
 
 		.step-wrapper__content {
-			max-height: 960px;
+			max-height: 1080px;
 		}
 	}
 }

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -1,7 +1,8 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
-.signup__step.is-design-setup-site, .signup__step.is-difm-design-setup-site {
+.signup__step.is-design-setup-site,
+.signup__step.is-difm-design-setup-site {
 	.step-wrapper {
 		padding-left: 24px;
 		padding-right: 24px;
@@ -61,8 +62,13 @@
 	.design-picker__has-categories {
 		.design-picker__grid {
 			@include break-medium {
+				grid-template-columns: 1fr;
 				column-gap: 24px;
 				row-gap: 36px;
+			}
+
+			@include break-large {
+				grid-template-columns: 1fr 1fr;
 			}
 		}
 

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -6,9 +6,8 @@ $design-picker-category-filter-text-color: #3c434a;
 $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 
 .design-picker-category-filter {
-	flex: 0 calc( 307px - 1rem );
-
 	@include break-small {
+		flex: 0 245px;
 		padding-right: 1rem;
 	}
 

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -7,7 +7,10 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 
 .design-picker-category-filter {
 	flex: 0 calc( 307px - 1rem );
-	padding-right: 1rem;
+
+	@include break-small {
+		padding-right: 1rem;
+	}
 
 	.design-picker-category-filter__menu-item {
 		padding-left: 0;
@@ -36,7 +39,8 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 
 			&:focus:not( :disabled ),
 			&:focus-visible:not( :disabled ) {
-				box-shadow: inset 0 0 0 1px #fff, 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
+				box-shadow: inset 0 0 0 1px #fff,
+					0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
 			}
 
 			&:focus:not( :disabled ):not( :focus-visible ) {
@@ -68,14 +72,17 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 	line-height: 24px;
 	font-weight: 500; // stylelint-disable-line scales/font-weights
 	border-radius: 4px; // stylelint-disable-line scales/radii
-	border-color: #c3c4c7;
+	border: 1px solid #c3c4c7;
 	padding: 0 35px 0 10px;
 	margin-bottom: 24px;
 	min-height: 44px;
+	height: 44px;
 	width: 100%;
 	-webkit-appearance: none;
 	appearance: none;
-	background: transparent url( 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3QgeD0iMCIgZmlsbD0ibm9uZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+PGc+PHBhdGggZmlsbD0iI2MzYzRjNyIgZD0iTTIwIDlsLTggOC04LTggMS40MTQtMS40MTRMMTIgMTQuMTcybDYuNTg2LTYuNTg2eiIvPjwvZz48L3N2Zz4=' ) no-repeat right 12px top 50%;
+	background: transparent
+		url( 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3QgeD0iMCIgZmlsbD0ibm9uZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+PGc+PHBhdGggZmlsbD0iI2MzYzRjNyIgZD0iTTIwIDlsLTggOC04LTggMS40MTQtMS40MTRMMTIgMTQuMTcybDYuNTg2LTYuNTg2eiIvPjwvZz48L3N2Zz4=' )
+		no-repeat right 12px top 50%;
 	background-size: 20px;
 
 	&:focus,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

According to p58i-bpK-p2#comment-52565, adjust styles as followed to provide better experience
* The style of design picker filter dropdown. We should specify the height for the vertical center alignment and make the border style to solid for the color of the border.
* Limit to 1 column if the width of the screen is smaller than 960px
* The height of design preview

![image](https://user-images.githubusercontent.com/13596067/143201108-7a9e33f5-a20f-458e-8df5-6835a9c093bf.png)

![image](https://user-images.githubusercontent.com/13596067/143201231-c3f66be9-e655-4910-9be6-c996182b1f1e.png)

![image](https://user-images.githubusercontent.com/13596067/143201483-aaae6119-817b-4ace-bf3d-ff420a73743d.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your_site>`
* Select build intent
* Check the style of Design Picker and Preview

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-bpK-p2#comment-52565