### PR TITLE
Add php 8.1 to hosting configuration

### DIFF
--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -59,6 +59,12 @@ const PhpVersionCard = ( {
 				} ),
 				value: '8.0',
 			},
+			{
+				label: translate( '8.1', {
+					comment: 'PHP Version for a version switcher',
+				} ),
+				value: '8.1',
+			},
 		];
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add PHP 8.1 to the Hosting Configuration picker.

#### Testing instructions

- Go to Settings -> Hosting Configuration
- Pick PHP 8.1
- Make sure it works

![Screenshot from 2021-11-26 13-34-38](https://user-images.githubusercontent.com/1103398/143581891-281f1494-42d2-41e0-86aa-c2bf6b4507d8.png)

