### PR TITLE
Store Stats: Fix direct state mutation in search form

### DIFF
--- a/client/my-sites/store/app/store-stats/referrers/index.js
+++ b/client/my-sites/store/app/store-stats/referrers/index.js
@@ -59,8 +59,10 @@ class Referrers extends Component {
 				queryParams: { referrer, ...queryParams },
 			} = this.props;
 			const widgetPath = getWidgetPath( unit, slug, queryParams );
-			this.state.filter = '';
-			this.state.selectedReferrer = {};
+			this.setState( {
+				filter: '',
+				selectedReferrer: {},
+			} );
 			page( `${ basePath }${ widgetPath }` );
 		}
 		this.setData( this.props, trimmedStr );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an instance where we directly mutate `this.state` in a React component. It occurs in the store stats referrers component and has been introduced in #24802.

#### Testing instructions

* Open `/store/stats/referrers/day/:site` where `:site` is a WooCommerce store.
* Verify the search form still works well, particularly when resetting the search form to an empty string.