### PR TITLE
Full Site Editing Design Picker: Enable Arbutus theme

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -21,26 +21,6 @@
 			"features": []
 		},
 		{
-			"title": "Russell",
-			"slug": "russell",
-			"template": "russell",
-			"theme": "russell",
-			"categories": [ { "slug": "featured", "name": "Featured" } ],
-			"is_premium": false,
-			"is_fse": true,
-			"features": []
-		},
-		{
-			"title": "Russell",
-			"slug": "russell",
-			"template": "russell",
-			"theme": "russell",
-			"categories": [ { "slug": "featured", "name": "Featured" } ],
-			"is_premium": false,
-			"is_fse": false,
-			"features": []
-		},
-		{
 			"title": "Quadrat",
 			"slug": "quadrat",
 			"template": "quadrat",

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -1,6 +1,26 @@
 {
 	"featured": [
 		{
+			"title": "Arbutus",
+			"slug": "arbutus",
+			"template": "arbutus",
+			"theme": "arbutus",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Russell",
+			"slug": "russell",
+			"template": "russell",
+			"theme": "russell",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
 			"title": "Quadrat",
 			"slug": "quadrat",
 			"template": "quadrat",

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -11,6 +11,16 @@
 			"features": []
 		},
 		{
+			"title": "Arbutus",
+			"slug": "arbutus",
+			"template": "arbutus",
+			"theme": "arbutus",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": false,
+			"features": []
+		},
+		{
 			"title": "Russell",
 			"slug": "russell",
 			"template": "russell",
@@ -18,6 +28,16 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Russell",
+			"slug": "russell",
+			"template": "russell",
+			"theme": "russell",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": false,
 			"features": []
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `available-designs-config.json` to include new Arbutus block theme.
* Arbutus is a selectable theme in the `/new` FSE beta onboarding design picker

#### Screenshots
<img width="1282" alt="Screen Shot 2021-11-30 at 5 20 56 PM" src="https://user-images.githubusercontent.com/5414230/144154576-690de611-0c62-4b47-91dd-1c185e1eb34d.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply branch to local calypso dev environment
* Visit http://calypso.localhost:3000/new/beta
* Enroll in the FSE beta
* Pick a free test domain
* Verify that Arbutus is a selectable theme
* Create a site with Arbutus enabled and smoke test the theme

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/58663
