### PR TITLE
Checkout: add onStepChanged handler

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -564,6 +564,33 @@ export default function CompositeCheckout( {
 		checkoutFlow,
 	} );
 
+	const handleStepChanged = useCallback(
+		( {
+			stepNumber,
+			previousStepNumber,
+			paymentMethodId,
+		}: {
+			stepNumber: number | null;
+			previousStepNumber: number;
+			paymentMethodId: string;
+		} ) => {
+			if ( stepNumber === 2 && previousStepNumber === 1 ) {
+				reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_composite_first_step_complete', {
+						payment_method:
+							translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
+					} )
+				);
+			}
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_step_changed', {
+					step: stepNumber,
+				} )
+			);
+		},
+		[ reduxDispatch ]
+	);
+
 	const handlePaymentComplete = useCallback(
 		( args ) => {
 			onPaymentComplete?.( args );
@@ -715,6 +742,7 @@ export default function CompositeCheckout( {
 				onPaymentError={ handlePaymentError }
 				onPaymentRedirect={ handlePaymentRedirect }
 				onPageLoadError={ onPageLoadError }
+				onStepChanged={ handleStepChanged }
 				onEvent={ recordEvent }
 				paymentMethods={ paymentMethods }
 				paymentProcessors={ paymentProcessors }

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -1,8 +1,5 @@
 import debugFactory from 'debug';
-import {
-	translateCheckoutPaymentMethodToWpcomPaymentMethod,
-	translateCheckoutPaymentMethodToTracksPaymentMethod,
-} from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
+import { translateCheckoutPaymentMethodToTracksPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { logStashEvent, recordCompositeCheckoutErrorDuringAnalytics } from './lib/analytics';
 
@@ -90,22 +87,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				case 'a8c_checkout_add_coupon_button_clicked':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} )
-					);
-				case 'STEP_NUMBER_CHANGED':
-					if ( action.payload.stepNumber === 2 && action.payload.previousStepNumber === 1 ) {
-						reduxDispatch(
-							recordTracksEvent( 'calypso_checkout_composite_first_step_complete', {
-								payment_method:
-									translateCheckoutPaymentMethodToWpcomPaymentMethod(
-										action.payload.paymentMethodId
-									) || '',
-							} )
-						);
-					}
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_step_changed', {
-							step: action.payload.stepNumber,
-						} )
 					);
 				case 'STRIPE_TRANSACTION_BEGIN': {
 					reduxDispatch(

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -155,6 +155,7 @@ It has the following props.
 - `onPaymentRedirect?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for redirect payment methods when payment begins to redirect. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentError?: ({paymentMethodId: string | null, transactionError: string | null }) => null`. A function to call for payment methods when payment is not successful.
 - `onPageLoadError?: ( errorType: string, errorMessage: string, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
+- `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 - `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -44,6 +44,7 @@ export function CheckoutProvider( {
 	onPaymentRedirect,
 	onPaymentError,
 	onPageLoadError,
+	onStepChanged,
 	redirectToUrl,
 	theme,
 	paymentMethods,
@@ -118,6 +119,7 @@ export function CheckoutProvider( {
 			transactionStatusManager,
 			paymentProcessors,
 			onPageLoadError,
+			onStepChanged,
 		} ),
 		[
 			formStatus,
@@ -128,6 +130,7 @@ export function CheckoutProvider( {
 			transactionStatusManager,
 			paymentProcessors,
 			onPageLoadError,
+			onStepChanged,
 		]
 	);
 

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -26,7 +26,6 @@ import {
 	getDefaultOrderSummary,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
-	useEvents,
 	usePaymentMethod,
 } from '../public-api';
 import { FormStatus, CheckoutStepProps } from '../types';
@@ -288,23 +287,19 @@ export const CheckoutStep = ( {
 	const { stepNumber, nextStepNumber, isStepActive, isStepComplete, areStepsActive } = useContext(
 		CheckoutSingleStepDataContext
 	);
-	const { onPageLoadError } = useContext( CheckoutContext );
+	const { onPageLoadError, onStepChanged } = useContext( CheckoutContext );
 	const { formStatus, setFormValidating, setFormReady } = useFormStatus();
 	const setThisStepCompleteStatus = ( newStatus: boolean ) =>
 		setStepCompleteStatus( { ...stepCompleteStatus, [ stepNumber ]: newStatus } );
 	const goToThisStep = () => setActiveStepNumber( stepNumber );
-	const onEvent = useEvents();
 	const activePaymentMethod = usePaymentMethod();
 	const finishIsCompleteCallback = ( completeResult: boolean ) => {
 		setThisStepCompleteStatus( !! completeResult );
 		if ( completeResult ) {
-			onEvent( {
-				type: 'STEP_NUMBER_CHANGED',
-				payload: {
-					stepNumber: nextStepNumber,
-					previousStepNumber: stepNumber,
-					paymentMethodId: activePaymentMethod?.id ?? '',
-				},
+			onStepChanged?.( {
+				stepNumber: nextStepNumber,
+				previousStepNumber: stepNumber,
+				paymentMethodId: activePaymentMethod?.id ?? '',
 			} );
 			if ( nextStepNumber ) {
 				saveStepNumberToUrl( nextStepNumber );

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
 import {
+	StepChangedCallback,
 	CheckoutPageErrorCallback,
 	FormStatus,
 	PaymentMethod,
@@ -18,6 +19,7 @@ interface CheckoutContext {
 	transactionStatusManager: TransactionStatusManager | null;
 	paymentProcessors: PaymentProcessorProp;
 	onPageLoadError?: CheckoutPageErrorCallback;
+	onStepChanged?: StepChangedCallback;
 }
 
 const defaultCheckoutContext: CheckoutContext = {

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -108,6 +108,7 @@ export interface CheckoutProviderProps {
 	onPaymentRedirect?: PaymentEventCallback;
 	onPaymentError?: PaymentErrorCallback;
 	onPageLoadError?: CheckoutPageErrorCallback;
+	onStepChanged?: StepChangedCallback;
 	onEvent?: ( event: ReactStandardAction ) => void;
 	isLoading?: boolean;
 	redirectToUrl?: ( url: string ) => void;
@@ -121,6 +122,7 @@ export interface PaymentProcessorProp {
 	[ key: string ]: PaymentProcessorFunction;
 }
 
+export type StepChangedCallback = ( args: StepChangedEventArguments ) => void;
 export type PaymentEventCallback = ( args: PaymentEventCallbackArguments ) => void;
 export type PaymentErrorCallback = ( args: {
 	paymentMethodId: string | null;
@@ -131,6 +133,12 @@ export type CheckoutPageErrorCallback = (
 	errorMessage: string,
 	errorData?: Record< string, string | number | undefined >
 ) => void;
+
+export type StepChangedEventArguments = {
+	stepNumber: number | null;
+	previousStepNumber: number;
+	paymentMethodId: string;
+};
 
 export type PaymentEventCallbackArguments = {
 	paymentMethodId: string | null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/57201 we move page load error handling from the generic and deprecated `onEvent` handler (see https://github.com/Automattic/wp-calypso/pull/48282 for more information about removing that property) to a custom event handler just for that purpose. This PR does the same thing for step changed events by adding an optional `onStepChanged` property to the `CheckoutProvider` component which will be called any time the active checkout step is changed.

This is the final removal of the `onEvent` handler within the `composite-checkout` package. The handler itself cannot be removed until we remove all uses of `useEvents` inside calypso, but this is still a good milestone.

#### Testing instructions

1. You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
2. Add a product to your cart and visit checkout.
3. Progress through the checkout steps to the final step (note that there are actually only two steps in checkout: the contact details step and the payment method step). If you are already on the final step, return to the previous step by clicking the "Edit" button.
6. Verify that you see the `calypso_checkout_composite_step_changed` Tracks messages displayed in the console and that their data looks sensible.

<img width="618" alt="Screen Shot 2021-11-24 at 5 43 33 PM" src="https://user-images.githubusercontent.com/2036909/143322058-d6591786-5435-4607-bc24-58bef7d02fb7.png">


