### PR TITLE
i18n: eliminate the setRawLocaleData action

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import i18n from 'i18n-calypso';
 import {
 	getLanguageSlugs,
 	isDefaultLocale,
@@ -6,7 +7,8 @@ import {
 } from 'calypso/lib/i18n-utils';
 import { initLanguageEmpathyMode } from 'calypso/lib/i18n-utils/empathy-mode';
 import { loadUserUndeployedTranslations } from 'calypso/lib/i18n-utils/switch-locale';
-import { setLocale, setLocaleRawData } from 'calypso/state/ui/language/actions';
+import { LOCALE_SET } from 'calypso/state/action-types';
+import { setLocale } from 'calypso/state/ui/language/actions';
 
 function getLocaleFromPathname() {
 	const pathname = window.location.pathname.replace( /\/$/, '' );
@@ -36,15 +38,15 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 
 	if ( window.i18nLocaleStrings ) {
 		// Use the locale translation data that were boostrapped by the server
-		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
+		const localeData = JSON.parse( window.i18nLocaleStrings );
 
-		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
+		i18n.setLocale( localeData );
+		const localeSlug = i18n.getLocaleSlug();
+		const localeVariant = i18n.getLocaleVariant();
+		reduxStore.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
 
-		// The empty string key [ '' ] where metadata about the translation file
-		// (e.g., the locale name, plurals definitions, etc.) are stored.
-		const languageSlug = i18nLocaleStringsObject?.[ '' ]?.localeSlug;
-		if ( languageSlug ) {
-			loadUserUndeployedTranslations( languageSlug );
+		if ( localeSlug ) {
+			loadUserUndeployedTranslations( localeSlug );
 		}
 	} else if ( currentUser && currentUser.localeSlug ) {
 		if ( shouldUseFallbackLocale ) {

--- a/client/controller/ssr-setup-locale.js
+++ b/client/controller/ssr-setup-locale.js
@@ -1,52 +1,50 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import { readFile } from 'fs/promises';
+import i18n from 'i18n-calypso';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import { getLanguage } from 'calypso/lib/i18n-utils';
 import config from 'calypso/server/config';
-import { setLocaleRawData } from 'calypso/state/ui/language/actions';
+import { LOCALE_SET } from 'calypso/state/action-types';
 
 export function ssrSetupLocaleMiddleware() {
 	const translationsCache = {};
 
 	return function ssrSetupLocale( context, next ) {
-		function resetLocaleData() {
-			const localeDataPlaceholder = { '': {} };
-			context.store.dispatch( setLocaleRawData( localeDataPlaceholder ) );
+		function setLocaleData( localeData ) {
+			i18n.setLocale( localeData );
+			const localeSlug = i18n.getLocaleSlug();
+			const localeVariant = i18n.getLocaleVariant();
+			context.store.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
+			context.lang = localeVariant || localeSlug;
+			context.isRTL = getLanguage( context.lang )?.rtl ?? false;
 			next();
 		}
 
-		if ( ! context.params.lang ) {
-			resetLocaleData();
+		const { lang } = context.params;
+
+		if ( ! lang ) {
+			setLocaleData( null );
 			return;
 		}
 
-		if ( ! config( 'magnificent_non_en_locales' ).includes( context.params.lang ) ) {
-			context.res.redirect( context.path.replace( `/${ context.params.lang }`, '' ) );
+		if ( ! config( 'magnificent_non_en_locales' ).includes( lang ) ) {
+			context.res.redirect( context.path.replace( `/${ lang }`, '' ) );
 			return;
 		}
 
-		const language = getLanguage( context.params.lang );
-		if ( ! language ) {
-			next();
-		}
-
-		context.lang = language.langSlug;
-		context.isRTL = language.rtl ? true : false;
-
-		const cachedTranslations = translationsCache[ context.lang ];
+		const cachedTranslations = translationsCache[ lang ];
 		if ( typeof cachedTranslations !== 'undefined' ) {
-			context.store.dispatch( setLocaleRawData( cachedTranslations ) );
-			next();
+			setLocaleData( cachedTranslations );
 		} else {
-			readFile( getAssetFilePath( `languages/${ context.lang }-v1.1.json` ), 'utf-8' )
+			readFile( getAssetFilePath( `languages/${ lang }-v1.1.json` ), 'utf-8' )
 				.then( ( data ) => {
 					const translations = JSON.parse( data );
-
-					context.store.dispatch( setLocaleRawData( translations ) );
-					translationsCache[ context.lang ] = translations;
-					next();
+					translationsCache[ lang ] = translations;
+					setLocaleData( translations );
 				} )
-				.catch( resetLocaleData );
+				.catch( () => {
+					setLocaleData( null );
+				} );
 		}
 	};
 }

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -1,4 +1,3 @@
-import i18n from 'i18n-calypso';
 import switchLocale from 'calypso/lib/i18n-utils/switch-locale';
 import { LOCALE_SET } from 'calypso/state/action-types';
 
@@ -13,24 +12,6 @@ import 'calypso/state/ui/init';
  */
 export const setLocale = ( localeSlug, localeVariant = null ) => {
 	switchLocale( localeVariant || localeSlug );
-	return {
-		type: LOCALE_SET,
-		localeSlug,
-		localeVariant,
-	};
-};
-
-/**
- * Set the ui locale using a raw (jed) translation object
- *
- * @param   {object} localeData the locale data to be set
- * @returns {object} Action
- */
-export const setLocaleRawData = ( localeData ) => {
-	i18n.setLocale( localeData );
-
-	const { localeSlug, localeVariant = null } = localeData[ '' ];
-
 	return {
 		type: LOCALE_SET,
 		localeSlug,

--- a/client/state/ui/language/test/actions.js
+++ b/client/state/ui/language/test/actions.js
@@ -1,5 +1,5 @@
 import { LOCALE_SET } from 'calypso/state/action-types';
-import { setLocale, setLocaleRawData } from '../actions';
+import { setLocale } from '../actions';
 
 describe( 'actions', () => {
 	describe( 'setLocale', () => {
@@ -13,37 +13,6 @@ describe( 'actions', () => {
 
 		test( 'returns an action with localeVariant set', () => {
 			expect( setLocale( 'he', 'he_formal' ) ).toEqual( {
-				type: LOCALE_SET,
-				localeSlug: 'he',
-				localeVariant: 'he_formal',
-			} );
-		} );
-	} );
-
-	describe( 'setLocaleRawData', () => {
-		test( 'returns an appropriate action', () => {
-			expect(
-				setLocaleRawData( {
-					'': {
-						localeSlug: 'he',
-					},
-				} )
-			).toEqual( {
-				type: LOCALE_SET,
-				localeSlug: 'he',
-				localeVariant: null,
-			} );
-		} );
-
-		test( 'returns an action with localeVariant set', () => {
-			expect(
-				setLocaleRawData( {
-					'': {
-						localeSlug: 'he',
-						localeVariant: 'he_formal',
-					},
-				} )
-			).toEqual( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
 				localeVariant: 'he_formal',


### PR DESCRIPTION
Less ambitious version of #58343, which tried to do too many things at once. Eliminates just the `setLocaleRawData` Redux action, which is not really a pure action, because it calls a `i18n.setLocale` side-effect. After this patch, all places that used to call `setLocaleRawData` (there were two), do the `i18n.setLocale` and `store.dispatch( LOCALE_SET )` statements separately.

This is a part of a series of PRs where I aim to clean up the i18n code a bit, so that I can eventually merge #58345 which moves locale-setting code for localized routes (ones that have locale prefix or suffix) from the `<LocaleSuggestions>` component to the page.js handlers. 