### PR TITLE
State: Remove unused `getCurrentUserLocaleVariant` selector

### DIFF
--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -52,14 +52,6 @@ export const createCurrentUserSelector = ( path, otherwise = null ) => ( state )
 export const getCurrentUserLocale = createCurrentUserSelector( 'localeSlug' );
 
 /**
- * Returns the locale variant slug for the current user.
- *
- * @param  {object}  state  Global state tree
- * @returns {?string}        Current user locale variant
- */
-export const getCurrentUserLocaleVariant = createCurrentUserSelector( 'localeVariant' );
-
-/**
  * Returns the country code for the current user.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/current-user/test/selectors.js
+++ b/client/state/current-user/test/selectors.js
@@ -2,7 +2,6 @@ import {
 	getCurrentUserId,
 	getCurrentUser,
 	getCurrentUserLocale,
-	getCurrentUserLocaleVariant,
 	getCurrentUserDate,
 	isUserLoggedIn,
 	getCurrentUserEmail,
@@ -93,45 +92,6 @@ describe( 'selectors', () => {
 			} );
 
 			expect( locale ).toBe( 'fr' );
-		} );
-	} );
-
-	describe( '#getCurrentUserLocaleVariant', () => {
-		test( 'should return null if the current user is not set', () => {
-			const locale = getCurrentUserLocaleVariant( {
-				currentUser: {
-					id: null,
-				},
-			} );
-
-			expect( locale ).toBeNull();
-		} );
-
-		test( 'should return null if the current user locale slug is not set', () => {
-			const locale = getCurrentUserLocaleVariant( {
-				currentUser: {
-					id: 73705554,
-					user: { ID: 73705554, login: 'testonesite2014' },
-				},
-			} );
-
-			expect( locale ).toBeNull();
-		} );
-
-		test( 'should return the current user locale variant slug', () => {
-			const locale = getCurrentUserLocaleVariant( {
-				currentUser: {
-					id: 73705554,
-					user: {
-						ID: 73705554,
-						login: 'testonesite2014',
-						localeSlug: 'fr',
-						localeVariant: 'fr_formal',
-					},
-				},
-			} );
-
-			expect( locale ).toBe( 'fr_formal' );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `getCurrentUserLocaleVariant` selector is unused. This PR removes it, along with its tests.

#### Testing instructions

Verify the removed `getCurrentUserLocaleVariant` selector is not in use.