### PR TITLE
`HelpSearch`: opt out of query persistence

### DIFF
--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -14,7 +14,11 @@ export default function HelpSearch( props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const [ searchQuery, setQuery ] = useState( '' );
-	const { data: helpLinks } = useHelpSearchQuery( searchQuery );
+	const { data: helpLinks } = useHelpSearchQuery( searchQuery, {
+		meta: {
+			persist: false,
+		},
+	} );
 
 	const onSearch = ( query ) => {
 		setQuery( query );


### PR DESCRIPTION
In case of the help search we don't want to persist search results on the client but make sure users always get a fresh search and the UI behaves accordingly. 

**Note**: it does a background fetch regardless, but that's not obvious to users and may cause confusion if background fetch results are different from what was persisted earlier.

#### Changes proposed in this Pull Request

* `HelpSearch`: opt out of query persistence

#### Testing instructions

* Go to `/help` and perform a search. Reload the window and make sure it 1) performs a fresh search and 2) the UI shows appropriate loading state to the user when performing

Previously it behaved like:



https://user-images.githubusercontent.com/9202899/143221021-0eb062b6-378f-4fb4-aa01-9c5a0af21f35.mp4


And now it should behave like this:

https://user-images.githubusercontent.com/9202899/143220895-d98ba083-80d4-4d47-8525-f4a1ccab015c.mp4



Follow up to #56502
