### PR TITLE
Emails: Fix display issues with buttons on Add New Mailboxes page

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .gsuite-new-user-list__new-user {
 	fieldset {
 		margin-bottom: 0;
@@ -9,15 +12,7 @@
 	flex-direction: column;
 	justify-content: space-between;
 
-	@include breakpoint-deprecated( '>480px' ) {
-		flex-direction: row;
-	}
-
-	@include breakpoint-deprecated( '>660px' ) {
-		flex-direction: column;
-	}
-
-	@include breakpoint-deprecated( '>800px' ) {
+	@include break-mobile {
 		flex-direction: row;
 	}
 }
@@ -25,16 +20,8 @@
 .gsuite-new-user-list__add-another-user-button {
 	width: 100%;
 
-	@include breakpoint-deprecated( '>480px' ) {
+	@include break-mobile {
 		width: auto;
-	}
-
-	@include breakpoint-deprecated( '>660px' ) {
-		margin-bottom: 20px;
-	}
-
-	@include breakpoint-deprecated( '>800px' ) {
-		margin-bottom: 0;
 	}
 }
 
@@ -63,37 +50,13 @@
 			margin-top: 5px;
 		}
 	}
-
-	&.gsuite-new-user-list__new-user-remove-user-button {
-		@include breakpoint-deprecated( '>800px' ) {
-			margin-top: calc( 1.5em + 5px );
-		}
-	}
 }
 
-.gsuite-new-user-list__new-user-section {
-	@include breakpoint-deprecated( '>800px' ) {
-		display: flex;
-		justify-content: space-between;
+.gsuite-new-user-list__new-user-remove-user-button {
+	width: 100%;
 
-		& > *:not( :first-child ) {
-			margin-left: 15px;
-		}
-	}
-
-	.gsuite-new-user-list__new-user-remove-user-button {
-		display: none; // TODO: Fix button displayed in the middle of form (see 1165571745647867-as-1198174007918339)
-		overflow: unset; // Prevents ellipsis from appearing because of a right margin applied on the gridicon
-
-		@include breakpoint-deprecated( '>800px' ) {
-			display: block;
-			height: 40px;
-			width: 50px;
-
-			span {
-				display: none;
-			}
-		}
+	@include break-mobile {
+		width: inherit;
 	}
 }
 

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -216,6 +216,7 @@ class GSuiteAddUsers extends Component {
 						>
 							<div className="gsuite-add-users__buttons">
 								<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>
+
 								<Button primary disabled={ ! canContinue } onClick={ this.handleContinue }>
 									{ translate( 'Continue' ) }
 								</Button>

--- a/client/my-sites/email/gsuite-add-users/style.scss
+++ b/client/my-sites/email/gsuite-add-users/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .gsuite-add-users__buttons {
 	display: flex;
 	flex-direction: column;
@@ -6,25 +9,7 @@
 		margin-top: 10px;
 	}
 
-	@include breakpoint-deprecated( '>480px' ) {
-		flex-direction: row;
-
-		button {
-			margin-left: 10px;
-			margin-top: 0;
-		}
-	}
-
-	@include breakpoint-deprecated( '>660px' ) {
-		flex-direction: column;
-
-		button {
-			margin-left: 0;
-			margin-top: 10px;
-		}
-	}
-
-	@include breakpoint-deprecated( '>800px' ) {
+	@include break-mobile {
 		flex-direction: row;
 
 		button {

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -49,6 +49,8 @@ import {
 } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
+import './style.scss';
+
 class TitanAddMailboxes extends Component {
 	state = {
 		mailboxes: [ buildNewTitanMailbox( this.props.selectedDomainName, false ) ],
@@ -215,17 +217,17 @@ class TitanAddMailboxes extends Component {
 						onMailboxesChange={ this.onMailboxesChange }
 						validatedMailboxUuids={ this.state.validatedMailboxUuids }
 					>
-						<Button className="titan-add-mailboxes__action-cancel" onClick={ this.handleCancel }>
-							{ translate( 'Cancel' ) }
-						</Button>
-						<Button
-							className="titan-add-mailboxes__action-continue"
-							primary
-							busy={ this.state.isAddingToCart || this.state.isCheckingAvailability }
-							onClick={ this.handleContinue }
-						>
-							{ translate( 'Continue' ) }
-						</Button>
+						<div className="titan-add-mailboxes__buttons">
+							<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>
+
+							<Button
+								primary
+								busy={ this.state.isAddingToCart || this.state.isCheckingAvailability }
+								onClick={ this.handleContinue }
+							>
+								{ translate( 'Continue' ) }
+							</Button>
+						</div>
 					</TitanNewMailboxList>
 				</Card>
 			</>

--- a/client/my-sites/email/titan-add-mailboxes/style.scss
+++ b/client/my-sites/email/titan-add-mailboxes/style.scss
@@ -1,0 +1,20 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.titan-add-mailboxes__buttons {
+	display: flex;
+	flex-direction: column;
+
+	button {
+		margin-top: 10px;
+	}
+
+	@include break-mobile {
+		flex-direction: row;
+
+		button {
+			margin-left: 10px;
+			margin-top: 0;
+		}
+	}
+}

--- a/client/my-sites/email/titan-new-mailbox-list/style.scss
+++ b/client/my-sites/email/titan-new-mailbox-list/style.scss
@@ -28,6 +28,7 @@
 	.titan-new-mailbox-list__supplied-actions {
 		display: flex;
 		flex-direction: column;
+		justify-content: space-between;
 
 		@include break-mobile {
 			flex-direction: row;


### PR DESCRIPTION
This pull request updates the `Add New Mailboxes` page in order to:

* Fix a wrong alignment of the `Cancel` and `Continue` buttons for Titan in desktop view
* Fix a wrong width of the `Remove this mailbox` button for Google Workspace in mobile view

##### Titan

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/144294933-fa15f8ea-e64e-44aa-b96c-cf7ae85493bc.png) | ![image](https://user-images.githubusercontent.com/594356/144294980-31062bd3-f773-4603-a316-041af9d6fd1e.png)

##### Google Workspace

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/144295275-81653405-1fb5-4181-97e0-f5d990b9a919.png) | ![image](https://user-images.githubusercontent.com/594356/144295296-e3a5f008-9cdd-4c62-9ca3-8d3ae6ad89d8.png)

Finally, this pull request removes the styles defined for the `660px` breakpoint for Google Workspace in order to be more consistent with Titan (which doesn't use that breakpoint).

#### Testing instructions

1. Run `git checkout update/add-new-mailboxes-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/58710#issuecomment-983951552)
2. Log into a WordPress.com that has a Professional Email as well as a Google Workspace account
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click your Professional Email to access the `Email Plan` page
5. Click the `Add new mailboxes` option
6. Assert that the form looks like the screenshot above (using a desktop view)
7. Repeat those steps for Google Workspace (using a mobile view)