### PR TITLE
Fix "Claim your free domain" banner style

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -352,6 +352,10 @@
 		display: inline-flex;
 		justify-content: flex-start;
 		flex-wrap: wrap;
+		flex-direction: column;
+		align-items: flex-start;
+		align-self: flex-start;
+
 		& > .button {
 			margin: 16px 8px 0;
 		}
@@ -359,6 +363,7 @@
 			& > .button:first-child {
 				margin-left: 0;
 			}
+			flex-direction: row;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -299,7 +299,8 @@
 }
 
 .domain-management-list__items + .empty-domains-list-card {
-	margin-top: 24px;
+	margin-top: 32px;
+	margin-bottom: 32px;
 }
 
 .domain-management-list__filter,
@@ -349,10 +350,15 @@
 
 	.empty-domains-list-card__actions {
 		display: inline-flex;
-		justify-content: center;
+		justify-content: flex-start;
 		flex-wrap: wrap;
 		& > .button {
 			margin: 16px 8px 0;
+		}
+		@include break-small {
+			& > .button:first-child {
+				margin-left: 0;
+			}
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -350,20 +350,16 @@
 
 	.empty-domains-list-card__actions {
 		display: inline-flex;
-		justify-content: flex-start;
+		justify-content: center;
 		flex-wrap: wrap;
-		flex-direction: column;
-		align-items: flex-start;
-		align-self: flex-start;
-
 		& > .button {
 			margin: 16px 8px 0;
 		}
 		@include break-small {
+			justify-content: flex-start;
 			& > .button:first-child {
 				margin-left: 0;
 			}
-			flex-direction: row;
 		}
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes the style of "Claim your free domain" banner, aligning buttons on the left (screen >600px) and increasing bottom and upper margins (32px).

## Testing instructions

Open a paid annual sub where you haven't claimed free domain yet and verify that the style matches the one in this screenshot.

![free-domain-banner](https://user-images.githubusercontent.com/2797601/143413110-cbccf55f-7b2c-411b-9b4a-ad8f31fe9e39.png)

Related to pcYYhz-pX-p2#comment-365

