### PR TITLE
New transfer domain to other user screen

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -336,14 +336,15 @@ export default {
 	},
 
 	domainManagementTransferToOtherUser( pageContext, next ) {
+		let transferComponent = DomainManagement.TransferToOtherUser;
 		if ( config.isEnabled( 'domains/transfers-redesign' ) ) {
-			// TODO: set different component for the new transfer page
+			transferComponent = DomainManagement.TransferDomainToOtherUser;
 		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransferToAnotherUser( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Transfer To Other User"
-				component={ DomainManagement.TransferToOtherUser }
+				component={ transferComponent }
 				context={ pageContext }
 				needsDomains
 				selectedDomainName={ pageContext.params.domain }

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -23,6 +23,7 @@ import TransferOut from './transfer/transfer-out';
 import TransferPage from './transfer/transfer-page';
 import TransferToOtherSite from './transfer/transfer-to-other-site';
 import TransferToOtherUser from './transfer/transfer-to-other-user';
+import TransferDomainToOtherUser from './transfer/transfer-to-other-user/transfer-domain-to-other-user';
 
 export default {
 	AddDnsRecord,
@@ -49,5 +50,6 @@ export default {
 	TransferPage,
 	TransferToOtherSite,
 	TransferToOtherUser,
+	TransferDomainToOtherUser,
 	Transfer,
 };

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
@@ -1,3 +1,10 @@
+@import '../../../../customer-home/grid-mixins.scss';
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/colors.native';
+
 .transfer-to-other-user__select {
 	margin-top: 20px;
 	width: 100%;
@@ -10,5 +17,44 @@
 
 	@include breakpoint-deprecated( '>480px' ) {
 		max-width: 500px;
+	}
+}
+
+body.transfer-to-other-user.theme-default.color-scheme {
+	--color-surface-backdrop: var( --studio-white );
+}
+
+body.transfer-to-other-user {
+	.formatted-header {
+		&.is-left-align,
+		&.is-right-align {
+			margin-bottom: 24px;
+
+			h1.formatted-header__title {
+				color: $gray-900;
+				font-size: $font-title-medium;
+
+				@include break-mobile {
+					font-size: $font-title-large;
+				}
+			}
+		}
+	}
+
+	.transfer-to-other-user__container {
+		.transfer-to-other-user__main {
+			margin: 16px;
+		}
+		@include break-xlarge {
+			@include grid-row( 1, 1 );
+			@include grid-column( 1, 12 );
+			@include display-grid;
+			@include grid-template-columns( 12, 24px, 1fr );
+			grid-gap: 24px;
+			.transfer-to-other-user__main {
+				@include grid-column( 1, 8 );
+				margin: 0;
+			}
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -1,0 +1,394 @@
+import { Dialog } from '@automattic/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+import { Component, Fragment } from 'react';
+import { connect, useSelector } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSelect from 'calypso/components/forms/form-select';
+import Main from 'calypso/components/main';
+import useUsersQuery from 'calypso/data/users/use-users-query';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
+import wp from 'calypso/lib/wp';
+import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
+import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
+import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
+import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainManagementTransfer,
+} from 'calypso/my-sites/domains/paths';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+const wpcom = wp.undocumented();
+
+const getWpcomUserId = ( user ) => user.linked_user_ID ?? user.ID;
+
+class TransferDomainToOtherUser extends Component {
+	static propTypes = {
+		currentUserId: PropTypes.number.isRequired,
+		domains: PropTypes.array.isRequired,
+		isRequestingSiteDomains: PropTypes.bool.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+		// From `withUsers` HoC
+		users: PropTypes.array.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			selectedUserId: '',
+			showConfirmationDialog: false,
+			disableDialogButtons: false,
+		};
+
+		this.handleUserChange = this.handleUserChange.bind( this );
+		this.handleTransferDomain = this.handleTransferDomain.bind( this );
+		this.handleDialogClose = this.handleDialogClose.bind( this );
+		this.handleConfirmTransferDomain = this.handleConfirmTransferDomain.bind( this );
+	}
+
+	handleUserChange( event ) {
+		event.preventDefault();
+
+		this.setState( { selectedUserId: event.target.value } );
+	}
+
+	handleTransferDomain() {
+		this.setState( { showConfirmationDialog: true } );
+	}
+
+	handleTransferCancel = () => {
+		const { selectedSite, selectedDomainName, currentRoute } = this.props;
+		page( domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ) );
+	};
+
+	handleConfirmTransferDomain( closeDialog ) {
+		const { selectedDomainName } = this.props;
+		const selectedUserDisplay = this.getSelectedUserDisplayName();
+		const successMessage = this.props.translate(
+			'%(selectedDomainName)s has been transferred to %(selectedUserDisplay)s',
+			{ args: { selectedDomainName, selectedUserDisplay } }
+		);
+		const defaultErrorMessage = this.props.translate(
+			'Failed to transfer %(selectedDomainName)s, please try again or contact support.',
+			{
+				args: { selectedDomainName },
+			}
+		);
+
+		this.setState( { disableDialogButtons: true } );
+		wpcom
+			.transferToUser(
+				this.props.selectedSite.ID,
+				this.props.selectedDomainName,
+				this.state.selectedUserId
+			)
+			.then(
+				() => {
+					this.setState( { disableDialogButtons: false } );
+					this.props.successNotice( successMessage, { duration: 4000, isPersistent: true } );
+					closeDialog();
+					page(
+						domainManagementEdit(
+							this.props.selectedSite.slug,
+							this.props.selectedDomainName,
+							this.props.currentRoute
+						)
+					);
+				},
+				( err ) => {
+					this.setState( { disableDialogButtons: false } );
+					this.props.errorNotice( err.message || defaultErrorMessage );
+					closeDialog();
+				}
+			);
+	}
+
+	handleDialogClose() {
+		if ( ! this.state.disableDialogButtons ) {
+			this.setState( { showConfirmationDialog: false } );
+		}
+	}
+
+	getSelectedUserDisplayName() {
+		const selectedUser = this.props.users.find(
+			( user ) => getWpcomUserId( user ) === Number( this.state.selectedUserId )
+		);
+
+		if ( ! selectedUser ) {
+			return '';
+		}
+
+		return this.getUserDisplayName( selectedUser );
+	}
+
+	getUserDisplayName( { first_name, last_name, nice_name } ) {
+		return first_name && last_name ? `${ first_name } ${ last_name } (${ nice_name })` : nice_name;
+	}
+
+	renderBreadcrumbs() {
+		const { translate, selectedSite, selectedDomainName, currentRoute } = this.props;
+
+		const items = [
+			{
+				label: translate( 'Domains' ),
+				href: domainManagementList( selectedSite.slug, selectedDomainName ),
+			},
+			{
+				label: selectedDomainName,
+				href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+			},
+			{
+				label: translate( 'Transfer' ),
+				href: domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ),
+			},
+			{ label: translate( 'Transfer to another user' ) },
+		];
+
+		const mobileItem = {
+			label: translate( 'Back to Transfer' ),
+			href: domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ),
+			showBackArrow: true,
+		};
+
+		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
+	}
+
+	render() {
+		if ( ! this.isDataReady() ) {
+			return (
+				<>
+					<BodySectionCssClass bodyClass={ [ 'transfer-to-other-user' ] } />
+					<DomainMainPlaceholder goBack={ this.goToEdit } />
+				</>
+			);
+		}
+
+		const { translate } = this.props;
+
+		return (
+			<Main wideLayout>
+				<BodySectionCssClass bodyClass={ [ 'transfer-to-other-user' ] } />
+				{ this.renderBreadcrumbs() }
+				<FormattedHeader
+					brandFont
+					headerText={ translate( 'Transfer to another user' ) }
+					align="left"
+				/>
+				<div className="transfer-to-other-user__container">
+					<div className="transfer-to-other-user__main">{ this.renderSection() }</div>
+				</div>
+			</Main>
+		);
+	}
+
+	renderDialog() {
+		const buttons = [
+			{
+				action: 'cancel',
+				label: this.props.translate( 'Cancel' ),
+				disabled: this.state.disableDialogButtons,
+			},
+			{
+				action: 'confirm',
+				label: this.props.translate( 'Confirm transfer' ),
+				onClick: this.handleConfirmTransferDomain,
+				disabled: this.state.disableDialogButtons,
+				isPrimary: true,
+			},
+		];
+		return (
+			<Dialog
+				className="transfer-to-other-user__confirmation-dialog"
+				isVisible={ this.state.showConfirmationDialog }
+				buttons={ buttons }
+				onClose={ this.handleDialogClose }
+			>
+				<h1>{ this.props.translate( 'Confirm Transfer' ) }</h1>
+				<p>{ this.getDialogMessage() }</p>
+			</Dialog>
+		);
+	}
+
+	getDialogMessage() {
+		const { selectedDomainName: domainName, isMapping, translate } = this.props;
+		const selectedUserDisplay = this.getSelectedUserDisplayName();
+
+		if ( isMapping ) {
+			return translate(
+				'Do you want to transfer the domain mapping of {{strong}}%(domainName)s{{/strong}} ' +
+					'to {{strong}}%(selectedUserDisplay)s{{/strong}}?',
+				{
+					args: { domainName, selectedUserDisplay },
+					components: { strong: <strong /> },
+				}
+			);
+		}
+
+		return translate(
+			'Do you want to transfer the ownership of {{strong}}%(domainName)s{{/strong}} ' +
+				'to {{strong}}%(selectedUserDisplay)s{{/strong}}?',
+			{
+				args: { domainName, selectedUserDisplay },
+				components: { strong: <strong /> },
+			}
+		);
+	}
+
+	renderSection() {
+		const { currentUserCanManage, domainRegistrationAgreementUrl } = getSelectedDomain(
+			this.props
+		);
+
+		if ( ! currentUserCanManage ) {
+			const { domains, selectedDomainName } = this.props;
+			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
+		}
+
+		const { isMapping, translate, users } = this.props;
+		const availableUsers = this.filterAvailableUsers( users );
+		const saveButtonLabel = isMapping
+			? translate( 'Transfer domain mapping' )
+			: translate( 'Transfer domain' );
+
+		return (
+			<>
+				{ this.renderTransferInformation() }
+				<FormFieldset>
+					<FormSelect
+						disabled={ availableUsers.length === 0 }
+						className="transfer-to-other-user__select"
+						onChange={ this.handleUserChange }
+						value={ this.state.selectedUserId }
+					>
+						{ availableUsers.length ? (
+							<Fragment>
+								<option value="">{ translate( 'Choose an administrator on this site' ) }</option>
+								{ availableUsers.map( ( user ) => {
+									const userId = getWpcomUserId( user );
+
+									return (
+										<option key={ userId } value={ userId }>
+											{ this.getUserDisplayName( user ) }
+										</option>
+									);
+								} ) }
+							</Fragment>
+						) : (
+							<option value="">{ translate( '-- Site has no other administrators --' ) }</option>
+						) }
+					</FormSelect>
+				</FormFieldset>
+				{ ! isMapping && (
+					<DesignatedAgentNotice
+						domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
+						saveButtonLabel={ saveButtonLabel }
+					/>
+				) }
+				<FormButton disabled={ ! this.state.selectedUserId } onClick={ this.handleTransferDomain }>
+					{ saveButtonLabel }
+				</FormButton>
+				<FormButton isPrimary={ false } onClick={ this.handleTransferCancel }>
+					{ translate( 'Cancel' ) }
+				</FormButton>
+				{ this.renderDialog() }
+			</>
+		);
+	}
+
+	renderTransferInformation() {
+		const { isMapping, selectedDomainName: domainName, selectedSite, translate } = this.props;
+
+		if ( isMapping ) {
+			return (
+				<>
+					<p>
+						{ translate(
+							'Please choose an administrator to transfer domain mapping of {{strong}}%(domainName)s{{/strong}} to.',
+							{ args: { domainName }, components: { strong: <strong /> } }
+						) }
+					</p>
+					<p>
+						{ translate(
+							'You can transfer this domain mapping to any administrator on this site. If the user you want to ' +
+								'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
+							{ components: { a: <a href={ `/people/new/${ selectedSite.slug }` } /> } }
+						) }
+					</p>
+				</>
+			);
+		}
+
+		return (
+			<>
+				<p>
+					{ translate(
+						'Transferring a domain to another user will give all the rights of the domain to that user. ' +
+							'Please choose an administrator to transfer {{strong}}%(domainName)s{{/strong}} to.',
+						{ args: { domainName }, components: { strong: <strong /> } }
+					) }
+				</p>
+				<p>
+					{ translate(
+						'You can transfer this domain to any administrator on this site. If the user you want to ' +
+							'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
+						{ components: { a: <a href={ `/people/new/${ selectedSite.slug }` } /> } }
+					) }
+				</p>
+			</>
+		);
+	}
+
+	filterAvailableUsers( users ) {
+		return users.filter(
+			( user ) =>
+				getWpcomUserId( user ) !== false && getWpcomUserId( user ) !== this.props.currentUserId
+		);
+	}
+
+	isDataReady() {
+		return this.props.hasSiteDomainsLoaded && ! this.props.isRequestingSiteDomains;
+	}
+}
+
+const withUsers = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const siteId = useSelector( getSelectedSiteId );
+		const usersQuery = useUsersQuery( siteId, { role: 'administrator' } );
+		const users = usersQuery.data?.users ?? [];
+
+		return <Wrapped { ...props } users={ users } />;
+	},
+	'WithUsers'
+);
+
+export default connect(
+	( state, ownProps ) => {
+		const domain = ! ownProps.isRequestingSiteDomains && getSelectedDomain( ownProps );
+
+		return {
+			currentUserId: getCurrentUserId( state ),
+			isMapping: Boolean( domain ) && isMappedDomain( domain ),
+			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite.ID ),
+			currentRoute: getCurrentRoute( state ),
+		};
+	},
+	{
+		successNotice,
+		errorNotice,
+	}
+)( localize( withUsers( TransferDomainToOtherUser ) ) );


### PR DESCRIPTION
Apple the new design to the transfer domain to other user screen

#### Changes proposed in this Pull Request

* Add new component to show the new redesigned transfer to other user screen

Before:

<img width="788" alt="Screenshot 2021-11-25 at 22 07 48" src="https://user-images.githubusercontent.com/1355045/143495926-ae263b6e-10b8-4d46-9f5a-fa0cf71a4a64.png">


After:

<img width="1151" alt="Screenshot 2021-11-25 at 22 05 21" src="https://user-images.githubusercontent.com/1355045/143495934-78fc1442-be29-4f2d-82a5-f9c604f43b0b.png">


#### Testing instructions

* Apply the PR or run calypso.live and then visit /domains/manage/{domain_name}/transfer/other-user/{site_name}
* on calypso.live you'll also need to add `?flags=domains/transfers-redesign` to the address to enable the feature flag