### PR TITLE
Plugin Details grid

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -125,7 +125,7 @@ $plugin-details-header-padding: 100px;
 	@include breakpoint-deprecated( '>1040px' ) {
 		@include display-grid;
 		@include grid-template-columns( 12, 24px, 1fr );
-		grid-gap: 24px;
+		grid-gap: 80px;
 	}
 
 	.plugin-details__layout-col-left {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -284,6 +284,7 @@ $plugin-details-header-padding: 100px;
 		.card {
 			box-shadow: none;
 			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the gap between column on Page Details from 24px to 80px.
* Remove padding-right from the card.

#### Testing instructions
* Go to `/plugins` page
* Select a plugin to go **Plugin Details** page
* Verify if the two columns (and the banner) are aligned as below: 


![Screen Shot 2021-11-30 at 11 12 27](https://user-images.githubusercontent.com/5039531/144074239-8edc6f1e-7d40-4583-81a6-910fc30e0d36.png)

----

Fixes  #58288