### PR TITLE
Playwright: wait until checkout cart stabilizes.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -10,6 +10,9 @@ const selectors = {
 	// Banner
 	dismissBanner: `button[aria-label="Dismiss"]`,
 
+	// Loading
+	cartLoading: ( state: boolean ) => `div[data-e2e-cart-is-loading="${ state }"]`,
+
 	// Cart item
 	cartItem: ( itemName: string ) =>
 		`[data-testid="review-order-step--visible"] .checkout-line-item >> text=${ itemName.trim() }`,
@@ -76,6 +79,20 @@ export class CartCheckoutPage {
 	}
 
 	/**
+	 * Waits until the cart is fully loaded.
+	 *
+	 * By fully loaded, this implies:
+	 * 	- network requests have been completed.
+	 * 	- cart total is fully rendered to the user.
+	 */
+	private async waitUntilCartLoaded(): Promise< void > {
+		await Promise.all( [
+			this.page.waitForLoadState( 'networkidle' ),
+			this.page.waitForSelector( selectors.cartLoading( false ) ),
+		] );
+	}
+
+	/**
 	 * Validates that an item is in the cart with the expected text. Throws if it isn't.
 	 *
 	 * @param {string} expectedCartItemName Expected text for the name of the item in the cart.
@@ -93,6 +110,7 @@ export class CartCheckoutPage {
 	async removeCartItem( cartItemName: string ): Promise< void > {
 		await this.page.click( selectors.removeCartItemButton( cartItemName ) );
 		await this.page.click( selectors.modalContinueButton );
+		await this.waitUntilCartLoaded();
 	}
 
 	/**
@@ -116,6 +134,7 @@ export class CartCheckoutPage {
 	 * @param {string} coupon Coupon code.
 	 */
 	async enterCouponCode( coupon: string ): Promise< void > {
+		await this.waitUntilCartLoaded();
 		await this.page.click( selectors.couponCodeInputButton );
 
 		await this.page.fill( selectors.couponCodeInput, coupon );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is part of an effort to restore some of the Quarantined E2E tests into the regular lineup.

The changes in this PR are meant to address an edge case seen in TeamCity Build 7048888 where the steps `Remove domain purchase from cart` and `Apply coupon and validate purchase amount` interfered with one another.

Key changes:
- implement a new private method `waitUntilCartLoaded` that:
  - waits for networkidle.
  - waits for the cart loading placeholder to disappear.
- tweak two methods in `CartCheckoutPage` to use the new method.

#### Testing instructions

- [x] quarantined tests

Additional monitoring of the Quarantined E2E once this merges is required. 
Time frame is about 1 week.

Related to #58683