### PR TITLE
Add type definitions to interpolate-components

### DIFF
--- a/packages/interpolate-components/CHANGELOG.md
+++ b/packages/interpolate-components/CHANGELOG.md
@@ -1,16 +1,35 @@
-# Releases
+# Changelog
 
-## 1.2.0
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0]
+
+### Added
 
 - Add TypeScript type declarations [#58711](https://github.com/Automattic/wp-calypso/pull/58711)
 
-## 1.1.2
+## [1.1.2]
 
-- Change supported React version to minimum `16.2` ([#56933](https://github.com/Automattic/wp-calypso/pull/56933), [#57564](https://github.com/Automattic/wp-calypso/pull/57564))
+### Changed
+
 - Rename package from `interpolate-components` to `@automattic/interpolate-components` ([#56933](https://github.com/Automattic/wp-calypso/pull/56933))
 - Move into [Automattic/wp-calypso](https://github.com/Automattic/wp-calypso/tree/trunk/packages/interpolate-components) repository ([#56933](https://github.com/Automattic/wp-calypso/pull/56933))
 
-## Older releases
+### Removed
+
+- Drop support for React versions below `16.2` ([#56933](https://github.com/Automattic/wp-calypso/pull/56933), [#57564](https://github.com/Automattic/wp-calypso/pull/57564))
+
+## [Older releases]
 
 `1.1.2` is the first release of `@automattic/interpolate-components`. Older releases can be found
 under `interpolate-components`.
+
+[unreleased]: https://github.com/Automattic/wp-calypso/tree/HEAD/packages/interpolate-components
+[1.2.0]: https://github.com/Automattic/wp-calypso/tree/%40automattic/interpolate-components%401.2.0
+[1.1.2]: https://github.com/Automattic/wp-calypso/tree/%40automattic/interpolate-components%401.1.2
+[older releases]: https://github.com/Automattic/interpolate-components

--- a/packages/interpolate-components/CHANGELOG.md
+++ b/packages/interpolate-components/CHANGELOG.md
@@ -30,6 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 under `interpolate-components`.
 
 [unreleased]: https://github.com/Automattic/wp-calypso/tree/HEAD/packages/interpolate-components
-[1.2.0]: https://github.com/Automattic/wp-calypso/tree/%40automattic/interpolate-components%401.2.0
-[1.1.2]: https://github.com/Automattic/wp-calypso/tree/%40automattic/interpolate-components%401.1.2
+[1.2.0]: https://github.com/Automattic/wp-calypso/tree/%40automattic/interpolate-components%401.2.0/packages/interpolate-components
+[1.1.2]: https://github.com/Automattic/wp-calypso/tree/%40automattic/interpolate-components%401.1.2/packages/interpolate-components
 [older releases]: https://github.com/Automattic/interpolate-components

--- a/packages/interpolate-components/CHANGELOG.md
+++ b/packages/interpolate-components/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Releases
+
+## 1.2.0
+
+- Add TypeScript type declarations [#58711](https://github.com/Automattic/wp-calypso/pull/58711)
+
+## 1.1.2
+
+- Change supported React version to minimum `16.2` ([#56933](https://github.com/Automattic/wp-calypso/pull/56933), [#57564](https://github.com/Automattic/wp-calypso/pull/57564))
+- Rename package from `interpolate-components` to `@automattic/interpolate-components` ([#56933](https://github.com/Automattic/wp-calypso/pull/56933))
+- Move into [Automattic/wp-calypso](https://github.com/Automattic/wp-calypso/tree/trunk/packages/interpolate-components) repository ([#56933](https://github.com/Automattic/wp-calypso/pull/56933))
+
+## Older releases
+
+`1.1.2` is the first release of `@automattic/interpolate-components`. Older releases can be found
+under `interpolate-components`.

--- a/packages/interpolate-components/README.md
+++ b/packages/interpolate-components/README.md
@@ -7,7 +7,7 @@ Interpolate-Components allows us to work with structured markup as strings and t
 `interpolateComponents` takes a single options object as an argument and returns a React element containing structured descendent components which can be rendered into a document. The option attributes are:
 
 - **mixedString** A string that contains component tokens to be interpolated
-- **components** An object with components assigned to named attributes
+- **components** (optional) An object with components assigned to named attributes. If not provided, `mixedString` is returned.
 - **throwErrors** (optional) Whether errors should be thrown (as in pre-production environments) or we should more gracefully return the un-interpolated original string (as in production). This is optional and is `false` by default.
 
 ## Component tokens

--- a/packages/interpolate-components/package.json
+++ b/packages/interpolate-components/package.json
@@ -22,6 +22,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/interpolate-components#readme",
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@types/react": "^17.0.37",
 		"react-dom": "^17.0.2"
 	},
 	"peerDependencies": {
@@ -31,5 +32,6 @@
 		"clean": "npx rimraf dist",
 		"build": "transpile",
 		"prepack": "yarn run clean && yarn run build"
-	}
+	},
+	"types": "types"
 }

--- a/packages/interpolate-components/package.json
+++ b/packages/interpolate-components/package.json
@@ -22,11 +22,16 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/interpolate-components#readme",
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@types/react": "^17.0.37",
 		"react-dom": "^17.0.2"
 	},
 	"peerDependencies": {
+		"@types/react": ">=16.1.0",
 		"react": ">=16.2.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/interpolate-components/package.json
+++ b/packages/interpolate-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/interpolate-components",
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"description": "Convert strings into structured React components",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/interpolate-components/types/index.d.ts
+++ b/packages/interpolate-components/types/index.d.ts
@@ -1,0 +1,7 @@
+interface InterpolateOptions {
+	mixedString: string;
+	components?: Record< string, JSX.Element >;
+	throwErrors?: boolean;
+}
+
+export default function interpolate( options: InterpolateOptions ): JSX.Element;

--- a/yarn.lock
+++ b/yarn.lock
@@ -570,6 +570,7 @@ __metadata:
   resolution: "@automattic/interpolate-components@workspace:packages/interpolate-components"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@types/react": ^17.0.37
     react-dom: ^17.0.2
   peerDependencies:
     react: ">=16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -570,10 +570,13 @@ __metadata:
   resolution: "@automattic/interpolate-components@workspace:packages/interpolate-components"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@types/react": ^17.0.37
     react-dom: ^17.0.2
   peerDependencies:
+    "@types/react": ">=16.1.0"
     react: ">=16.2.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This patch adds the type definitions for the `interpolate-components` package.
* Updates README to reflect implementation.

#### Testing instructions

No changes on behavior.