### PR TITLE
[wip] Improve error handling

### DIFF
--- a/client/components/eligibility-warnings/domain-warning/index.tsx
+++ b/client/components/eligibility-warnings/domain-warning/index.tsx
@@ -1,0 +1,29 @@
+import { Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
+
+const Title = styled.span``;
+const Container = styled.div``;
+const Content = styled.div``;
+const NewDomainSection = styled.div``;
+
+const DomainEliibilityWarning: React.FunctionComponent< Props > = ( props ) => {
+    const { sitename } = props;
+
+    return (
+        <Container>
+            <Title className="DomainEligibilityWarning__title">
+                New Store Domain
+            </Title>
+            <Content>       
+                <NewDomainSection>
+                    <span>{`${sitename}.wpstaging.com`}</span>
+                </NewDomainSection>
+                <p>
+                {`By installing this product your subdomain will change. Your old subdomain (${sitename}.wordpress.com) will no longer work. You can change it to a custom domain on us at anytime in future.`}
+                </p>
+            </Content>      
+        </Container>
+    );
+};
+
+export default DomainEliibilityWarning;

--- a/client/components/eligibility-warnings/domain-warning/index.tsx
+++ b/client/components/eligibility-warnings/domain-warning/index.tsx
@@ -7,23 +7,21 @@ const Content = styled.div``;
 const NewDomainSection = styled.div``;
 
 const DomainEliibilityWarning: React.FunctionComponent< Props > = ( props ) => {
-    const { sitename } = props;
+	const { sitename } = props;
 
-    return (
-        <Container>
-            <Title className="DomainEligibilityWarning__title">
-                New Store Domain
-            </Title>
-            <Content>       
-                <NewDomainSection>
-                    <span>{`${sitename}.wpstaging.com`}</span>
-                </NewDomainSection>
-                <p>
-                {`By installing this product your subdomain will change. Your old subdomain (${sitename}.wordpress.com) will no longer work. You can change it to a custom domain on us at anytime in future.`}
-                </p>
-            </Content>      
-        </Container>
-    );
+	return (
+		<Container>
+			<Title className="DomainEligibilityWarning__title">New Store Domain</Title>
+			<Content>
+				<NewDomainSection>
+					<span>{ `${ sitename }.wpstaging.com` }</span>
+				</NewDomainSection>
+				<p>
+					{ `By installing this product your subdomain will change. Your old subdomain (${ sitename }.wordpress.com) will no longer work. You can change it to a custom domain on us at anytime in future.` }
+				</p>
+			</Content>
+		</Container>
+	);
 };
 
 export default DomainEliibilityWarning;

--- a/client/components/eligibility-warnings/domain-warning/index.tsx
+++ b/client/components/eligibility-warnings/domain-warning/index.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 
 const Title = styled.span``;
@@ -11,7 +10,7 @@ const DomainEliibilityWarning: React.FunctionComponent< Props > = ( props ) => {
 
 	return (
 		<Container>
-			<Title className="DomainEligibilityWarning__title">New Store Domain</Title>
+			<Title>New Store Domain</Title>
 			<Content>
 				<NewDomainSection>
 					<span>{ `${ sitename }.wpstaging.com` }</span>

--- a/client/components/eligibility-warnings/warnings-list/index.tsx
+++ b/client/components/eligibility-warnings/warnings-list/index.tsx
@@ -1,8 +1,5 @@
-import { Gridicon } from '@automattic/components';
-import { localize, LocalizeProps } from 'i18n-calypso';
-import { map } from 'lodash';
 import styled from '@emotion/styled';
-import ActionPanelLink from 'calypso/components/action-panel/link';
+import { ReactElement } from 'react';
 
 const WarningsList = styled.ul`
 	margin: 10px 0 10px 20px;
@@ -12,25 +9,20 @@ const WarningListItem = styled.li`
 	font-size: 0.875rem;
 	letter-spacing: -0.16px;
 	color: var( --studio-gray-60 );
-	line-height: 2rem;
-`;
-
-const WarningTitle = styled.span`
-	font-weight: bold;
+	line-height: 1.25rem;
+	margin-bottom: 0.75rem;
 `;
 
 const WarningDescription = styled.span``;
 
-export const WarningList = ( { warnings } ) => (
+const WarningList = ( { warnings } ): ReactElement => (
 	<WarningsList>
-		{ warnings?.map( ( { name, description }, index ) => (
+		{ warnings?.map( ( warning: string, index: number ) => (
 			<WarningListItem key={ index }>
-				<WarningTitle>{ name }</WarningTitle>
-				:&nbsp;
-				<WarningDescription>{ description }</WarningDescription>
+				<WarningDescription>{ warning }</WarningDescription>
 			</WarningListItem>
 		) ) }
 	</WarningsList>
 );
 
-export default localize( WarningList );
+export default WarningList;

--- a/client/components/eligibility-warnings/warnings-list/index.tsx
+++ b/client/components/eligibility-warnings/warnings-list/index.tsx
@@ -1,0 +1,36 @@
+import { Gridicon } from '@automattic/components';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import { map } from 'lodash';
+import styled from '@emotion/styled';
+import ActionPanelLink from 'calypso/components/action-panel/link';
+
+const WarningsList = styled.ul`
+	margin: 10px 0 10px 20px;
+`;
+
+const WarningListItem = styled.li`
+	font-size: 0.875rem;
+	letter-spacing: -0.16px;
+	color: var( --studio-gray-60 );
+	line-height: 2rem;
+`;
+
+const WarningTitle = styled.span`
+	font-weight: bold;
+`;
+
+const WarningDescription = styled.span``;
+
+export const WarningList = ( { warnings } ) => (
+	<WarningsList>
+		{ warnings?.map( ( { name, description }, index ) => (
+			<WarningListItem key={ index }>
+				<WarningTitle>{ name }</WarningTitle>
+				:&nbsp;
+				<WarningDescription>{ description }</WarningDescription>
+			</WarningListItem>
+		) ) }
+	</WarningsList>
+);
+
+export default localize( WarningList );

--- a/client/components/eligibility-warnings/warnings-list/index.tsx
+++ b/client/components/eligibility-warnings/warnings-list/index.tsx
@@ -15,11 +15,17 @@ const WarningListItem = styled.li`
 
 const WarningDescription = styled.span``;
 
+const WarningTitle = styled.span`
+	font-weight: bold;
+`;
+
 const WarningList = ( { warnings } ): ReactElement => (
 	<WarningsList>
-		{ warnings?.map( ( warning: string, index: number ) => (
+		{ warnings?.map( ( { name, description }, index ) => (
 			<WarningListItem key={ index }>
-				<WarningDescription>{ warning }</WarningDescription>
+				<WarningTitle>{ name }</WarningTitle>
+				:&nbsp;
+				<WarningDescription>{ description }</WarningDescription>
 			</WarningListItem>
 		) ) }
 	</WarningsList>

--- a/client/components/warning-card/index.tsx
+++ b/client/components/warning-card/index.tsx
@@ -1,0 +1,41 @@
+import { Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+	color: var( --studio-gray-90 );
+	background-color: var( --studio-gray-0 );
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
+	padding: 10px;
+`;
+
+const ContentSection = styled.div`
+	line-height: 1.25rem;
+`;
+
+const IconSection = styled.div`
+	display: flex;
+	justify-content: center;
+	margin-right: 10px;
+`;
+
+const StyledIcon = styled( Gridicon )`
+	fill: #e65054;
+	margin-right: 0.5rem;
+`;
+
+const WarningCard: React.FunctionComponent< Props > = ( props ) => {
+	const { message } = props;
+
+	return (
+		<Container>
+			<IconSection>
+				<StyledIcon icon="notice-outline" />{ ' ' }
+			</IconSection>
+			<ContentSection>{ message }</ContentSection>
+		</Container>
+	);
+};
+
+export default WarningCard;

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -798,13 +798,9 @@ export function generateSteps( {
 		confirm: {
 			stepName: 'confirm',
 			props: {
-				headerTitle: i18n.translate( 'Your new store' ),
-				headerDescription: (
-					<>
-						{ i18n.translate( 'This will be your new store domain.' ) }
-						<br />
-						{ i18n.translate( 'You can change it later and get a custom one.' ) }
-					</>
+				headerTitle: i18n.translate( 'One final step' ),
+				headerDescription: i18n.translate(
+					'We’ve highlighted a few important details you should review before we create your store. '
 				),
 			},
 			dependencies: [ 'siteId' ],

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -788,12 +788,12 @@ export function generateSteps( {
 		confirm: {
 			stepName: 'confirm',
 			props: {
-				headerTitle: i18n.translate( 'Your new store' ),
+				headerTitle: i18n.translate( 'One final step' ),
 				headerDescription: (
 					<>
-						{ i18n.translate( 'This will be your new store domain.' ) }
-						<br />
-						{ i18n.translate( 'You can change it later and get a custom one.' ) }
+						{ i18n.translate(
+							'We’ve highlighted a few important details you should review before we create your store. '
+						) }
 					</>
 				),
 			},

--- a/client/signup/steps/woocommerce-install/components/signup-banner/Readme.md
+++ b/client/signup/steps/woocommerce-install/components/signup-banner/Readme.md
@@ -1,0 +1,15 @@
+# SignupBanner
+
+This component renders a simple customizable banner.
+
+## Usage
+
+```jsx
+import SignupBanner from '../components/signup-banner';
+
+function render() {
+	return (
+		<SignupBanner label={ __( 'New' ) }>{ stagingDomain }</SignupBanner>
+	);
+}
+```

--- a/client/signup/steps/woocommerce-install/components/signup-banner/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/signup-banner/index.tsx
@@ -1,0 +1,22 @@
+import { ReactElement, ReactNode } from 'react';
+
+import './style.scss';
+
+interface InfoLabelProps {
+	children: ReactNode;
+	label?: string;
+	type?: string;
+}
+
+export default function InfoLabel( {
+	children,
+	label,
+	type = 'info',
+}: InfoLabelProps ): ReactElement | null {
+	return (
+		<div className={ `signup-banner signup-banner--${ type }` }>
+			<div className="signup-banner__content">{ children }</div>
+			{ label && <div className="signup-banner__label">{ label }</div> }
+		</div>
+	);
+}

--- a/client/signup/steps/woocommerce-install/components/signup-banner/style.scss
+++ b/client/signup/steps/woocommerce-install/components/signup-banner/style.scss
@@ -20,7 +20,7 @@
 		height: 20px;
 		line-height: 20px;
 		padding: 0 10px;
-		background-color: var( --color-success-10 );
+		background-color: #B8E6BF; // have to find which color is this one
 		border-radius: 4px; /* stylelint-disable-line */
 		margin-left: 10px;
 	}

--- a/client/signup/steps/woocommerce-install/components/signup-banner/style.scss
+++ b/client/signup/steps/woocommerce-install/components/signup-banner/style.scss
@@ -1,0 +1,28 @@
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.signup-banner {
+	color: var( --studio-gray-90 );
+	background-color: var( --studio-gray-0 );
+	display: flex;
+	align-items: center;
+	height: 40px;
+	box-sizing: border-box;
+	padding: 0 16px;
+
+	.signup-banner__content {
+		flex-grow: 2;
+	}
+
+	.signup-banner__label {
+		font-size: $font-body-small;
+		height: 20px;
+		line-height: 20px;
+		padding: 0 10px;
+		background-color: var( --color-success-10 );
+		border-radius: 4px; /* stylelint-disable-line */
+		margin-left: 10px;
+	}
+}
+

--- a/client/signup/steps/woocommerce-install/components/signup-card/Readme.md
+++ b/client/signup/steps/woocommerce-install/components/signup-card/Readme.md
@@ -1,0 +1,22 @@
+# SignupCard
+
+A simple component to be used as a container to group similar information about the signup process.
+
+## Usage
+
+```jsx
+import CompactCard from './components/signup-card';
+
+function render() {
+	return (
+		<div className="your-stuff">
+			<SignupCard
+				title={ __( 'Title of your card ' ) }
+				icon="domains"
+			>
+				<span>Your stuff in a CompactCard</span>
+			</SignupCard>
+		</div>
+	);
+}
+```

--- a/client/signup/steps/woocommerce-install/components/signup-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/signup-card/index.tsx
@@ -1,0 +1,25 @@
+import { Gridicon } from '@automattic/components';
+import { ReactElement, ReactNode } from 'react';
+import './style.scss';
+
+interface Card {
+	title: string;
+	icon?: string;
+	children: ReactNode;
+}
+
+export default function SignupCard( {
+	title,
+	icon = 'domains',
+	children,
+}: Card ): ReactElement | null {
+	return (
+		<div className="signup-card">
+			<div className="signup-card__title">
+				<Gridicon icon={ icon } size={ 24 } />
+				<h2>{ title }</h2>
+			</div>
+			<div className="signup-card__body">{ children }</div>
+		</div>
+	);
+}

--- a/client/signup/steps/woocommerce-install/components/signup-card/style.scss
+++ b/client/signup/steps/woocommerce-install/components/signup-card/style.scss
@@ -1,0 +1,35 @@
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.signup-card {
+	.signup-card__title {
+		display: flex;
+		height: 40px;
+		align-items: center;
+		.gridicon {
+			width: 24px;
+			margin-right: 24px;
+			color: var( --studio-gray-40 );
+		}
+
+		h2 {
+			font-size: 1.25rem;
+			letter-spacing: 0.2px;
+			color: var( --studio-gray-90 );
+		}
+	}
+
+	.signup-card__body {
+		padding: 0 0 0 48px;
+		min-width: 300px;
+
+		p {
+			color: var( --studio-gray-60 );
+			font-size: $font-body-small;
+			letter-spacing: -0.16px;
+			line-height: 1.25rem;
+			margin-top: 30px;
+		}
+	}
+}

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -7,6 +7,7 @@ import { default as HoldList } from 'calypso/blocks/eligibility-warnings/hold-li
 import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
 import {
 	fetchAutomatedTransferStatusOnce,
 	requestEligibility,
@@ -63,87 +64,44 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	const isProcessing = ! siteId || isFetchingTransferStatus || ! wordPressSubdomainWarning;
 
 	function getWPComSubdomainWarningContent() {
-		// Get staging sudomain based on the wpcom subdomain.
-		const stagingDomain = wpcomDomain?.replace( /\b.wordpress.com/, '.wpcomstaging.com' );
+		// Get sitename from the wpcom domain.
+		const sitename = wpcomDomain?.replace( /\b.wordpress.com/, '' );
 
 		return (
+			<DomainEligibilityWarning sitename={sitename} />
+		);
+	}
+
+	function getOtherElegibiliytContent() {
+		return (
 			<>
-				<div className="confirm__instructions-container">
-					<div className="confirm__instructions-title confirm__instructions-wpcom-domain">
-						{ wpcomDomain }
-					</div>
-
-					<div className="confirm__instructions-title">{ stagingDomain }</div>
-
+				{ !! eligibilityHolds?.length && (
 					<p>
-						{ __(
-							'By installing this product your subdomain will change. You can change it later to a custom domain and we will pick up the tab for a year.'
-						) }
+						<HoldList holds={ eligibilityHolds } context={ 'plugins' } isPlaceholder={ false } />
 					</p>
-
-					<div className="confirm__instructions-title confirm__instructions-wpcom-domain">
-						{wpcomDomain}
-					</div>
-
-					<div className="confirm__instructions-title">{stagingDomain}</div>
-
+				) }
+				{ !! eligibilityWarnings?.length && (
 					<p>
-						{__(
-							'By installing this product your subdomain will change. You can change it later to a custom domain and we will pick up the tab for a year.'
-						)}
+						<WarningList warnings={ eligibilityWarnings } context={ 'plugins' } />
 					</p>
-
-
-					<p>
-						{ createInterpolateElement( __( '<a>Contact support</a> for help and questions.' ), {
-							a: <a href="#support-link" />,
-						} ) }
-					</p>
-
-					<NextButton
-						disabled={ isProcessing }
-						onClick={ () => {
-							if ( eligibilityHolds?.length || eligibilityWarnings?.length ) {
-								return goToStep( 'confirm', 'eligibility_substep' );
-							}
-
-							return goToStep( 'transfer' );
-						} }
-					>
-						{ __( 'Sounds good' ) }
-					</NextButton>
-				</div>
+				) }
 			</>
 		);
 	}
 
 	function getContent() {
-		// wpcom subdomain warning.
-		if (
-			wordPressSubdomainWarning &&
-			( stepSectionName === 'wpcom_subdomain_substep' || typeof stepSectionName === 'undefined' )
-		) {
-			return getWPComSubdomainWarningContent();
-		}
-
-		return (
-			<>
-				{isProcessing && <LoadingEllipsis />}
-				<div className="confirm__instructions-container">
-					{ !! eligibilityHolds?.length && (
-						<p>
-							<HoldList holds={ eligibilityHolds } context={ 'plugins' } isPlaceholder={ false } />
-						</p>
-					) }
-					{ !! eligibilityWarnings?.length && (
-						<p>
-							<WarningList warnings={ eligibilityWarnings } context={ 'plugins' } />
-						</p>
-					) }
-
-					<NextButton onClick={ () => goToStep( 'transfer' ) }>{ __( 'Confirm' ) }</NextButton>
-				</div>
-			</>
+		return(
+			<div className="confirm__instructions-container">
+			{isProcessing && <LoadingEllipsis />}
+			{ wordPressSubdomainWarning && getWPComSubdomainWarningContent() }
+			{ getOtherElegibiliytContent() }
+			<p>
+						{ createInterpolateElement( __( '<a>Contact support</a> for help and questions.' ), {
+							a: <a href="#support-link" />,
+						} ) }
+					</p>
+			<NextButton onClick={ () => goToStep( 'transfer' ) }>{ __( 'Confirm' ) }</NextButton>
+		</div>
 		);
 	}
 

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -48,27 +48,17 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		isFetching,
 		wpcomSubdomainWarning,
 		stagingDomain,
-		pluginsWarning,
-		widgetsWarning,
+		eligibilityWarnings,
 		hasBlockers,
 	} = useEligibility( siteId );
 
 	const isLoading = ! siteId || isFetching;
-	const warnings: string[] = [];
-
-	if ( pluginsWarning.length ) {
-		warnings.push( __( 'Some plugins behavior would be affected when installing this product.' ) );
-	}
-
-	if ( widgetsWarning.length ) {
-		warnings.push( __( 'Some widgets behavior would be affected when installing this product.' ) );
-	}
+	const warnings = eligibilityWarnings?.filter( ( { id } ) => id !== 'wordpress_subdomain' ) ?? [];
 
 	function getWarningsOrHoldsSection() {
 		if ( hasBlockers ) {
 			return (
 				<WarningsOrHoldsSection>
-					<Divider />
 					<WarningCard
 						message={ __(
 							'There is an error that is stopping us from being able to install this product, please contact support.'

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -1,6 +1,7 @@
 import { NextButton } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement } from 'react';
 import EligibilityWarningsList from 'calypso/components/eligibility-warnings/warnings-list';
@@ -50,6 +51,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		stagingDomain,
 		eligibilityWarnings,
 		hasBlockers,
+		wpcomDomain,
 	} = useEligibility( siteId );
 
 	const isLoading = ! siteId || isFetching;
@@ -92,8 +94,12 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 							<SignupCard title={ __( 'New Store Domain' ) }>
 								<SignupBanner label={ __( 'New' ) }>{ stagingDomain }</SignupBanner>
 								<p>
-									{ __(
-										'By installing this product your subdomain will change. Your old subdomain (sitename.wordpress.com) will no longer work. You can change it to a custom domain on us at anytime in future.'
+									{ sprintf(
+										/* translators: %s: The old site wordpress subdomain (ex.: sitename.wordpress.com) */
+										__(
+											'By installing this product your subdomain will change. Your old subdomain (%s) will no longer work. You can change it to a custom domain on us at anytime in future.'
+										),
+										wpcomDomain
 									) }
 								</p>
 							</SignupCard>

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -35,12 +35,12 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	const {
 		eligibilityHolds,
 		eligibilityWarnings,
-		isFetchingTransferStatus,
+		isFetching,
 		wpcomSubdomainWarning,
 		stagingDomain,
 	} = useEligibility( siteId );
 
-	const isLoading = ! siteId || isFetchingTransferStatus;
+	const isLoading = ! siteId || isFetching;
 
 	function getWPComSubdomainWarningContent() {
 		return (

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -3,7 +3,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import yourNewStoreImage from 'calypso/assets/images/woocommerce-install/your-new-store.png';
 import { default as HoldList } from 'calypso/blocks/eligibility-warnings/hold-list';
 import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -69,10 +68,6 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 
 		return (
 			<>
-				<div className="confirm__image-container">
-					{ isProcessing && <LoadingEllipsis /> }
-					<img src={ yourNewStoreImage } alt="" />
-				</div>
 				<div className="confirm__instructions-container">
 					<div className="confirm__instructions-title confirm__instructions-wpcom-domain">
 						{ wpcomDomain }
@@ -120,13 +115,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 
 		return (
 			<>
-				<div className="confirm__image-container">
-					{ isProcessing && <LoadingEllipsis /> }
-					<img src={ yourNewStoreImage } alt="" />
-					<div>
-						<BackButton onClick={ () => goToStep( 'confirm', 'wpcom_subdomain_substep' ) } />
-					</div>
-				</div>
+				{isProcessing && <LoadingEllipsis />}
 				<div className="confirm__instructions-container">
 					{ !! eligibilityHolds?.length && (
 						<p>

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -32,23 +32,9 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	const { siteId, goToStep, isReskinned, stepSectionName, headerTitle, headerDescription } = props;
 	const { __ } = useI18n();
 
-	// @ToDo: remove this before sending to production
-	const eligibilityWarnings = [
-		{
-			name: 'Warning #1',
-			description: 'This is a warning.',
-			supportUrl: '/',
-		},
-		{
-			name: 'Warning #2',
-			description: 'This is a warning that may need attention.',
-			supportUrl: '/',
-		},
-	];
-
 	const {
 		eligibilityHolds,
-		// eligibilityWarnings,
+		eligibilityWarnings,
 		isFetchingTransferStatus,
 		wpcomSubdomainWarning,
 		stagingDomain,

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -38,6 +38,8 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		isFetching,
 		wpcomSubdomainWarning,
 		stagingDomain,
+		pluginsWarning,
+		hasBlockers,
 	} = useEligibility( siteId );
 
 	const isLoading = ! siteId || isFetching;
@@ -61,6 +63,19 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 							<EligibilityWarningsList warnings={ eligibilityWarnings } />
 						</SignupCard>
 					) }
+
+					{ !! pluginsWarning.length && (
+						<p>{ __( 'There are some plugins that would be affected their functionallity.' ) }</p>
+					) }
+
+					{ hasBlockers && (
+						<p>
+							{ __(
+								'This is an erro that is stopping the user from proceeding of the reason why the install failed.'
+							) }
+						</p>
+					) }
+
 					<ActionSection>
 						<p>
 							{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
@@ -69,7 +84,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 						</p>
 						<NextButton
 							isBusy={ isLoading }
-							disabled={ isLoading }
+							disabled={ isLoading || hasBlockers }
 							onClick={ () => goToStep( 'transfer' ) }
 						>
 							{ __( 'Create my Store' ) }

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -152,7 +152,6 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 			fallbackHeaderText={ headerTitle }
 			subHeaderText={ headerDescription }
 			fallbackSubHeaderText={ headerDescription }
-			align={ isReskinned ? 'left' : 'center' }
 			stepContent={ getContent() }
 			isWideLayout={ isReskinned }
 			{ ...props }

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -5,7 +5,6 @@ import { ReactElement, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { default as HoldList } from 'calypso/blocks/eligibility-warnings/hold-list';
 import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	fetchAutomatedTransferStatusOnce,
@@ -66,7 +65,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 
 		return (
 			<>
-				<div className="confirm__info-section">{ isLoading && <LoadingEllipsis /> }</div>
+				<div className="confirm__info-section" />
 
 				<div className="confirm__instructions-container">
 					<div className="confirm__instructions-title confirm__instructions-wpcom-domain">
@@ -88,6 +87,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					</p>
 
 					<NextButton
+						isBusy={ isLoading }
 						disabled={ isLoading }
 						onClick={ () => {
 							if ( eligibilityHolds?.length || eligibilityWarnings?.length ) {
@@ -115,7 +115,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 
 		return (
 			<>
-				<div className="confirm__info-section">{ isLoading && <LoadingEllipsis /> }</div>
+				<div className="confirm__info-section" />
 
 				<div className="confirm__instructions-container">
 					{ !! eligibilityHolds?.length && (
@@ -129,7 +129,11 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 						</p>
 					) }
 
-					<NextButton disabled={ isLoading } onClick={ () => goToStep( 'transfer' ) }>
+					<NextButton
+						isBusy={ isLoading }
+						disabled={ isLoading }
+						onClick={ () => goToStep( 'transfer' ) }
+					>
 						{ __( 'Confirm' ) }
 					</NextButton>
 				</div>

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -129,7 +129,9 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 						</p>
 					) }
 
-					<NextButton onClick={ () => goToStep( 'transfer' ) }>{ __( 'Confirm' ) }</NextButton>
+					<NextButton disabled={ isLoading } onClick={ () => goToStep( 'transfer' ) }>
+						{ __( 'Confirm' ) }
+					</NextButton>
 				</div>
 			</>
 		);

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -1,5 +1,6 @@
 import { NextButton } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
+import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -7,6 +8,7 @@ import { default as HoldList } from 'calypso/blocks/eligibility-warnings/hold-li
 import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
+import EligibilityWarningsList from 'calypso/components/eligibility-warnings/warnings-list';
 import {
 	fetchAutomatedTransferStatusOnce,
 	requestEligibility,
@@ -22,6 +24,20 @@ import SignupCard from '../components/signup-card';
 import type { WooCommerceInstallProps } from '../';
 
 import './style.scss';
+
+const SupportLink = styled.a`
+	/* Gray / Gray 100 - have to find the var value for this color */
+	color: #101517 !important;
+	text-decoration: underline;
+	font-weight: bold;
+`;
+
+const ActionSection = styled.div`
+	display: flex;
+	justify-content: space-between;
+	margin-top: 40px;
+	align-items: baseline;
+`;
 
 export default function Confirm( props: WooCommerceInstallProps ): ReactElement | null {
 	const { siteId, goToStep, isReskinned, stepSectionName, headerTitle, headerDescription } = props;
@@ -53,9 +69,23 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		( { id } ) => id === 'wordpress_subdomain'
 	);
 
-	const eligibilityWarnings = allEligibilityWarnings?.filter(
+	/*const eligibilityWarnings = allEligibilityWarnings?.filter(
 		( { id } ) => id !== 'wordpress_subdomain'
-	);
+	);*/
+
+	// remove this before sending to production
+	const eligibilityWarnings = [
+		{
+			name: 'Warning #1',
+			description: 'This is a warning.',
+			supportUrl: '/',
+		},
+		{
+			name: 'Warning #2',
+			description: 'This is a warning that may need attention.',
+			supportUrl: '/',
+		},
+	];
 
 	// Pick the wpcom subdomain.
 	const wpcomDomain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
@@ -78,27 +108,26 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 								'By installing this product your subdomain will change. Your old subdomain (sitename.wordpress.com) will no longer work. You can change it to a custom domain on us at anytime in future.'
 							) }
 						</p>
-
+					</SignupCard>
+					{ !! eligibilityWarnings?.length && (
+						<SignupCard icon="notice-outline" title={ __( 'Things you should be aware of' ) }>
+							<EligibilityWarningsList warnings={ eligibilityWarnings } />
+						</SignupCard>
+					) }
+					<ActionSection>
 						<p>
-							{ createInterpolateElement( __( '<a>Contact support</a> for help and questions.' ), {
-								a: <a href="#support-link" />,
+							{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
+								a: <SupportLink href="#support-link" />,
 							} ) }
 						</p>
-
 						<NextButton
 							isBusy={ isLoading }
 							disabled={ isLoading }
-							onClick={ () => {
-								if ( eligibilityHolds?.length || eligibilityWarnings?.length ) {
-									return goToStep( 'confirm', 'eligibility_substep' );
-								}
-
-								return goToStep( 'transfer' );
-							} }
+							onClick={ () => goToStep( 'transfer' ) }
 						>
-							{ __( 'Sounds good' ) }
+							{ __( 'Create my Store' ) }
 						</NextButton>
-					</SignupCard>
+					</ActionSection>
 				</div>
 			</>
 		);

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -81,6 +81,19 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 						) }
 					</p>
 
+					<div className="confirm__instructions-title confirm__instructions-wpcom-domain">
+						{wpcomDomain}
+					</div>
+
+					<div className="confirm__instructions-title">{stagingDomain}</div>
+
+					<p>
+						{__(
+							'By installing this product your subdomain will change. You can change it later to a custom domain and we will pick up the tab for a year.'
+						)}
+					</p>
+
+
 					<p>
 						{ createInterpolateElement( __( '<a>Contact support</a> for help and questions.' ), {
 							a: <a href="#support-link" />,

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -61,7 +61,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 
 	function getWPComSubdomainWarningContent() {
 		// Get staging sudomain based on the wpcom subdomain.
-		const stagingDomain = wpcomDomain?.replace( /\b.wordpress.com/, '.wpcomstaging.com' );
+		const stagingDomain = wpcomDomain?.replace( /\b\.wordpress\.com/, '.wpcomstaging.com' );
 
 		return (
 			<>

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -16,6 +16,8 @@ import {
 	EligibilityData,
 } from 'calypso/state/automated-transfer/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
+import SignupBanner from '../components/signup-banner';
+import SignupCard from '../components/signup-card';
 import type { WooCommerceInstallProps } from '../';
 
 import './style.scss';
@@ -66,39 +68,36 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		return (
 			<>
 				<div className="confirm__info-section" />
-
 				<div className="confirm__instructions-container">
-					<div className="confirm__instructions-title confirm__instructions-wpcom-domain">
-						{ wpcomDomain }
-					</div>
+					<SignupCard title={ __( 'New Store Domain' ) }>
+						<SignupBanner label={ __( 'New' ) }>{ stagingDomain }</SignupBanner>
 
-					<div className="confirm__instructions-title">{ stagingDomain }</div>
+						<p>
+							{ __(
+								'By installing this product your subdomain will change. Your old subdomain (sitename.wordpress.com) will no longer work. You can change it to a custom domain on us at anytime in future.'
+							) }
+						</p>
 
-					<p>
-						{ __(
-							'By installing this product your subdomain will change. You can change it later to a custom domain and we will pick up the tab for a year.'
-						) }
-					</p>
+						<p>
+							{ createInterpolateElement( __( '<a>Contact support</a> for help and questions.' ), {
+								a: <a href="#support-link" />,
+							} ) }
+						</p>
 
-					<p>
-						{ createInterpolateElement( __( '<a>Contact support</a> for help and questions.' ), {
-							a: <a href="#support-link" />,
-						} ) }
-					</p>
+						<NextButton
+							isBusy={ isLoading }
+							disabled={ isLoading }
+							onClick={ () => {
+								if ( eligibilityHolds?.length || eligibilityWarnings?.length ) {
+									return goToStep( 'confirm', 'eligibility_substep' );
+								}
 
-					<NextButton
-						isBusy={ isLoading }
-						disabled={ isLoading }
-						onClick={ () => {
-							if ( eligibilityHolds?.length || eligibilityWarnings?.length ) {
-								return goToStep( 'confirm', 'eligibility_substep' );
-							}
-
-							return goToStep( 'transfer' );
-						} }
-					>
-						{ __( 'Sounds good' ) }
-					</NextButton>
+								return goToStep( 'transfer' );
+							} }
+						>
+							{ __( 'Sounds good' ) }
+						</NextButton>
+					</SignupCard>
 				</div>
 			</>
 		);

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -38,22 +38,6 @@ body.is-section-signup .is-woocommerce-install {
 }
 
 .confirm__info-section {
-.is-confirm {
-	margin: 0 0 0 20px;
-	padding: 0 20px;
-	display: flex;
-  justify-content: center;
-	align-items: center;
-	min-height: 94vh;
-
-	.step-wrapper {
-		margin-top: -60px; // remnove the space that the navigation bar took to properly vertically center the content
-		display: grid;
-    grid-template-columns: 1fr 1fr;
-	}
-}
-
-.confirm__image-container {
 	flex: 1;
 }
 

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -7,21 +7,35 @@ body.is-section-signup .is-woocommerce-install {
 		min-height: 95vh;
 		display: flex;
 		align-items: center;
+
+		@media ( max-width: 660px ) {
+			min-height: 0px;
+		}
 		// Two columns layout
 		.step-wrapper {
 			display: flex;
 
 			.step-wrapper__header {
-				margin-top: 0px !important;
+				@media ( min-width: 660px ) {
+					margin-top: 0px !important;
+				}
 
 				.formatted-header {
 					text-align: inherit;
 
 					.formatted-header__title {
 						text-align: inherit;
+						@media ( max-width: 660px ) {
+							padding: 0 10px;
+						}
 					}
 
 					.formatted-header__subtitle {
+						@media ( max-width: 660px ) {
+							margin-top: 8px;
+							padding: 0 10px;
+						}
+
 						margin-top: 20px;
 						text-align: inherit;
 						max-width: 448px;
@@ -37,6 +51,10 @@ body.is-section-signup .is-woocommerce-install {
 			align-items: flex-start;
 			justify-content: center;
 			column-gap: 2%;
+
+			@media ( max-width: 660px ) {
+				grid-template-columns: 1fr;
+			}
 		}
 
 		.step-wrapper__content {

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -9,7 +9,7 @@ body.is-section-signup .is-woocommerce-install {
 		align-items: center;
 
 		@media ( max-width: 660px ) {
-			min-height: 0px;
+			min-height: 0;
 		}
 		// Two columns layout
 		.step-wrapper {
@@ -17,7 +17,7 @@ body.is-section-signup .is-woocommerce-install {
 
 			.step-wrapper__header {
 				@media ( min-width: 660px ) {
-					margin-top: 0px !important;
+					margin-top: 0 !important;
 				}
 
 				.formatted-header {
@@ -59,12 +59,12 @@ body.is-section-signup .is-woocommerce-install {
 
 		.step-wrapper__content {
 			display: flex;
-			margin: 0px 24px;
+			margin: 0 24px;
 
 			.confirm__instructions-container {
 				font-size: 0.875rem;
 				letter-spacing: -0.16px;
-				color: var(--studio-gray-60);
+				color: var( --studio-gray-60 );
 				line-height: 2rem;
 				flex-direction: column;
 				max-width: 520px;

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -2,6 +2,7 @@ body.is-section-signup {
 	.signup__step.is-confirm {
 		.is-wide-layout {
 			max-width: 1024px;
+			align-items: baseline;
 		}
 
 		.step-wrapper__content {
@@ -13,8 +14,13 @@ body.is-section-signup {
 .is-confirm {
 	margin: 0 0 0 20px;
 	padding: 0 20px;
+	display: flex;
+  justify-content: center;
+	align-items: center;
+	min-height: 94vh;
 
 	.step-wrapper {
+		margin-top: -60px; // remnove the space that the navigation bar took to properly vertically center the content
 		display: grid;
     grid-template-columns: 1fr 1fr;
 	}

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -13,6 +13,11 @@ body.is-section-signup {
 .is-confirm {
 	margin: 0 0 0 20px;
 	padding: 0 20px;
+
+	.step-wrapper {
+		display: grid;
+    grid-template-columns: 1fr 1fr;
+	}
 }
 
 .confirm__image-container {

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -4,13 +4,16 @@
 
 body.is-section-signup .is-woocommerce-install {
 	.signup__step.is-confirm {
+		min-height: 95vh;
+		display: flex;
+		align-items: center;
 		// Two columns layout
 		.step-wrapper {
 			display: flex;
-			align-items: flex-start;
-			padding-top: 100px;
 
 			.step-wrapper__header {
+				margin-top: 0px !important;
+
 				.formatted-header {
 					text-align: inherit;
 
@@ -19,7 +22,9 @@ body.is-section-signup .is-woocommerce-install {
 					}
 
 					.formatted-header__subtitle {
+						margin-top: 20px;
 						text-align: inherit;
+						max-width: 448px;
 					}
 				}
 			}
@@ -27,21 +32,33 @@ body.is-section-signup .is-woocommerce-install {
 
 		.is-wide-layout {
 			max-width: 1024px;
-			align-items: baseline;
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			align-items: flex-start;
+			justify-content: center;
+			column-gap: 2%;
 		}
 
 		.step-wrapper__content {
 			display: flex;
-			margin: 24px 20px;
+			margin: 0px 24px;
+
+			.confirm__instructions-container {
+				font-size: 0.875rem;
+				letter-spacing: -0.16px;
+				color: var(--studio-gray-60);
+				line-height: 2rem;
+				flex-direction: column;
+				max-width: 520px;
+			
+				p {
+					margin-top: 16px;
+				}
+			}
 		}
 	}
 }
 
 .confirm__info-section {
 	flex: 1;
-}
-
-.confirm__instructions-container {
-	flex-direction: column;
-	max-width: 520px;
 }

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -1,18 +1,43 @@
-body.is-section-signup {
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+body.is-section-signup .is-woocommerce-install {
 	.signup__step.is-confirm {
+		// Two columns layout
+		.step-wrapper {
+			display: flex;
+			align-items: flex-start;
+			padding-top: 100px;
+
+			.step-wrapper__header {
+				.formatted-header {
+					text-align: inherit;
+
+					.formatted-header__title {
+						text-align: inherit;
+					}
+
+					.formatted-header__subtitle {
+						text-align: inherit;
+					}
+				}
+			}
+		}
+
 		.is-wide-layout {
 			max-width: 1024px;
 		}
 
 		.step-wrapper__content {
 			display: flex;
+			margin: 24px 20px;
+
+			@include break-large {
+				margin: 48px 0 40px;
+			}
 		}
 	}
-}
-
-.is-confirm {
-	margin: 0 0 0 20px;
-	padding: 0 20px;
 }
 
 .confirm__info-section {

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -32,10 +32,6 @@ body.is-section-signup .is-woocommerce-install {
 		.step-wrapper__content {
 			display: flex;
 			margin: 24px 20px;
-
-			@include break-large {
-				margin: 48px 0 40px;
-			}
 		}
 	}
 }
@@ -45,28 +41,6 @@ body.is-section-signup .is-woocommerce-install {
 }
 
 .confirm__instructions-container {
-	width: 40vw;
-	max-width: 500px;
-	padding: 0 50px;
 	flex-direction: column;
-
-	p {
-		color: var( --studio-gray-60 );
-		line-height: 1.25rem;
-		letter-spacing: -0.16px;
-		margin-top: 30px;
-		font-size: 0.875rem;
-	}
-}
-
-.confirm__instructions-title {
-	font-size: 1.5rem;
-	letter-spacing: 0.2px;
-	line-height: 2.5rem;
-	color: var( --studio-gray-90 );
-}
-
-.confirm__instructions-wpcom-domain {
-	text-decoration: line-through;
-	color: var( --studio-gray-20 );
+	max-width: 520px;
 }

--- a/client/signup/steps/woocommerce-install/hooks/use-eligibility/Readme.md
+++ b/client/signup/steps/woocommerce-install/hooks/use-eligibility/Readme.md
@@ -1,0 +1,22 @@
+# useEligibility
+
+Custom React hook to process eligibility data to provide a clear object to deal with the woocommerce-install flow.
+
+## Usage
+
+```es6
+import useEligibility from '../hooks/use-eligibility';
+
+function WordPressSubdomainWarningCard() {
+	const { wpcomSubdomainWarning, stagingDomain } = useEligibility( siteId );
+
+	if ( ! wpcomSubdomainWarning ) {
+		return null;
+	}
+
+	return (
+		<div className="card is-warning">
+			Domain is going to change to { stagingDomain }.
+		</div>
+	);
+}

--- a/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+	fetchAutomatedTransferStatusOnce,
+	requestEligibility,
+} from 'calypso/state/automated-transfer/actions';
+import {
+	isFetchingAutomatedTransferStatus,
+	getEligibility,
+	EligibilityData,
+	EligibilityWarning,
+} from 'calypso/state/automated-transfer/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+// import { eligibilityHolds } from 'calypso/state/automated-transfer/constants';
+
+type EligibilityHook = {
+	eligibilityHolds?: string[];
+	eligibilityWarnings?: EligibilityWarning[];
+	isFetchingTransferStatus: boolean;
+	wpcomSubdomainWarning: EligibilityWarning | undefined;
+	wpcomDomain: string | null;
+	stagingDomain: string | null;
+};
+
+export default function useEligibility( siteId: number ): EligibilityHook {
+	const dispatch = useDispatch();
+
+	// Request eligibility data.
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		dispatch( fetchAutomatedTransferStatusOnce( siteId ) );
+		dispatch( requestEligibility( siteId ) );
+	}, [ siteId, dispatch ] );
+
+	// Get eligibility data.
+	const {
+		eligibilityHolds,
+		eligibilityWarnings: allEligibilityWarnings,
+	}: EligibilityData = useSelector( ( state ) => getEligibility( state, siteId ) );
+
+	// Pick the wpcom subdomain.
+	const wpcomDomain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+
+	// Get staging sudomain based on the wpcom subdomain.
+	const stagingDomain = wpcomDomain?.replace( /\b\.wordpress\.com/, '.wpcomstaging.com' ) || null;
+
+	// Check whether it's requesting eligibility data.
+	const isFetchingTransferStatus = !! useSelector( ( state ) =>
+		isFetchingAutomatedTransferStatus( state, siteId )
+	);
+
+	// Check whether the wpcom.com subdomain warning is present.
+	const wpcomSubdomainWarning: EligibilityWarning | undefined = allEligibilityWarnings?.find(
+		( { id } ) => id === 'wordpress_subdomain'
+	);
+
+	// Remove warnings.
+	const eligibilityWarnings = allEligibilityWarnings?.filter(
+		( { id } ) => id !== 'wordpress_subdomain'
+	);
+
+	return {
+		eligibilityHolds,
+		eligibilityWarnings,
+		isFetchingTransferStatus,
+		wpcomSubdomainWarning,
+		wpcomDomain,
+		stagingDomain,
+	};
+}

--- a/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
@@ -84,7 +84,6 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		pluginsWarning,
 		widgetsWarning,
 		wpcomSubdomainWarning,
-
 		transferringBlockers,
 		hasBlockers: !! transferringBlockers.length,
 	};

--- a/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
@@ -11,7 +11,6 @@ import {
 	EligibilityWarning,
 } from 'calypso/state/automated-transfer/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
-// import { eligibilityHolds } from 'calypso/state/automated-transfer/constants';
 
 type EligibilityHook = {
 	eligibilityHolds?: string[];
@@ -38,10 +37,9 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	}, [ siteId, dispatch ] );
 
 	// Get eligibility data.
-	const {
-		eligibilityHolds,
-		eligibilityWarnings: allEligibilityWarnings,
-	}: EligibilityData = useSelector( ( state ) => getEligibility( state, siteId ) );
+	const { eligibilityHolds, eligibilityWarnings }: EligibilityData = useSelector( ( state ) =>
+		getEligibility( state, siteId )
+	);
 
 	// Pick the wpcom subdomain.
 	const wpcomDomain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
@@ -55,20 +53,15 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	);
 
 	// Check whether the wpcom.com subdomain warning is present.
-	const wpcomSubdomainWarning = allEligibilityWarnings?.find(
+	const wpcomSubdomainWarning = eligibilityWarnings?.find(
 		( { id } ) => id === 'wordpress_subdomain'
 	);
 
 	// Plugins warnings
-	const pluginsWarning = allEligibilityWarnings?.filter( ( { type } ) => type === 'plugins' ) || [];
+	const pluginsWarning = eligibilityWarnings?.filter( ( { type } ) => type === 'plugins' ) || [];
 
 	// Widgets warnings
-	const widgetsWarning = allEligibilityWarnings?.filter( ( { type } ) => type === 'widgets' ) || [];
-
-	// Remove warnings.
-	const eligibilityWarnings = allEligibilityWarnings?.filter(
-		( { id } ) => id !== 'wordpress_subdomain'
-	);
+	const widgetsWarning = eligibilityWarnings?.filter( ( { type } ) => type === 'widgets' ) || [];
 
 	return {
 		isFetching,

--- a/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
@@ -4,6 +4,7 @@ import {
 	fetchAutomatedTransferStatusOnce,
 	requestEligibility,
 } from 'calypso/state/automated-transfer/actions';
+import { eligibilityHolds as eligibilityHoldsConstants } from 'calypso/state/automated-transfer/constants';
 import {
 	isFetchingAutomatedTransferStatus,
 	getEligibility,
@@ -11,6 +12,11 @@ import {
 	EligibilityWarning,
 } from 'calypso/state/automated-transfer/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
+
+const TRANSFERRING_NOT_BLOCKERS = [
+	eligibilityHoldsConstants.NO_BUSINESS_PLAN, // let's redirect to checkout page
+	eligibilityHoldsConstants.TRANSFER_ALREADY_EXISTS, // let's handle it in transferring endpoint.
+];
 
 type EligibilityHook = {
 	eligibilityHolds?: string[];
@@ -21,6 +27,8 @@ type EligibilityHook = {
 	pluginsWarning: EligibilityWarning[];
 	widgetsWarning: EligibilityWarning[];
 	wpcomSubdomainWarning: EligibilityWarning | undefined;
+	transferringBlockers: string[];
+	hasBlockers: boolean;
 };
 
 export default function useEligibility( siteId: number ): EligibilityHook {
@@ -63,6 +71,10 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	// Widgets warnings
 	const widgetsWarning = eligibilityWarnings?.filter( ( { type } ) => type === 'widgets' ) || [];
 
+	// Trasferring blockers
+	const transferringBlockers =
+		eligibilityHolds?.filter( ( hold ) => ! TRANSFERRING_NOT_BLOCKERS.includes( hold ) ) || [];
+
 	return {
 		isFetching,
 		eligibilityHolds,
@@ -72,5 +84,8 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		pluginsWarning,
 		widgetsWarning,
 		wpcomSubdomainWarning,
+
+		transferringBlockers,
+		hasBlockers: !! transferringBlockers.length,
 	};
 }

--- a/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
@@ -16,7 +16,7 @@ import { getSiteDomain } from 'calypso/state/sites/selectors';
 type EligibilityHook = {
 	eligibilityHolds?: string[];
 	eligibilityWarnings?: EligibilityWarning[];
-	isFetchingTransferStatus: boolean;
+	isFetching: boolean;
 	wpcomSubdomainWarning: EligibilityWarning | undefined;
 	wpcomDomain: string | null;
 	stagingDomain: string | null;
@@ -48,7 +48,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	const stagingDomain = wpcomDomain?.replace( /\b\.wordpress\.com/, '.wpcomstaging.com' ) || null;
 
 	// Check whether it's requesting eligibility data.
-	const isFetchingTransferStatus = !! useSelector( ( state ) =>
+	const isFetching = !! useSelector( ( state ) =>
 		isFetchingAutomatedTransferStatus( state, siteId )
 	);
 
@@ -65,7 +65,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	return {
 		eligibilityHolds,
 		eligibilityWarnings,
-		isFetchingTransferStatus,
+		isFetching,
 		wpcomSubdomainWarning,
 		wpcomDomain,
 		stagingDomain,

--- a/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-eligibility/index.ts
@@ -17,9 +17,11 @@ type EligibilityHook = {
 	eligibilityHolds?: string[];
 	eligibilityWarnings?: EligibilityWarning[];
 	isFetching: boolean;
-	wpcomSubdomainWarning: EligibilityWarning | undefined;
 	wpcomDomain: string | null;
 	stagingDomain: string | null;
+	pluginsWarning: EligibilityWarning[];
+	widgetsWarning: EligibilityWarning[];
+	wpcomSubdomainWarning: EligibilityWarning | undefined;
 };
 
 export default function useEligibility( siteId: number ): EligibilityHook {
@@ -53,9 +55,15 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	);
 
 	// Check whether the wpcom.com subdomain warning is present.
-	const wpcomSubdomainWarning: EligibilityWarning | undefined = allEligibilityWarnings?.find(
+	const wpcomSubdomainWarning = allEligibilityWarnings?.find(
 		( { id } ) => id === 'wordpress_subdomain'
 	);
+
+	// Plugins warnings
+	const pluginsWarning = allEligibilityWarnings?.filter( ( { type } ) => type === 'plugins' ) || [];
+
+	// Widgets warnings
+	const widgetsWarning = allEligibilityWarnings?.filter( ( { type } ) => type === 'widgets' ) || [];
 
 	// Remove warnings.
 	const eligibilityWarnings = allEligibilityWarnings?.filter(
@@ -63,11 +71,13 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	);
 
 	return {
+		isFetching,
 		eligibilityHolds,
 		eligibilityWarnings,
-		isFetching,
-		wpcomSubdomainWarning,
 		wpcomDomain,
 		stagingDomain,
+		pluginsWarning,
+		widgetsWarning,
+		wpcomSubdomainWarning,
 	};
 }

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -90,6 +90,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 		) {
 			setProgress( 1 );
 			setError( { transferFailed, transferStatus } );
+			goToStep( 'confirm' );
 		}
 	}, [ siteId, goToStep, fetchingTransferStatus, transferStatus, transferFailed, wcAdmin, __ ] );
 

--- a/client/state/automated-transfer/selectors/index.ts
+++ b/client/state/automated-transfer/selectors/index.ts
@@ -16,6 +16,7 @@ export interface EligibilityWarning {
 	description: string;
 	name: string;
 	id: string;
+	type: string;
 	supportUrl?: string;
 }
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -60,12 +60,17 @@ export const eligibilityHoldsFromApi = ( { errors = [] }, options = {} ) =>
  */
 const eligibilityWarningsFromApi = ( { warnings = {} } ) =>
 	Object.keys( warnings )
-		.reduce( ( list, type ) => list.concat( warnings[ type ] ), [] ) // combine plugin and theme warnings into one list
-		.map( ( { description, name, support_url, id } ) => ( {
+		.reduce(
+			( list, type ) =>
+				list.concat( warnings[ type ].map( ( warning ) => ( { ...warning, type } ) ) ),
+			[]
+		) // combine plugin and theme warnings into one list populated with type
+		.map( ( { description, name, support_url, id, type } ) => ( {
 			id,
 			name,
 			description,
 			supportUrl: support_url,
+			type,
 		} ) );
 
 /**

--- a/packages/onboarding/src/action-buttons/index.tsx
+++ b/packages/onboarding/src/action-buttons/index.tsx
@@ -59,7 +59,7 @@ export const NextButton: React.FunctionComponent< Button.ButtonProps > = ( {
 
 	return (
 		<Button
-			className={ classnames( 'action_buttons__button action-buttons__next', className ) }
+			className={ classnames( 'button action_buttons__button action-buttons__next', className ) }
 			isPrimary
 			{ ...buttonProps }
 		>

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -65,11 +65,6 @@ button.action_buttons__button.components-button {
 		height: auto;
 	}
 
-	&.action-buttons__next {
-		color: var( --studio-white );
-		box-shadow: 0 0 0 1px var( --studio-blue-40 );
-	}
-
 	&.action-buttons__skip {
 		color: var( --studio-gray-50 );
 		box-shadow: inset 0 0 0 1px var( --studio-gray-50 );
@@ -91,7 +86,7 @@ button.action_buttons__button.components-button {
 
 		text-decoration: underline;
 		// stylelint-disable-next-line scales/font-weight
-		font-weight: 500;
+		font-weight: 600;
 		color: var( --mainColor );
 
 		// @TODO: We have to revisit the ArrowButton's padding when we pick up #48568 (https://github.com/Automattic/wp-calypso/issues/48568)

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -85,8 +85,8 @@ button.action_buttons__button.components-button {
 		justify-content: flex-start;
 
 		text-decoration: underline;
-		// stylelint-disable-next-line scales/font-weight
-		font-weight: 600;
+		// stylelint-disable-next-line scales/font-weights
+		font-weight: 500;
 		color: var( --mainColor );
 
 		// @TODO: We have to revisit the ArrowButton's padding when we pick up #48568 (https://github.com/Automattic/wp-calypso/issues/48568)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/wp-calypso/issues/58468

![image](https://user-images.githubusercontent.com/77539/143873878-ccf94023-9634-4e64-a3cc-ced63ab19006.png)


#### Testing instructions
There are a couple scenarios that need to be tested here, the testing flow follow the same pattern but for different scenarios we will have to modify the `wp-content/lib/atomic/eligibility.php` file in `wpcom` and sandbox the wpcom public api.
* Update `wp-content/lib/atomic/eligibility.php` to reflect the scenario you are testing.
* Navigate to `http://calypso.localhost:3000/start/woocommerce-install/confirm`
* Select your site from the site picker
* The page should render differently depending the scenario you are testing

##### Confirm screen with eligibility holds
To test this scenario we have to make sure that there is a eligibility hold present like `EXCESSIVE_DISK_SPACE` in the server response so we sandbox the api and change the eligibility endpoint to return a hold:
```php
// The value returned by get_space_used_bytes() excludes transcoded media files, but includes the original media.
	$disk_space_used = get_space_used_bytes( $blog_id );
	if ( $disk_space_used > 150 * GB_IN_BYTES) {  // make this if pass and it will return the eligibility hold
		$errors[] = build_error(
			EXCESSIVE_DISK_SPACE,
			'This site cannot be transferred due to disk space limitations.'
		);
	}
```
This should be the result:
<img width="1512" alt="Screen Shot 2021-11-30 at 11 57 11 PM" src="https://user-images.githubusercontent.com/1035546/144174533-3c51af73-35c9-4875-9020-592a5bc4dc8a.png">
* Button should be disabled
* It should show a hold alert

##### Confirm screen with eligibility warnings
To test this scenario we have to make sure that:
* The server returns eligibility warnings.
* The server doesn't return an eligibility hold, update the `eligbility.php` file so the API doesn't return a hold.

make sure that the `get_plugin_warnings()` returns all the plugin warnings to be able to test:
```php
// like this
function get_plugin_warnings() {
	$plugin_warnings = array_filter( get_unsupported_plugins(),
		function ( $plugin_element ) {
			$check_plugin_usage = __NAMESPACE__ . '\\is_using_plugin_' . $plugin_element['id'];

			return function_exists( $check_plugin_usage ) ? $check_plugin_usage() : false;
		}
	);

	// @ToDo: Remove - developing purposes. testing this 
	$plugin_warnings = array_filter( get_unsupported_plugins() );

	return array_values( $plugin_warnings );
}
```
This should be the result:
<img width="1355" alt="Screen Shot 2021-12-01 at 12 14 42 AM" src="https://user-images.githubusercontent.com/1035546/144176011-636f18c2-afcb-40e8-9764-39019fd1df37.png">
* Button should not be disabled and should link to the transfer step.
* It should show a list of the warnings.

##### Confirm screen without eligibility holds and warnings
To test this scenario we have to make sure that the endpoint doesn't return any hold or warning, this can be done by returning an empty array in the `get_plugin_warnings` and `get_widgets_warnings` functions.
```php
function get_plugin_warnings() {
	$plugin_warnings = array_filter( get_unsupported_plugins(),
		function ( $plugin_element ) {
			$check_plugin_usage = __NAMESPACE__ . '\\is_using_plugin_' . $plugin_element['id'];

			return function_exists( $check_plugin_usage ) ? $check_plugin_usage() : false;
		}
	);

	// @ToDo: Remove - developing purposes. testing this 
	$plugin_warnings = array_filter( get_unsupported_plugins() );

	return array_values([] ); // return an empty array
```
For the holds we want to make sure that the conditionals are not fired making the ifs `false` is enough (maybe there is a better way of doing this please update this comment).
This should be the result:
<img width="1354" alt="Screen Shot 2021-12-01 at 12 25 55 AM" src="https://user-images.githubusercontent.com/1035546/144176956-ae3979c6-d3dc-42f7-8c82-72d5a73a58a8.png">
* Button should be enabled
* It should only show the subdomain warning