### PR TITLE
Plugin focus and hover effect

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -8,8 +8,6 @@
 	margin: 10px 0;
 	position: relative;
 	overflow: hidden;
-	border: 1px solid var( --studio-gray-5 );
-	border-radius: 5px; /* stylelint-disable-line scales/radii */
 
 	&.is-placeholder {
 		cursor: default;
@@ -69,6 +67,12 @@
 	height: 100%;
 	padding: 30px;
 	box-sizing: border-box;
+	border: 1px solid var( --studio-gray-5 );
+	border-radius: 5px; /* stylelint-disable-line scales/radii */
+
+	&:focus, &:hover {
+		border-color: var( --studio-gray-30 );
+	}
 }
 
 .plugins-browser-item__title,

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -247,6 +247,10 @@ $plugin-details-header-padding: 100px;
 			padding: 12px 16px;
 			background-color: var( --studio-pink-50 );
 			color: var( --studio-white );
+
+			&:focus, &:hover {
+				background-color: var( --studio-pink-60 );
+			}
 		}
 	}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -245,11 +245,11 @@ $plugin-details-header-padding: 100px;
 		.plugin-details__install-button {
 			width: 100%;
 			padding: 12px 16px;
-			background-color: var( --studio-pink-50 );
+			background-color: var( --color-accent-50 );
 			color: var( --studio-white );
 
 			&:focus, &:hover {
-				background-color: var( --studio-pink-60 );
+				background-color: var( --color-accent-60 );
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add hover and focus effect on Plugin Details CTA.
* Add focus and hover effect to plugin browser items.

#### Testing instructions
* Go to `/plugins` page
* Hover your mouse on a plugin item and see if this item appears selected
* Use tab to select a plugin item and see if the items appear selected

<img width="1027" alt="Screen Shot 2021-11-30 at 15 33 46" src="https://user-images.githubusercontent.com/5039531/144115474-8fe831ed-8cf4-4ece-8834-9784c18e1f97.png">

* Select a plugin to go to **Plugin Details** page
* Hover your mouse over the CTA and see if it appears selected
* Use tab to select the CTA and see if it appears selected

|Unselected | Selected|
|-------|------|
|<img width="332" alt="Screen Shot 2021-11-30 at 14 31 54" src="https://user-images.githubusercontent.com/5039531/144115633-17cd29f1-d892-421f-9116-e027ae7bfc5b.png">|<img width="332" alt="Screen Shot 2021-11-30 at 14 32 01" src="https://user-images.githubusercontent.com/5039531/144115709-b116fc04-49bb-451e-a73b-312965dfb0d4.png">|
---

Fixes #58278