### PR TITLE
Domains: New transfer to another site screen

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -46,6 +46,7 @@ class SiteSelector extends Component {
 		filter: PropTypes.func,
 		groups: PropTypes.bool,
 		onSiteSelect: PropTypes.func,
+		searchPlaceholder: PropTypes.string,
 		showRecentSites: PropTypes.bool,
 		recentSites: PropTypes.array,
 		selectedSite: PropTypes.object,
@@ -409,6 +410,7 @@ class SiteSelector extends Component {
 				<Search
 					onSearch={ this.onSearch }
 					delaySearch={ true }
+					placeholder={ this.props.searchPlaceholder }
 					// eslint-disable-next-line jsx-a11y/no-autofocus
 					autoFocus={ this.props.autoFocus }
 					disabled={ ! this.props.hasLoadedSites }

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -320,14 +320,15 @@ export default {
 	},
 
 	domainManagementTransferToOtherSite( pageContext, next ) {
+		let transferComponent = DomainManagement.TransferToOtherSite;
 		if ( config.isEnabled( 'domains/transfers-redesign' ) ) {
-			// TODO: set different component for the new transfer page
+			transferComponent = DomainManagement.TransferDomainToOtherSite;
 		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransferToOtherSite( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Transfer To Other Site"
-				component={ DomainManagement.TransferToOtherSite }
+				component={ transferComponent }
 				context={ pageContext }
 				needsDomains
 				selectedDomainName={ pageContext.params.domain }

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -23,6 +23,7 @@ import Transfer from './transfer';
 import TransferOut from './transfer/transfer-out';
 import TransferPage from './transfer/transfer-page';
 import TransferToOtherSite from './transfer/transfer-to-other-site';
+import TransferDomainToOtherSite from './transfer/transfer-to-other-site/transfer-domain-to-other-site';
 import TransferToOtherUser from './transfer/transfer-to-other-user';
 import TransferDomainToOtherUser from './transfer/transfer-to-other-user/transfer-domain-to-other-user';
 
@@ -51,6 +52,7 @@ export default {
 	TransferOut,
 	TransferPage,
 	TransferToOtherSite,
+	TransferDomainToOtherSite,
 	TransferToOtherUser,
 	TransferDomainToOtherUser,
 	Transfer,

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
@@ -1,6 +1,19 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/colors';
 
 .transfer-to-other-site {
+	background: var( --studio-white );
+
+	.formatted-header__title {
+		font-size: $font-title-medium;
+
+		@include break-medium {
+			font-size: $font-title-large;
+		}
+
+	}
+
 	&__card {
 		padding: 0;
 		box-shadow: none;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
@@ -1,0 +1,44 @@
+@import '@wordpress/base-styles/colors';
+
+.transfer-to-other-site {
+	&__card {
+		padding: 0;
+		box-shadow: none;
+		background: transparent;
+
+		.site-selector {
+			.search {
+				margin: 0;
+			}
+
+			&__sites {
+				border-top: none;
+			}
+
+			&__sites {
+				background: transparent;
+				margin: 0;
+
+				.site {
+					padding: 24px 16px;
+
+					&__content {
+						padding: 0;
+					}
+
+					& ~ .site {
+						border-top: 1px solid var( --studio-gray-5 );
+					}
+
+					&__title::after, &__domain::after {
+						background: none;
+					}
+				}
+			}
+		}
+	}
+
+	.site-selector.is-large .site-selector__sites {
+		border-top: none;
+	}
+}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
@@ -9,6 +9,7 @@
 		.site-selector {
 			.search {
 				margin: 0;
+				min-height: 40px;
 			}
 
 			&__sites {
@@ -35,6 +36,14 @@
 					}
 				}
 			}
+		}
+	}
+
+	&__container {
+		margin: 16px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			margin: 0;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.jsx
@@ -1,0 +1,202 @@
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { find, get, omit } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import Main from 'calypso/components/main';
+import SiteSelector from 'calypso/components/site-selector';
+import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
+import wp from 'calypso/lib/wp';
+import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
+import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
+import Header from 'calypso/my-sites/domains/domain-management/components/header';
+import { domainManagementList, domainManagementTransfer } from 'calypso/my-sites/domains/paths';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getSites from 'calypso/state/selectors/get-sites';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import { requestSites } from 'calypso/state/sites/actions';
+import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import TransferConfirmationDialog from './confirmation-dialog';
+
+const wpcom = wp.undocumented();
+
+export class TransferDomainToOtherSite extends Component {
+	static propTypes = {
+		currentUserCanManage: PropTypes.bool.isRequired,
+		hasSiteDomainsLoaded: PropTypes.bool.isRequired,
+		isDomainOnly: PropTypes.bool.isRequired,
+		isMapping: PropTypes.bool.isRequired,
+		isRequestingSiteDomains: PropTypes.bool.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+	};
+
+	state = {
+		targetSiteId: null,
+		showConfirmationDialog: false,
+		disableDialogButtons: false,
+	};
+
+	isDataReady() {
+		return ! this.props.isRequestingSiteDomains && this.props.hasSiteDomainsLoaded;
+	}
+
+	isSiteEligible = ( site ) => {
+		// check if it's an Atomic site from the site options
+		const isAtomic = get( site, 'options.is_automated_transfer', false );
+
+		return (
+			site.capabilities.manage_options &&
+			! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
+			! get( site, 'options.is_domain_only', false ) &&
+			site.ID !== this.props.selectedSite.ID
+		);
+	};
+
+	handleSiteSelect = ( targetSiteId ) => {
+		this.setState( {
+			targetSiteId,
+			showConfirmationDialog: true,
+		} );
+	};
+
+	handleConfirmTransfer = ( targetSite, closeDialog ) => {
+		const { selectedDomainName } = this.props;
+		const targetSiteTitle = targetSite.title;
+		const successMessage = this.props.translate(
+			'%(selectedDomainName)s has been transferred to site: %(targetSiteTitle)s',
+			{ args: { selectedDomainName, targetSiteTitle } }
+		);
+		const defaultErrorMessage = this.props.translate(
+			'Failed to transfer %(selectedDomainName)s, please try again or contact support.',
+			{
+				args: { selectedDomainName },
+			}
+		);
+
+		this.setState( { disableDialogButtons: true } );
+		wpcom
+			.transferToSite( this.props.selectedSite.ID, this.props.selectedDomainName, targetSite.ID )
+			.then(
+				() => {
+					this.props.successNotice( successMessage, { duration: 10000, isPersistent: true } );
+					if ( this.props.isDomainOnly ) {
+						this.props.requestSites();
+						const transferedTo = find( this.props.sites, { ID: targetSite.ID } );
+						page( domainManagementList( transferedTo.slug ) );
+					} else {
+						page( domainManagementList( this.props.selectedSite.slug ) );
+					}
+				},
+				( error ) => {
+					this.setState( { disableDialogButtons: false } );
+					closeDialog();
+					this.props.errorNotice( error.message || defaultErrorMessage );
+				}
+			);
+	};
+
+	handleDialogClose = () => {
+		if ( ! this.state.disableDialogButtons ) {
+			this.setState( { showConfirmationDialog: false } );
+		}
+	};
+
+	getMessage() {
+		const { selectedDomainName: domainName, isMapping, translate } = this.props;
+		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
+
+		if ( isMapping ) {
+			return translate(
+				"Please choose a site you're an administrator on to transfer domain mapping for {{strong}}%(domainName)s{{/strong}} to:",
+				translateArgs
+			);
+		}
+
+		return translate(
+			"Please choose a site you're an administrator on to transfer {{strong}}%(domainName)s{{/strong}} to:",
+			translateArgs
+		);
+	}
+
+	render() {
+		const { selectedSite, selectedDomainName, currentRoute, isMapping } = this.props;
+		const { slug } = selectedSite;
+		if ( ! this.isDataReady() ) {
+			return (
+				<DomainMainPlaceholder
+					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
+				/>
+			);
+		}
+
+		return (
+			<Main className="transfer-to-other-site">
+				<Header
+					selectedDomainName={ selectedDomainName }
+					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
+				>
+					{ isMapping
+						? this.props.translate( 'Transfer Domain Mapping To Another Site' )
+						: this.props.translate( 'Transfer Domain To Another Site' ) }
+				</Header>
+				{ this.renderSection() }
+			</Main>
+		);
+	}
+
+	renderSection() {
+		const { currentUserCanManage, selectedDomainName } = this.props;
+		if ( ! currentUserCanManage ) {
+			return <NonOwnerCard { ...omit( this.props, [ 'children' ] ) } />;
+		}
+
+		return (
+			<div>
+				<Card className="transfer-to-other-site__card">
+					<p>{ this.getMessage() }</p>
+					<SiteSelector
+						filter={ this.isSiteEligible }
+						sites={ this.props.sites }
+						onSiteSelect={ this.handleSiteSelect }
+					/>
+				</Card>
+				{ this.state.targetSiteId && (
+					<TransferConfirmationDialog
+						disableDialogButtons={ this.state.disableDialogButtons }
+						domainName={ selectedDomainName }
+						isMapping={ this.props.isMapping }
+						isVisible={ this.state.showConfirmationDialog }
+						onConfirmTransfer={ this.handleConfirmTransfer }
+						onClose={ this.handleDialogClose }
+						targetSiteId={ this.state.targetSiteId }
+					/>
+				) }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => {
+		const domain = ! ownProps.isRequestingSiteDomains && getSelectedDomain( ownProps );
+		const siteId = getSelectedSiteId( state );
+		return {
+			currentRoute: getCurrentRoute( state ),
+			currentUserCanManage: Boolean( domain ) && domain.currentUserCanManage,
+			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, siteId ),
+			isDomainOnly: isDomainOnlySite( state, siteId ),
+			isMapping: Boolean( domain ) && isMappedDomain( domain ),
+			sites: getSites( state ),
+		};
+	},
+	{
+		errorNotice,
+		requestSites,
+		successNotice,
+	}
+)( localize( TransferDomainToOtherSite ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -111,18 +111,10 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	};
 
 	getMessage(): i18nCalypso.TranslateResult {
-		const { selectedDomainName: domainName, isMapping, translate } = this.props;
+		const { selectedDomainName: domainName, translate } = this.props;
 		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
-
-		if ( isMapping ) {
-			return translate(
-				"Please choose a site you're an administrator on to transfer domain mapping for {{strong}}%(domainName)s{{/strong}} to:",
-				translateArgs
-			);
-		}
-
 		return translate(
-			"Please choose a site you're an administrator on to transfer {{strong}}%(domainName)s{{/strong}} to:",
+			"Transfer {{strong}}%(domainName)s{{/strong}} to a site you're an administrator of:",
 			translateArgs
 		);
 	}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -3,14 +3,20 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import SiteSelector from 'calypso/components/site-selector';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
 import wp from 'calypso/lib/wp';
+import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
-import Header from 'calypso/my-sites/domains/domain-management/components/header';
-import { domainManagementList, domainManagementTransfer } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainManagementTransfer,
+} from 'calypso/my-sites/domains/paths';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -24,6 +30,8 @@ import type {
 	TransferDomainToOtherSiteProps,
 	TransferDomainToOtherSiteStateProps,
 } from './types';
+
+import './style.scss';
 
 const wpcom = wp.undocumented();
 
@@ -120,30 +128,66 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	}
 
 	render(): JSX.Element {
-		const { selectedSite, selectedDomainName, currentRoute, isMapping } = this.props;
+		const { selectedSite, selectedDomainName, currentRoute, translate } = this.props;
 		const { slug } = selectedSite;
+		const componentClassName = 'transfer-to-other-site';
 		if ( ! this.isDataReady() ) {
 			return (
 				<DomainMainPlaceholder
+					breadcrumbs={ this.renderBreadcrumbs }
 					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
 				/>
 			);
 		}
 
 		return (
-			<Main className="transfer-to-other-site">
-				<Header
-					selectedDomainName={ selectedDomainName }
-					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
-				>
-					{ isMapping
-						? this.props.translate( 'Transfer Domain Mapping To Another Site' )
-						: this.props.translate( 'Transfer Domain To Another Site' ) }
-				</Header>
-				{ this.renderSection() }
+			<Main wideLayout className={ componentClassName }>
+				<BodySectionCssClass
+					bodyClass={ [ componentClassName ] }
+					group={ componentClassName }
+					section={ componentClassName }
+				/>
+				{ this.renderBreadcrumbs() }
+				<FormattedHeader
+					hasScreenOptions={ false }
+					brandFont
+					headerText={ translate( 'Transfer to another WordPress.com site' ) }
+					align="left"
+				/>
+				<div className={ `${ componentClassName }__container` }>
+					<div className={ `${ componentClassName }__main` }>{ this.renderSection() }</div>
+				</div>
 			</Main>
 		);
 	}
+
+	renderBreadcrumbs = (): JSX.Element => {
+		const { translate, selectedSite, selectedDomainName, currentRoute } = this.props;
+
+		const items = [
+			{
+				label: translate( 'Domains' ),
+				href: domainManagementList( selectedSite.slug, selectedDomainName ),
+			},
+			{
+				label: selectedDomainName,
+				href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+			},
+			{
+				label: translate( 'Transfer' ),
+				href: domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ),
+			},
+			{ label: translate( 'To another WordPress.com site' ) },
+		];
+
+		const mobileItem = {
+			label: translate( 'Back to Transfer' ),
+			href: domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ),
+			showBackArrow: true,
+		};
+
+		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
+	};
 
 	renderSection(): JSX.Element {
 		const { currentUserCanManage, selectedDomainName } = this.props;
@@ -157,6 +201,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 				<Card className="transfer-to-other-site__card">
 					<p>{ this.getMessage() }</p>
 					<SiteSelector
+						className={ 'transfer-to-other-site__site-selector' }
 						filter={ this.isSiteEligible }
 						sites={ this.props.sites }
 						onSiteSelect={ this.handleSiteSelect }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -182,7 +182,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	};
 
 	renderSection(): JSX.Element {
-		const { currentUserCanManage, selectedDomainName } = this.props;
+		const { translate, currentUserCanManage, selectedDomainName } = this.props;
 		const { children, ...propsWithoutChildren } = this.props;
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...propsWithoutChildren } />;
@@ -197,6 +197,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 						filter={ this.isSiteEligible }
 						sites={ this.props.sites }
 						onSiteSelect={ this.handleSiteSelect }
+						searchPlaceholder={ translate( 'Search' ) }
 					/>
 				</Card>
 				{ this.state.targetSiteId && (

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
@@ -8,6 +8,10 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 type Maybe< T > = T | null;
 // TODO: remove this once the checkout types are further described
 type SiteDataExtraInfo = SiteData & {
+	options: {
+		is_automated_transfer: boolean;
+		is_domain_only: boolean;
+	};
 	title: string;
 	capabilities: Record< string, boolean >;
 };
@@ -28,7 +32,7 @@ export type TransferDomainToOtherSiteStateProps = {
 	isDomainOnly: Maybe< boolean >;
 	isMapping: boolean;
 	// eslint-disable-next-line @typescript-eslint/ban-types
-	sites: Maybe< object >[];
+	sites: Maybe< Maybe< SiteData >[] >;
 };
 // state props added by redux connect
 export type TransferDomainToOtherSiteStateToProps = (

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
@@ -1,0 +1,49 @@
+import { DefaultRootState } from 'react-redux';
+import { LocalizeProps } from 'calypso/../packages/i18n-calypso/types';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { requestSites } from 'calypso/state/sites/actions';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+
+type Maybe< T > = T | null;
+// TODO: remove this once the checkout types are further described
+type SiteDataExtraInfo = SiteData & {
+	title: string;
+	capabilities: Record< string, boolean >;
+};
+
+// props passed to the component
+export type TransferDomainToOtherSitePassedProps = {
+	domains: SiteDomain[];
+	isRequestingSiteDomains: boolean;
+	selectedDomainName: string;
+	selectedSite: SiteDataExtraInfo;
+};
+
+// state props
+export type TransferDomainToOtherSiteStateProps = {
+	currentRoute: string;
+	currentUserCanManage: boolean;
+	hasSiteDomainsLoaded: boolean;
+	isDomainOnly: Maybe< boolean >;
+	isMapping: boolean;
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	sites: Maybe< object >[];
+};
+// state props added by redux connect
+export type TransferDomainToOtherSiteStateToProps = (
+	state: DefaultRootState,
+	ownProps: TransferDomainToOtherSitePassedProps
+) => TransferDomainToOtherSiteStateProps;
+
+// all component props (passed + redux state props)
+export type TransferDomainToOtherSiteProps = TransferDomainToOtherSitePassedProps &
+	TransferDomainToOtherSiteStateProps &
+	TransferDomainToOtherSiteDispatchToProps &
+	LocalizeProps;
+
+export type TransferDomainToOtherSiteDispatchToProps = {
+	requestSites: typeof requestSites;
+	errorNotice: typeof errorNotice;
+	successNotice: typeof successNotice;
+};


### PR DESCRIPTION
Apply the new design changes to the transfer domain to another site screen. This is part of the domain management redesign project described in pcYYhz-m2-p2.

#### Preview
##### Before
![image](https://user-images.githubusercontent.com/18705930/143664598-89e1f624-a715-42fc-9da9-18fc0d8aa035.png)

##### After
![image](https://user-images.githubusercontent.com/18705930/145271700-276e8e4a-85a2-4ede-b1e6-77685fbb3cc9.png)

#### Testing instructions

- Build this branch locally or open the live Calypso link;
- Go to "Upgrades > Domains";
- Select one of your registered domains;
- If you're in the live Calypso link, please append ?flags=domains/transfers-redesign to your URL to enable the appropriate feature flag;
- Select "Transfer your domain" > "To another WordPress.com site";
- Make sure that the screen looks like the one in the screenshots above - also ensure that the new screen is not shown when the feature flag is disabled.