### PR TITLE
Update copy of license key activation instruction step

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
@@ -84,7 +84,7 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 			>
 				<p>
 					{ translate(
-						'Use your license key to activate your product after installing Jetpack. You can also find the activation link on your {{strong}}WP Admin Jetpack Dashboard > My Plan{{/strong}} page.',
+						'Go to your {{strong}}WP Admin Jetpack Dashboard > My Plan{{/strong}} page after Jetpack is installed, and use this license key to activate your product.',
 						{
 							components: {
 								strong: <strong />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Small copy improvement to make it more precise and straightforward how to use the license key.

#### Testing instructions

* Download this PR.
* Start Calypso with `yarn start`.
* Visit `http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-manual-activate-license-key/jetpack_backup_t1_monthly`.
* Verify that the paragraph below the title says: 
> Go to your WP Admin Jetpack Dashboard > My Plan page after Jetpack is installed, and use this license key to activate your product.

**Note**: it is expected to see nothing in the license key input box.

Related to 1201096622142517-as-1201431693192895

#### Demo – before
![image](https://user-images.githubusercontent.com/3418513/143877344-a395613e-70c0-4a5c-a14e-e22b0b6fc257.png)

#### Demo – after
![image](https://user-images.githubusercontent.com/3418513/143877323-d71d4288-6522-4010-926f-6d17c9916cfc.png)
