### PR TITLE
Update text colors to a darker tone of gray for accessibility purposes.

### DIFF
--- a/client/my-sites/plugins/plugin-install-button/style.scss
+++ b/client/my-sites/plugins/plugin-install-button/style.scss
@@ -27,7 +27,7 @@
 
 	.plugin-install-button__installing {
 		font-size: $font-body-extra-small;
-		color: var( --color-neutral-light );
+		color: var( --color-neutral-60 );
 		text-transform: uppercase;
 		display: block;
 	}
@@ -46,7 +46,7 @@
 .plugin-install-button__warning {
 	margin-right: 8px;
 	font-size: $font-body-extra-small;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral-60 );
 	text-transform: uppercase;
 	white-space: nowrap;
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -190,7 +190,7 @@ $plugin-details-header-padding: 100px;
 .plugin-details__tags {
 	position: absolute;
 	font-size: $font-body-extra-small;
-	color: var( --studio-gray-40 );
+	color: var( --studio-gray-60 );
 	top: calc( $plugin-details-header-padding - 15px );
 	left: 0;
 
@@ -234,7 +234,7 @@ $plugin-details-header-padding: 100px;
 		.plugin-details__info-title {
 			font-size: $font-body-extra-small;
 			font-weight: 400;
-			color: var( --studio-gray-40 );
+			color: var( --studio-gray-60 );
 		}
 
 		.plugin-details__info-value {
@@ -320,7 +320,7 @@ $plugin-details-header-padding: 100px;
 		margin-top: 100px;
 
 		.title {
-			color: var( --studio-gray-40 );
+			color: var( --studio-gray-60 );
 			font-size: $font-body-extra-small;
 		}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -239,7 +239,7 @@ $plugin-details-header-padding: 100px;
 
 		.plugin-details__info-value {
 			font-size: $font-body;
-			color: var( --studio-gray-70 );
+			color: var( --studio-gray-90 );
 		}
 	}
 
@@ -325,7 +325,7 @@ $plugin-details-header-padding: 100px;
 		}
 
 		.value {
-			color: var( --studio-gray-70 );
+			color: var( --studio-gray-90 );
 			font-size: $font-body-small;
 			padding-bottom: 16px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update light text colors on the Plugin Details page to a darker tone of gray (Gray 60) for accessibility purposes.

#### Testing instructions

* Go to `/plugins` page
* Select a plugin
* Check if the texts on the page offer enough contrast with the background


![Screen Shot 2021-11-29 at 05 47 36](https://user-images.githubusercontent.com/5039531/143845357-3a9cb040-596a-4930-be42-9f03d5468957.png)
---


Fixes #58279