### PR TITLE
Checkout: Show refund periods for each product if DIFM Lite is in cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -1,4 +1,13 @@
-import { isPlan, isMonthly, getYearlyPlanByMonthly, getPlan } from '@automattic/calypso-products';
+import {
+	isPlan,
+	isMonthly,
+	isMonthlyProduct,
+	getYearlyPlanByMonthly,
+	getPlan,
+	isDomainProduct,
+	isDomainTransfer,
+	isDIFMProduct,
+} from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
 	CheckoutCheckIcon,
@@ -14,7 +23,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -22,6 +31,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getPlanFeatures from '../lib/get-plan-features';
+import getRefundText from '../lib/get-refund-text';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
@@ -139,18 +149,13 @@ function CheckoutSummaryFeaturesList( props: {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const hasDomainsInCart = responseCart.products.some(
-		( product ) =>
-			product.is_domain_registration ||
-			product.product_slug === 'domain_transfer' ||
-			product.product_slug === 'domain_map'
+		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
 	);
 	const domains = responseCart.products.filter(
-		( product ) =>
-			product.is_domain_registration ||
-			product.product_slug === 'domain_transfer' ||
-			product.product_slug === 'domain_map'
+		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
 	);
 	const hasPlanInCart = responseCart.products.some( ( product ) => isPlan( product ) );
+	const hasDIFMLiteInCart = responseCart.products.some( ( product ) => isDIFMProduct( product ) );
 	const translate = useTranslate();
 	const siteId = props.siteId;
 	const isJetpackNotAtomic = useSelector( ( state ) =>
@@ -159,25 +164,29 @@ function CheckoutSummaryFeaturesList( props: {
 	const { hasMonthlyPlan = false } = props;
 
 	const showRefundText = responseCart.total_cost > 0;
-	let refundText = translate( 'Money back guarantee' );
 
-	let refundDays = 0;
-	if ( hasDomainsInCart && ! hasPlanInCart ) {
-		refundDays = 4;
-	} else if ( hasPlanInCart && ! hasDomainsInCart ) {
-		refundDays = hasMonthlyPlan ? 7 : 14;
-	}
+	const refundTexts = new Set< TranslateResult >();
 
-	if ( refundDays !== 0 ) {
-		// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
-		refundText = translate(
-			'%(days)d-day money back guarantee',
-			'%(days)d-day money back guarantee',
-			{
-				count: refundDays,
-				args: { days: refundDays },
+	if ( hasDIFMLiteInCart ) {
+		responseCart.products.forEach( ( product ) => {
+			let refundDays = 0;
+			if ( isDomainProduct( product ) || isDomainTransfer( product ) ) {
+				refundDays = 4;
+			} else if ( isPlan( product ) ) {
+				refundDays = isMonthlyProduct( product ) ? 7 : 14;
+			} else if ( isDIFMProduct( product ) ) {
+				refundDays = 2;
 			}
-		);
+			refundTexts.add( getRefundText( refundDays, product.product_name, translate ) );
+		} );
+	} else {
+		let refundDays = 0;
+		if ( hasDomainsInCart && ! hasPlanInCart ) {
+			refundDays = 4;
+		} else if ( hasPlanInCart && ! hasDomainsInCart ) {
+			refundDays = hasMonthlyPlan ? 7 : 14;
+		}
+		refundTexts.add( getRefundText( refundDays, null, translate ) );
 	}
 
 	return (
@@ -201,12 +210,13 @@ function CheckoutSummaryFeaturesList( props: {
 					{ ...props }
 				/>
 			</CheckoutSummaryFeaturesListItem>
-			{ showRefundText && (
-				<CheckoutSummaryFeaturesListItem>
-					<WPCheckoutCheckIcon id="features-list-refund-text" />
-					{ refundText }
-				</CheckoutSummaryFeaturesListItem>
-			) }
+			{ showRefundText &&
+				Array.from( refundTexts.values() ).map( ( refundText, index ) => (
+					<CheckoutSummaryFeaturesListItem key={ index }>
+						<WPCheckoutCheckIcon id="features-list-refund-text" />
+						{ refundText }
+					</CheckoutSummaryFeaturesListItem>
+				) ) }
 		</CheckoutSummaryFeaturesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/lib/get-refund-text.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-refund-text.ts
@@ -1,0 +1,40 @@
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+
+/**
+ * Returns the appropriate text describing the refund period for the product.
+ *
+ * @param refundDays The refund period of the product
+ * @param productName The name of the product, if available
+ * @param translate
+ * @returns The refund text to be shown in the cart order summary (translated)
+ */
+export default function getRefundText(
+	refundDays: number,
+	productName: string | null,
+	translate: ReturnType< typeof useTranslate >
+): TranslateResult {
+	let refundText: TranslateResult = translate( 'Money back guarantee' );
+	if ( refundDays !== 0 ) {
+		if ( productName ) {
+			// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
+			refundText = translate(
+				'%(days)d-day money back guarantee for %(product)s',
+				'%(days)d-day money back guarantee for %(product)s',
+				{
+					count: refundDays,
+					args: { days: refundDays, product: productName },
+				}
+			);
+		} else {
+			refundText = translate(
+				'%(days)d-day money back guarantee',
+				'%(days)d-day money back guarantee',
+				{
+					count: refundDays,
+					args: { days: refundDays },
+				}
+			);
+		}
+	}
+	return refundText;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The checkout order summary does not correctly show the refund period when products have different refund periods. For example, in a cart with a Premium Plan and DIFM Lite, the refund period is shown as 14 days. However, the DIFM Lite product has a refund period of 2 days.
![image](https://user-images.githubusercontent.com/5436027/144408941-02c45e6b-02bf-4833-9064-fdc43410834c.png)

This change shows the refund periods for each product in the cart so that there is no confusion when the user is buying products with different refund periods. However, this is enabled only if a DIFM Lite product is in the cart. Enabling this for all carts would require more testing and experimentation.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Testing with DIFM Lite in cart
* Start from the DIFM signup flow by navigating to `/start/do-it-for-me`. On the domains step, choose a paid domain.
* On the checkout screen, confirm that the order summary (right sidebar) shows the refund period for all 3 products (WPCOM Plan, DIFM Lite and domain registration).
* Add another domain to this cart. You can do this by going to `/domains/add/<site slug>`. The `site slug` can be found in the URL on the checkout screen.
* On the checkout screen, confirm that the order summary (right sidebar) shows the refund period for the 3 unique products (WPCOM Plan, DIFM Lite and domain registration).
![image](https://user-images.githubusercontent.com/5436027/144410482-0ebda46b-78ed-436f-b03f-76d346445301.png)

### Testing without DIFM Lite in cart
* Test the checkout screen for these scenarios:

| Test Case                          | Expected Output             |Screenshot|
|------------------------------------|-----------------------------|-----------------------------|
| Plan and multiple domains in cart. | Money back guarantee        |![image](https://user-images.githubusercontent.com/5436027/144411173-83b5e80c-da78-4925-a820-b25520cf3a92.png) |
| Plan and single domain in cart.    | Money back guarantee        |![image](https://user-images.githubusercontent.com/5436027/144411311-c39acdf3-1b35-4639-8258-dc2a8d58679b.png) |
| Only plan in cart.                 | 14-day money back guarantee (7 days if it's a monthly plan) |![image](https://user-images.githubusercontent.com/5436027/144411386-b2eb4791-f068-44ec-bb8d-fe45442f10bf.png)|
| Only domain in cart.               | 4-day money back guarantee  |![image](https://user-images.githubusercontent.com/5436027/144411464-b4666530-c789-4b46-908b-0e69b3a79753.png)|
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


