### PR TITLE
Drop jest-junit

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -79,7 +79,7 @@ private object EditingToolkit : BuildType({
 				export JEST_JUNIT_OUTPUT_DIR="../../test_results/editing-toolkit"
 
 				cd apps/editing-toolkit
-				yarn test:js --reporters=default --reporters=jest-junit --maxWorkers=${'$'}JEST_MAX_WORKERS
+				yarn test:js --reporters=default --reporters=jest-teamcity --maxWorkers=${'$'}JEST_MAX_WORKERS
 			"""
 		}
 		// Note: We run the PHP lint after the build to verify that the newspack-blocks

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -275,7 +275,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Run client tests
-				JEST_JUNIT_OUTPUT_DIR="./test_results/client" yarn test-client --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-junit --silent
+				JEST_JUNIT_OUTPUT_DIR="./test_results/client" yarn test-client --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-teamcity --silent
 			"""
 		}
 		bashNodeScript {
@@ -287,7 +287,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Run server tests
-				JEST_JUNIT_OUTPUT_DIR="./test_results/server" yarn test-server --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-junit --silent
+				JEST_JUNIT_OUTPUT_DIR="./test_results/server" yarn test-server --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-teamcity --silent
 			"""
 		}
 		bashNodeScript {
@@ -299,7 +299,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Run packages tests
-				JEST_JUNIT_OUTPUT_DIR="./test_results/packages" yarn test-packages --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-junit --silent
+				JEST_JUNIT_OUTPUT_DIR="./test_results/packages" yarn test-packages --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-teamcity --silent
 			"""
 		}
 		bashNodeScript {
@@ -311,7 +311,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Run build-tools tests
-				JEST_JUNIT_OUTPUT_DIR="./test_results/build-tools" yarn test-build-tools --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-junit --silent
+				JEST_JUNIT_OUTPUT_DIR="./test_results/build-tools" yarn test-build-tools --maxWorkers=${'$'}JEST_MAX_WORKERS --ci --reporters=default --reporters=jest-teamcity --silent
 			"""
 		}
 		bashNodeScript {
@@ -345,11 +345,6 @@ object RunAllUnitTests : BuildType({
 			param("xmlReportParsing.reportType", "checkstyle")
 			param("xmlReportParsing.reportDirs", "checkstyle_results/*.xml")
 			param("xmlReportParsing.verboseOutput", "true")
-		}
-		feature {
-			type = "xml-report-plugin"
-			param("xmlReportParsing.reportType", "junit")
-			param("xmlReportParsing.reportDirs", "test_results/**/*.xml")
 		}
 		perfmon {
 		}

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -118,6 +118,7 @@
 		"@types/wordpress__plugins": "^3.0.0",
 		"@wordpress/eslint-plugin": "^9.3.0",
 		"babel-jest": "^26.6.3",
+		"jest-teamcity": "^1.9.0",
 		"wait-for-expect": "^3.0.2",
 		"webpack": "^5.64.4"
 	}

--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
 		"jest-environment-jsdom": "^27.3.1",
 		"jest-enzyme": "^7.1.2",
 		"jest-junit": "^9.0.0",
+		"jest-teamcity": "^1.9.0",
 		"loader-utils": "^1.2.3",
 		"lodash": "^4.17.21",
 		"lunr": "^2.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,6 +1386,7 @@ __metadata:
     enzyme: ^3.11.0
     eslint: ^7.32.0
     jest: ^27.3.1
+    jest-teamcity: ^1.9.0
     lodash: ^4.17.21
     moment: ^2.26.0
     npm-run-all: ^4.1.5
@@ -38363,6 +38364,7 @@ testarmada-magellan@11.0.10:
     jest-environment-jsdom: ^27.3.1
     jest-enzyme: ^7.1.2
     jest-junit: ^9.0.0
+    jest-teamcity: ^1.9.0
     loader-utils: ^1.2.3
     lodash: ^4.17.21
     lunr: ^2.3.8


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Drop `jest-junit`. We use `jest-teamcity` instead, which sends test results using [TeamCity Service Messages](https://www.jetbrains.com/help/teamcity/service-messages.html) instead.

#### Testing instructions

Verify all tests are green.