### PR TITLE
Remove the jetpack/happychat feature flag

### DIFF
--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -1,26 +1,24 @@
 import { Gridicon } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import HappychatButton from 'calypso/components/happychat/button';
 import HappychatConnection from 'calypso/components/happychat/connection-connected';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 
-const getHappyChatButtonClickHandler = ( eventName = 'calypso_jpc_chat_initiated' ) => () =>
-	recordTracksEvent( eventName );
-
 const JetpackConnectHappychatButton = ( {
-	children,
-	isChatActive,
-	isChatAvailable,
-	isLoggedIn,
 	label,
-	translate,
-	eventName,
+	eventName = 'calypso_jpc_chat_initiated',
+	children,
 } ) => {
+	const translate = useTranslate();
+	const isChatAvailable = useSelector( isHappychatAvailable );
+	const isChatActive = useSelector( hasActiveHappychatSession );
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
 	if ( ! isLoggedIn ) {
 		return <div>{ children }</div>;
 	}
@@ -38,7 +36,7 @@ const JetpackConnectHappychatButton = ( {
 		<HappychatButton
 			borderless={ false }
 			className="logged-out-form__link-item jetpack-connect__happychat-button"
-			onClick={ getHappyChatButtonClickHandler( eventName ) }
+			onClick={ () => recordTracksEvent( eventName ) }
 		>
 			<HappychatConnection />
 			<Gridicon icon="chat" size={ 18 } /> { label || translate( 'Get help setting up Jetpack' ) }
@@ -51,8 +49,4 @@ JetpackConnectHappychatButton.propTypes = {
 	label: PropTypes.string,
 };
 
-export default connect( ( state ) => ( {
-	isChatAvailable: isHappychatAvailable( state ),
-	isChatActive: hasActiveHappychatSession( state ),
-	isLoggedIn: Boolean( getCurrentUserId( state ) ),
-} ) )( localize( JetpackConnectHappychatButton ) );
+export default JetpackConnectHappychatButton;

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -22,7 +21,7 @@ const JetpackConnectHappychatButton = ( {
 	translate,
 	eventName,
 } ) => {
-	if ( ! isEnabled( 'jetpack/happychat' ) || ! isLoggedIn ) {
+	if ( ! isLoggedIn ) {
 		return <div>{ children }</div>;
 	}
 

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -114,11 +114,11 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         >
           Create a new account
         </LoggedOutFormLinkItem>
-        <Connect(Localized(JetpackConnectHappychatButton))
+        <JetpackConnectHappychatButton
           eventName="calypso_jpc_authorize_chat_initiated"
         >
           <JetpackConnectHelpButton />
-        </Connect(Localized(JetpackConnectHappychatButton))>
+        </JetpackConnectHappychatButton>
       </LoggedOutFormLinks>
     </div>
   </div>

--- a/client/state/happychat/selectors/get-groups.js
+++ b/client/state/happychat/selectors/get-groups.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from 'calypso/state/happychat/constants';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -14,7 +13,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 export default ( state, siteId ) => {
 	// For Jetpack Connect we need to direct chat users to the JPOP group, to account for cases
 	// when the user does not have a site yet, or their primary site is not a Jetpack site.
-	if ( isEnabled( 'jetpack/happychat' ) && getSectionName( state ) === 'jetpack-connect' ) {
+	if ( getSectionName( state ) === 'jetpack-connect' ) {
 		return [ HAPPYCHAT_GROUP_JPOP ];
 	}
 

--- a/client/state/happychat/selectors/test/get-groups.js
+++ b/client/state/happychat/selectors/test/get-groups.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from 'calypso/state/happychat/constants';
 import { userState } from 'calypso/state/selectors/test/fixtures/user-state';
@@ -111,24 +110,22 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		if ( isEnabled( 'jetpack/happychat' ) ) {
-			test( 'should return JPOP group if within the jetpack-connect section', () => {
-				const state = {
-					...userState,
-					sites: {
-						items: {
-							1: {},
-						},
+		test( 'should return JPOP group if within the jetpack-connect section', () => {
+			const state = {
+				...userState,
+				sites: {
+					items: {
+						1: {},
 					},
-					ui: {
-						section: {
-							name: 'jetpack-connect',
-						},
+				},
+				ui: {
+					section: {
+						name: 'jetpack-connect',
 					},
-				};
+				},
+			};
 
-				expect( getGroups( state ) ).toMatchObject( [ HAPPYCHAT_GROUP_JPOP ] );
-			} );
-		}
+			expect( getGroups( state ) ).toMatchObject( [ HAPPYCHAT_GROUP_JPOP ] );
+		} );
 	} );
 } );

--- a/config/development.json
+++ b/config/development.json
@@ -86,7 +86,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/only-realtime-products": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -49,7 +49,6 @@
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,
-		"jetpack/happychat": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -52,7 +52,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/only-realtime-products": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/happychat": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/only-realtime-products": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/test.json
+++ b/config/test.json
@@ -48,7 +48,6 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
-		"jetpack/happychat": true,
 		"jetpack/only-realtime-products": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,7 +60,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/happychat": true,
 		"jetpack/only-realtime-products": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,


### PR DESCRIPTION
Removes the always-true `jetpack/happychat` feature flag. It was used to gradually deploy Happychat support during Jetpack Connect.

The second commit updates the `JetpackConnectHappychatButton` component, already functional, to use `useSelector`/`useTranslate` hooks instead of the `connect`/`localize` HOCs. A convenient drive-by.