### PR TITLE
Allow adding domain from the DIFM in-progress screen

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -227,6 +227,25 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 	return domainManagementPaths.indexOf( path ) > -1;
 }
 
+/**
+ * The paths allowed for domain-only sites and DIFM in-progress sites are the same
+ * with one exception - /domains/add should be allowed for DIFM in-progress sites.
+ *
+ * @param {*} path The path to be checked
+ * @param {*} slug The site slug
+ * @param {*} primaryDomain The primary domain if it exists
+ * @param {*} contextParams Context parameters
+ * @returns {boolean} true if the path is allowed, false otherwise
+ */
+function isPathAllowedForDIFMInProgressSite( path, slug, primaryDomain, contextParams ) {
+	const domainAdditionPath = '/domains/add';
+
+	return (
+		isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParams ) ||
+		path.startsWith( domainAdditionPath )
+	);
+}
+
 function onSelectedSiteAvailable( context ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
@@ -254,12 +273,11 @@ function onSelectedSiteAvailable( context ) {
 	}
 
 	/**
-	 * The paths allowed for domain-only sites and DIFM in-progress sites are the same.
 	 * Ignore this check if we are inside a support session.
 	 */
 	if (
 		isDIFMLiteInProgress( state, selectedSite.ID ) &&
-		! isPathAllowedForDomainOnlySite(
+		! isPathAllowedForDIFMInProgressSite(
 			context.pathname,
 			selectedSite.slug,
 			primaryDomain,

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -231,10 +231,10 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
  * The paths allowed for domain-only sites and DIFM in-progress sites are the same
  * with one exception - /domains/add should be allowed for DIFM in-progress sites.
  *
- * @param {*} path The path to be checked
- * @param {*} slug The site slug
- * @param {*} primaryDomain The primary domain if it exists
- * @param {*} contextParams Context parameters
+ * @param {string} path The path to be checked
+ * @param {string} slug The site slug
+ * @param {object} primaryDomain The primary domain if it exists
+ * @param {object} contextParams Context parameters
  * @returns {boolean} true if the path is allowed, false otherwise
  */
 function isPathAllowedForDIFMInProgressSite( path, slug, primaryDomain, contextParams ) {
@@ -273,17 +273,19 @@ function onSelectedSiteAvailable( context ) {
 	}
 
 	/**
+	 * For DIFM in-progress sites, render the in-progress screen for all
+	 * paths except those in the allow-list defined in `isPathAllowedForDIFMInProgressSite`.
 	 * Ignore this check if we are inside a support session.
 	 */
 	if (
 		isDIFMLiteInProgress( state, selectedSite.ID ) &&
+		! isSupportSession( state ) &&
 		! isPathAllowedForDIFMInProgressSite(
 			context.pathname,
 			selectedSite.slug,
 			primaryDomain,
 			context.params
-		) &&
-		! isSupportSession( state )
+		)
 	) {
 		renderSelectedSiteIsDIFMLiteInProgress( context, selectedSite );
 		return false;

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -7,7 +7,7 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmptyContent from 'calypso/components/empty-content';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
-import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
@@ -66,7 +66,7 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactE
 						'We’ll be in touch when your site is ready to be launched.'
 				) }
 				secondaryAction={ translate( 'Manage domain' ) }
-				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
+				secondaryActionURL={ domainManagementList( slug ) }
 				illustration={ Illustration }
 				illustrationWidth={ 225 }
 			>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For DIFM in-progress sites, the domain addition paths were blocked. Here's a video of the bug:

https://user-images.githubusercontent.com/5436027/143439088-4a111dbe-46b5-407b-8e87-700cd55dc19d.mp4

This change allows adding domains from the DIFM in-progress screen.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a site with the `difm-lite-in-progress` sticker enabled.
* Click on "Manage Domain", and then "Add a domain"
* Confirm that you are able to search for a domain and proceed to checkout.

https://user-images.githubusercontent.com/5436027/143439798-c345af1a-476f-4702-8927-db10fcfb7c6e.mp4




<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
