### PR TITLE
Domains: Email setup component design fixes

### DIFF
--- a/client/my-sites/domains/domain-management/email-setup/index.jsx
+++ b/client/my-sites/domains/domain-management/email-setup/index.jsx
@@ -1,3 +1,4 @@
+import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -119,8 +120,15 @@ class EmailSetup extends Component {
 				<span>{ translate( 'Set up an existing email service for this domain' ) }</span>
 			</span>
 		);
+
 		return (
-			<FoldableCard header={ header } clickableHeader className="email-setup">
+			<FoldableCard
+				header={ header }
+				clickableHeader
+				className="email-setup"
+				actionButton={ <Icon icon={ chevronDown } viewBox="6 4 12 14" size={ 16 } /> }
+				actionButtonExpanded={ <Icon icon={ chevronUp } viewBox="6 4 12 14" size={ 16 } /> }
+			>
 				{ this.renderProviderTabs() }
 				{ this.renderConfigurationForm() }
 			</FoldableCard>

--- a/client/my-sites/domains/domain-management/email-setup/index.jsx
+++ b/client/my-sites/domains/domain-management/email-setup/index.jsx
@@ -117,7 +117,9 @@ class EmailSetup extends Component {
 			<span>
 				<strong>{ translate( 'Email setup' ) }</strong>
 				<br />
-				<span>{ translate( 'Set up an existing email service for this domain' ) }</span>
+				<span className="email-setup__subtitle">
+					{ translate( 'Set up an existing email service for this domain' ) }
+				</span>
 			</span>
 		);
 

--- a/client/my-sites/domains/domain-management/email-setup/style.scss
+++ b/client/my-sites/domains/domain-management/email-setup/style.scss
@@ -27,7 +27,7 @@
 			margin-right: 0;
 		}
 
-		.foldable-card__main > span > span {
+		.email-setup__subtitle {
 			font-size: $font-body-small;
 			color: var( --color-neutral-50 );
 		}

--- a/client/my-sites/domains/domain-management/email-setup/style.scss
+++ b/client/my-sites/domains/domain-management/email-setup/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .email-setup {
 	.section-nav {
 		box-shadow: none;
@@ -16,12 +19,43 @@
 
 .email-setup.foldable-card {
 	.foldable-card__header {
-		padding: 24px;
+		padding: 16px;
+
+		.foldable-card__main {
+			justify-content: space-between;
+			max-width: 100%;
+			margin-right: 0;
+		}
+
+		.foldable-card__main > span > span {
+			font-size: $font-body-small;
+			color: var( --color-neutral-50 );
+		}
+
+		.foldable-card__action {
+			position: relative;
+
+			svg {
+				fill: var( --color-neutral-90 );
+			}
+		}
+
+		.foldable-card__secondary {
+			display: none;
+		}
+
+		@include break-mobile {
+			padding: 24px;
+		}
 	}
 
 	.foldable-card__content {
-		padding: 0 24px 24px;
+		padding: 0 16px 16px;
 		border-top: none;
+
+		@include break-mobile {
+			padding: 0 24px 24px;
+		}
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the design issues pointed out by the design review detailed in pcYYhz-q9-p2#comment-363.

The following two screenshots show the points that were updated:

![Markup on 2021-11-30 at 12:19:21](https://user-images.githubusercontent.com/5324818/144075172-5f5e98f3-c2f9-4bf0-9009-e3fcfabff98d.png)

<img width="397" alt="Screen Shot 2021-11-30 at 12 20 33" src="https://user-images.githubusercontent.com/5324818/144075215-68202374-326d-437e-832b-7a513183e0a7.png">

1. The description text is 14px (`$font-body-small`) and color `--color-neutral-50`
2. The chevron icons are the ones from Gutemberg (`chevronDown` and `chevronUp`, you can check them at https://gutenberg-icons.tungdu.com/) and they have color `--color-neutral-90`
3. The chevron is inside the padding of 24px
4. Mobile view: the component has a padding of 16px

For comparison, these next two screenshots show the component before the fixes:

<img width="1043" alt="Screen Shot 2021-11-30 at 11 33 03" src="https://user-images.githubusercontent.com/5324818/144076087-6220d388-422d-48e5-93cb-9e09c49f3c35.png">

<img width="397" alt="Screen Shot 2021-11-30 at 12 20 33" src="https://user-images.githubusercontent.com/5324818/144075799-8e88cc0b-779b-4545-b490-817b1847dde5.png">

### Testing instructions

- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/dns-records-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades > Domains"
- Select one of your registered domains or domain connections
- Go to "Change your name servers & DNS records"
- Check the email setup component and ensure the layout updates mentioned in the description are present