### PR TITLE
CI: Add Slack notifications to P2 E2E configuration

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -918,6 +918,28 @@ object P2E2ETests : BuildType({
 				}
 			}
 		}
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#e2eflowtesting-p2"
+				messageFormat = simpleMessageFormat()
+			}
+			branchFilter = "trunk"
+			buildFailed = true
+			buildFinishedSuccessfully = true
+			buildFailedToStart = true
+			firstSuccessAfterFailure = true
+			buildProbablyHanging = true
+		}
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#happytools-alerts"
+				messageFormat = simpleMessageFormat()
+			}
+			branchFilter = "trunk"
+			buildFailed = true
+		}
 	}
 
 	triggers {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds two Slack notifiers for the P2 E2E build configuration as requested in https://github.com/Automattic/wp-calypso/issues/56664#issuecomment-977766844.

Key changes:
- one notification to #e2eflowtesting-p2 for successful and failed builds.
- one noification to #happytools-alerts for failed builds only.

Related to #56664
