### PR TITLE
Switch to `lodash-es` on the Notifications app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ spec-xunit-reporter-0.0.1.tgz
 *xunit_*.xml
 /vendor
 checkstyle.xml
+/apps/notifications/stats.json
 
 # added during build
 /config/secrets.json

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -17,7 +17,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
-		"analyze-bundles": "EMIT_STATS=true yarn run build && webpack-bundle-analyzer stats.json dist -h 127.0.0.1 -p 9898 -s gzip",
+		"analyze-bundles": "EMIT_STATS=true yarn run build && webpack-bundle-analyzer stats.json dist -h 127.0.0.1 -s gzip",
 		"clean": "rm -rf dist stats.json",
 		"build:notifications": "calypso-build",
 		"dev-server": "NODE_ENV=development webpack serve",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -17,6 +17,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
+		"analyze-bundles": "EMIT_STATS=true yarn run build && webpack-bundle-analyzer stats.json dist -h 127.0.0.1 -p 9898 -s gzip",
 		"clean": "rm -rf dist",
 		"build:notifications": "calypso-build",
 		"dev-server": "NODE_ENV=development webpack serve",
@@ -27,6 +28,7 @@
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-polyfills": "workspace:^",
+		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
 		"autoprefixer": "^10.2.5",
 		"calypso": "workspace:^",
 		"classnames": "^2.3.1",
@@ -40,6 +42,7 @@
 		"react-redux": "^7.2.6",
 		"redux": "^4.1.2",
 		"redux-thunk": "^2.3.0",
+		"webpack-bundle-analyzer": "^4.5.0",
 		"wpcom": "workspace:^",
 		"wpcom-proxy-request": "workspace:^",
 		"wpcom-xhr-request": "workspace:^"

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -18,7 +18,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
 		"analyze-bundles": "EMIT_STATS=true yarn run build && webpack-bundle-analyzer stats.json dist -h 127.0.0.1 -p 9898 -s gzip",
-		"clean": "rm -rf dist",
+		"clean": "rm -rf dist stats.json",
 		"build:notifications": "calypso-build",
 		"dev-server": "NODE_ENV=development webpack serve",
 		"start": "yarn run clean && yarn run build:notifications && yarn run dev-server",

--- a/apps/notifications/webpack.config.js
+++ b/apps/notifications/webpack.config.js
@@ -5,7 +5,11 @@
 const spawnSync = require( 'child_process' ).spawnSync;
 const path = require( 'path' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const ExtensiveLodashReplacementPlugin = require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
 const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
+
+const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
 
 /**
  * Return a webpack config object
@@ -47,6 +51,9 @@ function getWebpackConfig(
 
 	return {
 		...webpackConfig,
+		optimization: {
+			concatenateModules: ! shouldEmitStats,
+		},
 		devServer: {
 			host: 'calypso.localhost',
 			port: 3000,
@@ -83,6 +90,20 @@ function getWebpackConfig(
 				templateContent: () => pageMeta.gitDescribe,
 				inject: false,
 			} ),
+			shouldEmitStats &&
+				new BundleAnalyzerPlugin( {
+					analyzerMode: 'disabled', // just write the stats.json file
+					generateStatsFile: true,
+					statsFilename: path.join( __dirname, 'stats.json' ),
+					statsOptions: {
+						source: false,
+						reasons: true,
+						optimizationBailout: false,
+						chunkOrigins: false,
+						chunkGroups: true,
+					},
+				} ),
+			new ExtensiveLodashReplacementPlugin(),
 		],
 	};
 }

--- a/apps/notifications/webpack.config.js
+++ b/apps/notifications/webpack.config.js
@@ -104,7 +104,7 @@ function getWebpackConfig(
 					},
 				} ),
 			new ExtensiveLodashReplacementPlugin(),
-		],
+		].filter( Boolean ),
 	};
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,6 +821,7 @@ __metadata:
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-polyfills": "workspace:^"
+    "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     autoprefixer: ^10.2.5
     calypso: "workspace:^"
     classnames: ^2.3.1
@@ -840,6 +841,7 @@ __metadata:
     redux: ^4.1.2
     redux-thunk: ^2.3.0
     webpack: ^5.64.4
+    webpack-bundle-analyzer: ^4.5.0
     webpack-dev-server: ^4.5.0
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"


### PR DESCRIPTION
It looks like the Notifications bundle is missing many of the optimisations that are part of the larger Calypso app.

This PR switches the Notifications app to `lodash-es`, so that we don't have to ship all of `lodash` for the few functions that we use.

In addition, it sets up the build environment to make it easier to analyse bundle size, as well as determine why a given package is being bundled.

This PR should save ~62KB uncompressed, or 21KB gzipped, through build changes alone.

#### Changes proposed in this Pull Request

* Switch to `lodash-es` on the Notifications app through the same webpack plugin that we use for the Calypso app
* Add easier bundle analysis to the Notifications app

#### Testing instructions

Smoke-test the standalone notifications and ensure they continue to work correctly, following the instructions from matticbot below.