### PR TITLE
Woop installer: skip to transfer when ready

### DIFF
--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -68,11 +68,9 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 
 	// Skip to transfer step if the site is ready for transfer.
 	useEffect( () => {
-		if ( ! isReadyForTransfer ) {
-			return;
+		if ( isReadyForTransfer ) {
+			goToStep( 'transfer' );
 		}
-
-		goToStep( 'transfer' );
 	}, [ goToStep, isReadyForTransfer ] );
 
 	function getWPComSubdomainWarningContent() {

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactElement } from 'react';
+import { ReactElement, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
 import PlanWarning from 'calypso/components/eligibility-warnings/plan-warning';
@@ -63,7 +63,17 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		siteUpgrading,
 		hasBlockers,
 		warnings,
+		isReadyForTransfer,
 	} = useWooCommerceOnPlansEligibility( siteId );
+
+	// Skip to transfer step if the site is ready for transfer.
+	useEffect( () => {
+		if ( ! isReadyForTransfer ) {
+			return;
+		}
+
+		goToStep( 'transfer' );
+	}, [ goToStep, isReadyForTransfer ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
@@ -25,8 +25,6 @@ function WordPressSubdomainWarningCard() {
 
 The hook returns an object with the following properties:
 
-### isFetching
-
 ### eligibilityHolds
 
 ### eligibilityWarnings
@@ -40,6 +38,8 @@ The hook returns an object with the following properties:
 ### transferringBlockers
 
 ### hasBlockers
+
+### isReadyForTransfer
 
 ### siteUpgrading
 

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -18,7 +18,7 @@ import { getSiteDomain } from 'calypso/state/sites/selectors';
 
 const TRANSFERRING_NOT_BLOCKERS = [
 	eligibilityHoldsConstants.NO_BUSINESS_PLAN, // let's redirect to checkout page
-	eligibilityHoldsConstants.TRANSFER_ALREADY_EXISTS, // let's handle it in transferring endpoint.
+	// eligibilityHoldsConstants.TRANSFER_ALREADY_EXISTS, // ToDo: let's handle it in transferring endpoint.
 ];
 
 type EligibilityHook = {
@@ -37,6 +37,7 @@ type EligibilityHook = {
 		productName: string;
 		description: string;
 	};
+	isReadyForTransfer: boolean;
 };
 
 export default function useEligibility( siteId: number ): EligibilityHook {
@@ -75,8 +76,13 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	);
 
 	// Transferring blockers
-	const transferringBlockers =
-		eligibilityHolds?.filter( ( hold ) => ! TRANSFERRING_NOT_BLOCKERS.includes( hold ) ) || [];
+	const transferringBlockers = eligibilityHolds?.filter(
+		( hold ) => ! TRANSFERRING_NOT_BLOCKERS.includes( hold )
+	);
+
+	// Check whether the site has transferring blockers. True as default.
+	const hasBlockers =
+		typeof transferringBlockers === 'undefined' || transferringBlockers?.length > 0;
 
 	/*
 	 * Plan site and `woop` site feature.
@@ -141,8 +147,9 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		stagingDomain,
 		wpcomSubdomainWarning,
 
-		transferringBlockers,
-		hasBlockers: !! transferringBlockers.length,
+		transferringBlockers: transferringBlockers || [],
+		hasBlockers,
 		siteUpgrading,
+		isReadyForTransfer: ! hasBlockers && ! ( eligibilityWarnings && eligibilityWarnings.length ),
 	};
 }

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -80,9 +80,10 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		( hold ) => ! TRANSFERRING_NOT_BLOCKERS.includes( hold )
 	);
 
+	const transferringDataIsAvailable = typeof transferringBlockers !== 'undefined';
+
 	// Check whether the site has transferring blockers. True as default.
-	const hasBlockers =
-		typeof transferringBlockers === 'undefined' || transferringBlockers?.length > 0;
+	const hasBlockers = ! transferringDataIsAvailable || transferringBlockers?.length > 0;
 
 	/*
 	 * Plan site and `woop` site feature.
@@ -150,6 +151,8 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		transferringBlockers: transferringBlockers || [],
 		hasBlockers,
 		siteUpgrading,
-		isReadyForTransfer: ! hasBlockers && ! ( eligibilityWarnings && eligibilityWarnings.length ),
+		isReadyForTransfer: transferringDataIsAvailable
+			? ! hasBlockers && ! ( eligibilityWarnings && eligibilityWarnings.length )
+			: false,
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR checks the site data to skip the confirm step when the site is ready for the transferring process.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm you see the `Sounds good` button when the site has warnings and/pr blockers that can be addressed on the fly.
* Confirm you can't transfer the site when there is some blocker
* Confirm it skip the confirm step, and therefore transfer the site on the fly, when the site doesn't have either blocker or warnings. For instance:
  * Simple site
  * with a Business plan
  * with a Custom domain.

Warnings and/or avoidable blockers | Blockers | Ready for transferring
-----|------|-----
![image](https://user-images.githubusercontent.com/77539/144449108-0f2059af-5b82-470a-8df7-14092fe46f52.png) | ![image](https://user-images.githubusercontent.com/77539/144449185-8368c3f7-9ccd-4e61-b179-31ac9a517e17.png) | ![image](https://user-images.githubusercontent.com/77539/144449310-36280859-af97-408f-8aad-616ca8503e9a.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
