### PR TITLE
Videos UI: Select next video for the user on load

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -50,22 +50,26 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	} );
 
 	useEffect( () => {
-		const videoKeys = Object.keys( course.videos );
-		if ( ! currentVideoKey && course ) {
-			const initialVideoId = 'find-theme';
-			setCurrentVideoKey( initialVideoId );
-			setSelectedVideoIndex( videoKeys.indexOf( initialVideoId ) );
+		if ( ! course ) {
+			return;
 		}
 
-		const viewedVideos = Object.keys( userCourseProgression );
-		if ( viewedVideos.length > 0 ) {
-			const nextVideos = videoKeys.slice(
-				( videoKeys.indexOf( viewedVideos.at( -1 ) ) + 1 ) % videoKeys.length
+		const videoSlugs = Object.keys( course.videos );
+		if ( ! currentVideoKey ) {
+			const initialVideoId = 'find-theme';
+			setCurrentVideoKey( initialVideoId );
+			setSelectedVideoIndex( videoSlugs.indexOf( initialVideoId ) );
+		}
+
+		const viewedSlugs = Object.keys( userCourseProgression );
+		if ( viewedSlugs.length > 0 ) {
+			const nextVideos = videoSlugs.slice(
+				( videoSlugs.indexOf( viewedSlugs.at( -1 ) ) + 1 ) % videoSlugs.length
 			);
-			const nextVideo = nextVideos.find( ( x ) => ! viewedVideos.includes( x ) );
-			if ( nextVideo ) {
-				setCurrentVideoKey( nextVideo );
-				setSelectedVideoIndex( videoKeys.indexOf( nextVideo ) );
+			const nextSlug = nextVideos.find( ( x ) => ! viewedSlugs.includes( x ) );
+			if ( nextSlug ) {
+				setCurrentVideoKey( nextSlug );
+				setSelectedVideoIndex( videoSlugs.indexOf( nextSlug ) );
 			}
 		}
 	}, [ currentVideoKey, course ] );
@@ -137,7 +141,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 							videoRef={ videoRef }
 							videoUrl={ currentVideo.url }
 							isPlaying={ isPlaying }
-							poster={ currentVideo.poster ? currentVideo.poster : false }
+							poster={ currentVideo.poster ? currentVideo.poster : undefined }
 						/>
 					) }
 					<div className="videos-ui__chapters">

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -50,11 +50,23 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	} );
 
 	useEffect( () => {
+		const videoKeys = Object.keys( course.videos );
 		if ( ! currentVideoKey && course ) {
-			// @TODO add logic to pick the first unseen video
 			const initialVideoId = 'find-theme';
 			setCurrentVideoKey( initialVideoId );
-			setSelectedVideoIndex( Object.keys( course.videos ).indexOf( initialVideoId ) );
+			setSelectedVideoIndex( videoKeys.indexOf( initialVideoId ) );
+		}
+
+		const viewedVideos = Object.keys( userCourseProgression );
+		if ( viewedVideos.length > 0 ) {
+			const nextVideos = videoKeys.slice(
+				( videoKeys.indexOf( viewedVideos.at( -1 ) ) + 1 ) % videoKeys.length
+			);
+			const nextVideo = nextVideos.find( ( x ) => ! viewedVideos.includes( x ) );
+			if ( nextVideo ) {
+				setCurrentVideoKey( nextVideo );
+				setSelectedVideoIndex( videoKeys.indexOf( nextVideo ) );
+			}
 		}
 	}, [ currentVideoKey, course ] );
 

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -63,16 +63,13 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 
 		const viewedSlugs = Object.keys( userCourseProgression );
 		if ( viewedSlugs.length > 0 ) {
-			const nextVideos = videoSlugs.slice(
-				( videoSlugs.indexOf( viewedSlugs.at( -1 ) ) + 1 ) % videoSlugs.length
-			);
-			const nextSlug = nextVideos.find( ( x ) => ! viewedSlugs.includes( x ) );
+			const nextSlug = videoSlugs.find( ( x ) => ! viewedSlugs.includes( x ) );
 			if ( nextSlug ) {
 				setCurrentVideoKey( nextSlug );
 				setSelectedVideoIndex( videoSlugs.indexOf( nextSlug ) );
 			}
 		}
-	}, [ currentVideoKey, course ] );
+	}, [ currentVideoKey, course, userCourseProgression ] );
 
 	useEffect( () => {
 		if ( currentVideoKey && course ) {

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -63,7 +63,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 
 		const viewedSlugs = Object.keys( userCourseProgression );
 		if ( viewedSlugs.length > 0 ) {
-			const nextSlug = videoSlugs.find( ( x ) => ! viewedSlugs.includes( x ) );
+			const nextSlug = videoSlugs.find( ( slug ) => ! viewedSlugs.includes( slug ) );
 			if ( nextSlug ) {
 				setCurrentVideoKey( nextSlug );
 				setSelectedVideoIndex( videoSlugs.indexOf( nextSlug ) );

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-const VideoPlayer = ( { videoRef, videoUrl, isPlaying, poster = false } ) => {
+const VideoPlayer = ( { videoRef, videoUrl, isPlaying, poster = undefined } ) => {
 	useEffect( () => {
 		if ( isPlaying ) {
 			videoRef.current.play();


### PR DESCRIPTION
This PR selects the corresponding video for the user depending on what she has marked as seen.

The algorithm for selecting the video is:
1. If the user has seen all or none of the videos  => **First video is selected**.
2. Try to select the first video in the sequence that has not been seen by user.

#### Demo with first video marked as viewed
![2021-11-25 13 12 19](https://user-images.githubusercontent.com/375980/143474490-0ee2e89b-0bd6-4d95-b672-6f81e38285d7.gif)

Closes https://github.com/Automattic/wp-calypso/issues/58257

