### PR TITLE
Checkout: Record plan length change analytics directly

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -397,16 +397,17 @@ export default function CompositeCheckout( {
 
 	const changePlanLength = useCallback(
 		( uuidToReplace, newProductSlug, newProductId ) => {
-			recordEvent( {
-				type: 'CART_CHANGE_PLAN_LENGTH',
-				payload: { newProductSlug },
-			} );
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_plan_length_change', {
+					new_product_slug: newProductSlug,
+				} )
+			);
 			replaceProductInCart( uuidToReplace, {
 				product_slug: newProductSlug,
 				product_id: newProductId,
 			} );
 		},
-		[ replaceProductInCart, recordEvent ]
+		[ replaceProductInCart, reduxDispatch ]
 	);
 
 	// Often products are added using just the product_slug but missing the

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -172,13 +172,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				case 'SHOW_MODAL_AUTHORIZATION': {
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 				}
-				case 'CART_CHANGE_PLAN_LENGTH': {
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_plan_length_change', {
-							new_product_slug: action.payload?.newProductSlug,
-						} )
-					);
-				}
 				case 'THANK_YOU_URL_GENERATED':
 					return logStashEvent( 'thank you url generated', {
 						url: action.payload.url,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the plan length change analytics from the checkout event handler directly into where the event occurs.

#### Testing instructions

- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- Add a plan to your cart and visit checkout.
- In checkout, click the "edit" button on the first step.
- Select a different term length for your plan (eg: monthly or biennial).
- Verify that you see the `calypso_checkout_composite_plan_length_change` event triggered with the new product slug included.