### PR TITLE
Videos UI: Remove duplicate Tracks event for video completion.

### DIFF
--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,5 +1,4 @@
 import { createRef, useEffect, useState } from 'react';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const VideoPlayer = ( {
 	videoData,
@@ -16,10 +15,6 @@ const VideoPlayer = ( {
 		if ( videoRef.current.currentTime < videoData.completed_seconds ) {
 			return;
 		}
-		recordTracksEvent( 'calypso_courses_video_completed', {
-			course: course.slug,
-			video: videoData.slug,
-		} );
 		onVideoCompleted( videoData );
 		setShouldCheckForVideoComplete( false );
 	};


### PR DESCRIPTION
This PR removes the client-side Tracks event for when a video is completed. This is already triggered server-side as `wpcom_courses_video_mark_complete` in the library's `mark_video_as_complete` function.

**Testing Instructions**
* Open the videos UI in My Home with a user that has not completed all the videos.
* Complete a video.
* Verify that the server-side Tracks event was still fired in your Tracks Live View. 