### PR TITLE
Update domains contact info page

### DIFF
--- a/client/components/domains/layout/style.scss
+++ b/client/components/domains/layout/style.scss
@@ -1,0 +1,18 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.two-columns-layout {
+	@include break-xlarge {
+		display: grid;
+		grid-template-columns: 1fr 315px;
+		column-gap: 48px;
+	}
+
+	&__content {
+		grid-column: 1 2;
+	}
+
+	&__sidebar {
+		grid-column: 2 3;
+	}
+}

--- a/client/components/domains/layout/two-columns-layout.tsx
+++ b/client/components/domains/layout/two-columns-layout.tsx
@@ -1,0 +1,19 @@
+import classNames from 'classnames';
+import React from 'react';
+import './style.scss';
+import { TwoColumnsLayoutProps } from './types';
+
+const TwoColumnsLayout = ( {
+	className = '',
+	content,
+	sidebar,
+}: TwoColumnsLayoutProps ): JSX.Element => {
+	return (
+		<div className={ classNames( 'two-columns-layout', className ) }>
+			<div className="two-columns-layout__content">{ content }</div>
+			<div className="two-columns-layout__sidebar">{ sidebar }</div>
+		</div>
+	);
+};
+
+export default TwoColumnsLayout;

--- a/client/components/domains/layout/types.ts
+++ b/client/components/domains/layout/types.ts
@@ -1,0 +1,5 @@
+export type TwoColumnsLayoutProps = {
+	className?: string;
+	content?: JSX.Element;
+	sidebar?: JSX.Element;
+};

--- a/client/my-sites/domains/domain-management/components/domain/non-owner-card.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/non-owner-card.jsx
@@ -1,8 +1,9 @@
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 import { getSelectedDomain } from 'calypso/lib/domains';
 
-const NonOwnerCard = ( { domains, selectedDomainName, translate } ) => {
+const NonOwnerCard = ( { domains, selectedDomainName } ) => {
+	const translate = useTranslate();
 	const domain = getSelectedDomain( { domains, selectedDomainName } );
 
 	return (
@@ -24,4 +25,4 @@ const NonOwnerCard = ( { domains, selectedDomainName, translate } ) => {
 	);
 };
 
-export default localize( NonOwnerCard );
+export default NonOwnerCard;

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -109,7 +109,13 @@ const EditContactInfoPage = ( {
 				icon={ false }
 			/>
 		);
-		const icannLink = <ExternalLink href="https://www.icann.org/" target="_blank" icon={ false } />;
+		const icannLink = (
+			<ExternalLink
+				href="https://www.icann.org/resources/pages/contact-verification-2013-05-03-en"
+				target="_blank"
+				icon={ false }
+			/>
+		);
 		const explanationText1 = translate(
 			'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.',
 			{

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -162,7 +162,7 @@ const EditContactInfoPage = ( {
 				brandFont
 				headerText={ translate( 'Edit contact information' ) }
 				subHeaderText={ translate(
-					'Domain owners are required to provide correct contact information'
+					'Domain owners are required to provide correct contact information.'
 				) }
 				align="left"
 			/>

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -8,7 +9,7 @@ const EditContactInfoPage = (): JSX.Element => {
 	return (
 		<Main className="edit-contact-info-page" wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-			Page goes here.
+			<TwoColumnsLayout content={ <div>CONTENT HERE</div> } sidebar={ <div>SIDEBAR HERE</div> } />
 		</Main>
 	);
 };

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -94,7 +94,7 @@ const EditContactInfoPage = ( {
 				domainRegistrationAgreementUrl={ domain.domainRegistrationAgreementUrl }
 				selectedDomain={ domain }
 				selectedSite={ selectedSite }
-				showContactInfoNote={ true }
+				showContactInfoNote={ false }
 			/>
 		);
 	};
@@ -128,11 +128,13 @@ const EditContactInfoPage = ( {
 		);
 		return (
 			<div className="edit-contact-info-page__sidebar">
+				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="edit-contact-info-page__sidebar__title">
 					<p>
 						<strong>{ translate( 'Provide accurate contact information' ) }</strong>
 					</p>
 				</div>
+				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="edit-contact-info-page__sidebar__content">
 					<p>{ explanationText1 }</p>
 					<p>{ explanationText2 }</p>

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -1,9 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
+import ExternalLink from 'calypso/components/external-link';
+import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
@@ -18,6 +21,8 @@ import EditContactInfoFormCard from '../edit-contact-info/form-card';
 import PendingWhoisUpdateCard from '../edit-contact-info/pending-whois-update-card';
 import EditContactInfoPrivacyEnabledCard from '../edit-contact-info/privacy-enabled-card';
 import { EditContactInfoPageProps } from './types';
+
+import './style.scss';
 
 const EditContactInfoPage = ( {
 	currentRoute,
@@ -85,13 +90,53 @@ const EditContactInfoPage = ( {
 		}
 
 		return (
-			<div>
-				<EditContactInfoFormCard
-					domainRegistrationAgreementUrl={ domain.domainRegistrationAgreementUrl }
-					selectedDomain={ domain }
-					selectedSite={ selectedSite }
-					showContactInfoNote={ true }
-				/>
+			<EditContactInfoFormCard
+				domainRegistrationAgreementUrl={ domain.domainRegistrationAgreementUrl }
+				selectedDomain={ domain }
+				selectedSite={ selectedSite }
+				showContactInfoNote={ true }
+			/>
+		);
+	};
+
+	const renderSidebar = () => {
+		const supportLink = (
+			<ExternalLink
+				href={ localizeUrl(
+					'https://wordpress.com/support/domains/domain-registrations-and-privacy/#privacy-protection'
+				) }
+				target="_blank"
+				icon={ false }
+			/>
+		);
+		const icannLink = <ExternalLink href="https://www.icann.org/" target="_blank" icon={ false } />;
+		const explanationText1 = translate(
+			'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.',
+			{
+				components: {
+					icannLinkComponent: icannLink,
+				},
+			}
+		);
+		const explanationText2 = translate(
+			'Domain privacy service is included for free on applicable domains. {{supportLinkComponent}}Learn more{{/supportLinkComponent}}.',
+			{
+				components: {
+					supportLinkComponent: supportLink,
+				},
+			}
+		);
+		return (
+			<div className="edit-contact-info-page__sidebar">
+				<div className="edit-contact-info-page__sidebar__title">
+					<p>
+						<strong>{ translate( 'Provide accurate contact information' ) }</strong>
+					</p>
+				</div>
+				<div className="edit-contact-info-page__sidebar__content">
+					<p>{ explanationText1 }</p>
+					<p>{ explanationText2 }</p>
+				</div>
 			</div>
 		);
 	};
@@ -104,7 +149,15 @@ const EditContactInfoPage = ( {
 		<Main className="edit-contact-info-page" wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
-			<TwoColumnsLayout content={ renderContent() } sidebar={ <div>SIDEBAR HERE</div> } />
+			<FormattedHeader
+				brandFont
+				headerText={ translate( 'Edit contact information' ) }
+				subHeaderText={ translate(
+					'Domain owners are required to provide correct contact information'
+				) }
+				align="left"
+			/>
+			<TwoColumnsLayout content={ renderContent() } sidebar={ renderSidebar() } />
 		</Main>
 	);
 };

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -116,22 +116,7 @@ const EditContactInfoPage = ( {
 				icon={ false }
 			/>
 		);
-		const explanationText1 = translate(
-			'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.',
-			{
-				components: {
-					icannLinkComponent: icannLink,
-				},
-			}
-		);
-		const explanationText2 = translate(
-			'Domain privacy service is included for free on applicable domains. {{supportLinkComponent}}Learn more{{/supportLinkComponent}}.',
-			{
-				components: {
-					supportLinkComponent: supportLink,
-				},
-			}
-		);
+
 		return (
 			<div className="edit-contact-info-page__sidebar">
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
@@ -142,8 +127,26 @@ const EditContactInfoPage = ( {
 				</div>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="edit-contact-info-page__sidebar__content">
-					<p>{ explanationText1 }</p>
-					<p>{ explanationText2 }</p>
+					<p>
+						{ translate(
+							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.',
+							{
+								components: {
+									icannLinkComponent: icannLink,
+								},
+							}
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Domain privacy service is included for free on applicable domains. {{supportLinkComponent}}Learn more{{/supportLinkComponent}}.',
+							{
+								components: {
+									supportLinkComponent: supportLink,
+								},
+							}
+						) }
+					</p>
 				</div>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -1,20 +1,57 @@
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
+import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isRequestingWhois from 'calypso/state/selectors/is-requesting-whois';
+import { EditContactInfoPageProps } from './types';
 
-const EditContactInfoPage = (): JSX.Element => {
+const EditContactInfoPage = ( props: EditContactInfoPageProps ): JSX.Element => {
+	const translate = useTranslate();
+
+	const renderBreadcrumbs = () => {
+		const { selectedSite, currentRoute, selectedDomainName } = props;
+
+		const previousPath = domainManagementEdit(
+			selectedSite?.slug,
+			selectedDomainName,
+			currentRoute
+		);
+
+		const items = [
+			{
+				label: translate( 'Domains' ),
+				href: domainManagementList( selectedSite?.slug, selectedDomainName ),
+			},
+			{
+				label: selectedDomainName,
+				href: previousPath,
+			},
+			{ label: translate( 'Edit contact infomation' ) },
+		];
+
+		const mobileItem = {
+			label: translate( 'Back' ),
+			href: previousPath,
+			showBackArrow: true,
+		};
+
+		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
+	};
+
 	return (
 		<Main className="edit-contact-info-page" wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+			{ renderBreadcrumbs() }
 			<TwoColumnsLayout content={ <div>CONTENT HERE</div> } sidebar={ <div>SIDEBAR HERE</div> } />
 		</Main>
 	);
 };
 
-export default connect( ( state, ownProps ) => {
+export default connect( ( state, ownProps: EditContactInfoPageProps ) => {
 	return {
 		currentRoute: getCurrentRoute( state ),
 		isRequestingWhois: isRequestingWhois( state, ownProps.selectedDomainName ),

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -119,14 +119,12 @@ const EditContactInfoPage = ( {
 
 		return (
 			<div className="edit-contact-info-page__sidebar">
-				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-				<div className="edit-contact-info-page__sidebar__title">
+				<div className="edit-contact-info-page__sidebar-title">
 					<p>
 						<strong>{ translate( 'Provide accurate contact information' ) }</strong>
 					</p>
 				</div>
-				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-				<div className="edit-contact-info-page__sidebar__content">
+				<div className="edit-contact-info-page__sidebar-content">
 					<p>
 						{ translate(
 							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.',

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -84,7 +84,7 @@ const EditContactInfoPage = ( {
 			return (
 				<EditContactInfoPrivacyEnabledCard
 					selectedDomainName={ selectedDomainName }
-					selectedSiteSlug={ selectedSite?.slug as string }
+					selectedSiteSlug={ selectedSite!.slug }
 				/>
 			);
 		}

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
@@ -1,0 +1,19 @@
+.edit-contact-info-page {
+	&__sidebar {
+		padding: 24px 16px;
+		background-color: var( --studio-gray-0 );
+		&__content {
+			p {
+				margin: 0 0 1em;
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+		&__title {
+			p {
+				margin-bottom: 0.5em;
+			}
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
@@ -1,8 +1,8 @@
 .edit-contact-info-page {
 	&__sidebar {
-		padding: 24px 16px;
+		padding: 24px;
 		background-color: var( --studio-gray-0 );
-		&__content {
+		&-content {
 			p {
 				margin: 0 0 1em;
 				&:last-child {
@@ -10,7 +10,7 @@
 				}
 			}
 		}
-		&__title {
+		&-title {
 			p {
 				margin-bottom: 0.5em;
 			}

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/types.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/types.tsx
@@ -4,6 +4,7 @@ import { SiteData } from 'calypso/state/ui/selectors/site-data';
 export type EditContactInfoPageProps = {
 	currentRoute: string;
 	domains: ResponseDomain[];
+	isRequestingWhois: boolean;
 	selectedDomainName: string;
 	selectedSite: SiteData | null;
 };

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/types.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/types.tsx
@@ -2,7 +2,8 @@ import { ResponseDomain } from 'calypso/lib/domains/types';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 export type EditContactInfoPageProps = {
+	currentRoute: string;
 	domains: ResponseDomain[];
 	selectedDomainName: string;
-	selectedSite: SiteData | boolean;
+	selectedSite: SiteData | null;
 };


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR updates new Edit Contact Info pages, adding two columns layout, form and sidebar message.

_Note 1: new form style/functionalities will be addressed in a new PR._ 

_Note 2: there are a couple of TS warning depending on how some imported componente where defined._ 

![Markup on 2021-11-30 at 09:25:34](https://user-images.githubusercontent.com/2797601/144011432-64a791db-6a44-488d-8343-00040bcaa980.png)

## Testing instructions

* Build this branch locally or open the live Calypso link
* Access to `Edit Contact Info` page from a domain you own (`Upgrades > Domains > [select a domain] > Update your contact info > Edit Contact Info`)
* If you're in the live Calypso link, please append `?flags=domains/contact-info-redesign` to your URL to enable the appropriate feature flag
* Very that layout reflects the new proposed on redesign i4 (hlVh2q24ad6MCwlwNnE9PQ-fi-600%3A53265)