### PR TITLE
Editor: Change post paragraph block placeholder

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/index.js
@@ -1,1 +1,2 @@
 import './navigation-toggle';
+import './paragraph-block';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/index.php
@@ -28,7 +28,11 @@ function wpcom_site_editor_script() {
 		wp_localize_script(
 			'wpcom-site-editor-script',
 			'wpcomSiteEditorParagraphPlaceholder',
-			fixme__( "Start writing or type '/' to insert a block", '', 'full-site-editing' )
+			translation_with_fallback(
+				"Start writing or type '/' to insert a block",
+				__( "Start writing or type '/' to insert a block", 'full-site-editing' ),
+				''
+			)
 		);
 	}
 }
@@ -51,7 +55,11 @@ function is_post_with_write_intent( $post ) {
  */
 function enter_title_here( $text, $post ) {
 	if ( is_post_with_write_intent( $post ) ) {
-		return fixme__( 'Add a post title', $text, 'full-site-editing' );
+		return translation_with_fallback(
+			'Add a post title',
+			__( 'Add a post title', 'full-site-editing' ),
+			$text
+		);
 	}
 
 	return $text;
@@ -66,9 +74,30 @@ add_filter( 'enter_title_here', __NAMESPACE__ . '\enter_title_here', 0, 2 );
  */
 function write_your_story( $text, $post ) {
 	if ( is_post_with_write_intent( $post ) ) {
-		return fixme__( "Start writing or type '/' to insert a block", $text, 'full-site-editing' );
+		return translation_with_fallback(
+			"Start writing or type '/' to insert a block",
+			__( "Start writing or type '/' to insert a block", 'full-site-editing' ),
+			$text
+		);
 	}
 
 	return $text;
 }
 add_filter( 'write_your_story', __NAMESPACE__ . '\write_your_story', 0, 2 );
+
+/**
+ * Translation with fallback message if it's not ready because fixme__ function doesn't work on atomic site
+ *
+ * @param string $new_text          New text without translation.
+ * @param string $new_translation   New text with translation.
+ * @param string $old_translation   Old text with translation.
+ */
+function translation_with_fallback( $new_text, $new_translation, $old_translation ) {
+	$is_english = 'en' === substr( get_locale(), 0, 2 );
+
+	if ( $is_english || $new_translation !== $new_text ) {
+		return $new_translation;
+	}
+
+	return $old_translation;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/index.php
@@ -22,5 +22,53 @@ function wpcom_site_editor_script() {
 		$version,
 		true
 	);
+
+	global $post;
+	if ( isset( $post ) && is_post_with_write_intent( $post ) ) {
+		wp_localize_script(
+			'wpcom-site-editor-script',
+			'wpcomSiteEditorParagraphPlaceholder',
+			fixme__( "Start writing or type '/' to insert a block", '', 'full-site-editing' )
+		);
+	}
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\wpcom_site_editor_script' );
+
+/**
+ * Check is it a post with “write” intent
+ *
+ * @param WP_Post $post Current post object.
+ */
+function is_post_with_write_intent( $post ) {
+	return 'post' === $post->post_type && 'write' === get_option( 'site_intent', '' );
+}
+
+/**
+ * Replace the title placeholder if it's the post with “write” intent
+ *
+ * @param string  $text Text to shown.
+ * @param WP_Post $post Current post object.
+ */
+function enter_title_here( $text, $post ) {
+	if ( is_post_with_write_intent( $post ) ) {
+		return fixme__( 'Add a post title', $text, 'full-site-editing' );
+	}
+
+	return $text;
+}
+add_filter( 'enter_title_here', __NAMESPACE__ . '\enter_title_here', 0, 2 );
+
+/**
+ * Replace the body placeholder if it's the post with “write” intent
+ *
+ * @param string  $text Text to shown.
+ * @param WP_Post $post Current post object.
+ */
+function write_your_story( $text, $post ) {
+	if ( is_post_with_write_intent( $post ) ) {
+		return fixme__( "Start writing or type '/' to insert a block", $text, 'full-site-editing' );
+	}
+
+	return $text;
+}
+add_filter( 'write_your_story', __NAMESPACE__ . '\write_your_story', 0, 2 );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/paragraph-block/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/paragraph-block/index.js
@@ -1,0 +1,1 @@
+import './placeholder';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/paragraph-block/placeholder.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/paragraph-block/placeholder.jsx
@@ -4,7 +4,7 @@ addFilter(
 	'blocks.registerBlockType',
 	'full-site-editing/wpcom-site-editor/paragraph-block-placeholder',
 	( settings, name ) => {
-		if ( name !== 'core/paragraph' ) {
+		if ( name !== 'core/paragraph' || ! window.wpcomSiteEditorParagraphPlaceholder ) {
 			return settings;
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/paragraph-block/placeholder.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/paragraph-block/placeholder.jsx
@@ -1,6 +1,3 @@
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 
 addFilter(
@@ -13,19 +10,13 @@ addFilter(
 
 		return {
 			...settings,
-			edit: compose(
-				withSelect( ( select, { attributes } ) => {
-					const { getSettings } = select( blockEditorStore );
-					const { bodyPlaceholder } = getSettings();
-
-					return {
-						attributes: {
-							...attributes,
-							placeholder: attributes.placeholder || bodyPlaceholder,
-						},
-					};
-				} )
-			)( settings.edit ),
+			attributes: {
+				...settings.attributes,
+				placeholder: {
+					...settings.attributes.placeholder,
+					default: window.wpcomSiteEditorParagraphPlaceholder,
+				},
+			},
 		};
 	}
 );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/paragraph-block/placeholder.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-site-editor/paragraph-block/placeholder.jsx
@@ -1,0 +1,31 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
+
+addFilter(
+	'blocks.registerBlockType',
+	'full-site-editing/wpcom-site-editor/paragraph-block-placeholder',
+	( settings, name ) => {
+		if ( name !== 'core/paragraph' ) {
+			return settings;
+		}
+
+		return {
+			...settings,
+			edit: compose(
+				withSelect( ( select, { attributes } ) => {
+					const { getSettings } = select( blockEditorStore );
+					const { bodyPlaceholder } = getSettings();
+
+					return {
+						attributes: {
+							...attributes,
+							placeholder: attributes.placeholder || bodyPlaceholder,
+						},
+					};
+				} )
+			)( settings.edit ),
+		};
+	}
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add filter with lowest priority to replace the title and body placeholder
* Inject the paragraph placeholder and set that value to the default of the placeholder schema so that it won't appear in the block markup

![image](https://user-images.githubusercontent.com/13596067/144406983-6c143910-bfc5-4baa-aaf5-ba4a85940620.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~Apply D70918-code to your sandbox~
* Ensure your API and site are pointed to the sandbox
* Open another terminal and run `cd apps/editing-toolkit && yarn dev --sync` 
* Go to the editor
* Check the placeholder of title, body and paragraph are correct!

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/58374