### PR TITLE
Pricing page: move recommended plan to top

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -44,7 +44,7 @@ interface ProductCardProps {
 	currencyCode: string | null;
 	selectedTerm?: Duration;
 	isAligned?: boolean;
-	featuredPlans?: string[];
+	isFeatured?: boolean;
 	featuredLabel?: TranslateResult;
 	hideSavingLabel?: boolean;
 	scrollCardIntoView: ScrollCardIntoViewCallback;
@@ -58,7 +58,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	currencyCode,
 	selectedTerm,
 	isAligned,
-	featuredPlans,
+	isFeatured,
 	featuredLabel,
 	hideSavingLabel,
 	scrollCardIntoView,
@@ -177,7 +177,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 				createButtonURL ? createButtonURL( item, isUpgradeableToYearly, purchase ) : undefined
 			}
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
-			isFeatured={ featuredPlans && featuredPlans.includes( item.productSlug ) }
+			isFeatured={ isFeatured }
 			isOwned={ isOwned }
 			isIncludedInPlan={ isIncludedInPlan || isSuperseded }
 			isDeprecated={ isDeprecated }

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -199,21 +199,30 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					} ) }
 					ref={ gridRef }
 				>
-					{ popularItems.map( ( product ) => (
-						<li key={ product.iconSlug }>
-							<ProductCard
-								item={ product }
-								onClick={ onSelectProduct }
-								siteId={ siteId }
-								currencyCode={ currencyCode }
-								selectedTerm={ duration }
-								isAligned={ ! shouldWrapGrid }
-								featuredPlans={ featuredPlans }
-								scrollCardIntoView={ scrollCardIntoView }
-								createButtonURL={ createButtonURL }
-							/>
-						</li>
-					) ) }
+					{ popularItems.map( ( product ) => {
+						const isFeatured = featuredPlans && featuredPlans.includes( product.productSlug );
+
+						return (
+							<li
+								className={ classNames( {
+									'is-featured': isFeatured,
+								} ) }
+								key={ product.iconSlug }
+							>
+								<ProductCard
+									item={ product }
+									onClick={ onSelectProduct }
+									siteId={ siteId }
+									currencyCode={ currencyCode }
+									selectedTerm={ duration }
+									isAligned={ ! shouldWrapGrid }
+									isFeatured={ isFeatured }
+									scrollCardIntoView={ scrollCardIntoView }
+									createButtonURL={ createButtonURL }
+								/>
+							</li>
+						);
+					} ) }
 				</ul>
 				<div
 					className={ classNames( 'product-grid__more', {

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -35,13 +35,22 @@
 
 .product-grid__plan-grid,
 .product-grid__product-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 16px;
+
 	margin: 0;
 
 	list-style-type: none;
 
-	display: grid;
-	grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
-	gap: 16px;
+	> li.is-featured {
+		// Put feature item(s) in first position
+		order: -1;
+	}
+
+	@include break-small {
+		grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
+	}
 }
 
 .product-grid__plan-grid:not( .is-wrapping ) {
@@ -58,6 +67,10 @@
 		&:last-child {
 			position: relative;
 			left: -8px;
+		}
+
+		&.is-featured {
+			order: 0;
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR moves the recommended plan to the top on tablet and mobile.

### Testing instructions

- Download the PR and run Calypso or cloud
- Visit the plans/pricing page
- Check that the page looks like production on desktop
- Resize the viewport down, and check that the recommended card is the first one in both the 2-column and 1-column layouts

### Screenshots
<img width="933" alt="Screen Shot 2021-12-07 at 4 46 27 PM" src="https://user-images.githubusercontent.com/1620183/145111109-bba2d36d-f14d-498c-aafe-fed6105a7989.png">
<img width="451" alt="Screen Shot 2021-12-07 at 4 46 37 PM" src="https://user-images.githubusercontent.com/1620183/145111112-e599ec49-4edb-47ef-a35b-51819460cd79.png">

