### PR TITLE
Plugin Browser: Search results with 1 item

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -11,8 +11,7 @@
 	border: 1px solid var( --studio-gray-5 );
 	border-radius: 5px; /* stylelint-disable-line scales/radii */
 
-	&.is-placeholder,
-	&.is-empty {
+	&.is-placeholder {
 		cursor: default;
 	}
 
@@ -57,10 +56,6 @@
 
 	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
-
-		&.is-empty {
-			display: none;
-		}
 	}
 }
 

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -25,8 +25,6 @@ class PluginsBrowserList extends Component {
 	};
 
 	renderPluginsViewList() {
-		let emptyCounter = 0;
-
 		const pluginsViewsList = this.props.plugins.map( ( plugin, n ) => {
 			return (
 				<PluginBrowserItem
@@ -43,15 +41,6 @@ class PluginsBrowserList extends Component {
 				/>
 			);
 		} );
-
-		// We need to complete the list with empty elements to keep the grid drawn.
-		while ( pluginsViewsList.length % 3 !== 0 || pluginsViewsList.length % 2 !== 0 ) {
-			/* eslint-disable wpcalypso/jsx-classname-namespace */
-			pluginsViewsList.push(
-				<div className="plugins-browser-item is-empty" key={ 'empty-item-' + emptyCounter++ } />
-			);
-			/* eslint-enable wpcalypso/jsx-classname-namespace */
-		}
 
 		if ( this.props.size ) {
 			return pluginsViewsList.slice( 0, this.props.size );

--- a/client/my-sites/plugins/plugins-browser-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/test/index.jsx
@@ -44,12 +44,6 @@ describe( 'PluginsBrowserList basic tests', () => {
 		const comp = shallow( <PluginsBrowserList { ...props } size={ 2 } /> );
 		expect( comp.find( 'Connect(PluginsBrowserListElement)' ).length ).toBe( 2 );
 	} );
-
-	test( 'should render empty elements to complete the grid', () => {
-		const comp = shallow( <PluginsBrowserList { ...props } plugins={ plugins.slice( 0, 2 ) } /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)' ).length ).toBe( 2 );
-		expect( comp.find( '.plugins-browser-item.is-empty' ).length ).toBe( 4 );
-	} );
 } );
 
 describe( 'InfiniteScroll variant', () => {
@@ -72,7 +66,7 @@ describe( 'InfiniteScroll variant', () => {
 	test( 'should not show placeholders if there are plugins and the `showPlaceholders` is not set', () => {
 		const comp = shallow( <PluginsBrowserList { ...infiniteScrollProps } /> );
 		expect( comp.find( 'Connect(PluginsBrowserListElement)' ).length ).toBe( 3 );
-		expect( comp.find( '.plugins-browser-item.is-empty' ).length ).toBe( 3 );
+		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 0 );
 	} );
 } );
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -224,7 +224,8 @@ export class PluginsBrowser extends Component {
 
 			const subtitle =
 				pluginsPagination &&
-				this.props.translate( '%(total)s plugins', {
+				this.props.translate( '%(total)s plugin', '%(total)s plugins', {
+					count: pluginsPagination.results,
 					textOnly: true,
 					args: {
 						total: pluginsPagination.results,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add plural version to the Plugins Browser subtitle.
* Stop adding empty items on the Plugins Browser page.

#### Testing instructions
* Go to `/Plugins` page
* Search for a term that has less than 6 plugins (Ex: generate audiogram block)
* Verify if no extra lines is showed on the screen

### Demo

|Before | After|
|-------|------|
|![Screen Shot 2021-11-24 at 10 03 15](https://user-images.githubusercontent.com/5039531/143253972-527807ea-79e7-4702-b293-636542d85cbe.png)|![Screen Shot 2021-11-24 at 10 04 07](https://user-images.githubusercontent.com/5039531/143253947-48373236-d36b-406d-b09e-f2c11c7cf7bd.png)|

---

Fixes #58292
