### PR TITLE
Communicate free trial and discount for Professional Email

### DIFF
--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -107,7 +107,7 @@ EmailProviderCard.propTypes = {
 	badge: PropTypes.object,
 	description: PropTypes.string,
 	formattedPrice: PropTypes.node,
-	discount: PropTypes.string,
+	discount: PropTypes.node,
 	formFields: PropTypes.node,
 	buttonLabel: PropTypes.string,
 	onButtonClick: PropTypes.func,

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -516,7 +516,7 @@ class EmailProvidersComparison extends Component {
 
 		const now = Date.now();
 		const showBlackFridaySale =
-			new Date( '2021-11-25T00:05:00Z' ) < now &&
+			new Date( '2021-11-26T00:05:00Z' ) < now &&
 			now < new Date( '2021-12-01T07:55:00Z' ).getTime();
 
 		const formattedPriceClassName = classNames( {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -11,6 +11,7 @@ import emailIllustration from 'calypso/assets/images/email-providers/email-illus
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan.svg';
+import Badge from 'calypso/components/badge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -519,7 +520,24 @@ class EmailProvidersComparison extends Component {
 		} );
 
 		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
-		const discount = isEligibleForFreeTrial ? translate( '3 months free' ) : null;
+
+		const blackFridaySaleEndTime = new Date( '2021-12-01T07:59:00Z' ).getTime();
+		const blackFridayDiscountClassName = isEligibleForFreeTrial
+			? 'discount-and-eligible-for-free-trial'
+			: null;
+		const blackFridayDiscountBadge =
+			Date.now() >= blackFridaySaleEndTime ? null : (
+				<Badge type="info-blue" className={ blackFridayDiscountClassName }>
+					{ translate( 'Lifetime 30% discount' ) }
+				</Badge>
+			);
+
+		const discount = (
+			<>
+				{ isEligibleForFreeTrial ? translate( '3 months free' ) : null }
+				{ blackFridayDiscountBadge }
+			</>
+		);
 
 		const logo = (
 			<Gridicon

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -1,6 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { withShoppingCart } from '@automattic/shopping-cart';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -512,7 +513,16 @@ class EmailProvidersComparison extends Component {
 		} = this.props;
 
 		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
-		const formattedPriceClassName = isEligibleForFreeTrial ? null : 'no-trial';
+
+		const now = Date.now();
+		const showBlackFridaySale =
+			new Date( '2021-11-25T00:05:00Z' ) < now &&
+			now < new Date( '2021-12-01T07:55:00Z' ).getTime();
+
+		const formattedPriceClassName = classNames( {
+			'email-providers-comparison__highlight-main-price': showBlackFridaySale,
+			'email-providers-comparison__keep-main-price': ! isEligibleForFreeTrial,
+		} );
 		const formattedPrice = translate( '{{price/}} /mailbox /month billed monthly', {
 			components: {
 				price: (
@@ -524,21 +534,20 @@ class EmailProvidersComparison extends Component {
 			comment: '{{price/}} is the formatted price, e.g. $20',
 		} );
 
-		const blackFridaySaleEndTime = new Date( '2021-12-01T07:59:00Z' ).getTime();
-		const blackFridayDiscountClassName = isEligibleForFreeTrial
-			? 'discount-and-eligible-for-free-trial'
-			: null;
-		const blackFridayDiscountBadge =
-			Date.now() >= blackFridaySaleEndTime ? null : (
-				<span className={ blackFridayDiscountClassName }>
-					{ translate( '30% discount for all renewals' ) }
-				</span>
-			);
+		const blackFridayDiscount = showBlackFridaySale ? (
+			<span
+				className={ classNames( {
+					'email-providers-comparison__discount-and-free-trial': isEligibleForFreeTrial,
+				} ) }
+			>
+				{ translate( '30% off applied for all renewals' ) }
+			</span>
+		) : null;
 
 		const discount = (
 			<>
 				{ isEligibleForFreeTrial ? translate( '3 months free' ) : null }
-				{ blackFridayDiscountBadge }
+				{ blackFridayDiscount }
 			</>
 		);
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -11,7 +11,6 @@ import emailIllustration from 'calypso/assets/images/email-providers/email-illus
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan.svg';
-import Badge from 'calypso/components/badge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -531,9 +530,9 @@ class EmailProvidersComparison extends Component {
 			: null;
 		const blackFridayDiscountBadge =
 			Date.now() >= blackFridaySaleEndTime ? null : (
-				<Badge type="info-blue" className={ blackFridayDiscountClassName }>
-					{ translate( 'Lifetime 30% discount' ) }
-				</Badge>
+				<span className={ blackFridayDiscountClassName }>
+					{ translate( '30% discount for all renewals' ) }
+				</span>
 			);
 
 		const discount = (

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -512,14 +512,18 @@ class EmailProvidersComparison extends Component {
 			translate,
 		} = this.props;
 
+		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
+		const formattedPriceClassName = isEligibleForFreeTrial ? null : 'no-trial';
 		const formattedPrice = translate( '{{price/}} /mailbox /month billed monthly', {
 			components: {
-				price: <span>{ formatCurrency( titanMailProduct?.cost ?? 0, currencyCode ) }</span>,
+				price: (
+					<span className={ formattedPriceClassName }>
+						{ formatCurrency( titanMailProduct?.cost ?? 0, currencyCode ) }
+					</span>
+				),
 			},
 			comment: '{{price/}} is the formatted price, e.g. $20',
 		} );
-
-		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
 
 		const blackFridaySaleEndTime = new Date( '2021-12-01T07:59:00Z' ).getTime();
 		const blackFridayDiscountClassName = isEligibleForFreeTrial

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -181,8 +181,17 @@
 					text-decoration: none;
 				}
 
-				&.no-trial {
+				&.email-providers-comparison__keep-main-price {
 					text-decoration: none;
+				}
+
+				&.email-providers-comparison__highlight-main-price {
+					color: var( --studio-green-50 );
+					text-decoration: none;
+				}
+
+				&.email-providers-comparison__titan-trial-with-sale {
+					display: block;
 				}
 			}
 		}
@@ -198,8 +207,8 @@
 				font-weight: 400;
 			}
 
-			.discount-and-eligible-for-free-trial::before {
-				content: '; ';
+			.email-providers-comparison__discount-and-free-trial {
+				display: block;
 			}
 		}
 	}

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -193,6 +193,14 @@
 				color: var( --color-text-subtle );
 				font-weight: 400;
 			}
+
+			.badge {
+				font-weight: 400;
+
+				&.discount-and-eligible-for-free-trial {
+					margin-left: 0.5em;
+				}
+			}
 		}
 	}
 

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -198,12 +198,8 @@
 				font-weight: 400;
 			}
 
-			.badge {
-				font-weight: 400;
-
-				&.discount-and-eligible-for-free-trial {
-					margin-left: 0.5em;
-				}
+			.discount-and-eligible-for-free-trial::before {
+				content: '; ';
 			}
 		}
 	}

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -180,6 +180,10 @@
 					color: var( --studio-gray-100 );
 					text-decoration: none;
 				}
+
+				&.no-trial {
+					text-decoration: none;
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR modifies the Professional Email pricing details in support of our Black Friday promotion. More specifically, it performs the following while our Black Friday sale is in effect:
  - We display the discounted price in the same green as the promotional text, and remove the strike through the price
  - We display a new trailing line with the text "30% off applied for all renewals"
  - If the user is eligible for a free trial, we continue to show "3 months free" text
* Note that this PR doesn't implement the new prices - those will need a back end change

#### Testing instructions

* Run this branch locally, and modify the date windows for testing:
```diff
		const showBlackFridaySale =
-			new Date( '2021-11-26T00:05:00Z' ) < now &&
+ 			new Date( '2021-11-25T00:05:00Z' ) < now &&
			now < new Date( '2021-12-01T07:55:00Z' ).getTime();

```
* Navigate to Upgrades -> Domains
* Click on the "Add a domain" button, and then on the "Search for a domain" item in the dropdown
* Select a domain from the resulting screen
* Verify that the Professional Email section shows the price in green with both "3 months free" and "30% off applied for all renewals" on separate trailing lines
* Find a domain where you have previously had a Professional Email subscription (or add and remove a Professional Email subscription from a domain)
* Navigate to Upgrades -> Emails
* If there are multiple domains on your site, click on the "Add Email" button next to your domain
* Verify that the Professional Email section shows the price in green with "30% off applied for all renewals" on the following line

#### Screenshots

##### With free trial

| Before | After |
| ------ | ------|
| <img width="1065" alt="Screenshot 2021-11-25 at 21 48 48" src="https://user-images.githubusercontent.com/3376401/143495563-bc99e25a-d635-4642-8e9d-720f09272bd8.png"> | <img width="1065" alt="Screenshot 2021-11-25 at 22 04 34" src="https://user-images.githubusercontent.com/3376401/143495678-495b7294-14b2-4cda-b546-893c0ec0bb6d.png"> |

##### Without free trial

| Before | After |
| ------ | ------|
| <img width="1065" alt="Screenshot 2021-11-25 at 21 49 42" src="https://user-images.githubusercontent.com/3376401/143495575-b85a5b09-a7ec-4101-910a-60c23f0d321f.png"> | <img width="1065" alt="Screenshot 2021-11-25 at 22 04 15" src="https://user-images.githubusercontent.com/3376401/143495696-22c8ec48-81d1-4c9f-ae0e-968df0b28b6a.png"> |
