### PR TITLE
Domains: Add header to the redesigned transfer page

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -3,6 +3,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
+import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
@@ -123,6 +124,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 		<Main className="transfer-page" wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
+			<FormattedHeader brandFont headerText={ __( 'Transfer' ) } align="left" />
 			{ renderTransferOptions() }
 		</Main>
 	);

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -1,7 +1,21 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/colors';
 
 .transfer-page {
+	header.formatted-header {
+		margin-bottom: 24px;
+
+		h1.formatted-header__title {
+			color: $gray-900;
+			font-size: $font-title-medium;
+
+			@include break-mobile {
+				font-size: $font-title-large;
+			}
+		}
+	}
+
 	.card {
 		padding: 16px;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds the "Transfer" header to the redesigned transfer page. This is part of the domain management redesign project described in pcYYhz-m2-p2.

#### Screenshot

![Markup on 2021-11-26 at 20:04:07](https://user-images.githubusercontent.com/5324818/143660429-4b37f3ea-6507-4935-9245-4ec6cb36b264.png)

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select one of your registered domains
- If you're in the live Calypso link, please append ?flags=domains/transfers-redesign to your URL to enable the appropriate feature flag
- Select the "Transfer your domain" options
- Ensure the "Transfer" header is present
