### PR TITLE
[Fix] woop confirmation step mobile styles

### DIFF
--- a/client/components/eligibility-warnings/card/index.tsx
+++ b/client/components/eligibility-warnings/card/index.tsx
@@ -21,7 +21,6 @@ const CardTitle = styled.span`
 
 const CardBody = styled.div`
 	padding: 0 0 0 48px;
-	min-width: 300px;
 
 	p {
 		color: var( --studio-gray-60 );
@@ -30,7 +29,17 @@ const CardBody = styled.div`
 		line-height: 1.25rem;
 		margin-top: 30px;
 	}
-}`;
+
+	@media ( max-width: 660px ) {
+		padding: 0;
+	}
+`;
+
+const Icon = styled( Gridicon )`
+	@media ( max-width: 660px ) {
+		display: none;
+	}
+`;
 
 interface Card {
 	title: string;
@@ -42,7 +51,7 @@ export default function Card( { title, icon = 'domains', children }: Card ): Rea
 	return (
 		<>
 			<CardTitle>
-				<Gridicon icon={ icon } size={ 24 } />
+				<Icon icon={ icon } size={ 24 } />
 				<h2>{ title }</h2>
 			</CardTitle>
 			<CardBody>{ children }</CardBody>

--- a/client/components/eligibility-warnings/info-label/index.tsx
+++ b/client/components/eligibility-warnings/info-label/index.tsx
@@ -13,6 +13,11 @@ const Banner = styled.div`
 
 const Content = styled.div`
 	flex-grow: 2;
+	@media ( max-width: 660px ) {
+		max-width: 80%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 `;
 
 const Label = styled.div`

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -29,6 +29,11 @@ const ActionSection = styled.div`
 	display: flex;
 	justify-content: space-between;
 	align-items: baseline;
+	flex-wrap: wrap;
+
+	@media ( max-width: 320px ) {
+		align-items: center;
+	}
 `;
 
 const Divider = styled.hr`
@@ -41,13 +46,27 @@ const WarningsOrHoldsSection = styled.div`
 	margin-bottom: 40px;
 `;
 
+const SupportLinkContainer = styled.p`
+	@media ( max-width: 320px ) {
+		margin-top: 0px;
+		width: 100%;
+	}
+`;
+
+const StyledNextButton = styled( NextButton )`
+	@media ( max-width: 320px ) {
+		width: 100%;
+		margin-bottom: 20px;
+	}
+`;
+
 function SupportLink() {
 	return (
-		<p>
+		<SupportLinkContainer>
 			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
 				a: <SupportLinkStyle href="#support-link" />,
 			} ) }
-		</p>
+		</SupportLinkContainer>
 	);
 }
 
@@ -130,7 +149,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					{ getWarningsOrHoldsSection() }
 					<ActionSection>
 						<SupportLink />
-						<NextButton
+						<StyledNextButton
 							disabled={ hasBlockers || ! isDataReady || isAtomicSite }
 							onClick={ () => {
 								if ( siteUpgrading.required ) {
@@ -140,7 +159,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 							} }
 						>
 							{ __( 'Sounds good' ) }
-						</NextButton>
+						</StyledNextButton>
 					</ActionSection>
 				</div>
 			</>

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -22,12 +22,17 @@ body.is-section-signup .is-woocommerce-install {
 
 				.formatted-header {
 					text-align: inherit;
+					@media ( min-width: 1024px ) {
+						margin-left: 24px;
+					}
 
 					.formatted-header__title {
 						text-align: inherit;
 						@media ( max-width: 660px ) {
 							padding: 0 10px;
+							
 						}
+
 					}
 
 					.formatted-header__subtitle {
@@ -53,6 +58,7 @@ body.is-section-signup .is-woocommerce-install {
 			column-gap: 2%;
 
 			@media ( max-width: 660px ) {
+				max-width: 90vw;
 				grid-template-columns: 1fr;
 			}
 		}
@@ -68,6 +74,10 @@ body.is-section-signup .is-woocommerce-install {
 				line-height: 2rem;
 				flex-direction: column;
 				max-width: 520px;
+
+				@media ( max-width: 660px ) {
+					max-width: 90vw;
+				}
 			
 				p {
 					margin-top: 16px;

--- a/client/signup/steps/woocommerce-install/confirm/style.scss
+++ b/client/signup/steps/woocommerce-install/confirm/style.scss
@@ -29,7 +29,7 @@ body.is-section-signup .is-woocommerce-install {
 					.formatted-header__title {
 						text-align: inherit;
 						@media ( max-width: 660px ) {
-							padding: 0 10px;
+							padding: 0 10px 0 0;
 							
 						}
 
@@ -38,7 +38,7 @@ body.is-section-signup .is-woocommerce-install {
 					.formatted-header__subtitle {
 						@media ( max-width: 660px ) {
 							margin-top: 8px;
-							padding: 0 10px;
+							padding: 0 10px 0 0;
 						}
 
 						margin-top: 20px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds an overflow ellipsis for long domains
* Solves the scrolling issue on mobile views
* Hides icons on mobile views
* Collapses the action section in 2 rows on <320px

| <320px      | < 375px |  <425px  |
| ----------- | ----------- | ----------- |
|![320px (1)](https://user-images.githubusercontent.com/1035546/144511058-d4fc195f-fa66-4a8b-9a39-acfe80a11663.png)|![375px (1)](https://user-images.githubusercontent.com/1035546/144511113-d50f0172-2db2-48b3-882f-963c44f263de.png)|![425px (1)](https://user-images.githubusercontent.com/1035546/144511150-11aab424-d734-4baf-9e6c-102bce7adb1c.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to `http://calypso.localhost:3000/start/woocommerce-install/confirm?site=[your-site]` on an empty public business site.
* Test as mobile view in the developer tools of your preference :).
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
:thread: - p1638460260245800-slack-C029UPVMGTW