### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` referral to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -31,27 +31,6 @@ UndocumentedMe.prototype.getReceipt = function ( receiptId, queryOrCallback ) {
 	);
 };
 
-UndocumentedMe.prototype.getPeerReferralLink = function ( callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/peer-referral-link',
-	};
-
-	return this.wpcom.req.get( args, callback );
-};
-
-UndocumentedMe.prototype.setPeerReferralLinkEnable = function ( enable, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/peer-referral-link-enable',
-		body: {
-			enable,
-		},
-	};
-
-	return this.wpcom.req.post( args, callback );
-};
-
 UndocumentedMe.prototype.sendVerificationEmail = function ( callback ) {
 	debug( '/me/send-verification-email' );
 

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -56,8 +56,6 @@ interface ConnectedProps {
 
 const overSome = ( ...checks ) => ( item ) => checks.some( ( check ) => check( item ) );
 
-const wpcom = wp.undocumented();
-
 const Home: FunctionComponent< ConnectedProps > = ( {
 	siteId,
 	selectedSiteSlug,
@@ -79,16 +77,20 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 
 	useEffect( () => {
 		if ( peerReferralLink ) return;
-		wpcom.me().getPeerReferralLink( ( error: string, data: string ) => {
+		wp.req.get( '/me/peer-referral-link', ( error: string, data: string ) => {
 			setPeerReferralLink( ! error && data ? data : '' );
 		} );
 	}, [ peerReferralLink ] );
 
 	const onPeerReferralCtaClick = () => {
 		if ( peerReferralLink ) return;
-		wpcom.me().setPeerReferralLinkEnable( true, ( error: string, data: string ) => {
-			setPeerReferralLink( ! error && data ? data : '' );
-		} );
+		wp.req.post(
+			'/me/peer-referral-link-enable',
+			{ enable: true },
+			( error: string, data: string ) => {
+				setPeerReferralLink( ! error && data ? data : '' );
+			}
+		);
 	};
 
 	const getAnyPlanNames = () => {

--- a/client/my-sites/earn/refer-a-friend/index.tsx
+++ b/client/my-sites/earn/refer-a-friend/index.tsx
@@ -26,8 +26,6 @@ interface ConnectedProps {
 	trackCtaButton: ( feature: string ) => void;
 }
 
-const wpcom = wp.undocumented();
-
 const ReferAFriendSection: FunctionComponent< ConnectedProps > = ( {
 	isJetpack,
 	isAtomicSite,
@@ -38,16 +36,20 @@ const ReferAFriendSection: FunctionComponent< ConnectedProps > = ( {
 
 	useEffect( () => {
 		if ( peerReferralLink ) return;
-		wpcom.me().getPeerReferralLink( ( error: string, data: string ) => {
+		wp.req.get( '/me/peer-referral-link', ( error: string, data: string ) => {
 			setPeerReferralLink( ! error && data ? data : '' );
 		} );
 	}, [ peerReferralLink ] );
 
 	const onPeerReferralCtaClick = () => {
 		if ( peerReferralLink ) return;
-		wpcom.me().setPeerReferralLinkEnable( true, ( error: string, data: string ) => {
-			setPeerReferralLink( ! error && data ? data : '' );
-		} );
+		wp.req.post(
+			'/me/peer-referral-link-enable',
+			{ enable: true },
+			( error: string, data: string ) => {
+				setPeerReferralLink( ! error && data ? data : '' );
+			}
+		);
 	};
 
 	const getPeerReferralsCard = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` referral methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`.

#### Testing instructions

* Go to `/earn/:site`.
* Click on the "Earn free credits" button in the "Refer a friend, you’ll both earn credits" section.
* Verify the request works successfully.
* Verify you can see the referral link in that section now.
* Refresh the page. 
* Verify you can still see the referral link.
