### PR TITLE
Server: remove the handleLocaleSubdomains route handler

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -13,7 +13,7 @@ import { stringify } from 'qs';
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { GUTENBOARDING_SECTION_DEFINITION } from 'calypso/landing/gutenboarding/section';
-import { getLanguage, filterLanguageRevisions } from 'calypso/lib/i18n-utils';
+import { filterLanguageRevisions } from 'calypso/lib/i18n-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
@@ -94,7 +94,6 @@ function setupLoggedInContext( req, res, next ) {
 
 function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	let initialServerState = {};
-	let lang = config( 'i18n_default_locale_slug' );
 	// We don't compare context.query against an allowed list here. Explicit allowance lists are route-specific,
 	// i.e. they can be created by route-specific middleware. `getDefaultContext` is always
 	// called before route-specific middleware, so it's up to the cache *writes* in server
@@ -106,12 +105,6 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	if ( cacheKey ) {
 		const serializeCachedServerState = stateCache.get( cacheKey ) || {};
 		initialServerState = getInitialServerState( serializeCachedServerState );
-	}
-
-	// We assign request.context.lang in the handleLocaleSubdomains()
-	// middleware function if we detect a language slug in subdomain
-	if ( request.context && request.context.lang ) {
-		lang = request.context.lang;
 	}
 
 	const oauthClientId = request.query.oauth2_client_id || request.query.client_id;
@@ -135,7 +128,7 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		isWCComConnect,
 		isWooDna: wooDnaConfig( request.query ).isWooDnaFlow(),
 		badge: false,
-		lang,
+		lang: config( 'i18n_default_locale_slug' ),
 		entrypoint: request.getFilesForEntrypoint( entrypoint ),
 		manifests: request.getAssets().manifests,
 		authHelper: !! config.isEnabled( 'dev/auth-helper' ),
@@ -496,44 +489,6 @@ const renderServerError = ( entrypoint = 'entry-main' ) => ( err, req, res, next
 };
 
 /**
- * Sets language properties to context if
- * a WordPress.com language slug is detected in the hostname
- *
- * @param {object} req Express request object
- * @param {object} res Express response object
- * @param {Function} next a callback to call when done
- * @returns {Function|undefined} res.redirect if not logged in
- */
-function handleLocaleSubdomains( req, res, next ) {
-	const langSlug = req.hostname?.endsWith( config( 'hostname' ) )
-		? req.hostname.split( '.' )[ 0 ]
-		: null;
-
-	if ( langSlug && includes( config( 'magnificent_non_en_locales' ), langSlug ) ) {
-		// Retrieve the language object for the RTL information.
-		const language = getLanguage( langSlug );
-
-		// Switch locales only in a logged-out state.
-		if ( language && ! req.context.isLoggedIn ) {
-			req.context = {
-				...req.context,
-				lang: language.langSlug,
-				isRTL: !! language.rtl,
-			};
-		} else {
-			// Strip the langSlug and redirect using hostname
-			// so that the user's locale preferences take priority.
-			const protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
-			const port = process.env.PORT || config( 'port' ) || '';
-			const hostname = req.hostname.substr( langSlug.length + 1 );
-			const redirectUrl = `${ protocol }://${ hostname }:${ port }${ req.path }`;
-			return res.redirect( redirectUrl );
-		}
-	}
-	next();
-}
-
-/**
  * Checks if the passed URL has the same origin as the request
  *
  * @param {express.Request} req Request
@@ -748,7 +703,6 @@ export default function pages() {
 	app.use( middlewareAssets() );
 	app.use( middlewareCache() );
 	app.use( setupLoggedInContext );
-	app.use( handleLocaleSubdomains );
 	app.use( middlewareUnsupportedBrowser() );
 
 	if ( ! isJetpackCloud() ) {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1004,61 +1004,6 @@ describe( 'main app', () => {
 		} );
 	} );
 
-	describe( 'Middleware localSubdomains', () => {
-		describe( 'sets locale info in the request context', () => {
-			it( 'rtl language', async () => {
-				const { request } = await app.run( {
-					request: {
-						hostname: 'ar.valid.hostname',
-					},
-				} );
-
-				expect( request.context.lang ).toBe( 'ar' );
-			} );
-
-			it( 'ltr language', async () => {
-				const { request } = await app.run( {
-					request: {
-						hostname: 'es.valid.hostname',
-					},
-				} );
-
-				expect( request.context.lang ).toBe( 'es' );
-			} );
-		} );
-
-		describe( 'strips language from the hostname for logged in users', () => {
-			it( 'redirects to http', async () => {
-				const { response } = await app.run( {
-					request: {
-						url: '/my-path',
-						hostname: 'es.valid.hostname',
-						cookies: {
-							wordpress_logged_in: true,
-						},
-					},
-				} );
-
-				expect( response.redirect ).toHaveBeenCalledWith( 'http://valid.hostname:3000/my-path' );
-			} );
-
-			it( 'redirects to https', async () => {
-				const { response } = await app.run( {
-					request: {
-						url: '/my-path',
-						hostname: 'es.valid.hostname',
-						get: jest.fn( ( header ) => ( header === 'X-Forwarded-Proto' ? 'https' : undefined ) ),
-						cookies: {
-							wordpress_logged_in: true,
-						},
-					},
-				} );
-
-				expect( response.redirect ).toHaveBeenCalledWith( 'https://valid.hostname:3000/my-path' );
-			} );
-		} );
-	} );
-
 	describe( 'Route /sites/:site/:section', () => {
 		[
 			{ section: 'posts', url: '/posts/my-site' },


### PR DESCRIPTION
There is a `handleLocaleSubdomains` handler in the Calypso server that looks at the domain name and if it's like `de.wordpress.com`, will set `context.lang = 'de'` to make the page localized.

But such URLs don't seem to be routed to Calypso at all. `curl -I https://de.wordpress.com/themes` redirects me to `https://wordpress.com/themes`, without localization. The handler was added by @ramonjd in #25296, 3 years ago, and seems to be no longer used. Instead of that, we're localizing Themes on URLs like `wordpress.com/de/themes`, since #41410 by @yuliyan.

This PR removes the `handleLocaleSubdomains` handler.