### PR TITLE
Domains: Add right-hand column to the transfer page

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { connect } from 'react-redux';
@@ -9,6 +10,7 @@ import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
+import { TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import {
 	domainManagementEdit,
@@ -135,8 +137,13 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 						<span className="transfer-page__help-section-text">
 							{ __( 'Transferring a domain within WordPress.com is immediate.' ) }
 							<br />
-							{ __(
-								'However, transferring a domain to another provider can take five to seven days during which no changes to the domain can be made. Read this important information before starting a transfer.'
+							{ createInterpolateElement(
+								__(
+									'However, transferring a domain to another provider can take five to seven days during which no changes to the domain can be made. Read <a>this important information</a> before starting a transfer.'
+								),
+								{
+									a: createElement( 'a', { href: TRANSFER_DOMAIN_REGISTRATION } ),
+								}
 							) }
 						</span>
 					</Card>

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -4,6 +4,8 @@ import { useI18n } from '@wordpress/react-i18n';
 import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
 import FormattedHeader from 'calypso/components/formatted-header';
+import Layout from 'calypso/components/layout';
+import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
@@ -125,7 +127,21 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
 			<FormattedHeader brandFont headerText={ __( 'Transfer' ) } align="left" />
-			{ renderTransferOptions() }
+			<Layout>
+				<Column type="main">{ renderTransferOptions() }</Column>
+				<Column type="sidebar">
+					<Card className="transfer-page__help-section-card">
+						<p className="transfer-page__help-section-title">{ __( 'How do transfers work?' ) }</p>
+						<span className="transfer-page__help-section-text">
+							{ __( 'Transferring a domain within WordPress.com is immediate.' ) }
+							<br />
+							{ __(
+								'However, transferring a domain to another provider can take five to seven days during which no changes to the domain can be made. Read this important information before starting a transfer.'
+							) }
+						</span>
+					</Card>
+				</Column>
+			</Layout>
 		</Main>
 	);
 };

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -91,4 +91,15 @@
 			}
 		}
 	}
+
+	@include breakpoint-deprecated( '>1280px' ) {
+		.layout__column--main {
+			padding-right: 24px;
+		}
+	
+		.layout__column--sidebar {
+			padding-left: 24px;
+		}
+	}
+	
 }

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -62,4 +62,33 @@
 			margin: 24px 0;
 		}
 	}
+
+	.transfer-page__help {
+		&-section-card {
+			background: var( --studio-gray-0 );
+			border-radius: 2px;
+			box-shadow: none;
+			padding: 24px;
+		}
+
+		&-section-title {
+			font-size: $font-body-small;
+			line-height: 24px;
+			font-weight: 600;
+			margin-bottom: 4px;
+			color: var( --studio-gray-80 );
+		}
+		
+		&-section-text {
+			color: var( --studio-gray-50 );
+			font-size: $font-body-small;
+			line-height: 20px;
+
+			br {
+				content: ' ';
+				display: block;
+				margin-bottom: 20px;
+			}
+		}
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds the right-hand column to the transfer page with a help text. This is part of the domain management redesign project described in pcYYhz-m2-p2.

#### Preview
##### Desktop
![image](https://user-images.githubusercontent.com/18705930/144122763-2a70ab87-b6d9-4729-b511-1fefc12417c2.png)

##### Mobile
![image](https://user-images.githubusercontent.com/18705930/144122735-8f6cb055-21f7-4284-8b05-b80708fae44a.png)

#### Testing instructions
- Go to "Upgrades > Domains";
- Select one of your registered domains;
- If you're in the live Calypso link, please append `?flags=domains/transfers-redesign` to your URL to enable the appropriate feature flag;
- Check that the second column is displayed correctly as in the screenshots above.