### PR TITLE
WIP: Create "setup" section in Calypso and add Hero Flow components to it

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -351,7 +351,7 @@ export default withCurrentRoute(
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
 		const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
-		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
+		const noMasterbarForSection = [ 'signup', 'jetpack-connect', 'setup' ].includes( sectionName );
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
 			noMasterbarForSection ||

--- a/client/sections.js
+++ b/client/sections.js
@@ -190,6 +190,11 @@ const sections = [
 		isomorphic: true,
 	},
 	{
+		name: 'setup',
+		paths: [ '/setup' ],
+		module: 'calypso/setup',
+	},
+	{
 		name: 'stats',
 		paths: [ '/stats' ],
 		module: 'calypso/my-sites/stats',

--- a/client/setup/README.md
+++ b/client/setup/README.md
@@ -1,0 +1,5 @@
+# Setup Section
+
+Section for setup flows/wizards/UIs.
+
+All routes appear under the `/setup` URL tree.

--- a/client/setup/index.ts
+++ b/client/setup/index.ts
@@ -1,0 +1,22 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { siteSelection, sites } from 'calypso/my-sites/controller';
+import { setupSite } from './setup-site/controller';
+import { STEP_SLUGS } from './setup-site/types';
+
+export default function (): void {
+	// Forgot to specify a site, show a UI to select one
+	page( '/setup', sites, makeLayout, clientRender );
+
+	// The `?` makes the step slug optional, that way if it's missing the
+	// "intent" step will be rendered.
+	const siteSetupStepSlugs = `:stepSlug(${ STEP_SLUGS.join( '|' ) })?`;
+
+	page(
+		`/setup/${ siteSetupStepSlugs }/:siteId`,
+		siteSelection,
+		setupSite, // Create <SetupSite> component in `context.primary`
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/setup/setup-site/components/back-button.tsx
+++ b/client/setup/setup-site/components/back-button.tsx
@@ -1,0 +1,15 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useStepBackHref, useStepBackNav } from '../hooks/use-setup-nav';
+import { StepSlug } from '../types';
+
+export function BackButton( { defaultBack }: { defaultBack: StepSlug } ): React.ReactElement {
+	const translate = useTranslate();
+	const stepBackHref = useStepBackHref( { defaultBack } );
+	const stepBackNav = useStepBackNav( { defaultBack } );
+	return (
+		<Button href={ stepBackHref() } onClick={ () => stepBackNav() }>
+			{ translate( 'Back' ) }
+		</Button>
+	);
+}

--- a/client/setup/setup-site/controller.tsx
+++ b/client/setup/setup-site/controller.tsx
@@ -1,0 +1,45 @@
+import { translate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
+import { sectionify } from 'calypso/lib/route';
+import { Design } from './design';
+import { StepNavProvider } from './hooks/use-setup-nav';
+import { IntentScreen } from './intent-screen';
+import { SetupSite } from './setup-site';
+import { SiteOptions } from './site-options';
+import { StartingPoint } from './starting-point';
+import { StepSlug } from './types';
+
+export const setupSite: PageJS.Callback = ( context, next ) => {
+	const pageTitle = translate( 'Setup your site' );
+
+	const basePath = sectionify( context.path );
+	recordPageView( basePath, pageTitle );
+
+	const stepSlug: StepSlug = context.params.stepSlug;
+	const StepComponent = getStepComponent( stepSlug );
+
+	context.primary = (
+		<>
+			<StepNavProvider currentStep={ stepSlug }>
+				<DocumentHead title={ pageTitle } />
+				<SetupSite step={ <StepComponent /> } />
+			</StepNavProvider>
+		</>
+	);
+
+	next();
+};
+
+function getStepComponent( stepSlug: StepSlug ) {
+	switch ( stepSlug ) {
+		case undefined:
+			return IntentScreen;
+		case 'site-options':
+			return SiteOptions;
+		case 'starting-point':
+			return StartingPoint;
+		case 'design':
+			return Design;
+	}
+}

--- a/client/setup/setup-site/design/index.tsx
+++ b/client/setup/setup-site/design/index.tsx
@@ -1,0 +1,105 @@
+import DesignPicker, { useCategorization } from '@automattic/design-picker';
+import { englishLocales } from '@automattic/i18n-utils';
+import { shuffle } from '@automattic/js-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { getRecommendedThemes as fetchRecommendedThemes } from 'calypso/state/themes/actions';
+import { getRecommendedThemes } from 'calypso/state/themes/selectors';
+import { BackButton } from '../components/back-button';
+
+// Ideally this data should come from the themes API, maybe by a tag that's applied to
+// themes? e.g. `link-in-bio` or `no-fold`
+const STATIC_PREVIEWS = [ 'bantry', 'sigler', 'miller', 'pollard', 'paxton', 'jones', 'baker' ];
+
+export function Design(): React.ReactElement {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const apiThemes = useSelector( ( state ) =>
+		getRecommendedThemes( state, 'auto-loading-homepage' )
+	);
+
+	useEffect(
+		() => {
+			if ( ! apiThemes.length ) {
+				dispatch( fetchRecommendedThemes( 'auto-loading-homepage' ) );
+			}
+		},
+		// Ignoring dependencies because we only want these actions to run on first mount
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	);
+
+	const designs = useMemo( () => {
+		// TODO fetching and filtering code should be pulled to a shared place that's usable by both
+		// `/start` and `/new` onboarding flows. Or perhaps fetching should be done within the <DesignPicker>
+		// component itself. The `/new` environment needs helpers for making authenticated requests to
+		// the theme API before we can do this.
+		const allThemes = apiThemes.map( ( { id, name, taxonomies } ) => ( {
+			categories: taxonomies?.theme_subject ?? [],
+			// Blank Canvas uses the theme_picks taxonomy with a "featured" term in order to
+			// appear prominently in theme galleries.
+			showFirst: !! taxonomies?.theme_picks?.find( ( { slug } ) => slug === 'featured' ),
+			features: [],
+			is_premium: false,
+			slug: id,
+			template: id,
+			theme: id,
+			title: name,
+			...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+		} ) );
+
+		if ( allThemes.length === 0 ) {
+			return [];
+		}
+
+		return [ allThemes[ 0 ], ...shuffle( allThemes.slice( 1 ) ) ];
+	}, [ apiThemes ] );
+
+	const handleSelection = () => {
+		throw new Error( 'not implemented' );
+	};
+
+	const categorization = useCategorization( designs, {
+		showAllFilter: true,
+	} );
+
+	function subHeaderText() {
+		const text = translate( 'Choose a starting theme. You can change it later.' );
+
+		if ( englishLocales.includes( translate.localeSlug || '' ) ) {
+			// An English only trick so the line wraps between sentences.
+			return text
+				.replace( /\s/g, '\xa0' ) // Replace all spaces with non-breaking spaces
+				.replace( /\.\s/g, '. ' ); // Replace all spaces at the end of sentences with a regular breaking space
+		}
+
+		return text;
+	}
+
+	return (
+		<div>
+			<BackButton defaultBack={ undefined } />
+			<DesignPicker
+				designs={ designs }
+				theme="light"
+				locale={ translate.localeSlug }
+				onSelect={ handleSelection }
+				onPreview={ handleSelection }
+				highResThumbnails
+				categorization={ categorization }
+				categoriesHeading={
+					<FormattedHeader
+						id="step-header"
+						headerText={ translate( 'Themes' ) }
+						subHeaderText={ subHeaderText() }
+						align="left"
+						hasScreenOptions={ false }
+					/>
+				}
+			/>
+		</div>
+	);
+}

--- a/client/setup/setup-site/hooks/use-setup-nav.tsx
+++ b/client/setup/setup-site/hooks/use-setup-nav.tsx
@@ -1,0 +1,125 @@
+import page from 'page';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { StepSlug } from '../types';
+
+interface StepNavContextValue {
+	push: ( step: StepSlug ) => void;
+	pop: () => void;
+	hasNoBackInStack: () => boolean;
+	peekPreviousStep: () => StepSlug;
+}
+
+const stepNavContext = createContext< StepNavContextValue >( {
+	push: () => undefined,
+	pop: () => undefined,
+	hasNoBackInStack: () => true,
+	peekPreviousStep: () => undefined,
+} );
+
+export function StepNavProvider( {
+	children,
+	currentStep,
+}: {
+	children?: React.ReactNode;
+	currentStep: StepSlug;
+} ): React.ReactElement {
+	const Provider = stepNavContext.Provider;
+
+	const [ stack, setStackLocal ] = useState< StepSlug[] >( () => {
+		const storedStack = sessionStorage.getItem( 'a8c-setup-nav-stack' );
+		if ( ! storedStack ) {
+			return [ currentStep ];
+		}
+
+		const previousStack = JSON.parse( storedStack ).map( ( s: string ) =>
+			s === 'UNDEFINED' ? undefined : s
+		);
+		if ( previousStack.length && previousStack[ previousStack.length - 1 ] === currentStep ) {
+			return previousStack;
+		}
+
+		return [ currentStep ];
+	} );
+
+	const setStack = useCallback( ( stack: StepSlug[] ) => {
+		sessionStorage.setItem(
+			'a8c-setup-nav-stack',
+			JSON.stringify( stack.map( ( s ) => ( typeof s === 'undefined' ? 'UNDEFINED' : s ) ) )
+		);
+		setStackLocal( stack );
+	}, [] );
+
+	useEffect( () => {
+		if ( currentStep !== stack[ stack.length - 1 ] ) {
+			stack.push( currentStep );
+			setStack( stack );
+		}
+	}, [ currentStep, stack, setStack ] );
+
+	const contextValue = useMemo(
+		() => ( {
+			push: ( step: StepSlug ) => {
+				stack.push( step );
+				setStack( stack );
+			},
+			pop: () => {
+				stack.pop();
+				setStack( stack );
+			},
+			hasNoBackInStack: () => stack.length < 2,
+			peekPreviousStep: () => stack[ stack.length - 2 ],
+		} ),
+		[ stack, setStack ]
+	);
+
+	return <Provider value={ contextValue }>{ children }</Provider>;
+}
+
+export function useStepHref(): ( step: StepSlug ) => string {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	return useCallback(
+		( step: StepSlug ) => {
+			if ( step ) {
+				return `/setup/${ step }/${ siteSlug }`;
+			}
+			return `/setup/${ siteSlug }`;
+		},
+		[ siteSlug ]
+	);
+}
+
+export function useStepNav(): ( step: StepSlug ) => void {
+	const stepHref = useStepHref();
+
+	return useCallback(
+		( step: StepSlug ) => {
+			page( stepHref( step ) );
+		},
+		[ stepHref ]
+	);
+}
+
+export function useStepBackHref( { defaultBack }: { defaultBack: StepSlug } ): () => string {
+	const stepHref = useStepHref();
+	const stack = useContext( stepNavContext );
+
+	return useCallback( () => {
+		if ( stack.hasNoBackInStack() ) {
+			return stepHref( defaultBack );
+		}
+		return stepHref( stack.peekPreviousStep() );
+	}, [ defaultBack, stepHref, stack ] );
+}
+
+export function useStepBackNav( { defaultBack }: { defaultBack: StepSlug } ): () => void {
+	const stepHref = useStepBackHref( { defaultBack } );
+	const navStack = useContext( stepNavContext );
+
+	return useCallback( () => {
+		page( stepHref() );
+		navStack.pop();
+	}, [ stepHref, navStack ] );
+}

--- a/client/setup/setup-site/intent-screen/index.tsx
+++ b/client/setup/setup-site/intent-screen/index.tsx
@@ -1,0 +1,17 @@
+import ImportedIntentScreen from 'calypso/signup/steps/intent/intent-screen';
+import { IntentFlag } from 'calypso/signup/steps/intent/types';
+import { useStepNav } from '../hooks/use-setup-nav';
+
+export function IntentScreen(): React.ReactElement {
+	const page = useStepNav();
+
+	const handleSelect = ( intent: IntentFlag ) => {
+		if ( intent === 'write' ) {
+			page( 'site-options' );
+		} else {
+			page( 'design' );
+		}
+	};
+
+	return <ImportedIntentScreen onSelect={ handleSelect } />;
+}

--- a/client/setup/setup-site/setup-site.tsx
+++ b/client/setup/setup-site/setup-site.tsx
@@ -1,0 +1,17 @@
+import WordPressLogo from 'calypso/components/wordpress-logo';
+
+interface Props {
+	step: React.ReactNode;
+}
+
+export function SetupSite( { step }: Props ): React.ReactElement {
+	return (
+		<div>
+			<header>
+				<WordPressLogo size={ 120 } />
+			</header>
+
+			{ step }
+		</div>
+	);
+}

--- a/client/setup/setup-site/site-options/index.tsx
+++ b/client/setup/setup-site/site-options/index.tsx
@@ -1,0 +1,18 @@
+import ImportedSiteOptions from 'calypso/signup/steps/site-options/site-options';
+import { BackButton } from '../components/back-button';
+import { useStepNav } from '../hooks/use-setup-nav';
+
+export function SiteOptions(): React.ReactElement {
+	const page = useStepNav();
+
+	const handleSubmit = () => {
+		page( 'starting-point' );
+	};
+
+	return (
+		<div>
+			<BackButton defaultBack={ undefined } />
+			<ImportedSiteOptions defaultSiteTitle="" defaultTagline="" onSubmit={ handleSubmit } />
+		</div>
+	);
+}

--- a/client/setup/setup-site/starting-point/index.tsx
+++ b/client/setup/setup-site/starting-point/index.tsx
@@ -1,0 +1,23 @@
+import ImportedStartingPoint from 'calypso/signup/steps/starting-point/starting-point';
+import { StartingPointFlag } from 'calypso/signup/steps/starting-point/types';
+import { BackButton } from '../components/back-button';
+import { useStepNav } from '../hooks/use-setup-nav';
+
+export function StartingPoint(): React.ReactElement {
+	const page = useStepNav();
+
+	const handleSelect = ( startingPoint: StartingPointFlag ) => {
+		if ( startingPoint === 'design' ) {
+			page( 'design' );
+		} else {
+			throw new Error( 'not implemented' );
+		}
+	};
+
+	return (
+		<div>
+			<BackButton defaultBack="site-options" />
+			<ImportedStartingPoint onSelect={ handleSelect } />
+		</div>
+	);
+}

--- a/client/setup/setup-site/types.ts
+++ b/client/setup/setup-site/types.ts
@@ -1,0 +1,4 @@
+// `undefined` represents the first "intent" step
+export type StepSlug = undefined | 'site-options' | 'starting-point' | 'design';
+
+export const STEP_SLUGS: StepSlug[] = [ 'site-options', 'starting-point', 'design' ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

See pbAok1-2iM-p2

* Adds a new `setup` section
* Add routes for each of the Hero Flow steps (the initial "intent" step doesn't have a step slug in the url)
* Naively/quickly implements each step by `import`ing components from the signup framework
* Implement "back" button that goes to previous step
  * Deals with case where step could be in two branches of the flow (e.g. design picker) and goes "back" to the correct one
  * Deals with browser refreshes by persisting the navigation stack
  * Deals with case where navigation stack could be missing from `sessionStorage` could be empty by requiring steps to have a default previous step (e.g. if the user navigates directly to the design picker then by default clicking back will go to the intent picker)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Restart Node server because this PR creates a new section
* `/setup/:siteSlug` will start the Hero flow
* `/setup` without a site slug shows the standard Calypso site picker
* The Back button's should work after a page refresh, even if you refresh on the design picker, which is part of two branches
