### PR TITLE
Blank box appearing on a search result for specific plugin keywords

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -7,6 +7,7 @@ import { Component } from 'react';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
 import { PluginsBrowserListVariant } from './types';
+import { trim } from 'lodash';
 import './style.scss';
 
 const DEFAULT_PLACEHOLDER_NUMBER = 6;
@@ -83,7 +84,12 @@ class PluginsBrowserList extends Component {
 		return (
 			<div className="plugins-browser-list">
 				<div className="plugins-browser-list__header">
-					<div className={ classnames( 'plugins-browser-list__title', this.props.listName ) }>
+					<div
+						className={ classnames(
+							'plugins-browser-list__title',
+							this.props.listName.replace( /\s/g, '' )
+						) }
+					>
 						{ this.props.title }
 					</div>
 					<div className="plugins-browser-list__subtitle">{ this.props.subtitle }</div>

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -7,7 +7,6 @@ import { Component } from 'react';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
 import { PluginsBrowserListVariant } from './types';
-import { trim } from 'lodash';
 import './style.scss';
 
 const DEFAULT_PLACEHOLDER_NUMBER = 6;

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
@@ -82,7 +83,9 @@ class PluginsBrowserList extends Component {
 		return (
 			<div className="plugins-browser-list">
 				<div className="plugins-browser-list__header">
-					<div className="plugins-browser-list__title">{ this.props.title }</div>
+					<div className={ classnames( 'plugins-browser-list__title', this.props.listName ) }>
+						{ this.props.title }
+					</div>
 					<div className="plugins-browser-list__subtitle">{ this.props.subtitle }</div>
 				</div>
 				<Card className="plugins-browser-list__elements">{ this.renderViews() }</Card>

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,5 +1,4 @@
 import { Card } from '@automattic/components';
-import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
@@ -83,14 +82,7 @@ class PluginsBrowserList extends Component {
 		return (
 			<div className="plugins-browser-list">
 				<div className="plugins-browser-list__header">
-					<div
-						className={ classnames(
-							'plugins-browser-list__title',
-							this.props.listName.replace( /\s/g, '' )
-						) }
-					>
-						{ this.props.title }
-					</div>
+					<div className="plugins-browser-list__title">{ this.props.title }</div>
 					<div className="plugins-browser-list__subtitle">{ this.props.subtitle }</div>
 				</div>
 				<Card className="plugins-browser-list__elements">{ this.renderViews() }</Card>

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -35,7 +35,11 @@
 
 	.plugins-browser-list__title {
 		font-size: $font-title-small;
-		font-weight: 400;
+		font-weight: 500;
+
+		&[class*='plugins-browser-list__search-for'] {
+			font-weight: 400;
+		}
 	}
 
 	.plugins-browser-list__subtitle {

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -35,11 +35,7 @@
 
 	.plugins-browser-list__title {
 		font-size: $font-title-small;
-		font-weight: 500;
-
-		&[class*='search-'] {
-			font-weight: 400;
-		}
+		font-weight: 400;
 	}
 
 	.plugins-browser-list__subtitle {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -237,7 +237,7 @@ export class PluginsBrowser extends Component {
 				<>
 					<PluginsBrowserList
 						plugins={ pluginsBySearchTerm }
-						listName={ 'search-' + searchTerm }
+						listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
 						title={ searchTitle }
 						subtitle={ subtitle }
 						site={ this.props.siteSlug }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes issue of blank box appearing on a search result for specific plugin keywords

#### Testing instructions
- Plugins > Add New
- Search for `lightweight sidebar manager`
- Check if results are properly displayed and you can no longer see the black box page

**Before:**
![image](https://user-images.githubusercontent.com/86406124/144384133-34170312-c5b4-480a-a189-2dc7937f4925.png)

**After:**
<img width="1076" alt="Screenshot 2021-12-02 at 1 52 51 PM" src="https://user-images.githubusercontent.com/86406124/144384557-785abb2c-6c27-4968-8318-38571554aa81.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoids
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58734
