### PR TITLE
Checkout: Record "thank you generated" logstash event directly

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -259,12 +259,11 @@ export default function CompositeCheckout( {
 
 	const getThankYouUrl = useCallback( () => {
 		const url = getThankYouUrlBase();
-		recordEvent( {
-			type: 'THANK_YOU_URL_GENERATED',
-			payload: { url },
+		logStashEvent( 'thank you url generated', {
+			url,
 		} );
 		return url;
-	}, [ getThankYouUrlBase, recordEvent ] );
+	}, [ getThankYouUrlBase ] );
 
 	const contactDetailsType = getContactDetailsType( responseCart );
 

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -1,6 +1,6 @@
 import debugFactory from 'debug';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { logStashEvent, recordCompositeCheckoutErrorDuringAnalytics } from './lib/analytics';
+import { recordCompositeCheckoutErrorDuringAnalytics } from './lib/analytics';
 
 const debug = debugFactory( 'calypso:composite-checkout:record-analytics' );
 
@@ -121,10 +121,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
 					);
 				}
-				case 'THANK_YOU_URL_GENERATED':
-					return logStashEvent( 'thank you url generated', {
-						url: action.payload.url,
-					} );
 				default:
 					debug( 'unknown checkout event', action );
 					return reduxDispatch(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the "thank you url generated" analytics from the checkout event handler directly into where the event occurs.

#### Testing instructions

- Add a product to your cart and visit checkout.
- Open devtools in your browser, open the network monitor, and set it to preserve logs across page loads.
- Select PayPal as your payment method and submit the purchase (no need to actually pay for anything).
- Verify that you see the `thank you url generated` logstash call in the network devtools.

<img width="595" alt="Screen Shot 2021-12-01 at 4 02 36 PM" src="https://user-images.githubusercontent.com/2036909/144313657-8902d610-2ae1-4f7d-8527-36524fd28ab8.png">


