### PR TITLE
Video UI: fixes back button on mobile

### DIFF
--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
@@ -11,7 +11,7 @@ const BloggingQuickStartModal = ( props ) => {
 		isVisible && (
 			<BlankCanvas className={ 'blogging-quick-start-modal' }>
 				<BlankCanvas.Content>
-					<VideosUi headerBar={ <ModalHeaderBar onClose={ onClose } /> } />
+					<VideosUi headerBar={ <ModalHeaderBar onClose={ onClose } /> } onBackClick={ onClose } />
 				</BlankCanvas.Content>
 			</BlankCanvas>
 		)


### PR DESCRIPTION
This PR fixes de back button on mobile.

#### Testing
1. Load calypso.live for this PR
2. Open the Video UI clicking on the "Blog like an expert from day one" card on the home page. 
![image](https://user-images.githubusercontent.com/375980/143455046-a1bf5fc3-f3cf-4e4d-8949-94e3e72a7a0d.png)
2. verify the back button works correctly on mobile.

Closes https://github.com/Automattic/wp-calypso/issues/58511