### PR TITLE
Checkout: Record 3ds auth modal display analytics directly

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -5,6 +5,7 @@ import {
 	makeErrorResponse,
 } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import submitWpcomTransaction from './submit-wpcom-transaction';
@@ -35,10 +36,10 @@ export default async function existingCardProcessor(
 	}
 	const {
 		stripe,
-		recordEvent,
 		includeDomainDetails,
 		includeGSuiteDetails,
 		contactDetails,
+		reduxDispatch,
 	} = dataForProcessor;
 	if ( ! stripe ) {
 		throw new Error( 'Stripe is required to submit an existing card payment' );
@@ -71,7 +72,7 @@ export default async function existingCardProcessor(
 			if ( stripeResponse?.message?.payment_intent_client_secret ) {
 				debug( 'transaction requires authentication' );
 				// 3DS authentication required
-				recordEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
+				reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 				return confirmStripePaymentIntent(
 					stripe,
 					stripeResponse?.message?.payment_intent_client_secret

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -6,6 +6,7 @@ import {
 } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import submitWpcomTransaction from './submit-wpcom-transaction';
@@ -66,10 +67,10 @@ async function stripeCardProcessor(
 	const {
 		includeDomainDetails,
 		includeGSuiteDetails,
-		recordEvent: onEvent,
 		responseCart,
 		siteId,
 		contactDetails,
+		reduxDispatch,
 	} = transactionOptions;
 
 	let paymentMethodToken;
@@ -112,7 +113,7 @@ async function stripeCardProcessor(
 		.then( ( stripeResponse ) => {
 			if ( stripeResponse?.message?.payment_intent_client_secret ) {
 				// 3DS authentication required
-				onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
+				reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 				return confirmStripePaymentIntent(
 					submitData.stripe,
 					stripeResponse?.message?.payment_intent_client_secret

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -121,9 +121,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
 					);
 				}
-				case 'SHOW_MODAL_AUTHORIZATION': {
-					return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
-				}
 				case 'THANK_YOU_URL_GENERATED':
 					return logStashEvent( 'thank you url generated', {
 						url: action.payload.url,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the 3DS modal display analytics from the checkout event handler directly into where the event occurs.

#### Testing instructions

- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- Add a product to your cart and visit checkout.
- Submit the checkout form using a 3DS card, like `4000008260003178` (which will be declined by design).
- Verify that you see the `calypso_checkout_modal_authorization` event triggered.