### PR TITLE
Videos UI: Tracks for completed video.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -20,7 +20,6 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		return courses !== null && courseSlug in courses ? courses[ courseSlug ] : [];
 	} );
 
-	const [ selectedVideoIndex, setSelectedVideoIndex ] = useState( null );
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ currentVideo, setCurrentVideo ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
@@ -32,6 +31,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		} );
 
 		setCurrentVideo( videoInfo );
+		setCurrentVideoKey( videoSlug );
 		setIsPlaying( true );
 	};
 
@@ -39,40 +39,31 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		if ( ! course ) {
 			return;
 		}
-
 		const videoSlugs = Object.keys( course.videos );
-		if ( ! currentVideoKey ) {
-			const initialVideoId = 'find-theme';
-			setCurrentVideoKey( initialVideoId );
-			setSelectedVideoIndex( videoSlugs.indexOf( initialVideoId ) );
-		}
-
 		const viewedSlugs = Object.keys( userCourseProgression );
 		if ( viewedSlugs.length > 0 ) {
 			const nextSlug = videoSlugs.find( ( slug ) => ! viewedSlugs.includes( slug ) );
 			if ( nextSlug ) {
 				setCurrentVideoKey( nextSlug );
-				setSelectedVideoIndex( videoSlugs.indexOf( nextSlug ) );
+				setSelectedChapterIndex( videoSlugs.indexOf( nextSlug ) );
+				return;
 			}
 		}
-	}, [ currentVideoKey, course, userCourseProgression ] );
-
-	useEffect( () => {
-		if ( currentVideoKey && course ) {
-			setCurrentVideo( course.videos[ currentVideoKey ] );
-			setSelectedVideoIndex( Object.keys( course.videos ).indexOf( currentVideoKey ) );
-		}
-	}, [ currentVideoKey, course ] );
+		const initialVideoId = 'find-theme';
+		setCurrentVideoKey( initialVideoId );
+		setSelectedChapterIndex( videoSlugs.indexOf( initialVideoId ) );
+	}, [ course, userCourseProgression ] );
 
 	const isVideoSelected = ( idx ) => {
-		return selectedVideoIndex === idx;
+		return Object.keys( course.videos ).indexOf( currentVideoKey ) === idx;
 	};
 
 	const onVideoSelected = ( idx ) => {
 		if ( isVideoSelected( idx ) ) {
-			setSelectedVideoIndex( null );
+			setCurrentVideoKey( null );
 		} else {
-			setSelectedVideoIndex( idx );
+			const selectedVideoKey = Object.keys( course.videos )[ idx ];
+			setCurrentVideoKey( selectedVideoKey );
 		}
 	};
 
@@ -121,11 +112,10 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 				<div className="videos-ui__video-content">
 					{ currentVideo && (
 						<VideoPlayer
-							completedSeconds={ currentVideo.completed_seconds }
-							videoUrl={ currentVideo.url }
+							videoData={ { ...currentVideo, ...{ slug: currentVideoKey } } }
 							onVideoPlayStatusChanged={ ( isVideoPlaying ) => setIsPlaying( isVideoPlaying ) }
 							isPlaying={ isPlaying }
-							poster={ currentVideo.poster ? currentVideo.poster : undefined }
+							course={ course }
 						/>
 					) }
 					<div className="videos-ui__chapters">

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -23,7 +23,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	const [ selectedChapterIndex, setSelectedChapterIndex ] = useState( 0 );
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
-	const currentVideo = currentVideoKey ? course.videos[ currentVideoKey ] : course.videos[ 0 ];
+	const currentVideo = currentVideoKey ? course?.videos[ currentVideoKey ] : course?.videos[ 0 ];
 
 	const onVideoPlayClick = ( videoSlug ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
@@ -39,7 +39,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		if ( ! course ) {
 			return;
 		}
-		const videoSlugs = Object.keys( course.videos );
+		const videoSlugs = Object.keys( course?.videos ?? [] );
 		const viewedSlugs = Object.keys( userCourseProgression );
 		if ( viewedSlugs.length > 0 ) {
 			const nextSlug = videoSlugs.find( ( slug ) => ! viewedSlugs.includes( slug ) );
@@ -118,7 +118,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 					) }
 					<div className="videos-ui__chapters">
 						{ course &&
-							Object.entries( course.videos ).map( ( data, i ) => {
+							Object.entries( course?.videos ).map( ( data, i ) => {
 								const isVideoCompleted =
 									data[ 0 ] in userCourseProgression && userCourseProgression[ data[ 0 ] ];
 								const videoInfo = data[ 1 ];

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -20,17 +20,17 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		return courses !== null && courseSlug in courses ? courses[ courseSlug ] : [];
 	} );
 
+	const [ selectedChapterIndex, setSelectedChapterIndex ] = useState( 0 );
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
-	const [ currentVideo, setCurrentVideo ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
+	const currentVideo = currentVideoKey ? course.videos[ currentVideoKey ] : course.videos[ 0 ];
 
-	const onVideoPlayClick = ( videoSlug, videoInfo ) => {
+	const onVideoPlayClick = ( videoSlug ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
 			course: course.slug,
 			video: videoSlug,
 		} );
 
-		setCurrentVideo( videoInfo );
 		setCurrentVideoKey( videoSlug );
 		setIsPlaying( true );
 	};
@@ -54,17 +54,15 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		setSelectedChapterIndex( videoSlugs.indexOf( initialVideoId ) );
 	}, [ course, userCourseProgression ] );
 
-	const isVideoSelected = ( idx ) => {
-		return Object.keys( course.videos ).indexOf( currentVideoKey ) === idx;
+	const isChapterSelected = ( idx ) => {
+		return selectedChapterIndex === idx;
 	};
 
-	const onVideoSelected = ( idx ) => {
-		if ( isVideoSelected( idx ) ) {
-			setCurrentVideoKey( null );
-		} else {
-			const selectedVideoKey = Object.keys( course.videos )[ idx ];
-			setCurrentVideoKey( selectedVideoKey );
+	const onChapterSelected = ( idx ) => {
+		if ( isChapterSelected( idx ) ) {
+			return;
 		}
+		setSelectedChapterIndex( idx );
 	};
 
 	useEffect( () => {
@@ -128,12 +126,12 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 								return (
 									<div
 										key={ i }
-										className={ `${ isVideoSelected( i ) ? 'selected ' : '' }videos-ui__chapter` }
+										className={ `${ isChapterSelected( i ) ? 'selected ' : '' }videos-ui__chapter` }
 									>
 										<button
 											type="button"
 											className="videos-ui__chapter-accordion-toggle"
-											onClick={ () => onVideoSelected( i ) }
+											onClick={ () => onChapterSelected( i ) }
 										>
 											<span className="videos-ui__video-title">
 												{ i + 1 }. { videoInfo.title }{ ' ' }
@@ -144,12 +142,12 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 													<Gridicon icon="checkmark" size={ 12 } />
 												</span>
 											) }
-											{ isVideoSelected( i ) && ! isVideoCompleted && (
+											{ isChapterSelected( i ) && ! isVideoCompleted && (
 												<span className="videos-ui__status-icon">
 													<Gridicon icon="chevron-up" size={ 18 } />
 												</span>
 											) }
-											{ ! isVideoSelected( i ) && ! isVideoCompleted && (
+											{ ! isChapterSelected( i ) && ! isVideoCompleted && (
 												<span className="videos-ui__status-icon">
 													<Gridicon icon="chevron-down" size={ 18 } />
 												</span>

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,20 +1,19 @@
 import { createRef, useEffect, useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-const VideoPlayer = ( {
-	completedSeconds,
-	videoUrl,
-	onVideoPlayStatusChanged,
-	isPlaying,
-	poster = undefined,
-} ) => {
+const VideoPlayer = ( { videoData, isPlaying, course, onVideoPlayStatusChanged } ) => {
 	const [ addTimeUpdateHandler, setAddTimeUpdateHandler ] = useState( true );
 
 	const videoRef = createRef();
 
 	const markVideoAsComplete = () => {
-		if ( videoRef.current.currentTime < completedSeconds ) {
+		if ( videoRef.current.currentTime < videoData.completed_seconds ) {
 			return;
 		}
+		recordTracksEvent( 'calypso_courses_video_completed', {
+			course: course.slug,
+			video: videoData.slug,
+		} );
 		setAddTimeUpdateHandler( false );
 	};
 
@@ -36,16 +35,20 @@ const VideoPlayer = ( {
 		}
 	} );
 
+	useEffect( () => {
+		setAddTimeUpdateHandler( true );
+	}, [ course?.slug, videoData?.slug ] );
+
 	return (
-		<div key={ videoUrl } className="videos-ui__video">
+		<div key={ videoData.url } className="videos-ui__video">
 			<video
 				controls
 				ref={ videoRef }
-				poster={ poster }
+				poster={ videoData.poster }
 				autoPlay={ isPlaying }
 				onTimeUpdate={ addTimeUpdateHandler ? markVideoAsComplete : undefined }
 			>
-				<source src={ videoUrl } />{ ' ' }
+				<source src={ videoData.url } />{ ' ' }
 				{ /* @TODO: check if tracks are available, the linter demands one */ }
 				<track src="caption.vtt" kind="captions" srcLang="en" label="english_captions" />
 			</video>


### PR DESCRIPTION
This reverts commit 30d423c2bc70d9b6ffc04f8ab6d207084af07aab.

This brings back the work done in https://github.com/Automattic/wp-calypso/pull/58691. A regression was found so the PR was reverted (https://github.com/Automattic/wp-calypso/pull/58714).

This PR should add the tracks for completed video AND fix this regression (this is not done yet)
![2021-12-01 16 27 56](https://user-images.githubusercontent.com/375980/144302668-6543437a-0f6c-4b70-bf35-e0e664fbbb72.gif)

