### PR TITLE
Activity Log: Fix template syntax in string literal

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -14,7 +14,7 @@ const fromApi = ( data ) => {
 	const restoreId = parseInt( data.restore_id, 10 );
 
 	if ( Number.isNaN( restoreId ) ) {
-		throw new SchemaError( 'missing numeric restore id - found `${ data.restore_id }`' );
+		throw new SchemaError( `missing numeric restore id - found '${ data.restore_id }'` );
 	}
 
 	return restoreId;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an instance where we meant to use template literal with a variable inside, but we used string literal. Judging by how the line looks, it appears that the single quote character and backtick were meant to be used the other way around.

#### Testing instructions

Should not be necessary - just verify syntax is now correct and the variable will be displayed correctly. 