### PR TITLE
Jetpack: use Inter as typeface on pricing page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -84,7 +84,7 @@
 
 	color: var( --studio-gray-100 );
 
-	font-family: 'Noto Sans SemiCondensed Bold', 'Noto Sans', $sans;
+	font-family: 'Inter', $sans;
 	font-size: 2rem;
 	font-weight: 700;
 	line-height: 1.2;
@@ -103,7 +103,7 @@
 
 	color: var( --studio-gray-100 );
 
-	font-family: 'Noto Sans SemiCondensed Bold', 'Noto Sans', $sans;
+	font-family: 'Inter', $sans;
 	font-size: 1rem;
 	font-weight: 700;
 	line-height: 1.2;

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -8,7 +8,7 @@
 
 	background-color: var( --color-surface );
 
-	font-family: 'Noto Sans', $sans;
+	font-family: 'Inter', $sans;
 
 	h2 {
 		line-height: inherit;
@@ -31,7 +31,7 @@
 
 			color: var( --color-text );
 
-			font-size: rem( 21px );
+			font-size: rem( 21px ); /* stylelint-disable declaration-property-unit-allowed-list */
 
 			@include break-medium {
 				margin: 1.5rem 0 40px;

--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -1,11 +1,65 @@
+/* cyrillic-ext */
 @font-face {
-	font-display: swap;
-	font-family: 'Noto Sans SemiCondensed Bold';
-	font-weight: 700;
-	src:
-		url( 'https://s1.wp.com/i/fonts/notosans/NotoSans-SemiCondensedBold.woff2' ) format( 'woff2' ),
-		url( 'https://s1.wp.com/i/fonts/notosans/NotoSans-SemiCondensedBold.woff' ) format( 'woff' ),
-		url( 'https://s1.wp.com/i/fonts/notosans/NotoSans-SemiCondensedBold.ttf' ) format( 'truetype' );
+  font-family: 'Inter';
+  font-style: oblique 0deg 10deg;
+  font-weight: 400 700;
+  font-display: swap;
+  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvvYwYZ8UA3J58.woff2' ) format( 'woff2' );
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: oblique 0deg 10deg;
+  font-weight: 400 700;
+  font-display: swap;
+  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvmYwYZ8UA3J58.woff2' ) format( 'woff2' );
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: oblique 0deg 10deg;
+  font-weight: 400 700;
+  font-display: swap;
+  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvuYwYZ8UA3J58.woff2' ) format( 'woff2' );
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: oblique 0deg 10deg;
+  font-weight: 400 700;
+  font-display: swap;
+  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvhYwYZ8UA3J58.woff2' ) format( 'woff2' );
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: oblique 0deg 10deg;
+  font-weight: 400 700;
+  font-display: swap;
+  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvtYwYZ8UA3J58.woff2' ) format( 'woff2' );
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: oblique 0deg 10deg;
+  font-weight: 400 700;
+  font-display: swap;
+  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvsYwYZ8UA3J58.woff2' ) format( 'woff2' );
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: oblique 0deg 10deg;
+  font-weight: 400 700;
+  font-display: swap;
+  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcviYwYZ8UA3.woff2' ) format( 'woff2' );
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 .selector__main {

--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -1,65 +1,70 @@
 /* cyrillic-ext */
 @font-face {
-  font-family: 'Inter';
-  font-style: oblique 0deg 10deg;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvvYwYZ8UA3J58.woff2' ) format( 'woff2' );
-  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+	font-family: 'Inter';
+	font-style:  normal;
+	font-weight: 400;
+	font-display: swap;
+	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-Regular.woff2?v=3.19' ) format( 'woff2' ),
+	url( 'https://s0.wp.com/i/fonts/inter/Inter-Regular.woff?v=3.19' ) format( 'woff' );
 }
-/* cyrillic */
 @font-face {
-  font-family: 'Inter';
-  font-style: oblique 0deg 10deg;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvmYwYZ8UA3J58.woff2' ) format( 'woff2' );
-  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+	font-family: 'Inter';
+	font-style:  italic;
+	font-weight: 400;
+	font-display: swap;
+	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-Italic.woff2?v=3.19' ) format( 'woff2' ),
+	url( 'https://s0.wp.com/i/fonts/inter/Inter-Italic.woff?v=3.19' ) format( 'woff' );
 }
-/* greek-ext */
+
 @font-face {
-  font-family: 'Inter';
-  font-style: oblique 0deg 10deg;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvuYwYZ8UA3J58.woff2' ) format( 'woff2' );
-  unicode-range: U+1F00-1FFF;
+	font-family: 'Inter';
+	font-style:  normal;
+	font-weight: 500; /* stylelint-disable scales/font-weights */
+	font-display: swap;
+	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-Medium.woff2?v=3.19' ) format( 'woff2' ),
+	url( 'https://s0.wp.com/i/fonts/inter/Inter-Medium.woff?v=3.19' ) format( 'woff' );
 }
-/* greek */
 @font-face {
-  font-family: 'Inter';
-  font-style: oblique 0deg 10deg;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvhYwYZ8UA3J58.woff2' ) format( 'woff2' );
-  unicode-range: U+0370-03FF;
+	font-family: 'Inter';
+	font-style:  italic;
+	font-weight: 500;
+	font-display: swap;
+	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-MediumItalic.woff2?v=3.19' ) format( 'woff2' ),
+	url( 'https://s0.wp.com/i/fonts/inter/Inter-MediumItalic.woff?v=3.19' ) format( 'woff' );
 }
-/* vietnamese */
+
 @font-face {
-  font-family: 'Inter';
-  font-style: oblique 0deg 10deg;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvtYwYZ8UA3J58.woff2' ) format( 'woff2' );
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+	font-family: 'Inter';
+	font-style:  normal;
+	font-weight: 600;
+	font-display: swap;
+	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-SemiBold.woff2?v=3.19' ) format( 'woff2' ),
+	url( 'https://s0.wp.com/i/fonts/inter/Inter-SemiBold.woff?v=3.19' ) format( 'woff' );
 }
-/* latin-ext */
 @font-face {
-  font-family: 'Inter';
-  font-style: oblique 0deg 10deg;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcvsYwYZ8UA3J58.woff2' ) format( 'woff2' );
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	font-family: 'Inter';
+	font-style:  italic;
+	font-weight: 600;
+	font-display: swap;
+	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-SemiBoldItalic.woff2?v=3.19' ) format( 'woff2' ),
+	url( 'https://s0.wp.com/i/fonts/inter/Inter-SemiBoldItalic.woff?v=3.19' ) format( 'woff' );
 }
-/* latin */
+
 @font-face {
-  font-family: 'Inter';
-  font-style: oblique 0deg 10deg;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url( 'https://fonts.gstatic.com/s/inter/v7/UcCo3FwrK3iLTcviYwYZ8UA3.woff2' ) format( 'woff2' );
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+	font-family: 'Inter';
+	font-style:  normal;
+	font-weight: 700;
+	font-display: swap;
+	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-Bold.woff2?v=3.19' ) format( 'woff2' ),
+	url( 'https://s0.wp.com/i/fonts/inter/Inter-Bold.woff?v=3.19' ) format( 'woff' );
+}
+@font-face {
+	font-family: 'Inter';
+	font-style:  italic;
+	font-weight: 700;
+	font-display: swap;
+	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-BoldItalic.woff2?v=3.19' ) format( 'woff2' ),
+	url( 'https://s0.wp.com/i/fonts/inter/Inter-BoldItalic.woff?v=3.19' ) format( 'woff' );
 }
 
 .selector__main {


### PR DESCRIPTION
**_All related typeface changes need to go out at the same time._**

#### Changes proposed in this Pull Request

* Updates typography in pricing page.
* Gets rid of Noto Sans in favor of Inter.
* Complements this diff: D70711-code


#### Testing instructions

* Spin up this PR.
* Head to http://jetpack.cloud.localhost:3000/pricing
* Ensure all typography is set to Inter and that it's loaded from our CDNs.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/144095637-53d2f665-bb95-4c86-ae8e-0bd0ed042ee2.png) | ![image](https://user-images.githubusercontent.com/390760/144095790-99e7250a-bf56-43fc-9688-61f473fefd20.png)


