### PR TITLE
Domains: Fix DNS pages header design issues

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -171,6 +171,10 @@
 .breadcrumbs__buttons-mobile {
 	display: flex;
 
+	> * + * {
+		margin-left: 8px;
+	}
+
 	@include break-mobile {
 		display: none;
 	}

--- a/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { Icon, plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
 import { domainManagementDnsAddRecord } from 'calypso/my-sites/domains/paths';
 import { DndAddNewRecordButtonProps } from './types';
 
@@ -10,11 +11,14 @@ function DnsAddNewRecordButton( {
 	isMobile,
 }: DndAddNewRecordButtonProps ): JSX.Element {
 	const { __ } = useI18n();
+	const className = classNames( 'dns__breadcrumb-button add-record', {
+		'is-icon-button': isMobile,
+	} );
 	return (
 		<Button
 			borderless={ isMobile }
 			href={ domainManagementDnsAddRecord( site, domain ) }
-			className={ 'dns__breadcrumb-button add-record' }
+			className={ className }
 		>
 			<Icon icon={ plus } viewBox="4 4 16 16" size={ 16 } />
 			{ ! isMobile && __( 'Add a record' ) }

--- a/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
@@ -1,17 +1,23 @@
 import { Button } from '@automattic/components';
+import { Icon, plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { domainManagementDnsAddRecord } from 'calypso/my-sites/domains/paths';
 import { DndAddNewRecordButtonProps } from './types';
 
-function DnsAddNewRecordButton( { site, domain }: DndAddNewRecordButtonProps ): JSX.Element {
+function DnsAddNewRecordButton( {
+	site,
+	domain,
+	isMobile,
+}: DndAddNewRecordButtonProps ): JSX.Element {
 	const { __ } = useI18n();
 	return (
 		<Button
-			primary
+			borderless={ isMobile }
 			href={ domainManagementDnsAddRecord( site, domain ) }
-			className={ 'dns__breadcrumb-button' }
+			className={ 'dns__breadcrumb-button add-record' }
 		>
-			{ __( 'Add a new record' ) }
+			<Icon icon={ plus } viewBox="4 4 16 16" size={ 16 } />
+			{ ! isMobile && __( 'Add a record' ) }
 		</Button>
 	);
 }

--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -16,7 +16,7 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 				/>
 			}
 			popoverClassName="dns-records-list-item__action-menu-popover"
-			position="top left"
+			position="bottom left"
 			disabled={ actions.length === 0 }
 		>
 			{ actions.map( ( action ) => {

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -56,7 +56,8 @@ class DnsRecords extends Component {
 		];
 
 		const mobileItem = {
-			label: translate( 'Back' ),
+			// translators: %(domain)s is the domain name (e.g. example.com) to which settings page the user will return to when pressing the link
+			label: translate( 'Back to %(domain)s', { args: { domain: selectedDomainName } } ),
 			href: domainManagementNameServers( selectedSite.slug, selectedDomainName, currentRoute ),
 			showBackArrow: true,
 		};
@@ -75,12 +76,20 @@ class DnsRecords extends Component {
 			/>,
 		];
 
+		const mobileButtons = [
+			<DnsAddNewRecordButton
+				site={ selectedSite.slug }
+				domain={ selectedDomainName }
+				isMobile={ true }
+			/>,
+		];
+
 		return (
 			<Breadcrumbs
 				items={ items }
 				mobileItem={ mobileItem }
 				buttons={ buttons }
-				mobileButtons={ buttons }
+				mobileButtons={ mobileButtons }
 			/>
 		);
 	};

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -62,18 +62,22 @@ class DnsRecords extends Component {
 			showBackArrow: true,
 		};
 
+		const optionsButton = (
+			<DnsMenuOptionsButton
+				key="menu-options-button"
+				domain={ selectedDomainName }
+				dns={ dns }
+				pointsToWpcom={ pointsToWpcom }
+			/>
+		);
+
 		const buttons = [
 			<DnsAddNewRecordButton
 				key="add-new-record-button"
 				site={ selectedSite.slug }
 				domain={ selectedDomainName }
 			/>,
-			<DnsMenuOptionsButton
-				key="menu-options-button"
-				domain={ selectedDomainName }
-				dns={ dns }
-				pointsToWpcom={ pointsToWpcom }
-			/>,
+			optionsButton,
 		];
 
 		const mobileButtons = [
@@ -82,6 +86,7 @@ class DnsRecords extends Component {
 				domain={ selectedDomainName }
 				isMobile={ true }
 			/>,
+			optionsButton,
 		];
 
 		return (

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -207,3 +207,38 @@ body.dns__body-white {
 		max-width: 600px;
 	}
 }
+
+a.dns__breadcrumb-button {
+	display: flex;
+	align-items: center;
+
+	&.add-record {
+		margin-right: 12px;
+	}
+
+	@include break-mobile {
+		&.add-record {
+			margin-right: 0;
+		}
+
+		svg {
+			margin-right: 8px;
+			fill: var( --color-neutral-70 );
+		}
+	}
+}
+
+.dns__breadcrumb-button {
+	.popover__menu-item[disabled] {
+		svg.gridicon {
+			fill: var( --color-neutral-20 );
+		}
+	}
+
+	&.is-borderless.ellipsis {
+		svg.gridicon {
+			top: 0;
+			margin-top: 0;
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -213,22 +213,24 @@ a.dns__breadcrumb-button {
 	align-items: center;
 
 	&.add-record {
-		margin-right: 12px;
+		@include break-mobile {
+			svg {
+				margin-right: 8px;
+			}
+		}
 	}
-
-	@include break-mobile {
-		&.add-record {
-			margin-right: 0;
-		}
-
-		svg {
-			margin-right: 8px;
-			fill: var( --color-neutral-70 );
-		}
+	&.add-record.is-icon-button {
+		width: 40px;
+		display: flex;
+		justify-content: center;
 	}
 }
 
 .dns__breadcrumb-button {
+	color: var( --color-neutral-80 );
+	fill: var( --color-neutral-80 );
+	height: 40px;
+
 	.popover__menu-item[disabled] {
 		svg.gridicon {
 			fill: var( --color-neutral-20 );
@@ -236,9 +238,12 @@ a.dns__breadcrumb-button {
 	}
 
 	&.is-borderless.ellipsis {
+		width: 40px;
+
 		svg.gridicon {
 			top: 0;
 			margin-top: 0;
+			fill: var( --color-neutral-80 );
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -166,6 +166,11 @@ body.dns__body-white {
 						top: 0;
 						right: 0;
 
+						.ellipsis-menu__toggle {
+							position: relative;
+							right: 8px;
+						}
+
 						@include break-mobile {
 							position: initial;
 							min-width: 24px;

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -79,7 +79,7 @@ body.dns__body-white {
 			}
 
 			@include break-mobile {
-				padding: 10px 0;
+				padding: 16px 0;
 				border-top: none;
 				border-bottom: 1px solid $gray-5;
 			}
@@ -163,11 +163,12 @@ body.dns__body-white {
 
 					&.dns-records-list-item__menu {
 						position: absolute;
-						top: 0;
+						top: -4px;
 						right: 0;
 
 						.ellipsis-menu__toggle {
 							position: relative;
+							padding: 0;
 							right: 8px;
 						}
 

--- a/client/my-sites/domains/domain-management/dns/types.tsx
+++ b/client/my-sites/domains/domain-management/dns/types.tsx
@@ -43,4 +43,5 @@ export type RestoreDialogResult = {
 export type DndAddNewRecordButtonProps = {
 	site: string;
 	domain: string;
+	isMobile?: boolean;
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes design issues in the DNS pages header pointed out by the design review in pcYYhz-q9-p2#comment-358.

The following screenshots highlight what was updated:

![Markup on 2021-11-30 at 19:48:05](https://user-images.githubusercontent.com/5324818/144140850-f31c2da4-9903-4620-b9eb-8ca958444651.png)

![Markup on 2021-11-30 at 19:46:47](https://user-images.githubusercontent.com/5324818/144140859-5335dbba-94df-4046-88f5-b9dd02b7b270.png)

1. Button is now not primary and reads "+ Add a record"
2. Ellipsis icon is vertically aligned with the other items in the breadcrumbs
3. Inactive `redo` icon is now visible in menu
4. The "+ Add a record" button becomes a borderless "+" button in mobile view and the ellipsis menu is removed

You can compare them with the previous designs:

<img width="1035" alt="Screen Shot 2021-11-30 at 19 48 57" src="https://user-images.githubusercontent.com/5324818/144140938-d52241e2-5443-4d49-8e35-f213b4878ae8.png">

<img width="399" alt="Screen Shot 2021-11-30 at 19 49 06" src="https://user-images.githubusercontent.com/5324818/144140947-28802ceb-58f8-49ea-8159-6fc3e5149d0d.png">

**Note**: Breadcrumbs issues are being addressed in #58601 and #58519.

### Testing instructions

- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/dns-records-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades > Domains"
- Select one of your registered domains or domain connections
- Go to "Change your name servers & DNS records"
- Ensure the design updates described above are present
