### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` tlds to `wpcom.req`

### DIFF
--- a/client/lib/domains/get-available-tlds.js
+++ b/client/lib/domains/get-available-tlds.js
@@ -1,5 +1,5 @@
 import wpcom from 'calypso/lib/wp';
 
 export function getAvailableTlds( query = {} ) {
-	return wpcom.undocumented().getAvailableTlds( query );
+	return wpcom.req.get( '/domains/suggestions/tlds', query );
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -150,16 +150,6 @@ Undocumented.prototype.startInboundTransfer = function ( siteId, domain, authCod
 };
 
 /**
- * Fetches a list of available top-level domain names ordered by popularity.
- *
- * @param {object} query Optional query parameters
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.getAvailableTlds = function ( query = {} ) {
-	return this.wpcom.req.get( '/domains/suggestions/tlds', query );
-};
-
-/**
  *
  * @param domain {string}
  * @param fn {function}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` TLDs retrieval to `wpcom.req.post()`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Go to `/domains/add/:site` where `:site` is an existing WP.com site.
* Search for something.
* Verify the TLDs are still loading properly.