### PR TITLE
Theme Showcase: Remove references to individual theme prices

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,4 +1,4 @@
-import { Card, Ribbon, Button, Gridicon } from '@automattic/components';
+import { Card, Ribbon, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty, isEqual, some } from 'lodash';
@@ -7,10 +7,8 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Badge from 'calypso/components/badge';
-import InfoPopover from 'calypso/components/info-popover';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -38,8 +36,6 @@ export class Theme extends Component {
 		} ),
 		// If true, highlight this theme as active
 		active: PropTypes.bool,
-		// Theme price (pre-formatted string) -- empty string indicates free theme
-		price: PropTypes.string,
 		// If true, the theme is being installed
 		installing: PropTypes.bool,
 		// If true, render a placeholder
@@ -88,7 +84,6 @@ export class Theme extends Component {
 		return (
 			nextProps.theme.id !== this.props.theme.id ||
 			nextProps.active !== this.props.active ||
-			nextProps.price !== this.props.price ||
 			nextProps.installing !== this.props.installing ||
 			! isEqual(
 				Object.keys( nextProps.buttonContents ),
@@ -133,33 +128,18 @@ export class Theme extends Component {
 		}
 	}
 
-	onUpsellClick = () => {
-		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
-			cta_name: 'theme-upsell-popup',
-			theme: this.props.theme.id,
-		} );
-	};
-
 	setBookmark = () => {
 		this.props.setThemesBookmark( this.props.theme.id );
 	};
 
 	render() {
-		const { active, blockEditorSettings, price, theme, translate, upsellUrl } = this.props;
+		const { active, blockEditorSettings, theme, translate } = this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
 			'is-active': active,
 			'is-actionable': isActionable,
 		} );
-
-		const hasPrice = /\d/g.test( price );
-		const showUpsell = hasPrice && upsellUrl;
-		const priceClass = classNames( 'theme__badge-price', {
-			'theme__badge-price-upgrade': ! hasPrice,
-			'theme__badge-price-test': showUpsell,
-		} );
-
 		const themeDescription = decodeEntities( description );
 
 		// for performance testing
@@ -168,37 +148,6 @@ export class Theme extends Component {
 		if ( this.props.isPlaceholder ) {
 			return this.renderPlaceholder();
 		}
-
-		const impressionEventName = 'calypso_upgrade_nudge_impression';
-		const upsellEventProperties = { cta_name: 'theme-upsell', theme: theme.id };
-		const upsellPopupEventProperties = { cta_name: 'theme-upsell-popup', theme: theme.id };
-		const upsell = showUpsell && (
-			<span className="theme__upsell">
-				<TrackComponentView
-					eventName={ impressionEventName }
-					eventProperties={ upsellEventProperties }
-				/>
-				<InfoPopover icon="star" className="theme__upsell-icon" position="top left">
-					<TrackComponentView
-						eventName={ impressionEventName }
-						eventProperties={ upsellPopupEventProperties }
-					/>
-					<div className="theme__upsell-popover">
-						<h2 className="theme__upsell-heading">
-							{ translate( 'Use this theme at no extra cost on our Premium or Business Plan' ) }
-						</h2>
-						<Button
-							onClick={ this.onUpsellClick }
-							className="theme__upsell-cta"
-							primary
-							href={ upsellUrl }
-						>
-							{ translate( 'Upgrade Now' ) }
-						</Button>
-					</div>
-				</InfoPopover>
-			</span>
-		);
 
 		const fit = '479,360';
 		const themeImgSrc = photon( screenshot, { fit } );
@@ -259,8 +208,6 @@ export class Theme extends Component {
 								} ) }
 							</span>
 						) }
-						<span className={ priceClass }>{ price }</span>
-						{ upsell }
 						{ ! isEmpty( this.props.buttonContents ) ? (
 							<ThemeMoreButton
 								index={ this.props.index }

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -83,53 +83,6 @@ $theme-info-height: 54px;
 	}
 }
 
-.theme__badge-price {
-	flex: 0 0 auto;
-	padding: 18px 10px 0;
-	color: var( --color-success );
-	font-size: $font-body-small;
-	font-weight: 600;
-}
-
-.theme__badge-price-test {
-	padding: 18px 5px;
-}
-
-.theme__upsell {
-	flex: 0 0 auto;
-	padding: 16px 10px 0 0;
-	color: var( --color-neutral-light );
-}
-
-.theme__upsell-icon svg {
-	transform: scale( 0.8 );
-	border: 2px solid var( --color-neutral-20 );
-	border-radius: 100%;
-	display: inline-block;
-	width: 22px;
-	height: 22px;
-	z-index: 0;
-	padding: 0 1px 1px 0;
-	box-sizing: border-box;
-
-	&:hover {
-		border-color: #000;
-	}
-}
-
-.theme__upsell-popover {
-	text-align: center;
-}
-
-.theme__upsell-cta {
-	margin-top: 10px;
-}
-
-.theme__badge-price-upgrade {
-	text-transform: uppercase;
-	font-size: 80%;
-}
-
 .theme__badge-active {
 	flex: 0 0 auto;
 	padding: 18px 10px 0;

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -33,9 +33,6 @@ exports[`Theme rendering with default display buttonContents should match snapsh
       >
         Twenty Seventeen
       </h2>
-      <span
-        className="theme__badge-price theme__badge-price-upgrade"
-      />
       <ThemeMoreButton
         active={false}
         onMoreButtonClick={[Function]}

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -74,13 +74,6 @@ describe( 'Theme', () => {
 				assert( props.onScreenshotClick.calledOnce, 'onClick did not trigger onScreenshotClick' );
 			} );
 
-			test( 'should not show a price when there is none', () => {
-				assert(
-					themeNode.getElementsByClassName( 'price' ).length === 0,
-					'price should not appear'
-				);
-			} );
-
 			test( 'should render a More button', () => {
 				const more = themeNode.getElementsByClassName( 'theme__more-button' );
 
@@ -124,19 +117,6 @@ describe( 'Theme', () => {
 		test( 'should render a <div> with an is-placeholder class', () => {
 			assert( themeNode.nodeName === 'DIV', 'nodeName doesn\'t equal "DIV"' );
 			assert.include( themeNode.className, 'is-placeholder', 'no is-placeholder' );
-		} );
-	} );
-
-	describe( 'when the theme has a price', () => {
-		beforeEach( () => {
-			const themeElement = TestUtils.renderIntoDocument(
-				createElement( Theme, { ...props, price: '$50' } )
-			);
-			themeNode = ReactDom.findDOMNode( themeElement );
-		} );
-
-		test( 'should show a price', () => {
-			assert( themeNode.getElementsByClassName( 'theme__badge-price' )[ 0 ].textContent === '$50' );
 		} );
 	} );
 } );

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { parse } from 'url';
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import { createElement } from 'react';
@@ -61,11 +60,10 @@ describe( 'Theme', () => {
 			test( 'should include photon parameters', () => {
 				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
 				const src = imgNode.getAttribute( 'src' );
-				const { query } = parse( src, true );
-
-				expect( query ).toMatchObject( {
-					fit: expect.stringMatching( /\d+,\d+/ ),
-				} );
+				const url = new URL( src );
+				const params = new URLSearchParams( url.search );
+				const fitParam = params.get( 'fit' );
+				expect( fitParam ).toEqual( expect.stringMatching( /\d+,\d+/ ) );
 			} );
 
 			test( 'should call onScreenshotClick() on click on screenshot', () => {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -824,6 +824,7 @@ export default connect(
 		const backPath = getBackPath( state );
 		const isCurrentUserPaid = isUserPaid( state );
 		const theme = getCanonicalTheme( state, siteId, id );
+		//@TODO: This is only for test purposes, remove next line before deploying.
 		theme.retired = false;
 		const siteIdOrWpcom = siteId || 'wpcom';
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -50,7 +50,6 @@ import {
 	isPremiumThemeAvailable,
 	isWpcomTheme as isThemeWpcom,
 	getCanonicalTheme,
-	getPremiumThemePrice,
 	getThemeDetailsUrl,
 	getThemeRequestErrors,
 	getThemeForumUrl,
@@ -73,7 +72,6 @@ class ThemeSheet extends Component {
 		author: PropTypes.string,
 		screenshot: PropTypes.string,
 		screenshots: PropTypes.array,
-		price: PropTypes.string,
 		description: PropTypes.string,
 		descriptionLong: PropTypes.oneOfType( [
 			PropTypes.string,
@@ -597,25 +595,9 @@ class ThemeSheet extends Component {
 		);
 	};
 
-	renderPrice = () => {
-		let price = this.props.price;
-		if ( ! this.isLoaded() || this.props.isActive ) {
-			price = '';
-		} else if ( ! this.props.isPremium ) {
-			price = this.props.translate( 'Free' );
-		}
-
-		const className = classNames( 'theme__sheet-action-bar-cost', {
-			'theme__sheet-action-bar-cost-upgrade': ! /\d/g.test( this.props.price ),
-		} );
-
-		return price ? <span className={ className }>{ price }</span> : '';
-	};
-
 	renderButton = () => {
 		const { getUrl } = this.props.defaultOption;
 		const label = this.getDefaultOptionLabel();
-		const price = this.renderPrice();
 		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
 		const { isActive } = this.props;
 
@@ -628,11 +610,6 @@ class ThemeSheet extends Component {
 				target={ isActive ? '_blank' : null }
 			>
 				{ this.isLoaded() ? label : placeholder }
-				{ price && this.props.isWpcomTheme && (
-					<Badge type="info" className="theme__sheet-badge-beta">
-						{ price }
-					</Badge>
-				) }
 			</Button>
 		);
 	};
@@ -847,6 +824,7 @@ export default connect(
 		const backPath = getBackPath( state );
 		const isCurrentUserPaid = isUserPaid( state );
 		const theme = getCanonicalTheme( state, siteId, id );
+		theme.retired = false;
 		const siteIdOrWpcom = siteId || 'wpcom';
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
 		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, id );
@@ -854,7 +832,6 @@ export default connect(
 		return {
 			...theme,
 			id,
-			price: getPremiumThemePrice( state, id, siteId ),
 			error,
 			siteId,
 			siteSlug,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -824,8 +824,6 @@ export default connect(
 		const backPath = getBackPath( state );
 		const isCurrentUserPaid = isUserPaid( state );
 		const theme = getCanonicalTheme( state, siteId, id );
-		//@TODO: This is only for test purposes, remove next line before deploying.
-		theme.retired = false;
 		const siteIdOrWpcom = siteId || 'wpcom';
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
 		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, id );

--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: true,
+		isomorphic: false,
 		title: 'Themes',
 	},
 	{

--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: false,
+		isomorphic: true,
 		title: 'Themes',
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove individual theme price on theme sheet
* Remove individual theme price and upsell icon/tooltip on multi-theme views
* Remove related tests/snapshots
* We may re-add some kind of upsell/marketing here in the future, but we don't want to risk seeing individual prices at launch.

**Before**


<img width="1154" alt="Screen Shot 2021-11-30 at 2 15 20 PM" src="https://user-images.githubusercontent.com/2124984/144112818-856735b9-56ff-4c25-9042-9e3c46c96f68.png">
<img width="1449" alt="Screen Shot 2021-11-30 at 2 15 39 PM" src="https://user-images.githubusercontent.com/2124984/144112832-a3a43fef-7b00-4760-bbae-6e755924b5b0.png">

**After**

<img width="1798" alt="Screen Shot 2021-11-30 at 2 01 27 PM" src="https://user-images.githubusercontent.com/2124984/144111746-c3ee9522-69dd-4011-9239-6a32450dedbc.png">
<img width="1450" alt="Screen Shot 2021-11-30 at 2 01 46 PM" src="https://user-images.githubusercontent.com/2124984/144111765-0e07d6cf-dd4c-4517-8819-49c0210d83a9.png">

#### Testing instructions

* Switch to this PR
* Test this change *without* any of the following hacks first; nothing should be affected or broken for free themes, or for the logged-out showcase.
* Sandbox the API and on your sandbox, comment out the retired themes filter on line 194 of `public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-themes-v1-2-endpoint.php`
* Visit `/themes/siteurl.wordpress.com/?flags=themes/premium` to enable the feature flag
* Edit your local calypso and add `theme.retired = false;` on or around line 827 of `/client/my-sites/theme/main.jsx`
* Click on the Premium filter to show only Premium themes; you should be able to see all retired premium themes in the Showcase now!
* You should no longer see individual price information when viewing all premium themes in the Showcase
* Clicking on any premium theme should show the theme sheet, which should not have an individual price, either.


Related to #58678 
