### PR TITLE
Jetpack Partner Coupon: prioritise coupon redirect

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -152,7 +152,7 @@ export class JetpackAuthorize extends Component {
 		const { alreadyAuthorized, redirectAfterAuth, site } = nextProps.authQuery;
 
 		if ( this.isJetpackPartnerCoupon( nextProps ) && ( siteReceived || authorizeSuccess ) ) {
-			// The current implementation of the paThe current implementation of the partner coupon URL is supposed to
+			// The current implementation of the partner coupon URL is supposed to
 			// just take over the entire flow and send directly to checkout.
 			// This will happen by the partnerCouponRedirects controller logic if we just
 			// redirect the customer without any special conditions.

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -151,7 +151,16 @@ export class JetpackAuthorize extends Component {
 		const { authorizeError, authorizeSuccess, siteReceived } = nextProps.authorizationData;
 		const { alreadyAuthorized, redirectAfterAuth, site } = nextProps.authQuery;
 
-		if (
+		if ( this.isJetpackPartnerCoupon( nextProps ) && ( siteReceived || authorizeSuccess ) ) {
+			// The current implementation of the paThe current implementation of the partner coupon URL is supposed to
+			// just take over the entire flow and send directly to checkout.
+			// This will happen by the partnerCouponRedirects controller logic if we just
+			// redirect the customer without any special conditions.
+			// The reason we have to do this is because e.g. "shouldRedirectJetpackStart" has
+			// logic that will always go straight to the redirect URI after authorization which
+			// means we never hit the "plans" page where our partner coupon logic takes over.
+			return this.redirect();
+		} else if (
 			this.isSso( nextProps ) ||
 			this.isWooRedirect( nextProps ) ||
 			this.isFromJpo( nextProps ) ||
@@ -229,7 +238,18 @@ export class JetpackAuthorize extends Component {
 			window.close();
 		}
 
-		if (
+		if ( this.isJetpackPartnerCoupon() ) {
+			// The current implementation of the partner coupon URL is supposed to
+			// just take over the entire flow and send directly to checkout.
+			// This will happen by the partnerCouponRedirects controller logic if we just
+			// redirect the customer without any special conditions.
+			// The reason we have to do this is because e.g. "shouldRedirectJetpackStart" has
+			// logic that will always go straight to the redirect URI after authorization which
+			// means we never hit the "plans" page where our partner coupon logic takes over.
+			const redirectionTarget = this.getRedirectionTarget();
+			debug( `Jetpack Partner Coupon Redirecting to: ${ redirectionTarget }` );
+			navigate( redirectionTarget );
+		} else if (
 			this.isSso() ||
 			this.isWooRedirect() ||
 			this.isFromJpo() ||
@@ -347,6 +367,11 @@ export class JetpackAuthorize extends Component {
 
 	getWooDnaConfig( props = this.props ) {
 		return wooDnaConfig( props.authQuery );
+	}
+
+	isJetpackPartnerCoupon( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-partner-coupon' );
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -154,8 +154,8 @@ export class JetpackAuthorize extends Component {
 		if ( this.isJetpackPartnerCoupon( nextProps ) && ( siteReceived || authorizeSuccess ) ) {
 			// The current implementation of the partner coupon URL is supposed to
 			// just take over the entire flow and send directly to checkout.
-			// This will happen by the partnerCouponRedirects controller logic if we just
-			// redirect the customer without any special conditions.
+			// This will happen by the partnerCouponRedirects controller logic if we
+			// just redirect the customer to the plans page.
 			// The reason we have to do this is because e.g. "shouldRedirectJetpackStart" has
 			// logic that will always go straight to the redirect URI after authorization which
 			// means we never hit the "plans" page where our partner coupon logic takes over.
@@ -217,7 +217,13 @@ export class JetpackAuthorize extends Component {
 
 	redirect() {
 		const { isMobileAppFlow, mobileAppRedirect } = this.props;
-		const { from, redirectAfterAuth, scope, closeWindowAfterAuthorize } = this.props.authQuery;
+		const {
+			from,
+			homeUrl,
+			redirectAfterAuth,
+			scope,
+			closeWindowAfterAuthorize,
+		} = this.props.authQuery;
 		const { isRedirecting } = this.state;
 
 		if ( isRedirecting ) {
@@ -241,12 +247,15 @@ export class JetpackAuthorize extends Component {
 		if ( this.isJetpackPartnerCoupon() ) {
 			// The current implementation of the partner coupon URL is supposed to
 			// just take over the entire flow and send directly to checkout.
-			// This will happen by the partnerCouponRedirects controller logic if we just
-			// redirect the customer without any special conditions.
+			// This will happen by the partnerCouponRedirects controller logic if we
+			// just redirect the customer to the plans page.
 			// The reason we have to do this is because e.g. "shouldRedirectJetpackStart" has
 			// logic that will always go straight to the redirect URI after authorization which
 			// means we never hit the "plans" page where our partner coupon logic takes over.
-			const redirectionTarget = this.getRedirectionTarget();
+			const redirectionTarget = addQueryArgs(
+				{ redirect: redirectAfterAuth },
+				`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
+			);
 			debug( `Jetpack Partner Coupon Redirecting to: ${ redirectionTarget }` );
 			navigate( redirectionTarget );
 		} else if (

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -98,6 +98,9 @@ const analyticsPageTitleByType = {
  *
  * @todo Should we dynamically fetch partners and presets?
  * @todo Should we make a coupon validation request? If the coupon is invalid, we leave the user on the plans page.
+ * @todo Accept partner coupon as a query parameter during the initial auth request (client/jetpack-connect/schema.js).
+ *       This should allow us to have more flexible return URLs as well.
+ * @todo Fetch the partner coupon with a selector instead (e.g. like: getPartnerIdFromQuery()).
  */
 export function partnerCouponRedirects( context, next ) {
 	const queryArgs = new URLSearchParams( context?.query?.redirect );


### PR DESCRIPTION
### Summary

The current implementation of catching a Jetpack partner coupon and redirecting users directly to checkout is having some issues. Specifically with sites that have a partner ID.

We would expect all `from: jetpack-partner-coupon` flows to be send over to the plans page after authorisation.
_We specifically catch users on the plans page and redirect them because we expect to make special upsell offers on the plan page in the future, so we might as well make sure the flow works now - which will also allow us to do it async of Jetpack plugin releases._

An issue we currently face is that some redirect conditions take over the normal flow like; is it a partner hosted site? (the `shouldRedirectJetpackStart` redirect condition).
We should prioritise the coupon redirect over these conditions because the customer has specifically entered the partner coupon flow and is expected to "Go straight to checkout".

**Aside**: I would consider this a pretty low risk change since we require the "from" property to specifically be `jetpack-partner-coupon`, so I'm not too worried about actually messing with existing flows.

### Changes proposed in this Pull Request

* Prioritise "Jetpack Partner Coupon" condition in the Calypso redirect conditions after a user has authorized a Jetpack connection.

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Verify failing flow**
* Spin up a Jurassic Ninja site
  * Go to "Want more options?"
  * Select `Include Jetpack Beta`
  * Select `add/partner-coupon-connection` as the Jetpack branch
  * Go down to "Plugins" and select "Include Code Snippets"
* Copy the **Filters snippet** found below to a Code Snippet (this will make the WordPress site recognise test coupons and the flow will not work without it).
* Create a Site Connection with the Jetpack Licensing API or a `free` plan with Jetpack Start API.
  * _We do this step so the site will be recognized as having special conditions due to partner provisioned plans._
* Go to `/wp-admin/admin.php?jetpack-partner-coupon=JPTST_JPTA_123AB`.
* Click the "Redeem <Product>" button.
* Press the "Approve" / "Authorize" button in Calypso.
* You should now be taken back to your WordPress site without seeing the checkout (**this is the failure we want to fix**).

**Verify fixed flow**
_This assumes that you've just completed **Verify failing flow** and continues in the same flow._

* Go through all the steps of _**Verify failing flow**_ right up until you get redirected back to WP Admin.
* Disconnect Jetpack.
* Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
* You should now see the redeem component again.
* Click the "Set up & redeem <Product>" button.
* Spin up this branch.
  * Start up Calypso locally with this branch and use `http://calypso.localhost:3000`.
  * Use [the Calypso link generated with this PR](https://github.com/Automattic/wp-calypso/pull/58552#issuecomment-980174632).
* Copy the URL and replace `https://wordpress.com` with `http://calypso.localhost:3000` / `the PR link`.
* Go to the development URL.
* Press the "Approve" / "Authorize" button in Calypso.
* You should now be taken directly to Jetpack Checkout (whereas you got redirect to WP Admin before in the live version).

**Filters snippet**
```php
add_filter( 'jetpack_partner_coupon_supported_partners', function ( $partners ) {
	$partners['JPTST'] = 'Jetpack Test';

	return $partners;
} );

add_filter( 'jetpack_partner_coupon_supported_presets', function ( $presets ) {
	$presets['JPTA'] = 'jetpack_backup_daily';

	return $presets;
} );
```

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/21813
