### PR TITLE
Site Settings: Migrate `JetpackSyncPanel` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -26,6 +26,12 @@ class JetpackSyncPanel extends Component {
 		this.fetchSyncStatus();
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.siteId !== this.props.siteId ) {
+			this.fetchSyncStatus();
+		}
+	}
+
 	fetchSyncStatus = () => {
 		this.props.getSyncStatus( this.props.siteId );
 	};

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -22,8 +22,7 @@ const debug = debugModule( 'calypso:site-settings:jetpack-sync-panel' );
 const SYNC_STATUS_ERROR_NOTICE_THRESHOLD = 3; // Only show sync status error notice if >= this number
 
 class JetpackSyncPanel extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.fetchSyncStatus();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `JetpackSyncPanel` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions

* Go to `/settings/manage-connection/:site` where `:site` is one of your Jetpack sites.
* Verify you can see the sync status correctly: `Last fully synced 1 hour ago`
* Switch to another Jetpack site.
* Verify that another HTTP request to `/sites/:siteId/sync/status` has been issued.