### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` imports to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -341,49 +341,6 @@ Undocumented.prototype.isSiteImportable = function ( site_url ) {
 	);
 };
 
-Undocumented.prototype.fetchImporterState = function ( siteId ) {
-	debug( `/sites/${ siteId }/importer/` );
-
-	return this.wpcom.req.get( { path: `/sites/${ siteId }/imports/` } );
-};
-
-Undocumented.prototype.updateImporter = function ( siteId, importerStatus ) {
-	debug( `/sites/${ siteId }/imports/${ importerStatus.importId }` );
-
-	return this.wpcom.req.post( {
-		path: `/sites/${ siteId }/imports/${ importerStatus.importerId }`,
-		formData: [ [ 'importStatus', JSON.stringify( importerStatus ) ] ],
-	} );
-};
-
-Undocumented.prototype.uploadExportFile = function ( siteId, params ) {
-	return new Promise( ( resolve, rejectPromise ) => {
-		const resolver = ( error, data ) => {
-			error ? rejectPromise( error ) : resolve( data );
-		};
-
-		const formData = [
-			[ 'importStatus', JSON.stringify( params.importStatus ) ],
-			[ 'import', params.file ],
-		];
-
-		if ( params.url ) {
-			formData.push( [ 'url', params.url ] );
-		}
-
-		const req = this.wpcom.req.post(
-			{
-				path: `/sites/${ siteId }/imports/new`,
-				formData,
-			},
-			resolver
-		);
-
-		req.upload.onprogress = params.onprogress;
-		req.onabort = params.onabort;
-	} );
-};
-
 /**
  * Check different info about WordPress and Jetpack status on a url
  *

--- a/client/state/imports/actions.js
+++ b/client/state/imports/actions.js
@@ -1,4 +1,4 @@
-import wpLib from 'calypso/lib/wp';
+import wp from 'calypso/lib/wp';
 import {
 	IMPORTS_AUTHORS_SET_MAPPING,
 	IMPORTS_AUTHORS_START_MAPPING,
@@ -19,8 +19,6 @@ import { appStates } from './constants';
 import { isImporterLocked } from './selectors';
 
 import 'calypso/state/imports/init';
-
-const wpcom = wpLib.undocumented();
 
 const ID_GENERATOR_PREFIX = 'local-generated-id-';
 
@@ -49,6 +47,39 @@ const createImportOrder = ( importerStatus ) =>
 	toApi( {
 		...importerStatus,
 		importerState: appStates.IMPORTING,
+	} );
+
+const updateImporter = ( siteId, importerStatus ) =>
+	wp.req.post( {
+		path: `/sites/${ siteId }/imports/${ importerStatus.importerId }`,
+		formData: [ [ 'importStatus', JSON.stringify( importerStatus ) ] ],
+	} );
+
+const uploadExportFile = ( siteId, params ) =>
+	new Promise( ( resolve, reject ) => {
+		const resolver = ( error, data ) => {
+			error ? reject( error ) : resolve( data );
+		};
+
+		const formData = [
+			[ 'importStatus', JSON.stringify( params.importStatus ) ],
+			[ 'import', params.file ],
+		];
+
+		if ( params.url ) {
+			formData.push( [ 'url', params.url ] );
+		}
+
+		const req = wp.req.post(
+			{
+				path: `/sites/${ siteId }/imports/new`,
+				formData,
+			},
+			resolver
+		);
+
+		req.upload.onprogress = params.onprogress;
+		req.onabort = params.onabort;
 	} );
 
 export const lockImport = ( importerId ) => ( {
@@ -82,12 +113,12 @@ export const cancelImport = ( siteId, importerId ) => async ( dispatch ) => {
 		return;
 	}
 
-	const data = await wpcom.updateImporter( siteId, createCancelOrder( siteId, importerId ) );
+	const data = await updateImporter( siteId, createCancelOrder( siteId, importerId ) );
 	dispatch( receiveImporterStatus( data ) );
 };
 
 export const fetchImporterState = ( siteId ) => async ( dispatch ) => {
-	const data = await wpcom.fetchImporterState( siteId );
+	const data = await wp.req.get( `/sites/${ siteId }/imports/` );
 	dispatch( receiveImporterStatus( data ) );
 };
 
@@ -115,7 +146,7 @@ export const resetImport = ( siteId, importerId ) => async ( dispatch ) => {
 	};
 	dispatch( resetImportAction );
 
-	const data = await wpcom.updateImporter( siteId, createExpiryOrder( siteId, importerId ) );
+	const data = await updateImporter( siteId, createExpiryOrder( siteId, importerId ) );
 	dispatch( receiveImporterStatus( data ) );
 };
 
@@ -130,7 +161,7 @@ export const clearImport = ( siteId, importerId ) => async ( dispatch ) => {
 	};
 	dispatch( resetImportAction );
 
-	const data = await wpcom.updateImporter( siteId, createClearOrder( siteId, importerId ) );
+	const data = await updateImporter( siteId, createClearOrder( siteId, importerId ) );
 	dispatch( receiveImporterStatus( data ) );
 };
 
@@ -173,7 +204,7 @@ export const startImporting = ( importerStatus ) => ( dispatch ) => {
 	};
 	dispatch( startImportingAction );
 
-	return wpcom.updateImporter( siteId, createImportOrder( importerStatus ) );
+	return updateImporter( siteId, createImportOrder( importerStatus ) );
 };
 
 export const setUploadStartState = ( importerId, filenameOrUrl ) => ( {
@@ -190,23 +221,22 @@ export const startUpload = ( importerStatus, file, url = undefined ) => ( dispat
 
 	dispatch( setUploadStartState( importerId, file.name ) );
 
-	return wpcom
-		.uploadExportFile( siteId, {
-			importStatus: toApi( importerStatus ),
-			file,
-			url,
-			onprogress: ( event ) => {
-				dispatch(
-					setUploadProgress( importerId, {
-						uploadLoaded: event.loaded,
-						uploadTotal: event.total,
-					} )
-				);
-			},
-			onabort: () => {
-				dispatch( cancelImport( siteId, importerId ) );
-			},
-		} )
+	return uploadExportFile( siteId, {
+		importStatus: toApi( importerStatus ),
+		file,
+		url,
+		onprogress: ( event ) => {
+			dispatch(
+				setUploadProgress( importerId, {
+					uploadLoaded: event.loaded,
+					uploadTotal: event.total,
+				} )
+			);
+		},
+		onabort: () => {
+			dispatch( cancelImport( siteId, importerId ) );
+		},
+	} )
 		.then( ( data ) => {
 			dispatch( finishUpload( importerId, fromApi( data ) ) );
 		} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` import methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()` and part of #58458.

#### Testing instructions

* Go to `/import/:site` where `:site` is a WP.com simple site.
* Click on **WordPress**
* Click on the "upload it to import content" link.
* Upload a WordPress export file. If you need one, you can grab it from [here](https://raw.githubusercontent.com/WPTT/theme-unit-test/master/themeunittestdata.wordpress.xml).
* Verify import progress still works the same way and succeeds as it did before.
* Verify tests still pass: `yarn run test-client client/state/imports`.