### PR TITLE
Checkout: Fix error triggered when renewing G Suite subscription

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -469,11 +469,11 @@ export function getGoogleApps( cart ) {
  * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function googleApps( properties ) {
-	const { domain, meta, product_slug, quantity, new_quantity, users } = properties;
+	const { domain, meta, quantity, new_quantity, users } = properties;
 
 	const domainName = meta ?? domain;
 
-	const productSlug = product_slug || GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+	const productSlug = camelOrSnakeSlug( properties ) || GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
 
 	const extra = {
 		google_apps_users: users,

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -465,7 +465,8 @@ export function getGoogleApps( cart ) {
 /**
  * Creates a new shopping cart item for G Suite or Google Workspace.
  *
- * @param {object} properties - list of properties
+ * @typedef {import('@automattic/shopping-cart').GSuiteProductUser} GSuiteProductUser
+ * @param {{domain: string, meta?: string, new_quantity?: number, productSlug: string, quantity?: number, users: GSuiteProductUser[] }} properties - list of properties
  * @returns {import('@automattic/shopping-cart').RequestCartProduct} the new item
  */
 export function googleApps( properties ) {


### PR DESCRIPTION
This pull request fixes a `Sorry, this user account does not own the product you are trying to renew.` error shown when renewing a G Suite subscription:

![image](https://user-images.githubusercontent.com/594356/143901016-73c0a498-e97f-494c-a155-58a65eee618f.png)


This error is triggered when the product is added to the shopping cart because it has the product id of a Google Workspace subscription, and not the one of G Suite. The backend then returns an error because it cannot find the subscription record with that wrong product id. This fixes a regression introduced in 5dab659cab3eb0eead84ee847fba803e1225b80d.

#### Testing instructions

1. Run `git checkout fix/checkout-gsuite` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/58592#issuecomment-981771879)
2. Log into a WordPress.com account that has a site with G Suite
3. Open the [`Purchases` page](http://calypso.localhost:3000/purchases/subscriptions)
4. Click on your G Suite subscription to access the `Purchase Settings` page
5. Click the `Renew Now` button
6. Assert that no error is displayed in the checkout
7. Assert that there is a line for G Suite in the `Your order` section