### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` 2FA to `wpcom.req`

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -11,7 +11,6 @@ import { requestUserProfileLinks } from 'calypso/state/profile-links/actions';
 import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 
 const debug = debugFactory( 'calypso:two-step-authorization' );
-const wpcom = wp.undocumented();
 
 /*
  * Initialize TwoStepAuthorization with defaults
@@ -39,7 +38,7 @@ function TwoStepAuthorization() {
  * fetch data about users two step configuration from /me/two-step
  */
 TwoStepAuthorization.prototype.fetch = function ( callback ) {
-	wpcom.me().getTwoStep( ( error, data ) => {
+	wp.req.get( '/me/two-step/', ( error, data ) => {
 		if ( ! error ) {
 			this.data = data;
 
@@ -132,7 +131,8 @@ TwoStepAuthorization.prototype.loginUserWithSecurityKey = function ( args ) {
  * Given a code, validate the code which will update a user's twostep_auth cookie
  */
 TwoStepAuthorization.prototype.validateCode = function ( args, callback ) {
-	wpcom.me().validateTwoStepCode(
+	wp.req.post(
+		'/me/two-step/validate',
 		{
 			...args,
 			code: args.code.replace( /\s/g, '' ),
@@ -175,7 +175,7 @@ TwoStepAuthorization.prototype.validateCode = function ( args, callback ) {
  * /me/two-step/sms/new
  */
 TwoStepAuthorization.prototype.sendSMSCode = function ( callback ) {
-	wpcom.me().sendSMSValidationCode( ( error, data ) => {
+	wp.req.post( '/me/two-step/sms/new', ( error, data ) => {
 		if ( error ) {
 			debug( 'Sending SMS code failed: ' + JSON.stringify( error ) );
 
@@ -201,7 +201,7 @@ TwoStepAuthorization.prototype.sendSMSCode = function ( callback ) {
  * Fetches a new set of backup codes by calling /me/two-step/backup-codes/new
  */
 TwoStepAuthorization.prototype.backupCodes = function ( callback ) {
-	wpcom.me().backupCodes( ( error, data ) => {
+	wp.req.post( '/me/two-step/backup-codes/new', ( error, data ) => {
 		if ( error ) {
 			debug( 'Fetching Backup Codes failed: ' + JSON.stringify( error ) );
 		} else {
@@ -225,7 +225,7 @@ TwoStepAuthorization.prototype.validateBackupCode = function ( code, callback ) 
 		action: 'create-backup-receipt',
 	};
 
-	wpcom.me().validateTwoStepCode( args, ( error, data ) => {
+	wp.req.post( '/me/two-step/validate', args, ( error, data ) => {
 		if ( error ) {
 			debug( 'Validating Two Step Code failed: ' + JSON.stringify( error ) );
 		}
@@ -247,7 +247,7 @@ TwoStepAuthorization.prototype.validateBackupCode = function ( code, callback ) 
  * from me/two-step/app-auth-setup
  */
 TwoStepAuthorization.prototype.getAppAuthCodes = function ( callback ) {
-	wpcom.me().getAppAuthCodes( function ( error, data ) {
+	wp.req.get( '/me/two-step/app-auth-setup/', function ( error, data ) {
 		if ( error ) {
 			debug( 'Getting App Auth Codes failed: ' + JSON.stringify( error ) );
 		}

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -31,43 +31,6 @@ UndocumentedMe.prototype.getReceipt = function ( receiptId, queryOrCallback ) {
 	);
 };
 
-UndocumentedMe.prototype.sendSMSValidationCode = function ( callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/two-step/sms/new',
-	};
-
-	return this.wpcom.req.post( args, callback );
-};
-
-UndocumentedMe.prototype.validateTwoStepCode = function ( body, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/two-step/validate',
-		body: body,
-	};
-
-	return this.wpcom.req.post( args, callback );
-};
-
-UndocumentedMe.prototype.getTwoStep = function ( callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/two-step/',
-	};
-
-	return this.wpcom.req.get( args, callback );
-};
-
-UndocumentedMe.prototype.getAppAuthCodes = function ( callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/two-step/app-auth-setup/',
-	};
-
-	return this.wpcom.req.get( args, callback );
-};
-
 UndocumentedMe.prototype.getPeerReferralLink = function ( callback ) {
 	const args = {
 		apiVersion: '1.1',
@@ -84,15 +47,6 @@ UndocumentedMe.prototype.setPeerReferralLinkEnable = function ( enable, callback
 		body: {
 			enable,
 		},
-	};
-
-	return this.wpcom.req.post( args, callback );
-};
-
-UndocumentedMe.prototype.backupCodes = function ( callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/two-step/backup-codes/new',
 	};
 
 	return this.wpcom.req.post( args, callback );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` two-factor authentication methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/me/security/two-step`
* Start with 2FA enabled and disable it. Verify that works well.
* Start with 2FA disabled. 
* Go through the flow to add a 2FA with an app and verify it works well.
* Start again with 2FA disabled. 
* Go through the flow to add a 2FA with SMS and verify it works well.

Pinging @xknown for review and testing since he worked a lot in this area recently.