### PR TITLE
Add count bubble besides the status header in the site domains list

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -54,6 +54,7 @@ import { filterDomainsByOwner } from './helpers';
 import ListItemPlaceholder from './item-placeholder';
 import ListHeader from './list-header';
 import {
+	countDomainsInOrangeStatus,
 	getDomainManagementPath,
 	getSimpleSortFunctionBy,
 	getReverseSimpleSortFunctionBy,
@@ -443,6 +444,14 @@ class AllDomains extends Component {
 					},
 					getReverseSimpleSortFunctionBy( 'domain' ),
 				],
+				bubble: countDomainsInOrangeStatus(
+					filterDomainsByOwner( this.mergeFilteredDomainsWithDomainsDetails(), selectedFilter ).map(
+						( domain ) =>
+							resolveDomainStatus( domain, null, {
+								getMappingErrors: true,
+							} )
+					)
+				),
 			},
 			{
 				name: 'registered-until',

--- a/client/my-sites/domains/domain-management/list/domains-table-header.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-header.jsx
@@ -131,7 +131,11 @@ class DomainsTableHeader extends PureComponent {
 							} ) }
 							data-column={ column.name }
 						>
-							{ column.label } { this.renderSortIcon( column, activeSortKey, activeSortOrder ) }
+							{ column.label }{ ' ' }
+							{ column.bubble > 0 && (
+								<span className={ `list__${ column.name }-cell__bubble` }>{ column.bubble }</span>
+							) }
+							{ this.renderSortIcon( column, activeSortKey, activeSortOrder ) }
 						</Button>
 					) ) }
 				</div>

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -56,6 +56,7 @@ import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
 import { filterDomainsByOwner } from './helpers';
 import {
+	countDomainsInOrangeStatus,
 	filterOutWpcomDomains,
 	getDomainManagementPath,
 	getSimpleSortFunctionBy,
@@ -140,6 +141,13 @@ export class SiteDomains extends Component {
 					},
 					getReverseSimpleSortFunctionBy( 'domain' ),
 				],
+				bubble: countDomainsInOrangeStatus(
+					nonWpcomDomains.map( ( domain ) =>
+						resolveDomainStatus( domain, null, {
+							getMappingErrors: true,
+						} )
+					)
+				),
 			},
 			{
 				name: 'registered-until',

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -457,6 +457,19 @@
 }
 .list__status-cell {
 	flex: 40 40 0;
+	&__bubble {
+		display: flex;
+		width: 20px;
+		background: #d67709;
+		border-radius: 16px;
+		justify-content: center;
+		align-items: center;
+		color: #ffffff;
+		font-size: 12px;
+		height: 18px;
+		margin: 0 4px;
+		line-height: 20px;
+	}
 }
 .list__registered-until-cell {
 	flex: 50 50 0;

--- a/client/my-sites/domains/domain-management/list/test/utils.js
+++ b/client/my-sites/domains/domain-management/list/test/utils.js
@@ -1,0 +1,22 @@
+import { countDomainsInOrangeStatus } from '../utils';
+
+describe( 'countDomainsInOrangeStatus function', () => {
+	const domains = [
+		{ statusClass: 'status-neutral-dot' },
+		{ statusClass: 'status-neutral-dot' },
+		{ statusClass: 'status-error' },
+		{ statusClass: 'status-warning' },
+		{ statusClass: 'status-warning' },
+		{ statusClass: 'status-warning' },
+		{ statusClass: 'status-success' },
+		{ statusClass: 'status-success' },
+		{ statusClass: 'status-success' },
+		{ statusClass: 'status-success' },
+		{ statusClass: 'status-success' },
+		{ statusClass: 'status-premium' },
+	];
+
+	test( 'It should return the number of domains that have set one of the following values for the statusClass property: "status-neutral-dot", "status-alert", "status-warning", "status-error"', () => {
+		expect( countDomainsInOrangeStatus( domains ) ).toBe( 6 );
+	} );
+} );

--- a/client/my-sites/domains/domain-management/list/utils.js
+++ b/client/my-sites/domains/domain-management/list/utils.js
@@ -51,3 +51,10 @@ export const getSimpleSortFunctionBy = ( column ) => ( first, second, sortOrder 
 
 export const getReverseSimpleSortFunctionBy = ( column ) => ( first, second, sortOrder ) =>
 	getSimpleSortFunctionBy( column )( first, second, sortOrder ) * -1;
+
+export const countDomainsInOrangeStatus = ( domainStatutes ) =>
+	domainStatutes.filter( ( domainStatus ) =>
+		[ 'status-neutral-dot', 'status-alert', 'status-warning', 'status-error' ].includes(
+			domainStatus.statusClass
+		)
+	).length;


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR adds a count bubble besides the **status** header cell (in the all/single site domains list), that counts the total number of domains in an orange status.

![Markup on 2021-11-30 at 12:31:46](https://user-images.githubusercontent.com/2797601/144039910-b90f5304-09f2-4a31-96ed-099cd0d6e7ac.png)

## Testing instructions

* Build this branch locally or open the live Calypso link
* Go to "`Upgrades > Domains`" (header it's same for All sites/Single site)
* If you're in the live Calypso link, please append `?flags=domains/management-list-redesign` to your URL to enable the appropriate feature flag
* Verify that the number of domains displayed in the bubble reflects the number of domains in the orange status (if there are no domains in orange status, the counter should not be displayed).
