### PR TITLE
Fix incorrect usages of isATEnabled

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -25,6 +25,8 @@ import {
 import TransferDomain from 'calypso/my-sites/domains/transfer-domain';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSiteId,
 	getSelectedSite,
@@ -296,13 +298,14 @@ const redirectToUseYourDomainIfVipSite = () => {
 
 const jetpackNoDomainsWarning = ( context, next ) => {
 	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const isJetpack = isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId );
 
-	if ( selectedSite && selectedSite.jetpack && ! selectedSite.options.is_automated_transfer ) {
+	if ( siteId && isJetpack ) {
 		context.primary = (
 			<Main>
 				<PageViewTracker
-					path={ context.path.indexOf( '/domains/add' ) === 0 ? '/domains/add' : '/domains/manage' }
+					path={ context.path.startsWith( '/domains/add' ) ? '/domains/add' : '/domains/manage' }
 					title="My Sites > Domains > No Domains On Jetpack"
 				/>
 				<EmptyContent
@@ -311,7 +314,7 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 						'You can only purchase domains for sites hosted on WordPress.com at this time.'
 					) }
 					action={ translate( 'View Plans' ) }
-					actionURL={ '/plans/' + ( selectedSite.slug || '' ) }
+					actionURL={ '/plans/' + getSelectedSiteSlug( state ) }
 				/>
 			</Main>
 		);

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -10,7 +10,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { isATEnabled } from 'calypso/lib/automated-transfer';
 import { sectionify } from 'calypso/lib/route';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import MapDomain from 'calypso/my-sites/domains/map-domain';
@@ -299,7 +298,7 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 
-	if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
+	if ( selectedSite && selectedSite.jetpack && ! selectedSite.options.is_automated_transfer ) {
 		context.primary = (
 			<Main>
 				<PageViewTracker

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -4,12 +4,12 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryJetpackSettings from 'calypso/components/data/query-jetpack-settings';
-import { isATEnabled } from 'calypso/lib/automated-transfer';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Protect from './protect';
 import SpamFilteringSettings from './spam-filtering-settings';
 import Sso from './sso';
@@ -96,7 +96,7 @@ class SiteSettingsFormSecurity extends Component {
 
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const selectedSite = getSelectedSite( state );
+	const isAtomic = isSiteAutomatedTransfer( siteId );
 	const protectModuleActive = !! isJetpackModuleActive( state, siteId, 'protect' );
 	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
 	const protectIsUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
@@ -111,7 +111,7 @@ const connectComponent = connect( ( state ) => {
 	);
 
 	return {
-		isAtomic: isATEnabled( selectedSite ),
+		isAtomic,
 		protectModuleActive,
 		protectModuleUnavailable: siteInDevMode && protectIsUnavailableInDevMode,
 		akismetUnavailable: siteInDevMode && akismetIsUnavailableInDevMode,

--- a/client/state/happychat/selectors/get-groups.js
+++ b/client/state/happychat/selectors/get-groups.js
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { isATEnabled } from 'calypso/lib/automated-transfer';
 import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from 'calypso/state/happychat/constants';
-import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 /**
@@ -12,24 +12,16 @@ import { getSectionName } from 'calypso/state/ui/selectors';
  * @returns {Array} of groups for site Id
  */
 export default ( state, siteId ) => {
-	const groups = [];
-
 	// For Jetpack Connect we need to direct chat users to the JPOP group, to account for cases
 	// when the user does not have a site yet, or their primary site is not a Jetpack site.
 	if ( isEnabled( 'jetpack/happychat' ) && getSectionName( state ) === 'jetpack-connect' ) {
-		groups.push( HAPPYCHAT_GROUP_JPOP );
-		return groups;
+		return [ HAPPYCHAT_GROUP_JPOP ];
 	}
 
-	const siteDetails = getSite( state, siteId );
-
-	if ( isATEnabled( siteDetails ) ) {
-		// AT sites should go to WP.com even though they are jetpack also
-		groups.push( HAPPYCHAT_GROUP_WPCOM );
-	} else if ( isJetpackSite( state, siteId ) ) {
-		groups.push( HAPPYCHAT_GROUP_JPOP );
-	} else {
-		groups.push( HAPPYCHAT_GROUP_WPCOM );
+	// AT sites should go to WP.com even though they are jetpack also
+	if ( isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId ) ) {
+		return [ HAPPYCHAT_GROUP_JPOP ];
 	}
-	return groups;
+
+	return [ HAPPYCHAT_GROUP_WPCOM ];
 };


### PR DESCRIPTION
There is an `isATEnabled` function exported from `lib/automated-transfer` that checks that a site is either Atomic or _is capable of being transferred_. E.g., it checks if the site has a Business plan, if the user can manage the site...

But we've been using this function at places where we want to check just if the site is Atomic or not. `isATEnabled` is incorrect there. The `isSiteAutomatedTransfer` selector is the right one to use.

The only place where `isATEnabled` should be used is in the plugin upload UI. A plugin can be uploaded either to an Atomic site, or to a Simple site that is eligible for a transfer. Performing the upload then starts the transfer. The same workflow works for theme upload.

I found this bug when investigating why the Inline Help widget in #55189 depends on `calypso-products` 🙂 

**How to test:**
Verify the three features that are affected by this:
- redirecting true Jetpack sites away from `/domains`
- showing anti-spam settings in Site Settings / Security
- sorting Happychat users into JPOP and WPCOM groups
