### PR TITLE
Small fixes for the domains table design view

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -51,8 +51,11 @@
 .breadcrumbs__bottom-border {
 	height: 0;
 	/* hack to make the border line cover the entire width of the content area */
-	margin: 0 -1000px 32px;
+	margin: 0 -1000px 16px;
 	border-bottom: 1px solid #dcdcde;
+	@include break-mobile {
+		margin-bottom: 32px;
+	}
 }
 
 .breadcrumbs__items {

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { Icon, home, moreVertical } from '@wordpress/icons';
+import { Icon, home, moreVertical, redo, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -22,7 +22,11 @@ import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/ema
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
-import { domainManagementList, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementList,
+	createSiteFromDomainOnly,
+	domainTransferIn,
+} from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -303,6 +307,7 @@ class DomainRow extends PureComponent {
 	renderEllipsisMenu() {
 		const {
 			isLoadingDomainDetails,
+			site,
 			domain,
 			showDomainDetails,
 			disabled,
@@ -314,7 +319,7 @@ class DomainRow extends PureComponent {
 			return <div className="domain-row__action-cell"></div>;
 		}
 
-		if ( isLoadingDomainDetails || ! domain ) {
+		if ( isLoadingDomainDetails || ! domain || ! site ) {
 			return (
 				<div className="domain-row__action-cell">
 					<p className="domain-row__placeholder" />
@@ -322,31 +327,44 @@ class DomainRow extends PureComponent {
 			);
 		}
 
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="domain-row__action-cell">
+				{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 				<EllipsisMenu
 					disabled={ disabled || isBusy }
 					onClick={ this.stopPropagation }
 					toggleTitle={ translate( 'Options' ) }
 					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
 					popoverClassName="domain-row__popover"
+					position="bottom"
 				>
 					<PopoverMenuItem icon="domains" onClick={ this.handleClick }>
-						{ translate( 'View settings' ) }
+						{ domain.type === domainTypes.TRANSFER
+							? translate( 'View transfer' )
+							: translate( 'View settings' ) }
 					</PopoverMenuItem>
 					{ this.canSetAsPrimary() && (
 						<PopoverMenuItem onClick={ this.makePrimary }>
-							{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 							<Icon icon={ home } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
-							{ /* eslint-enable wpcalypso/jsx-classname-namespace */ }
 							{ translate( 'Make primary site address' ) }
 						</PopoverMenuItem>
 					) }
+					{ domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer && (
+						<PopoverMenuItem href={ domainTransferIn( site.slug, domain.name, true ) }>
+							<Icon icon={ redo } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+							{ translate( 'Transfer to WordPress.com' ) }
+						</PopoverMenuItem>
+					) }
+					{ site.options?.is_domain_only && (
+						<PopoverMenuItem href={ createSiteFromDomainOnly( site.slug, site.siteId ) }>
+							<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+							{ translate( 'Create site' ) }
+						</PopoverMenuItem>
+					) }
 				</EllipsisMenu>
+				{ /* eslint-enable wpcalypso/jsx-classname-namespace */ }
 			</div>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	canSetAsPrimary() {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -257,6 +257,10 @@
 	height: 20px;
 	margin-left: 20px;
 
+	.ellipsis-menu {
+		float: right;
+	}
+
 	.ellipsis-menu__toggle {
 		transform: translateY( -4px );
 		padding: 0;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -77,6 +77,7 @@
 
 .domain-row__mobile-container2 {
 	display: block;
+	font-size: $font-body-extra-small;
 	@include break-mobile {
 		display: none;
 	}
@@ -129,7 +130,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		font-size: $font-body-large;
+		font-size: $font-body;
 		font-weight: 500; /* stylelint-disable-line */
 
 		a {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -77,7 +77,7 @@
 
 .domain-row__mobile-container2 {
 	display: block;
-	font-size: $font-body-extra-small;
+	font-size: $font-body-small;
 	@include break-mobile {
 		display: none;
 	}

--- a/client/my-sites/domains/domain-management/list/free-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.jsx
@@ -54,6 +54,7 @@ export default function FreeDomainItem( {
 					toggleTitle={ __( 'Free WordPress address options' ) }
 					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
 					popoverClassName="free-domain-item__popover"
+					position="bottom"
 				>
 					{ canMakePrimary && (
 						<PopoverMenuItem onClick={ handleMakePrimary }>

--- a/client/my-sites/domains/domain-management/list/free-domain-item.scss
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.scss
@@ -14,7 +14,7 @@
 	@include break-mobile {
 		margin: 24px 0;
 		align-items: center;
-		padding: 12px 16px;
+		padding: 12px 0 12px 16px;
 	}
 
 	& > * + * {

--- a/client/my-sites/domains/domain-management/list/free-domain-item.scss
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.scss
@@ -68,7 +68,7 @@
 	}
 
 	& .ellipsis-menu {
-		transform: translateY( -4px );
+		transform: translateY( -6px );
 		height: 20px;
 	}
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -393,10 +393,14 @@
 	display: flex;
 	justify-content: space-between;
 	padding: 8px 0;
-	border-bottom: 1px solid var( --color-neutral-20 );
 	font-size: $font-body-small;
 	font-weight: 600;
 	color: var( --color-neutral-50 );
+
+	border-bottom: 1px solid var( --color-neutral-5 );
+	@include break-mobile {
+		border-bottom: 1px solid var( --color-neutral-20 );
+	}
 
 	.button-plain {
 		text-align: left;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -417,7 +417,7 @@
 			fill: var( --color-neutral-50 );
 		}
 		&:hover > svg {
-			fill: var( --color-neutral-10 );
+			fill: var( --color-neutral-30 );
 		}
 	}
 


### PR DESCRIPTION
Some small design fixes that we missed

#### Changes proposed in this Pull Request

* Fixed the table sort button hover color
* Made the 3dots popover menu render below the dots
* Horizontally aligned the 3dots menus in the header, domain rows and the free site address
* Fixed the color of the header border on mobile
* Fixed the font size on mobile for the domain and the site name
* Updated the margin between the header and the filter button to be 16px

Here's how the new menus look:

<img width="1099" alt="Screenshot 2021-12-06 at 15 11 54" src="https://user-images.githubusercontent.com/1355045/144852963-cbc515c6-0108-4670-995c-b758e6a9ab7a.png">
<img width="1091" alt="Screenshot 2021-12-06 at 15 12 11" src="https://user-images.githubusercontent.com/1355045/144852967-9b82e43a-d619-4992-946d-46ddf1e95619.png">
<img width="1102" alt="Screenshot 2021-12-06 at 15 16 48" src="https://user-images.githubusercontent.com/1355045/144852970-0df3088e-acab-4a7c-aaa4-fae9c69d021d.png">


see: pcYYhz-pX-p2#comment-355
and: pcYYhz-pX-p2#comment-356

#### Testing instructions

* Spin up the branch and verify that all of the above changes are present