### PR TITLE
Add: mobile app banner to site list

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -224,6 +224,8 @@ const SiteSetupList = ( {
 		}
 	};
 
+	let isMobileAppTaskCompleted = false;
+
 	return (
 		<Card className={ classnames( 'site-setup-list', { 'is-loading': isLoading } ) }>
 			{ isLoading && <Spinner /> }
@@ -263,6 +265,10 @@ const SiteSetupList = ( {
 						const enhancedTask = getTask( task, { isBlogger, userEmail } );
 						const isCurrent = task.id === currentTask.id;
 						const isCompleted = task.isCompleted;
+
+						if ( task.id === CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED ) {
+							isMobileAppTaskCompleted = isCompleted;
+						}
 
 						return (
 							<li key={ task.id } className={ `site-setup-list__task-${ task.id }` }>
@@ -319,7 +325,7 @@ const SiteSetupList = ( {
 						);
 					} ) }
 				</ul>
-				<MobileAppDownload />
+				{ ! isMobileAppTaskCompleted && <MobileAppDownload /> }
 			</div>
 		</Card>
 	);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -224,7 +224,9 @@ const SiteSetupList = ( {
 		}
 	};
 
-	let isMobileAppTaskCompleted = false;
+	const isMobileAppTaskCompleted = tasks.some(
+		( task ) => task.id === CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED && task.isCompleted
+	);
 
 	return (
 		<Card className={ classnames( 'site-setup-list', { 'is-loading': isLoading } ) }>
@@ -260,15 +262,15 @@ const SiteSetupList = ( {
 				<CardHeading>
 					{ isBlogger ? translate( 'Blog setup' ) : translate( 'Site setup' ) }
 				</CardHeading>
-				<ul className="site-setup-list__list">
+				<ul
+					className={ classnames( 'site-setup-list__list', {
+						'is-mobile-app-completed': isMobileAppTaskCompleted,
+					} ) }
+				>
 					{ tasks.map( ( task ) => {
 						const enhancedTask = getTask( task, { isBlogger, userEmail } );
 						const isCurrent = task.id === currentTask.id;
 						const isCompleted = task.isCompleted;
-
-						if ( task.id === CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED ) {
-							isMobileAppTaskCompleted = isCompleted;
-						}
 
 						return (
 							<li key={ task.id } className={ `site-setup-list__task-${ task.id }` }>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -23,6 +23,7 @@ import { getSiteOption, getSiteSlug, getCustomizerUrl } from 'calypso/state/site
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CurrentTaskItem from './current-task-item';
 import { getTask } from './get-task';
+import MobileAppDownload from './mobile-app-download';
 import NavItem from './nav-item';
 
 /**
@@ -264,7 +265,7 @@ const SiteSetupList = ( {
 						const isCompleted = task.isCompleted;
 
 						return (
-							<li key={ task.id }>
+							<li key={ task.id } className={ `site-setup-list__task-${ task.id }` }>
 								<NavItem
 									key={ task.id }
 									taskId={ task.id }
@@ -318,6 +319,7 @@ const SiteSetupList = ( {
 						);
 					} ) }
 				</ul>
+				<MobileAppDownload />
 			</div>
 		</Card>
 	);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
@@ -1,48 +1,26 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
+import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
 import userAgent from 'calypso/lib/user-agent';
 
 const MobileAppDownload = () => {
 	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
-
-	let appLink = 'https://apps.wordpress.com/mobile';
-	let linkType = 'general';
+	const isIos = isiPad || isiPod || isiPhone;
+	const showIosBadge = ! isAndroid;
+	const showAndroidBadge = ! isIos;
 
 	const utm_source = 'calypso-customer-home-site-setup';
-	if ( isiPad || isiPod || isiPhone ) {
-		appLink = `https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=${ utm_source }&mt=8`;
-		linkType = 'ios';
-	}
-
-	if ( isAndroid ) {
-		appLink = `https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3D%${ utm_source }`;
-		linkType = 'android';
-	}
 
 	return (
 		<div className="mobile-app-download">
-			<div className="mobile-app-download__app-icon">
-				<Gridicon icon="my-sites" size={ 48 } />
-			</div>
 			<div className="mobile-app-download__text">
 				<h2 className="mobile-app-download__title">{ translate( 'WordPress app' ) }</h2>
 				<p className="mobile-app-download__description">
 					{ translate( 'Make updates on the go.' ) }
 				</p>
-				<a
-					className="mobile-app-download__link"
-					href={ appLink }
-					target="_blank"
-					onClick={ () => {
-						recordTracksEvent( 'calypso_mobile_app_download_link_click', {
-							type_of_link: linkType,
-						} );
-					} }
-					rel="noopener noreferrer"
-				>
-					{ translate( 'Download' ) }
-				</a>
+				{ showIosBadge && <AppsBadge storeName={ 'ios' } utm_source={ utm_source }></AppsBadge> }
+				{ showAndroidBadge && (
+					<AppsBadge storeName={ 'android' } utm_source={ utm_source }></AppsBadge>
+				) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
@@ -1,0 +1,61 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Gridicon } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
+import userAgent from 'calypso/lib/user-agent';
+
+const MobileAppDownload = () => {
+	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
+
+	const appLink = 'https://apps.wordpress.com/mobile';
+	let linkType = 'general';
+	let showIosBadge = false;
+	let showAndroidBadge = false;
+
+	if ( isiPad || isiPod || isiPhone ) {
+		showIosBadge = true;
+		linkType = 'ios';
+	}
+
+	if ( isAndroid ) {
+		showAndroidBadge = true;
+		linkType = 'ios';
+	}
+
+	return (
+		<div className="mobile-app-download">
+			<div className="mobile-app-download__app-icon">
+				<Gridicon icon="my-sites" size={ 48 } />
+			</div>
+			<div className="mobile-app-download__text">
+				<h2 className="mobile-app-download__title">{ translate( 'WordPress app' ) }</h2>
+				<p className="mobile-app-download__description">
+					{ translate( 'Make updates on the go.' ) }
+				</p>
+				{ ! showIosBadge && ! showAndroidBadge && (
+					<a
+						className="mobile-app-download__link"
+						href={ appLink }
+						target="_blank"
+						onClick={ () => {
+							recordTracksEvent( 'calypso_mobile_app_download_link_click', {
+								type_of_link: linkType,
+							} );
+						} }
+						rel="noreferrer"
+					>
+						{ translate( 'Learn more' ) }
+					</a>
+				) }
+				{ showIosBadge && (
+					<AppsBadge storeName={ 'ios' } utm_source={ 'calypso-customer-home' }></AppsBadge>
+				) }
+				{ showAndroidBadge && (
+					<AppsBadge storeName={ 'android' } utm_source={ 'calypso-customer-home' }></AppsBadge>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default MobileAppDownload;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
@@ -3,34 +3,34 @@ import { translate } from 'i18n-calypso';
 import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
 import userAgent from 'calypso/lib/user-agent';
 
+const showBadge = ( isIosDevice, isAndroidDevice ) => {
+	const utm_source = 'calypso-customer-home-site-setup';
+
+	if ( isIosDevice ) {
+		return <AppsBadge storeName={ 'ios' } utm_source={ utm_source }></AppsBadge>;
+	}
+	if ( isAndroidDevice ) {
+		return <AppsBadge storeName={ 'android' } utm_source={ utm_source }></AppsBadge>;
+	}
+
+	return (
+		<a
+			href="https://apps.wordpress.com/mobile"
+			onClick={ () => {
+				recordTracksEvent( 'calypso_mobile_app_download_link_click_learn_more' );
+			} }
+			rel="noopener noreferrer"
+			className="mobile-app-download__link"
+			target="_blank"
+		>
+			{ translate( 'Learn more' ) }
+		</a>
+	);
+};
+
 const MobileAppDownload = () => {
 	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
 	const isIos = isiPad || isiPod || isiPhone;
-
-	const showBadge = ( isIosDevice, isAndroidDevice ) => {
-		const utm_source = 'calypso-customer-home-site-setup';
-
-		if ( isIosDevice ) {
-			return <AppsBadge storeName={ 'ios' } utm_source={ utm_source }></AppsBadge>;
-		}
-		if ( isAndroidDevice ) {
-			return <AppsBadge storeName={ 'android' } utm_source={ utm_source }></AppsBadge>;
-		}
-
-		return (
-			<a
-				href="https://apps.wordpress.com/mobile"
-				onClick={ () => {
-					recordTracksEvent( 'calypso_mobile_app_download_link_click_learn_more' );
-				} }
-				rel="noopener noreferrer"
-				className="mobile-app-download__link"
-				target="_blank"
-			>
-				{ translate( 'Learn more' ) }
-			</a>
-		);
-	};
 
 	return (
 		<div className="mobile-app-download">

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
@@ -1,25 +1,23 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
-import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
 import userAgent from 'calypso/lib/user-agent';
 
 const MobileAppDownload = () => {
 	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
 
-	const appLink = 'https://apps.wordpress.com/mobile';
+	let appLink = 'https://apps.wordpress.com/mobile';
 	let linkType = 'general';
-	let showIosBadge = false;
-	let showAndroidBadge = false;
 
+	const utm_source = 'calypso-customer-home-site-setup';
 	if ( isiPad || isiPod || isiPhone ) {
-		showIosBadge = true;
+		appLink = `https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=${ utm_source }&mt=8`;
 		linkType = 'ios';
 	}
 
 	if ( isAndroid ) {
-		showAndroidBadge = true;
-		linkType = 'ios';
+		appLink = `https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3D%${ utm_source }`;
+		linkType = 'android';
 	}
 
 	return (
@@ -32,27 +30,19 @@ const MobileAppDownload = () => {
 				<p className="mobile-app-download__description">
 					{ translate( 'Make updates on the go.' ) }
 				</p>
-				{ ! showIosBadge && ! showAndroidBadge && (
-					<a
-						className="mobile-app-download__link"
-						href={ appLink }
-						target="_blank"
-						onClick={ () => {
-							recordTracksEvent( 'calypso_mobile_app_download_link_click', {
-								type_of_link: linkType,
-							} );
-						} }
-						rel="noreferrer"
-					>
-						{ translate( 'Learn more' ) }
-					</a>
-				) }
-				{ showIosBadge && (
-					<AppsBadge storeName={ 'ios' } utm_source={ 'calypso-customer-home' }></AppsBadge>
-				) }
-				{ showAndroidBadge && (
-					<AppsBadge storeName={ 'android' } utm_source={ 'calypso-customer-home' }></AppsBadge>
-				) }
+				<a
+					className="mobile-app-download__link"
+					href={ appLink }
+					target="_blank"
+					onClick={ () => {
+						recordTracksEvent( 'calypso_mobile_app_download_link_click', {
+							type_of_link: linkType,
+						} );
+					} }
+					rel="noopener noreferrer"
+				>
+					{ translate( 'Download' ) }
+				</a>
 			</div>
 		</div>
 	);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/mobile-app-download.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { translate } from 'i18n-calypso';
 import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
 import userAgent from 'calypso/lib/user-agent';
@@ -5,10 +6,31 @@ import userAgent from 'calypso/lib/user-agent';
 const MobileAppDownload = () => {
 	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
 	const isIos = isiPad || isiPod || isiPhone;
-	const showIosBadge = ! isAndroid;
-	const showAndroidBadge = ! isIos;
 
-	const utm_source = 'calypso-customer-home-site-setup';
+	const showBadge = ( isIosDevice, isAndroidDevice ) => {
+		const utm_source = 'calypso-customer-home-site-setup';
+
+		if ( isIosDevice ) {
+			return <AppsBadge storeName={ 'ios' } utm_source={ utm_source }></AppsBadge>;
+		}
+		if ( isAndroidDevice ) {
+			return <AppsBadge storeName={ 'android' } utm_source={ utm_source }></AppsBadge>;
+		}
+
+		return (
+			<a
+				href="https://apps.wordpress.com/mobile"
+				onClick={ () => {
+					recordTracksEvent( 'calypso_mobile_app_download_link_click_learn_more' );
+				} }
+				rel="noopener noreferrer"
+				className="mobile-app-download__link"
+				target="_blank"
+			>
+				{ translate( 'Learn more' ) }
+			</a>
+		);
+	};
 
 	return (
 		<div className="mobile-app-download">
@@ -17,10 +39,7 @@ const MobileAppDownload = () => {
 				<p className="mobile-app-download__description">
 					{ translate( 'Make updates on the go.' ) }
 				</p>
-				{ showIosBadge && <AppsBadge storeName={ 'ios' } utm_source={ utm_source }></AppsBadge> }
-				{ showAndroidBadge && (
-					<AppsBadge storeName={ 'android' } utm_source={ utm_source }></AppsBadge>
-				) }
+				{ showBadge( isIos, isAndroid ) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -287,8 +287,6 @@
 	font-weight: 600;
 	font-size: $font-body;
 	line-height: 19px;
-	display: flex;
-	align-items: flex-end;
 	letter-spacing: -0.45px;
 
 	/* Blue / Blue 50 */

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -233,3 +233,95 @@
 		display: block;
 	}
 }
+
+.mobile-app-download {
+	background: #f6f7f7;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 4px;
+	position: relative;
+	overflow: hidden;
+	display: flex;
+	padding: 16px;
+	margin: 16px;
+
+	@include break-medium {
+		display: none;
+	}
+
+	.get-apps__app-badge {
+		margin-left: 0;
+	}
+}
+
+.mobile-app-download__app-icon {
+	background: #0675c4;
+	color: #fff;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 10px;
+	width: 44px;
+	height: 44px;
+
+	.gridicon {
+		margin: 3px;
+		width: 38px;
+		height: 38px;
+	}
+}
+
+.mobile-app-download__title {
+	font-style: normal;
+	font-weight: 600;
+	font-size: $font-body;
+	line-height: 19px;
+	margin-bottom: 2px;
+
+	/* identical to box height */
+	letter-spacing: -0.154px;
+
+	/* Gray / Gray 80 */
+	color: #2c3338;
+}
+
+.mobile-app-download__description {
+	font-style: normal;
+	font-weight: normal;
+	font-size: $font-body-small;
+	line-height: 17px;
+
+	/* identical to box height */
+	letter-spacing: -0.154px;
+	margin-bottom: 16px;
+
+	/* Gray / Gray 40 */
+	color: #787c82;
+}
+
+.mobile-app-download__link {
+	font-weight: 600;
+	font-size: $font-body;
+	line-height: 19px;
+	display: flex;
+	align-items: flex-end;
+	letter-spacing: -0.45px;
+
+	/* Blue / Blue 50 */
+	color: #0675c4;
+}
+.mobile-app-download__text {
+	margin-left: 16px;
+}
+
+.site-setup-list .site-setup-list__list li:last-child {
+	border-bottom: 1px solid var( --color-border-subtle );
+	@include break-medium {
+		border-bottom: inherit;
+	}
+}
+
+.site-setup-list__task-mobile_app_installed {
+	display: none;
+
+	@include break-medium {
+		display: block;
+	}
+}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -235,7 +235,6 @@
 }
 
 .mobile-app-download {
-	background: #f6f7f7;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 4px;
 	position: relative;
@@ -244,6 +243,9 @@
 	padding: 16px;
 	margin: 16px;
 
+	background: #f6f7f7 url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='84' height='108' fill='none'%3E%3Cg filter='url(%23a)'%3E%3Crect width='65.761' height='83.3' y='16.7' fill='%23fff' rx='8'/%3E%3C/g%3E%3Cpath stroke='%238C8F94' stroke-linecap='round' d='M55.066 27.153h5.98M55.066 30.153h5.98M55.066 33.153h5.98'/%3E%3Crect width='7' height='7' x='7.354' y='27.153' fill='%238C8F94' stroke='%238C8F94' rx='.5'/%3E%3Cpath stroke='%23C5D9ED' stroke-linecap='round' d='M7.354 44.153h54.001M7.354 49.153h31.001'/%3E%3Cpath fill='%23E9EFF5' d='M6.854 54.099h51.501v32.172H6.854z'/%3E%3Cpath fill='%23DCDCDE' d='m53.453 70.527-19.5 15.744h24.63V75.319l-5.13-4.792Z'/%3E%3Cpath fill='%23F5E6B3' stroke='%23F0C930' stroke-width='.633' d='M18.903 66.736a3.054 3.054 0 1 0-.002-6.107 3.054 3.054 0 0 0 .002 6.107Z'/%3E%3Cpath fill='%23FFD60A' d='M61.08 23.76c-.508-.758-1.585-1.254-2.423-1.117l-7.21.342c-.838.137-.998-.285-.399-1.056l5.298-5.408c.759-.349 1.198-1.542 1.069-2.474l-.355-8.012c-.13-.932.25-1.106.947-.436l4.904 5.922c.508.757 1.585 1.253 2.423 1.116l7.21-.341c.838-.137.998.285.4 1.056l-5.569 5.284c-.678.56-1.117 1.753-.988 2.684l.355 8.013c.129.932-.25 1.106-.948.436l-4.714-6.01ZM74.966 30.893c-.246-.366-.768-.607-1.173-.54l-3.491.165c-.406.067-.483-.138-.193-.51l2.565-2.62c.367-.168.58-.745.517-1.196l-.172-3.88c-.062-.45.121-.535.46-.21l2.373 2.867c.246.366.768.606 1.173.54l3.49-.165c.406-.067.484.138.194.51l-2.696 2.559c-.328.27-.54.848-.478 1.3l.172 3.879c.062.45-.121.535-.46.21l-2.281-2.909Z'/%3E%3Cdefs%3E%3Cfilter id='a' width='73.762' height='91.3' x='0' y='16.7' color-interpolation-filters='sRGB' filterUnits='userSpaceOnUse'%3E%3CfeFlood flood-opacity='0' result='BackgroundImageFix'/%3E%3CfeColorMatrix in='SourceAlpha' result='hardAlpha' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0'/%3E%3CfeOffset dx='4' dy='4'/%3E%3CfeGaussianBlur stdDeviation='2'/%3E%3CfeColorMatrix values='0 0 0 0 0.95 0 0 0 0 0.95 0 0 0 0 0.95 0 0 0 0.06 0'/%3E%3CfeBlend in2='BackgroundImageFix' result='effect1_dropShadow_263_27850'/%3E%3CfeBlend in='SourceGraphic' in2='effect1_dropShadow_263_27850' result='shape'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E%0A" );
+	background-position: bottom -26px right 1%;
+	background-repeat: no-repeat;
 	@include break-medium {
 		display: none;
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -261,12 +261,8 @@
 	font-size: $font-body;
 	line-height: 19px;
 	margin-bottom: 2px;
-
-	/* identical to box height */
 	letter-spacing: -0.154px;
-
-	/* Gray / Gray 80 */
-	color: #2c3338;
+	color: var( --studio-gray-80 );
 }
 
 .mobile-app-download__description {
@@ -274,13 +270,9 @@
 	font-weight: normal;
 	font-size: $font-body-small;
 	line-height: 17px;
-
-	/* identical to box height */
 	letter-spacing: -0.154px;
 	margin-bottom: 16px;
-
-	/* Gray / Gray 40 */
-	color: #787c82;
+	color: var( --studio-gray-40 );
 }
 
 .mobile-app-download__link {
@@ -288,9 +280,7 @@
 	font-size: $font-body;
 	line-height: 19px;
 	letter-spacing: -0.45px;
-
-	/* Blue / Blue 50 */
-	color: #0675c4;
+	color: var( -studio-blue-50 );
 }
 .site-setup-list .site-setup-list__list.is-mobile-app-completed li:last-child {
 	border-bottom: none;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -280,7 +280,7 @@
 	font-size: $font-body;
 	line-height: 19px;
 	letter-spacing: -0.45px;
-	color: var( -studio-blue-50 );
+	color: var( --studio-blue-50 );
 }
 .site-setup-list .site-setup-list__list.is-mobile-app-completed li:last-child {
 	border-bottom: none;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -255,21 +255,6 @@
 	}
 }
 
-.mobile-app-download__app-icon {
-	background: #0675c4;
-	color: #fff;
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 10px;
-	width: 44px;
-	height: 44px;
-
-	.gridicon {
-		margin: 3px;
-		width: 38px;
-		height: 38px;
-	}
-}
-
 .mobile-app-download__title {
 	font-style: normal;
 	font-weight: 600;
@@ -308,9 +293,6 @@
 
 	/* Blue / Blue 50 */
 	color: #0675c4;
-}
-.mobile-app-download__text {
-	margin-left: 16px;
 }
 
 .site-setup-list .site-setup-list__list li:last-child {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -292,6 +292,9 @@
 	/* Blue / Blue 50 */
 	color: #0675c4;
 }
+.site-setup-list .site-setup-list__list.is-mobile-app-completed li:last-child {
+	border-bottom: none;
+}
 
 .site-setup-list .site-setup-list__list li:last-child {
 	border-bottom: 1px solid var( --color-border-subtle );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently on mobile the download the app is a bit hidden in the mobile with browser. 
This PR fixes this by making the download the app banner always visible. 


Before:
iPhone 13
<img width="300" src="https://user-images.githubusercontent.com/115071/143950787-7b7a66f6-499e-4d04-8aed-bd18262dcd47.png" />


After:
 
<img src="https://user-images.githubusercontent.com/115071/144360012-254ce084-eb30-495b-9818-e1eaa355a2fa.png" width="300" />
<img src="https://user-images.githubusercontent.com/115071/144360024-1e301e3a-6a53-4802-958b-df78f021f2d2.png"  width="300"  />


Desktop
<img width="300" src="https://user-images.githubusercontent.com/115071/143950864-2f527021-7181-4dfa-b84b-e529179419ce.png" />


#### Testing instructions

* load the PR on mobile in the developer tools using iOS header.  
Notice that you see the ios download app badge. 
* load the PR on mobile in the developer tools using android header.  
Notice that you see the Google Play store download app badge. 

* load the code on the desktop. 
Notice that the display looks the same as before. 



Related to #
