### PR TITLE
Add premium theme ref to /start/plans

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -243,7 +243,7 @@ export const FEATURES_LIST = {
 		getDescription: () => {
 			return isEnabled( 'themes/premium' )
 				? i18n.translate(
-						'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+						'Including premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
 				  )
 				: i18n.translate(
 						'Including advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_13GB_STORAGE,
 	FEATURE_200GB_STORAGE,
@@ -99,6 +100,7 @@ import {
 	FEATURE_PREMIUM_CONTENT_BLOCK,
 	FEATURE_PREMIUM_CUSTOMIZABE_THEMES,
 	FEATURE_PREMIUM_SUPPORT,
+	FEATURE_PREMIUM_THEMES,
 	FEATURE_PRODUCT_BACKUP_DAILY_V2,
 	FEATURE_PRODUCT_BACKUP_REALTIME_V2,
 	FEATURE_PRODUCT_SCAN_DAILY_V2,
@@ -239,9 +241,13 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_ALL_PREMIUM_FEATURES,
 		getTitle: () => i18n.translate( 'All Premium features' ),
 		getDescription: () => {
-			return i18n.translate(
-				'Including advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
-			);
+			return isEnabled( 'themes/premium' )
+				? i18n.translate(
+						'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+				  )
+				: i18n.translate(
+						'Including advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+				  );
 		},
 	},
 
@@ -292,6 +298,15 @@ export const FEATURES_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'Site hosting is included with your plan, eliminating additional cost and technical hassle.'
+			),
+	},
+
+	[ FEATURE_PREMIUM_THEMES ]: {
+		getSlug: () => FEATURE_PREMIUM_THEMES,
+		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
+		getDescription: () =>
+			i18n.translate(
+				'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
 			),
 	},
 

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -88,6 +88,7 @@ export const FEATURE_SFTP_DATABASE = 'sftp-and-database-access';
 export const FEATURE_SITE_BACKUPS_AND_RESTORE = 'site-backups-and-restore';
 export const FEATURE_SECURITY_SETTINGS = 'security-settings';
 export const FEATURE_WOOP = 'woop';
+export const FEATURE_PREMIUM_THEMES = 'unlimited-premium-themes';
 
 // Jetpack features constants
 export const FEATURE_BLANK = 'blank-feature';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -755,7 +755,7 @@ const getJetpackBusinessDetails = (): IncompleteJetpackPlan => ( {
 			  )
 			: i18n.translate(
 					'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites: real-time backups ' +
-						'and unlimited premium themes.',
+						'and premium themes.',
 					plansDescriptionHeadingComponent
 			  ),
 	getTagline: () => i18n.translate( 'You have the full suite of security and performance tools.' ),

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -104,6 +104,7 @@ import {
 	FEATURE_PREMIUM_CONTENT_BLOCK,
 	FEATURE_PREMIUM_CUSTOMIZABE_THEMES,
 	FEATURE_PREMIUM_SUPPORT,
+	FEATURE_PREMIUM_THEMES,
 	FEATURE_PRODUCT_BACKUP_DAILY_V2,
 	FEATURE_PRODUCT_BACKUP_REALTIME_V2,
 	FEATURE_PRODUCT_SCAN_DAILY_V2,
@@ -430,23 +431,25 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SHIPPING_CARRIERS,
 		FEATURE_ALL_BUSINESS_FEATURES,
 	],
-	getSignupCompareAvailableFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_HOSTING,
-		FEATURE_NO_ADS,
-		FEATURE_COLLECT_PAYMENTS_V2,
-		FEATURE_EMAIL_SUPPORT_SIGNUP,
-		FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
-		FEATURE_EARN_AD,
-		FEATURE_GOOGLE_ANALYTICS,
-		FEATURE_INSTALL_PLUGINS,
-		FEATURE_ADVANCED_SEO_EXPANDED_ABBR,
-		FEATURE_SITE_BACKUPS_AND_RESTORE,
-		FEATURE_SFTP_DATABASE,
-		FEATURE_ACCEPT_PAYMENTS,
-		FEATURE_SHIPPING_CARRIERS,
-		PREMIUM_DESIGN_FOR_STORES,
-	],
+	getSignupCompareAvailableFeatures: () =>
+		[
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_HOSTING,
+			FEATURE_NO_ADS,
+			FEATURE_COLLECT_PAYMENTS_V2,
+			FEATURE_EMAIL_SUPPORT_SIGNUP,
+			FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
+			FEATURE_EARN_AD,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+			FEATURE_GOOGLE_ANALYTICS,
+			FEATURE_INSTALL_PLUGINS,
+			FEATURE_ADVANCED_SEO_EXPANDED_ABBR,
+			FEATURE_SITE_BACKUPS_AND_RESTORE,
+			FEATURE_SFTP_DATABASE,
+			FEATURE_ACCEPT_PAYMENTS,
+			FEATURE_SHIPPING_CARRIERS,
+			PREMIUM_DESIGN_FOR_STORES,
+		].filter( isValueTruthy ),
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,
@@ -512,21 +515,30 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_ADVANCED_CUSTOMIZATION,
 		FEATURE_ALL_PERSONAL_FEATURES,
 	],
-	getBlogSignupFeatures: () => [ FEATURE_MONETISE, FEATURE_ALL_PERSONAL_FEATURES ],
-	getPortfolioSignupFeatures: () => [
-		FEATURE_ADVANCED_CUSTOMIZATION,
-		FEATURE_ALL_PERSONAL_FEATURES,
-	],
-	getSignupCompareAvailableFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_HOSTING,
-		FEATURE_NO_ADS,
-		FEATURE_COLLECT_PAYMENTS_V2,
-		FEATURE_EMAIL_SUPPORT_SIGNUP,
-		FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
-		FEATURE_EARN_AD,
-		FEATURE_GOOGLE_ANALYTICS,
-	],
+	getBlogSignupFeatures: () =>
+		[
+			FEATURE_MONETISE,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+			FEATURE_ALL_PERSONAL_FEATURES,
+		].filter( isValueTruthy ),
+	getPortfolioSignupFeatures: () =>
+		[
+			FEATURE_ADVANCED_CUSTOMIZATION,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+			FEATURE_ALL_PERSONAL_FEATURES,
+		].filter( isValueTruthy ),
+	getSignupCompareAvailableFeatures: () =>
+		[
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_HOSTING,
+			FEATURE_NO_ADS,
+			FEATURE_COLLECT_PAYMENTS_V2,
+			FEATURE_EMAIL_SUPPORT_SIGNUP,
+			FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
+			FEATURE_EARN_AD,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+			FEATURE_GOOGLE_ANALYTICS,
+		].filter( isValueTruthy ),
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS, FEATURE_CLOUDFLARE_ANALYTICS ],
 	getInferiorFeatures: () => [],
@@ -605,20 +617,22 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_200GB_STORAGE,
 		FEATURE_ALL_PREMIUM_FEATURES,
 	],
-	getSignupCompareAvailableFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_HOSTING,
-		FEATURE_NO_ADS,
-		FEATURE_COLLECT_PAYMENTS_V2,
-		FEATURE_EMAIL_SUPPORT_SIGNUP,
-		FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
-		FEATURE_EARN_AD,
-		FEATURE_GOOGLE_ANALYTICS,
-		FEATURE_INSTALL_PLUGINS,
-		FEATURE_ADVANCED_SEO_EXPANDED_ABBR,
-		FEATURE_SITE_BACKUPS_AND_RESTORE,
-		FEATURE_SFTP_DATABASE,
-	],
+	getSignupCompareAvailableFeatures: () =>
+		[
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_HOSTING,
+			FEATURE_NO_ADS,
+			FEATURE_COLLECT_PAYMENTS_V2,
+			FEATURE_EMAIL_SUPPORT_SIGNUP,
+			FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
+			FEATURE_EARN_AD,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+			FEATURE_GOOGLE_ANALYTICS,
+			FEATURE_INSTALL_PLUGINS,
+			FEATURE_ADVANCED_SEO_EXPANDED_ABBR,
+			FEATURE_SITE_BACKUPS_AND_RESTORE,
+			FEATURE_SFTP_DATABASE,
+		].filter( isValueTruthy ),
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,
@@ -734,10 +748,16 @@ const getJetpackBusinessDetails = (): IncompleteJetpackPlan => ( {
 			PLAN_JETPACK_PERSONAL_MONTHLY,
 		].includes( plan ),
 	getDescription: () =>
-		i18n.translate(
-			'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites.',
-			plansDescriptionHeadingComponent
-		),
+		isEnabled( 'themes/premium' )
+			? i18n.translate(
+					'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites.',
+					plansDescriptionHeadingComponent
+			  )
+			: i18n.translate(
+					'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites: real-time backups ' +
+						'and unlimited premium themes.',
+					plansDescriptionHeadingComponent
+			  ),
 	getTagline: () => i18n.translate( 'You have the full suite of security and performance tools.' ),
 	getPlanCardFeatures: () => [
 		FEATURE_BACKUP_REALTIME_V2,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Premium themes reference to the `/start/plans` page under the `themes/premium` feature-flag.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To go the `/start/plans` (using the feature-flag)
![image](https://user-images.githubusercontent.com/3801502/144417916-be286808-6731-4c59-bd8a-9c639246de0b.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58616
