### PR TITLE
Remove usages of Lodash has

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { numberFormat, localize } from 'i18n-calypso';
-import { has } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
@@ -45,13 +44,13 @@ class AuthorCompactProfile extends Component {
 			return <AuthorCompactProfilePlaceholder />;
 		}
 
-		const hasAuthorName = has( author, 'name' );
+		const hasAuthorName = Object.hasOwn( author, 'name' );
 		const hasMatchingAuthorAndSiteNames =
 			hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, author.name );
 		const classes = classnames( {
 			'author-compact-profile': true,
 			'has-author-link': ! hasMatchingAuthorAndSiteNames,
-			'has-author-icon': siteIcon || feedIcon || ( author && author.has_avatar ),
+			'has-author-icon': siteIcon || feedIcon || author.has_avatar,
 		} );
 		const streamUrl = getStreamUrl( feedId, siteId );
 

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -44,7 +44,7 @@ class AuthorCompactProfile extends Component {
 			return <AuthorCompactProfilePlaceholder />;
 		}
 
-		const hasAuthorName = Object.hasOwn( author, 'name' );
+		const hasAuthorName = author.hasOwnProperty( 'name' );
 		const hasMatchingAuthorAndSiteNames =
 			hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, author.name );
 		const classes = classnames( {

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -1,7 +1,6 @@
 import classnames from 'classnames';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
-import { has } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import ReactDom from 'react-dom';
@@ -98,7 +97,8 @@ class ReaderCombinedCardPost extends Component {
 			);
 		}
 
-		const hasAuthorName = has( post, 'author.name' ) && ! isAuthorNameBlocked( post.author.name );
+		const hasAuthorName =
+			Object.hasOwn( post.author, 'name' ) && ! isAuthorNameBlocked( post.author.name );
 		let featuredAsset = null;
 		if ( post.canonical_media && post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = (

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -98,7 +98,7 @@ class ReaderCombinedCardPost extends Component {
 		}
 
 		const hasAuthorName =
-			Object.hasOwn( post.author, 'name' ) && ! isAuthorNameBlocked( post.author.name );
+			post.author.hasOwnProperty( 'name' ) && ! isAuthorNameBlocked( post.author.name );
 		let featuredAsset = null;
 		if ( post.canonical_media && post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = (

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -1,7 +1,6 @@
 import { Button, Popover, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { has } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -64,10 +63,9 @@ export class DateRange extends Component {
 
 		// Define the date range that is selectable (ie: not disabled)
 		const firstSelectableDate =
-			has( this.props, 'firstSelectableDate' ) &&
-			this.props.moment( this.props.firstSelectableDate );
+			this.props.firstSelectableDate && this.props.moment( this.props.firstSelectableDate );
 		const lastSelectableDate =
-			has( this.props, 'lastSelectableDate' ) && this.props.moment( this.props.lastSelectableDate );
+			this.props.lastSelectableDate && this.props.moment( this.props.lastSelectableDate );
 
 		// Clamp start/end dates to ranges (if specified)
 		let startDate =

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { get, has } from 'lodash';
 import { makeLayout, render } from 'calypso/controller';
 import { addQueryArgs } from 'calypso/lib/route';
 import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
@@ -227,7 +226,7 @@ function showDraftPostModal() {
 export const post = ( context, next ) => {
 	const postId = getPostID( context );
 	const postType = determinePostType( context );
-	const jetpackCopy = parseInt( get( context, 'query.jetpack-copy', null ) );
+	const jetpackCopy = parseInt( context.query[ 'jetpack-copy' ] );
 
 	// Check if this value is an integer.
 	const duplicatePostId = Number.isInteger( jetpackCopy ) ? jetpackCopy : null;
@@ -255,7 +254,7 @@ export const post = ( context, next ) => {
 			anchorFmData={ anchorFmData }
 			fseParentPageId={ fseParentPageId }
 			parentPostId={ parentPostId }
-			creatingNewHomepage={ postType === 'page' && has( context, 'query.new-homepage' ) }
+			creatingNewHomepage={ postType === 'page' && Object.hasOwn( context.query, 'new-homepage' ) }
 			stripeConnectSuccess={ context.query.stripe_connect_success ?? null }
 			showDraftPostModal={ showDraftPostModal() }
 		/>

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -254,7 +254,7 @@ export const post = ( context, next ) => {
 			anchorFmData={ anchorFmData }
 			fseParentPageId={ fseParentPageId }
 			parentPostId={ parentPostId }
-			creatingNewHomepage={ postType === 'page' && Object.hasOwn( context.query, 'new-homepage' ) }
+			creatingNewHomepage={ postType === 'page' && context.query.hasOwnProperty( 'new-homepage' ) }
 			stripeConnectSuccess={ context.query.stripe_connect_success ?? null }
 			showDraftPostModal={ showDraftPostModal() }
 		/>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -142,7 +142,7 @@ class Account extends Component {
 	}
 
 	hasUnsavedUserSetting( settingName ) {
-		return Object.hasOwn( this.props.unsavedUserSettings, settingName );
+		return this.props.unsavedUserSettings.hasOwnProperty( settingName );
 	}
 
 	hasUnsavedUserSettings( settingNames ) {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -4,7 +4,7 @@ import languages from '@automattic/languages';
 import debugFactory from 'debug';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
-import { debounce, flowRight as compose, get, has, map, size } from 'lodash';
+import { debounce, flowRight as compose, get, map, size } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
@@ -142,7 +142,7 @@ class Account extends Component {
 	}
 
 	hasUnsavedUserSetting( settingName ) {
-		return has( this.props.unsavedUserSettings, settingName );
+		return Object.hasOwn( this.props.unsavedUserSettings, settingName );
 	}
 
 	hasUnsavedUserSettings( settingNames ) {

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -1,7 +1,7 @@
 import { ProgressBar } from '@automattic/components';
 import classNames from 'classnames';
 import { numberFormat, localize } from 'i18n-calypso';
-import { has, omit } from 'lodash';
+import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -62,16 +62,14 @@ const hasProgressInfo = ( progress ) => {
 		return false;
 	}
 
-	const types = Object.keys( progress )
-		.map( ( k ) => progress[ k ] )
-		.filter( ( { total } ) => total > 0 );
+	const types = Object.values( progress ).filter( ( { total } ) => total > 0 );
 
 	if ( ! types.length ) {
 		return false;
 	}
 
 	const firstType = types.shift();
-	if ( ! has( firstType, 'completed' ) ) {
+	if ( ! Object.hasOwn( firstType, 'completed' ) ) {
 		return false;
 	}
 

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -69,7 +69,7 @@ const hasProgressInfo = ( progress ) => {
 	}
 
 	const firstType = types.shift();
-	if ( ! Object.hasOwn( firstType, 'completed' ) ) {
+	if ( ! firstType.hasOwnProperty( 'completed' ) ) {
 		return false;
 	}
 

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -137,7 +137,7 @@ class SiteImporterInputPane extends Component {
 		if ( this.state.selectedEndpoint ) {
 			params.force_endpoint = this.state.selectedEndpoint;
 		}
-		if ( Object.hasOwn( this.props.importerData, 'engine' ) ) {
+		if ( this.props.importerData.hasOwnProperty( 'engine' ) ) {
 			params.engine = this.props.importerData.engine;
 		}
 		return params;

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -1,7 +1,7 @@
 import url from 'url'; // eslint-disable-line no-restricted-imports
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { isEmpty, flowRight, has, trim, sortBy } from 'lodash';
+import { isEmpty, flowRight, trim, sortBy } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -137,7 +137,7 @@ class SiteImporterInputPane extends Component {
 		if ( this.state.selectedEndpoint ) {
 			params.force_endpoint = this.state.selectedEndpoint;
 		}
-		if ( has( this.props, 'importerData.engine' ) ) {
+		if ( Object.hasOwn( this.props.importerData, 'engine' ) ) {
 			params.engine = this.props.importerData.engine;
 		}
 		return params;

--- a/client/my-sites/site-settings/date-time-format/utils.js
+++ b/client/my-sites/site-settings/date-time-format/utils.js
@@ -135,7 +135,7 @@ export function phpToMomentDatetimeFormat( momentDate, formatString ) {
 			}
 
 			// Check if character is a recognized mapping token
-			if ( Object.hasOwn( phpToMomentMapping, c ) ) {
+			if ( phpToMomentMapping.hasOwnProperty( c ) ) {
 				return phpToMomentMapping[ c ];
 			}
 

--- a/client/my-sites/site-settings/date-time-format/utils.js
+++ b/client/my-sites/site-settings/date-time-format/utils.js
@@ -1,4 +1,4 @@
-import { has, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 import moment from 'moment-timezone';
 
 /**
@@ -10,7 +10,6 @@ import moment from 'moment-timezone';
  *
  * @see http://momentjs.com/docs/#/manipulating/utc-offset/
  * @see http://momentjs.com/timezone/docs/#/using-timezones/parsing-in-zone/
- *
  * @param {string} timezoneString A timezone string.
  * @returns {object} The timezone-adjusted Moment.js object of the current date and time.
  */
@@ -29,7 +28,6 @@ export function getLocalizedDate( timezoneString ) {
  *
  * @see http://php.net/manual/en/function.date.php#refsect1-function.date-parameters
  * @see http://momentjs.com/docs/#/displaying/format/
- *
  * @type {object}
  */
 const phpToMomentMapping = {
@@ -137,7 +135,7 @@ export function phpToMomentDatetimeFormat( momentDate, formatString ) {
 			}
 
 			// Check if character is a recognized mapping token
-			if ( has( phpToMomentMapping, c ) ) {
+			if ( Object.hasOwn( phpToMomentMapping, c ) ) {
 				return phpToMomentMapping[ c ];
 			}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -3,7 +3,7 @@ import { isBusiness, FEATURE_NO_BRANDING, PLAN_BUSINESS } from '@automattic/caly
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
 import languages from '@automattic/languages';
 import classNames from 'classnames';
-import { flowRight, get, has } from 'lodash';
+import { flowRight, get } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
@@ -273,21 +273,20 @@ export class SiteSettingsFormGeneral extends Component {
 			},
 		};
 		const noticeContent = errors[ langId ];
+		if ( ! noticeContent ) {
+			return null;
+		}
 
 		return (
-			has( noticeContent, 'text' ) && (
-				<Notice
-					text={ noticeContent.text }
-					className="site-settings__language-picker-notice"
-					isCompact
-				>
-					{ has( noticeContent, 'link' ) && (
-						<NoticeAction href={ noticeContent.link } external>
-							{ noticeContent.linkText }
-						</NoticeAction>
-					) }
-				</Notice>
-			)
+			<Notice
+				text={ noticeContent.text }
+				className="site-settings__language-picker-notice"
+				isCompact
+			>
+				<NoticeAction href={ noticeContent.link } external>
+					{ noticeContent.linkText }
+				</NoticeAction>
+			</Notice>
 		);
 	};
 

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -248,7 +248,7 @@ const connectOptionsHoc = connect(
 	( options, actions, ownProps ) => {
 		const { defaultOption, secondaryOption, getScreenshotOption } = ownProps;
 		options = mapValues( options, ( option, name ) => {
-			if ( Object.hasOwn( option, 'action' ) ) {
+			if ( option.hasOwnProperty( 'action' ) ) {
 				return { ...option, action: actions[ name ] };
 			}
 			return option;

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { has, mapValues, pickBy, flowRight as compose } from 'lodash';
+import { mapValues, pickBy, flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
@@ -248,7 +248,7 @@ const connectOptionsHoc = connect(
 	( options, actions, ownProps ) => {
 		const { defaultOption, secondaryOption, getScreenshotOption } = ownProps;
 		options = mapValues( options, ( option, name ) => {
-			if ( has( option, 'action' ) ) {
+			if ( Object.hasOwn( option, 'action' ) ) {
 				return { ...option, action: actions[ name ] };
 			}
 			return option;

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { debounce, filter, get, has, last, map, throttle } from 'lodash';
+import { debounce, get, last, map, throttle } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -162,19 +162,18 @@ class EditorDiffViewer extends PureComponent {
 	render() {
 		const { diff, diffView } = this.props;
 		const classes = classNames( 'editor-diff-viewer', {
-			'is-loading': ! has( diff, 'post_content' ) && ! has( diff, 'post_title' ),
+			'is-loading':
+				! Object.hasOwn( diff, 'post_content' ) && ! Object.hasOwn( diff, 'post_title' ),
 			'is-split': diffView === 'split',
 		} );
 
 		const bottomBoundary = this.state.scrollTop + this.state.viewportHeight;
 
 		// saving to `this` so we can access if from `scrollAbove` and `scrollBelow`
-		this.changesAboveViewport = filter(
-			this.state.changeOffsets,
+		this.changesAboveViewport = this.state.changeOffsets.filter(
 			( offset ) => offset < this.state.scrollTop
 		);
-		this.changesBelowViewport = filter(
-			this.state.changeOffsets,
+		this.changesBelowViewport = this.state.changeOffsets.filter(
 			( offset ) => offset > bottomBoundary
 		);
 

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -163,7 +163,7 @@ class EditorDiffViewer extends PureComponent {
 		const { diff, diffView } = this.props;
 		const classes = classNames( 'editor-diff-viewer', {
 			'is-loading':
-				! Object.hasOwn( diff, 'post_content' ) && ! Object.hasOwn( diff, 'post_title' ),
+				! diff.hasOwnProperty( 'post_content' ) && ! diff.hasOwnProperty( 'post_title' ),
 			'is-split': diffView === 'split',
 		} );
 

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -4,7 +4,7 @@ import displayTypes from 'calypso/state/reader/posts/display-types';
 const { X_POST } = displayTypes;
 
 export function isXPost( post ) {
-	return post && ( post.display_type & X_POST || Object.hasOwn( post.tags, 'p2-xpost' ) );
+	return post && ( post.display_type & X_POST || post.tags.hasOwnProperty( 'p2-xpost' ) );
 }
 
 const exported = {

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -1,11 +1,10 @@
 import { getUrlParts } from '@automattic/calypso-url';
-import { has } from 'lodash';
 import displayTypes from 'calypso/state/reader/posts/display-types';
 
 const { X_POST } = displayTypes;
 
 export function isXPost( post ) {
-	return post && ( post.display_type & X_POST || has( post, [ 'tags', 'p2-xpost' ] ) );
+	return post && ( post.display_type & X_POST || Object.hasOwn( post.tags, 'p2-xpost' ) );
 }
 
 const exported = {

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -1,4 +1,4 @@
-import { get, includes, map, without, has } from 'lodash';
+import { get, includes, map, without } from 'lodash';
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,
@@ -98,7 +98,7 @@ export const pendingActions = function ( state = [], action ) {
 		case COMMENTS_CHANGE_STATUS:
 		case COMMENTS_DELETE: {
 			const key = getRequestKey( action );
-			if ( has( action, 'meta.dataLayer.trackRequest' ) && state.indexOf( key ) === -1 ) {
+			if ( action.meta?.dataLayer?.trackRequest && ! state.includes( key ) ) {
 				return [ ...state, key ];
 			}
 			return state;

--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -1,4 +1,3 @@
-import { has } from 'lodash';
 import {
 	ANALYTICS_EVENT_RECORD,
 	HELP_CONTACT_FORM_SITE_SELECT,
@@ -128,7 +127,7 @@ export const sendActionLogsAndEvents = ( { getState, dispatch }, action ) => {
 	}
 
 	// If there's analytics metadata attached to this action, send analytics events
-	if ( has( action, 'meta.analytics' ) ) {
+	if ( action.meta?.analytics ) {
 		sendAnalyticsLogEvent( dispatch, action );
 	}
 

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -235,9 +235,7 @@ export function isRequestingLists( state = false, action ) {
 export const errors = withSchemaValidation( errorsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case READER_LIST_UPDATE_FAILURE:
-			const newError = {};
-			newError[ action.list.ID ] = action.error.statusCode;
-			return Object.assign( {}, state, newError );
+			return { ...state, [ action.list.ID ]: action.error.statusCode };
 	}
 
 	return state;

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -89,7 +89,7 @@ export function isUpdatedList( state, listId ) {
  * @returns {boolean}        Whether list has an error
  */
 export function hasError( state, listId ) {
-	return Object.hasOwn( state.reader.lists.errors, listId );
+	return state.reader.lists.errors.hasOwnProperty( listId );
 }
 
 /**

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
-import { filter, find, has, includes } from 'lodash';
+import { filter, find } from 'lodash';
 import { withoutHttp } from 'calypso/lib/url';
 import getCurrentIntlCollator from 'calypso/state/selectors/get-current-intl-collator';
 import 'calypso/state/reader/init';
@@ -78,10 +78,7 @@ export const getSubscribedLists = createSelector(
  * @returns {boolean}        Whether lists are being requested
  */
 export function isUpdatedList( state, listId ) {
-	if ( ! has( state, 'reader.lists.updatedLists' ) ) {
-		return false;
-	}
-	return includes( state.reader.lists.updatedLists, listId );
+	return state.reader.lists.updatedLists.includes( listId );
 }
 
 /**
@@ -92,11 +89,7 @@ export function isUpdatedList( state, listId ) {
  * @returns {boolean}        Whether list has an error
  */
 export function hasError( state, listId ) {
-	if ( ! has( state, 'reader.lists.errors' ) ) {
-		return false;
-	}
-
-	return listId in state.reader.lists.errors;
+	return Object.hasOwn( state.reader.lists.errors, listId );
 }
 
 /**
@@ -108,7 +101,7 @@ export function hasError( state, listId ) {
  * @returns {?object}        Reader list
  */
 export function getListByOwnerAndSlug( state, owner, slug ) {
-	if ( ! has( state, 'reader.lists.items' ) || ! owner || ! slug ) {
+	if ( ! owner || ! slug ) {
 		return;
 	}
 
@@ -121,7 +114,7 @@ export function getListByOwnerAndSlug( state, owner, slug ) {
 }
 
 export function getListItems( state, listId ) {
-	return state.reader?.lists?.listItems?.[ listId ];
+	return state.reader.lists.listItems[ listId ];
 }
 
 export function getMatchingItem( state, { feedUrl, feedId, listId, siteId, tagId } ) {
@@ -137,7 +130,7 @@ export function getMatchingItem( state, { feedUrl, feedId, listId, siteId, tagId
 		}
 	}
 
-	const list = state.reader?.lists?.listItems?.[ listId ]?.filter( ( item ) => {
+	const list = state.reader.lists.listItems[ listId ]?.filter( ( item ) => {
 		if ( feedId && item.feed_ID ) {
 			return +item.feed_ID === +feedId;
 		} else if ( siteId && item.site_ID ) {
@@ -163,7 +156,7 @@ export function isSubscribedByOwnerAndSlug( state, owner, slug ) {
 	if ( ! list ) {
 		return false;
 	}
-	return includes( state.reader.lists.subscribedLists, list.ID );
+	return state.reader.lists.subscribedLists.includes( list.ID );
 }
 
 /**

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { has, keyBy, get, omit } from 'lodash';
+import { keyBy, get, omit } from 'lodash';
 import stepsConfig from 'calypso/signup/config/steps-pure';
 import {
 	SIGNUP_COMPLETE_RESET,
@@ -83,7 +83,7 @@ const completeStep = ( state, { step } ) => updateStep( state, { ...step, status
 const invalidateStep = ( state, { step, errors } ) => {
 	const newStepState = { ...step, errors, status: 'invalid' };
 
-	return has( state, step.stepName )
+	return Object.hasOwn( state, step.stepName )
 		? updateStep( state, newStepState )
 		: addStep( state, newStepState );
 };
@@ -93,7 +93,7 @@ const processStep = ( state, { step } ) => updateStep( state, { ...step, status:
 const saveStep = ( state, { step } ) => {
 	const status = get( state, [ step.stepName, 'status' ] );
 
-	return has( state, step.stepName )
+	return Object.hasOwn( state, step.stepName )
 		? updateStep( state, {
 				...step,
 				// The pending status means this step needs to delay api requests until the setup-site flow completes
@@ -109,7 +109,7 @@ const submitStep = ( state, { step } ) => {
 	const stepHasApiRequestFunction = get( stepsConfig, [ step.stepName, 'apiRequestFunction' ] );
 	const status = stepHasApiRequestFunction ? 'pending' : 'completed';
 
-	return has( state, step.stepName )
+	return Object.hasOwn( state, step.stepName )
 		? updateStep( state, { ...step, status } )
 		: addStep( state, { ...step, status } );
 };

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -83,7 +83,7 @@ const completeStep = ( state, { step } ) => updateStep( state, { ...step, status
 const invalidateStep = ( state, { step, errors } ) => {
 	const newStepState = { ...step, errors, status: 'invalid' };
 
-	return Object.hasOwn( state, step.stepName )
+	return state.hasOwnProperty( step.stepName )
 		? updateStep( state, newStepState )
 		: addStep( state, newStepState );
 };
@@ -93,7 +93,7 @@ const processStep = ( state, { step } ) => updateStep( state, { ...step, status:
 const saveStep = ( state, { step } ) => {
 	const status = get( state, [ step.stepName, 'status' ] );
 
-	return Object.hasOwn( state, step.stepName )
+	return state.hasOwnProperty( step.stepName )
 		? updateStep( state, {
 				...step,
 				// The pending status means this step needs to delay api requests until the setup-site flow completes
@@ -109,7 +109,7 @@ const submitStep = ( state, { step } ) => {
 	const stepHasApiRequestFunction = get( stepsConfig, [ step.stepName, 'apiRequestFunction' ] );
 	const status = stepHasApiRequestFunction ? 'pending' : 'completed';
 
-	return Object.hasOwn( state, step.stepName )
+	return state.hasOwnProperty( step.stepName )
 		? updateStep( state, { ...step, status } )
 		: addStep( state, { ...step, status } );
 };

--- a/client/state/support-articles-alternates/selectors.js
+++ b/client/state/support-articles-alternates/selectors.js
@@ -1,4 +1,4 @@
-import { get, has, isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { keyToString } from 'calypso/reader/post-key';
 
 import 'calypso/state/support-articles-alternates/init';
@@ -14,7 +14,7 @@ export const isRequestingSupportArticleAlternates = ( state, postKeySegments ) =
 	const postKey = keyToString( postKeySegments );
 
 	return (
-		has( state.supportArticlesAlternates.requests, [ postKey ] ) &&
+		Object.hasOwn( state.supportArticlesAlternates.requests, postKey ) &&
 		isEmpty( get( state.supportArticlesAlternates.requests, [ postKey ] ) )
 	);
 };
@@ -55,7 +55,7 @@ export const isRequestingSupportArticleAlternatesFailed = ( state, postKeySegmen
 export const shouldRequestSupportArticleAlternates = ( state, postKeySegments ) => {
 	const postKey = keyToString( postKeySegments );
 
-	return ! has( state.supportArticlesAlternates.requests, [ postKey ] );
+	return ! Object.hasOwn( state.supportArticlesAlternates.requests, postKey );
 };
 
 /**

--- a/client/state/support-articles-alternates/selectors.js
+++ b/client/state/support-articles-alternates/selectors.js
@@ -14,8 +14,8 @@ export const isRequestingSupportArticleAlternates = ( state, postKeySegments ) =
 	const postKey = keyToString( postKeySegments );
 
 	return (
-		Object.hasOwn( state.supportArticlesAlternates.requests, postKey ) &&
-		isEmpty( get( state.supportArticlesAlternates.requests, [ postKey ] ) )
+		state.supportArticlesAlternates.requests.hasOwnProperty( postKey ) &&
+		isEmpty( state.supportArticlesAlternates.requests[ postKey ] )
 	);
 };
 
@@ -55,7 +55,7 @@ export const isRequestingSupportArticleAlternatesFailed = ( state, postKeySegmen
 export const shouldRequestSupportArticleAlternates = ( state, postKeySegments ) => {
 	const postKey = keyToString( postKeySegments );
 
-	return ! Object.hasOwn( state.supportArticlesAlternates.requests, postKey );
+	return ! state.supportArticlesAlternates.requests.hasOwnProperty( postKey );
 };
 
 /**

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -1,4 +1,4 @@
-import { get, has, includes } from 'lodash';
+import { get } from 'lodash';
 import { GUIDED_TOUR_UPDATE, ROUTE_SET, SITE_SETTINGS_RECEIVE } from 'calypso/state/action-types';
 import { THEMES_REQUEST_SUCCESS } from 'calypso/state/themes/action-types';
 
@@ -17,11 +17,11 @@ const relevantTypes = {
 
 const hasRelevantAnalytics = ( action ) =>
 	get( action, 'meta.analytics', [] ).some( ( record ) =>
-		includes( relevantAnalyticsEvents, record.payload.name )
+		relevantAnalyticsEvents.includes( record.payload.name )
 	);
 
 const isRelevantActionType = ( action ) =>
-	has( relevantTypes, action.type ) &&
+	Object.hasOwn( relevantTypes, action.type ) &&
 	( typeof relevantTypes[ action.type ] !== 'function' || relevantTypes[ action.type ]( action ) );
 
 const overSome = ( checks ) => ( item ) => checks.some( ( check ) => check( item ) );

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -21,7 +21,7 @@ const hasRelevantAnalytics = ( action ) =>
 	);
 
 const isRelevantActionType = ( action ) =>
-	Object.hasOwn( relevantTypes, action.type ) &&
+	relevantTypes.hasOwnProperty( action.type ) &&
 	( typeof relevantTypes[ action.type ] !== 'function' || relevantTypes[ action.type ]( action ) );
 
 const overSome = ( checks ) => ( item ) => checks.some( ( check ) => check( item ) );


### PR DESCRIPTION
Removes usages of `_.has` and replace them with `Object.hasOwn` ([this ESLint rule](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-object-has-own.md) inspired me).

The main thing to review is that the checked object is always a valid object. Unlike `_.has`, `Object.hasOwn` would crash when passed `null` or `undefined`. For example, in Reader, a `post` always has an `.author` and `.tags`, but you should verify that. In Redux reducers, there were several selectors where checks can be removed, because that particular slice of state is always present and has the expected type (object or array).
