### PR TITLE
Checkout: Move cart error logging directly into CompositeCheckout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -281,9 +281,18 @@ export default function CompositeCheckout( {
 	} );
 
 	useActOnceOnStrings( [ cartLoadingError ].filter( isValueTruthy ), ( messages ) => {
-		messages.forEach( ( message ) =>
-			recordEvent( { type: 'CART_ERROR', payload: { type: cartLoadingErrorType, message } } )
-		);
+		messages.forEach( ( message ) => {
+			logStashEvent( 'calypso_checkout_composite_cart_error', {
+				type: cartLoadingErrorType ?? '',
+				message,
+			} );
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_cart_error', {
+					error_type: cartLoadingErrorType,
+					error_message: String( message ),
+				} )
+			);
+		} );
 	} );
 
 	// Display errors. Note that we display all errors if any of them change,

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -37,17 +37,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							error_message: String( action.payload ),
 						} )
 					);
-				case 'CART_ERROR':
-					logStashEvent( 'calypso_checkout_composite_cart_error', {
-						type: action.payload.type,
-						message: action.payload.message,
-					} );
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_cart_error', {
-							error_type: action.payload.type,
-							error_message: String( action.payload.message ),
-						} )
-					);
 				case 'a8c_checkout_stripe_field_invalid_error':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_stripe_field_invalid_error', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the cart error analytics from the checkout event handler directly into where the event occurs.

#### Testing instructions

- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- Add a product to your cart and visit checkout.
- You'll need to break the shopping cart endpoint to cause a loading error; D50045-code should do it.
- Reload checkout.
- Verify that you see the `calypso_checkout_composite_cart_error` event triggered.