### PR TITLE
Remove setup-site-after-checkout and hero-flow feature flags

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -437,12 +437,8 @@ export function generateFlows( {
 		},
 		{
 			name: 'setup-site',
-			steps: isEnabled( 'signup/hero-flow' )
-				? [ 'intent', 'site-options', 'starting-point', 'design-setup-site' ]
-				: [ 'design-setup-site' ],
-			destination: isEnabled( 'signup/hero-flow' )
-				? getDestinationFromIntent
-				: getChecklistThemeDestination,
+			steps: [ 'intent', 'site-options', 'starting-point', 'design-setup-site' ],
+			destination: getDestinationFromIntent,
 			description:
 				'Sets up a site that has already been created and paid for (if purchases were made)',
 			lastModified: '2021-10-14',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { englishLocales } from '@automattic/i18n-utils';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
@@ -74,11 +73,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 	}
 
 	// Initially ship to English users only, then ship to all users when translations complete
-	if ( isEnabled( 'signup/hero-flow' ) && englishLocales.includes( localeSlug ) ) {
-		return addQueryArgs( queryParam, '/start/setup-site' ) + '&flags=signup/hero-flow'; // we don't want the flag name to be escaped
-	}
-
-	if ( isEnabled( 'signup/setup-site-after-checkout' ) && englishLocales.includes( localeSlug ) ) {
+	if ( englishLocales.includes( localeSlug ) ) {
 		return addQueryArgs( queryParam, '/start/setup-site' );
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -147,8 +147,6 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
-		"signup/setup-site-after-checkout": true,
-		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,8 +96,6 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
-		"signup/setup-site-after-checkout": true,
-		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,

--- a/config/production.json
+++ b/config/production.json
@@ -99,8 +99,6 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
-		"signup/setup-site-after-checkout": true,
-		"signup/hero-flow": true,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -101,8 +101,6 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
-		"signup/setup-site-after-checkout": true,
-		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -110,8 +110,6 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
-		"signup/setup-site-after-checkout": true,
-		"signup/hero-flow": true,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

These features have been enabled and stable in production for some time now. I think we're safe to simplify the code and remove these flags. Especially since we've been adding more flags. Good to remove the unused ones.

* Remove `signup/setup-site-after-checkout` flag
* Remove `signup/hero-flow` flag
* Change hero flow logic to now only depend on being English-speaking

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site using `/start` hero flow should work as before
* Create a site with a non-empty cart and ensure the hero flow appears after the checkout

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

