### PR TITLE
Videos UI: Show CTA when course is complete.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -20,6 +20,10 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 		return courses !== null && courseSlug in courses ? courses[ courseSlug ] : [];
 	} );
 
+	const completedVideoCount = Object.keys( userCourseProgression ).length;
+	const courseChapterCount = course ? Object.keys( course.videos ).length : 0;
+	const isCourseComplete = completedVideoCount > 0 && courseChapterCount === completedVideoCount;
+
 	const [ selectedChapterIndex, setSelectedChapterIndex ] = useState( 0 );
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
@@ -188,7 +192,8 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 					</div>
 				</div>
 			</div>
-			{ course && cloneElement( footerBar, { course: course } ) }
+			{ course &&
+				cloneElement( footerBar, { course: course, isCourseComplete: isCourseComplete } ) }
 		</div>
 	);
 };


### PR DESCRIPTION
This PR shows CTA when a course is completed.

#### Testing
1. Mark all videos as complete. (If https://github.com/Automattic/wp-calypso/pull/58727 is merged you can use the Video UI)
2. Verify that the CTA appears when all videos are complete.

#### Demo
The demo was recorded applying this branch over https://github.com/Automattic/wp-calypso/pull/58727 for effect.

![2021-12-02 12 33 05](https://user-images.githubusercontent.com/375980/144452800-a626c3ca-2424-4b52-a081-83aead96b677.gif)

Closes https://github.com/Automattic/wp-calypso/issues/58259