### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` reader post to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,6 +1,5 @@
 import debugFactory from 'debug';
 import { omit } from 'lodash';
-import readerContentWidth from 'calypso/reader/lib/content-width';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?
@@ -119,39 +118,6 @@ Undocumented.prototype.getDomainPrice = function ( domain, fn ) {
 		},
 		fn
 	);
-};
-
-function addReaderContentWidth( params ) {
-	if ( params.content_width ) {
-		return;
-	}
-	const contentWidth = readerContentWidth();
-	if ( contentWidth ) {
-		params.content_width = contentWidth;
-	}
-}
-
-Undocumented.prototype.readFeedPost = function ( query, fn ) {
-	const params = omit( query, [ 'feedId', 'postId' ] );
-	debug( '/read/feed/' + query.feedId + '/posts/' + query.postId );
-	params.apiVersion = '1.2';
-	addReaderContentWidth( params );
-
-	return this.wpcom.req.get(
-		'/read/feed/' +
-			encodeURIComponent( query.feedId ) +
-			'/posts/' +
-			encodeURIComponent( query.postId ),
-		params,
-		fn
-	);
-};
-
-Undocumented.prototype.readSitePost = function ( query, fn ) {
-	const params = omit( query, [ 'site', 'postId' ] );
-	debug( '/read/sites/:site/post/:post' );
-	addReaderContentWidth( params );
-	return this.wpcom.req.get( '/read/sites/' + query.site + '/posts/' + query.postId, params, fn );
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` reader post request methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Go to the reader
* Open a full post of a site you're following.
* Verify the post loads correctly and the request to `/v1.2/read/feed/FEED_ID/posts/POST_ID` loads well.
* Go to `/read/search` and open a post.
* Verify the post loads correctly and the request to `/v1.1/read/sites/SITE_ID/posts/POST_ID` loads well.
* Verify tests still pass: `yarn run test-client client/state/reader/posts/test/actions.js`