### PR TITLE
Woop installer: do not dispatch AT status from hook

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -112,10 +112,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		required: requiresUpgrade,
 		checkoutUrl: addQueryArgs(
 			{
-				redirect_to: addQueryArgs(
-					{ site: wpcomDomain },
-					'/start/woocommerce-install/confirm/plan'
-				),
+				redirect_to: addQueryArgs( { site: wpcomDomain }, '/start/woocommerce-install/confirm' ),
 			},
 			`/checkout/${ wpcomDomain }/${ upgradingPlan.product_slug }`
 		),

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -3,13 +3,9 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { addQueryArgs } from 'calypso/lib/url';
-import {
-	fetchAutomatedTransferStatusOnce,
-	requestEligibility,
-} from 'calypso/state/automated-transfer/actions';
+import { requestEligibility } from 'calypso/state/automated-transfer/actions';
 import { eligibilityHolds as eligibilityHoldsConstants } from 'calypso/state/automated-transfer/constants';
 import {
-	isFetchingAutomatedTransferStatus,
 	getEligibility,
 	EligibilityData,
 	EligibilityWarning,
@@ -29,7 +25,6 @@ type EligibilityHook = {
 	eligibilityHolds?: string[];
 	eligibilityWarnings?: EligibilityWarning[];
 	warnings: EligibilityWarning[];
-	isFetching: boolean;
 	wpcomDomain: string | null;
 	stagingDomain: string | null;
 	wpcomSubdomainWarning: EligibilityWarning | undefined;
@@ -53,7 +48,6 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 			return;
 		}
 
-		dispatch( fetchAutomatedTransferStatusOnce( siteId ) );
 		dispatch( requestEligibility( siteId ) );
 		dispatch( requestProductsList() );
 	}, [ siteId, dispatch ] );
@@ -74,11 +68,6 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 
 	// Get staging sudomain based on the wpcom subdomain.
 	const stagingDomain = wpcomDomain?.replace( /\b\.wordpress\.com/, '.wpcomstaging.com' ) || null;
-
-	// Check whether it's requesting eligibility data.
-	const isFetching = !! useSelector( ( state ) =>
-		isFetchingAutomatedTransferStatus( state, siteId )
-	);
 
 	// Check whether the wpcom.com subdomain warning is present.
 	const wpcomSubdomainWarning = eligibilityWarnings?.find(
@@ -148,7 +137,6 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	};
 
 	return {
-		isFetching,
 		eligibilityHolds,
 		eligibilityWarnings,
 		warnings,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes dispatching the transferring status from the `useWooCommerceOnPlansEligibility` hook. It is not required to check the site store conditions.
Also, it removes the `plan` from the redirect_to URL.
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the confirm step is working as expected :`http://calypso.localhost:3000/start/woocommerce-install/confirm?site=<your-testing-site>`
* Check the cancel button on the checkout page brings to the proper woop installer step.

<img width="250" alt="Screen Shot 2021-12-02 at 11 09 41 AM" src="https://user-images.githubusercontent.com/77539/144438121-614088ec-b903-47e6-a58b-68dd79959a80.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
