### PR TITLE
Theme Showcase: Add segmented control for theme tiers behind feature flag

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -302,6 +302,7 @@ class ThemeShowcase extends Component {
 			pathName,
 			title,
 			filterString,
+			isMultisite,
 			locale,
 		} = this.props;
 		const tier = '';
@@ -397,6 +398,7 @@ class ThemeShowcase extends Component {
 						onSearch={ this.doSearch }
 						search={ filterString + search }
 						tier={ tier }
+						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect }
 					/>
 					{ isLoggedIn && (

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -280,7 +280,7 @@ class ThemesMagicSearchCard extends Component {
 	render() {
 		const { translate, filters, showTierThemesControl } = this.props;
 		const { isPopoverVisible } = this.state;
-		const isPremiumThemesEnabled = true || config.isEnabled( 'themes/premium' );
+		const isPremiumThemesEnabled = config.isEnabled( 'themes/premium' );
 
 		const tiers = [
 			{ value: 'all', label: translate( 'All' ) },

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -280,7 +280,7 @@ class ThemesMagicSearchCard extends Component {
 	render() {
 		const { translate, filters, showTierThemesControl } = this.props;
 		const { isPopoverVisible } = this.state;
-		const isPremiumThemesEnabled = config.isEnabled( 'themes/premium' );
+		const isPremiumThemesEnabled = true || config.isEnabled( 'themes/premium' );
 
 		const tiers = [
 			{ value: 'all', label: translate( 'All' ) },

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -10,6 +10,7 @@ import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import KeyedSuggestions from 'calypso/components/keyed-suggestions';
 import Search from 'calypso/components/search';
+import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import StickyPanel from 'calypso/components/sticky-panel';
 import { getThemeFilters, getThemeFilterToTermTable } from 'calypso/state/themes/selectors';
 import MagicSearchWelcome from './welcome';
@@ -21,11 +22,19 @@ const preferredOrderOfTaxonomies = [ 'feature', 'layout', 'column', 'subject', '
 
 class ThemesMagicSearchCard extends Component {
 	static propTypes = {
+		tier: PropTypes.string,
+		select: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		onSearch: PropTypes.func.isRequired,
 		search: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+		showTierThemesControl: PropTypes.bool,
 		isBreakpointActive: PropTypes.bool, // comes from withMobileBreakpoint HOC
+	};
+
+	static defaultProps = {
+		tier: 'all',
+		showTierThemesControl: true,
 	};
 
 	constructor( props ) {
@@ -269,8 +278,15 @@ class ThemesMagicSearchCard extends Component {
 	};
 
 	render() {
-		const { translate, filters } = this.props;
+		const { translate, filters, showTierThemesControl } = this.props;
 		const { isPopoverVisible } = this.state;
+		const isPremiumThemesEnabled = config.isEnabled( 'themes/premium' );
+
+		const tiers = [
+			{ value: 'all', label: translate( 'All' ) },
+			{ value: 'free', label: translate( 'Free' ) },
+			{ value: 'premium', label: translate( 'Premium' ) },
+		];
 
 		const filtersKeys = [
 			...intersection( preferredOrderOfTaxonomies, Object.keys( filters ) ),
@@ -364,6 +380,14 @@ class ThemesMagicSearchCard extends Component {
 						onClick={ this.handleClickInside }
 					>
 						{ searchField }
+						{ isPremiumThemesEnabled && showTierThemesControl && (
+							<SimplifiedSegmentedControl
+								key={ this.props.tier }
+								initialSelected={ this.props.tier || 'all' }
+								options={ tiers }
+								onSelect={ this.props.select }
+							/>
+						) }
 					</div>
 					{ config.isEnabled( 'themes/premium' ) && <div>Premium Themes Enabled</div> }
 				</StickyPanel>

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -389,7 +389,6 @@ class ThemesMagicSearchCard extends Component {
 							/>
 						) }
 					</div>
-					{ config.isEnabled( 'themes/premium' ) && <div>Premium Themes Enabled</div> }
 				</StickyPanel>
 			</div>
 		);

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -218,7 +218,7 @@ export const ConnectedThemesSelection = connect(
 		const query = {
 			search,
 			page,
-			tier: true || config.isEnabled( 'themes/premium' ) ? tier : 'free',
+			tier: config.isEnabled( 'themes/premium' ) ? tier : 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number,
 		};

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { compact, isEqual, property, snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -190,7 +191,16 @@ function bindGetPremiumThemePrice( state, siteId ) {
 export const ConnectedThemesSelection = connect(
 	(
 		state,
-		{ filter, page, search, vertical, siteId, source, isLoading: isCustomizedThemeListLoading }
+		{
+			filter,
+			page,
+			search,
+			tier,
+			vertical,
+			siteId,
+			source,
+			isLoading: isCustomizedThemeListLoading,
+		}
 	) => {
 		const isJetpack = isJetpackSite( state, siteId );
 		let sourceSiteId;
@@ -208,7 +218,7 @@ export const ConnectedThemesSelection = connect(
 		const query = {
 			search,
 			page,
-			tier: '',
+			tier: config.isEnabled( 'themes/premium' ) ? tier : 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number,
 		};

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -218,7 +218,7 @@ export const ConnectedThemesSelection = connect(
 		const query = {
 			search,
 			page,
-			tier: config.isEnabled( 'themes/premium' ) ? tier : 'free',
+			tier: true || config.isEnabled( 'themes/premium' ) ? tier : 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number,
 		};

--- a/config/test.json
+++ b/config/test.json
@@ -79,7 +79,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
-		"themes/premium": false,
+		"themes/premium": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -50,6 +50,24 @@ export class ThemesPage {
 	}
 
 	/**
+	 * Filters the themes on page according to the pricing structure.
+	 *
+	 * @param {string} type Pre-defined types of themes.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async filterThemes( type: 'All' | 'Free' | 'Premium' ): Promise< void > {
+		await this.pageSettled();
+
+		const selector = `a[role="radio"]:has-text("${ type }")`;
+		await this.page.click( selector );
+		const button = await this.page.waitForSelector( selector );
+
+		// Wait for placeholder to disappear (indicating load is completed).
+		await this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } );
+		await this.page.waitForFunction( ( element: any ) => element.ariaChecked === 'true', button );
+	}
+
+	/**
 	 * Given a keyword, perform a search in the Themes toolbar.
 	 *
 	 * @param {string} keyword Theme name to search for. Can be a partial match.

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -49,7 +49,8 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 
 	it( `Search for free theme with keyword ${ themeName }`, async function () {
 		themesPage = new ThemesPage( page );
-		await themesPage.filterThemes( 'Free' );
+		// 2021-11-29: Turn this on when premium themes are activated for everyone. -mreishus
+		// await themesPage.filterThemes( 'Free' );
 		await themesPage.search( themeName );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -49,6 +49,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 
 	it( `Search for free theme with keyword ${ themeName }`, async function () {
 		themesPage = new ThemesPage( page );
+		await themesPage.filterThemes( 'Free' );
 		await themesPage.search( themeName );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -46,6 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 
 	it( `Search for free theme with keyword ${ themeName }`, async function () {
 		themesPage = new ThemesPage( page );
+		await themesPage.filterThemes( 'Free' );
 		await themesPage.search( themeName );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -46,7 +46,8 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 
 	it( `Search for free theme with keyword ${ themeName }`, async function () {
 		themesPage = new ThemesPage( page );
-		await themesPage.filterThemes( 'Free' );
+		// 2021-11-29: Turn this on when premium themes are activated for everyone. -mreishus
+		// await themesPage.filterThemes( 'Free' );
 		await themesPage.search( themeName );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For existing users with no flag changes: Everything should be exactly the same
* When the `themes/premium` flag is enabled: Bring back the `[ All | Free | Premium ]` selector on the theme showcase
* Undoes the changes in #55863
* Part of this project: pdgA0m-8k-p2

#### Testing instructions

* Turn off [the isomorphic attribute in sections.js](https://github.com/Automattic/wp-calypso/blob/2d83eba7292941ed1ceebe0cc481d0646dcdca73/client/sections.js#L213)
* Visit `http://calypso.localhost:3000/themes/<site>` - Should look and act normal, including searches and theme showcase tabs
* Visit `http://calypso.localhost:3000/themes/<site>?flags=themes/premium` - Should have the `[ All | Free | Premium ]` selector on the theme showcase
![2021-11-29_14-35](https://user-images.githubusercontent.com/937354/143939287-51943726-7de1-4ada-8d01-76666314652a.png)
