### PR TITLE
Videos UI: Mark a video as complete when played far enough.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -135,6 +135,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 				<div className="videos-ui__video-content">
 					{ currentVideo && (
 						<VideoPlayer
+							completedSeconds={ currentVideo.completed_seconds }
 							videoRef={ videoRef }
 							videoUrl={ currentVideo.url }
 							isPlaying={ isPlaying }

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,6 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
-const VideoPlayer = ( { videoRef, videoUrl, isPlaying, poster = undefined } ) => {
+const VideoPlayer = ( { completedSeconds, videoRef, videoUrl, isPlaying, poster = undefined } ) => {
+	const [ addTimeUpdateHandler, setAddTimeUpdateHandler ] = useState( true );
+
+	const markVideoAsComplete = () => {
+		if ( videoRef.current.currentTime < completedSeconds ) {
+			return;
+		}
+		setAddTimeUpdateHandler( false );
+	};
+
 	useEffect( () => {
 		if ( isPlaying ) {
 			videoRef.current.play();
@@ -9,7 +18,13 @@ const VideoPlayer = ( { videoRef, videoUrl, isPlaying, poster = undefined } ) =>
 
 	return (
 		<div key={ videoUrl } className="videos-ui__video">
-			<video controls ref={ videoRef } poster={ poster } autoPlay={ isPlaying }>
+			<video
+				controls
+				ref={ videoRef }
+				poster={ poster }
+				autoPlay={ isPlaying }
+				onTimeUpdate={ addTimeUpdateHandler ? markVideoAsComplete : undefined }
+			>
 				<source src={ videoUrl } />{ ' ' }
 				{ /* @TODO: check if tracks are available, the linter demands one */ }
 				<track src="caption.vtt" kind="captions" srcLang="en" label="english_captions" />


### PR DESCRIPTION
This PR adds an event handler that constantly compares the progressing timestamp of a playing video to the `completed_seconds` property of the rendered course. When the former surpasses the latter, the videos is marked as complete in the UI and an API call is made to update the back-end.

**Testing Instructions**
* Load the videos UI on My Home by clicking "Start learning" in its education card.
* One the videos UI has opened, play an incomplete video (one without a green checkmark.
* Fast-forward the video to a few seconds before its `completed_seconds` count (which can be found in the `/courses` API call result in devtools).
* Play the video through the completed point, and verify that `markVideoAsCompleted` stops firing past the completed point.

<img width="360" alt="Screen Shot 2021-11-29 at 12 59 41 PM" src="https://user-images.githubusercontent.com/349751/143942366-604e6c8e-736c-4b20-9784-e8da568563a0.png">