### PR TITLE
Migrate ETK to new Sass module system

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.scss
@@ -1,9 +1,9 @@
-@import '@wordpress/base-styles/mixins';
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/breakpoints';
+@use '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/variables';
+@use '@wordpress/base-styles/breakpoints';
 
 .interface-pinned-items > button:not( :first-child ) {
-	@media ( max-width: $break-medium ) {
+	@media ( max-width: breakpoints.$break-medium ) {
 		display: none;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/style.scss
@@ -1,4 +1,4 @@
-@import '../../sass/mixins';
+@use '../../sass/mixins';
 
 .block-editor {
 	.wp-block-a8c-site-description:focus {
@@ -7,6 +7,6 @@
 	}
 
 	.wp-block.is-selected .wp-block-a8c-site-description {
-		@include hide-input-placeholder;
+		@include mixins.hide-input-placeholder;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/style.scss
@@ -1,4 +1,4 @@
-@import '../../sass/mixins';
+@use '../../sass/mixins';
 
 .block-editor {
 	.wp-block-a8c-site-title:focus {
@@ -7,6 +7,6 @@
 	}
 
 	.wp-block.is-selected .wp-block-a8c-site-title {
-		@include hide-input-placeholder;
+		@include mixins.hide-input-placeholder;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/styles.scss
@@ -1,4 +1,4 @@
-@import '@automattic/onboarding/styles/mixins';
+@use '@automattic/onboarding/styles/mixins' as styles-mixins;
 
 .nux-launch-menu {
 	h4 {
@@ -12,7 +12,7 @@
 }
 
 .nux-launch-menu__item.components-button.is-link {
-	@include onboarding-medium-text;
+	@include styles-mixins.onboarding-medium-text;
 	display: flex;
 	color: var( --studio-gray-30 );
 	width: 100%;
@@ -38,7 +38,7 @@
 	}
 
 	// This is only highlighted when sidebar is not fullscreen
-	@include break-medium {
+	@include styles-mixins.break-medium {
 		&.is-current {
 			background: var( --studio-blue-0 );
 			color: initial;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
@@ -1,10 +1,10 @@
-@import '@wordpress/base-styles/mixins';
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/z-index';
-@import '@automattic/typography/styles/variables';
-@import '@automattic/onboarding/styles/variables';
-@import '@automattic/onboarding/styles/mixins';
+@use '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/variables' as variables3;
+@use '@wordpress/base-styles/breakpoints';
+@use '@wordpress/base-styles/z-index';
+@use '@automattic/typography/styles/variables' as variables2;
+@use '@automattic/onboarding/styles/variables';
+@use '@automattic/onboarding/styles/mixins' as styles-mixins;
 
 body.has-nux-launch-modal {
 	overflow: hidden;
@@ -36,7 +36,7 @@ body.has-nux-launch-modal {
 }
 
 .nux-launch-modal-header {
-	@include onboarding-block-edge2edge;
+	@include styles-mixins.onboarding-block-edge2edge;
 	display: flex;
 
 	// Modal header uses position: fixed instead of position: sticky because:
@@ -45,21 +45,21 @@ body.has-nux-launch-modal {
 	position: fixed;
 	top: 0;
 	width: 100%;
-	height: $onboarding-header-height;
-	border-bottom: 1px solid $gray-200;
+	height: variables.$onboarding-header-height;
+	border-bottom: 1px solid variables3.$gray-200;
 	background: var( --studio-white );
-	z-index: z-index( '.components-modal__header' );
+	z-index: z-index.z-index( '.components-modal__header' );
 
 	// On desktop, do not show bottom border.
-	@include break-medium {
+	@include mixins.break-medium {
 		position: relative;
 		border-bottom: none;
 	}
 
 	.nux-launch-progress {
-		height: $onboarding-header-height;
+		height: variables.$onboarding-header-height;
 
-		@include break-medium {
+		@include mixins.break-medium {
 			display: none;
 		}
 	}
@@ -79,7 +79,7 @@ body.has-nux-launch-modal {
 	min-width: 0;
 	display: flex;
 	flex-direction: column;
-	@include onboarding-block-margin;
+	@include styles-mixins.onboarding-block-margin;
 
 	.nux-launch-step__body {
 		flex-grow: 1;
@@ -94,9 +94,9 @@ body.has-nux-launch-modal {
 	}
 
 	// To accomodate fixed .nux-launch-modal-header
-	padding-top: $onboarding-header-height;
+	padding-top: variables.$onboarding-header-height;
 
-	@include break-medium {
+	@include mixins.break-medium {
 		// Modal header is not sticky on desktop.
 		padding-top: 0;
 	}
@@ -113,25 +113,25 @@ body.has-nux-launch-modal {
 	width: 100%;
 	height: 100%;
 	background: var( --studio-white );
-	z-index: z-index( '.components-modal__header' ) + 2;
+	z-index: z-index.z-index( '.components-modal__header' ) + 2;
 
-	@media ( max-width: $break-medium ) {
+	@media ( max-width: breakpoints.$break-medium ) {
 		// This brings the sidebar that is hiding offscreen into view.
 		.is-sidebar-fullscreen & {
 			left: 0;
 		}
 	}
 
-	@include break-medium {
+	@include mixins.break-medium {
 		// Use sticky or relative positioning because fixed or absolute
 		// positioning causes the vertical scrollbar from the parent element
 		// to overlap the content on the sidebar.
 		position: sticky;
 		top: 0;
 		left: auto;
-		width: $sidebar-width;
-		min-width: $sidebar-width;
-		max-width: $sidebar-width;
+		width: variables3.$sidebar-width;
+		min-width: variables3.$sidebar-width;
+		max-width: variables3.$sidebar-width;
 		border-left: 1px solid var( --studio-gray-5 );
 	}
 }
@@ -140,7 +140,7 @@ body.has-nux-launch-modal {
 	// This keeps the button on the top right corner even when scrolled down
 	position: sticky;
 	top: 0;
-	z-index: z-index( '.components-modal__header' ) + 3;
+	z-index: z-index.z-index( '.components-modal__header' ) + 3;
 
 	// Give it no dimension so it doesn't take any flex space
 	// but overflow it so the close button is visible
@@ -161,12 +161,12 @@ body.has-nux-launch-modal {
 	> span {
 		// Push the icon back out from the right side
 		position: relative;
-		right: $onboarding-header-height;
+		right: variables.$onboarding-header-height;
 
 		// Use padding to create width
 		// (18px left padding + 24px icon width + 18px right padding = 60px width)
-		padding: 0 #{( $onboarding-header-height - 24px ) * 0.5};
-		height: $onboarding-header-height;
+		padding: 0 #{( variables.$onboarding-header-height - 24px ) * 0.5};
+		height: variables.$onboarding-header-height;
 
 		// Vertically align icon
 		display: flex;
@@ -183,5 +183,5 @@ body.has-nux-launch-modal {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	font-size: $font-body;
+	font-size: variables2.$font-body;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
@@ -1,15 +1,15 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@automattic/onboarding/styles/mixins';
+@use '@wordpress/base-styles/breakpoints';
+@use '@automattic/onboarding/styles/mixins' as styles-mixins;
 
 .nux-launch-sidebar {
-	@include onboarding-block-margin;
+	@include styles-mixins.onboarding-block-margin;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
 	background: var( --studio-white );
-	padding-top: $onboarding-header-height;
+	padding-top: styles-mixins.$onboarding-header-height;
 
-	@include break-medium {
+	@include styles-mixins.break-medium {
 		display: block;
 		height: auto;
 		margin: 0 24px;
@@ -18,13 +18,13 @@
 		// On mobile & tablet, inherit onboarding title & subtitle styling.
 		// On desktop, use designated title & subtitle styling.
 		h1.onboarding-title {
-			font-size: $font-title-medium;
+			font-size: styles-mixins.$font-title-medium;
 		}
 
 		h2.onboarding-subtitle {
-			font-family: $default-font;
+			font-family: styles-mixins.$default-font;
 			font-weight: normal;
-			font-size: $font-body-small;
+			font-size: styles-mixins.$font-body-small;
 			line-height: 1.5;
 			color: var( --studio-gray-60 );
 		}
@@ -32,17 +32,17 @@
 }
 
 .nux-launch-sidebar__header {
-	@include onboarding-heading-padding;
+	@include styles-mixins.onboarding-heading-padding;
 }
 
 .nux-launch-sidebar__body {
 	flex-grow: 1;
-	@include onboarding-body-margin;
+	@include styles-mixins.onboarding-body-margin;
 }
 
 .nux-launch-sidebar__footer {
 	// On mobile & tablet, show sidebar footer, sticky at bottom.
-	@include onboarding-block-edge2edge;
+	@include styles-mixins.onboarding-block-edge2edge;
 	position: sticky;
 	bottom: 0;
 
@@ -52,7 +52,7 @@
 	}
 
 	// On desktop, hide sidebar footer.
-	@include break-medium {
+	@include styles-mixins.break-medium {
 		display: none;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
@@ -1,10 +1,10 @@
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/breakpoints';
-@import '@automattic/typography/styles/fonts';
-@import '@automattic/onboarding/styles/mixins';
+@use '@wordpress/base-styles/variables';
+@use '@wordpress/base-styles/breakpoints';
+@use '@automattic/typography/styles/fonts';
+@use '@automattic/onboarding/styles/mixins' as styles-mixins;
 
 .nux-launch-step__header {
-	@include onboarding-heading-padding;
+	@include styles-mixins.onboarding-heading-padding;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -14,19 +14,19 @@
 	.action-buttons {
 		display: none;
 
-		@include break-medium {
+		@include styles-mixins.break-medium {
 			display: block;
 		}
 	}
 }
 
 .nux-launch-step__body {
-	@include onboarding-body-margin;
+	@include styles-mixins.onboarding-body-margin;
 }
 
 .nux-launch-step__footer {
 	// On mobile & tablet, show step footer, sticky at bottom.
-	@include onboarding-block-edge2edge;
+	@include styles-mixins.onboarding-block-edge2edge;
 	position: sticky;
 	bottom: 0;
 
@@ -35,7 +35,7 @@
 	}
 
 	// On desktop, hide step footer.
-	@include break-medium {
+	@include styles-mixins.break-medium {
 		display: none;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
@@ -1,5 +1,5 @@
-@import '@automattic/typography/styles/variables';
-@import '@automattic/onboarding/styles/mixins';
+@use '@automattic/typography/styles/variables';
+@use '@automattic/onboarding/styles/mixins';
 
 // TODO: This is former dark-gray-500 from @wordpress/base-styles.
 // Replace with a color from the standard palette.
@@ -21,7 +21,7 @@ ul.nux-launch__feature-item-group {
 	margin: 0;
 }
 .nux-launch__feature-item {
-	font-size: $font-body-small;
+	font-size: variables.$font-body-small;
 	line-height: 20px;
 	letter-spacing: 0.2px;
 	margin: 4px 0;
@@ -55,7 +55,7 @@ ul.nux-launch__feature-item-group {
 	}
 
 	&:disabled {
-		color: $white;
+		color: mixins.$white;
 		opacity: 0.5;
 
 		&:hover {
@@ -83,10 +83,10 @@ ul.nux-launch__feature-item-group {
 		font-weight: 600;
 
 		&.is-loading {
-			@include onboarding-placeholder();
+			@include mixins.onboarding-placeholder();
 		}
 	}
 	&__domain-price {
-		font-size: $font-body-small;
+		font-size: variables.$font-body-small;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/styles.scss
@@ -1,4 +1,4 @@
-@import '@automattic/onboarding/styles/variables';
+@use '@automattic/onboarding/styles/variables' as variables2;
 
 .nux-launch-step__input {
 	position: relative;
@@ -7,7 +7,7 @@
 	input[type='text'].components-text-control__input {
 		padding: 6px 40px 6px 16px;
 		height: 38px;
-		background: $gray-100;
+		background: variables2.$gray-100;
 		border: none;
 
 		&::placeholder {
@@ -31,7 +31,7 @@
 	display: flex;
 	align-items: center;
 	color: var( --studio-gray-50 );
-	font-family: $default-font;
+	font-family: variables2.$default-font;
 	font-size: 14px;
 	line-height: 14px;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
@@ -1,5 +1,5 @@
-@import '@automattic/onboarding/styles/mixins';
-@import '@automattic/plans-grid/src/variables';
+@use '@automattic/onboarding/styles/mixins';
+@use '@automattic/plans-grid/src/variables';
 
 .nux-launch-modal.step-plan {
 	// Remove extraneous whitespace after plans details.
@@ -10,9 +10,9 @@
 
 	.plans-grid__details-container {
 		position: relative;
-		@include onboarding-block-edge2edge-container;
+		@include mixins.onboarding-block-edge2edge-container;
 
-		@media ( min-width: $plans-grid-max-page-width ) {
+		@media ( min-width: variables.$plans-grid-max-page-width ) {
 			margin-left: 0;
 			margin-right: 0;
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/editor.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/editor.scss
@@ -1,2 +1,2 @@
-@import './src/global-styles-sidebar.scss';
-@import './src/font-pairings-panel.scss';
+@use 'src/global-styles-sidebar.scss';
+@use 'src/font-pairings-panel.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.scss
@@ -1,4 +1,4 @@
-@import '@automattic/page-pattern-modal/src/styles/page-pattern-modal';
+@use '@automattic/page-pattern-modal/src/styles/page-pattern-modal';
 
 .sidebar-modal-opener {
 	display: flex;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
@@ -1,4 +1,4 @@
-@import '@wordpress/base-styles/colors';
+@use '@wordpress/base-styles/colors';
 
 // TODO: This is former light-gray-900 from @wordpress/base-styles.
 // Replace with a color from the standard palette.
@@ -13,8 +13,8 @@ $create-page-text-color: #a2aab2;
 	min-height: 45px;
 
 	&:focus {
-		color: $white;
-		border: 1px solid $white;
+		color: colors.$white;
+		border: 1px solid colors.$white;
 		box-shadow: none !important;
 		outline: none !important;
 		border-radius: 0;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
@@ -1,5 +1,5 @@
-@import '@wordpress/base-styles/colors';
-@import '@wordpress/base-styles/variables';
+@use '@wordpress/base-styles/colors';
+@use '@wordpress/base-styles/variables';
 
 // TODO: These colors used to be in @wordpress/base-styles.
 // Replace them with colors from the updated standard palette.
@@ -14,22 +14,22 @@ $nav-item-untitled-text-color: #b5bcc2; // former $light-gray-800
 	width: 100%;
 	height: auto;
 	margin: 0;
-	padding: ( $grid-unit-20 * 0.5 ) $grid-unit-20;
+	padding: ( variables.$grid-unit-20 * 0.5 ) variables.$grid-unit-20;
 	text-align: initial;
-	color: $white;
+	color: colors.$white;
 
 	&:hover,
 	&:not( [aria-disabled='true'] ):active {
-		color: $white;
+		color: colors.$white;
 	}
 
 	&:focus {
-		color: $white;
-		border: 1px solid $white;
+		color: colors.$white;
+		border: 1px solid colors.$white;
 		box-shadow: none !important;
 		outline: none !important;
 		border-radius: 0;
-		padding: ( ( $grid-unit-20 * 0.5 ) - 1 ) ( $grid-unit-20 - 1 );
+		padding: ( ( variables.$grid-unit-20 * 0.5 ) - 1 ) ( variables.$grid-unit-20 - 1 );
 	}
 
 	&.is-selected {
@@ -56,7 +56,7 @@ $nav-item-untitled-text-color: #b5bcc2; // former $light-gray-800
 .wpcom-block-editor-nav-item__label {
 	display: inline-block;
 	padding: 4px;
-	border-radius: $radius-block-ui;
+	border-radius: variables.$radius-block-ui;
 	background: $nav-item-label-background-color;
 	font-weight: 600;
 	margin-left: 4px;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -1,9 +1,9 @@
-@import '@wordpress/base-styles/colors';
-@import '@wordpress/base-styles/mixins';
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/z-index';
+@use '@wordpress/base-styles/colors';
+@use '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/variables';
+@use '@wordpress/base-styles/z-index';
 
-$sidebar-width: 272px;
+variables.$sidebar-width: 272px;
 $sidebar-transition-period: 100ms;
 $sidebar-background-color: #23282e; // WP-admin gray to match the close button background color
 $sidebar-nav-header-background-color: #32373d; // WP-admin gray to match the close button background hover color
@@ -17,24 +17,24 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 	right: 0;
 	bottom: 0;
 	// Use the same z-index as the edit-post-layout header
-	z-index: z-index( '.interface-interface-skeleton__header' );
+	z-index: z-index.z-index( '.interface-interface-skeleton__header' );
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $sidebar-transition-period ease-out
 		forwards;
-	@include reduce-motion( 'animation' );
+	@include mixins.reduce-motion( 'animation' );
 
 	&.is-fading-out {
 		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $sidebar-transition-period ease-in
 			reverse;
-		@include reduce-motion( 'animation' );
+		@include mixins.reduce-motion( 'animation' );
 	}
 }
 
 @keyframes wpcom-block-editor-nav-sidebar-nav-sidebar__fade {
 	0% {
-		background-color: rgba( $black, 0 );
+		background-color: rgba( colors.$black, 0 );
 	}
 	100% {
-		background-color: rgba( $black, 0.7 );
+		background-color: rgba( colors.$black, 0.7 );
 	}
 }
 
@@ -43,24 +43,24 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 	position: fixed;
 	top: 0;
 	bottom: 0;
-	width: $sidebar-width;
+	width: variables.$sidebar-width;
 	background: $sidebar-background-color;
 	display: flex;
 	flex-direction: column;
-	box-shadow: -5px 0 20px $black;
+	box-shadow: -5px 0 20px colors.$black;
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $sidebar-transition-period ease-out;
-	@include reduce-motion( 'animation' );
+	@include mixins.reduce-motion( 'animation' );
 
 	&.is-sliding-left {
 		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $sidebar-transition-period ease-in
 			reverse;
-		@include reduce-motion( 'animation' );
+		@include mixins.reduce-motion( 'animation' );
 	}
 }
 
 @keyframes wpcom-block-editor-nav-sidebar-nav-sidebar__slide {
 	0% {
-		left: -$sidebar-width;
+		left: -(variables.$sidebar-width);
 	}
 	100% {
 		left: 0;
@@ -74,16 +74,16 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__site-title {
-	margin-left: $grid-unit-10;
+	margin-left: variables.$grid-unit-10;
 	align-items: center;
 	display: flex;
 	min-height: 60px;
 
 	h2 {
-		color: $white;
+		color: colors.$white;
 		margin: 0;
-		font-size: $text-editor-font-size;
-		line-height: $default-line-height;
+		font-size: variables.$text-editor-font-size;
+		line-height: variables.$default-line-height;
 		word-wrap: break-word;
 		font-weight: normal;
 		display: flex;
@@ -98,13 +98,13 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 		&:active,
 		&:focus,
 		&:hover {
-			color: $white;
+			color: colors.$white;
 		}
 	}
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button {
-	height: $header-height !important;
+	height: variables.$header-height !important;
 	background-color: $sidebar-nav-header-background-color !important;
 	// Prevents the icon button from shrinking when the site title goes on 2+ lines
 	flex-shrink: 0;
@@ -114,19 +114,19 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 	width: 100%;
 	border: none !important;
 	box-shadow: none !important;
-	color: $white;
+	color: colors.$white;
 	flex-shrink: 0;
 	padding: 8px 11px !important;
 	margin: 12px 0;
 
 	&:hover,
 	&:not( [aria-disabled='true'] ):active {
-		color: $white;
+		color: colors.$white;
 	}
 
 	&:focus {
-		color: $white;
-		border: 1px solid $white !important;
+		color: colors.$white;
+		border: 1px solid colors.$white !important;
 		box-shadow: none !important;
 		outline: none !important;
 		border-radius: 0;
@@ -136,15 +136,15 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-heading,
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading {
-	padding: $grid-unit-05 $grid-unit-20;
+	padding: variables.$grid-unit-05 variables.$grid-unit-20;
 	/* stylelint-disable-next-line scales/font-size, declaration-property-unit-allowed-list */
 	font-size: 18px;
-	color: $white;
+	color: colors.$white;
 	margin: 0 0 8px;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading {
-	font-size: $default-font-size;
+	font-size: variables.$default-font-size;
 	font-weight: normal;
 }
 
@@ -161,7 +161,7 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 	}
 
 	.is-selected {
-		color: $white;
+		color: colors.$white;
 	}
 	/*
 	@TODO Work out how we're going to handle overflow

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -1,12 +1,12 @@
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/mixins';
-@import '../nav-sidebar/style.scss';
+@use '@wordpress/base-styles/variables';
+@use '@wordpress/base-styles/mixins';
+@use '../nav-sidebar/style.scss';
 
 .wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button {
 	// Match this animation with the nav-sidebar, so that the button is not hidden
 	// before the sidebar menu finishes sliding out.
-	transition: visibility $sidebar-transition-period linear;
-	@include reduce-motion( 'transition' );
+	transition: visibility style.$sidebar-transition-period linear;
+	@include mixins.reduce-motion( 'transition' );
 
 	&.is-hidden {
 		visibility: hidden;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/draft-post-modal/style.scss
@@ -1,9 +1,9 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/breakpoints';
+@use '@wordpress/base-styles/mixins';
 
 .wpcom-block-editor-draft-post-modal {
 	.components-modal__content {
-		@include break-small {
+		@include mixins.break-small {
 			padding: 48px 128px;
 		}
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/style.scss
@@ -1,6 +1,6 @@
-@import '@automattic/typography/styles/variables';
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
+@use '@automattic/typography/styles/variables';
+@use '@wordpress/base-styles/breakpoints';
+@use '@wordpress/base-styles/mixins';
 
 .wpcom-block-editor-nux-modal {
 	.components-modal__header {
@@ -33,7 +33,7 @@
 			margin: 0;
 		}
 
-		@include break-mobile {
+		@include mixins.break-mobile {
 			text-align: center;
 		}
 	}
@@ -45,11 +45,11 @@
 
 	.wpcom-block-editor-nux-modal__title {
 		margin: 34px 0 0;
-		font-size: $font-headline-small;
+		font-size: variables.$font-headline-small;
 		font-weight: 500; // stylelint-disable-line scales/font-weights
 		line-height: 1.2;
 
-		@include break-mobile {
+		@include mixins.break-mobile {
 			margin-top: 24px;
 		}
 	}
@@ -57,11 +57,11 @@
 	.wpcom-block-editor-nux-modal__description {
 		max-width: 352px;
 		margin: 16px 0 0;
-		font-size: $font-body;
+		font-size: variables.$font-body;
 
-		@include break-mobile {
+		@include mixins.break-mobile {
 			margin: 20px auto 0;
-			font-size: $font-body-large;
+			font-size: variables.$font-body-large;
 		}
 	}
 
@@ -76,14 +76,14 @@
 			height: 40px;
 			justify-content: center;
 			border-radius: 3px; // stylelint-disable-line scales/radii
-			font-size: $font-body-small;
+			font-size: variables.$font-body-small;
 		}
 
 		.components-button + .components-button {
 			margin-top: 12px;
 		}
 
-		@include break-mobile {
+		@include mixins.break-mobile {
 			flex-direction: row;
 			margin-top: 28px;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/style.scss
@@ -1,9 +1,9 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/breakpoints';
+@use '@wordpress/base-styles/mixins';
 
 .wpcom-block-editor-post-published-modal {
 	.components-modal__content {
-		@include break-small {
+		@include mixins.break-small {
 			padding: 48px 90px;
 		}
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/style.scss
@@ -1,8 +1,8 @@
 // @TODO: remove the ignore rule and replace font sizes accordingly
 /* stylelint-disable scales/font-size */
 
-@import '@automattic/typography/styles/fonts';
-@import '@automattic/onboarding/styles/mixins';
+@use '@automattic/typography/styles/fonts';
+@use '@automattic/onboarding/styles/mixins';
 
 $wpcom-modal-breakpoint: 660px;
 
@@ -151,7 +151,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 }
 
 .wpcom-block-editor-nux__heading {
-	@include onboarding-font-recoleta;
+	@include mixins.onboarding-font-recoleta;
 	/* Gray / Gray 90 */
 	color: #1d2327;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -1,8 +1,8 @@
 @use 'sass:math';
-@import '@wordpress/base-styles/colors';
-@import '@wordpress/base-styles/mixins';
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/z-index';
+@use '@wordpress/base-styles/colors';
+@use '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/variables';
+@use '@wordpress/base-styles/z-index';
 
 $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: replace with standard color
 
@@ -28,14 +28,14 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	border-radius: 2px;
 	box-shadow: 0 2px 6px rgba( 60, 66, 87, 0.08 ), 0 0 0 1px rgba( 60, 66, 87, 0.16 ),
 		0 1px 1px rgba( 0, 0, 0, 0.08 );
-	background-color: $white;
-	color: $black;
+	background-color: colors.$white;
+	color: colors.$black;
 
 	.components-button {
 		height: 44px;
 
 		.wpcom-editor-welcome-tour__minimized-tour-index {
-			color: $gray-600;
+			color: colors.$gray-600;
 		}
 
 		svg {
@@ -56,7 +56,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 
 	.components-guide__page-control {
 		bottom: 0;
-		left: $grid-unit-20;
+		left: variables.$grid-unit-20;
 		margin: 0;
 		position: absolute;
 
@@ -92,12 +92,12 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	.components-card__body,
 	.components-card__footer {
 		border-top: none;
-		padding: $grid-unit-20 !important;
+		padding: variables.$grid-unit-20 !important;
 	}
 
 	.components-card__footer {
 		.welcome-tour__end-text {
-			color: $gray-600;
+			color: colors.$gray-600;
 			font-size: 0.875rem;
 			font-style: italic;
 		}
@@ -105,19 +105,19 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 		.welcome-tour__end-icon.components-button.has-icon {
 			background-color: #f6f7f7;
 			border-radius: 50%; /* stylelint-disable-line */
-			color: $gray-600;
+			color: colors.$gray-600;
 			margin-left: 8px;
 
 			path {
-				fill: $gray-600;
+				fill: colors.$gray-600;
 			}
 
 			&.active {
-				background-color: $black;
+				background-color: colors.$black;
 				opacity: 1;
 
 				path {
-					fill: $white;
+					fill: colors.$white;
 				}
 			}
 		}
@@ -160,7 +160,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 
 .welcome-tour-card__overlay-controls {
 	left: 0;
-	padding: $grid-unit-15;
+	padding: variables.$grid-unit-15;
 	position: absolute;
 	right: 0;
 	z-index: 1; // z-index is needed because overlay controls are written before components-card__media, and so ends up under the image
@@ -199,7 +199,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 }
 
 .welcome-tour-card__next-btn {
-	margin-left: $grid-unit-15;
+	margin-left: variables.$grid-unit-15;
 	justify-content: center;
 	min-width: 85px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This is the result of running `npx sass-migrator module --load-path node_modules "apps/editing-toolkit/**/*.scss"`

See this post for more info.

**NOTE: this is blocked by https://github.com/WordPress/gutenberg/issues/37044 in Gutenberg**

#### Testing instructions
- [ ] ETK build should successfully complete
- [ ] Smoke test all ETK features on WordPress.com
