### PR TITLE
Ryu no longer explicitly excluded from the design picker

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -29,11 +29,6 @@ import './style.scss';
 // themes? e.g. `link-in-bio` or `no-fold`
 const STATIC_PREVIEWS = [ 'bantry', 'sigler', 'miller', 'pollard', 'paxton', 'jones', 'baker' ];
 
-const EXCLUDED_THEMES = [
-	// The Ryu theme doesn't currently have any annotations
-	'ryu',
-];
-
 export default function DesignPickerStep( props ) {
 	const { flowName, stepName, isReskinned } = props;
 
@@ -85,21 +80,19 @@ export default function DesignPickerStep( props ) {
 		// `/start` and `/new` onboarding flows. Or perhaps fetching should be done within the <DesignPicker>
 		// component itself. The `/new` environment needs helpers for making authenticated requests to
 		// the theme API before we can do this.
-		const allThemes = themesToBeTransformed
-			.filter( ( { id } ) => ! EXCLUDED_THEMES.includes( id ) )
-			.map( ( { id, name, taxonomies } ) => ( {
-				categories: taxonomies?.theme_subject ?? [],
-				// Blank Canvas uses the theme_picks taxonomy with a "featured" term in order to
-				// appear prominently in theme galleries.
-				showFirst: !! taxonomies?.theme_picks?.find( ( { slug } ) => slug === 'featured' ),
-				features: [],
-				is_premium: false,
-				slug: id,
-				template: id,
-				theme: id,
-				title: name,
-				...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
-			} ) );
+		const allThemes = themesToBeTransformed.map( ( { id, name, taxonomies } ) => ( {
+			categories: taxonomies?.theme_subject ?? [],
+			// Blank Canvas uses the theme_picks taxonomy with a "featured" term in order to
+			// appear prominently in theme galleries.
+			showFirst: !! taxonomies?.theme_picks?.find( ( { slug } ) => slug === 'featured' ),
+			features: [],
+			is_premium: false,
+			slug: id,
+			template: id,
+			theme: id,
+			title: name,
+			...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+		} ) );
 
 		if ( allThemes.length === 0 ) {
 			return [];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ryu has been removed from the list of `auto-loading-homepage` themes, so it no longer needs the explicit exclusion. pdgK6S-mr-p2#comment-692

* Remove `EXCLUDED_THEMES` list from design picker step

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Can test on calypso.live
* View the design picker and ensure Ryu still doesn't appear

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

