### PR TITLE
Update additional info column to a fixed width of 25%.

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -217,10 +217,11 @@ $plugin-details-header-padding: 100px;
 
 	.plugin-details__additional-info {
 		display: flex;
-		justify-content: space-between;
 		flex-wrap: wrap;
 
 		.plugin-details__info {
+			width: 25%;
+
 			@media screen and ( max-width: 1040px ) {
 				width: 50%;
 				padding-bottom: 12px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update additional info column to a fixed width of 25% and keep it even when columns are missing.

#### Testing instructions
* Go to `/plugins` page
* Select a plugin from the **Featured** or **Popular** list and see if the additional info section on the Plugin Details page is properly rendered
* Go back to `/plugins` page
* Select a plugin from the **New** list (which probably won't have reviews) and see if the additional info section on the Plugin Details page is properly rendered

#### Demo
 |with reviews | without reviews|
|-------|------|
|<img width="1103" alt="Screen Shot 2021-11-30 at 14 02 30" src="https://user-images.githubusercontent.com/5039531/144104162-35c59957-8822-4aa4-8f26-77a8563d355b.png">|<img width="1103" alt="Screen Shot 2021-11-30 at 14 02 45" src="https://user-images.githubusercontent.com/5039531/144104251-c603f90b-7f29-4c2c-b7cc-2d1459c90d41.png">|

---
Fixes #58289
