### PR TITLE
Checkout: Record coupon analytics directly in useCouponFieldState

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-coupon-field-state.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-coupon-field-state.ts
@@ -1,5 +1,6 @@
-import { useEvents } from '@automattic/composite-checkout';
 import { useState, useEffect, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export type CouponFieldStateProps = {
 	couponFieldValue: string;
@@ -13,7 +14,7 @@ export type CouponFieldStateProps = {
 export default function useCouponFieldState(
 	applyCoupon: ( couponId: string ) => void
 ): CouponFieldStateProps {
-	const onEvent = useEvents();
+	const reduxDispatch = useDispatch();
 	const [ couponFieldValue, setCouponFieldValue ] = useState< string >( '' );
 
 	// Used to hide the `Apply` button
@@ -34,21 +35,23 @@ export default function useCouponFieldState(
 		const trimmedValue = couponFieldValue.trim();
 
 		if ( isCouponValid( trimmedValue ) ) {
-			onEvent( {
-				type: 'a8c_checkout_add_coupon',
-				payload: { coupon: trimmedValue },
-			} );
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
+					coupon: trimmedValue,
+				} )
+			);
 
 			applyCoupon( trimmedValue );
 
 			return;
 		}
 
-		onEvent( {
-			type: 'a8c_checkout_add_coupon_error',
-			payload: { type: 'Invalid code' },
-		} );
-	}, [ couponFieldValue, onEvent, applyCoupon ] );
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {
+				error_type: 'Invalid code',
+			} )
+		);
+	}, [ couponFieldValue, reduxDispatch, applyCoupon ] );
 
 	return {
 		couponFieldValue,

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -56,12 +56,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							error_message: action.payload.message,
 						} )
 					);
-				case 'a8c_checkout_add_coupon':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
-							coupon: action.payload.coupon,
-						} )
-					);
 				case 'a8c_checkout_cancel_delete_product':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' )
@@ -76,12 +70,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_delete_product_press', {
 							product_name: action.payload.product_name,
-						} )
-					);
-				case 'a8c_checkout_add_coupon_error':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {
-							error_type: action.payload.type,
 						} )
 					);
 				case 'a8c_checkout_add_coupon_button_clicked':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the coupon application analytics from the checkout event handler directly into where the event occurs.

#### Testing instructions

- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- Add a product to your cart and visit checkout.
- Apply a coupon.
- Verify that you see the `calypso_checkout_composite_coupon_add_submit` event triggered with the value included.