### PR TITLE
Help: Cleanup some unused bits from HelpContact

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -58,7 +58,6 @@ import getInlineHelpSupportVariation, {
 	SUPPORT_UPWORK_TICKET,
 } from 'calypso/state/selectors/get-inline-help-support-variation';
 import getLocalizedLanguageNames from 'calypso/state/selectors/get-localized-language-names';
-import getSupportLevel from 'calypso/state/selectors/get-support-level';
 import hasUserAskedADirectlyQuestion from 'calypso/state/selectors/has-user-asked-a-directly-question';
 import isDirectlyFailed from 'calypso/state/selectors/is-directly-failed';
 import isDirectlyReady from 'calypso/state/selectors/is-directly-ready';
@@ -359,16 +358,6 @@ class HelpContact extends Component {
 			} );
 
 		this.clearSavedContactForm();
-	};
-
-	shouldUseHappychat = () => {
-		// if happychat is disabled in the config, do not use it
-		if ( ! config.isEnabled( 'happychat' ) ) {
-			return false;
-		}
-
-		// if the happychat connection is able to accept chats, use it
-		return this.props.isHappychatAvailable && this.props.isHappychatUserEligible;
 	};
 
 	recordCompactSubmit = ( variation ) => {
@@ -766,7 +755,6 @@ export default connect(
 			isRequestingSites: isRequestingSites( state ),
 			supportVariation: getInlineHelpSupportVariation( state ),
 			activeSupportTickets: getActiveSupportTickets( state ),
-			supportLevel: getSupportLevel( state ),
 		};
 	},
 	{

--- a/client/state/selectors/get-support-level.js
+++ b/client/state/selectors/get-support-level.js
@@ -1,14 +1,4 @@
-import { get } from 'lodash';
-
 import 'calypso/state/help/init';
-
-export const SUPPORT_LEVEL_FREE = 'free';
-export const SUPPORT_LEVEL_PERSONAL = 'personal';
-export const SUPPORT_LEVEL_PERSONAL_WITH_LEGACY_CHAT = 'personal-with-legacy-chat';
-export const SUPPORT_LEVEL_PREMIUM = 'premium';
-export const SUPPORT_LEVEL_BUSINESS = 'business';
-export const SUPPORT_LEVEL_ECOMMERCE = 'ecommerce';
-export const SUPPORT_LEVEL_JETPACK_PAID = 'jetpack-paid';
 
 /**
  * Returns the current user's support level, representing their highest paid plan.
@@ -17,5 +7,5 @@ export const SUPPORT_LEVEL_JETPACK_PAID = 'jetpack-paid';
  * @returns {string} Level of support
  */
 export default function getSupportLevel( state ) {
-	return get( state, 'help.supportLevel', null );
+	return state.help.supportLevel ?? null;
 }

--- a/client/state/selectors/get-support-level.js
+++ b/client/state/selectors/get-support-level.js
@@ -4,8 +4,8 @@ import 'calypso/state/help/init';
  * Returns the current user's support level, representing their highest paid plan.
  *
  * @param  {object}  state   Global state tree
- * @returns {string} Level of support
+ * @returns {?string} Level of support
  */
 export default function getSupportLevel( state ) {
-	return state.help.supportLevel ?? null;
+	return state.help.supportLevel;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up some unused code from `HelpContact`, namely:

* An unused method, `shouldUseHappychat`
* An unused prop, `supportLevel`
* Some constants defined near `getSupportLevel`
* A simple Lodash `get()` usage

#### Testing instructions

Verify `/help/contact` still works well.