### PR TITLE
Videos UI: Fix up header margins and layout.

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -19,13 +19,12 @@
 
 	.videos-ui__header {
 		background: #151b1e;
-		padding: 0 20px;
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.1 );
 
 		.videos-ui__header-content {
 			display: flex;
 			flex-direction: column;
-			padding: 20px 0;
+			padding: 20px 20px 30px;
 			padding-top: 21px;
 
 			ul {
@@ -205,7 +204,7 @@
 		&.videos-ui__video-completed {
 			background-color: #263135;
 			span {
-				color:rgba( 255, 255, 255, 0.5 );
+				color: rgba( 255, 255, 255, 0.5 );
 			}
 
 			svg {
@@ -246,15 +245,14 @@
 				margin: auto;
 				flex-direction: row;
 				justify-content: space-between;
-				padding: 60px 40px;
+				padding: 60px 20px;
 
 				.videos-ui__titles {
 					flex-basis: auto;
 				}
 
 				.videos-ui__summary {
-					flex-basis: auto;
-					padding-top: 16px;
+					flex: 0 0 360px;
 				}
 
 				ul {
@@ -278,6 +276,7 @@
 				}
 
 				.videos-ui__summary {
+					flex-basis: auto;
 					width: 31%;
 				}
 			}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -20,11 +20,12 @@
 	.videos-ui__header {
 		background: #151b1e;
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.1 );
+		padding: 0 20px;
 
 		.videos-ui__header-content {
 			display: flex;
 			flex-direction: column;
-			padding: 20px 20px 30px;
+			padding: 20px 0 30px;
 			padding-top: 21px;
 
 			ul {
@@ -218,7 +219,7 @@
 	}
 
 	.videos-ui__bar {
-		padding: 20px 20px 15px;
+		padding: 20px 0 15px;
 		display: flex;
 		flex-direction: row;
 		align-items: center;
@@ -245,7 +246,7 @@
 				margin: auto;
 				flex-direction: row;
 				justify-content: space-between;
-				padding: 60px 20px;
+				padding: 60px 0;
 
 				.videos-ui__titles {
 					flex-basis: auto;
@@ -266,7 +267,6 @@
 		.videos-ui__header {
 			.videos-ui__header-content {
 				max-width: 1160px;
-				padding: 60px 0;
 
 				.videos-ui__titles {
 					h2 {


### PR DESCRIPTION
Some fixups are needed after the last merge of videos UI styles.

| Production | This PR |
| --- | --- |
| ![2021-11-29 14 45 04](https://user-images.githubusercontent.com/349751/143954970-13b555de-96de-478b-925b-e1c381a7d462.gif) | ![2021-11-29 14 39 25](https://user-images.githubusercontent.com/349751/143955031-10ba5ecf-59ea-44a8-b197-de29ef4d6798.gif) |

**Testing Instructions**
* Open videos UI from My Home.
* At screen widths from 375px and up, compare production to this PR at its calypso.live link.
* Verify the logo is not indented, the title is not indented after the first breakpoint, the checklist isn't sitting too low.
 