### PR TITLE
Sections dropdown on mobile polish 

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -293,10 +293,6 @@ $plugin-details-header-padding: 100px;
 			border-bottom-color: transparent;
 		}
 
-		&:first-child .section-nav-tab__link {
-			padding-left: 0;
-		}
-
 		.section-nav-tab__link {
 			font-size: $font-body-small;
 
@@ -357,9 +353,9 @@ $plugin-details-header-padding: 100px;
 		}
 	}
 
-	@media screen and ( max-width: 480px ) {
+	@media screen and ( min-width: 481px ) {
 		.section-nav-tab:first-child .section-nav-tab__link {
-			padding-left: 15px;
+			padding-left: 0;
 		}
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -299,16 +299,13 @@ $plugin-details-header-padding: 100px;
 
 		.section-nav-tab__link {
 			font-size: $font-body-small;
-			color: var( --studio-gray-60 );
 
 			&:hover {
 				background-color: transparent;
-				color: var( --studio-black );
 			}
 		}
 
 		&.is-selected .section-nav-tab__link {
-			color: var( --studio-black );
 			font-weight: bold;
 			border-bottom: none;
 		}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -359,6 +359,12 @@ $plugin-details-header-padding: 100px;
 			border-bottom: 1px solid var( --studio-gray-5 );
 		}
 	}
+
+	@media screen and ( max-width: 480px ) {
+		.section-nav-tab:first-child .section-nav-tab__link {
+			padding-left: 15px;
+		}
+	}
 }
 
 .plugin-details__sites-list-background + .plugin-details__body {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reset the padding for mobile layouts.
* Remove the hard setting of colors on tabs link and background.

#### Testing instructions
1. Open a tab on https://wordpress.com/me/account and let it open
1. Go to `/plugins` page
1. Select a plugin to go to **Plugin Details** page
1. Check the tabs (Description, Installation, Changelog, FAQ) colors and background to see if they are visible and offers enough contrast
1. Change to mobile view and check the same aspects as step 4
1. Change the theme on the opened tab on step 1, and verify again the steps 4 and 5

There should be enough contrast in desktop and mobile views of all themes.

#### Demo

|Desktop | Mobile|
|-------|------|
|![Screen Shot 2021-11-30 at 10 04 21](https://user-images.githubusercontent.com/5039531/144066891-c933df45-bbae-43d5-8256-d63d91d87ba7.png)|![Screen Shot 2021-11-30 at 10 19 08](https://user-images.githubusercontent.com/5039531/144066836-e1aab889-40b0-4414-96e3-8a8ea5b07ffa.png)|



---
Fixes #58290
