### PR TITLE
Add premium theme ref to cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -54,6 +54,9 @@ export default function getPlanFeatures(
 		return [
 			isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
 			isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
+			isEnabled( 'themes/premium' )
+				? String( translate( 'Unlimited access to our library of Premium Themes' ) )
+				: null,
 			isEnabled( 'earn/pay-with-paypal' )
 				? String( translate( 'Subscriber-only content and Pay with PayPal buttons' ) )
 				: String( translate( 'Subscriber-only content and payment buttons' ) ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Premium themes reference in the cart's feature list under the `themes/premium` feature-flag.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Choose to upgrade to the Premium Plan.
* To go the checkout (using the feature-flag)
![image](https://user-images.githubusercontent.com/3801502/144410511-47d7c063-03c0-41ec-822b-0e5d5950c8a4.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58616
