### PR TITLE
`QueryKeyringServices`: Migrate away from `UNSAFE_` methods

### DIFF
--- a/client/components/data/query-keyring-services/index.jsx
+++ b/client/components/data/query-keyring-services/index.jsx
@@ -1,30 +1,20 @@
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestKeyringServices } from 'calypso/state/sharing/services/actions';
 import { isKeyringServicesFetching } from 'calypso/state/sharing/services/selectors';
 
-class QueryKeyringServices extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.isRequesting ) {
-			this.props.requestKeyringServices();
-		}
+const request = () => ( dispatch, getState ) => {
+	if ( ! isKeyringServicesFetching( getState() ) ) {
+		dispatch( requestKeyringServices() );
 	}
-
-	render() {
-		return null;
-	}
-}
-
-QueryKeyringServices.propTypes = {
-	isRequesting: PropTypes.bool,
-	requestKeyringServices: PropTypes.func,
 };
 
-export default connect(
-	( state ) => ( {
-		isRequesting: isKeyringServicesFetching( state ),
-	} ),
-	{ requestKeyringServices }
-)( QueryKeyringServices );
+export default function QueryKeyringServices() {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( request() );
+	}, [ dispatch ] );
+
+	return null;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `QueryKeyringServices` query component away from the `UNSAFE_` deprecated React component methods.

We also use the opportunity to refactor it to a functional component, which simplifies the code quite a bit.

Part of #58453.

#### Testing instructions

* Go to `/marketing/connections/:site` where `:site` is one of your sites.
* Verify that external services (Facebook, Twitter, Tumblr, etc.) still appear after the request loads.