### PR TITLE
Domains: Update breadcrumbs styling to reflect latest Figma designs

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
@@ -34,10 +34,7 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 	const renderItemLabel = ( item ) => {
 		if ( item.href ) {
 			return (
-				<a
-					className="breadcrumbs__item-label breadcrumbs__item-label--clickable"
-					href={ item.href }
-				>
+				<a className="breadcrumbs__item-label is-clickable" href={ item.href }>
 					{ item.label }
 				</a>
 			);

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
@@ -34,7 +34,7 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 	const renderItemLabel = ( item ) => {
 		if ( item.href ) {
 			return (
-				<a className="breadcrumbs__item-label is-clickable" href={ item.href }>
+				<a className="breadcrumbs__item-label" href={ item.href }>
 					{ item.label }
 				</a>
 			);

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
@@ -69,8 +69,8 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 
 	const renderItem = ( item, index ) => {
 		const classes = classNames( 'breadcrumbs__item', {
-			// We don't use the last-child selector here because there might be a help bubble after this element
 			'is-last-item': index === items.length - 1,
+			'is-only-item': items.length === 1,
 		} );
 		return (
 			<React.Fragment key={ `breadcrumb${ index }` }>

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/index.jsx
@@ -67,13 +67,19 @@ const Breadcrumbs = ( { items, mobileItem, buttons, mobileButtons, className } )
 		/* eslint-enable wpcalypso/jsx-gridicon-size */
 	};
 
-	const renderItem = ( item, index ) => (
-		<React.Fragment key={ `breadcrumb${ index }` }>
-			<span className="breadcrumbs__item">{ renderItemLabel( item ) }</span>
-			{ renderHelpBubble( item ) }
-			{ renderSeparator( index ) }
-		</React.Fragment>
-	);
+	const renderItem = ( item, index ) => {
+		const classes = classNames( 'breadcrumbs__item', {
+			// We don't use the last-child selector here because there might be a help bubble after this element
+			'is-last-item': index === items.length - 1,
+		} );
+		return (
+			<React.Fragment key={ `breadcrumb${ index }` }>
+				<span className={ classes }>{ renderItemLabel( item ) }</span>
+				{ renderHelpBubble( item ) }
+				{ renderSeparator( index ) }
+			</React.Fragment>
+		);
+	};
 
 	const renderBackArrow = () => {
 		if ( mobileItem.showBackArrow && mobileItem.href ) {

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -67,11 +67,15 @@
 		& .breadcrumbs__item {
 			.breadcrumbs__item-label {
 				color: var( --color-neutral-50 );
+
+				&:hover {
+					color: var( --color-neutral-80 );
+				}
 			}
 
 			&:last-child {
 				.breadcrumbs__item-label {
-					font-weight: 600;
+					font-weight: 500; /* stylelint-disable-line */
 					color: var( --color-neutral-80 );
 				}
 			}

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -83,6 +83,7 @@
 			&.is-only-item {
 				.breadcrumbs__item-label {
 					font-weight: 600;
+					font-size: $font-body;
 					color: var( --color-neutral-80 );
 				}
 			}
@@ -107,6 +108,7 @@
 		/* This rule applies when there's no back arrow present */
 		span:first-child {
 			font-weight: 600;
+			font-size: $font-body;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -62,26 +62,17 @@
 		display: flex;
 		align-items: center;
 		font-size: 13px; /* stylelint-disable-line */
-		font-weight: 500; /* stylelint-disable-line */
-		color: var( --color-neutral-80 );
+		font-weight: 400;
 
 		& .breadcrumbs__item {
-			color: var( --color-neutral-80 );
-
-			& .breadcrumbs__item-label {
-				color: var( --color-neutral-80 );
-			}
-
-			&:first-child {
-				.breadcrumbs__item-label {
-					font-size: $font-body;
-					font-weight: 600;
-				}
+			.breadcrumbs__item-label {
+				color: var( --color-neutral-50 );
 			}
 
 			&:last-child {
 				.breadcrumbs__item-label {
-					color: var( --color-neutral-50 );
+					font-weight: 600;
+					color: var( --color-neutral-80 );
 				}
 			}
 		}
@@ -91,30 +82,16 @@
 .breadcrumbs__items-mobile {
 	display: flex;
 	align-items: center;
+	font-size: 13px; /* stylelint-disable-line */
+	font-weight: 400;
 
 	& .breadcrumbs__item {
 		display: flex;
 		align-items: center;
-	}
 
-	& .breadcrumbs__item-label {
-		color: var( --color-neutral-80 );
-		font-size: 13px; /* stylelint-disable-line */
-	}
-
-	& .breadcrumbs__item:first-child {
-		font-size: $font-body;
-		font-weight: 600;
-		color: var( --color-neutral-50 );
-
-		& .breadcrumbs__item-label {
-			font-size: $font-body;
+		.breadcrumbs__item-label {
+			color: var( --color-neutral-50 );
 		}
-	}
-	& span:first-child {
-		font-size: $font-body;
-		font-weight: 600;
-		color: var( --color-neutral-80 );
 	}
 
 	@include break-mobile {
@@ -134,7 +111,7 @@
 
 .breadcrumbs__separator {
 	margin: 0 12px;
-	color: var( --color-neutral-20 );
+	color: var( --color-neutral-10 );
 }
 
 .breadcrumbs__buttons,

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -73,7 +73,7 @@
 				}
 			}
 
-			&:last-child {
+			&.is-last-item {
 				.breadcrumbs__item-label {
 					font-weight: 500; /* stylelint-disable-line */
 					color: var( --color-neutral-80 );
@@ -94,7 +94,12 @@
 		align-items: center;
 
 		.breadcrumbs__item-label {
-			color: var( --color-neutral-50 );
+			color: var( --color-neutral-80 );
+		}
+
+		/* This rule applies when there's no back arrow present */
+		span:first-child {
+			font-weight: 600;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -79,6 +79,13 @@
 					color: var( --color-neutral-80 );
 				}
 			}
+
+			&.is-only-item {
+				.breadcrumbs__item-label {
+					font-weight: 600;
+					color: var( --color-neutral-80 );
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

When I had implemented #57038, I based the breadcrumbs design on i3 of the domain management pages redesign project (`hlVh2q24ad6MCwlwNnE9PQ-fi-600%3A53112`), but the latest iteration was i4. This PR updates the styling to reflect the newest designs. Thanks @hambai for noticing this!

The main differences are:
- All labels are the same size (13px) and color (`--color-neutral-50` = `rgb(100, 105, 112)` = `#646970`)
- Only the last breadcrumb is bold (font-weight 600) and has color `--color-neutral-80` (= `rgb(44, 51, 56)` = `#2c3338`)
- The separators are lighter in color (`--color-neutral-10` = `rgb(195, 196, 199)` = `#c3c4c7`)
- Breadcrumb links become color `--color-neutral-80` when hovered

Check the changes between the following screenshots:

Before:

<img width="400" alt="Screen Shot 2021-11-29 at 16 51 39" src="https://user-images.githubusercontent.com/5324818/143933386-570038e5-3c0d-42dd-96e1-517617775712.png">

After:

<img width="365" alt="Screen Shot 2021-11-29 at 16 45 38" src="https://user-images.githubusercontent.com/5324818/143933275-58bfafa6-bb32-48f4-971a-b334b669e188.png">

For the mobile view, the only difference is that the label was darker and now it's lighter.

Before:

<img width="400" alt="Screen Shot 2021-11-29 at 17 14 55" src="https://user-images.githubusercontent.com/5324818/143936616-c6ad1672-6ed4-4d2a-90c4-3923557f3b30.png">

After:

<img width="409" alt="Screen Shot 2021-11-29 at 17 11 55" src="https://user-images.githubusercontent.com/5324818/143936631-bb9b1d44-2521-4503-a002-3566fd0c683b.png">

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select one of your registered domains or domain connections
- If you're in the live Calypso link, please append ?flags=domains/transfers-redesign to your URL to enable the appropriate feature flag
- Select the "Transfer your domain" options (or any other page that has breadcrumbs)
- Ensure the layout updates described are present
