### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` reader related posts to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -207,18 +207,6 @@ Undocumented.prototype.readSitePost = function ( query, fn ) {
 	return this.wpcom.req.get( '/read/sites/' + query.site + '/posts/' + query.postId, params, fn );
 };
 
-Undocumented.prototype.readSitePostRelated = function ( query, fn ) {
-	debug( '/read/site/:site/post/:post/related' );
-	const params = omit( query, [ 'site_id', 'post_id' ] );
-	params.apiVersion = '1.2';
-	addReaderContentWidth( params );
-	return this.wpcom.req.get(
-		'/read/site/' + query.site_id + '/post/' + query.post_id + '/related',
-		params,
-		fn
-	);
-};
-
 /**
  * Launches a private site
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` reader related posts to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Go to the Reader
* Open a post that displays related posts in production.
* Verify it still displays related posts properly.
* Verify tests pass: `yarn run test-client client/state/reader/related-posts`