### PR TITLE
chore: Drop unused fork-ts-checker-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,6 @@
 		"eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
 		"exports-loader": "^0.7.0",
 		"fake-indexeddb": "^3.1.3",
-		"fork-ts-checker-webpack-plugin": "^3.1.1",
 		"gettext-parser": "^4.0.3",
 		"glob": "^7.1.6",
 		"globby": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10630,17 +10630,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-code-frame@npm:^6.22.0":
-  version: 6.26.0
-  resolution: "babel-code-frame@npm:6.26.0"
-  dependencies:
-    chalk: ^1.1.3
-    esutils: ^2.0.2
-    js-tokens: ^3.0.2
-  checksum: 7fecc128e87578cf1b96e78d2b25e0b260e202bdbbfcefa2eac23b7f8b7b2f7bc9276a14599cde14403cc798cc2a38e428e2cab50b77658ab49228b09ae92473
-  languageName: node
-  linkType: hard
-
 "babel-core@npm:^7.0.0-bridge.0":
   version: 7.0.0-bridge.0
   resolution: "babel-core@npm:7.0.0-bridge.0"
@@ -18303,22 +18292,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fork-ts-checker-webpack-plugin@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "fork-ts-checker-webpack-plugin@npm:3.1.1"
-  dependencies:
-    babel-code-frame: ^6.22.0
-    chalk: ^2.4.1
-    chokidar: ^3.3.0
-    micromatch: ^3.1.10
-    minimatch: ^3.0.4
-    semver: ^5.6.0
-    tapable: ^1.0.0
-    worker-rpc: ^0.1.0
-  checksum: 9f12f11abe0bbcbcc87c6571594ad38e1e3439002bb6fa00b003232ddca3fbb76a40a3db6e05e4a4a25b820b25d9296f5149aae7430036a946280ac02f369eaf
-  languageName: node
-  linkType: hard
-
 "fork-ts-checker-webpack-plugin@npm:^6.0.4":
   version: 6.3.2
   resolution: "fork-ts-checker-webpack-plugin@npm:6.3.2"
@@ -23200,13 +23173,6 @@ fsevents@~2.1.2:
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: e248708d377aa058eacf2037b07ded847790e6de892bbad3dac0abba2e759cb9f121b00099a65195616badcb6eca8d14d975cb3e89eb1cfda644756402c8aeed
-  languageName: node
-  linkType: hard
-
-"js-tokens@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "js-tokens@npm:3.0.2"
-  checksum: e3c3ee4d12643d90197628eb022a2884a15f08ea7dcac1ce97fdeee43031fbfc7ede674f2cdbbb582dcd4c94388b22e52d56c6cbeb2ac7d1b57c2f33c405e2ba
   languageName: node
   linkType: hard
 
@@ -38347,7 +38313,6 @@ testarmada-magellan@11.0.10:
     eslint-plugin-you-dont-need-lodash-underscore: ^6.12.0
     exports-loader: ^0.7.0
     fake-indexeddb: ^3.1.3
-    fork-ts-checker-webpack-plugin: ^3.1.1
     fsevents: ^2.1.2
     gettext-parser: ^4.0.3
     glob: ^7.1.6


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Drop dependency `fork-ts-checker-webpack-plugin` as is not used anywhere.
