### PR TITLE
Domains: Add conditions to show transfer options depending on type of site

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -26,7 +26,14 @@ import './style.scss';
 
 const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 	const { __ } = useI18n();
-	const { selectedSite, currentRoute, selectedDomainName } = props;
+	const {
+		currentRoute,
+		isAtomic,
+		isDomainOnly,
+		isPrimaryDomain,
+		selectedDomainName,
+		selectedSite,
+	} = props;
 
 	const renderBreadcrumbs = () => {
 		const items = [
@@ -58,12 +65,13 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
 	};
 
-	return (
-		<Main className="transfer-page" wideLayout>
-			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-			{ renderBreadcrumbs() }
-			<Card>
+	const renderTransferOptions = () => {
+		const options = [];
+
+		if ( ! isDomainOnly ) {
+			options.push(
 				<ActionCard
+					key="transfer-to-another-user"
 					buttonHref={ domainManagementTransferToAnotherUser(
 						selectedSite.slug,
 						selectedDomainName,
@@ -75,8 +83,17 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 					headerText={ __( 'To another user' ) }
 					mainText={ __( 'Transfer this domain to any administrator on this site' ) }
 				/>
-				<div className="transfer-page__item-separator"></div>
+			);
+		}
+
+		if ( ! ( isPrimaryDomain && isAtomic ) ) {
+			if ( options.length > 0 ) {
+				options.push( <div key="separator" className="transfer-page__item-separator"></div> );
+			}
+
+			options.push(
 				<ActionCard
+					key="transfer-to-another-site"
 					buttonHref={ domainManagementTransferToOtherSite(
 						selectedSite.slug,
 						selectedDomainName,
@@ -88,7 +105,17 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 					headerText={ __( 'To another WordPress.com site' ) }
 					mainText={ __( 'Transfer this domain to any site you are an administrator on' ) }
 				/>
-			</Card>
+			);
+		}
+
+		return options.length > 0 ? <Card>{ options }</Card> : null;
+	};
+
+	return (
+		<Main className="transfer-page" wideLayout>
+			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+			{ renderBreadcrumbs() }
+			{ renderTransferOptions() }
 		</Main>
 	);
 };

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -30,6 +30,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 		currentRoute,
 		isAtomic,
 		isDomainOnly,
+		isMapping,
 		isPrimaryDomain,
 		selectedDomainName,
 		selectedSite,
@@ -69,6 +70,10 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 		const options = [];
 
 		if ( ! isDomainOnly ) {
+			const mainText = isMapping
+				? __( 'Transfer this domain connection to any administrator on this site' )
+				: __( 'Transfer this domain to any administrator on this site' );
+
 			options.push(
 				<ActionCard
 					key="transfer-to-another-user"
@@ -81,7 +86,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 					buttonText={ __( 'Continue' ) }
 					// translators: Transfer a domain to another user
 					headerText={ __( 'To another user' ) }
-					mainText={ __( 'Transfer this domain to any administrator on this site' ) }
+					mainText={ mainText }
 				/>
 			);
 		}
@@ -90,6 +95,9 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			if ( options.length > 0 ) {
 				options.push( <div key="separator" className="transfer-page__item-separator"></div> );
 			}
+			const mainText = isMapping
+				? __( 'Transfer this domain connection to any site you are an administrator on' )
+				: __( 'Transfer this domain to any site you are an administrator on' );
 
 			options.push(
 				<ActionCard
@@ -103,7 +111,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 					buttonText={ __( 'Continue' ) }
 					// translators: Transfer a domain to another WordPress.com site
 					headerText={ __( 'To another WordPress.com site' ) }
-					mainText={ __( 'Transfer this domain to any site you are an administrator on' ) }
+					mainText={ mainText }
 				/>
 			);
 		}

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
@@ -2,8 +2,11 @@ import { ResponseDomain } from 'calypso/lib/domains/types';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 export type TransferPageProps = {
+	currentRoute: string;
 	domains: ResponseDomain[];
+	isAtomic: boolean;
+	isDomainOnly: boolean;
+	isPrimaryDomain: boolean;
 	selectedDomainName: string;
 	selectedSite: SiteData;
-	currentRoute: string;
 };

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
@@ -6,6 +6,7 @@ export type TransferPageProps = {
 	domains: ResponseDomain[];
 	isAtomic: boolean;
 	isDomainOnly: boolean;
+	isMapping: boolean;
 	isPrimaryDomain: boolean;
 	selectedDomainName: string;
 	selectedSite: SiteData;


### PR DESCRIPTION
### Changes proposed in this Pull Request

#58354 added transfer options to the redesigned transfer page but did not include the conditions in which each one should be shown. This PR updates the `TransferPage` component with those conditions, which are the same as in the `domains/domain-management/transfer/index.jsx` component. This PR also fixes the transfer option labels when managing a domain connection - they should read `Transfer this domain connection...` instead of only `Transfer this domain...`

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select one of your registered domains
- If you're in the live Calypso link, please append `?flags=domains/transfers-redesign` to your URL to enable the appropriate feature flag
- Select the "Transfer your domain" options

If your site is domain-only, you should only see the "Transfer to another site" option. If your site is atomic _and_ the domain you selected is primary, you should only see the "Transfer to another user" option. In all other conditions, both options should be visible.

Please also check the transfer options for a domain connection and ensure the labels are correctly showing "domain connection" instead of just "domain".

