### PR TITLE
Update title of the Jetpack manual activation final step

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
@@ -72,7 +72,7 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 				title="Checkout > Jetpack Thank You Licensing Manual Activation License Key"
 			/>
 			<LicensingActivation
-				title={ translate( 'Activate your %(productName)s', {
+				title={ translate( 'Activate your %(productName)s plan', {
 					args: { productName },
 				} ) }
 				footerImage={ licensingActivationPluginBanner }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Append at the end of the title the word `plan`, which makes the title goes from `Activate your [plan name]` to `Activate your [plan name] plan`.

#### Testing instructions

* Download this PR.
* Start Calypso with `yarn start`.
* Complete a purchase starting from cloud.jetpack.com/pricing.
* Go through the manual activation flow (do not select a site from the dropdown – select the option where you state that you don't see the site you're looking for).
* On the last step of the process, make sure the title looks as expected.

Related to 1201096622142517-as-1201419627847970

#### Demo – before
<img width="1214" alt="Screen Shot 2021-11-24 at 12 33 57" src="https://user-images.githubusercontent.com/3418513/143268412-846c8ae7-52cf-4cb5-bc11-a64da99c42a1.png">

#### Demo – after
<img width="1214" alt="Screen Shot 2021-11-24 at 12 33 47" src="https://user-images.githubusercontent.com/3418513/143268436-16a1367b-5d6e-454e-8af1-33de19a37f06.png">
