### PR TITLE
Woop installer: Error in landing page, improve loading state, handling Atomic sites

### DIFF
--- a/client/components/cta-section/index.tsx
+++ b/client/components/cta-section/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
+import { ReactElement } from 'react';
 
 const Container = styled.div`
 	display: grid;
@@ -47,6 +48,7 @@ interface Props {
 	buttonText: TranslateResult;
 	buttonDisabled: boolean;
 	buttonAction: () => void;
+	notice: ReactElement | null;
 	ctaRef?: React.RefObject< HTMLButtonElement >;
 }
 
@@ -58,6 +60,7 @@ const CtaSection: React.FunctionComponent< Props > = ( props ) => {
 		buttonText,
 		buttonDisabled = false,
 		buttonAction,
+		notice = null,
 		ctaRef,
 	} = props;
 	return (
@@ -65,6 +68,7 @@ const CtaSection: React.FunctionComponent< Props > = ( props ) => {
 			<CtaContainer>
 				<Headline>{ title }</Headline>
 				<Title>{ headline }</Title>
+				{ notice }
 				<Button primary onClick={ buttonAction } ref={ ctaRef } disabled={ buttonDisabled }>
 					{ buttonText }
 				</Button>

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -34,7 +34,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 	const navigationItems = [ { label: 'WooCommerce', href: `/woocommerce-installation` } ];
 	const ctaRef = useRef( null );
 
-	const { hasBlockers, wpcomDomain } = useWooCommerceOnPlansEligibility( siteId );
+	const { hasBlockers, wpcomDomain, isDataReady } = useWooCommerceOnPlansEligibility( siteId );
 	const isAtomic = !! useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
 	function onCTAClickHandler() {
@@ -46,7 +46,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 	}
 
 	function renderWarningNotice() {
-		if ( ! hasBlockers ) {
+		if ( ! hasBlockers || ! isDataReady ) {
 			return null;
 		}
 

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
@@ -11,10 +12,15 @@ import Image04 from 'calypso/assets/images/woocommerce/woop-cta-image04.jpeg';
 import CtaSection from 'calypso/components/cta-section';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import MasonryWave from 'calypso/components/masonry-wave';
+import WarningCard from 'calypso/components/warning-card';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 import './style.scss';
+
+const WarningsOrHoldsSection = styled.div`
+	margin-bottom: 40px;
+`;
 
 interface Props {
 	startSetup: () => void;
@@ -39,6 +45,22 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 		return startSetup();
 	}
 
+	function renderWarningNotice() {
+		if ( ! hasBlockers ) {
+			return null;
+		}
+
+		return (
+			<WarningsOrHoldsSection>
+				<WarningCard
+					message={ __(
+						'There is an error that is stopping us from being able to install this product, please contact support.'
+					) }
+				/>
+			</WarningsOrHoldsSection>
+		);
+	}
+
 	return (
 		<div className="woop__landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
@@ -53,6 +75,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 				buttonAction={ onCTAClickHandler }
 				buttonDisabled={ hasBlockers }
 				ctaRef={ ctaRef }
+				notice={ renderWarningNotice() }
 			>
 				<MasonryWave images={ images } />
 			</CtaSection>

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -119,14 +119,6 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	}
 
 	function getContent() {
-		if ( ! siteId || ! isDataReady ) {
-			return (
-				<div className="confirm__info-section">
-					<LoadingEllipsis />
-				</div>
-			);
-		}
-
 		return (
 			<>
 				<div className="confirm__info-section" />
@@ -150,6 +142,14 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					</ActionSection>
 				</div>
 			</>
+		);
+	}
+
+	if ( ! siteId || ! isDataReady ) {
+		return (
+			<div className="confirm__info-section">
+				<LoadingEllipsis />
+			</div>
 		);
 	}
 

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -147,7 +147,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		);
 	}
 
-	if ( ! siteId || ! isDataReady ) {
+	if ( ! siteId || ! isDataReady || isAtomicSite ) {
 		return (
 			<div className="confirm__info-section">
 				<LoadingEllipsis />

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -65,15 +65,8 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		hasBlockers,
 		isDataReady,
 		warnings,
-		isReadyForTransfer,
+		isAtomicSite,
 	} = useWooCommerceOnPlansEligibility( siteId );
-
-	// Skip to transfer step if the site is ready for transfer.
-	useEffect( () => {
-		if ( isReadyForTransfer ) {
-			goToStep( 'transfer' );
-		}
-	}, [ goToStep, isReadyForTransfer ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {
@@ -94,7 +87,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	}
 
 	function getWarningsOrHoldsSection() {
-		if ( hasBlockers ) {
+		if ( hasBlockers || isAtomicSite ) {
 			return (
 				<WarningsOrHoldsSection>
 					<WarningCard
@@ -129,7 +122,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					<ActionSection>
 						<SupportLink />
 						<NextButton
-							disabled={ hasBlockers || ! isDataReady }
+							disabled={ hasBlockers || ! isDataReady || isAtomicSite }
 							onClick={ () => {
 								if ( siteUpgrading.required ) {
 									return ( window.location.href = siteUpgrading.checkoutUrl );

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -96,7 +96,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	}
 
 	function getWarningsOrHoldsSection() {
-		if ( hasBlockers || isAtomicSite ) {
+		if ( hasBlockers ) {
 			return (
 				<WarningsOrHoldsSection>
 					<WarningCard
@@ -108,7 +108,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 			);
 		}
 
-		if ( warnings.length ) {
+		if ( warnings.length || isAtomicSite ) {
 			return (
 				<WarningsOrHoldsSection>
 					<Divider />

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
 import PlanWarning from 'calypso/components/eligibility-warnings/plan-warning';
 import EligibilityWarningsList from 'calypso/components/eligibility-warnings/warnings-list';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WarningCard from 'calypso/components/warning-card';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -62,7 +63,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		wpcomSubdomainWarning,
 		siteUpgrading,
 		hasBlockers,
-
+		isDataReady,
 		warnings,
 		isReadyForTransfer,
 	} = useWooCommerceOnPlansEligibility( siteId );
@@ -118,8 +119,12 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	}
 
 	function getContent() {
-		if ( ! siteId ) {
-			return null;
+		if ( ! siteId || ! isDataReady ) {
+			return (
+				<div className="confirm__info-section">
+					<LoadingEllipsis />
+				</div>
+			);
 		}
 
 		return (
@@ -132,7 +137,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					<ActionSection>
 						<SupportLink />
 						<NextButton
-							disabled={ hasBlockers }
+							disabled={ hasBlockers || ! isDataReady }
 							onClick={ () => {
 								if ( siteUpgrading.required ) {
 									return ( window.location.href = siteUpgrading.checkoutUrl );

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import page from 'page';
 import { ReactElement, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
@@ -67,6 +68,14 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		warnings,
 		isAtomicSite,
 	} = useWooCommerceOnPlansEligibility( siteId );
+
+	useEffect( () => {
+		if ( ! isAtomicSite ) {
+			return;
+		}
+
+		page.redirect( `/woocommerce-installation/${ wpcomDomain }` );
+	}, [ isAtomicSite, wpcomDomain ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -79,4 +79,9 @@ body.is-section-signup .is-woocommerce-install {
 
 .confirm__info-section {
 	flex: 1;
+
+	.wpcom__loading-ellipsis {
+		display: block;
+		margin: 0 auto;
+	}
 }

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
@@ -39,7 +39,8 @@ The hook returns an object with the following properties:
 
 ### hasBlockers
 
-### isReadyForTransfer
-
 ### siteUpgrading
 
+### isReadyForTransfer
+
+### isDataReady

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -14,6 +14,7 @@ import { requestProductsList } from 'calypso/state/products-list/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 
 const TRANSFERRING_NOT_BLOCKERS = [
@@ -39,6 +40,7 @@ type EligibilityHook = {
 		description: string;
 	};
 	isReadyForTransfer: boolean;
+	isAtomicSite: boolean;
 };
 
 export default function useEligibility( siteId: number ): EligibilityHook {
@@ -156,5 +158,6 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		isReadyForTransfer: transferringDataIsAvailable
 			? ! hasBlockers && ! ( eligibilityWarnings && eligibilityWarnings.length )
 			: false,
+		isAtomicSite: !! useSelector( ( state ) => isAtomicSite( state, siteId ) ),
 	};
 }

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -29,6 +29,7 @@ type EligibilityHook = {
 	stagingDomain: string | null;
 	wpcomSubdomainWarning: EligibilityWarning | undefined;
 	transferringBlockers: string[];
+	isDataReady: boolean;
 	hasBlockers: boolean;
 	siteUpgrading: {
 		required: boolean;
@@ -151,6 +152,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		transferringBlockers: transferringBlockers || [],
 		hasBlockers,
 		siteUpgrading,
+		isDataReady: transferringDataIsAvailable,
 		isReadyForTransfer: transferringDataIsAvailable
 			? ! hasBlockers && ! ( eligibilityWarnings && eligibilityWarnings.length )
 			: false,

--- a/client/state/selectors/has-active-site-feature.js
+++ b/client/state/selectors/has-active-site-feature.js
@@ -6,7 +6,7 @@ import getSiteFeatures from 'calypso/state/selectors/get-site-features';
  * @param  {object}  state      Global state tree
  * @param  {number}  siteId     The ID of the site we're querying
  * @param  {string}  featureId  The dotcom feature to check.
- * @returns {?object}           True if the feature is active. Otherwise, False.
+ * @returns {boolean}           True if the feature is active. Otherwise, False.
  */
 export default function hasActiveSiteFeature( state, siteId, featureId ) {
 	const siteFeatures = getSiteFeatures( state, siteId );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/58702 follow up

#### Changes proposed in this Pull Request

On this PR

* It adds relevant errors in the landing page
* Improve loading state (ellipsis)
* Redirect to the landing page when running the new flow for Atomic sites.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the landing page with a site with blockers

http://calypso.localhost:3000/woocommerce-installation/<your-testing-site>
![image](https://user-images.githubusercontent.com/77539/144600608-41f5de0c-58df-4177-b1b5-c258adf1a155.png)

* Check the loading state (you should see the Ellipsis when loading data)

https://user-images.githubusercontent.com/77539/144600862-766f5752-3877-4e02-a8b9-a220c65d22d9.mov

* Check with an Atomic site. It redirects to the landing page, and probably to the woo wizard page in case the site already has woo installed.


https://user-images.githubusercontent.com/77539/144601144-877a1f64-9969-489e-9e0e-e406707feb44.mov


<!-


-
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
