### PR TITLE
Add woocommerce-install site-picker step

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -461,10 +461,12 @@ export function generateFlows( {
 		{
 			name: 'woocommerce-install',
 			pageTitle: translate( 'Add WooCommerce to your site' ),
-			steps: [ 'confirm', 'transfer' ],
+			steps: [ 'confirm', 'transfer', 'select-site' ],
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',
 			providesDependenciesInQuery: [ 'site' ],
+			optionalDependenciesInQuery: [ 'site' ],
+			disallowResume: false,
 			lastModified: '2021-11-11',
 		},
 	];

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -789,6 +789,10 @@ export function generateSteps( {
 		},
 
 		// Woocommerce Install steps
+		'select-site': {
+			stepName: 'select-site',
+			providesDependencies: [ 'site' ],
+		},
 		confirm: {
 			stepName: 'confirm',
 			props: {
@@ -802,10 +806,11 @@ export function generateSteps( {
 				),
 			},
 			dependencies: [ 'site' ],
+			providesDependencies: [ 'siteConfirmed' ],
 		},
 		transfer: {
 			stepName: 'transfer',
-			dependencies: [ 'site' ],
+			dependencies: [ 'siteConfirmed' ],
 		},
 	};
 }

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -330,6 +330,7 @@ export default {
 			return;
 		}
 		const siteId = getSiteId( getState(), siteIdOrSlug );
+
 		if ( siteId ) {
 			dispatch( setSelectedSiteId( siteId ) );
 			next();
@@ -338,6 +339,7 @@ export default {
 			dispatch( requestSite( siteIdOrSlug ) )
 				.catch( () => {
 					next();
+
 					return null;
 				} )
 				.then( () => {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -116,7 +116,12 @@ function removeLoadingScreenClassNamesFromBody() {
 }
 
 function showProgressIndicator( flowName ) {
-	const DISABLED_PROGRESS_INDICATOR_FLOWS = [ 'pressable-nux', 'setup-site', 'importer' ];
+	const DISABLED_PROGRESS_INDICATOR_FLOWS = [
+		'pressable-nux',
+		'setup-site',
+		'importer',
+		'woocommerce-install',
+	];
 
 	return ! DISABLED_PROGRESS_INDICATOR_FLOWS.includes( flowName );
 }

--- a/client/signup/steps/woocommerce-install/index.tsx
+++ b/client/signup/steps/woocommerce-install/index.tsx
@@ -1,7 +1,6 @@
 import type { GoToStep } from '../../types';
 
 export interface WooCommerceInstallProps {
-	siteId: number;
 	goToStep: GoToStep;
 	stepName: string;
 	stepSectionName: string;
@@ -9,7 +8,11 @@ export interface WooCommerceInstallProps {
 	headerTitle: string;
 	headerDescription: string;
 	queryObject: {
-		siteSlug: string;
+		site: string;
+	};
+	signupDependencies: {
+		site: string;
+		siteConfirmed: number;
 	};
 	signupDependencies: {
 		siteSlug: string;

--- a/client/signup/steps/woocommerce-install/select-site/index.tsx
+++ b/client/signup/steps/woocommerce-install/select-site/index.tsx
@@ -1,0 +1,82 @@
+import {
+	isFreePlan,
+	isPremiumPlan,
+	isPersonalPlan,
+	isEcommercePlan,
+	isBusinessPlan,
+} from '@automattic/calypso-products';
+import { Card } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { ReactElement, useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import SiteSelector from 'calypso/components/site-selector';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import type { WooCommerceInstallProps } from '../';
+
+import './style.scss';
+
+interface Site {
+	capabilities: {
+		manage_options: boolean;
+	};
+	jetpack: boolean;
+	plan: {
+		product_slug: string;
+	};
+}
+
+export default function SelectSite( props: WooCommerceInstallProps ): ReactElement | null {
+	const { goToStep, isReskinned } = props;
+	const { __ } = useI18n();
+
+	const filterSites = ( site: Site ) => {
+		return (
+			site.capabilities.manage_options &&
+			( isFreePlan( site.plan.product_slug ) ||
+				isPersonalPlan( site.plan.product_slug ) ||
+				isPremiumPlan( site.plan.product_slug ) ||
+				isBusinessPlan( site.plan.product_slug ) ||
+				isEcommercePlan( site.plan.product_slug ) )
+		);
+	};
+
+	const [ selectedId, setSelectedId ] = useState();
+
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, selectedId ) );
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( ! siteSlug || ! selectedId ) {
+			return;
+		}
+
+		dispatch( submitSignupStep( { stepName: 'select-site' }, { site: siteSlug } ) );
+		goToStep( 'confirm' );
+	}, [ siteSlug, selectedId, goToStep, dispatch ] );
+
+	const title = __( 'Select a site' );
+	const subtitle = __( 'Pick which site you would like to use to set up your new store.' );
+	return (
+		<StepWrapper
+			flowName="woocommerce-install"
+			hideSkip={ true }
+			nextLabelText={ __( 'Confirm' ) }
+			shouldHideNavButtons={ true }
+			className="select-site__step-wrapper"
+			align={ isReskinned ? 'left' : 'center' }
+			isWideLayout={ isReskinned }
+			headerText={ title }
+			fallbackHeaderText={ title }
+			subHeaderText={ subtitle }
+			fallbackSubHeaderText={ subtitle }
+			stepContent={
+				<Card className="select-site__card">
+					<SiteSelector filter={ filterSites } onSiteSelect={ setSelectedId } />
+				</Card>
+			}
+			{ ...props }
+		/>
+	);
+}

--- a/client/signup/steps/woocommerce-install/select-site/style.scss
+++ b/client/signup/steps/woocommerce-install/select-site/style.scss
@@ -1,0 +1,4 @@
+@import '@automattic/onboarding/styles/base-styles.scss';
+@import '@automattic/onboarding/styles/mixins.scss';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -8,16 +8,19 @@ import {
 	isFetchingAutomatedTransferStatus,
 	getAutomatedTransferStatus,
 } from 'calypso/state/automated-transfer/selectors';
-import { getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
+import { getSiteWooCommerceUrl, getSiteId } from 'calypso/state/sites/selectors';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { hasUploadFailed } from 'calypso/state/themes/upload-theme/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { WooCommerceInstallProps } from '../';
 
 import './style.scss';
 
 export default function Transfer( props: WooCommerceInstallProps ): ReactElement | null {
-	const { goToStep, isReskinned } = props;
+	const {
+		goToStep,
+		isReskinned,
+		signupDependencies: { siteConfirmed },
+	} = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
@@ -25,8 +28,8 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 	const [ error, setError ] = useState( { transferFailed: false, transferStatus: null } );
 	const [ step, setStep ] = useState( __( 'Building your store' ) );
 
-	// selectedSiteId is set by the controller whenever site is provided as a query param.
-	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteId = useSelector( ( state ) => getSiteId( state, siteConfirmed ) ) as number;
+
 	const fetchingTransferStatus = !! useSelector( ( state ) =>
 		isFetchingAutomatedTransferStatus( state, siteId )
 	);


### PR DESCRIPTION
Re-introduces the site-picker removed in #58561

Todo:
- Loading /confirm without a site slug should redirect to the site-picker - unless you're coming from the site-picker which won't have the site query param (this can be done but requires a secondary dependency set by the site-picker that isn't modified by the controller like `site` is)
- Hide the confirm step while redirecting to the site-picker
- Hide p2 sites p1638330066305700-slack-C02DQP0FP selectors this is using is not enough to block p2 sites - they're free plans, need to also check they're not wpforteams

#### Changes proposed in this Pull Request

* Replaces siteSlug/siteId with new `site` query param
* Moves confirm step to step 0 so it becomes the default
* If site isn't known, it redirects to the select-site step to pick a site
* Backurl clean up
* Nav button hiding on select step (no way to know where back is)
* Hide step count as it no longer makes sense (1, 2, done of 3)

#### Testing instructions

* `http://calypso.localhost:3000/start/woocommerce-install/select-site` should let you select a site. Back should be disabled.
* `http://calypso.localhost:3000/start/woocommerce-install/confirm?site=example.com` should let you skip the select-site step. Back should take you to `/woocommerce-installation/example.com`
* `http://calypso.localhost:3000/start/woocommerce-install/confirm` should redirect to `/select-site` but this will only happen on a fresh state, hitting back button here should load `/select-site`.
* `http://calypso.localhost:3000/start/woocommerce-install/select-site` at this point should load the picker and clear the stored site, now going to `/confirm` will redirect back to `/select-site`

Related to #58229
