### PR TITLE
Add feature flag: themes/premium

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, Popover, Gridicon } from '@automattic/components';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
@@ -364,6 +365,7 @@ class ThemesMagicSearchCard extends Component {
 					>
 						{ searchField }
 					</div>
+					{ config.isEnabled( 'themes/premium' ) && <div>Premium Themes Enabled</div> }
 				</StickyPanel>
 			</div>
 		);

--- a/config/development.json
+++ b/config/development.json
@@ -152,6 +152,7 @@
 		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
+		"themes/premium": false,
 		"titan/iframe-control-panel": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -99,6 +99,7 @@
 		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
+		"themes/premium": false,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -105,6 +105,7 @@
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,
+		"themes/premium": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,6 +106,7 @@
 		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
+		"themes/premium": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/test.json
+++ b/config/test.json
@@ -79,6 +79,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
+		"themes/premium": false,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -115,6 +115,7 @@
 		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
+		"themes/premium": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add feature flag: themes/premium

#### Testing instructions

* Turn off [the isomorphic attribute in sections.js](https://github.com/Automattic/wp-calypso/blob/2d83eba7292941ed1ceebe0cc481d0646dcdca73/client/sections.js#L213)
* Visit `http://calypso.localhost:3000/themes/<site>` - Should look normal
* Visit `http://calypso.localhost:3000/themes/<site>?flags=themes/premium` - Should have extra text

![2021-11-29_10-32](https://user-images.githubusercontent.com/937354/143906207-d88a468d-416b-4457-8c87-68489b8cae6e.png)

