### PR TITLE
Checkout: Move help link analytics directly into CheckoutHelpLink

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -6,7 +6,6 @@ import {
 	isPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { useEvents } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -140,9 +139,8 @@ export default function CheckoutHelpLink(): JSX.Element {
 	const presalesEligiblePlanLabel = getHighestWpComPlanLabel( plans );
 	const isPresalesChatEligible = presalesChatAvailable && presalesEligiblePlanLabel;
 
-	const onEvent = useEvents();
 	const handleHelpButtonClicked = () => {
-		onEvent( { type: 'calypso_checkout_composite_summary_help_click', payload: {} } );
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_summary_help_click' ) );
 		reduxDispatch( showInlineHelpPopover() );
 	};
 

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -199,11 +199,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				case 'SHOW_MODAL_AUTHORIZATION': {
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 				}
-				case 'calypso_checkout_composite_summary_help_click': {
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_summary_help_click' )
-					);
-				}
 				case 'CART_CHANGE_PLAN_LENGTH': {
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_plan_length_change', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the help link analytics from the checkout event handler directly into where the event occurs.

#### Testing instructions

You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.

See instructions for making the help link appear in https://github.com/Automattic/wp-calypso/pull/49349

Click on the link and verify that the `calypso_checkout_composite_summary_help_click` event is fired.

