### PR TITLE
Plugin Details: Show CTA only when plugin status has resolved.

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -194,15 +194,7 @@ function PluginDetails( props ) {
 					<div
 						className={ classNames(
 							'plugin-details__layout-col',
-							'plugin-details__layout-col-left',
-							{
-								'no-cta ': ! shouldDisplayCTA(
-									selectedSite,
-									props.pluginSlug,
-									isPluginInstalledOnsite,
-									isJetpackSelfHosted
-								),
-							}
+							'plugin-details__layout-col-left'
 						) }
 					>
 						<div className="plugin-details__tags">{ tags }</div>
@@ -239,51 +231,51 @@ function PluginDetails( props ) {
 							</div>
 						</div>
 					</div>
-					<div
-						className={ classNames(
-							'plugin-details__layout-col',
-							'plugin-details__layout-col-right',
-							{
-								'no-cta': ! shouldDisplayCTA(
-									selectedSite,
-									props.pluginSlug,
-									isPluginInstalledOnsite,
-									isJetpackSelfHosted
-								),
-							}
-						) }
-					>
-						<div className="plugin-details__header">
-							<div className="plugin-details__price">{ translate( 'Free' ) }</div>
-							<div className="plugin-details__install">
-								<CTA
-									slug={ props.pluginSlug }
-									isPluginInstalledOnsite={ isPluginInstalledOnsite }
-									isJetpackSelfHosted={ isJetpackSelfHosted }
-									selectedSite={ selectedSite }
-									isJetpack={ isJetpack }
-									isVip={ isVip }
-									hasEligibilityMessages={ hasEligibilityMessages }
-								/>
-							</div>
-							<div className="plugin-details__t-and-c">
-								{ translate(
-									'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the Third-Party plugin Terms.',
-									{
-										components: {
-											a: (
-												<a
-													target="_blank"
-													rel="noopener noreferrer"
-													href="https://wordpress.com/tos/"
-												/>
-											),
-										},
-									}
-								) }
+					{ shouldDisplayCTA(
+						selectedSite,
+						props.pluginSlug,
+						isPluginInstalledOnsite,
+						isJetpackSelfHosted,
+						requestingPluginsForSites
+					) && (
+						<div
+							className={ classNames(
+								'plugin-details__layout-col',
+								'plugin-details__layout-col-right'
+							) }
+						>
+							<div className="plugin-details__header">
+								<div className="plugin-details__price">{ translate( 'Free' ) }</div>
+								<div className="plugin-details__install">
+									<CTA
+										slug={ props.pluginSlug }
+										isPluginInstalledOnsite={ isPluginInstalledOnsite }
+										isJetpackSelfHosted={ isJetpackSelfHosted }
+										selectedSite={ selectedSite }
+										isJetpack={ isJetpack }
+										isVip={ isVip }
+										hasEligibilityMessages={ hasEligibilityMessages }
+									/>
+								</div>
+								<div className="plugin-details__t-and-c">
+									{ translate(
+										'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the Third-Party plugin Terms.',
+										{
+											components: {
+												a: (
+													<a
+														target="_blank"
+														rel="noopener noreferrer"
+														href="https://wordpress.com/tos/"
+													/>
+												),
+											},
+										}
+									) }
+								</div>
 							</div>
 						</div>
-					</div>
+					) }
 				</div>
 
 				{ ! isJetpackSelfHosted && ! isCompatiblePlugin( props.pluginSlug ) && (
@@ -347,7 +339,17 @@ function PluginDetails( props ) {
 	);
 }
 
-function shouldDisplayCTA( selectedSite, slug, isPluginInstalledOnsite, isJetpackSelfHosted ) {
+function shouldDisplayCTA(
+	selectedSite,
+	slug,
+	isPluginInstalledOnsite,
+	isJetpackSelfHosted,
+	requestingPluginsForSites
+) {
+	if ( requestingPluginsForSites ) {
+		// Display nothing if we are still requesting the plugin status.
+		return false;
+	}
 	if ( ! isJetpackSelfHosted && ! isCompatiblePlugin( slug ) ) {
 		// Check for WordPress.com compatibility.
 		return false;
@@ -361,22 +363,10 @@ function shouldDisplayCTA( selectedSite, slug, isPluginInstalledOnsite, isJetpac
 	return ! isPluginInstalledOnsite;
 }
 
-function CTA( {
-	slug,
-	isPluginInstalledOnsite,
-	isJetpackSelfHosted,
-	selectedSite,
-	isJetpack,
-	isVip,
-	hasEligibilityMessages,
-} ) {
+function CTA( { slug, selectedSite, isJetpack, isVip, hasEligibilityMessages } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ showEligibility, setShowEligibility ] = useState( false );
-
-	if ( ! shouldDisplayCTA( selectedSite, slug, isPluginInstalledOnsite, isJetpackSelfHosted ) ) {
-		return null;
-	}
 
 	const shouldUpgrade = ! (
 		isBusiness( selectedSite.plan ) ||

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -152,14 +152,6 @@ $plugin-details-header-padding: 100px;
 }
 
 .plugin-details__top-section {
-	.plugin-details__layout-col-right.no-cta {
-		visibility: hidden;
-
-		@media screen and ( max-width: 1040px ) {
-			display: none;
-		}
-	}
-
 	&.is-placeholder {
 		.plugin-details__name,
 		.plugin-details__price,
@@ -249,7 +241,8 @@ $plugin-details-header-padding: 100px;
 			background-color: var( --color-accent-50 );
 			color: var( --studio-white );
 
-			&:focus, &:hover {
+			&:focus,
+			&:hover {
 				background-color: var( --color-accent-60 );
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* removes CSS based CTA hiding
* removes `shouldDisplayCTA` inside CTA function. We are using `shouldDisplayCTA` in the JSX level, there is no need to check it again inside the function
* adds a `requestingPluginsForSites` check so that CTA doesn't promptly appear only to disappear if plugin is already installed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|![SS 2021-12-02 at 12 25 42](https://user-images.githubusercontent.com/12430020/144404250-69c82e00-d8e1-4b48-8277-c85b6addec7d.gif)|![SS 2021-12-02 at 12 26 56](https://user-images.githubusercontent.com/12430020/144404440-ae9c5691-8569-4b83-b948-f37d2cc3cfed.gif)|

* Go to `/plugins/woocommerce/[DOMAIN]` of an ecommerce plan site 
* Observe the CTA behavior 
* Repeat in a free site and make sure that CTA still displays

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58295
