### PR TITLE
Emails: Update Email Forwarding form in Email Comparison page to be more consistent

### DIFF
--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
@@ -81,13 +81,6 @@ class EmailForwardingAddNewCompact extends Component {
 
 	renderFormFields() {
 		const { translate, selectedDomainName, index, fields } = this.props;
-		const contactText = translate( 'contact', {
-			context: 'part of e-mail address',
-			comment: 'As it would be part of an e-mail address contact@example.com',
-		} );
-		const exampleEmailText = translate( 'e.g. %(example)s', {
-			args: { example: contactText },
-		} );
 		const isValidMailbox = this.isValid( 'mailbox' );
 		const isValidDestination = this.isValid( 'destination' );
 		const { mailbox, destination } = fields;
@@ -97,13 +90,12 @@ class EmailForwardingAddNewCompact extends Component {
 		return (
 			<div className="email-forwarding__form-content">
 				<FormFieldset>
-					<FormLabel>{ translate( 'Emails Sent To' ) }</FormLabel>
+					<FormLabel>{ translate( 'Emails sent to' ) }</FormLabel>
 					<FormTextInputWithAffixes
 						disabled={ this.state.formSubmitting }
 						name="mailbox"
 						onChange={ ( event ) => this.onChange( event, index ) }
 						isError={ ! isValidMailbox }
-						placeholder={ exampleEmailText }
 						suffix={ '@' + selectedDomainName }
 						value={ mailbox }
 					/>
@@ -111,13 +103,12 @@ class EmailForwardingAddNewCompact extends Component {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>{ translate( 'Will Be Forwarded To' ) }</FormLabel>
+					<FormLabel>{ translate( 'Will be forwarded to this email address' ) }</FormLabel>
 					<FormTextInput
 						disabled={ this.state.formSubmitting }
 						name="destination"
 						onChange={ ( event ) => this.onChange( event, index ) }
 						isError={ ! isValidDestination }
-						placeholder={ translate( 'Your Existing Email Address' ) }
 						value={ destination }
 					/>
 					{ ! isValidDestination && (

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
@@ -159,17 +159,17 @@ class EmailForwardingAddNewCompact extends Component {
 
 		if ( fieldName === 'mailbox' ) {
 			if ( errorMessage.filter( ( t ) => t === 'Invalid' ).length === 1 ) {
-				return translate( 'Invalid mailbox - only characters [a-z0-9._+-] are allowed' );
+				return translate( 'Only numbers, letters, dashes, underscores, and periods are allowed.' );
 			}
 
 			if ( errorMessage.filter( ( t ) => t === 'Duplicated' ).length === 1 ) {
-				return translate( 'Invalid mailbox - Duplicated' );
+				return translate( 'Please use unique mailboxes' );
 			}
 		}
 
 		if ( fieldName === 'destination' ) {
 			if ( errorMessage.filter( ( t ) => t === 'Invalid' ).length === 1 ) {
-				return translate( 'Invalid destination address' );
+				return translate( 'Invalid email address' );
 			}
 		}
 

--- a/client/my-sites/email/email-forwarding/style.scss
+++ b/client/my-sites/email/email-forwarding/style.scss
@@ -89,3 +89,8 @@ ul.email-forwarding__list {
 	line-height: 3em;
 	margin-bottom: 15px;
 }
+
+.email-forwarding-add-new-compact-list__actions {
+	display: flex;
+	justify-content: flex-end
+}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -527,15 +527,10 @@ class EmailProvidersComparison extends Component {
 
 		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
 
-		const now = Date.now();
-		const showBlackFridaySale =
-			new Date( '2021-11-26T00:05:00Z' ) < now &&
-			now < new Date( '2021-12-01T07:55:00Z' ).getTime();
-
 		const formattedPriceClassName = classNames( {
-			'email-providers-comparison__highlight-main-price': showBlackFridaySale,
 			'email-providers-comparison__keep-main-price': ! isEligibleForFreeTrial,
 		} );
+
 		const formattedPrice = translate( '{{price/}} /mailbox /month (billed monthly)', {
 			components: {
 				price: (
@@ -547,22 +542,7 @@ class EmailProvidersComparison extends Component {
 			comment: '{{price/}} is the formatted price, e.g. $20',
 		} );
 
-		const blackFridayDiscount = showBlackFridaySale ? (
-			<span
-				className={ classNames( {
-					'email-providers-comparison__discount-and-free-trial': isEligibleForFreeTrial,
-				} ) }
-			>
-				{ translate( '30% off applied for all renewals' ) }
-			</span>
-		) : null;
-
-		const discount = (
-			<>
-				{ isEligibleForFreeTrial ? translate( '3 months free' ) : null }
-				{ blackFridayDiscount }
-			</>
-		);
+		const discount = isEligibleForFreeTrial ? translate( '3 months free' ) : null;
 
 		const logo = (
 			<Gridicon

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -393,7 +393,7 @@ class EmailProvidersComparison extends Component {
 					comment:
 						'{{fullPrice/}} is the formatted full price, e.g. $20; {{discountedPrice/}} is the discounted, formatted price, e.g. $10',
 			  } )
-			: translate( '{{price/}} /mailbox /month billed annually', {
+			: translate( '{{price/}} /mailbox /month (billed annually)', {
 					components: {
 						price: <span>{ monthlyPrice }</span>,
 					},

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -184,15 +184,6 @@
 				&.email-providers-comparison__keep-main-price {
 					text-decoration: none;
 				}
-
-				&.email-providers-comparison__highlight-main-price {
-					color: var( --studio-green-50 );
-					text-decoration: none;
-				}
-
-				&.email-providers-comparison__titan-trial-with-sale {
-					display: block;
-				}
 			}
 		}
 
@@ -205,10 +196,6 @@
 			.email-providers-comparison__discount-with-renewal span {
 				color: var( --color-text-subtle );
 				font-weight: 400;
-			}
-
-			.email-providers-comparison__discount-and-free-trial {
-				display: block;
 			}
 
 			.email-providers-comparison__discount-with-renewal .info-popover {


### PR DESCRIPTION
This pull request mainly refines the Email Forwarding form in the `Email Comparison` page to be more consistent with other forms from this page. More specifically, it:

* Fixes wrong case of labels in the Email Forwarding form
* Removes placeholders in the Email Forwarding form
* Updates validation errors in the Email Forwarding form to use a consistent messaging
* Aligns the `Add` button to the right in the Email Forwarding form
* Refines a label in the Google Workspace form
* Removes temporary code for the Black Friday promotion added in [this pull request](https://github.com/Automattic/wp-calypso/pull/58513)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/144241382-89db81f8-f56c-4847-9087-15ce75d782d9.png) | ![image](https://user-images.githubusercontent.com/594356/144241462-5bb9865a-89eb-4966-8574-aa15a3534ca6.png)


#### Testing instructions

1. Run `git checkout update/email-comparison-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/58703#issuecomment-983631791)
2. Log into a WordPress.com account that has a site with a domain
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button for that domain to access the `Email Comparison` page
5. Assert that forms now look like in the screenshot above