### PR TITLE
Checkout: Move analytics for free and full-credits transactions to the processors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
@@ -1,5 +1,6 @@
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
+import { recordTransactionBeginAnalytics } from './analytics';
 import getDomainDetails from './get-domain-details';
 import submitWpcomTransaction from './submit-wpcom-transaction';
 import {
@@ -27,7 +28,10 @@ export default async function freePurchaseProcessor(
 		includeDomainDetails,
 		includeGSuiteDetails,
 		contactDetails,
+		reduxDispatch,
 	} = transactionOptions;
+
+	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'free-purchase' } ) );
 
 	const formattedTransactionData = prepareFreePurchaseTransaction(
 		{

--- a/client/my-sites/checkout/composite-checkout/lib/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/full-credits-processor.ts
@@ -1,5 +1,6 @@
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
+import { recordTransactionBeginAnalytics } from './analytics';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import submitWpcomTransaction from './submit-wpcom-transaction';
@@ -27,7 +28,10 @@ export default async function fullCreditsProcessor(
 		includeDomainDetails,
 		includeGSuiteDetails,
 		contactDetails,
+		reduxDispatch,
 	} = transactionOptions;
+
+	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'full-credits' } ) );
 
 	const formattedTransactionData = prepareCreditsTransaction(
 		{

--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.js
@@ -1,10 +1,4 @@
-import {
-	Button,
-	useFormStatus,
-	FormStatus,
-	useLineItems,
-	useEvents,
-} from '@automattic/composite-checkout';
+import { Button, useFormStatus, FormStatus, useLineItems } from '@automattic/composite-checkout';
 import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
 import WordPressLogo from '../components/wordpress-logo';
@@ -22,10 +16,8 @@ export function createFreePaymentMethod() {
 function FreePurchaseSubmitButton( { disabled, onClick } ) {
 	const [ items ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 
 	const handleButtonPress = () => {
-		onEvent( { type: 'FREE_TRANSACTION_BEGIN' } );
 		onClick( 'free-purchase', {
 			items,
 		} );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
@@ -1,10 +1,4 @@
-import {
-	Button,
-	FormStatus,
-	useLineItems,
-	useFormStatus,
-	useEvents,
-} from '@automattic/composite-checkout';
+import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -27,10 +21,8 @@ function FullCreditsSubmitButton( { disabled, onClick } ) {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 
 	const handleButtonPress = () => {
-		onEvent( { type: 'FULL_CREDITS_TRANSACTION_BEGIN' } );
 		onClick( 'full-credits', {
 			items,
 		} );

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -124,23 +124,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 					);
 				}
-				case 'FREE_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_WPCOM',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_WPCOM',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_free_purchase_submit_clicked', {} )
-					);
-				}
 				case 'EXISTING_CARD_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -141,23 +141,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_free_purchase_submit_clicked', {} )
 					);
 				}
-				case 'FULL_CREDITS_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_WPCOM',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_WPCOM',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
-					);
-				}
 				case 'EXISTING_CARD_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (https://github.com/Automattic/wp-calypso/pull/48282), and as part of standardizing our payment processors, this PR moves the submission analytics from the `free-purchase` and `full-credits` payment methods into their associated payment processors. This matches the behavior of all payment methods that have been migrated out of calypso.

#### Testing instructions

You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.

To test the `free-purchase` method:

- Use a site that has a domain credit.
- Add a domain product to your cart and visit checkout.
- Select the "free" payment method (it should be the only one) and submit the purchase.
- Verify that you see analytics events fired for `calypso_checkout_form_submit`, `calypso_checkout_composite_form_submit`, and `calypso_checkout_composite_free_purchase_submit_clicked`.

To test the `full-credits` method:

- Use a user that has enough credits to completely cover a plan purchase.
- Add a plan product to your cart and visit checkout.
- Select the "credits" payment method (it should be the only one) and submit the purchase.
- Verify that you see analytics events fired for `calypso_checkout_form_submit`, `calypso_checkout_composite_form_submit`, and `calypso_checkout_composite_full_credits_submit_clicked`.


