### PR TITLE
`QueryPlans`: Migrate away from `UNSAFE_` methods

### DIFF
--- a/client/components/data/query-plans/index.jsx
+++ b/client/components/data/query-plans/index.jsx
@@ -1,36 +1,20 @@
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestPlans } from 'calypso/state/plans/actions';
 import { isRequestingPlans } from 'calypso/state/plans/selectors';
 
-class QueryPlans extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.requestingPlans ) {
-			this.props.requestPlans();
-		}
+const request = () => ( dispatch, getState ) => {
+	if ( ! isRequestingPlans( getState() ) ) {
+		dispatch( requestPlans() );
 	}
+};
 
-	render() {
-		return null;
-	}
+export default function QueryPlans() {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( request() );
+	}, [ dispatch ] );
+
+	return null;
 }
-
-QueryPlans.propTypes = {
-	requestingPlans: PropTypes.bool,
-	requestPlans: PropTypes.func,
-};
-
-QueryPlans.defaultProps = {
-	requestPlans: () => {},
-};
-
-export default connect(
-	( state ) => {
-		return {
-			requestingPlans: isRequestingPlans( state ),
-		};
-	},
-	{ requestPlans }
-)( QueryPlans );

--- a/client/components/data/query-plans/index.jsx
+++ b/client/components/data/query-plans/index.jsx
@@ -1,19 +1,12 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestPlans } from 'calypso/state/plans/actions';
-import { isRequestingPlans } from 'calypso/state/plans/selectors';
-
-const request = () => ( dispatch, getState ) => {
-	if ( ! isRequestingPlans( getState() ) ) {
-		dispatch( requestPlans() );
-	}
-};
 
 export default function QueryPlans() {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( request() );
+		dispatch( requestPlans() );
 	}, [ dispatch ] );
 
 	return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `QueryPlans` query component away from the `UNSAFE_` deprecated React component methods.

We also use the opportunity to refactor it to a functional component, which simplifies the code quite a bit.

Part of #58453.

#### Testing instructions

* Go to `/plans/:site` where `:site` is one of your sites.
* Verify that the request to `/plans` still works well. Keep in mind that there's another one to `/sites/:site/plans` - that's a different one!
* Verify plans page continues to work well.