### PR TITLE
Licensing post-checkout: Fix site dropdown width when site URL's are short

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -291,7 +291,11 @@ const LicensingActivationThankYou: FC< Props > = ( {
 								) }
 							>
 								<span className="licensing-thank-you-auto-activation__dropdown-item-text">
-									{ option.label }
+									{ option.value === 'activate-license-manually' ? (
+										<strong>{ option.label }</strong>
+									) : (
+										option.label
+									) }
 								</span>
 								{ option.value !== 'activate-license-manually' && (
 									<span>

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -951,6 +951,11 @@
 }
 
 .licensing-thank-you-auto-activation__select {
+	.select-dropdown__header {
+		.select-dropdown__header-text {
+			padding-right: 10px;
+		}
+	}
 	.licensing-thank-you-auto-activation__dropdown-item-flex-container {
 		display: flex;
 		justify-content: space-between;
@@ -965,12 +970,21 @@
 		max-height: 220px;
 		overflow-y: scroll;
 	}
-	.select-dropdown__item {
-		padding-right: 110px;
+	a.select-dropdown__item {
+		padding: 0 16px;
+		text-decoration: none;
 		.select-dropdown__item-text {
+			display: block;
+			position: static;
 			.licensing-thank-you-auto-activation__dropdown-item-text {
 				padding-right: 10px;
 			}
+		}
+		&::before {
+			display: none;
+		}
+		&.is-selected {
+			background-color: var( --color-neutral-10 );
 		}
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -973,6 +973,9 @@
 	a.select-dropdown__item {
 		padding: 0 16px;
 		text-decoration: none;
+		&:hover {
+			color: var( --studio-jetpack-green );
+		}
 		.select-dropdown__item-text {
 			display: block;
 			position: static;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue where when a user has a site(s) URLs that are short, the site-select dropdown box width would shrink, cutting off the text in the **last** item label (the one where users can choose to go through the manual flow). (see this Screenshot below)

![image (5)](https://user-images.githubusercontent.com/11078128/144306312-21c96e14-c239-4683-b469-60d4acecdae1.png)

**This PR fixes the above behavior.**

Report: p1HpG7-dIr-p2#comment-50817

Asana task: 1201096622142517-as-1201431693192904

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and `yarn start`
* Go to http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_scan
* Verify the select dropdown box renders at least as wide as the **last** item label (the one that says, "I don't see my site. Let me configure it manually")

#### Screenshots

**BEFORE**

![Markup 2021-12-01 at 15 37 09](https://user-images.githubusercontent.com/11078128/144310385-a985e63e-a985-4754-a047-5297336cf837.png)

**AFTER**

![Markup 2021-12-01 at 15 34 43](https://user-images.githubusercontent.com/11078128/144310427-90f20cc3-53cf-4e24-a683-40c271032f36.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->