### PR TITLE
New import E2E tests

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -23,6 +23,7 @@ const selectors = {
 	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
 	startImportButton:
 		'div.is-intent button.select-items-alt__item-button:text("Import your site content")',
+	// And entry of the list of selectable importers
 	importerListButton: ( index: number ) =>
 		`div.list__importers-primary:nth-child(${ index + 1 }) .action-card__button-container button`,
 };
@@ -44,7 +45,10 @@ export class StartImportFlow {
 	 * @param {string} text User-visible text on the button.
 	 */
 	async clickButton( text: string ): Promise< void > {
-		await this.page.click( selectors.button( text ) );
+		const selector = selectors.button( text );
+
+		await this.page.waitForSelector( selector );
+		await this.page.click( selector );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -48,6 +48,13 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Validates that we've landed on the setup page.
+	 */
+	async validateSetupPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.startImportButton );
+	}
+
+	/**
 	 * Validates that we've landed on the URL capture page.
 	 */
 	async validateURLCapturePage(): Promise< void > {
@@ -128,7 +135,7 @@ export class StartImportFlow {
 	 */
 	async startSetup( siteSlug: string ): Promise< void > {
 		await this.page.goto( DataHelper.getCalypsoURL( '/start/setup-site/intent', { siteSlug } ) );
-		await this.page.waitForSelector( selectors.startImportButton );
+		await this.validateSetupPage();
 		await this.page.click( selectors.startImportButton );
 	}
 

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -31,16 +31,12 @@ const selectors = {
  * Class encapsulating the flow when starting a new start importer ('/start/importer')
  */
 export class StartImportFlow {
-	private page: Page;
-
 	/**
 	 * Constructs an instance of the flow.
 	 *
 	 * @param {Page} page The underlying page.
 	 */
-	constructor( page: Page ) {
-		this.page = page;
-	}
+	constructor( private page: Page ) {}
 
 	/**
 	 * Given text, clicks on the first instance of the button with the text.

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -20,7 +20,8 @@ const selectors = {
 	// Buttons
 	checkUrlButton: 'form.capture__input-wrapper button.action-buttons__next',
 	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
-	startImportButton: 'div.is-intent button.select-items-alt__item-button:text("Import your site content")'
+	startImportButton:
+		'div.is-intent button.select-items-alt__item-button:text("Import your site content")',
 };
 
 /**
@@ -57,7 +58,7 @@ export class StartImportFlow {
 	/**
 	 * Validates that we've landed on the URL capture page with 'typo' error.
 	 */
-	 async validateErrorCapturePage( error: string ): Promise< void > {
+	async validateErrorCapturePage( error: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.analyzeError( error ) );
 	}
 
@@ -72,7 +73,9 @@ export class StartImportFlow {
 	 * Validates that we've landed on the import page.
 	 */
 	async validateImportPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.startBuildingHeader( 'Your content is ready for its brand new home' ) );
+		await this.page.waitForSelector(
+			selectors.startBuildingHeader( 'Your content is ready for its brand new home' )
+		);
 	}
 
 	/**
@@ -80,15 +83,14 @@ export class StartImportFlow {
 	 *
 	 * @param {string} reason The reason shown in main header.
 	 */
-	 async validateBuildingPage( reason: string ): Promise< void > {
-		console.log(selectors.startBuildingHeader( reason ));
+	async validateBuildingPage( reason: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.startBuildingHeader( reason ) );
 	}
 
 	/**
 	 * Validates that we've landed on the design setup page.
 	 */
-	 async validateDesignPage(): Promise< void > {
+	async validateDesignPage(): Promise< void > {
 		await this.page.waitForSelector( selectors.setupHeader );
 	}
 
@@ -107,10 +109,8 @@ export class StartImportFlow {
 	 *
 	 * @param {string} siteSlug The site slug URL.
 	 */
-	 async startImport( siteSlug: string ): Promise< void > {
-		await this.page.goto(
-			DataHelper.getCalypsoURL( '/start/importer', { siteSlug } )
-		);
+	async startImport( siteSlug: string ): Promise< void > {
+		await this.page.goto( DataHelper.getCalypsoURL( '/start/importer', { siteSlug } ) );
 	}
 
 	/**
@@ -118,10 +118,8 @@ export class StartImportFlow {
 	 *
 	 * @param {string} siteSlug The site slug URL.
 	 */
-	 async startSetup( siteSlug: string ): Promise< void > {
-		await this.page.goto(
-			DataHelper.getCalypsoURL( '/start/setup-site/intent', { siteSlug } )
-		);
+	async startSetup( siteSlug: string ): Promise< void > {
+		await this.page.goto( DataHelper.getCalypsoURL( '/start/setup-site/intent', { siteSlug } ) );
 		await this.page.waitForSelector( selectors.startImportButton );
 		await this.page.click( selectors.startImportButton );
 	}
@@ -129,7 +127,7 @@ export class StartImportFlow {
 	/**
 	 * Start the building.
 	 */
-	 async startBuilding(): Promise< void > {
+	async startBuilding(): Promise< void > {
 		await this.page.click( selectors.startBuildingButton );
 	}
 

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -9,6 +9,8 @@ const selectors = {
 
 	// Inputs
 	urlInput: 'input.capture__input',
+	migrationInput: ( value: string ) =>
+		`input#sites-block__faux-site-selector-url-input[value="${ value }"]`,
 
 	// Errors
 	analyzeError: ( text: string ) => `div.capture__input-error-msg:text("${ text }")`,
@@ -102,6 +104,13 @@ export class StartImportFlow {
 	 */
 	async validateDesignPage(): Promise< void > {
 		await this.page.waitForSelector( selectors.setupHeader );
+	}
+
+	/**
+	 * Validates that we've landed on the migration page.
+	 */
+	async validateMigrationPage( siteSlug: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.migrationInput( siteSlug ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -5,6 +5,7 @@ const selectors = {
 	// Generic
 	button: ( text: string ) => `button:text("${ text }")`,
 	backLink: 'a:text("Back")',
+	dontHaveASiteButton: 'a:text("I don\'t have a site address")',
 
 	// Inputs
 	urlInput: 'input.capture__input',
@@ -22,6 +23,8 @@ const selectors = {
 	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
 	startImportButton:
 		'div.is-intent button.select-items-alt__item-button:text("Import your site content")',
+	importerListButton: ( index: number ) =>
+		`div.list__importers-primary:nth-child(${ index + 1 }) .action-card__button-container button`,
 };
 
 /**
@@ -95,6 +98,15 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Validates that we've landed on the importer list page.
+	 */
+	async validateImporterListPage(): Promise< void > {
+		await this.page.waitForSelector(
+			selectors.startBuildingHeader( 'Import your content from another platform' )
+		);
+	}
+
+	/**
 	 * Enter the URL to import from on the "Enter your site address" input form.
 	 *
 	 * @param {string} url The source URL.
@@ -129,6 +141,25 @@ export class StartImportFlow {
 	 */
 	async startBuilding(): Promise< void > {
 		await this.page.click( selectors.startBuildingButton );
+	}
+
+	/**
+	 * Open the importer list page.
+	 */
+	async startImporterList(): Promise< void > {
+		await this.page.click( selectors.dontHaveASiteButton );
+	}
+
+	/**
+	 * An entry from the list of importers.
+	 *
+	 * @param index the desired importer
+	 */
+	async selectImporterFromList( index: number ): Promise< void > {
+		await this.page.click( selectors.importerListButton( index ) );
+		await this.page.waitForSelector(
+			selectors.startBuildingHeader( 'Your content is ready for its new home' )
+		);
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { DataHelper } from '../..';
 
 const selectors = {
 	// Generic
@@ -8,11 +9,18 @@ const selectors = {
 	// Inputs
 	urlInput: 'input.capture__input',
 
+	// Errors
+	analyzeError: ( text: string ) => `div.capture__input-error-msg:text("${ text }")`,
+
 	// Headers
 	scanningHeader: 'h1:text("Scanning your site")',
+	setupHeader: 'h1:text("Themes")',
+	startBuildingHeader: ( text: string ) => `h1.onboarding-title:text("${ text }")`,
 
 	// Buttons
 	checkUrlButton: 'form.capture__input-wrapper button.action-buttons__next',
+	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
+	startImportButton: 'div.is-intent button.select-items-alt__item-button:text("Import your site content")'
 };
 
 /**
@@ -47,6 +55,13 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Validates that we've landed on the URL capture page with 'typo' error.
+	 */
+	 async validateErrorCapturePage( error: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.analyzeError( error ) );
+	}
+
+	/**
 	 * Validates that we've landed on the scanning page.
 	 */
 	async validateScanningPage(): Promise< void > {
@@ -57,17 +72,65 @@ export class StartImportFlow {
 	 * Validates that we've landed on the import page.
 	 */
 	async validateImportPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.button( 'Import your content' ) );
+		await this.page.waitForSelector( selectors.startBuildingHeader( 'Your content is ready for its brand new home' ) );
 	}
 
 	/**
-	 * Enter the URL to import from.
+	 * Validates that we've landed on the building page.
+	 *
+	 * @param {string} reason The reason shown in main header.
+	 */
+	 async validateBuildingPage( reason: string ): Promise< void > {
+		console.log(selectors.startBuildingHeader( reason ));
+		await this.page.waitForSelector( selectors.startBuildingHeader( reason ) );
+	}
+
+	/**
+	 * Validates that we've landed on the design setup page.
+	 */
+	 async validateDesignPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.setupHeader );
+	}
+
+	/**
+	 * Enter the URL to import from on the "Enter your site address" input form.
 	 *
 	 * @param {string} url The source URL.
 	 */
 	async enterURL( url: string ): Promise< void > {
 		await this.page.fill( selectors.urlInput, url );
 		await this.page.click( selectors.checkUrlButton );
+	}
+
+	/**
+	 * Go to first import page.
+	 *
+	 * @param {string} siteSlug The site slug URL.
+	 */
+	 async startImport( siteSlug: string ): Promise< void > {
+		await this.page.goto(
+			DataHelper.getCalypsoURL( '/start/importer', { siteSlug } )
+		);
+	}
+
+	/**
+	 * Go to first setup page.
+	 *
+	 * @param {string} siteSlug The site slug URL.
+	 */
+	 async startSetup( siteSlug: string ): Promise< void > {
+		await this.page.goto(
+			DataHelper.getCalypsoURL( '/start/setup-site/intent', { siteSlug } )
+		);
+		await this.page.waitForSelector( selectors.startImportButton );
+		await this.page.click( selectors.startImportButton );
+	}
+
+	/**
+	 * Start the building.
+	 */
+	 async startBuilding(): Promise< void > {
+		await this.page.click( selectors.startBuildingButton );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -87,4 +87,26 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.selectImporterFromList( 0 );
 		} );
 	} );
+
+	// Go back through pages
+	describe( 'Go back to first page', () => {
+		navigateToSetup();
+
+		it( 'Go to Import page', async () => {
+			await startImportFlow.enterURL( 'make.wordpress.org' );
+			await startImportFlow.validateImportPage();
+		} );
+
+		// Back one page
+		it( 'Back to URL capture page', async () => {
+			await startImportFlow.goBackOneScreen();
+			await startImportFlow.validateURLCapturePage();
+		} );
+
+		// Back one page
+		it( 'Back to Setup page', async () => {
+			await startImportFlow.goBackOneScreen();
+			await startImportFlow.validateSetupPage();
+		} );
+	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -40,6 +40,10 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateScanningPage();
 			await startImportFlow.validateImportPage();
+			await startImportFlow.clickButton( 'Import your content' );
+
+			// When the new flows will be created this check will need to be replaced
+			await startImportFlow.validateMigrationPage( 'https://make.wordpress.org/' );
 		} );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -5,7 +5,7 @@
 import { DataHelper, LoginPage, setupHooks, StartImportFlow } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
+describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	let page: Page;
 	let startImportFlow: StartImportFlow;
 
@@ -15,14 +15,14 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 	} );
 
 	// Login in default page.
-	it( 'Log in', async function () {
+	it( 'Log in', async () => {
 		const loginPage = new LoginPage( page );
 		await loginPage.login( { account: 'defaultUser' } );
 	} );
 
 	// A normal and valid import flow.
-	describe( 'Follow the import flow', function () {
-		it( 'Navigate to Setup page', async function () {
+	describe( 'Follow the import flow', () => {
+		it( 'Navigate to Setup page', async () => {
 			await startImportFlow.startSetup( 'e2eflowtesting4.wordpress.com' );
 			await startImportFlow.validateURLCapturePage();
 		} );
@@ -40,8 +40,8 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 		{ url: 'wordpress.com', reason: 'Your site is already on WordPress.com' },
 		// example.com will never be a WordPress site.
 		{ url: 'example.com', reason: "Your existing content can't be imported" },
-	] )( "Follow the WordPress can't be imported flow", function ( { url, reason } ) {
-		it( `Navigate to Capture page`, async function () {
+	] )( "Follow the WordPress can't be imported flow", ( { url, reason } ) => {
+		it( 'Navigate to Capture page', async () => {
 			await startImportFlow.startImport( 'e2eflowtesting4.wordpress.com' );
 			await startImportFlow.validateURLCapturePage();
 		} );
@@ -56,21 +56,35 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 	} );
 
 	// An import flow which show an error below the "Enter your site address" input form.
-	describe( 'Follow the WordPress domain error flow', function () {
-		it( `Navigate to Capture page`, async function () {
+	describe( 'Follow the WordPress domain error flow', () => {
+		it( 'Navigate to Capture page', async () => {
 			await startImportFlow.startImport( 'e2eflowtesting4.wordpress.com' );
 			await startImportFlow.validateURLCapturePage();
 		} );
 
 		// One of several errors found on Blogs::get_blog_name_error_code.
 		// A deleted wpcom site does generate the same error.
-		it( `Start an invalid WordPress import typo`, async () => {
+		it( 'Start an invalid WordPress import typo', async () => {
 			// 1.example.com is guaranteed never to be a valid DNS
 			await startImportFlow.enterURL( '1.example.com' );
 			await startImportFlow.validateScanningPage();
 			await startImportFlow.validateErrorCapturePage(
 				'The address you entered is not valid. Please try again.'
 			);
+		} );
+	} );
+
+	// The "I don't have a site address" flow
+	describe( "I don't have a site flow", () => {
+		it( 'Navigate to Capture page', async () => {
+			await startImportFlow.startImport( 'e2eflowtesting4.wordpress.com' );
+			await startImportFlow.validateURLCapturePage();
+		} );
+
+		it( 'Select that there is no site', async () => {
+			await startImportFlow.startImporterList();
+			await startImportFlow.validateImporterListPage();
+			await startImportFlow.selectImporterFromList( 0 );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -14,13 +14,13 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 		startImportFlow = new StartImportFlow( page );
 	} );
 
-	// Login in default page
+	// Login in default page.
 	it( 'Log in', async function () {
 		const loginPage = new LoginPage( page );
 		await loginPage.login( { account: 'defaultUser' } );
 	} );
 
-	// A normal and valid import flow
+	// A normal and valid import flow.
 	describe( 'Follow the import flow', function () {
 		it( 'Navigate to Setup page', async function () {
 			await startImportFlow.startSetup( 'e2eflowtesting4.wordpress.com' );
@@ -34,11 +34,13 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 		} );
 	} );
 
-	// An import flow that redirect to a page that
+	// An import flow that redirect to the "start building" page.
 	describe.each( [
+		// wordpress.com is already a WPCOM site and ever will be.
 		{ url: 'wordpress.com', reason: 'Your site is already on WordPress.com' },
-		{ url: 'example.com', reason: 'Your existing content can\'t be imported' },
-	] )( 'Follow the WordPress can\'t be imported flow', function ( { url, reason } ) {
+		// example.com will never be a WordPress site.
+		{ url: 'example.com', reason: "Your existing content can't be imported" },
+	] )( "Follow the WordPress can't be imported flow", function ( { url, reason } ) {
 		it( `Navigate to Capture page`, async function () {
 			await startImportFlow.startImport( 'e2eflowtesting4.wordpress.com' );
 			await startImportFlow.validateURLCapturePage();
@@ -53,18 +55,22 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 		} );
 	} );
 
-	describe( 'Follow the WordPress domain error flow', function ( ) {
+	// An import flow which show an error below the "Enter your site address" input form.
+	describe( 'Follow the WordPress domain error flow', function () {
 		it( `Navigate to Capture page`, async function () {
 			await startImportFlow.startImport( 'e2eflowtesting4.wordpress.com' );
 			await startImportFlow.validateURLCapturePage();
 		} );
 
-		// One of several errors found on Blogs::get_blog_name_error_code
-		// A deleted wpcom site does generate the same error
+		// One of several errors found on Blogs::get_blog_name_error_code.
+		// A deleted wpcom site does generate the same error.
 		it( `Start an invalid WordPress import typo`, async () => {
+			// 1.example.com is guaranteed never to be a valid DNS
 			await startImportFlow.enterURL( '1.example.com' );
 			await startImportFlow.validateScanningPage();
-			await startImportFlow.validateErrorCapturePage( 'The address you entered is not valid. Please try again.' );
+			await startImportFlow.validateErrorCapturePage(
+				'The address you entered is not valid. Please try again.'
+			);
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -20,12 +20,21 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		await loginPage.login( { account: 'defaultUser' } );
 	} );
 
-	// A normal and valid import flow.
-	describe( 'Follow the import flow', () => {
-		it( 'Navigate to Setup page', async () => {
-			await startImportFlow.startSetup( 'e2eflowtesting4.wordpress.com' );
+	/**
+	 * Navigate to initial setup page
+	 *
+	 * @param siteSlug The site slug URL.
+	 */
+	const navigateToSetup = ( siteSlug = 'e2eflowtesting4.wordpress.com' ) => {
+		it( `Navigate to Setup page as ${ siteSlug }`, async () => {
+			await startImportFlow.startSetup( siteSlug );
 			await startImportFlow.validateURLCapturePage();
 		} );
+	};
+
+	// A normal and valid import flow.
+	describe( 'Follow the import flow', () => {
+		navigateToSetup();
 
 		it( 'Start a WordPress import', async () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
@@ -41,10 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		// example.com will never be a WordPress site.
 		{ url: 'example.com', reason: "Your existing content can't be imported" },
 	] )( "Follow the WordPress can't be imported flow", ( { url, reason } ) => {
-		it( 'Navigate to Capture page', async () => {
-			await startImportFlow.startImport( 'e2eflowtesting4.wordpress.com' );
-			await startImportFlow.validateURLCapturePage();
-		} );
+		navigateToSetup();
 
 		it( `Start an invalid WordPress import (${ reason })`, async () => {
 			await startImportFlow.enterURL( url );
@@ -57,10 +63,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 	// An import flow which show an error below the "Enter your site address" input form.
 	describe( 'Follow the WordPress domain error flow', () => {
-		it( 'Navigate to Capture page', async () => {
-			await startImportFlow.startImport( 'e2eflowtesting4.wordpress.com' );
-			await startImportFlow.validateURLCapturePage();
-		} );
+		navigateToSetup();
 
 		// One of several errors found on Blogs::get_blog_name_error_code.
 		// A deleted wpcom site does generate the same error.
@@ -74,12 +77,9 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		} );
 	} );
 
-	// The "I don't have a site address" flow
+	// The "I don't have a site address" flow.
 	describe( "I don't have a site flow", () => {
-		it( 'Navigate to Capture page', async () => {
-			await startImportFlow.startImport( 'e2eflowtesting4.wordpress.com' );
-			await startImportFlow.validateURLCapturePage();
-		} );
+		navigateToSetup();
 
 		it( 'Select that there is no site', async () => {
 			await startImportFlow.startImporterList();

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -109,4 +109,30 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.validateSetupPage();
 		} );
 	} );
+
+	// Go back from a importer error page
+	describe( 'Go back from error', () => {
+		navigateToSetup();
+
+		// Back to URL capture page from the error page
+		it( 'Back to URL capture page from error page', async () => {
+			await startImportFlow.enterURL( 'example.com' );
+			await startImportFlow.clickButton( 'Back to start' );
+			await startImportFlow.validateURLCapturePage();
+		} );
+	} );
+
+	// Go back from a importer error page
+	describe( 'Go back from building page', () => {
+		navigateToSetup();
+
+		// Back to setup page from the design page
+		it( 'Back to URL capture page from error page', async () => {
+			await startImportFlow.enterURL( 'example.com' );
+			await startImportFlow.startBuilding();
+			await startImportFlow.validateDesignPage();
+			await startImportFlow.goBackOneScreen();
+			await startImportFlow.validateSetupPage();
+		} );
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add all the most important E2E tests that cover up the start import flow.

* **Valid** import flow
* Flow where a site **can't be imported**
* Flow where `public-api` returns an **error**
* Flow where the user select **I don't have a site**
* Flow where the user goes back from **import page**
* Flow where the user goes back from **error page**
* Flow where the user goes back from **building page**

When the new flows are added the tests will have to be modified a bit. The first one check if the last page is `/migrate/<SITE>?from-site=<SLUG>`. The new flows will not end on internal pages.

#### Testing instructions

Ensure that the environment variable `NODE_CONFIG_ENV` is set. Otherwise:

```bash
export NODE_CONFIG_ENV='decrypted'
```

From the project root:

```bash
cd test/e2e
yarn jest specs/specs-playwright/wp-start__importer.ts
```

Detailed instructions here: **pcmemI-h6-p2**. Jest will open a Chromium window and all the tests will be run there.