### PR TITLE
E2E: Fix publishing when certain blocks cause the post-publish panel to close

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -37,6 +37,12 @@ export class ImageBlock {
 		await input.setInputFiles( filePath );
 
 		await Promise.all( [
+			// Checking spinner isn't enough sometimes, as can be observed with the
+			// Logos block: While the spinner has already disappeared, the image is
+			// still being uploaded and the block gets refreshed when it's done. Only
+			// when the image is properly uploaded, its source is updated (refreshed)
+			// from the initial "blob:*" to "https:*". This is what we're checking now
+			// to make sure the block is valid and ready to be published.
 			this.block.waitForSelector( 'img:not([src^="blob:"])' ),
 			this.block.waitForElementState( 'stable' ),
 		] );

--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -3,8 +3,6 @@ import { Page, ElementHandle } from 'playwright';
 const selectors = {
 	block: '.wp-block-image',
 	fileInput: '.components-form-file-upload input[type="file"]',
-	spinner: '.components-spinner',
-
 	// Use the attribute CSS selector to perform partial match, beginning with the filename.
 	// If a file with the same name already exists in the Media Gallery, WPCOM resolves this clash
 	// by appending a numerical postfix (eg. <original-filename>-2).
@@ -32,13 +30,14 @@ export class ImageBlock {
 	/**
 	 * Uplaods the target file at the supplied path to WPCOM.
 	 *
-	 * @param {string} path Path to the file on disk.
+	 * @param {string} filePath Path to the file on disk.
 	 */
-	async upload( path: string ): Promise< void > {
+	async upload( filePath: string ): Promise< void > {
 		const input = await this.block.waitForSelector( selectors.fileInput, { state: 'attached' } );
-		await input.setInputFiles( path );
+		await input.setInputFiles( filePath );
+
 		await Promise.all( [
-			this.block.waitForSelector( selectors.spinner, { state: 'hidden' } ),
+			this.block.waitForSelector( 'img:not([src^="blob:"])' ),
 			this.block.waitForElementState( 'stable' ),
 		] );
 	}

--- a/packages/calypso-e2e/src/lib/blocks/logos-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/logos-block.ts
@@ -3,8 +3,6 @@ import { Page, ElementHandle } from 'playwright';
 const selectors = {
 	block: '.wp-block-coblocks-logos',
 	fileInput: '.components-form-file-upload input[type="file"]',
-	spinner: '.components-spinner',
-
 	imageTitleData: ( filename: string ) =>
 		`${ selectors.block } img[data-image-title*="${ filename }" i]`,
 };
@@ -29,13 +27,14 @@ export class LogosBlock {
 	/**
 	 * Uplaods the target file at the supplied path to WPCOM.
 	 *
-	 * @param {string} path Path to the file on disk.
+	 * @param {string} filePath Path to the file on disk.
 	 */
-	async upload( path: string ): Promise< void > {
+	async upload( filePath: string ): Promise< void > {
 		const input = await this.block.waitForSelector( selectors.fileInput, { state: 'attached' } );
-		await input.setInputFiles( path );
+		await input.setInputFiles( filePath );
+
 		await Promise.all( [
-			this.block.waitForSelector( selectors.spinner, { state: 'hidden' } ),
+			this.block.waitForSelector( 'img:not([src^="blob:"])' ),
 			this.block.waitForElementState( 'stable' ),
 		] );
 	}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -36,7 +36,12 @@ const selectors = {
 
 	// Publish panel (including post-publish)
 	publishPanel: '.editor-post-publish-panel',
-	viewButton: '.editor-post-publish-panel a:has-text("View")',
+	// With the selector below, we're targeting both "View Post" buttons: the one
+	// in the post-publish pane, and the one that pops up in the bottom-left
+	// corner. This addresses the bug where the post-publish panel is immediately
+	// closed when publishing with certain blocks on the editor canvas.
+	// See https://github.com/Automattic/wp-calypso/issues/54421.
+	viewButton: 'text=/View (Post|Page)/i',
 	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
 	closePublishPanel: 'button[aria-label="Close panel"]',
 
@@ -289,15 +294,8 @@ export class GutenbergEditorPage {
 	 * @param {boolean} visit Whether to then visit the page.
 	 * @returns {Promise<void} No return value.
 	 */
-	async publish( {
-		visit = false,
-		saveDraft = false,
-	}: { visit?: boolean; saveDraft?: boolean } = {} ): Promise< string > {
+	async publish( { visit = false }: { visit?: boolean } = {} ): Promise< string > {
 		const frame = await this.getEditorFrame();
-
-		if ( saveDraft ) {
-			await this.saveDraft();
-		}
 
 		await frame.click( selectors.publishButton( selectors.postToolbar ) );
 		await frame.click( selectors.publishButton( selectors.publishPanel ) );

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
@@ -109,10 +109,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), function () {
 	} );
 
 	it( 'Publish and visit post', async function () {
-		// Must save as draft first to bypass issue with post-publish panel being auto-dismissed when
-		// ClickToTweet and Logos blocks are present.
-		// See https://github.com/Automattic/wp-calypso/issues/54421.
-		await gutenbergEditorPage.publish( { visit: true, saveDraft: true } );
+		await gutenbergEditorPage.publish( { visit: true } );
 	} );
 
 	// Pass in a 1D array of values or text strings to validate each block.

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -89,10 +89,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	} );
 
 	it( 'Publish and visit post', async function () {
-		// Must save as draft first to bypass issue with post-publish panel being auto-dismissed
-		// after publishing. May be related to the following issue?
-		// See https://github.com/Automattic/wp-calypso/issues/54421.
-		await gutenbergEditorPage.publish( { visit: true, saveDraft: true } );
+		await gutenbergEditorPage.publish( { visit: true } );
 	} );
 
 	it( `Confirm Image block is visible in published post`, async function () {


### PR DESCRIPTION
I’ve noticed something weird while running CoBlocks tests locally. I couldn’t get them to pass although they consistently pass in TC, so I checked the build log and applied the same env vars locally. Turns out that the tests fail if the  `DEBUG=pw:api` var is not present:

```shell
> HEADLESS=true npx jest specs/specs-playwright/wp-blocks__coblocks.ts

Blocks: CoBlocks › Publish and visit post

    frame.waitForSelector: Timeout 30000ms exceeded.
    =========================== logs ===========================
    waiting for selector ".editor-post-publish-panel a:has-text("View")" to be visible
    ============================================================

      302 |             await frame.click( selectors.publishButton( selectors.postToolbar ) );
      303 |             await frame.click( selectors.publishButton( selectors.publishPanel ) );
    > 304 |             const viewPublishedArticleButton = await frame.waitForSelector( selectors.viewButton );
          |                                                            ^
      305 |             const publishedURL = ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
      306 |
      307 |             if ( visit ) {

      at GutenbergEditorPage.publish (../../packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts:304:50)
      at Object.<anonymous> (specs/specs-playwright/wp-blocks__coblocks.ts:115:3)
```

The following makes the tests pass:

```shell
DEBUG=pw:api HEADLESS=true npx jest specs/specs-playwright/wp-blocks__coblocks.ts
```

I checked visually and the Publish panel is simply disappearing, which is a [known issue](https://github.com/Automattic/wp-calypso/issues/54421) caused by certain blocks. I'm not sure why the debug flag is causing this change but I suppose it might have something to do with the execution speed, as the tests seem to be a tad slower with the debugging enabled.

#### Changes proposed in this Pull Request

* Tweak the `publish` helper to target both "View Post" buttons. This fixes the issue described above.

#### Testing instructions

* All tests should pass
