### PR TITLE
Video UI: Fix checkmark alignment

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -127,6 +127,7 @@
 					text-align: center;
 					margin-left: auto;
 					flex-shrink: 0;
+					flex-basis: 22px;
 
 					svg {
 						vertical-align: middle;


### PR DESCRIPTION
Fixes alignment of checkmark and disclosure icon.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/143613493-7e7b4982-c70a-46dc-8d2c-e51ea91cb1f4.png) | ![image](https://user-images.githubusercontent.com/375980/143613436-c8434acd-ed5e-4ab5-87c7-a037f6bb50df.png)  |

Closes https://github.com/Automattic/wp-calypso/issues/58529
