### PR TITLE
Design picker: Enable categories filter in Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -39,7 +39,7 @@ const Header: React.FunctionComponent = () => {
 	const locale = useLocale();
 	const isAnchorFmSignup = useIsAnchorFm();
 	const isDesignPickerCategoriesEnabled =
-		isAnchorFmSignup && isEnabled( 'signup/design-picker-categories' );
+		! isAnchorFmSignup && isEnabled( 'signup/design-picker-categories' );
 
 	const { goBack } = useStepNavigation();
 	const title = isDesignPickerCategoriesEnabled ? __( 'Themes' ) : __( 'Choose a design' );
@@ -91,7 +91,7 @@ const Designs: React.FunctionComponent = () => {
 
 	// As the amount of the anchorfm related designs is little, we don't need to enable categories filter
 	const isDesignPickerCategoriesEnabled =
-		isAnchorFmSignup && isEnabled( 'signup/design-picker-categories' );
+		! isAnchorFmSignup && isEnabled( 'signup/design-picker-categories' );
 
 	const useFeaturedPicksButtons =
 		isDesignPickerCategoriesEnabled &&

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -37,8 +37,10 @@ const sortBlogToTop = ( a: Category, b: Category ) => {
 const Header: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const locale = useLocale();
-	const isDesignPickerCategoriesEnabled = isEnabled( 'signup/design-picker-categories' );
 	const isAnchorFmSignup = useIsAnchorFm();
+	const isDesignPickerCategoriesEnabled =
+		isAnchorFmSignup && isEnabled( 'signup/design-picker-categories' );
+
 	const { goBack } = useStepNavigation();
 	const title = isDesignPickerCategoriesEnabled ? __( 'Themes' ) : __( 'Choose a design' );
 	let subTitle = isAnchorFmSignup
@@ -86,7 +88,11 @@ const Designs: React.FunctionComponent = () => {
 
 	const selectedDesign = getSelectedDesign();
 	const isFse = isEnrollingInFseBeta();
-	const isDesignPickerCategoriesEnabled = isEnabled( 'signup/design-picker-categories' );
+
+	// As the amount of the anchorfm related designs is little, we don't need to enable categories filter
+	const isDesignPickerCategoriesEnabled =
+		isAnchorFmSignup && isEnabled( 'signup/design-picker-categories' );
+
 	const useFeaturedPicksButtons =
 		isDesignPickerCategoriesEnabled &&
 		isEnabled( 'signup/design-picker-use-featured-picks-buttons' );

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -9,7 +9,7 @@ import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboardi
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import * as React from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo'; // @TODO: extract to @automattic package
 import Badge from '../../components/badge';
@@ -90,12 +90,21 @@ const Designs: React.FunctionComponent = () => {
 	const useFeaturedPicksButtons =
 		isDesignPickerCategoriesEnabled &&
 		isEnabled( 'signup/design-picker-use-featured-picks-buttons' );
-	const designs = getRandomizedDesigns().featured.filter(
+
+	const allDesigns = getRandomizedDesigns().featured.filter(
 		( design ) =>
 			// TODO Add finalized design templates to available designs config
 			// along with `is_anchorfm` prop (config is stored in the
 			// `@automattic/design-picker` package)
 			isAnchorFmSignup === design.features.includes( 'anchorfm' )
+	);
+
+	const { designs, featuredPicksDesigns } = useMemo(
+		() => ( {
+			designs: allDesigns.filter( ( theme ) => ! theme.is_featured_picks ),
+			featuredPicksDesigns: allDesigns.filter( ( theme ) => theme.is_featured_picks ),
+		} ),
+		[ allDesigns ]
 	);
 
 	const categorization = useCategorization( designs, {
@@ -150,11 +159,7 @@ const Designs: React.FunctionComponent = () => {
 				className={ classnames( {
 					'designs__has-categories': isDesignPickerCategoriesEnabled,
 				} ) }
-				designs={
-					useFeaturedPicksButtons
-						? designs.filter( ( design ) => ! design.is_featured_picks )
-						: designs
-				}
+				designs={ useFeaturedPicksButtons ? designs : allDesigns }
 				isGridMinimal={ isAnchorFmSignup }
 				locale={ locale }
 				onSelect={ onSelect }
@@ -170,7 +175,7 @@ const Designs: React.FunctionComponent = () => {
 					useFeaturedPicksButtons && (
 						<FeaturedPicksButtons
 							className="designs__featured-picks-buttons"
-							designs={ designs.filter( ( design ) => design.is_featured_picks ) }
+							designs={ featuredPicksDesigns }
 							onSelect={ onSelect }
 						/>
 					)

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -58,13 +58,13 @@ const Header: React.FunctionComponent = () => {
 
 	return (
 		<div className="designs__header">
-			<ActionButtons>
-				<BackButton onClick={ goBack } />
-			</ActionButtons>
 			<div className="designs__heading">
 				<Title className="designs__heading-title">{ title }</Title>
 				<SubTitle>{ subTitle }</SubTitle>
 			</div>
+			<ActionButtons>
+				<BackButton onClick={ goBack } />
+			</ActionButtons>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -171,6 +171,7 @@ const Designs: React.FunctionComponent = () => {
 				categoriesFooter={
 					useFeaturedPicksButtons && (
 						<FeaturedPicksButtons
+							className="designs__featured-picks-buttons"
 							designs={ designs.filter( ( design ) => design.is_featured_picks ) }
 							onSelect={ onSelect }
 						/>

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -1,8 +1,10 @@
-import DesignPicker, { getAvailableDesigns } from '@automattic/design-picker';
-import { useLocale } from '@automattic/i18n-utils';
+import { isEnabled } from '@automattic/calypso-config';
+import DesignPicker, { getAvailableDesigns, useCategorization } from '@automattic/design-picker';
+import { useLocale, englishLocales } from '@automattic/i18n-utils';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import { useEffect } from 'react';
 import * as React from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo'; // @TODO: extract to @automattic package
@@ -11,14 +13,64 @@ import useStepNavigation from '../../hooks/use-step-navigation';
 import { useTrackStep } from '../../hooks/use-track-step';
 import { useIsAnchorFm } from '../../path';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import type { Design } from '@automattic/design-picker';
+import type { Design, Category } from '@automattic/design-picker';
 
 import './style.scss';
+
+// Ensures Blog category appears at the top of the design category list
+// (directly below the All Themes category).
+const sortBlogToTop = ( a: Category, b: Category ) => {
+	if ( a.slug === b.slug ) {
+		return 0;
+	} else if ( a.slug === 'blog' ) {
+		return -1;
+	} else if ( b.slug === 'blog' ) {
+		return 1;
+	}
+	return 0;
+};
+
+const Header: React.FunctionComponent = () => {
+	const { __ } = useI18n();
+	const locale = useLocale();
+	const isDesignPickerCategoriesEnabled = isEnabled( 'signup/design-picker-categories' );
+	const isAnchorFmSignup = useIsAnchorFm();
+	const { goBack } = useStepNavigation();
+	const title = isDesignPickerCategoriesEnabled ? __( 'Themes' ) : __( 'Choose a design' );
+	let subTitle = isAnchorFmSignup
+		? __( 'Pick a homepage layout for your podcast site. You can customize or change it later.' )
+		: __( 'Pick your favorite homepage layout. You can customize or change it later.' );
+
+	if ( isDesignPickerCategoriesEnabled ) {
+		subTitle = __( 'Choose a starting theme. You can change it later.' );
+
+		if ( englishLocales.includes( locale ) ) {
+			// An English only trick so the line wraps between sentences.
+			subTitle = subTitle
+				.replace( /\s/g, '\xa0' ) // Replace all spaces with non-breaking spaces
+				.replace( /\.\s/g, '. ' ); // Replace all spaces at the end of sentences with a regular breaking space
+		}
+	}
+
+	return (
+		<div className="designs__header">
+			<div className="designs__heading">
+				<Title className="designs__heading-title">{ title }</Title>
+				<SubTitle>{ subTitle }</SubTitle>
+			</div>
+			{ ! isDesignPickerCategoriesEnabled && (
+				<ActionButtons>
+					<BackButton onClick={ goBack } />
+				</ActionButtons>
+			) }
+		</div>
+	);
+};
 
 const Designs: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const locale = useLocale();
-	const { goBack, goNext } = useStepNavigation();
+	const { goNext } = useStepNavigation();
 	const { setSelectedDesign, setFonts, resetFonts, setRandomizedDesigns } = useDispatch(
 		ONBOARD_STORE
 	);
@@ -32,6 +84,20 @@ const Designs: React.FunctionComponent = () => {
 
 	const selectedDesign = getSelectedDesign();
 	const isFse = isEnrollingInFseBeta();
+	const isDesignPickerCategoriesEnabled = isEnabled( 'signup/design-picker-categories' );
+	const designs = getRandomizedDesigns().featured.filter(
+		( design ) =>
+			// TODO Add finalized design templates to available designs config
+			// along with `is_anchorfm` prop (config is stored in the
+			// `@automattic/design-picker` package)
+			isAnchorFmSignup === design.features.includes( 'anchorfm' )
+	);
+
+	const categorization = useCategorization( designs, {
+		showAllFilter: isDesignPickerCategoriesEnabled,
+		defaultSelection: null,
+		sort: sortBlogToTop,
+	} );
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: selectedDesign?.slug,
@@ -62,29 +128,12 @@ const Designs: React.FunctionComponent = () => {
 
 	return (
 		<div className="gutenboarding-page designs">
-			<div className="designs__header">
-				<div className="designs__heading">
-					<Title>{ __( 'Choose a design' ) }</Title>
-					<SubTitle>
-						{ isAnchorFmSignup
-							? __(
-									'Pick a homepage layout for your podcast site. You can customize or change it later.'
-							  )
-							: __( 'Pick your favorite homepage layout. You can customize or change it later.' ) }
-					</SubTitle>
-				</div>
-				<ActionButtons>
-					<BackButton onClick={ goBack } />
-				</ActionButtons>
-			</div>
+			{ ! isDesignPickerCategoriesEnabled && <Header /> }
 			<DesignPicker
-				designs={ getRandomizedDesigns().featured.filter(
-					( design ) =>
-						// TODO Add finalized design templates to available designs config
-						// along with `is_anchorfm` prop (config is stored in the
-						// `@automattic/design-picker` package)
-						isAnchorFmSignup === design.features.includes( 'anchorfm' )
-				) }
+				className={ classnames( {
+					'designs__has-categories': isDesignPickerCategoriesEnabled,
+				} ) }
+				designs={ designs }
 				isGridMinimal={ isAnchorFmSignup }
 				locale={ locale }
 				onSelect={ ( design: Design ) => {
@@ -104,6 +153,8 @@ const Designs: React.FunctionComponent = () => {
 						<span className="designs__premium-badge-text">{ __( 'Premium' ) }</span>
 					</Badge>
 				}
+				categorization={ isDesignPickerCategoriesEnabled ? categorization : undefined }
+				categoriesHeading={ isDesignPickerCategoriesEnabled && <Header /> }
 			/>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -58,15 +58,13 @@ const Header: React.FunctionComponent = () => {
 
 	return (
 		<div className="designs__header">
+			<ActionButtons>
+				<BackButton onClick={ goBack } />
+			</ActionButtons>
 			<div className="designs__heading">
 				<Title className="designs__heading-title">{ title }</Title>
 				<SubTitle>{ subTitle }</SubTitle>
 			</div>
-			{ ! isDesignPickerCategoriesEnabled && (
-				<ActionButtons>
-					<BackButton onClick={ goBack } />
-				</ActionButtons>
-			) }
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -89,7 +89,9 @@ const Designs: React.FunctionComponent = () => {
 	const selectedDesign = getSelectedDesign();
 	const isFse = isEnrollingInFseBeta();
 	const isDesignPickerCategoriesEnabled = isEnabled( 'signup/design-picker-categories' );
-	const useFeaturedPicksButtons = isEnabled( 'signup/design-picker-use-featured-picks-buttons' );
+	const useFeaturedPicksButtons =
+		isDesignPickerCategoriesEnabled &&
+		isEnabled( 'signup/design-picker-use-featured-picks-buttons' );
 	const designs = getRandomizedDesigns().featured.filter(
 		( design ) =>
 			// TODO Add finalized design templates to available designs config

--- a/client/landing/gutenboarding/onboarding-block/designs/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/designs/style.scss
@@ -63,4 +63,12 @@
 			margin-bottom: 12px;
 		}
 	}
+
+	.designs__featured-picks-buttons {
+		button {
+			box-shadow: inset 0 0 0 1px #c3c4c7;
+			color: #101517;
+			font-size: 0.875rem;
+		}
+	}
 }

--- a/client/landing/gutenboarding/onboarding-block/designs/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/designs/style.scss
@@ -55,7 +55,7 @@
 		margin-bottom: 0;
 
 		.designs__header {
-			flex-direction: column;
+			flex-direction: column-reverse;
 			align-items: flex-start;
 			margin-top: 0;
 			margin-bottom: 40px;

--- a/client/landing/gutenboarding/onboarding-block/designs/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/designs/style.scss
@@ -49,4 +49,18 @@
 		margin-top: -0.05em;
 		text-transform: uppercase;
 	}
+
+	.designs__has-categories {
+		@include onboarding-heading-padding;
+		margin-bottom: 0;
+
+		.designs__header {
+			margin-top: 24px;
+			margin-bottom: 40px;
+		}
+
+		.designs__heading-title {
+			margin-bottom: 12px;
+		}
+	}
 }

--- a/client/landing/gutenboarding/onboarding-block/designs/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/designs/style.scss
@@ -55,12 +55,24 @@
 		margin-bottom: 0;
 
 		.designs__header {
-			margin-top: 24px;
+			flex-direction: column;
+			align-items: flex-start;
+			margin-top: 0;
 			margin-bottom: 40px;
 		}
 
 		.designs__heading-title {
 			margin-bottom: 12px;
+		}
+
+		.action-buttons {
+			margin-left: 0;
+
+			.components-button {
+				@include break-small {
+					padding: 0;
+				}
+			}
 		}
 	}
 

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -523,7 +523,7 @@
 			"features": [ "anchorfm" ]
 		},
 		{
-			"title": "Start with an empty page",
+			"title": "Blank Canvas",
 			"slug": "blank-canvas",
 			"template": "blank-canvas",
 			"theme": "blank-canvas",

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -11,12 +11,12 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 		padding-right: 1rem;
 	}
 
-	.design-picker-category-filter__menu-item {
-		padding-left: 0;
-		padding-right: 0;
+	button.components-button.design-picker-category-filter__menu-item {
+		padding: 0;
 		color: $design-picker-category-filter-text-color;
 		display: block;
 		width: auto;
+		font-size: 1rem;
 
 		&:hover:not( :disabled ),
 		&:active:not( :disabled ) {

--- a/packages/design-picker/src/components/featured-picks-buttons/index.tsx
+++ b/packages/design-picker/src/components/featured-picks-buttons/index.tsx
@@ -3,7 +3,6 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React from 'react';
-import { isBlankCanvasDesign } from '../../utils';
 import type { Design } from '../../types';
 import './style.scss';
 
@@ -29,13 +28,10 @@ const FeaturedPicksButtons: React.FC< Props > = ( { className, designs, onSelect
 					isSecondary
 					onClick={ () => onSelect( design ) }
 				>
-					{ sprintf(
+					{
 						/* translators: %s is the title of design */
-						__( 'Use %s' ),
-						isBlankCanvasDesign( design )
-							? __( 'Blank Canvas', __i18n_text_domain__ )
-							: design.title
-					) }
+						sprintf( __( 'Use %s' ), design.title )
+					}
 				</Button>
 			) ) }
 		</div>

--- a/packages/design-picker/src/components/featured-picks-buttons/index.tsx
+++ b/packages/design-picker/src/components/featured-picks-buttons/index.tsx
@@ -3,6 +3,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React from 'react';
+import { isBlankCanvasDesign } from '../../utils';
 import type { Design } from '../../types';
 import './style.scss';
 
@@ -28,10 +29,13 @@ const FeaturedPicksButtons: React.FC< Props > = ( { className, designs, onSelect
 					isSecondary
 					onClick={ () => onSelect( design ) }
 				>
-					{
+					{ sprintf(
 						/* translators: %s is the title of design */
-						sprintf( __( 'Use %s' ), design.title )
-					}
+						__( 'Use %s' ),
+						isBlankCanvasDesign( design )
+							? __( 'Blank Canvas', __i18n_text_domain__ )
+							: design.title
+					) }
 				</Button>
 			) ) }
 		</div>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -17,9 +17,7 @@ import {
 import { DesignPickerCategoryFilter } from './design-picker-category-filter';
 import MShotsImage from './mshots-image';
 import type { Categorization } from '../hooks/use-categorization';
-export { default as MShotsImage } from './mshots-image';
 import type { Design } from '../types';
-
 import './style.scss';
 
 const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name__${ slug }`;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -10,5 +10,5 @@ export {
 	isBlankCanvasDesign,
 } from './utils';
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS } from './constants';
-export type { FontPair, Design } from './types';
+export type { FontPair, Design, Category } from './types';
 export { useCategorization } from './hooks/use-categorization';


### PR DESCRIPTION
#### Changes proposed in this Pull Request


* Update the Design Picker in the  /new (aka Gutenboarding) flow to make it consistent with the  Design Picker consistent in the /start flow 
* This PR is for the Gutenboarding flow only 

Prior work on the Design Picker in the /start flow can be found on the [Blogger Experience Pod board](https://github.com/orgs/Automattic/projects/272)

TODO
- [x] Check how to show “Go back” in the design picker of Gutenboarding if enabling the categories filter

**Desktop**

| Before/Disabled | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/144196839-55610dad-6a54-412c-903d-e92c4fccaf00.png) | ![image](https://user-images.githubusercontent.com/13596067/144194410-f0188de8-5cec-4ede-9a73-163935060bdb.png) |

**Mobile**

| Before/Disabled | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/144197009-102d56f0-74c9-475e-a628-f72184075c58.png) | ![image](https://user-images.githubusercontent.com/13596067/144194329-c9b4a2fb-9826-48a8-a63a-f20146c19d51.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new/design`
* Check the category filter show on the left side

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1638178895225900/1637819354.184500-slack-C029SB8JT8S