### PR TITLE
Videos UI: Record a Tracks event for every video marked as completed.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -20,7 +20,6 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		return courses !== null && courseSlug in courses ? courses[ courseSlug ] : [];
 	} );
 
-	const [ selectedVideoIndex, setSelectedVideoIndex ] = useState( null );
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ currentVideo, setCurrentVideo ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
@@ -51,43 +50,36 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	} );
 
 	useEffect( () => {
-		if ( ! course ) {
-			return;
-		}
-
-		const videoSlugs = Object.keys( course.videos );
 		if ( ! currentVideoKey ) {
 			const initialVideoId = 'find-theme';
-			setCurrentVideoKey( initialVideoId );
-			setSelectedVideoIndex( videoSlugs.indexOf( initialVideoId ) );
+			setCurrentVideo( course.videos[ initialVideoId ] );
 		}
+		if ( currentVideoKey && course ) {
+			setCurrentVideo( course.videos[ currentVideoKey ] );
+		}
+	}, [ currentVideoKey, course ] );
 
+	useEffect( () => {
+		const videoSlugs = Object.keys( course.videos );
 		const viewedSlugs = Object.keys( userCourseProgression );
 		if ( viewedSlugs.length > 0 ) {
 			const nextSlug = videoSlugs.find( ( slug ) => ! viewedSlugs.includes( slug ) );
 			if ( nextSlug ) {
 				setCurrentVideoKey( nextSlug );
-				setSelectedVideoIndex( videoSlugs.indexOf( nextSlug ) );
 			}
 		}
-	}, [ currentVideoKey, course, userCourseProgression ] );
-
-	useEffect( () => {
-		if ( currentVideoKey && course ) {
-			setCurrentVideo( course.videos[ currentVideoKey ] );
-			setSelectedVideoIndex( Object.keys( course.videos ).indexOf( currentVideoKey ) );
-		}
-	}, [ currentVideoKey, course ] );
+	}, [ course, userCourseProgression ] );
 
 	const isVideoSelected = ( idx ) => {
-		return selectedVideoIndex === idx;
+		return Object.keys( course.videos ).indexOf( currentVideoKey ) === idx;
 	};
 
 	const onVideoSelected = ( idx ) => {
 		if ( isVideoSelected( idx ) ) {
-			setSelectedVideoIndex( null );
+			setCurrentVideoKey( null );
 		} else {
-			setSelectedVideoIndex( idx );
+			const selectedVideoKey = Object.keys( course.videos )[ idx ];
+			setCurrentVideoKey( selectedVideoKey );
 		}
 	};
 

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -34,6 +34,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		} );
 
 		setCurrentVideo( videoInfo );
+		setCurrentVideoKey( videoSlug );
 		setIsPlaying( true );
 	};
 
@@ -135,11 +136,10 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 				<div className="videos-ui__video-content">
 					{ currentVideo && (
 						<VideoPlayer
-							completedSeconds={ currentVideo.completed_seconds }
+							videoData={ { ...currentVideo, ...{ slug: currentVideoKey } } }
 							videoRef={ videoRef }
-							videoUrl={ currentVideo.url }
 							isPlaying={ isPlaying }
-							poster={ currentVideo.poster ? currentVideo.poster : undefined }
+							course={ course }
 						/>
 					) }
 					<div className="videos-ui__chapters">

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -21,6 +21,10 @@ const VideoPlayer = ( { videoData, videoRef, isPlaying, course } ) => {
 		}
 	} );
 
+	useEffect( () => {
+		setAddTimeUpdateHandler( true );
+	}, [ course?.slug, videoData?.slug ] );
+
 	return (
 		<div key={ videoData.url } className="videos-ui__video">
 			<video

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,12 +1,17 @@
 import { useEffect, useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-const VideoPlayer = ( { completedSeconds, videoRef, videoUrl, isPlaying, poster = undefined } ) => {
+const VideoPlayer = ( { videoData, videoRef, isPlaying, course } ) => {
 	const [ addTimeUpdateHandler, setAddTimeUpdateHandler ] = useState( true );
 
 	const markVideoAsComplete = () => {
-		if ( videoRef.current.currentTime < completedSeconds ) {
+		if ( videoRef.current.currentTime < videoData.completed_seconds ) {
 			return;
 		}
+		recordTracksEvent( 'calypso_courses_video_completed', {
+			course: course.slug,
+			video: videoData.slug,
+		} );
 		setAddTimeUpdateHandler( false );
 	};
 
@@ -17,15 +22,15 @@ const VideoPlayer = ( { completedSeconds, videoRef, videoUrl, isPlaying, poster 
 	} );
 
 	return (
-		<div key={ videoUrl } className="videos-ui__video">
+		<div key={ videoData.url } className="videos-ui__video">
 			<video
 				controls
 				ref={ videoRef }
-				poster={ poster }
+				poster={ videoData.poster }
 				autoPlay={ isPlaying }
 				onTimeUpdate={ addTimeUpdateHandler ? markVideoAsComplete : undefined }
 			>
-				<source src={ videoUrl } />{ ' ' }
+				<source src={ videoData.url } />{ ' ' }
 				{ /* @TODO: check if tracks are available, the linter demands one */ }
 				<track src="caption.vtt" kind="captions" srcLang="en" label="english_captions" />
 			</video>


### PR DESCRIPTION
Let's record a Tracks event with the course and video slugs every time a user passes the `completed_seconds` mark of their video.

This PR also simplifies all the props passed to the video player component.

**Testing Instructions**
* Open this PR with the calypso.live link below.
* Enter the videos UI in My Home, via "Start learning" in the education cards.
* Open your dev tools, and make sure `localStorage.setItem( 'debug', 'calypso:analytics*' )` is set. Reload the page.
* Enter the videos UI in My Home, via "Start learning" in the education cards.
* Play a video past its `completed_seconds` point (this can be found in the API response for `/courses`).
* Verify the Tracks event fires, with the correct data.

<img width="955" alt="Screen Shot 2021-11-30 at 2 20 04 PM" src="https://user-images.githubusercontent.com/349751/144137450-7b2d6f0b-a878-425c-96ee-9c1c85cf1b7a.png">


