### PR TITLE
Checkout: Record cart item removal analytics events directly

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -54,6 +54,9 @@ export function WPOrderReviewLineItems( {
 	createUserAndSiteBeforeTransaction,
 	responseCart,
 	isPwpoUser,
+	onRemoveProduct,
+	onRemoveProductClick,
+	onRemoveProductCancel,
 }: {
 	className?: string;
 	siteId?: number | undefined;
@@ -64,6 +67,9 @@ export function WPOrderReviewLineItems( {
 	createUserAndSiteBeforeTransaction?: boolean;
 	responseCart: ResponseCart;
 	isPwpoUser: boolean;
+	onRemoveProduct?: ( label: string ) => void;
+	onRemoveProductClick?: ( label: string ) => void;
+	onRemoveProductCancel?: ( label: string ) => void;
 } ): JSX.Element {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
@@ -85,6 +91,9 @@ export function WPOrderReviewLineItems( {
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 							responseCart={ responseCart }
 							isPwpoUser={ isPwpoUser }
+							onRemoveProduct={ onRemoveProduct }
+							onRemoveProductClick={ onRemoveProductClick }
+							onRemoveProductCancel={ onRemoveProductCancel }
 						>
 							{ shouldShowVariantSelector && (
 								<ItemVariationPicker

--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -2,10 +2,8 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
 import page from 'page';
 import { useCallback, useState, useRef, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useValidCheckoutBackUrl from './use-valid-checkout-back-url';
 import type { RemoveProductFromCart, ResponseCart } from '@automattic/shopping-cart';
 
@@ -19,8 +17,7 @@ export default function useRemoveFromCartAndRedirect(
 	removeProductFromCartAndMaybeRedirect: RemoveProductFromCart;
 } {
 	const cartKey = useCartKey();
-	const reduxDispatch = useDispatch();
-	const { responseCart, removeProductFromCart } = useShoppingCart( cartKey );
+	const { removeProductFromCart } = useShoppingCart( cartKey );
 
 	// In some cases, the cloud.jetpack.com/pricing page sends a `checkoutBackUrl` url query param to checkout.
 	const checkoutBackUrl = useValidCheckoutBackUrl( siteSlug );
@@ -67,12 +64,6 @@ export default function useRemoveFromCartAndRedirect(
 	const removeProductFromCartAndMaybeRedirect = useCallback(
 		( uuid: string ) => {
 			setIsRemovingFromCart( true );
-			const product = responseCart.products.find( ( product ) => product.uuid === uuid );
-			reduxDispatch(
-				recordTracksEvent( 'calypso_checkout_composite_delete_product', {
-					product_name: product?.product_slug,
-				} )
-			);
 			return removeProductFromCart( uuid ).then( ( cart: ResponseCart ) => {
 				if ( cart.products.length === 0 ) {
 					redirectDueToEmptyCart();
@@ -83,7 +74,7 @@ export default function useRemoveFromCartAndRedirect(
 				return cart;
 			} );
 		},
-		[ redirectDueToEmptyCart, removeProductFromCart, responseCart, reduxDispatch ]
+		[ redirectDueToEmptyCart, removeProductFromCart ]
 	);
 
 	return {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -2,8 +2,10 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
 import page from 'page';
 import { useCallback, useState, useRef, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useValidCheckoutBackUrl from './use-valid-checkout-back-url';
 import type { RemoveProductFromCart, ResponseCart } from '@automattic/shopping-cart';
 
@@ -17,7 +19,8 @@ export default function useRemoveFromCartAndRedirect(
 	removeProductFromCartAndMaybeRedirect: RemoveProductFromCart;
 } {
 	const cartKey = useCartKey();
-	const { removeProductFromCart } = useShoppingCart( cartKey );
+	const reduxDispatch = useDispatch();
+	const { responseCart, removeProductFromCart } = useShoppingCart( cartKey );
 
 	// In some cases, the cloud.jetpack.com/pricing page sends a `checkoutBackUrl` url query param to checkout.
 	const checkoutBackUrl = useValidCheckoutBackUrl( siteSlug );
@@ -64,6 +67,12 @@ export default function useRemoveFromCartAndRedirect(
 	const removeProductFromCartAndMaybeRedirect = useCallback(
 		( uuid: string ) => {
 			setIsRemovingFromCart( true );
+			const product = responseCart.products.find( ( product ) => product.uuid === uuid );
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_delete_product', {
+					product_name: product?.product_slug,
+				} )
+			);
 			return removeProductFromCart( uuid ).then( ( cart: ResponseCart ) => {
 				if ( cart.products.length === 0 ) {
 					redirectDueToEmptyCart();
@@ -74,7 +83,7 @@ export default function useRemoveFromCartAndRedirect(
 				return cart;
 			} );
 		},
-		[ redirectDueToEmptyCart, removeProductFromCart ]
+		[ redirectDueToEmptyCart, removeProductFromCart, responseCart, reduxDispatch ]
 	);
 
 	return {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -31,22 +31,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							error_message: action.payload.message,
 						} )
 					);
-				case 'a8c_checkout_cancel_delete_product':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' )
-					);
-				case 'a8c_checkout_delete_product':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_delete_product', {
-							product_name: action.payload.product_name,
-						} )
-					);
-				case 'a8c_checkout_delete_product_press':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_delete_product_press', {
-							product_name: action.payload.product_name,
-						} )
-					);
 				case 'a8c_checkout_add_coupon_button_clicked':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} )

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -13,13 +13,7 @@ import {
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackProductSlug,
 } from '@automattic/calypso-products';
-import {
-	CheckoutModal,
-	FormStatus,
-	useFormStatus,
-	useEvents,
-	Button,
-} from '@automattic/composite-checkout';
+import { CheckoutModal, FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -727,7 +721,6 @@ function WPLineItem( {
 		createUserAndSiteBeforeTransaction || false,
 		isPwpoUser || false
 	);
-	const onEvent = useEvents();
 	const isDisabled = formStatus !== FormStatus.READY;
 
 	const isRenewal = isWpComProductRenewal( product );
@@ -782,12 +775,6 @@ function WPLineItem( {
 							disabled={ isDisabled }
 							onClick={ () => {
 								setIsModalVisible( true );
-								onEvent( {
-									type: 'a8c_checkout_delete_product_press',
-									payload: {
-										product_name: label,
-									},
-								} );
 							} }
 						>
 							{ translate( 'Remove from cart' ) }
@@ -801,17 +788,6 @@ function WPLineItem( {
 						} }
 						primaryAction={ () => {
 							removeProductFromCart( product.uuid );
-							onEvent( {
-								type: 'a8c_checkout_delete_product',
-								payload: {
-									product_name: label,
-								},
-							} );
-						} }
-						cancelAction={ () => {
-							onEvent( {
-								type: 'a8c_checkout_cancel_delete_product',
-							} );
 						} }
 						title={ modalCopy.title }
 						copy={ modalCopy.description }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -695,6 +695,9 @@ function WPLineItem( {
 	createUserAndSiteBeforeTransaction,
 	responseCart,
 	isPwpoUser,
+	onRemoveProduct,
+	onRemoveProductClick,
+	onRemoveProductCancel,
 }: {
 	children?: React.ReactNode;
 	product: ResponseCartProduct;
@@ -705,6 +708,9 @@ function WPLineItem( {
 	createUserAndSiteBeforeTransaction?: boolean;
 	responseCart: ResponseCart;
 	isPwpoUser?: boolean;
+	onRemoveProduct?: ( label: string ) => void;
+	onRemoveProductClick?: ( label: string ) => void;
+	onRemoveProductCancel?: ( label: string ) => void;
 } ): JSX.Element {
 	const id = product.uuid;
 	const translate = useTranslate();
@@ -775,6 +781,7 @@ function WPLineItem( {
 							disabled={ isDisabled }
 							onClick={ () => {
 								setIsModalVisible( true );
+								onRemoveProductClick?.( label );
 							} }
 						>
 							{ translate( 'Remove from cart' ) }
@@ -788,6 +795,10 @@ function WPLineItem( {
 						} }
 						primaryAction={ () => {
 							removeProductFromCart( product.uuid );
+							onRemoveProduct?.( label );
+						} }
+						cancelAction={ () => {
+							onRemoveProductCancel?.( label );
 						} }
 						title={ modalCopy.title }
 						copy={ modalCopy.description }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the cart item deletion analytics from the checkout event handler directly into where the events occur (well, closer to where they occur, anyway).

#### Testing instructions

- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- Add a plan to your cart and visit checkout.
- Click to remove the product from the cart, cancel the modal, then click to remove the product again and confirm the modal.
- Verify that you see the `calypso_checkout_composite_delete_product_press`, `calypso_checkout_composite_cancel_delete_product` and `calypso_checkout_composite_delete_product` events triggered.
<img width="508" alt="press-event" src="https://user-images.githubusercontent.com/2036909/144320054-fc5479cd-7f27-475c-8c0d-42a0e9969431.png">
<img width="530" alt="cancel-event" src="https://user-images.githubusercontent.com/2036909/144320066-d4ff037b-7c31-469d-b3ad-0d0765b9ce61.png">
<img width="512" alt="delete-event" src="https://user-images.githubusercontent.com/2036909/144320073-8131fd8c-2080-4e7a-9d03-2d5a2f7c2f70.png">


