### PR TITLE
Woop: Point the landing page at the new installer for non-Atomic sites

### DIFF
--- a/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
+++ b/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
@@ -80,6 +80,7 @@ class RequiredPluginsInstallView extends Component {
 		skipConfirmation: PropTypes.bool,
 		isFeatureActive: PropTypes.bool,
 		upgradingPlan: PropTypes.object,
+		isAtomicSite: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -581,6 +582,7 @@ class RequiredPluginsInstallView extends Component {
 			translate,
 			isFeatureActive,
 			upgradingPlan,
+			isAtomicSite,
 			siteSlug,
 		} = this.props;
 		const { engineState, progress, totalSeconds } = this.state;
@@ -593,6 +595,7 @@ class RequiredPluginsInstallView extends Component {
 						startSetup={ this.startSetup }
 						isFeatureActive={ isFeatureActive }
 						upgradingPlan={ upgradingPlan }
+						isAtomicSite={ isAtomicSite }
 						siteSlug={ siteSlug }
 					/>
 				</>

--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -9,6 +9,7 @@ import { isLoaded as arePluginsLoaded } from 'calypso/state/plugins/installed/se
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import RequiredPluginsInstallView from './dashboard/required-plugins-install-view';
@@ -28,6 +29,8 @@ function WooCommerce() {
 	const hasWoopFeatureAvailable = useSelector( ( state ) =>
 		hasAvailableSiteFeature( state, siteId, FEATURE_WOOP )
 	);
+
+	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 
 	/*
 	 * We pick the first plan from the available plans list.
@@ -52,6 +55,7 @@ function WooCommerce() {
 						siteSlug={ siteSlug }
 						isFeatureActive={ isWoopFeatureActive }
 						upgradingPlan={ upgradingPlan }
+						isAtomicSite={ isAtomicSite }
 					/>
 				) }
 			</Main>

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -16,6 +16,7 @@ interface Props {
 	startSetup: () => void;
 	isFeatureActive: boolean;
 	upgradingPlan: Record< string, unknown >;
+	isAtomicSite: boolean;
 	siteSlug: string;
 }
 
@@ -26,12 +27,18 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( {
 	siteSlug,
 	isFeatureActive,
 	upgradingPlan,
+	isAtomicSite,
 } ) => {
 	const { __ } = useI18n();
 	const navigationItems = [ { label: 'WooCommerce', href: `/woocommerce-installation` } ];
 	const ctaRef = useRef( null );
 
 	function onCTAHandler() {
+		if ( ! isAtomicSite ) {
+			// Redirect to to the new woo onboarding flow for Atomic transfer.
+			return ( window.location.href = `/start/woocommerce-install/confirm?siteSlug=${ siteSlug }` );
+		}
+
 		if ( ! isFeatureActive && upgradingPlan?.product_slug ) {
 			return ( window.location.href = addQueryArgs(
 				{ redirect_to: window.location.href },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Point the landing page at the new installer for non-Atomic sites

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Atomic site with business plan: go to /woocommerce-installation and click "Set up my store". The flow should stay on /woocommerce-installation and install Woo.
* Atomic site without business plan: go to /woocommerce-installation and click "Upgrade to WordPress.com Business". The flow should take you to checkout, then back to /woocommerce-installation and install Woo.
* Simple site with business plan: go to /woocommerce-installation and click "Set up my store". You should be redirected to /start/woocommerce-install/confirm?siteSlug={the-site-slug}.
* Simple site without business plan: go to /woocommerce-installation and click "Upgrade to WordPress.com Business". You should be redirected to /start/woocommerce-install/confirm?siteSlug={the-site-slug}.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58385
