### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` reader import to `wpcom.req`

### DIFF
--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -39,7 +39,17 @@ class ReaderImportButton extends Component {
 		}
 
 		this.fileName = file.name;
-		const req = wpcom.undocumented().importReaderFeed( file, this.onImport );
+		const req = wpcom.req.post(
+			{
+				path: '/read/following/mine/import',
+				formData: [ [ 'import', file ] ],
+			},
+			{
+				apiVersion: '1.2',
+			},
+			null,
+			this.onImport
+		);
 		req.upload.onprogress = this.onImportProgress;
 
 		this.setState( {

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -44,6 +44,8 @@ class ReaderImportButton extends Component {
 				path: '/read/following/mine/import',
 				formData: [ [ 'import', file ] ],
 			},
+			// XXX: kind strange, wpcom.js, that `apiVersion` must be in `query`
+			// *and* pass a `body` of null for this to work properly…
 			{
 				apiVersion: '1.2',
 			},

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -287,29 +287,6 @@ Undocumented.prototype.getSiteConnectInfo = function ( inputUrl ) {
 };
 
 /**
- * Imports given XML file into the user's Reader feed.
- * XML file is expected to be in OPML format.
- *
- * @param {globalThis.File}     file         The File object to upload
- * @param {Function} fn           The callback function
- * @returns {globalThis.XMLHttpRequest} The XHR instance, to attach `progress`
- *   listeners to, etc.
- */
-Undocumented.prototype.importReaderFeed = function ( file, fn ) {
-	debug( '/read/following/mine/import' );
-	const params = {
-		path: '/read/following/mine/import',
-		formData: [ [ 'import', file ] ],
-	};
-	// XXX: kind strange, wpcom.js, that `apiVersion` must be in `query`
-	// *and* pass a `body` of null for this to work properly…
-	const query = {
-		apiVersion: '1.2',
-	};
-	return this.wpcom.req.post( params, query, null, fn );
-};
-
-/**
  * Requests streamlined approval to WordAds program
  *
  * @param {number}       siteId            The site ID


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` reader feed import method to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Go to `/following/manage`
* Click on the ellipsis and make an export.
* Manually edit the export file, and leave only 1 site in it.
* Unsubscribe from that site in the reader
* Click on the ellipsis, and click Import, then select the export file.
* Verify import works successfully like it did before.