### PR TITLE
Change post-site selection UI for Jetpack manual activation flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
@@ -67,6 +67,9 @@ const LicensingActivationThankYouCompleted: FC< Props > = ( {
 				footerImage={ productConfirmationInfo.image }
 				isLoading={ isProductListFetching }
 				showContactUs
+				showProgressIndicator
+				progressIndicatorValue={ 3 }
+				progressIndicatorTotal={ 3 }
 			>
 				{ ! subscriptionTransferSucceeded && (
 					<p>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -250,7 +250,9 @@ const LicensingActivationThankYou: FC< Props > = ( {
 					</>
 				}
 				footerImage={ footerCardImg }
-				showProgressIndicator={ false }
+				showProgressIndicator
+				progressIndicatorValue={ 1 }
+				progressIndicatorTotal={ 3 }
 				showContactUs
 			>
 				{ hasProductInfo && ( isProductListFetching || productName ) && (

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -86,7 +86,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 				source,
 				jetpackTemporarySiteId,
 			},
-			`/checkout/jetpack/thank-you/licensing-manual-activate/${ productSlug }`
+			`/checkout/jetpack/thank-you/licensing-manual-activate-instructions/${ productSlug }`
 		);
 	}, [ jetpackTemporarySiteId, productSlug, source, receiptId ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, when a user makes a site-less purchase, they can choose between a connected site (from a dropdown) or select the manual activation option. When a user chooses the latter, they are sent to step 1 of the manual activation flow. This is incorrect and redundant since that step does not offer any important content to a user going through this flow. This PR changes that and makes the flow lead the user immediately to step number 2 of such flow.

**Note**: I added the progress indicator (green bar at the top right corner of the left panel) to all steps because flows looked inconsistent having some steps with it and some without.

#### Testing instructions

* Download this PR.
* Start Calypso with `yarn start`.
* Visit `http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_scan_monthly`.
* On the dropdown, select the last option, which says `I don't see my site`.
* Click on Continue.
* Verify that you're taken to a page titled `Be sure that you have the latest version of Jetpack`.
* Visit `https://wordpress.com/checkout/jetpack/thank-you/licensing-manual-activate/jetpack_scan_monthly`.
* On the dropdown, select the last option, which says `I don't see my site`.
* Click on Continue.
* Verify that you're taken to a page titled `Thank you for your purchase! 🎉`.
 
Related to 1201096622142517-as-1201419627847991

#### Demo of post-site selection UI – before 
<img width="1417" alt="Screen Shot 2021-11-24 at 15 28 10" src="https://user-images.githubusercontent.com/3418513/143294651-a9bae428-b519-4f74-87d8-ec42010fd14a.png">

#### Demo of post-site selection UI – after
<img width="1417" alt="Screen Shot 2021-11-24 at 15 28 01" src="https://user-images.githubusercontent.com/3418513/143294680-d5825621-1839-4e10-b8b0-f128a21daa6b.png">

