### PR TITLE
Tour Kit:  viewport based reference element and code style refactors

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -66,7 +66,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	}
 }
 
-.wpcom-editor-welcome-tour > .tour-kit__frame {
+.wpcom-editor-welcome-tour > .tour-kit-frame__container {
 	box-shadow: none;
 }
 
@@ -184,8 +184,8 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 			opacity: 0;
 		}
 
-		.tour-kit__frame:hover &,
-		.tour-kit__frame:focus-within & {
+		.tour-kit-frame__container:hover &,
+		.tour-kit-frame__container:focus-within & {
 			.components-button {
 				opacity: 0.7;
 

--- a/packages/tour-kit/.storybook/preview.js
+++ b/packages/tour-kit/.storybook/preview.js
@@ -1,2 +1,1 @@
-import '@automattic/calypso-color-schemes';
 import './styles.scss';

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -36,12 +36,9 @@
 		"classnames": "^2.3.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
-		"react-popper": "^2.2.5",
-		"typescript": "^4.4.4",
-		"use-debounce": "^3.1.0"
+		"react-popper": "^2.2.5"
 	},
 	"devDependencies": {
-		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/preset-scss": "^1.0.3",
 		"css-loader": "^3.6.0",

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -35,7 +35,10 @@
 		"@popperjs/core": "^2.10.2",
 		"classnames": "^2.3.1",
 		"react": "^17.0.2",
-		"react-popper": "^2.2.5"
+		"react-dom": "^17.0.2",
+		"react-popper": "^2.2.5",
+		"typescript": "^4.4.4",
+		"use-debounce": "^3.1.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -31,6 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/viewport-react": "workspace:^",
 		"@popperjs/core": "^2.10.2",
 		"classnames": "^2.3.1",
 		"react": "^17.0.2",

--- a/packages/tour-kit/src/components/tour-frame.tsx
+++ b/packages/tour-kit/src/components/tour-frame.tsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 /**
@@ -29,8 +30,9 @@ const TourFrame: React.FunctionComponent< Props > = ( { config } ) => {
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ currentStepIndex, setCurrentStepIndex ] = useState( 0 );
 	const lastStepIndex = config.steps.length - 1;
+	const isMobile = useMobileBreakpoint();
 	const referenceElementSelector =
-		config.steps[ currentStepIndex ].referenceElements?.desktop || null;
+		config.steps[ currentStepIndex ].referenceElements?.[ isMobile ? 'mobile' : 'desktop' ] || null;
 	const referenceElement = referenceElementSelector
 		? document.querySelector< HTMLElement >( referenceElementSelector )
 		: null;

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -21,7 +21,7 @@ const handleCallback = ( currentStepIndex: number, callback?: Callback ) => {
 	typeof callback === 'function' && callback( currentStepIndex );
 };
 
-const TourFrame: React.FunctionComponent< Props > = ( { config } ) => {
+const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 	const tourContainerRef = useRef( null );
 	const popperElementRef = useRef( null );
 	const [ initialFocusedElement, setInitialFocusedElement ] = useState< HTMLElement | null >(
@@ -145,7 +145,7 @@ const TourFrame: React.FunctionComponent< Props > = ( { config } ) => {
 		setTimeout( () => initialFocusedElement?.focus() );
 	}, [ initialFocusedElement ] );
 
-	const classNames = classnames( 'tour-kit', config.options?.className );
+	const classNames = classnames( 'tour-kit-frame', config.options?.className );
 
 	return (
 		<>
@@ -160,9 +160,13 @@ const TourFrame: React.FunctionComponent< Props > = ( { config } ) => {
 			<div className={ classNames } ref={ tourContainerRef }>
 				{ showOverlay() && <Overlay visible={ true } /> }
 				{ showSpotlight() && <Spotlight referenceElement={ referenceElement } /> }
-				<div className="tour-kit__frame" ref={ popperElementRef } { ...stepRepositionProps }>
+				<div
+					className="tour-kit-frame__container"
+					ref={ popperElementRef }
+					{ ...stepRepositionProps }
+				>
 					{ showArrowIndicator() && (
-						<div className="tour-kit__arrow" data-popper-arrow { ...arrowPositionProps } />
+						<div className="tour-kit-frame__arrow" data-popper-arrow { ...arrowPositionProps } />
 					) }
 					{ ! isMinimized ? (
 						<>
@@ -193,4 +197,4 @@ const TourFrame: React.FunctionComponent< Props > = ( { config } ) => {
 	);
 };
 
-export default TourFrame;
+export default TourKitFrame;

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -9,8 +9,8 @@ import classnames from 'classnames';
  */
 import usePopperHandler from '../hooks/use-popper-handler';
 import KeyboardNavigation from './keyboard-navigation';
-import Overlay from './overlay';
-import Spotlight from './spotlight';
+import Overlay from './tour-kit-overlay';
+import Spotlight from './tour-kit-spotlight';
 import type { Config, Callback } from '../types';
 
 interface Props {

--- a/packages/tour-kit/src/components/tour-kit-overlay.tsx
+++ b/packages/tour-kit/src/components/tour-kit-overlay.tsx
@@ -7,14 +7,14 @@ interface Props {
 	visible: boolean;
 }
 
-const Overlay: React.FunctionComponent< Props > = ( { visible } ) => {
+const TourKitOverlay: React.FunctionComponent< Props > = ( { visible } ) => {
 	return (
 		<div
-			className={ classnames( 'tour-kit__overlay', {
+			className={ classnames( 'tour-kit-overlay', {
 				'--visible': visible,
 			} ) }
 		/>
 	);
 };
 
-export default Overlay;
+export default TourKitOverlay;

--- a/packages/tour-kit/src/components/tour-kit-portal.tsx
+++ b/packages/tour-kit/src/components/tour-kit-portal.tsx
@@ -14,7 +14,7 @@ interface Props {
 	config: Config;
 }
 
-const TourPortal: React.FunctionComponent< Props > = ( { config } ) => {
+const TourKitPortal: React.FunctionComponent< Props > = ( { config } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 
 	useEffect( () => {
@@ -30,4 +30,4 @@ const TourPortal: React.FunctionComponent< Props > = ( { config } ) => {
 	return <div>{ createPortal( <TourKitFrame config={ config } />, portalParent ) }</div>;
 };
 
-export default TourPortal;
+export default TourKitPortal;

--- a/packages/tour-kit/src/components/tour-kit-portal.tsx
+++ b/packages/tour-kit/src/components/tour-kit-portal.tsx
@@ -5,7 +5,7 @@ import { createPortal, useEffect, useRef } from '@wordpress/element';
 /**
  * Internal Dependencies
  */
-import TourFrame from './tour-frame';
+import TourKitFrame from './tour-kit-frame';
 import type { Config } from '../types';
 
 import '../styles.scss';
@@ -19,7 +19,7 @@ const TourPortal: React.FunctionComponent< Props > = ( { config } ) => {
 
 	useEffect( () => {
 		// @todo clk "tour-kit"
-		portalParent.classList.add( 'tour-kit__portal-parent' );
+		portalParent.classList.add( 'tour-kit-portal' );
 		document.body.appendChild( portalParent );
 
 		return () => {
@@ -27,7 +27,7 @@ const TourPortal: React.FunctionComponent< Props > = ( { config } ) => {
 		};
 	}, [ portalParent ] );
 
-	return <div>{ createPortal( <TourFrame config={ config } />, portalParent ) }</div>;
+	return <div>{ createPortal( <TourKitFrame config={ config } />, portalParent ) }</div>;
 };
 
 export default TourPortal;

--- a/packages/tour-kit/src/components/tour-kit-spotlight.tsx
+++ b/packages/tour-kit/src/components/tour-kit-spotlight.tsx
@@ -1,14 +1,14 @@
 import { useMemo, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import usePopperHandler from '../hooks/use-popper-handler';
-import Overlay from './overlay';
+import Overlay from './tour-kit-overlay';
 import type { Rect, Placement } from '@popperjs/core';
 
 interface Props {
 	referenceElement: HTMLElement | null;
 }
 
-const Spotlight: React.FunctionComponent< Props > = ( { referenceElement } ) => {
+const TourKitSpotlight: React.FunctionComponent< Props > = ( { referenceElement } ) => {
 	const popperElementRef = useRef( null );
 	const modifiers = [
 		useMemo(
@@ -52,7 +52,7 @@ const Spotlight: React.FunctionComponent< Props > = ( { referenceElement } ) => 
 		<>
 			<Overlay visible={ ! clipRepositionProps } />
 			<div
-				className={ classnames( 'tour-kit__spotlight', {
+				className={ classnames( 'tour-kit-spotlight', {
 					'--visible': !! clipRepositionProps,
 				} ) }
 				ref={ popperElementRef }
@@ -62,4 +62,4 @@ const Spotlight: React.FunctionComponent< Props > = ( { referenceElement } ) => 
 	);
 };
 
-export default Spotlight;
+export default TourKitSpotlight;

--- a/packages/tour-kit/src/index.ts
+++ b/packages/tour-kit/src/index.ts
@@ -1,2 +1,2 @@
-export { default } from './components/tour-portal';
+export { default } from './components/tour-kit-portal';
 export * from './types';

--- a/packages/tour-kit/src/styles.scss
+++ b/packages/tour-kit/src/styles.scss
@@ -11,7 +11,7 @@
 	background: white;
 }
 
-.tour-kit__overlay {
+.tour-kit-overlay {
 	position: fixed;
 	width: 100vw;
 	height: 100vh;
@@ -25,7 +25,7 @@
 	}
 }
 
-.tour-kit__spotlight {
+.tour-kit-spotlight {
 	&.--visible {
 		position: fixed;
 		width: 50px;

--- a/packages/tour-kit/src/styles.scss
+++ b/packages/tour-kit/src/styles.scss
@@ -1,4 +1,4 @@
-.tour-kit__frame {
+.tour-kit-frame__container {
 	border-radius: 2px;
 	bottom: 44px;
 	display: inline;
@@ -7,7 +7,7 @@
 	z-index: 9999;
 	// Avoid the text cursor when the text is not selectable
 	cursor: default;
-    box-shadow: 0px 0px 3px 0px rgba( 0, 0, 0, 0.25 );
+    box-shadow: 0 0 3px 0 rgba( 0, 0, 0, 0.25 );
 	background: white;
 }
 
@@ -38,12 +38,12 @@
 	}
 }
 
-.tour-kit__arrow {
+.tour-kit-frame__arrow {
     visibility: hidden;
 }
 
-.tour-kit__arrow,
-.tour-kit__arrow::before {
+.tour-kit-frame__arrow,
+.tour-kit-frame__arrow::before {
     position: absolute;
     width: 12px;
     height: 12px;
@@ -51,34 +51,34 @@
     z-index: -1;
 }
 
-.tour-kit__arrow::before {
+.tour-kit-frame__arrow::before {
     visibility: visible;
     content: '';
-    transform: rotate(45deg);
+    transform: rotate( 45deg );
 }
 
-.tour-kit__frame[data-popper-placement^='top'] > .tour-kit__arrow {
+.tour-kit-frame__container[data-popper-placement^='top'] > .tour-kit-frame__arrow {
     bottom: -6px;
     &::before {
         box-shadow: 1px 1px 2px -1px rgb( 0 0 0 / 25% );
     }
 }
 
-.tour-kit__frame[data-popper-placement^='bottom'] > .tour-kit__arrow {
+.tour-kit-frame__container[data-popper-placement^='bottom'] > .tour-kit-frame__arrow {
     top: -6px;
     &::before {
         box-shadow: -1px -1px 2px -1px rgb( 0 0 0 / 25% );
     }
 }
 
-.tour-kit__frame[data-popper-placement^='left'] > .tour-kit__arrow {
+.tour-kit-frame__container[data-popper-placement^='left'] > .tour-kit-frame__arrow {
     right: -6px;
     &::before {
         box-shadow: -1px 1px 2px -1px rgb( 0 0 0 / 25% );
     }
 }
 
-.tour-kit__frame[data-popper-placement^='right'] > .tour-kit__arrow {
+.tour-kit-frame__container[data-popper-placement^='right'] > .tour-kit-frame__arrow {
     left: -6px;
     &::before {
         box-shadow: 1px -1px 2px -1px rgb( 0 0 0 / 25% );

--- a/packages/tour-kit/src/types-patch.d.ts
+++ b/packages/tour-kit/src/types-patch.d.ts
@@ -1,0 +1,3 @@
+declare module '@automattic/viewport-react' {
+	export const useMobileBreakpoint: () => boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,6 +1114,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/viewport-react": "workspace:^"
     "@popperjs/core": ^2.10.2
     "@storybook/preset-scss": ^1.0.3
     classnames: ^2.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,7 +1112,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/tour-kit@workspace:packages/tour-kit"
   dependencies:
-    "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/viewport-react": "workspace:^"
     "@popperjs/core": ^2.10.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,6 +1120,7 @@ __metadata:
     classnames: ^2.3.1
     css-loader: ^3.6.0
     react: ^17.0.2
+    react-dom: ^17.0.2
     react-popper: ^2.2.5
     sass-loader: ^10.1.1
     style-loader: ^1.2.1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Each Welcome Tour step has a `referenceElements` object, with `desktop` and `mobile` as selectors of the reference elements to be used in the repositioning ( https://github.com/Automattic/wp-calypso/pull/57757 ).

Until now, only `desktop` was used, but with this PR we can use `useMobileBreakpoint` to define the viewport ad use it accordingly to choose the right selector.

Refactored class names in the package to follow guidelines.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Sandbox a site, checkout branch, and `yarn dev --sync` from `apps/editing-toolkit` to sync sandbox.
2. Go to the editor, append `&welcome-tour-next` to the URL, reload. 
3. Open the sidebar and from there click on "Welcome Guide".
3. TBD

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57223
Fixes #57223
