### PR TITLE
QueryManager: remove usages of _.includes

### DIFF
--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import moment from 'moment';
 import PaginatedQueryManager from '../paginated';
 import { DEFAULT_MEDIA_QUERY } from './constants';
@@ -27,7 +26,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 						return true;
 					}
 
-					return media.title && includes( media.title.toLowerCase(), value.toLowerCase() );
+					return media.title && media.title.toLowerCase().includes( value.toLowerCase() );
 
 				case 'mime_type':
 					if ( ! value ) {

--- a/client/lib/query-manager/paginated/index.js
+++ b/client/lib/query-manager/paginated/index.js
@@ -1,4 +1,4 @@
-import { cloneDeep, includes, omit, range } from 'lodash';
+import { cloneDeep, omit, range } from 'lodash';
 import QueryManager from '../';
 import { DEFAULT_PAGINATED_QUERY, PAGINATION_QUERY_KEYS } from './constants';
 import PaginatedQueryKey from './key';
@@ -210,7 +210,7 @@ export default class PaginatedQueryManager extends QueryManager {
 				// Ensure that item set is comprised of all indices leading up
 				// to received page, even if those items are not known.
 				const itemKey = nextQuery.itemKeys[ index ];
-				if ( ! includes( pageItemKeys, itemKey ) ) {
+				if ( ! pageItemKeys.includes( itemKey ) ) {
 					return itemKey;
 				}
 			} ),
@@ -222,7 +222,7 @@ export default class PaginatedQueryManager extends QueryManager {
 			...nextQuery.itemKeys.slice( startOffset + perPage ).filter( ( itemKey ) => {
 				// Filter out any item keys which exist in the page set, as
 				// this indicates that they've trickled down from later page
-				return itemKey && ! includes( pageItemKeys, itemKey );
+				return itemKey && ! pageItemKeys.includes( itemKey );
 			} ),
 		];
 

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -1,4 +1,4 @@
-import { some, includes, get } from 'lodash';
+import { some, get } from 'lodash';
 import moment from 'moment';
 import PaginatedQueryManager from '../paginated';
 import { DEFAULT_POST_QUERY } from './constants';
@@ -29,8 +29,8 @@ export default class PostQueryManager extends PaginatedQueryManager {
 
 					const search = value.toLowerCase();
 					return (
-						( post.title && includes( post.title.toLowerCase(), search ) ) ||
-						( post.content && includes( post.content.toLowerCase(), search ) )
+						( post.title && post.title.toLowerCase().includes( search ) ) ||
+						( post.content && post.content.toLowerCase().includes( search ) )
 					);
 				}
 
@@ -47,7 +47,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 				case 'term':
 					return Object.entries( value ).every( ( [ taxonomy, slugs ] ) => {
 						slugs = slugs.split( ',' );
-						return some( post.terms[ taxonomy ], ( { slug } ) => includes( slugs, slug ) );
+						return some( post.terms[ taxonomy ], ( { slug } ) => slugs.includes( slug ) );
 					} );
 
 				case 'tag':
@@ -74,7 +74,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 
 				case 'exclude':
 					if ( Array.isArray( value ) ) {
-						return ! includes( value, post.ID );
+						return ! value.includes( post.ID );
 					}
 
 					return value !== post.ID;

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import PaginatedQueryManager from '../paginated';
 import { DEFAULT_TERM_QUERY } from './constants';
 import TermQueryKey from './key';
@@ -24,8 +23,8 @@ export default class TermQueryManager extends PaginatedQueryManager {
 
 		const search = query.search.toLowerCase();
 		return (
-			( term.name && includes( term.name.toLowerCase(), search ) ) ||
-			( term.slug && includes( term.slug.toLowerCase(), search ) )
+			( term.name && term.name.toLowerCase().includes( search ) ) ||
+			( term.slug && term.slug.toLowerCase().includes( search ) )
 		);
 	}
 


### PR DESCRIPTION
Removes usages of `_.includes` from the various `QueryManager`s in `lib/query-manager`.

In all cases, it's easy to verify that the tested array/string is valid. There is already a guard condition, or the array is an output of `.map` or `.split`.