### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` email verification to `wpcom.req`

### DIFF
--- a/client/components/email-verification/email-verification-gate/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-verification-gate/email-unverified-notice.jsx
@@ -39,16 +39,13 @@ class EmailUnverifiedNotice extends Component {
 			pendingRequest: true,
 		} );
 
-		wpcom
-			.undocumented()
-			.me()
-			.sendVerificationEmail( ( error, response ) => {
-				this.setState( {
-					emailSent: response && response.success,
-					error: error,
-					pendingRequest: false,
-				} );
+		wpcom.req.post( '/me/send-verification-email', ( error, response ) => {
+			this.setState( {
+				emailSent: response && response.success,
+				error: error,
+				pendingRequest: false,
 			} );
+		} );
 	};
 
 	renderEmailSendPending() {

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -31,10 +31,4 @@ UndocumentedMe.prototype.getReceipt = function ( receiptId, queryOrCallback ) {
 	);
 };
 
-UndocumentedMe.prototype.sendVerificationEmail = function ( callback ) {
-	debug( '/me/send-verification-email' );
-
-	return this.wpcom.req.post( { path: '/me/send-verification-email' }, callback );
-};
-
 export default UndocumentedMe;

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -48,10 +48,8 @@ class HelpUnverifiedWarning extends Component {
 				resendState: RESEND_IN_PROGRESS,
 			} );
 
-			wpcom
-				.undocumented()
-				.me()
-				.sendVerificationEmail()
+			wpcom.req
+				.post( '/me/send-verification-email' )
 				.then( () => {
 					const nextResendState = RESEND_SUCCESS;
 

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -50,24 +50,21 @@ class AtomicStoreThankYouCard extends Component {
 
 		this.setState( { resendStatus: RESEND_PENDING } );
 
-		wpcom
-			.undocumented()
-			.me()
-			.sendVerificationEmail( ( error ) => {
-				if ( error ) {
-					this.props.errorNotice(
-						translate( "Couldn't resend verification email. Please try again." ),
-						{
-							id: VERIFY_EMAIL_ERROR_NOTICE,
-						}
-					);
+		wpcom.req.post( '/me/send-verification-email', ( error ) => {
+			if ( error ) {
+				this.props.errorNotice(
+					translate( "Couldn't resend verification email. Please try again." ),
+					{
+						id: VERIFY_EMAIL_ERROR_NOTICE,
+					}
+				);
 
-					this.setState( { resendStatus: RESEND_ERROR } );
-					return;
-				}
+				this.setState( { resendStatus: RESEND_ERROR } );
+				return;
+			}
 
-				this.setState( { resendStatus: RESEND_SUCCESS } );
-			} );
+			this.setState( { resendStatus: RESEND_SUCCESS } );
+		} );
 	};
 
 	resendButtonText = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` email verification method to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()` and part of #58458.

#### Testing instructions

* Create a WP.com account using any flow, but don't verify the email.
* Go to `/help`
* Click the "Resend Email" button on the notice.
* Verify sending an email still works well.
* Purchase an eCommerce plan for a free site.
* In the checkout "thank you" page, you should see a "Resend email" button inside the "Thank you for your purchase!" card. 
* Click the button and verify sending an email still works well.
* Go to `/import/:site`
* You should see a notice that you're not verified, with a "Resend Email" button.
* Click the button and verify sending an email still works well.