### PR TITLE
Video UI: fix svg errors on Javascript console

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -185,9 +185,9 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 															d="M1.9165 1.75L10.0832 7L1.9165 12.25V1.75Z"
 															fill="#101517"
 															stroke="#101517"
-															stroke-width="2"
-															stroke-linecap="round"
-															stroke-linejoin="round"
+															strokeWidth="2"
+															strokeLinecap="round"
+															strokeLinejoin="round"
 														/>
 													</svg>
 													<span>{ translate( 'Play video' ) }</span>


### PR DESCRIPTION
This PR fixes errors due to malformed svg attributes.

#### Testing
1. Load this PR
2. Open the Video UI modal
2. Verify you don't see the following errors on the Javascript console
    * ```Warning: Invalid DOM property `stroke-linejoin`. Did you mean `strokeLinejoin`?```
    * ```Warning: Invalid DOM property `stroke-linecap`. Did you mean `strokeLinecap`?```
    * ```Warning: Invalid DOM property `stroke-width`. Did you mean `strokeWidth`?```

Closes: https://github.com/Automattic/wp-calypso/issues/58525