### PR TITLE
Videos UI: keeps the video ref inside the VideoPlayer component

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { cloneElement, useEffect, useState, useRef } from 'react';
+import { cloneElement, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -25,8 +25,6 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	const [ currentVideo, setCurrentVideo ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
 
-	const videoRef = useRef( null );
-
 	const onVideoPlayClick = ( videoSlug, videoInfo ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
 			course: course.slug,
@@ -36,18 +34,6 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		setCurrentVideo( videoInfo );
 		setIsPlaying( true );
 	};
-
-	useEffect( () => {
-		if ( videoRef.current ) {
-			videoRef.current.onplay = () => {
-				setIsPlaying( true );
-			};
-
-			videoRef.current.onpause = () => {
-				setIsPlaying( false );
-			};
-		}
-	} );
 
 	useEffect( () => {
 		if ( ! course ) {
@@ -136,8 +122,8 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 					{ currentVideo && (
 						<VideoPlayer
 							completedSeconds={ currentVideo.completed_seconds }
-							videoRef={ videoRef }
 							videoUrl={ currentVideo.url }
+							onVideoPlayStatusChanged={ ( isVideoPlaying ) => setIsPlaying( isVideoPlaying ) }
 							isPlaying={ isPlaying }
 							poster={ currentVideo.poster ? currentVideo.poster : undefined }
 						/>

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,7 +1,15 @@
-import { useEffect, useState } from 'react';
+import { createRef, useEffect, useState } from 'react';
 
-const VideoPlayer = ( { completedSeconds, videoRef, videoUrl, isPlaying, poster = undefined } ) => {
+const VideoPlayer = ( {
+	completedSeconds,
+	videoUrl,
+	onVideoPlayStatusChanged,
+	isPlaying,
+	poster = undefined,
+} ) => {
 	const [ addTimeUpdateHandler, setAddTimeUpdateHandler ] = useState( true );
+
+	const videoRef = createRef();
 
 	const markVideoAsComplete = () => {
 		if ( videoRef.current.currentTime < completedSeconds ) {
@@ -9,6 +17,18 @@ const VideoPlayer = ( { completedSeconds, videoRef, videoUrl, isPlaying, poster 
 		}
 		setAddTimeUpdateHandler( false );
 	};
+
+	useEffect( () => {
+		if ( videoRef.current ) {
+			videoRef.current.onplay = () => {
+				onVideoPlayStatusChanged( true );
+			};
+
+			videoRef.current.onpause = () => {
+				onVideoPlayStatusChanged( false );
+			};
+		}
+	} );
 
 	useEffect( () => {
 		if ( isPlaying ) {


### PR DESCRIPTION
This should be merged after https://github.com/Automattic/wp-calypso/pull/58717.

This PR removes the ref to the html5 video component that was being used in the `index.jsx` file and keeps it inside the `VideoPlayer` component. It helps to keep the ref in context and also to unclutter `index.jsx`.

I figured it would be nice to make this refactor before starting [this issue](https://github.com/Automattic/wp-calypso/issues/58251)

#### Testing
1. Load the calypso live link in this PR.
2. Verify the play button works exactly like it did before.