### PR TITLE
Fix Reader combined card error on missing author

### DIFF
--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -98,7 +98,7 @@ class ReaderCombinedCardPost extends Component {
 		}
 
 		const hasAuthorName =
-			post.author.hasOwnProperty( 'name' ) && ! isAuthorNameBlocked( post.author.name );
+			post.author?.hasOwnProperty( 'name' ) && ! isAuthorNameBlocked( post.author.name );
 		let featuredAsset = null;
 		if ( post.canonical_media && post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = (


### PR DESCRIPTION
Following #58570, the Reader breaks when a post doesn't include an author. This change addresses that.

#### Changes proposed in this Pull Request

* Fix Reader breakage on posts with missing author

#### Testing instructions

This one might be a little difficult to test, as I'm not sure how to recreate the conditions that lead to the problem. Hopefully the code is self-explanatory 🙂
