### PR TITLE
Checkout: Update Titan and Google Workspace descriptions to be more consistent

### DIFF
--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -3,7 +3,8 @@ import {
 	isDomainTransfer,
 	isDomainProduct,
 	isDotComPlan,
-	isGSuiteOrGoogleWorkspace,
+	isGSuiteOrExtraLicenseProductSlug,
+	isGoogleWorkspace,
 	isTitanMail,
 	isP2Plus,
 	isJetpackSearch,
@@ -22,7 +23,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		return '';
 	}
 
-	if ( isDotComPlan( serverCartItem ) || ( ! isRenewalItem && isTitanMail( serverCartItem ) ) ) {
+	if ( isDotComPlan( serverCartItem ) ) {
 		if ( isRenewalItem ) {
 			return String( translate( 'Plan Renewal' ) );
 		}
@@ -38,12 +39,20 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 			: String( translate( 'Plan Subscription' ) );
 	}
 
-	if ( isGSuiteOrGoogleWorkspace( serverCartItem ) ) {
+	if ( isGSuiteOrExtraLicenseProductSlug || isGoogleWorkspace( serverCartItem ) ) {
 		if ( isRenewalItem ) {
-			return String( translate( 'Productivity and Collaboration Tools Renewal' ) );
+			return String( translate( 'Productivity Tools and Mailboxes Renewal' ) );
 		}
 
-		return String( translate( 'Productivity and Collaboration Tools' ) );
+		return String( translate( 'Productivity Tools and Mailboxes' ) );
+	}
+
+	if ( isTitanMail( serverCartItem ) ) {
+		if ( isRenewalItem ) {
+			return String( translate( 'Mailboxes Renewal' ) );
+		}
+
+		return String( translate( 'Mailboxes' ) );
 	}
 
 	if ( meta && ( isDomainProduct( serverCartItem ) || isDomainTransfer( serverCartItem ) ) ) {

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -3,8 +3,8 @@ import {
 	isDomainTransfer,
 	isDomainProduct,
 	isDotComPlan,
-	isGSuiteOrExtraLicenseProductSlug,
 	isGoogleWorkspace,
+	isGSuiteOrExtraLicenseProductSlug,
 	isTitanMail,
 	isP2Plus,
 	isJetpackSearch,
@@ -39,7 +39,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 			: String( translate( 'Plan Subscription' ) );
 	}
 
-	if ( isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspace( serverCartItem ) ) {
+	if ( isGoogleWorkspace( serverCartItem ) || isGSuiteOrExtraLicenseProductSlug( productSlug ) ) {
 		if ( isRenewalItem ) {
 			return String( translate( 'Productivity Tools and Mailboxes Renewal' ) );
 		}

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -39,7 +39,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 			: String( translate( 'Plan Subscription' ) );
 	}
 
-	if ( isGSuiteOrExtraLicenseProductSlug || isGoogleWorkspace( serverCartItem ) ) {
+	if ( isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspace( serverCartItem ) ) {
 		if ( isRenewalItem ) {
 			return String( translate( 'Productivity Tools and Mailboxes Renewal' ) );
 		}

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -264,8 +264,8 @@ function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRe
 	let mailboxes = [];
 
 	if (
-		isGSuiteOrExtraLicenseProductSlug( product.product_slug ) ||
-		isGoogleWorkspaceProductSlug( product.product_slug )
+		isGoogleWorkspaceProductSlug( product.product_slug ) ||
+		isGSuiteOrExtraLicenseProductSlug( product.product_slug )
 	) {
 		mailboxes = product.extra?.google_apps_users ?? [];
 	}
@@ -548,8 +548,8 @@ function LineItemSublabelAndPrice( {
 	}
 
 	if (
-		isGSuiteOrExtraLicenseProductSlug( productSlug ) ||
 		isGoogleWorkspaceProductSlug( productSlug ) ||
+		isGSuiteOrExtraLicenseProductSlug( productSlug ) ||
 		isTitanMail( product )
 	) {
 		let interval = null;
@@ -581,9 +581,9 @@ function LineItemSublabelAndPrice( {
 	}
 
 	const isDomainRegistration = product.is_domain_registration;
-	const isDomainMap = productSlug === 'domain_map';
+	const isDomainMapping = productSlug === 'domain_map';
 
-	if ( ( isDomainRegistration || isDomainMap ) && product.months_per_bill_period === 12 ) {
+	if ( ( isDomainRegistration || isDomainMapping ) && product.months_per_bill_period === 12 ) {
 		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : null;
 
 		return (
@@ -787,8 +787,8 @@ function WPLineItem( {
 	);
 
 	const isEmail =
-		isGSuiteOrExtraLicenseProductSlug( productSlug ) ||
 		isGoogleWorkspaceProductSlug( productSlug ) ||
+		isGSuiteOrExtraLicenseProductSlug( productSlug ) ||
 		isTitanMail( product );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -500,16 +500,13 @@ function LineItemSublabelAndPrice( {
 	product: ResponseCartProduct;
 } ): JSX.Element | null {
 	const translate = useTranslate();
-	const isDomainRegistration = product.is_domain_registration;
-	const isDomainMap = product.product_slug === 'domain_map';
 	const productSlug = product.product_slug;
 	const sublabel = getSublabel( product );
 
-	// This is the price for one item for products with a quantity (eg. seats in a license).
-	const itemPrice = product.item_original_cost_for_quantity_one_display;
-
 	if ( isPlan( product ) || isJetpackProductSlug( productSlug ) ) {
 		if ( isP2Plus( product ) ) {
+			// This is the price for one item for products with a quantity (eg. seats in a license).
+			const itemPrice = product.item_original_cost_for_quantity_one_display;
 			const members = product?.current_quantity || 1;
 			const p2Options = {
 				args: {
@@ -518,6 +515,7 @@ function LineItemSublabelAndPrice( {
 				},
 				count: members,
 			};
+
 			return (
 				<>
 					{ translate(
@@ -582,8 +580,12 @@ function LineItemSublabelAndPrice( {
 		);
 	}
 
+	const isDomainRegistration = product.is_domain_registration;
+	const isDomainMap = productSlug === 'domain_map';
+
 	if ( ( isDomainRegistration || isDomainMap ) && product.months_per_bill_period === 12 ) {
 		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : null;
+
 		return (
 			<>
 				{ translate( '%(premiumLabel)s %(sublabel)s: %(interval)s', {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -23,9 +23,11 @@ import { isWpComProductRenewal } from './is-wpcom-product-renewal';
 import { joinClasses } from './join-classes';
 import type { Theme, LineItem as LineItemType } from '@automattic/composite-checkout';
 import type {
+	GSuiteProductUser,
 	ResponseCart,
 	RemoveProductFromCart,
 	ResponseCartProduct,
+	TitanProductUser,
 } from '@automattic/shopping-cart';
 
 export const NonProductLineItem = styled( WPNonProductLineItem )< {
@@ -267,7 +269,7 @@ function EmailMeta( {
 		);
 	}
 
-	let mailboxes = [];
+	let mailboxes: GSuiteProductUser[] | TitanProductUser[] | [  ] = [];
 
 	if (
 		isGoogleWorkspaceProductSlug( product.product_slug ) ||
@@ -569,7 +571,7 @@ function LineItemSublabelAndPrice( {
 		}
 
 		if ( billingInterval === null ) {
-			return sublabel;
+			return <>{ sublabel }</>;
 		}
 
 		return (

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -226,7 +226,13 @@ function WPNonProductLineItem( {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
-function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRenewal: boolean } ) {
+function EmailMeta( {
+	product,
+	isRenewal,
+}: {
+	product: ResponseCartProduct;
+	isRenewal: boolean;
+} ): JSX.Element | null {
 	const translate = useTranslate();
 
 	if ( isRenewal ) {
@@ -241,7 +247,7 @@ function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRe
 		}
 
 		if ( numberOfMailboxes === null ) {
-			return;
+			return null;
 		}
 
 		return (

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -558,29 +558,29 @@ function LineItemSublabelAndPrice( {
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) ||
 		isTitanMail( product )
 	) {
-		let interval = null;
+		let billingInterval = null;
 
 		if ( product.months_per_bill_period === 12 || product.months_per_bill_period === null ) {
-			interval = translate( 'billed annually' );
+			billingInterval = translate( 'billed annually' );
 		}
 
 		if ( product.months_per_bill_period === 1 ) {
-			interval = translate( 'billed monthly' );
+			billingInterval = translate( 'billed monthly' );
 		}
 
-		if ( interval === null ) {
+		if ( billingInterval === null ) {
 			return sublabel;
 		}
 
 		return (
 			<>
-				{ translate( '%(productType)s: %(interval)s', {
+				{ translate( '%(productDescription)s: %(billingInterval)s', {
 					args: {
-						productType: sublabel,
-						interval,
+						productDescription: sublabel,
+						billingInterval,
 					},
 					comment:
-						"Product type and billing interval separated by a colon (e.g. 'Productivity Tools and Mailboxes: billed annually')",
+						"Product description and billing interval (already translated) separated by a colon (e.g. 'Productivity Tools and Mailboxes: billed annually')",
 				} ) }
 			</>
 		);


### PR DESCRIPTION
This pull request updates the `Your order` section of the checkout in order to show consistent information for all our email solutions: i.e. Professional Email, G Suite, and Google Workspace. The goal is to show the list of mailboxes for new accounts and additional mailboxes, and the number of mailboxes for renewals. This pull request also makes sure we display the product type:

##### New accounts

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/145090592-622bc166-e5c2-4190-91c8-613424c2da3a.png) | ![image](https://user-images.githubusercontent.com/594356/145090629-e4a0bb4e-1321-4fd8-b433-0358c694fcd1.png)


##### Additional mailboxes

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/145089613-ef0c280a-a202-46a8-bb1b-9a42b6dbf6e2.png) | ![image](https://user-images.githubusercontent.com/594356/145089889-bcf2defc-cced-4759-b4d1-700980369ca0.png)

##### Renewals

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/145090122-34ffaa10-a6f0-4d11-86e2-c24130f32518.png) | ![image](https://user-images.githubusercontent.com/594356/145090179-29eb2334-412e-43d3-91f2-babc8d71ce85.png)


#### Testing instructions

1. Run `git checkout update/checkout-for-emails` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/58771#issuecomment-984885561)
2. Open the [`Emails` page](http://calypso.localhost:3000/email)
3. Click on a G Suite account
4. Click the `Add new mailboxes` option
5. Add one or several mailboxes to your shopping cart
6. Assert that the checkout looks like the screenshot above
7. Repeat steps `#2`-`#6` with Google Workspace and Titan
8. Navigate to the [`Purchases` page](http://calypso.localhost:3000/purchases/subscriptions)
9. Click on a G Suite subscription
10. Click the `Renew now` button
11. Assert that the checkout looks like the screenshot above
12. Repeat steps `#8`-`#11` with Google Workspace and Titan
13. Navigate to the [`Domain Search` page](http://calypso.localhost:3000/domains/add)
14. Select a domain, then add either Google Workspace or Titan
15. Assert that the checkout looks like the screenshot above