### PR TITLE
Comments: Cleanup unused component state in `PostCommentList`

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -254,7 +254,7 @@ class PostCommentList extends Component {
 		recordGaEvent( 'Clicked Cancel Reply to Comment' );
 		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_cancel_click', {
 			blog_id: this.props.post.site_ID,
-			comment_id: this.state.activeReplyCommentId,
+			comment_id: this.props.activeReplyCommentId,
 		} );
 		this.resetActiveReplyComment();
 	};

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -87,7 +87,6 @@ class PostCommentList extends Component {
 
 	state = {
 		amountOfCommentsToTake: this.props.initialSize,
-		commentsFilter: 'all',
 	};
 
 	shouldFetchInitialComment = ( { startingCommentId, initialComment } ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up some unused component state from `PostCommentList`:

* `activeReplyCommentId` is a prop, so when recording an event, we should pick it from the prop, not the component state
* `commentsFilter` is not used, so we're removing it.

#### Testing instructions

* Verify comment threads under a post in the full post view of the Reader still work well.