### PR TITLE
Sidebar: Add link to parent menu items (2nd attempt)

### DIFF
--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -113,9 +113,9 @@ export const ExpandableSidebarMenu = ( {
 				<ExpandableSidebarHeading
 					title={ title }
 					count={ count }
-					onClick={ () => {
+					onClick={ ( event ) => {
 						setSubmenuHovered( false );
-						onClick();
+						onClick( event );
 					} }
 					customIcon={ customIcon }
 					icon={ icon }

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -72,11 +72,6 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	 * @returns {boolean} Whether the user is allowed to navigate.
 	 */
 	const canNavigate = ( url ) => {
-		// Users contacting support via Happychat should be refrained from visiting
-		// external links in the current browser tab, since that would terminates
-		// the chat. We instead show a modal awaiting for user confirmation to visit
-		// it on a new tab, so the active Happychat session in the current tab is not
-		// affected.
 		if ( isHappychatSessionActive && isExternal( url ) && shouldOpenExternalLinksInCurrentTab ) {
 			setExternalUrl( url );
 			setShowDialog( true );

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -44,7 +44,6 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
-	const isJetpackNonAtomicSite = isJetpack && ! isSiteAtomic;
 	const [ showDialog, setShowDialog ] = useState( false );
 	const [ externalUrl, setExternalUrl ] = useState();
 
@@ -58,19 +57,27 @@ export const MySitesSidebarUnified = ( { path } ) => {
 		return <Spinner className="sidebar-unified__menu-loading" />;
 	}
 
-	// Checks if there is a Happy Chat active and user clicks on an External link.
-	// On which case we show a modal awaiting for user confirmation for opening that
-	// link on new tab in order to avoid Happy Chat session disconnection.
-	// We return a bool that shows if the logic should terminate here.
-	const continueInCalypso = ( url, event ) => {
-		if ( isHappychatSessionActive && isExternal( url ) ) {
-			// Do not show warning modal on Jetpack sites, since all external links are
-			// always opened on new tabs for these sites.
-			if ( isJetpackNonAtomicSite ) {
-				return false;
-			}
+	// Jetpack self-hosted sites should open external links to WP Admin in new tabs,
+	// since WP Admin is considered a separate area from Calypso on those sites.
+	const shouldOpenExternalLinksInCurrentTab = ! isJetpack || isSiteAtomic;
 
-			event && event.preventDefault();
+	/**
+	 * Checks whether the user can navigate to the given URL. Users contacting support
+	 * via Happychat should be refrained from visiting external links in the current
+	 * browser tab, since that would terminates the chat. We instead show a modal
+	 * awaiting for user confirmation to visit it on a new tab, so the active Happychat
+	 * session in the current tab is not affected.
+	 *
+	 * @param {string} url The URL to check.
+	 * @returns {boolean} Whether the user is allowed to navigate.
+	 */
+	const canNavigate = ( url ) => {
+		// Users contacting support via Happychat should be refrained from visiting
+		// external links in the current browser tab, since that would terminates
+		// the chat. We instead show a modal awaiting for user confirmation to visit
+		// it on a new tab, so the active Happychat session in the current tab is not
+		// affected.
+		if ( isHappychatSessionActive && isExternal( url ) && shouldOpenExternalLinksInCurrentTab ) {
 			setExternalUrl( url );
 			setShowDialog( true );
 			dispatch(
@@ -80,6 +87,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 			);
 			return false;
 		}
+
 		return true;
 	};
 
@@ -116,9 +124,8 @@ export const MySitesSidebarUnified = ( { path } ) => {
 								link={ item.url }
 								selected={ isSelected }
 								sidebarCollapsed={ sidebarIsCollapsed }
-								isHappychatSessionActive={ isHappychatSessionActive }
-								isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-								continueInCalypso={ continueInCalypso }
+								shouldOpenExternalLinksInCurrentTab={ shouldOpenExternalLinksInCurrentTab }
+								canNavigate={ canNavigate }
 								{ ...item }
 							/>
 						);
@@ -128,9 +135,8 @@ export const MySitesSidebarUnified = ( { path } ) => {
 						<MySitesSidebarUnifiedItem
 							key={ item.slug }
 							selected={ isSelected }
-							isHappychatSessionActive={ isHappychatSessionActive }
-							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-							continueInCalypso={ continueInCalypso }
+							shouldOpenExternalLinksInCurrentTab={ shouldOpenExternalLinksInCurrentTab }
+							canNavigate={ canNavigate }
 							{ ...item }
 						/>
 					);

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -23,13 +23,17 @@ export const MySitesSidebarUnifiedItem = ( {
 	slug,
 	title,
 	url,
-	isHappychatSessionActive,
-	isJetpackNonAtomicSite,
-	continueInCalypso,
+	shouldOpenExternalLinksInCurrentTab,
+	canNavigate,
 } ) => {
 	const reduxDispatch = useDispatch();
 
-	const onNavigate = () => {
+	const onNavigate = ( event ) => {
+		if ( ! canNavigate( url ) ) {
+			event?.preventDefault();
+			return;
+		}
+
 		reduxDispatch( collapseAllMySitesSidebarSections() );
 		window.scrollTo( 0, 0 );
 	};
@@ -40,10 +44,10 @@ export const MySitesSidebarUnifiedItem = ( {
 			count={ count }
 			label={ title }
 			link={ url }
-			onNavigate={ ( event ) => continueInCalypso( url, event ) && onNavigate() }
+			onNavigate={ onNavigate }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			forceInternalLink={ ! isHappychatSessionActive && ! isJetpackNonAtomicSite }
+			forceInternalLink={ shouldOpenExternalLinksInCurrentTab }
 			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
 			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />
@@ -59,9 +63,8 @@ MySitesSidebarUnifiedItem.propTypes = {
 	slug: PropTypes.string,
 	title: PropTypes.string,
 	url: PropTypes.string,
-	isHappychatSessionActive: PropTypes.bool.isRequired,
-	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
-	continueInCalypso: PropTypes.func.isRequired,
+	shouldOpenExternalLinksInCurrentTab: PropTypes.bool.isRequired,
+	canNavigate: PropTypes.func.isRequired,
 };
 
 export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -43,16 +43,18 @@ export const MySitesSidebarUnifiedMenu = ( {
 		( isDesktop && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
 
 	const onClick = ( event ) => {
-		if ( ! canNavigate( link ) ) {
-			event?.preventDefault();
-			return;
-		}
-
 		// Block the navigation on mobile viewports and just toggle the section,
 		// since we don't show the child items on hover and users should have a
 		// chance to see them.
 		if ( isMobile ) {
 			event?.preventDefault();
+			reduxDispatch( toggleSection( sectionId ) );
+			return;
+		}
+
+		if ( ! canNavigate( link ) ) {
+			event?.preventDefault();
+			return;
 		}
 
 		window.scrollTo( 0, 0 );

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
-import { navigate } from 'calypso/lib/navigate';
 import { toggleMySitesSidebarSection as toggleSection } from 'calypso/state/my-sites/sidebar/actions';
 import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import MySitesSidebarUnifiedItem from './item';
@@ -26,9 +25,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 	link,
 	selected,
 	sidebarCollapsed,
-	isHappychatSessionActive,
-	isJetpackNonAtomicSite,
-	continueInCalypso,
+	shouldOpenExternalLinksInCurrentTab,
+	canNavigate,
 	...props
 } ) => {
 	const reduxDispatch = useDispatch();
@@ -38,20 +36,23 @@ export const MySitesSidebarUnifiedMenu = ( {
 		Array.isArray( children ) &&
 		children.find( ( menuItem ) => menuItem?.url && itemLinkMatches( menuItem.url, path ) );
 	const childIsSelected = !! selectedMenuItem;
+	const isDesktop = isWithinBreakpoint( '>782px' );
+	const isMobile = ! isDesktop;
 	const showAsExpanded =
-		( ! isWithinBreakpoint( '>782px' ) && ( childIsSelected || isExpanded ) ) || // For mobile breakpoints, we dont' care about the sidebar collapsed status.
-		( isWithinBreakpoint( '>782px' ) && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
+		( isMobile && ( childIsSelected || isExpanded ) ) || // For mobile breakpoints, we dont' care about the sidebar collapsed status.
+		( isDesktop && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
 
-	const onClick = () => {
-		// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
-		if ( isWithinBreakpoint( '>782px' ) ) {
-			if ( link ) {
-				if ( ! continueInCalypso( link ) ) {
-					return;
-				}
+	const onClick = ( event ) => {
+		if ( ! canNavigate( link ) ) {
+			event?.preventDefault();
+			return;
+		}
 
-				navigate( link );
-			}
+		// Block the navigation on mobile viewports and just toggle the section,
+		// since we don't show the child items on hover and users should have a
+		// chance to see them.
+		if ( isMobile ) {
+			event?.preventDefault();
 		}
 
 		window.scrollTo( 0, 0 );
@@ -61,7 +62,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	return (
 		<li>
 			<ExpandableSidebarMenu
-				onClick={ () => onClick() }
+				onClick={ onClick }
 				expanded={ showAsExpanded }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
@@ -69,6 +70,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				count={ count }
 				hideExpandableIcon={ true }
 				inlineText={ props.inlineText }
+				href={ link }
 				{ ...props }
 			>
 				{ children.map( ( item ) => {
@@ -79,9 +81,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 							{ ...item }
 							selected={ isSelected }
 							isSubItem={ true }
-							isHappychatSessionActive={ isHappychatSessionActive }
-							isJetpackNonAtomicSite={ isJetpackNonAtomicSite }
-							continueInCalypso={ continueInCalypso }
+							shouldOpenExternalLinksInCurrentTab={ shouldOpenExternalLinksInCurrentTab }
+							canNavigate={ canNavigate }
 						/>
 					);
 				} ) }
@@ -99,9 +100,8 @@ MySitesSidebarUnifiedMenu.propTypes = {
 	children: PropTypes.array.isRequired,
 	link: PropTypes.string,
 	sidebarCollapsed: PropTypes.bool,
-	isHappychatSessionActive: PropTypes.bool.isRequired,
-	isJetpackNonAtomicSite: PropTypes.bool.isRequired,
-	continueInCalypso: PropTypes.func.isRequired,
+	shouldOpenExternalLinksInCurrentTab: PropTypes.bool.isRequired,
+	canNavigate: PropTypes.func.isRequired,
 	/*
 	Example of children shape:
 	[


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/52291.

#### Changes proposed in this Pull Request

Adds a `href` attribute to the parent menu items of the sidebar so they can be opened on separated tabs if desired.

This is the take two of https://github.com/Automattic/wp-calypso/pull/57642, which had to be reverted because it introduced an unexpected regression.

The logic controlling whether a user is allowed to navigate to a menu item was a bit convoluted (one of the reasons why the regression noted above wasn't noticed), so I took the opportunity to rename a few variables and functions to make it more readable.

#### Testing instructions

- Use the Calypso live link below.
- ⌘+click on any parent menu item.
- Make sure it's opened on a separated tab.
- Collapse the sidebar.
- ⌘+click on any parent menu item.
- Make sure it's opened on a separated tab.
- Log in as operator in the Happychat HUD staging (URL can be found in PCYsg-b99-p2).
- Initiates a chat.
- Make sure you can navigate normally between Calypso screens.
- Click (or ⌘+click) on any menu item that points to WP Admin.
- Make sure you get a warning dialog offering you to open the page on a separate tab.
- Resize the browser to simulate a mobile viewport.
- Reload Calypso (otherwise, Calypso still thinks you're on a desktop viewport).
- Click (or ⌘+click) on any parent menu item.
- Make sure only the menu section is toggled, no new page should be opened.