### PR TITLE
Re-add premium themes references

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1120,6 +1120,21 @@ const contextLinksForSection = {
 		},
 		{
 			get link() {
+				return localizeUrl( 'https://wordpress.com/support/premium-themes/' );
+			},
+			post_id: 12112,
+			get title() {
+				return translate( 'Premium Themes' );
+			},
+			get description() {
+				return translate(
+					'On a site with the Premium or Business plan, you can switch to any premium theme at ' +
+						'no extra cost, as many times as you’d like.'
+				);
+			},
+		},
+		{
+			get link() {
 				return localizeUrl(
 					'https://wordpress.com/support/themes/uploading-setting-up-custom-themes/child-themes/'
 				);
@@ -1149,6 +1164,21 @@ const contextLinksForSection = {
 				return translate(
 					'A theme controls the general look and feel of your site including things like ' +
 						'page layout, widget locations, and default font.'
+				);
+			},
+		},
+		{
+			get link() {
+				return localizeUrl( 'https://wordpress.com/support/premium-themes/' );
+			},
+			post_id: 12112,
+			get title() {
+				return translate( 'Premium Themes' );
+			},
+			get description() {
+				return translate(
+					'On a site with the Premium or Business plan, you can switch to any premium theme at ' +
+						'no extra cost, as many times as you’d like.'
 				);
 			},
 		},

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -27,6 +27,7 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 			translate( 'Remove all advertising from your site.' ),
 			translate( 'Enjoy live chat support.' ),
 			translate( 'Easy monetization options' ),
+			translate( 'Unlimited premium themes.' ),
 		];
 	}
 

--- a/client/blocks/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features-list/find-new-theme.jsx
@@ -1,0 +1,19 @@
+import { localize } from 'i18n-calypso';
+import premiumThemesImage from 'calypso/assets/images/illustrations/themes.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+
+export default localize( ( { selectedSite, translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon={ <img alt="" src={ premiumThemesImage } /> }
+				title={ translate( 'Try a premium theme' ) }
+				description={ translate(
+					'Access a diverse selection of beautifully designed premium themes included with your plan.'
+				) }
+				buttonText={ translate( 'Browse premium themes' ) }
+				href={ '/themes/' + selectedSite.slug }
+			/>
+		</div>
+	);
+} );

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -34,6 +34,7 @@ import BusinessOnboarding from './business-onboarding';
 import CustomCSS from './custom-css';
 import CustomDomain from './custom-domain';
 import CustomizeTheme from './customize-theme';
+import FindNewTheme from './find-new-theme';
 import GoogleAnalyticsStats from './google-analytics-stats';
 import GoogleMyBusiness from './google-my-business';
 import HappinessSupportCard from './happiness-support-card';
@@ -85,6 +86,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ showCustomizerFeature && <CustomizeTheme selectedSite={ selectedSite } /> }
 				{ ! showCustomizerFeature && <CustomCSS selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
+				<FindNewTheme selectedSite={ selectedSite } />
 				<UploadPlugins selectedSite={ selectedSite } />
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
@@ -149,6 +151,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ ! showCustomizerFeature && <CustomCSS selectedSite={ selectedSite } /> }
 				<CustomCSS selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
+				<FindNewTheme selectedSite={ selectedSite } />
 				<UploadPlugins selectedSite={ selectedSite } />
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
@@ -286,6 +289,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<SellOnlinePaypal isJetpack />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
+				<FindNewTheme selectedSite={ selectedSite } />
 
 				{ isEnabled( 'jetpack/concierge-sessions' ) && (
 					<BusinessOnboarding
@@ -313,6 +317,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackPublicize selectedSite={ selectedSite } />
 				<SellOnlinePaypal isJetpack />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<FindNewTheme selectedSite={ selectedSite } />
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
@@ -333,6 +338,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackPublicize selectedSite={ selectedSite } />
 				<SellOnlinePaypal isJetpack />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<FindNewTheme selectedSite={ selectedSite } />
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -99,6 +99,7 @@ import {
 	FEATURE_PREMIUM_CONTENT_BLOCK,
 	FEATURE_PREMIUM_CUSTOMIZABE_THEMES,
 	FEATURE_PREMIUM_SUPPORT,
+	FEATURE_PREMIUM_THEMES,
 	FEATURE_PRODUCT_BACKUP_DAILY_V2,
 	FEATURE_PRODUCT_BACKUP_REALTIME_V2,
 	FEATURE_PRODUCT_SCAN_DAILY_V2,
@@ -240,7 +241,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'All Premium features' ),
 		getDescription: () => {
 			return i18n.translate(
-				'Including advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+				'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
 			);
 		},
 	},
@@ -292,6 +293,15 @@ export const FEATURES_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'Site hosting is included with your plan, eliminating additional cost and technical hassle.'
+			),
+	},
+
+	[ FEATURE_PREMIUM_THEMES ]: {
+		getSlug: () => FEATURE_PREMIUM_THEMES,
+		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
+		getDescription: () =>
+			i18n.translate(
+				'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
 			),
 	},
 
@@ -954,7 +964,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'All Business features' ),
 		getDescription: () =>
 			i18n.translate(
-				'Including the ability to upload plugins and themes, priority support and advanced monetization options.'
+				'Including the ability to upload plugins and themes, priority support, advanced monetization options, and unlimited premium themes.'
 			),
 	},
 

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -6,6 +6,7 @@ import { connect, useSelector } from 'react-redux';
 import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
 import analyticsImage from 'calypso/assets/images/illustrations/google-analytics.svg';
 import jetpackBackupImage from 'calypso/assets/images/illustrations/jetpack-backup.svg';
+import themeImage from 'calypso/assets/images/illustrations/themes.svg';
 import updatesImage from 'calypso/assets/images/illustrations/updates.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import PurchaseDetail from 'calypso/components/purchase-detail';
@@ -77,6 +78,18 @@ const BusinessPlanDetails = ( {
 					) }
 					buttonText={ i18n.translate( 'Upload a plugin now' ) }
 					href={ '/plugins/manage/' + selectedSite.slug }
+				/>
+			) }
+
+			{ ! selectedFeature && (
+				<PurchaseDetail
+					icon={ <img alt="" src={ themeImage } /> }
+					title={ i18n.translate( 'Try a New Theme' ) }
+					description={ i18n.translate(
+						"You've now got access to every premium theme, at no extra cost. Give one a try!"
+					) }
+					buttonText={ i18n.translate( 'Browse premium themes' ) }
+					href={ '/themes/' + selectedSite.slug }
 				/>
 			) }
 

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -54,6 +54,7 @@ export default function getPlanFeatures(
 		return [
 			isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
 			isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
+			String( translate( 'Unlimited access to our library of Premium Themes' ) ),
 			isEnabled( 'earn/pay-with-paypal' )
 				? String( translate( 'Subscriber-only content and Pay with PayPal buttons' ) )
 				: String( translate( 'Subscriber-only content and payment buttons' ) ),

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,4 +1,4 @@
-import { FEATURE_UPLOAD_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { FEATURE_PREMIUM_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { pickBy } from 'lodash';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -50,10 +50,10 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	const upsellBanner = (
 		<UpsellNudge
 			className="themes__showcase-banner"
-			event="calypso_themes_list_install_themes"
-			feature={ FEATURE_UPLOAD_THEMES }
+			event="calypso_themes_list_premium_themes"
+			feature={ FEATURE_PREMIUM_THEMES }
 			plan={ PLAN_BUSINESS }
-			title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
+			title={ translate( 'Get unlimited premium themes' ) }
 			forceHref={ true }
 			showIcon={ true }
 		/>

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,4 +1,4 @@
-import { PLAN_BUSINESS, FEATURE_UPLOAD_THEMES } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import Main from 'calypso/components/main';
@@ -22,10 +22,10 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 		upsellBanner = (
 			<UpsellNudge
 				className="themes__showcase-banner"
-				event="calypso_themes_list_install_themes"
-				feature={ FEATURE_UPLOAD_THEMES }
+				event="calypso_themes_list_premium_themes"
+				feature={ FEATURE_PREMIUM_THEMES }
 				plan={ PLAN_BUSINESS }
-				title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
+				title={ translate( 'Unlock ALL premium themes with our Business and eCommerce plans!' ) }
 				forceHref={ true }
 				showIcon={ true }
 			/>

--- a/client/state/plans/test/fixture/index.js
+++ b/client/state/plans/test/fixture/index.js
@@ -124,7 +124,8 @@ export const PLAN_1008 = {
 	product_name_short: 'Business',
 	product_slug: 'business-bundle',
 	tagline: 'Take it to the next level',
-	shortdesc: 'Everything included with Premium, as well as live chat support.',
+	shortdesc:
+		'Everything included with Premium, as well as live chat support, and unlimited access to our premium themes.',
 	description:
 		'All you need to build a great website:' +
 		'<ul><li>Chat live with a WordPress.com specialist, ' +

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -70,6 +70,7 @@ export const FEATURE_ALL_PERSONAL_FEATURES_JETPACK = 'all-personal-features-jetp
 export const FEATURE_ALL_PREMIUM_FEATURES = 'all-premium-features';
 export const FEATURE_ALL_PREMIUM_FEATURES_JETPACK = 'all-premium-features-jetpack';
 export const FEATURE_ADVANCED_CUSTOMIZATION = 'advanced-customization';
+export const FEATURE_PREMIUM_THEMES = 'unlimited-premium-themes';
 export const FEATURE_UPLOAD_THEMES_PLUGINS = 'upload-themes-and-plugins';
 export const FEATURE_FREE_DOMAIN = 'free-custom-domain';
 export const FEATURE_FREE_BLOG_DOMAIN = 'free-blog-domain';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -104,6 +104,7 @@ import {
 	FEATURE_PREMIUM_CONTENT_BLOCK,
 	FEATURE_PREMIUM_CUSTOMIZABE_THEMES,
 	FEATURE_PREMIUM_SUPPORT,
+	FEATURE_PREMIUM_THEMES,
 	FEATURE_PRODUCT_BACKUP_DAILY_V2,
 	FEATURE_PRODUCT_BACKUP_REALTIME_V2,
 	FEATURE_PRODUCT_SCAN_DAILY_V2,
@@ -438,6 +439,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
 		FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
 		FEATURE_EARN_AD,
+		FEATURE_PREMIUM_THEMES,
 		FEATURE_GOOGLE_ANALYTICS,
 		FEATURE_INSTALL_PLUGINS,
 		FEATURE_ADVANCED_SEO_EXPANDED_ABBR,
@@ -512,9 +514,14 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_ADVANCED_CUSTOMIZATION,
 		FEATURE_ALL_PERSONAL_FEATURES,
 	],
-	getBlogSignupFeatures: () => [ FEATURE_MONETISE, FEATURE_ALL_PERSONAL_FEATURES ],
+	getBlogSignupFeatures: () => [
+		FEATURE_MONETISE,
+		FEATURE_PREMIUM_THEMES,
+		FEATURE_ALL_PERSONAL_FEATURES,
+	],
 	getPortfolioSignupFeatures: () => [
 		FEATURE_ADVANCED_CUSTOMIZATION,
+		FEATURE_PREMIUM_THEMES,
 		FEATURE_ALL_PERSONAL_FEATURES,
 	],
 	getSignupCompareAvailableFeatures: () => [
@@ -525,6 +532,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
 		FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 		FEATURE_EARN_AD,
+		FEATURE_PREMIUM_THEMES,
 		FEATURE_GOOGLE_ANALYTICS,
 	],
 	// Features not displayed but used for checking plan abilities
@@ -613,6 +621,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
 		FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
 		FEATURE_EARN_AD,
+		FEATURE_PREMIUM_THEMES,
 		FEATURE_GOOGLE_ANALYTICS,
 		FEATURE_INSTALL_PLUGINS,
 		FEATURE_ADVANCED_SEO_EXPANDED_ABBR,
@@ -735,7 +744,8 @@ const getJetpackBusinessDetails = (): IncompleteJetpackPlan => ( {
 		].includes( plan ),
 	getDescription: () =>
 		i18n.translate(
-			'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites.',
+			'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites: real-time backups ' +
+				'and unlimited premium themes.',
 			plansDescriptionHeadingComponent
 		),
 	getTagline: () => i18n.translate( 'You have the full suite of security and performance tools.' ),

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -496,6 +496,10 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							</li>
 							<li className="focused-launch-summary__side-commentary-list-item">
 								<Icon icon={ check } />
+								{ __( 'Unlimited premium themes', __i18n_text_domain__ ) }
+							</li>
+							<li className="focused-launch-summary__side-commentary-list-item">
+								<Icon icon={ check } />
 								{ __( 'Accept payments', __i18n_text_domain__ ) }
 							</li>
 						</ul>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-add the Premium Themes / premium plan upsell nudge for Free and Personal plan sites that was removed in https://github.com/Automattic/wp-calypso/pull/55942/files#diff-e1414f0851e1ef5a3807284b9645fa8c8ddf7abefdf68353fca4e8b6b210fc1eL30 and 45c80fa#diff-e1414f0851e1ef5a3807284b9645fa8c8ddf7abefdf68353fca4e8b6b210fc1eL30

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Upgrading to Premium - Cart
![image](https://user-images.githubusercontent.com/3801502/144306124-6853002a-79e2-4954-8f4f-fefab677d937.png)

* `/start/plans`
![image](https://user-images.githubusercontent.com/3801502/144306656-cf2f6e3a-6b40-4eab-b06d-a7b90e10efbe.png)

* `/plans/my-plan/<site>`
![image](https://user-images.githubusercontent.com/3801502/144307167-7eefe6d5-cb6e-42d1-85ec-8800aa246260.png)

* `/themes/<site>` on an Atomic site
![image](https://user-images.githubusercontent.com/3801502/144308837-e70022fe-799d-4da7-af9f-6bd96823ad92.png)


* `/themes/<site>` without a plan
![image](https://user-images.githubusercontent.com/3801502/144309261-6241a53c-56eb-46e8-8168-6ea2ef8b3203.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---

Related to #58616
