### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` Jetpack authorize to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -18,28 +18,6 @@ function Undocumented( wpcom ) {
 	this.wpcom = wpcom;
 }
 
-Undocumented.prototype.jetpackLogin = function ( siteId, _wp_nonce, redirect_uri, scope, state ) {
-	debug( '/jetpack-blogs/:site_id:/jetpack-login query' );
-	const endpointUrl = '/jetpack-blogs/' + siteId + '/jetpack-login';
-	const params = { _wp_nonce, redirect_uri, scope, state };
-	return this.wpcom.req.get( { path: endpointUrl }, params );
-};
-
-Undocumented.prototype.jetpackAuthorize = function (
-	siteId,
-	code,
-	state,
-	redirect_uri,
-	secret,
-	jp_version,
-	from
-) {
-	debug( '/jetpack-blogs/:site_id:/authorize query' );
-	const endpointUrl = '/jetpack-blogs/' + siteId + '/authorize';
-	const params = { code, state, redirect_uri, secret, jp_version, from };
-	return this.wpcom.req.post( { path: endpointUrl }, params );
-};
-
 Undocumented.prototype.jetpackIsUserConnected = function ( siteId ) {
 	debug( '/sites/:site_id:/jetpack-connect/is-user-connected query' );
 	const endpointUrl = '/sites/' + siteId + '/jetpack-connect/is-user-connected';

--- a/client/state/jetpack-connect/actions/authorize.js
+++ b/client/state/jetpack-connect/actions/authorize.js
@@ -37,18 +37,28 @@ export function authorize( queryObject ) {
 			type: JETPACK_CONNECT_AUTHORIZE,
 			queryObject: queryObject,
 		} );
-		return wpcom
-			.undocumented()
-			.jetpackLogin( client_id, _wp_nonce, redirect_uri, scope, state )
+
+		return wpcom.req
+			.get( '/jetpack-blogs/' + client_id + '/jetpack-login', {
+				_wp_nonce,
+				redirect_uri,
+				scope,
+				state,
+			} )
 			.then( ( data ) => {
 				debug( 'Jetpack login complete. Trying Jetpack authorize.', data );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_LOGIN_COMPLETE,
 					data,
 				} );
-				return wpcom
-					.undocumented()
-					.jetpackAuthorize( client_id, data.code, state, redirect_uri, secret, jp_version, from );
+				return wpcom.req.post( '/jetpack-blogs/' + client_id + '/authorize', {
+					code: data.code,
+					state,
+					redirect_uri,
+					secret,
+					jp_version,
+					from,
+				} );
 			} )
 			.then( ( data ) => {
 				debug( 'Jetpack authorize complete. Updating sites list.', data );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` Jetpack authorize methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Create a test JN site from https://jurassic.ninja/create
* Open the site admin.
* Click on the "Set up Jetpack" button in wp-admin.
* Verify it leads you successfully through the Jetpack Connect flow and authorization goes successfully.
* Verify tests still pass: `yarn run test-client client/state/jetpack-connect`