### PR TITLE
Videos UI - Add front-end reflection of videos UI user progression

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -15,10 +15,14 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	const courseSlug = 'blogging-quick-start';
 	const { data: course } = useCourseQuery( courseSlug, { retry: false } );
 
-	const userCourseProgression = useSelector( ( state ) => {
+	const initialUserCourseProgression = useSelector( ( state ) => {
 		const courses = getOriginalUserSetting( state, 'courses' );
 		return courses !== null && courseSlug in courses ? courses[ courseSlug ] : [];
 	} );
+	const [ userCourseProgression, setUserCourseProgression ] = useState( [] );
+	useEffect( () => {
+		setUserCourseProgression( initialUserCourseProgression );
+	}, [ initialUserCourseProgression ] );
 
 	const [ selectedChapterIndex, setSelectedChapterIndex ] = useState( 0 );
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
@@ -63,6 +67,12 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 			return;
 		}
 		setSelectedChapterIndex( idx );
+	};
+
+	const markVideoCompleted = ( videoData ) => {
+		const updatedUserCourseProgression = { ...userCourseProgression };
+		updatedUserCourseProgression[ videoData.slug ] = true;
+		setUserCourseProgression( updatedUserCourseProgression );
 	};
 
 	useEffect( () => {
@@ -114,6 +124,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 							onVideoPlayStatusChanged={ ( isVideoPlaying ) => setIsPlaying( isVideoPlaying ) }
 							isPlaying={ isPlaying }
 							course={ course }
+							onVideoCompleted={ markVideoCompleted }
 						/>
 					) }
 					<div className="videos-ui__chapters">

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -2,8 +2,9 @@ import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { cloneElement, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
+import useUpdateUserCourseProgressionMutation from 'calypso/data/courses/use-update-user-course-progression-mutation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import getOriginalUserSetting from 'calypso/state/selectors/get-original-user-setting';
 import VideoPlayer from './video-player';
@@ -14,11 +15,12 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 
 	const courseSlug = 'blogging-quick-start';
 	const { data: course } = useCourseQuery( courseSlug, { retry: false } );
+	const { updateUserCourseProgression } = useUpdateUserCourseProgressionMutation();
 
 	const initialUserCourseProgression = useSelector( ( state ) => {
 		const courses = getOriginalUserSetting( state, 'courses' );
 		return courses !== null && courseSlug in courses ? courses[ courseSlug ] : [];
-	} );
+	}, shallowEqual );
 	const [ userCourseProgression, setUserCourseProgression ] = useState( [] );
 	useEffect( () => {
 		setUserCourseProgression( initialUserCourseProgression );
@@ -40,11 +42,11 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	};
 
 	useEffect( () => {
-		if ( ! course ) {
+		if ( ! course || ! initialUserCourseProgression ) {
 			return;
 		}
 		const videoSlugs = Object.keys( course?.videos ?? [] );
-		const viewedSlugs = Object.keys( userCourseProgression );
+		const viewedSlugs = Object.keys( initialUserCourseProgression );
 		if ( viewedSlugs.length > 0 ) {
 			const nextSlug = videoSlugs.find( ( slug ) => ! viewedSlugs.includes( slug ) );
 			if ( nextSlug ) {
@@ -56,7 +58,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		const initialVideoId = 'find-theme';
 		setCurrentVideoKey( initialVideoId );
 		setSelectedChapterIndex( videoSlugs.indexOf( initialVideoId ) );
-	}, [ course, userCourseProgression ] );
+	}, [ course, initialUserCourseProgression ] );
 
 	const isChapterSelected = ( idx ) => {
 		return selectedChapterIndex === idx;
@@ -73,6 +75,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		const updatedUserCourseProgression = { ...userCourseProgression };
 		updatedUserCourseProgression[ videoData.slug ] = true;
 		setUserCourseProgression( updatedUserCourseProgression );
+		updateUserCourseProgression( courseSlug, videoData.slug );
 	};
 
 	useEffect( () => {

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,8 +1,14 @@
 import { createRef, useEffect, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-const VideoPlayer = ( { videoData, isPlaying, course, onVideoPlayStatusChanged } ) => {
-	const [ addTimeUpdateHandler, setAddTimeUpdateHandler ] = useState( true );
+const VideoPlayer = ( {
+	videoData,
+	isPlaying,
+	course,
+	onVideoPlayStatusChanged,
+	onVideoCompleted,
+} ) => {
+	const [ shouldCheckForVideoComplete, setShouldCheckForVideoComplete ] = useState( true );
 
 	const videoRef = createRef();
 
@@ -14,7 +20,8 @@ const VideoPlayer = ( { videoData, isPlaying, course, onVideoPlayStatusChanged }
 			course: course.slug,
 			video: videoData.slug,
 		} );
-		setAddTimeUpdateHandler( false );
+		onVideoCompleted( videoData );
+		setShouldCheckForVideoComplete( false );
 	};
 
 	useEffect( () => {
@@ -36,7 +43,7 @@ const VideoPlayer = ( { videoData, isPlaying, course, onVideoPlayStatusChanged }
 	} );
 
 	useEffect( () => {
-		setAddTimeUpdateHandler( true );
+		setShouldCheckForVideoComplete( true );
 	}, [ course?.slug, videoData?.slug ] );
 
 	return (
@@ -46,7 +53,7 @@ const VideoPlayer = ( { videoData, isPlaying, course, onVideoPlayStatusChanged }
 				ref={ videoRef }
 				poster={ videoData.poster }
 				autoPlay={ isPlaying }
-				onTimeUpdate={ addTimeUpdateHandler ? markVideoAsComplete : undefined }
+				onTimeUpdate={ shouldCheckForVideoComplete ? markVideoAsComplete : undefined }
 			>
 				<source src={ videoData.url } />{ ' ' }
 				{ /* @TODO: check if tracks are available, the linter demands one */ }

--- a/client/data/courses/use-update-user-course-progression-mutation.js
+++ b/client/data/courses/use-update-user-course-progression-mutation.js
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+function useUpdateUserCourseProgressionMutation( queryOptions = {} ) {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		( { courseSlug, videoSlug } ) =>
+			wpcom.req.post(
+				'/courses/videos',
+				{
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					course_slug: courseSlug,
+					video_slug: videoSlug,
+				}
+			),
+		{
+			...queryOptions,
+			onSuccess( ...args ) {
+				queryClient.invalidateQueries( [ 'course-progression', args.courseSlug ] );
+				queryOptions.onSuccess?.( ...args );
+			},
+		}
+	);
+
+	const { mutate } = mutation;
+
+	const updateUserCourseProgression = useCallback(
+		( courseSlug, videoSlug ) => mutate( { courseSlug, videoSlug } ),
+		[ mutate ]
+	);
+
+	return { updateUserCourseProgression, ...mutation };
+}
+
+export default useUpdateUserCourseProgressionMutation;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR follows on existing work done to the Videos UI project, adding a front-end reflection of which videos a user has completed watching.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this diff locally and view the videos UI on an account that has not watched all videos in the current Videos UI view. (You can reset which videos are marked as complete using the shell.)
* Watch a video past its completion point.
* Verify that a check mark appears next to the video you have completed.
* Reload the page and open the videos UI again. Verify that the completed video is still marked as completed.

![Untitled-1](https://user-images.githubusercontent.com/13437011/144331643-72919859-1fe4-4fa4-ad14-271f88228d86.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58248
