### PR TITLE
Composite Checkout: Add onPaymentMethodChanged prop

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import { translateCheckoutPaymentMethodToTracksPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { logStashEvent, recordCompositeCheckoutErrorDuringAnalytics } from './lib/analytics';
 
@@ -17,19 +16,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'PAYMENT_METHOD_SELECT': {
-					logStashEvent( 'payment_method_select', {
-						newMethodId: String( action.payload ),
-					} );
-					// Need to convert to the slug format used in old checkout so events are comparable
-					const rawPaymentMethodSlug = String( action.payload );
-					const legacyPaymentMethodSlug = translateCheckoutPaymentMethodToTracksPaymentMethod(
-						rawPaymentMethodSlug
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_switch_to_' + legacyPaymentMethodSlug )
-					);
-				}
 				case 'STORED_CARD_ERROR':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_stored_card_error', {

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -156,6 +156,7 @@ It has the following props.
 - `onPaymentError?: ({paymentMethodId: string | null, transactionError: string | null }) => null`. A function to call for payment methods when payment is not successful.
 - `onPageLoadError?: ( errorType: string, errorMessage: string, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
 - `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
+- `onPaymentMethodChanged?: (method: string) => void`. A function to call when the active payment method is changed. The argument will be the method's id.
 - `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -12,7 +12,6 @@ import {
 	usePaymentMethodId,
 	useIsStepActive,
 	useIsStepComplete,
-	useEvents,
 	useFormStatus,
 } from '../public-api';
 import { FormStatus } from '../types';
@@ -36,8 +35,7 @@ export default function CheckoutPaymentMethods( {
 	className?: string;
 } ): JSX.Element | null {
 	const { __ } = useI18n();
-	const onEvent = useEvents();
-	const { onPageLoadError } = useContext( CheckoutContext );
+	const { onPageLoadError, onPaymentMethodChanged } = useContext( CheckoutContext );
 	const onError = useCallback( ( error ) => onPageLoadError?.( 'payment_method_load', error ), [
 		onPageLoadError,
 	] );
@@ -46,7 +44,7 @@ export default function CheckoutPaymentMethods( {
 	const [ , setPaymentMethod ] = usePaymentMethodId();
 	const onClickPaymentMethod = ( newMethod: string ) => {
 		debug( 'setting payment method to', newMethod );
-		onEvent( { type: 'PAYMENT_METHOD_SELECT', payload: newMethod } );
+		onPaymentMethodChanged?.( newMethod );
 		setPaymentMethod( newMethod );
 	};
 	const paymentMethods = useAllPaymentMethods();

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -45,6 +45,7 @@ export function CheckoutProvider( {
 	onPaymentError,
 	onPageLoadError,
 	onStepChanged,
+	onPaymentMethodChanged,
 	redirectToUrl,
 	theme,
 	paymentMethods,
@@ -120,6 +121,7 @@ export function CheckoutProvider( {
 			paymentProcessors,
 			onPageLoadError,
 			onStepChanged,
+			onPaymentMethodChanged,
 		} ),
 		[
 			formStatus,
@@ -131,6 +133,7 @@ export function CheckoutProvider( {
 			paymentProcessors,
 			onPageLoadError,
 			onStepChanged,
+			onPaymentMethodChanged,
 		]
 	);
 

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -7,6 +7,7 @@ import {
 	PaymentProcessorProp,
 	ReactStandardAction,
 	TransactionStatusManager,
+	PaymentMethodChangedCallback,
 } from '../types';
 
 interface CheckoutContext {
@@ -20,6 +21,7 @@ interface CheckoutContext {
 	paymentProcessors: PaymentProcessorProp;
 	onPageLoadError?: CheckoutPageErrorCallback;
 	onStepChanged?: StepChangedCallback;
+	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 }
 
 const defaultCheckoutContext: CheckoutContext = {

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -109,6 +109,7 @@ export interface CheckoutProviderProps {
 	onPaymentError?: PaymentErrorCallback;
 	onPageLoadError?: CheckoutPageErrorCallback;
 	onStepChanged?: StepChangedCallback;
+	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 	onEvent?: ( event: ReactStandardAction ) => void;
 	isLoading?: boolean;
 	redirectToUrl?: ( url: string ) => void;
@@ -123,6 +124,7 @@ export interface PaymentProcessorProp {
 }
 
 export type StepChangedCallback = ( args: StepChangedEventArguments ) => void;
+export type PaymentMethodChangedCallback = ( method: string ) => void;
 export type PaymentEventCallback = ( args: PaymentEventCallbackArguments ) => void;
 export type PaymentErrorCallback = ( args: {
 	paymentMethodId: string | null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a new optional prop to the `CheckoutProvider` component in the `composite-checkout` package called `onPaymentMethodChanged` which is called when the active payment method changes. The new prop is then used to replace the deprecated `onEvent` property for that purpose (see https://github.com/Automattic/wp-calypso/pull/48282).

I was wrong in https://github.com/Automattic/wp-calypso/pull/58475 and I thought that was the final instance of `useEvents` in the package, but this one is. (The handler itself cannot be removed until we remove all uses of `useEvents` inside calypso.)

#### Testing instructions

1. You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
2. Add a product to your cart and visit checkout.
3. Progress through the checkout steps to the final step (you may already be on the final step).
4. Select a different payment method than whatever is already selected.
6. Verify that you see the `calypso_checkout_switch_to_`... event fire, and that the end of its name is the payment method slug.
<img width="622" alt="Screen Shot 2021-11-30 at 2 13 05 PM" src="https://user-images.githubusercontent.com/2036909/144112522-48f41da7-15b0-4111-a314-5eca0c6e86da.png">


