### PR TITLE
Checkout: Move transaction error analytics to onPaymentError

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -29,6 +29,7 @@ import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import wp from 'calypso/lib/wp';
 import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -572,9 +573,35 @@ export default function CompositeCheckout( {
 	);
 
 	const handlePaymentError = useCallback(
-		( { transactionError }: { transactionError: string | null } ) => {
+		( {
+			transactionError,
+			paymentMethodId,
+		}: {
+			transactionError: string | null;
+			paymentMethodId: string | null;
+		} ) => {
 			reduxDispatch(
 				errorNotice( transactionError || translate( 'An error occurred during your purchase.' ) )
+			);
+
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_payment_error', {
+					error_code: null,
+					reason: String( transactionError ),
+				} )
+			);
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_payment_error', {
+					error_code: null,
+					payment_method:
+						translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ?? '' ) || '',
+					reason: String( transactionError ),
+				} )
+			);
+			return reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
+					error_message: String( transactionError ),
+				} )
 			);
 		},
 		[ reduxDispatch, translate ]

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -598,7 +598,7 @@ export default function CompositeCheckout( {
 					reason: String( transactionError ),
 				} )
 			);
-			return reduxDispatch(
+			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
 					error_message: String( transactionError ),
 				} )

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -143,29 +143,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 					);
 				}
-				case 'TRANSACTION_ERROR': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_payment_error', {
-							error_code: null,
-							reason: String( action.payload.message ),
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_payment_error', {
-							error_code: null,
-							payment_method:
-								translateCheckoutPaymentMethodToWpcomPaymentMethod(
-									action.payload.paymentMethodId
-								) || '',
-							reason: String( action.payload.message ),
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
-							error_message: String( action.payload.message ),
-						} )
-					);
-				}
 				case 'FREE_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -168,9 +168,9 @@ The line items are for display purposes only. They should also include subtotals
 In addition, `CheckoutProvider` monitors the [transaction status](#useTransactionStatus) and will take actions when it changes.
 
 - If the `transactionStatus` changes to [`.PENDING`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.SUBMITTING`](#FormStatus).
-- If the `transactionStatus` changes to [`.ERROR`](#TransactionStatus), the transaction status will be set to [`.NOT_STARTED`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.READY`](#FormStatus), and the error message will be displayed.
+- If the `transactionStatus` changes to [`.ERROR`](#TransactionStatus), the transaction status will be set to [`.NOT_STARTED`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.READY`](#FormStatus), and the error message will be sent to the `onPaymentError` handler.
 - If the `transactionStatus` changes to [`.COMPLETE`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.COMPLETE`](#FormStatus) (which will cause the `onPaymentComplete` function to be called).
-- If the `transactionStatus` changes to [`.REDIRECTING`](#TransactionStatus), the page will be redirected to the `transactionRedirectUrl` (or will display an error as above if there is no url).
+- If the `transactionStatus` changes to [`.REDIRECTING`](#TransactionStatus), the page will be redirected to the `transactionRedirectUrl` (or will register an error as above if there is no url).
 - If the `transactionStatus` changes to [`.NOT_STARTED`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.READY`](#FormStatus).
 
 ### CheckoutReviewOrder

--- a/packages/composite-checkout/src/components/transaction-status-handler.ts
+++ b/packages/composite-checkout/src/components/transaction-status-handler.ts
@@ -2,10 +2,8 @@ import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { useCallback, useEffect } from 'react';
 import { useFormStatus } from '../lib/form-status';
-import { usePaymentMethodId } from '../lib/payment-methods';
 import { useTransactionStatus } from '../lib/transaction-status';
 import { TransactionStatus } from '../types';
-import useEvents from './use-events';
 
 const debug = debugFactory( 'composite-checkout:transaction-status-handler' );
 
@@ -30,8 +28,6 @@ function useTransactionStatusHandler( redirectToUrl: ( url: string ) => void ): 
 		resetTransaction,
 		setTransactionError,
 	} = useTransactionStatus();
-	const onEvent = useEvents();
-	const [ paymentMethodId ] = usePaymentMethodId();
 
 	const redirectErrormessage = __(
 		'An error occurred while redirecting to the payment partner. Please try again or contact support.'
@@ -46,11 +42,7 @@ function useTransactionStatusHandler( redirectToUrl: ( url: string ) => void ): 
 			setFormSubmitting();
 		}
 		if ( transactionStatus === TransactionStatus.ERROR ) {
-			debug( 'showing error', transactionError );
-			onEvent( {
-				type: 'TRANSACTION_ERROR',
-				payload: { message: transactionError || '', paymentMethodId },
-			} );
+			debug( 'an error occurred', transactionError );
 			resetTransaction();
 		}
 		if ( transactionStatus === TransactionStatus.COMPLETE ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/55809 we modified the `CheckoutProvider` component to add a new prop called `onPaymentError` which can be used by the consumer to take actions when a transaction error occurs. This was used in that PR to move the code that displayed the error into that prop, but the analytics for that event remained handled by the deprecated `onEvent` property (see https://github.com/Automattic/wp-calypso/pull/48282 for more information about removing that property).

This PR moves the analytics for transaction errors to occur in the `onPaymentError` handler as well.

This is similar to the work done in https://github.com/Automattic/wp-calypso/pull/57201 for page load errors.

#### Testing instructions

1. You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
2. Add a product to your cart and visit checkout.
3. Select "Credit or debit card" as the payment method.
4. Enter a valid but fake credit card number (eg: 4242 4242 4242 4242 when the API is _not_ sandboxed) as the payment method and submit the form.
5. Verify that an error message is displayed.
6. Verify that you see the `calypso_checkout_composite_payment_error` Tracks error displayed in the console and that its data looks sensible, including the payment method and the error message.

<img width="604" alt="Screen Shot 2021-11-24 at 5 12 09 PM" src="https://user-images.githubusercontent.com/2036909/143319287-17d36d66-6ecc-4107-b656-2363dbc3ef45.png">


