### PR TITLE
Explain that Google discounts are only available for new purchases

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -421,6 +421,20 @@ class EmailProvidersComparison extends Component {
 						},
 					}
 				) }
+				<br />
+				<span>
+					<em>
+						{ translate(
+							'Discount is only available for first-time %(googleMailService)s purchases',
+							{
+								args: {
+									googleMailService: getGoogleMailServiceFamily(),
+								},
+								comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+							}
+						) }
+					</em>
+				</span>
 			</span>
 		) : null;
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -20,6 +20,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import HeaderCake from 'calypso/components/header-cake';
+import InfoPopover from 'calypso/components/info-popover';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import PromoCard from 'calypso/components/promo-section/promo-card';
@@ -380,7 +381,7 @@ class EmailProvidersComparison extends Component {
 		const productIsDiscounted = hasDiscount( gSuiteProduct );
 		const monthlyPrice = getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode );
 		const formattedPrice = productIsDiscounted
-			? translate( '{{fullPrice/}} {{discountedPrice/}} /mailbox /month billed annually', {
+			? translate( '{{fullPrice/}} {{discountedPrice/}} /mailbox /month (billed annually)', {
 					components: {
 						fullPrice: <span>{ monthlyPrice }</span>,
 						discountedPrice: (
@@ -405,7 +406,7 @@ class EmailProvidersComparison extends Component {
 		const discount = productIsDiscounted ? (
 			<span className="email-providers-comparison__discount-with-renewal">
 				{ translate(
-					'%(discount)d% Off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
+					'%(discount)d% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
 					{
 						args: {
 							discount: gSuiteProduct.sale_coupon.discount,
@@ -421,20 +422,18 @@ class EmailProvidersComparison extends Component {
 						},
 					}
 				) }
-				<br />
-				<span>
-					<em>
-						{ translate(
-							'Discount is only available for first-time %(googleMailService)s purchases',
-							{
-								args: {
-									googleMailService: getGoogleMailServiceFamily(),
-								},
-								comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-							}
-						) }
-					</em>
-				</span>
+
+				<InfoPopover position="right" showOnHover>
+					{ translate(
+						'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
+						{
+							args: {
+								googleMailService: getGoogleMailServiceFamily(),
+							},
+							comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+						}
+					) }
+				</InfoPopover>
 			</span>
 		) : null;
 
@@ -537,7 +536,7 @@ class EmailProvidersComparison extends Component {
 			'email-providers-comparison__highlight-main-price': showBlackFridaySale,
 			'email-providers-comparison__keep-main-price': ! isEligibleForFreeTrial,
 		} );
-		const formattedPrice = translate( '{{price/}} /mailbox /month billed monthly', {
+		const formattedPrice = translate( '{{price/}} /mailbox /month', {
 			components: {
 				price: (
 					<span className={ formattedPriceClassName }>

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -536,7 +536,7 @@ class EmailProvidersComparison extends Component {
 			'email-providers-comparison__highlight-main-price': showBlackFridaySale,
 			'email-providers-comparison__keep-main-price': ! isEligibleForFreeTrial,
 		} );
-		const formattedPrice = translate( '{{price/}} /mailbox /month', {
+		const formattedPrice = translate( '{{price/}} /mailbox /month (billed monthly)', {
 			components: {
 				price: (
 					<span className={ formattedPriceClassName }>

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -177,7 +177,7 @@
 				color: var( --color-text-subtle );
 
 				&.email-providers-comparison__discounted-price {
-					color: var( --studio-gray-100 );
+					color: var( --studio-green-50 );
 					text-decoration: none;
 				}
 

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -210,6 +210,11 @@
 			.email-providers-comparison__discount-and-free-trial {
 				display: block;
 			}
+
+			.email-providers-comparison__discount-with-renewal .info-popover {
+				margin-left: 2px;
+				vertical-align: text-top;
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds some explanatory text to explain that Google Workspace sales only apply to the initial purchase, and modifies the colour of the current price to make it clearer that it is linked to the discount called out below.

 H/T @arunsathiya for the suggestion and thanks to @stephanethomas for contributing the change to the popover.

#### Testing instructions

* Ensure that a sale coupon has been enabled for new Google Workspace purchases.
* Run this branch locally or via the live branch (links are [here](https://github.com/Automattic/wp-calypso/pull/58507#issuecomment-979189452)).
* Go to Upgrades -> Domains.
* Click on the "Add a domain" button
* Click on the "Search for a domain" option in the dropdown that appears
* Search for and select a domain (it doesn't matter which one)
* Verify that you see the email upsell page
* Verify that the Google Workspace discount is displayed
* Verify that the discounted price is highlighted in green
* Verify that the (i) icon is visible, and shows the following text on hover/tap:
> This discount is only available the first time you purchase a Google Workspace account, any additional mailboxes purchased after that will be at the regular price.
* Click on the "Add Google Workspace" button to expand that card
* Verify that you can still see the (i) icon from above, and that it continues to show the same text on hover/tab

##### Screenshots

###### Initial display

<img width="1065" alt="Screenshot 2021-11-26 at 09 52 08" src="https://user-images.githubusercontent.com/3376401/143546103-606c19dd-158c-47f4-8b4b-c2c9de4ded7f.png">

###### Additional info expanded

<img width="1065" alt="Screenshot 2021-11-26 at 09 52 17" src="https://user-images.githubusercontent.com/3376401/143546115-525eb9f9-5f56-4601-802b-a5827cf87bc9.png">