### PR TITLE
Videos UI: Add the call-to-action capabilities to the modal footer component.

### DIFF
--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -30,11 +30,14 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 					<Gridicon icon="chevron-left" size={ 24 } />
 					<span>{ translate( 'Back' ) }</span>
 				</a>
-				<p>
-					{ translate(
-						"You did it! Now it's time to put your skills to work and draft your first post."
-					) }
-				</p>
+				{ isCourseComplete && (
+					<p>
+						{ translate(
+							"You did it! Now it's time to put your skills to work and draft your first post."
+						) }
+					</p>
+				) }
+
 				{ isCourseComplete && (
 					<Button onClick={ onStartWritingClick } className="videos-ui__button">
 						{ translate( 'Start writing' ) }

--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -1,10 +1,10 @@
-import { Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 import './modal-footer-bar.scss';
 
-const ModalFooterBar = ( { onBackClick = () => {}, course = {} } ) => {
+const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete = false } ) => {
 	const translate = useTranslate();
 	const onBackLinkClick = ( event ) => {
 		recordTracksEvent( 'calypso_courses_mobile_back_click', {
@@ -14,11 +14,14 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {} } ) => {
 	};
 
 	return (
-		<div className={ 'videos-ui__bar videos-ui__modal-footer-bar' }>
+		<div className={ 'videos-ui__bar videos-ui__footer-bar videos-ui__modal-footer-bar' }>
 			<a href="/" onClick={ onBackLinkClick }>
 				<Gridicon icon="chevron-left" size={ 24 } />
 				<span>{ translate( 'Back' ) }</span>
 			</a>
+			{ isCourseComplete && (
+				<Button className="videos-ui__button">{ translate( 'Start writing' ) }</Button>
+			) }
 		</div>
 	);
 };

--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -5,7 +5,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 import './modal-footer-bar.scss';
 
-const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete = true } ) => {
+const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete = false } ) => {
 	const translate = useTranslate();
 	const onBackLinkClick = ( event ) => {
 		recordTracksEvent( 'calypso_courses_mobile_back_click', {

--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -26,7 +26,7 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 					'videos-ui__course-completed': isCourseComplete,
 				} ) }
 			>
-				<a href="/" onClick={ onBackLinkClick }>
+				<a href="/" className={ 'videos-ui__back-button' } onClick={ onBackLinkClick }>
 					<Gridicon icon="chevron-left" size={ 24 } />
 					<span>{ translate( 'Back' ) }</span>
 				</a>
@@ -39,8 +39,12 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 				) }
 
 				{ isCourseComplete && (
-					<Button onClick={ onStartWritingClick } className="videos-ui__button">
-						{ translate( 'Start writing' ) }
+					<Button
+						onClick={ onStartWritingClick }
+						className="videos-ui__button"
+						href={ course?.cta.url }
+					>
+						{ course?.cta.action }
 					</Button>
 				) }
 			</div>

--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -1,12 +1,15 @@
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './modal-footer-bar.scss';
 
 const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete = false } ) => {
 	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
 	const onBackLinkClick = ( event ) => {
 		recordTracksEvent( 'calypso_courses_mobile_back_click', {
 			course: course?.slug,
@@ -17,6 +20,13 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 		recordTracksEvent( 'calypso_courses_cta_click', {
 			course: course?.slug,
 		} );
+	};
+
+	const getStartWritingUrl = () => {
+		if ( ! course?.cta?.url || ! selectedSite?.domain ) {
+			return 'https://wordpress.com/post/';
+		}
+		return `${ course.cta.url }/${ selectedSite.domain }`;
 	};
 
 	return (
@@ -42,7 +52,7 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 					<Button
 						onClick={ onStartWritingClick }
 						className="videos-ui__button"
-						href={ course?.cta.url }
+						href={ getStartWritingUrl() }
 					>
 						{ course?.cta.action }
 					</Button>

--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
@@ -12,16 +13,34 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 		} );
 		onBackClick( event );
 	};
+	const onStartWritingClick = () => {
+		recordTracksEvent( 'calypso_courses_cta_click', {
+			course: course?.slug,
+		} );
+	};
 
 	return (
-		<div className={ 'videos-ui__bar videos-ui__footer-bar videos-ui__modal-footer-bar' }>
-			<a href="/" onClick={ onBackLinkClick }>
-				<Gridicon icon="chevron-left" size={ 24 } />
-				<span>{ translate( 'Back' ) }</span>
-			</a>
-			{ isCourseComplete && (
-				<Button className="videos-ui__button">{ translate( 'Start writing' ) }</Button>
-			) }
+		<div class="videos-ui__footer-bar">
+			<div
+				className={ classNames( 'videos-ui__bar videos-ui__modal-footer-bar', {
+					'videos-ui__course-completed': isCourseComplete,
+				} ) }
+			>
+				<a href="/" onClick={ onBackLinkClick }>
+					<Gridicon icon="chevron-left" size={ 24 } />
+					<span>{ translate( 'Back' ) }</span>
+				</a>
+				<p>
+					{ translate(
+						"You did it! Now it's time to put your skills to work and draft your first post."
+					) }
+				</p>
+				{ isCourseComplete && (
+					<Button onClick={ onStartWritingClick } className="videos-ui__button">
+						{ translate( 'Start writing' ) }
+					</Button>
+				) }
+			</div>
 		</div>
 	);
 };

--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -20,7 +20,7 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 	};
 
 	return (
-		<div class="videos-ui__footer-bar">
+		<div className="videos-ui__footer-bar">
 			<div
 				className={ classNames( 'videos-ui__bar videos-ui__modal-footer-bar', {
 					'videos-ui__course-completed': isCourseComplete,

--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -5,7 +5,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 import './modal-footer-bar.scss';
 
-const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete = false } ) => {
+const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete = true } ) => {
 	const translate = useTranslate();
 	const onBackLinkClick = ( event ) => {
 		recordTracksEvent( 'calypso_courses_mobile_back_click', {

--- a/client/components/videos-ui/modal-footer-bar.scss
+++ b/client/components/videos-ui/modal-footer-bar.scss
@@ -5,4 +5,18 @@
 	.videos-ui .videos-ui__modal-footer-bar {
 		display: none;
 	}
+	.videos-ui .videos-ui__modal-footer-bar.videos-ui__course-completed {
+		display: flex;
+		margin: auto;
+		max-width: 1160px;
+
+		a {
+			display: none;
+		}
+
+		p {
+			font-size: $font-body-large;
+			margin: 0;
+		}
+	}
 }

--- a/client/components/videos-ui/modal-footer-bar.scss
+++ b/client/components/videos-ui/modal-footer-bar.scss
@@ -15,10 +15,6 @@
 		min-width: 136px;
 	}
 
-	.videos-ui__back-button {
-		color: #fff;
-	}
-
 	p {
 		font-size: $font-body;
 		margin: 0;

--- a/client/components/videos-ui/modal-footer-bar.scss
+++ b/client/components/videos-ui/modal-footer-bar.scss
@@ -1,16 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.videos-ui .videos-ui__modal-footer-bar {
-	background-color: #101517;
-	border-top: 1px solid rgba( 255, 255, 255, 0.1 );
-	margin-top: auto;
-	padding-top: 16px;
-	position: fixed;
-	bottom: 0;
-	width: 100%;
-}
-
 @include break-small {
 	.videos-ui .videos-ui__modal-footer-bar {
 		display: none;

--- a/client/components/videos-ui/modal-footer-bar.scss
+++ b/client/components/videos-ui/modal-footer-bar.scss
@@ -19,8 +19,6 @@
 		font-size: $font-body;
 		margin: 0;
 		display: none;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 		overflow: hidden;
 	}
 }

--- a/client/components/videos-ui/modal-footer-bar.scss
+++ b/client/components/videos-ui/modal-footer-bar.scss
@@ -33,6 +33,7 @@
 	.videos-ui .videos-ui__modal-footer-bar.videos-ui__course-completed {
 		p {
 			display: block;
+			margin-right: 20px;
 		}
 	}
 }

--- a/client/components/videos-ui/modal-footer-bar.scss
+++ b/client/components/videos-ui/modal-footer-bar.scss
@@ -15,6 +15,10 @@
 		min-width: 136px;
 	}
 
+	.videos-ui__back-button {
+		color: #fff;
+	}
+
 	p {
 		font-size: $font-body;
 		margin: 0;
@@ -28,7 +32,7 @@
 @include break-small {
 	.videos-ui .videos-ui__modal-footer-bar {
 		display: none;
-		a {
+		.videos-ui__back-button {
 			display: none;
 		}
 	}

--- a/client/components/videos-ui/modal-footer-bar.scss
+++ b/client/components/videos-ui/modal-footer-bar.scss
@@ -1,22 +1,40 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.videos-ui .videos-ui__modal-footer-bar {
+	display: flex;
+	padding: 0;
+}
+
+.videos-ui .videos-ui__modal-footer-bar.videos-ui__course-completed {
+	display: flex;
+	margin: auto;
+	max-width: 1160px;
+
+	.videos-ui__button {
+		min-width: 136px;
+	}
+
+	p {
+		font-size: $font-body;
+		margin: 0;
+		display: none;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+	}
+}
+
 @include break-small {
 	.videos-ui .videos-ui__modal-footer-bar {
 		display: none;
-	}
-	.videos-ui .videos-ui__modal-footer-bar.videos-ui__course-completed {
-		display: flex;
-		margin: auto;
-		max-width: 1160px;
-
 		a {
 			display: none;
 		}
-
+	}
+	.videos-ui .videos-ui__modal-footer-bar.videos-ui__course-completed {
 		p {
-			font-size: $font-body-large;
-			margin: 0;
+			display: block;
 		}
 	}
 }

--- a/client/components/videos-ui/modal-header-bar.jsx
+++ b/client/components/videos-ui/modal-header-bar.jsx
@@ -4,7 +4,7 @@ import './modal-header-bar.scss';
 
 const ModalHeaderBar = ( { onClose = () => {} } ) => {
 	return (
-		<div className={ 'videos-ui__bar videos-ui__modal-header-bar' }>
+		<div className={ 'videos-ui__bar videos-ui__header-bar videos-ui__modal-header-bar' }>
 			<Gridicon icon="my-sites" size={ 24 } />
 			<span role="button" onKeyDown={ onClose } tabIndex={ 0 } onClick={ onClose }>
 				<Gridicon icon="cross" size={ 24 } />

--- a/client/components/videos-ui/modal-header-bar.scss
+++ b/client/components/videos-ui/modal-header-bar.scss
@@ -2,7 +2,6 @@
 @import '@wordpress/base-styles/mixins';
 
 .videos-ui .videos-ui__modal-header-bar {
-	padding: 12px 20px;
 	span {
 		cursor: pointer;
 		display: none;

--- a/client/components/videos-ui/modal-header-bar.scss
+++ b/client/components/videos-ui/modal-header-bar.scss
@@ -2,6 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 
 .videos-ui .videos-ui__modal-header-bar {
+	padding: 12px 20px;
 	span {
 		cursor: pointer;
 		display: none;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -234,6 +234,20 @@
 		}
 	}
 
+	.videos-ui__header-bar {
+		padding-top: 20px;
+	}
+
+	.videos-ui__footer-bar {
+		background-color: #101517;
+		border-top: 1px solid rgba( 255, 255, 255, 0.1 );
+		margin-top: auto;
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
+
 	@include break-small {
 		.videos-ui__button {
 			max-width: 300px;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -251,7 +251,6 @@
 	.videos-ui__footer-bar {
 		background-color: #101517;
 		border-top: 1px solid rgba( 255, 255, 255, 0.1 );
-		margin-top: auto;
 		position: fixed;
 		bottom: 0;
 		left: 0;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -216,7 +216,6 @@
 	}
 
 	.videos-ui__bar {
-		padding: 12px 20px;
 		display: flex;
 		flex-direction: row;
 		align-items: center;
@@ -241,6 +240,7 @@
 	}
 
 	.videos-ui__footer-bar {
+		padding: 0 20px;
 		background-color: #101517;
 		border-top: 1px solid rgba( 255, 255, 255, 0.1 );
 		position: fixed;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -9,14 +9,6 @@
 	display: flex;
 	flex-direction: column;
 
-	* {
-		box-sizing: border-box;
-	}
-
-	svg {
-		box-sizing: content-box;
-	}
-
 	.videos-ui__header {
 		background: #151b1e;
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.1 );

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -103,12 +103,12 @@
 				border-bottom: 1px solid #343c3f;
 
 				&:first-child {
-					border-radius: 2px 2px 0 0;
+					border-radius: 4px 4px 0 0; /* stylelint-disable-line scales/radii */
 				}
 
 				&:last-child {
 					border-bottom: none;
-					border-radius: 0 0 2px 2px;
+					border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
 				}
 
 				.videos-ui__duration {
@@ -125,7 +125,7 @@
 					flex-shrink: 0;
 					flex-grow: 0;
 					height: 22px;
-					border-radius: 50px;
+					border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 
 					svg {
 						margin-top: 5px;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -306,6 +306,7 @@
 		}
 
 		.videos-ui__body {
+			max-width: 1160px;
 			padding: 0 20px 80px;
 			h3 {
 				margin: 80px 0 20px;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -256,6 +256,10 @@
 		.videos-ui__button {
 			max-width: 300px;
 		}
+
+		.videos-ui__bar {
+			min-height: 72px;
+		}
 	}
 
 	@include break-medium {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -178,6 +178,10 @@
 				&.selected .videos-ui__active-video-content {
 					max-height: 250px;
 				}
+
+				.videos-ui__button {
+					width: 100%;
+				}
 			}
 		}
 	}
@@ -187,9 +191,10 @@
 	}
 
 	.videos-ui__button {
-		width: 100%;
 		border: 0;
-		border-radius: 2px;
+		border-radius: 4px; /* stylelint-disable-line scales/radii */
+		color: #101517;
+		padding: 10px 28px;
 		span {
 			font-weight: 400;
 			color: #101517;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -229,6 +229,10 @@
 			align-items: center;
 		}
 
+		.videos-ui__back-button {
+			color: #fff;
+		}
+
 		* {
 			line-height: 20px;
 		}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -219,12 +219,13 @@
 	}
 
 	.videos-ui__bar {
-		padding: 20px 0 15px;
+		padding: 12px 20px;
 		display: flex;
 		flex-direction: row;
 		align-items: center;
 		justify-content: space-between;
 		font-size: $font-body-small;
+		min-height: 64px;
 
 		div,
 		a {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -226,7 +226,6 @@
 		div,
 		a {
 			display: flex;
-			color: #fff;
 			align-items: center;
 		}
 

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -238,10 +238,6 @@
 		}
 	}
 
-	.videos-ui__header-bar {
-		padding-top: 20px;
-	}
-
 	.videos-ui__footer-bar {
 		padding: 0 20px;
 		background-color: #101517;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -238,6 +238,10 @@
 			color: #fff;
 			align-items: center;
 		}
+
+		* {
+			line-height: 20px;
+		}
 	}
 
 	.videos-ui__header-bar {


### PR DESCRIPTION
This PR adds the call-to-action button and messaging to the videos UI. It shouldn't be merged before https://github.com/Automattic/wp-calypso/pull/58550.

![2021-12-01 08 56 22](https://user-images.githubusercontent.com/349751/144278662-b6a1e8a4-71a5-4e82-ac3b-a4070ce5bf43.gif)

#### Testing
1. Checkout the PR.
3. Verify everything works the same as in production with the CTA disabled.
4. Enable the CTA by setting the `isCourseComplete` to `true` in `client/components/videos-ui/modal-footer-bar.jsx` like this:
![image](https://user-images.githubusercontent.com/375980/143622604-1e9b7e06-ad28-4edb-ab1b-855518c79183.png)
5. Verify it works as expected at all widths.
6. Verify CTA button forwards you correctly to the editor.

