### PR TITLE
CI: alert Slack channel for every run of P2 E2E.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -928,7 +928,6 @@ object P2E2ETests : BuildType({
 			buildFailed = true
 			buildFinishedSuccessfully = true
 			buildFailedToStart = true
-			firstSuccessAfterFailure = true
 			buildProbablyHanging = true
 		}
 		notifications {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR corrects an unintentional mistake in the P2 E2E configuration, so the `e2eflowtesting-p2` channel is alerted for every failure, hang, failed to start and passing builds.

Related to #56664.