### PR TITLE
Fix plugin installation on self-hosted sites.

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -24,6 +24,8 @@ import getPluginUploadProgress from 'calypso/state/selectors/get-plugin-upload-p
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { initiateThemeTransfer as initiateTransfer } from 'calypso/state/themes/actions';
 import {
 	getSelectedSite,
@@ -65,6 +67,12 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 		getStatusForPlugin( state, siteId, productSlug )
 	);
 
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ?? null ) );
+	const isAtomic = useSelector( ( state ) =>
+		isSiteAutomatedTransfer( state, selectedSite?.ID ?? null )
+	);
+	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
+
 	const supportsAtomicUpgrade = useRef< boolean >();
 	useEffect( () => {
 		supportsAtomicUpgrade.current =
@@ -81,12 +89,15 @@ const MarketplacePluginInstall = ( { productSlug } ): JSX.Element => {
 		}
 	}, [ isWporgPluginFetched, productSlug ] );
 
-	// Check if the user plan is enough for installation
+	// Check if the user plan is enough for installation or it is a self-hosted jetpack site
 	// if not, check again in 2s and show an error message
 	useEffect( () => {
-		if ( ! supportsAtomicUpgrade.current ) {
+		if ( ! supportsAtomicUpgrade.current && ! isJetpackSelfHosted ) {
 			waitFor( 2 ).then(
-				() => ! supportsAtomicUpgrade.current && setNonInstallablePlanError( true )
+				() =>
+					! supportsAtomicUpgrade.current &&
+					! isJetpackSelfHosted &&
+					setNonInstallablePlanError( true )
 			);
 		}
 	} );


### PR DESCRIPTION


#### Changes proposed in this Pull Request

Stop showing plan upgrade error for self-hosted sites.

#### Testing instructions
* Go to plugin details page with a self-hosted site selected
* Click on install plugin
* See if the plugin installation goes through.

#### Demo
|Before | After|
|-------|------|
|![Kapture 2021-11-29 at 05 10 06](https://user-images.githubusercontent.com/5039531/143839477-4f830ce2-7dde-4d92-a596-59044b55f658.gif)|![Kapture 2021-11-29 at 05 24 32](https://user-images.githubusercontent.com/5039531/143842386-cc12ea04-cf11-4ae7-a272-685dd4a46494.gif)|

---


Fixes #58566
