### PR TITLE
Checkout: Fix custom step analytics error reporting

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -342,9 +342,7 @@ export default function WPCheckout( {
 								return validateContactDetails(
 									contactInfo,
 									isLoggedOutCart,
-									activePaymentMethod,
 									responseCart,
-									onEvent,
 									showErrorMessageBriefly,
 									applyDomainContactValidationResults,
 									clearDomainContactErrorMessages,
@@ -363,9 +361,7 @@ export default function WPCheckout( {
 										validateContactDetails(
 											contactInfo,
 											isLoggedOutCart,
-											activePaymentMethod,
 											responseCart,
-											onEvent,
 											showErrorMessageBriefly,
 											applyDomainContactValidationResults,
 											clearDomainContactErrorMessages,

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -240,7 +240,7 @@ export default function WPCheckout( {
 	const onReviewError = useCallback(
 		( error ) =>
 			onPageLoadError( 'step_load', String( error ), {
-				stepId: 'review',
+				step_id: 'review',
 			} ),
 		[ onPageLoadError ]
 	);
@@ -248,7 +248,7 @@ export default function WPCheckout( {
 	const onSummaryError = useCallback(
 		( error ) =>
 			onPageLoadError( 'step_load', String( error ), {
-				stepId: 'summary',
+				step_id: 'summary',
 			} ),
 		[ onPageLoadError ]
 	);

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -8,7 +8,6 @@ import {
 	CheckoutStepBody,
 	CheckoutSummaryArea as CheckoutSummaryAreaUnstyled,
 	getDefaultPaymentMethodStep,
-	useEvents,
 	useFormStatus,
 	useIsStepActive,
 	useIsStepComplete,
@@ -46,6 +45,7 @@ import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from '../components/item-variation-picker';
+import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, RequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
 
@@ -123,6 +123,7 @@ export default function WPCheckout( {
 	isLoggedOutCart,
 	infoMessage,
 	createUserAndSiteBeforeTransaction,
+	onPageLoadError,
 }: {
 	removeProductFromCart: RemoveProductFromCart;
 	changePlanLength: OnChangeItemVariant;
@@ -134,6 +135,7 @@ export default function WPCheckout( {
 	isLoggedOutCart: boolean;
 	infoMessage?: JSX.Element;
 	createUserAndSiteBeforeTransaction: boolean;
+	onPageLoadError: CheckoutPageErrorCallback;
 } ): JSX.Element {
 	const cartKey = useCartKey();
 	const {
@@ -146,7 +148,6 @@ export default function WPCheckout( {
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const total = useTotal();
 	const activePaymentMethod = usePaymentMethod();
-	const onEvent = useEvents();
 	const reduxDispatch = useReduxDispatch();
 
 	const areThereDomainProductsInCart =
@@ -238,26 +239,18 @@ export default function WPCheckout( {
 
 	const onReviewError = useCallback(
 		( error ) =>
-			onEvent( {
-				type: 'STEP_LOAD_ERROR',
-				payload: {
-					message: error,
-					stepId: 'review',
-				},
+			onPageLoadError( 'step_load', String( error ), {
+				stepId: 'review',
 			} ),
-		[ onEvent ]
+		[ onPageLoadError ]
 	);
 
 	const onSummaryError = useCallback(
 		( error ) =>
-			onEvent( {
-				type: 'STEP_LOAD_ERROR',
-				payload: {
-					message: error,
-					stepId: 'summary',
-				},
+			onPageLoadError( 'step_load', String( error ), {
+				stepId: 'summary',
 			} ),
-		[ onEvent ]
+		[ onPageLoadError ]
 	);
 
 	const validatingButtonText = isCartPendingUpdate

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -762,6 +762,7 @@ export default function CompositeCheckout( {
 					isLoggedOutCart={ !! isLoggedOutCart }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 					infoMessage={ infoMessage }
+					onPageLoadError={ onPageLoadError }
 				/>
 			</CheckoutProvider>
 		</Fragment>

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -5,7 +5,6 @@ import {
 	isDomainMapping,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 } from '@automattic/calypso-products';
-import { useEvents } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
@@ -21,8 +20,6 @@ import {
 	getSignupValidationErrorResponse,
 } from '../types/wpcom-store-state';
 import getContactDetailsType from './get-contact-details-type';
-import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './translate-payment-method-names';
-import type { PaymentMethod } from '@automattic/composite-checkout';
 import type { RequestCartProduct, ResponseCart } from '@automattic/shopping-cart';
 import type {
 	ManagedContactDetails,
@@ -118,9 +115,7 @@ async function runLoggedOutEmailValidationCheck(
 export async function validateContactDetails(
 	contactInfo: ManagedContactDetails,
 	isLoggedOutCart: boolean,
-	activePaymentMethod: PaymentMethod | null,
 	responseCart: ResponseCart,
-	onEvent: ReturnType< typeof useEvents >,
 	showErrorMessageBriefly: ( message: string ) => void,
 	applyDomainContactValidationResults: ( results: ManagedContactDetailsErrors ) => void,
 	clearDomainContactErrorMessages: () => void,
@@ -135,9 +130,7 @@ export async function validateContactDetails(
 		if ( shouldDisplayErrors ) {
 			handleContactValidationResult( {
 				translate,
-				recordEvent: onEvent,
 				showErrorMessage: showErrorMessageBriefly,
-				paymentMethodId: activePaymentMethod?.id ?? '',
 				validationResult,
 				applyDomainContactValidationResults,
 				clearDomainContactErrorMessages,
@@ -155,9 +148,7 @@ export async function validateContactDetails(
 		if ( shouldDisplayErrors ) {
 			handleContactValidationResult( {
 				translate,
-				recordEvent: onEvent,
 				showErrorMessage: showErrorMessageBriefly,
-				paymentMethodId: activePaymentMethod?.id ?? '',
 				validationResult: loggedOutValidationResult,
 				applyDomainContactValidationResults,
 				clearDomainContactErrorMessages,
@@ -361,17 +352,13 @@ async function getGSuiteValidationResult(
 
 function handleContactValidationResult( {
 	translate,
-	recordEvent,
 	showErrorMessage,
-	paymentMethodId,
 	validationResult,
 	applyDomainContactValidationResults,
 	clearDomainContactErrorMessages,
 }: {
 	translate: ReturnType< typeof useTranslate >;
-	recordEvent: ReturnType< typeof useEvents >;
 	showErrorMessage: ( message: string ) => void;
-	paymentMethodId: string;
 	validationResult: unknown;
 	applyDomainContactValidationResults: ( results: ManagedContactDetailsErrors ) => void;
 	clearDomainContactErrorMessages: () => void;
@@ -379,14 +366,6 @@ function handleContactValidationResult( {
 	if ( ! isContactValidationResponse( validationResult ) ) {
 		return;
 	}
-
-	recordEvent( {
-		type: 'VALIDATE_DOMAIN_CONTACT_INFO',
-		payload: {
-			credits: null,
-			payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ),
-		},
-	} );
 
 	if ( ! validationResult ) {
 		showErrorMessage(

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -192,10 +192,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
 					);
 				}
-				case 'VALIDATE_DOMAIN_CONTACT_INFO': {
-					// TODO: Decide what to do here
-					return;
-				}
 				case 'SHOW_MODAL_AUTHORIZATION': {
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a regression added by https://github.com/Automattic/wp-calypso/pull/57201. That PR reorganized checkout step error handling so that it did not use the deprecated `useEvents` hook and instead recorded the events with an explicit `onPageLoadError` function. However, it did this for the automated step progression system built into the `composite-checkout` package. In calypso checkout, we have two custom steps that must be provided their own explicit error handlers. The handlers provided to these steps still use the `useEvents` hook, but fire an event that has had no effect since https://github.com/Automattic/wp-calypso/pull/57201.

This PR modifies both of those step error handlers (the review step and the summary step) to call the `onPageLoadError` function instead.

#### Testing instructions

Since this is testing JS error boundaries, you must manually break the checkout steps in question in order to see the analytics events fired.

The following diff should trigger errors on both boundaries:

```diff
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -83,6 +83,7 @@ export default function WPCheckoutOrderReview( {
        isSummary?: boolean;
        createUserAndSiteBeforeTransaction?: boolean;
 } ): JSX.Element {
+       throw new Error( 'test error 1' );
        const translate = useTranslate();
        const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
        const cartKey = useCartKey();
diff --git a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx b/client/my-sites/checkout/composite-checkout/components/wp-checkout-or
der-summary.tsx
index 10cf418fd3..f5766ceb56 100644
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -36,6 +36,7 @@ export default function WPCheckoutOrderSummary( {
        onChangePlanLength: ( uuid: string, productSlug: string, productId: number ) => void;
        nextDomainIsFree?: boolean;
 } ): JSX.Element {
+       throw new Error( 'test error 2' );
        const translate = useTranslate();
        const { formStatus } = useFormStatus();
        const cartKey = useCartKey();
```

- Apply the above changes.
- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- Add a product to your cart and visit checkout.
- Verify that you see the `calypso_checkout_composite_step_load_error` analytics event fired twice, once for each of the errors added in the diff above.
<img width="624" alt="Screen Shot 2021-11-29 at 9 54 24 PM" src="https://user-images.githubusercontent.com/2036909/143977488-cca897f4-4331-4e97-8d2c-c56cf064ef75.png">
<img width="625" alt="Screen Shot 2021-11-29 at 9 54 04 PM" src="https://user-images.githubusercontent.com/2036909/143977496-f7a94951-74a0-4738-9ac5-f4072ca993d2.png">


