### PR TITLE
Sets signup destination to /home for DIFM signup

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -12,6 +12,7 @@ export function generateFlows( {
 	getChecklistThemeDestination = noop,
 	getImportDestination = noop,
 	getDestinationFromIntent = noop,
+	getDIFMSignupDestination = noop,
 } = {} ) {
 	const flows = [
 		{
@@ -445,7 +446,7 @@ export function generateFlows( {
 		{
 			name: 'do-it-for-me',
 			steps: [ 'user', 'difm-design-setup-site', 'site-info-collection', 'domains' ],
-			destination: getSignupDestination,
+			destination: getDIFMSignupDestination,
 			description: 'A flow for DIFM Lite leads',
 			lastModified: '2021-09-30',
 		},

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -126,6 +126,10 @@ function getImportDestination( { importSiteEngine, importSiteUrl, siteSlug } ) {
 	);
 }
 
+function getDIFMSignupDestination( { siteSlug } ) {
+	return `/home/${ siteSlug }`;
+}
+
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -136,6 +140,7 @@ const flows = generateFlows( {
 	getEditorDestination,
 	getImportDestination,
 	getDestinationFromIntent,
+	getDIFMSignupDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* After checkout, the default signup destination is the `site-setup` flow (enabled via #58223). For DIFM signup, however, the desired post-checkout destination is the thank you screen. This PR changes the signup destination to /home for the `do-it-for-me` signup flow, which was the previous default.
* Related discussion in p1637777040201600-slack-C028NRBP2AU and p1637767893005700-slack-C02KVCAL7GX

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the flow at `/start/do-it-for-me`.
* Go through the flow steps and complete checkout.
* After checkout, confirm that you see the thank-you screen.
![image](https://user-images.githubusercontent.com/5436027/143412595-bec3d651-044d-47c3-b3ed-291b8a3daf04.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->