### PR TITLE
Playwright: Use selector instead to locate the `close tour` button.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -95,9 +95,11 @@ export class GutenbergEditorPage {
 	 */
 	async dismissWelcomeTourIfPresent(): Promise< void > {
 		const frame = await this.getEditorFrame();
+		const locator = frame.locator( selectors.welcomeTourCloseButton );
+
 		try {
-			await frame.click( selectors.welcomeTourCloseButton, { timeout: 5 * 1000 } );
-		} catch ( err ) {
+			await locator.click( { timeout: 5 * 1000, force: true } );
+		} catch {
 			// noop - welcome tour was not found, which is great.
 		}
 	}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -85,7 +85,12 @@ export class GutenbergEditorPage {
 		// `nux?_envelope=1` request has been completed.
 		// On the other hand, `page.on` is able to monitor every request, including the
 		// one to the `nux` endpoint.
-		this.page.on( 'response', async ( response ) => {
+		this.page.on( 'requestfinished', async ( request ) => {
+			const response = await request.response();
+			if ( ! response ) {
+				return;
+			}
+
 			if ( ! response.url().includes( 'nux?_envelope=1' ) ) {
 				return;
 			}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -110,10 +110,16 @@ export class GutenbergEditorPage {
 	 * @returns {Promise<Frame>} iframe holding the editor.
 	 */
 	async getEditorFrame(): Promise< Frame > {
-		const elementHandle = await this.page.waitForSelector( selectors.editorFrame, {
+		const locator = this.page.locator( selectors.editorFrame );
+
+		const elementHandle = await locator.elementHandle( {
 			timeout: 105 * 1000,
-			state: 'attached',
 		} );
+
+		if ( ! elementHandle ) {
+			throw new Error( 'Could not locate editor iframe.' );
+		}
+
 		return ( await elementHandle.contentFrame() ) as Frame;
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -95,9 +95,15 @@ export class GutenbergEditorPage {
 				return;
 			}
 
-			const body: { [ index: string ]: never } = await response.json();
-			if ( body[ 'body' ][ 'show_welcome_guide' ] === true ) {
-				await this.dismissWelcomeTourIfPresent();
+			interface NuxPayload {
+				body: {
+					show_welcome_guide: boolean;
+				};
+			}
+
+			const body = ( await response.json() ) as NuxPayload;
+			if ( body?.body?.show_welcome_guide === true ) {
+				await this.dismissWelcomeTour();
 			}
 		} );
 
@@ -112,7 +118,7 @@ export class GutenbergEditorPage {
 	/**
 	 * Dismisses the Welcome Tour (card) if it is present.
 	 */
-	async dismissWelcomeTourIfPresent(): Promise< void > {
+	async dismissWelcomeTour(): Promise< void > {
 		const frame = await this.getEditorFrame();
 		const locator = frame.locator( selectors.welcomeTourCloseButton );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR uses the new Locator API in order to click the `close tour` button, which is causing many issues with the editor related tests.

Key changes:
- replace the `frame.click` call with `locator.click` call in `dismissWelcomeTourIfPresent`.
- use Locator API to locate the iframed editor in `getEditorFrame`.

#### Testing instructions

In my local test, it was able to locate the `close tour` button where the previous approach failed to do so.

Related to #57460 