### PR TITLE
Domains: DNS Records list updates

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -23,7 +23,7 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 					<PopoverMenuItem
 						disabled={ record.protected_field }
 						key={ key++ }
-						onClick={ () => ! record.protected_field && action.callback( record ) }
+						onClick={ () => action.callback( record ) }
 					>
 						{ action.icon }
 						{ action.title }

--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -17,11 +17,14 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 			}
 			popoverClassName="dns-records-list-item__action-menu-popover"
 			position="bottom left"
-			disabled={ actions.length === 0 }
 		>
 			{ actions.map( ( action ) => {
 				return (
-					<PopoverMenuItem key={ key++ } onClick={ () => action.callback( record ) }>
+					<PopoverMenuItem
+						disabled={ record.protected_field }
+						key={ key++ }
+						onClick={ () => ! record.protected_field && action.callback( record ) }
+					>
 						{ action.icon }
 						{ action.title }
 					</PopoverMenuItem>

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -31,7 +31,7 @@ class DnsRecordsList extends Component {
 			<MaterialIcon
 				icon="do_not_disturb"
 				className="gridicon dns-records-list__action-menu-item"
-				viewBox="2 2 20 20"
+				viewBox="0 0 20 20"
 			/>
 		),
 		title: this.props.translate( 'Disable' ),

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -184,10 +184,6 @@ class DnsRecordsList extends Component {
 	}
 
 	getActionsForDnsRecord( record ) {
-		if ( record.protected_field ) {
-			return [];
-		}
-
 		if ( this.isDomainConnectRecord( record ) ) {
 			return [
 				record.enabled ? this.disableRecordAction : this.enableRecordAction,

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -195,6 +195,12 @@ body.dns__body-white {
 		svg {
 			fill: var( --studio-gray-90 );
 		}
+
+		&:disabled, &:disabled:hover {
+			svg {
+				fill: var( --color-neutral-20 );
+			}
+		}
 	}
 
 	.popover__menu-item.is-selected,

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -131,7 +131,6 @@ body.dns__body-white {
 					}
 
 					&.dns-records-list-item__type {
-						color: $gray-900;
 						overflow-wrap: break-word;
 
 						@include break-mobile {

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -86,7 +86,7 @@ body.dns__body-white {
 
 			&.is-header {
 				border-bottom: 1px solid $gray-20;
-				font-weight: 500; /* stylelint-disable-line */
+				font-weight: 600; /* stylelint-disable-line */
 				display: none;
 
 				@include break-mobile {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Some small improvements to the DNS records list page. See here: pcYYhz-q9-p2#comment-362.

#### Preview
![image](https://user-images.githubusercontent.com/18705930/143946639-22dfdeb4-9a65-4485-90b1-4910a8599630.png)

#### Testing instructions
- Go to `/domains/manage/:yoursite`
- Go to the DNS records list page: `Change your name servers & DNS records > DNS records`
- Append `?flags=domains/dns-records-redesign` to your URL
- Make sure that these layout changes are reflected:
  - "Type" column has the same color as the other ones;
  - Action buttons (3 dot menu) for the protected records are now enabled, but their options are disabled;
  - Action's icon is now centered with the action's text;
  - Action popover is now displayed below the 3 dot menu (it was above previously).
