### PR TITLE
WIP seeing what it'd take to add Hero Flow to gutenboarding

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -3,9 +3,11 @@ import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { Popover, DropZoneProvider } from '@wordpress/components';
 import '@wordpress/format-library';
+import { Icon, wordpress } from '@wordpress/icons';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
+import { Route, Switch } from 'react-router-dom';
 import Header from './components/header';
 import SignupForm from './components/signup-form';
 import { useFontPairings } from './fonts';
@@ -17,6 +19,7 @@ import useSignup from './hooks/use-signup';
 import useSiteTitle from './hooks/use-site-title';
 import useTrackOnboardingStart from './hooks/use-track-onboarding-start';
 import { name, settings } from './onboarding-block';
+import { Step, usePath } from './path';
 import './style.scss';
 import '@wordpress/components/build-style/style.css';
 
@@ -72,12 +75,28 @@ const Gutenboard: React.FunctionComponent = () => {
 	// (and would lead to weird mounting/unmounting behavior).
 	const onboardingBlock = React.useRef( createBlock( name, {} ) );
 
+	const makePath = usePath();
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="block-editor__container">
 			<DropZoneProvider>
 				<div className="gutenboarding__layout edit-post-layout">
-					<Header />
+					<Switch>
+						<Route
+							path={ [
+								makePath( Step.HeroIntentGathering ),
+								makePath( Step.HeroThemeSelection ),
+								makePath( Step.HeroSiteOptions ),
+								makePath( Step.HeroStartingPoint ),
+							] }
+						>
+							<Icon icon={ wordpress } size={ 28 } />
+						</Route>
+						<Route>
+							<Header />
+						</Route>
+					</Switch>
 					{ showSignupDialog && <SignupForm onRequestClose={ onSignupDialogClose } /> }
 					<ShortcutProvider>
 						<BlockEditorProvider

--- a/client/landing/gutenboarding/hooks/use-hero-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-hero-navigation.ts
@@ -1,0 +1,49 @@
+import { useHistory } from 'react-router-dom';
+import { Step, usePath, useCurrentStep, StepType } from '../path';
+import { useHeroSteps } from './use-hero-steps';
+
+interface UseHeroStepNavigationResult {
+	goBack: () => void;
+
+	/**
+	 * Proceed to the next step in the hero flow. Allows an explicit next step to
+	 * be specified to enable "branching of the flow".
+	 */
+	goNext: ( explicitStep?: StepType ) => void;
+}
+
+/**
+ * A React hook that returns callback to navigate to previous and next steps in Gutenboarding flow
+ */
+export function useHeroStepNavigation(): UseHeroStepNavigationResult {
+	const makePath = usePath();
+	const history = useHistory();
+	const currentStep = useCurrentStep();
+
+	const steps = useHeroSteps();
+
+	const currentStepIndex = steps.findIndex( ( step ) => step === Step[ currentStep ] );
+
+	const previousStepPath = currentStepIndex > 0 ? makePath( steps[ currentStepIndex - 1 ] ) : '';
+
+	const handleBack = () => history.push( previousStepPath );
+	const handleNext = ( explicitStep?: StepType ) => {
+		let nextStepPath = '';
+
+		if ( explicitStep ) {
+			nextStepPath = makePath( explicitStep );
+		} else if (
+			currentStepIndex !== -1 && // check first if current step still exists
+			currentStepIndex < steps.length - 1
+		) {
+			nextStepPath = makePath( steps[ currentStepIndex + 1 ] );
+		}
+
+		history.push( nextStepPath );
+	};
+
+	return {
+		goBack: handleBack,
+		goNext: handleNext,
+	};
+}

--- a/client/landing/gutenboarding/hooks/use-hero-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-hero-steps.ts
@@ -1,0 +1,26 @@
+import { useSelect } from '@wordpress/data';
+import { Step, StepType } from '../path';
+import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
+
+export function useHeroSteps(): Array< StepType > {
+	const siteIntent = useSelect( ( select ) => select( ONBOARD_STORE ).getSiteIntent(), [
+		ONBOARD_STORE,
+	] );
+
+	switch ( siteIntent ) {
+		case '':
+			return [ Step.HeroIntentGathering ];
+		case 'write':
+			return [
+				Step.HeroIntentGathering,
+				Step.HeroSiteOptions,
+				Step.HeroStartingPoint,
+				Step.HeroThemeSelection,
+			];
+		case 'build':
+			return [ Step.HeroIntentGathering, Step.HeroThemeSelection ];
+		case 'import':
+			// TODO
+			return [];
+	}
+}

--- a/client/landing/gutenboarding/hooks/use-themes-query.ts
+++ b/client/landing/gutenboarding/hooks/use-themes-query.ts
@@ -1,0 +1,21 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+export function useThemesQuery( filter: string ): UseQueryResult< any[] > {
+	return useQuery(
+		[ 'themes', filter ],
+		() =>
+			wpcom.req.get( '/themes', {
+				search: '',
+				number: 50,
+				tier: '',
+				filter,
+				apiVersion: '1.2',
+			} ),
+		{
+			refetchIntervalInBackground: false,
+			refetchOnWindowFocus: false,
+			select: ( responseBody ) => responseBody.themes,
+		}
+	);
+}

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -6,6 +6,7 @@ import { getAvailableDesigns } from '@automattic/design-picker';
 import { subscribe, select, dispatch } from '@wordpress/data';
 import { isEqual } from 'lodash';
 import ReactDom from 'react-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import { LocaleContext } from './components/locale-context';
@@ -58,17 +59,19 @@ window.AppBoot = async () => {
 
 	ReactDom.render(
 		<LocaleContext>
-			<WindowLocaleEffectManager />
-			<BrowserRouter basename="new">
-				<Switch>
-					<Route exact path={ path }>
-						<Gutenboard />
-					</Route>
-					<Route>
-						<Redirect to="/" />
-					</Route>
-				</Switch>
-			</BrowserRouter>
+			<QueryClientProvider client={ new QueryClient() }>
+				<WindowLocaleEffectManager />
+				<BrowserRouter basename="new">
+					<Switch>
+						<Route exact path={ path }>
+							<Gutenboard />
+						</Route>
+						<Route>
+							<Redirect to="/" />
+						</Route>
+					</Switch>
+				</BrowserRouter>
+			</QueryClientProvider>
 		</LocaleContext>,
 		document.getElementById( 'wpcom' )
 	);

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -25,6 +25,10 @@ import Designs from './designs';
 import Domains from './domains';
 import Features from './features';
 import FseBetaOptIn from './fse-beta-opt-in';
+import { HeroFlowIntentGathering } from './hero-flow/intent-gathering';
+import { HeroFlowSiteOptions } from './hero-flow/site-options';
+import { HeroFlowStaringPoint } from './hero-flow/starting-point';
+import { HeroFlowThemePicker } from './hero-flow/theme-picker';
 import Language from './language';
 import Plans from './plans';
 import StylePreview from './style-preview';
@@ -260,6 +264,22 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.CreateSite ) }>{ createSiteOrError() }</Route>
+
+				<Route path={ makePath( Step.HeroIntentGathering ) }>
+					<HeroFlowIntentGathering />
+				</Route>
+
+				<Route path={ makePath( Step.HeroThemeSelection ) }>
+					<HeroFlowThemePicker />
+				</Route>
+
+				<Route path={ makePath( Step.HeroSiteOptions ) }>
+					<HeroFlowSiteOptions />
+				</Route>
+
+				<Route path={ makePath( Step.HeroStartingPoint ) }>
+					<HeroFlowStaringPoint />
+				</Route>
 			</Switch>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/hero-flow/intent-gathering/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/hero-flow/intent-gathering/index.tsx
@@ -1,0 +1,18 @@
+import { useDispatch } from '@wordpress/data';
+import ImportedIntentScreen from 'calypso/signup/steps/intent/intent-screen';
+import { useHeroStepNavigation } from '../../../hooks/use-hero-navigation';
+import { Step } from '../../../path';
+import { STORE_KEY as ONBOARD_STORE } from '../../../stores/onboard';
+import type { SiteIntent } from '../../../stores/onboard/types';
+
+export function HeroFlowIntentGathering(): React.ReactElement {
+	const { setSiteIntent } = useDispatch( ONBOARD_STORE );
+	const { goNext } = useHeroStepNavigation();
+
+	const handleClick = ( intent: SiteIntent ) => {
+		setSiteIntent( intent );
+		goNext( intent === 'write' ? Step.HeroSiteOptions : Step.HeroThemeSelection );
+	};
+
+	return <ImportedIntentScreen onSelect={ handleClick } />;
+}

--- a/client/landing/gutenboarding/onboarding-block/hero-flow/site-options/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/hero-flow/site-options/index.tsx
@@ -1,0 +1,18 @@
+import { BackButton } from '@automattic/onboarding';
+import ImportedSiteOptions from 'calypso/signup/steps/site-options/site-options';
+import { useHeroStepNavigation } from '../../../hooks/use-hero-navigation';
+
+export function HeroFlowSiteOptions(): React.ReactElement {
+	const { goBack, goNext } = useHeroStepNavigation();
+
+	const handleSubmit = () => {
+		goNext();
+	};
+
+	return (
+		<div>
+			<BackButton onClick={ goBack } />
+			<ImportedSiteOptions defaultSiteTitle="" defaultTagline="" onSubmit={ handleSubmit } />
+		</div>
+	);
+}

--- a/client/landing/gutenboarding/onboarding-block/hero-flow/starting-point/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/hero-flow/starting-point/index.tsx
@@ -1,0 +1,22 @@
+import { BackButton } from '@automattic/onboarding';
+import ImportedStartingPoint from 'calypso/signup/steps/starting-point/starting-point';
+import { StartingPointFlag } from 'calypso/signup/steps/starting-point/types';
+import { useHeroStepNavigation } from '../../../hooks/use-hero-navigation';
+import { Step } from '../../../path';
+
+export function HeroFlowStaringPoint(): React.ReactElement {
+	const { goBack, goNext } = useHeroStepNavigation();
+
+	const handleSelect = ( startingPoint: StartingPointFlag ) => {
+		if ( startingPoint === 'design' ) {
+			goNext( Step.HeroThemeSelection );
+		}
+	};
+
+	return (
+		<div>
+			<BackButton onClick={ goBack } />
+			<ImportedStartingPoint onSelect={ handleSelect } />
+		</div>
+	);
+}

--- a/client/landing/gutenboarding/onboarding-block/hero-flow/theme-picker/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/hero-flow/theme-picker/index.tsx
@@ -1,0 +1,91 @@
+import DesignPicker, { useCategorization } from '@automattic/design-picker';
+import { englishLocales } from '@automattic/i18n-utils';
+import { shuffle } from '@automattic/js-utils';
+import { BackButton } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { useThemesQuery } from 'calypso/landing/gutenboarding/hooks/use-themes-query';
+import { useHeroStepNavigation } from '../../../hooks/use-hero-navigation';
+
+// Ideally this data should come from the themes API, maybe by a tag that's applied to
+// themes? e.g. `link-in-bio` or `no-fold`
+const STATIC_PREVIEWS = [ 'bantry', 'sigler', 'miller', 'pollard', 'paxton', 'jones', 'baker' ];
+
+export function HeroFlowThemePicker(): React.ReactElement {
+	const translate = useTranslate();
+	const { goBack } = useHeroStepNavigation();
+
+	const { data: apiThemes = [] } = useThemesQuery( 'auto-loading-homepage' );
+
+	const designs = useMemo( () => {
+		// TODO fetching and filtering code should be pulled to a shared place that's usable by both
+		// `/start` and `/new` onboarding flows. Or perhaps fetching should be done within the <DesignPicker>
+		// component itself. The `/new` environment needs helpers for making authenticated requests to
+		// the theme API before we can do this.
+		const allThemes = apiThemes.map( ( { id, name, taxonomies } ) => ( {
+			categories: taxonomies?.theme_subject ?? [],
+			// Blank Canvas uses the theme_picks taxonomy with a "featured" term in order to
+			// appear prominently in theme galleries.
+			showFirst: !! taxonomies?.theme_picks?.find( ( { slug } ) => slug === 'featured' ),
+			features: [],
+			is_premium: false,
+			slug: id,
+			template: id,
+			theme: id,
+			title: name,
+			...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+		} ) );
+
+		if ( allThemes.length === 0 ) {
+			return [];
+		}
+
+		return [ allThemes[ 0 ], ...shuffle( allThemes.slice( 1 ) ) ];
+	}, [ apiThemes ] );
+
+	const handleSelection = () => {
+		throw new Error( 'not implemented' );
+	};
+
+	const categorization = useCategorization( designs, {
+		showAllFilter: true,
+	} );
+
+	function subHeaderText() {
+		const text = translate( 'Choose a starting theme. You can change it later.' );
+
+		if ( englishLocales.includes( translate.localeSlug || '' ) ) {
+			// An English only trick so the line wraps between sentences.
+			return text
+				.replace( /\s/g, '\xa0' ) // Replace all spaces with non-breaking spaces
+				.replace( /\.\s/g, '. ' ); // Replace all spaces at the end of sentences with a regular breaking space
+		}
+
+		return text;
+	}
+
+	return (
+		<div>
+			<BackButton onClick={ goBack } />
+			<DesignPicker
+				designs={ designs }
+				theme="light"
+				locale={ translate.localeSlug }
+				onSelect={ handleSelection }
+				onPreview={ handleSelection }
+				highResThumbnails
+				categorization={ categorization }
+				categoriesHeading={
+					<FormattedHeader
+						id="step-header"
+						headerText={ translate( 'Themes' ) }
+						subHeaderText={ subHeaderText() }
+						align="left"
+						hasScreenOptions={ false }
+					/>
+				}
+			/>
+		</div>
+	);
+}

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -36,6 +36,11 @@ export const Step = {
 	DomainsModal: 'domains-modal',
 	PlansModal: 'plans-modal',
 	LanguageModal: 'language-modal',
+
+	HeroIntentGathering: 'intent',
+	HeroThemeSelection: 'select-theme',
+	HeroSiteOptions: 'site-options',
+	HeroStartingPoint: 'starting-point',
 } as const;
 
 // We remove falsey `steps` with `.filter( Boolean )` as they'd mess up our |-separated route pattern.
@@ -45,6 +50,7 @@ const routeFragments = {
 	// We add the possibility of an empty step fragment through the `?` question mark at the end of that fragment.
 	step: `:step(${ steps.join( '|' ) })?`,
 	plan: `:plan(${ plansPaths.join( '|' ) })?`,
+	siteSlug: `:siteSlug?`,
 	lang: `:lang(${ languages.map( ( lang ) => lang.langSlug ).join( '|' ) })?`,
 };
 
@@ -66,14 +72,16 @@ export type GutenLocationStateKeyType = keyof GutenLocationStateType;
 export function usePath() {
 	const langParam = useLangRouteParam();
 	const planParam = usePlanRouteParam();
+	const siteSlugParam = useSiteSlugRouteParam();
 
-	return ( step?: StepType, lang?: string, plan?: string ): string => {
+	return ( step?: StepType, lang?: string, plan?: string, siteSlug?: string ): string => {
 		// When lang is null, remove lang.
 		// When lang is empty or undefined, get lang from route param.
 		lang = lang === null ? '' : lang || langParam;
 		plan = plan === null ? '' : plan || planParam;
+		siteSlug = siteSlug === null ? '' : siteSlug || siteSlugParam;
 
-		if ( ! step && ! lang && ! plan ) {
+		if ( ! step && ! lang && ! plan && ! siteSlug ) {
 			return '/';
 		}
 
@@ -82,10 +90,11 @@ export function usePath() {
 				step,
 				plan,
 				lang,
+				siteSlug,
 			} );
 		} catch {
 			// If we get an invalid lang or plan, `generatePath` throws a TypeError.
-			return generatePath( path, { step } );
+			return generatePath( path, { step, siteSlug } );
 		}
 	};
 }
@@ -103,6 +112,11 @@ export function useStepRouteParam() {
 export function usePlanRouteParam() {
 	const match = useRouteMatch< { plan?: PlanPath } >( path );
 	return match?.params.plan;
+}
+
+export function useSiteSlugRouteParam(): string | undefined {
+	const match = useRouteMatch< { siteSlug?: string } >( path );
+	return match?.params.siteSlug;
 }
 
 export function useCurrentStep(): StepNameType {

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -12,7 +12,7 @@ import guessTimezone from '../../../../lib/i18n-utils/guess-timezone';
 import { SITE_STORE } from '../site';
 import { STORE_KEY as ONBOARD_STORE } from './constants';
 import type { State } from '.';
-import type { SiteVertical } from './types';
+import type { SiteIntent, SiteVertical } from './types';
 import type { Design, FontPair } from '@automattic/design-picker';
 
 type CreateSiteParams = Site.CreateSiteParams;
@@ -229,6 +229,11 @@ export const enrollInFseBeta = ( enrollInFseBeta: boolean ) => ( {
 	enrollInFseBeta,
 } );
 
+export const setSiteIntent = ( siteIntent: SiteIntent ) => ( {
+	type: 'SET_SITE_INTENT' as const,
+	siteIntent,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -254,4 +259,5 @@ export type OnboardAction = ReturnType<
 	| typeof togglePageLayout
 	| typeof startOnboarding
 	| typeof enrollInFseBeta
+	| typeof setSiteIntent
 >;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -34,6 +34,7 @@ registerStore< State >( STORE_KEY, {
 		'siteVertical',
 		'wasVerticalSkipped',
 		'isEnrollingInFseBeta',
+		'siteIntent',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from '@wordpress/data';
 import type { OnboardAction } from './actions';
-import type { SiteVertical } from './types';
+import type { SiteIntent, SiteVertical } from './types';
 import type { DomainSuggestions, WPCOMFeatures } from '@automattic/data-stores';
 import type { Design, FontPair } from '@automattic/design-picker';
 import type { Reducer } from 'redux';
@@ -236,6 +236,16 @@ const isEnrollingInFseBeta: Reducer< boolean, OnboardAction > = ( state = false,
 	return state;
 };
 
+const siteIntent: Reducer< SiteIntent | '', OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_SITE_INTENT' ) {
+		return action.siteIntent;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return '';
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainSearch,
@@ -257,6 +267,7 @@ const reducer = combineReducers( {
 	hasOnboardingStarted,
 	lastLocation,
 	isEnrollingInFseBeta,
+	siteIntent,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -1,5 +1,6 @@
 import { isGoodDefaultDomainQuery } from '@automattic/domain-picker';
 import type { State } from './reducer';
+import type { SiteIntent } from './types';
 
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlanProductId = ( state: State ) => state.planProductId;
@@ -40,3 +41,5 @@ export const hasSelectedDesignWithoutFonts = ( state: State ) =>
 	hasSelectedDesign( state ) && ! state.selectedFonts;
 
 export const isEnrollingInFseBeta = ( state: State ): boolean => state.isEnrollingInFseBeta;
+
+export const getSiteIntent = ( state: State ): SiteIntent | '' => state.siteIntent;

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -23,3 +23,5 @@ export interface SiteVertical {
 	 */
 	slug?: string;
 }
+
+export type SiteIntent = 'write' | 'build' | 'import';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

See pbAok1-2iM-p2

* Adds a new routes to Gutenboarding for the Hero Flow steps
* Create basic implementation of the Hero Flow steps by importing components directly from the signup framework
* Add "site intent" to the onboarding store. It's still needed in this proof-of-concept to determine which branch in the flow the user has taken
* Add `useHeroStepNavigation()`and `useHeroSteps()` hooks as alternatives to the existing `useStepNavigation()` and `useSteps()` hooks. They work in the same way, except they're for the Hero Flow.
* Updated the `usePath()` hook so that it keeps the `siteSlug` in the URL while the user navigates.
* Use React Router to hide the header in the Hero Flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/new/intent/:siteSlug` will start the Hero flow
* The Back button's should work after a page refresh, even if you refresh on the design picker, which is part of two branches