### PR TITLE
Woop installer: improve redirect_to checkout URL

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -115,7 +115,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	const siteUpgrading = {
 		required: requiresUpgrade,
 		checkoutUrl: addQueryArgs(
-			{ redirect_to: addQueryArgs( { siteSlug: wpcomDomain }, window.location.href ) },
+			{ redirect_to: addQueryArgs( { site: wpcomDomain }, window.location.href ) },
 			`/checkout/${ wpcomDomain }/${ upgradingPlan.product_slug }`
 		),
 		productName,

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -115,7 +115,12 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	const siteUpgrading = {
 		required: requiresUpgrade,
 		checkoutUrl: addQueryArgs(
-			{ redirect_to: addQueryArgs( { site: wpcomDomain }, window.location.href ) },
+			{
+				redirect_to: addQueryArgs(
+					{ site: wpcomDomain },
+					'/start/woocommerce-install/confirm/plan'
+				),
+			},
 			`/checkout/${ wpcomDomain }/${ upgradingPlan.product_slug }`
 		),
 		productName,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the `redirect_to` URL param of the checkout URL, setting the site via the `site` param.
Also, it changes the URL making it relative, fixing the `close` checkout button.

https://user-images.githubusercontent.com/77539/144229496-7529ac06-28d8-4e8e-a71e-de34da821d5b.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a testing site: Simple w/Free plan.
* Start the woop installer workflow:
`http://calypso.localhost:3000/start/woocommerce-install/confirm?site=<your-testing-site>`
* Accept upgrading the site plan
* Confirm clicking on the close button (the cross one) it redirects to confirm step, upgrading plan subsection

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
