### PR TITLE
Update PluginUpdateIndicator layout and position

### DIFF
--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -64,14 +64,17 @@ class PluginAction extends Component {
 
 	renderToggle() {
 		return (
-			<ToggleControl
-				onChange={ this.props.action }
-				checked={ this.props.status }
-				disabled={ this.props.inProgress || this.props.disabled || !! this.props.disabledInfo }
-				id={ this.props.htmlFor }
-				label={ this.renderLabel() }
-				aria-label={ this.props.label }
-			/>
+			<>
+				<ToggleControl
+					onChange={ this.props.action }
+					checked={ this.props.status }
+					disabled={ this.props.inProgress || this.props.disabled || !! this.props.disabledInfo }
+					id={ this.props.htmlFor }
+					label={ this.renderLabel() }
+					aria-label={ this.props.label }
+				/>
+				{ this.props.toggleExtraContent }
+			</>
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -85,6 +85,7 @@
 
 .plugin-activate-toggle, .plugin-autoupdate-toggle {
 	.components-toggle-control {
+		display: flex;
 		.components-base-control__field {
 			display: flex;
 

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -133,7 +133,15 @@ export class PluginAutoUpdateToggle extends Component {
 	}
 
 	render() {
-		const { inProgress, site, plugin, disabled, translate, hideLabel } = this.props;
+		const {
+			inProgress,
+			site,
+			plugin,
+			disabled,
+			translate,
+			hideLabel,
+			toggleExtraContent,
+		} = this.props;
 		if ( ! site.jetpack ) {
 			return null;
 		}
@@ -155,6 +163,7 @@ export class PluginAutoUpdateToggle extends Component {
 				disabledInfo={ getDisabledInfo }
 				htmlFor={ 'autoupdates-' + plugin.slug + '-' + site.ID }
 				hideLabel={ hideLabel }
+				toggleExtraContent={ toggleExtraContent }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -179,7 +179,7 @@ class PluginRemoveButton extends Component {
 
 		if ( this.props.menuItem ) {
 			return (
-				<PopoverMenuItem onClick={ handleClick } className="plugin-remove-button__remove-icon">
+				<PopoverMenuItem onClick={ handleClick } className="plugin-remove-button__remove-button">
 					{ label }
 				</PopoverMenuItem>
 			);
@@ -193,8 +193,8 @@ class PluginRemoveButton extends Component {
 				disabledInfo={ disabledInfo }
 				className="plugin-remove-button__remove-link"
 			>
-				<Button onClick={ handleClick } className="plugin-remove-button__remove-icon">
-					<Icon icon={ trash } />
+				<Button onClick={ handleClick } className="plugin-remove-button__remove-button">
+					<Icon icon={ trash } className="plugin-remove-button__remove-icon" />
 					{ label }
 				</Button>
 			</PluginAction>

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -20,9 +20,13 @@
 	padding: 16px;
 }
 
-.plugin-remove-button__remove-icon {
+.plugin-remove-button__remove-button {
 	color: var( --studio-gray-80 );
 	font-size: $font-body-small;
+}
+
+.plugin-remove-button__remove-icon {
+	margin-right: 3px;
 }
 
 .plugin-remove-button__remove-link.is-disabled .plugin-remove-button__remove-icon .gridicons-trash {

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -90,6 +90,11 @@ const PluginSiteJetpack = ( props ) => {
 					plugin={ pluginOnSite }
 					wporg={ true }
 					hideLabel={ ! isMobileLayout }
+					toggleExtraContent={
+						! isMobileLayout && (
+							<PluginUpdateIndicator site={ props.site } plugin={ props.plugin } expanded />
+						)
+					}
 				/>
 			) }
 			{ isAutoManaged ? (
@@ -98,13 +103,8 @@ const PluginSiteJetpack = ( props ) => {
 				</div>
 			) : (
 				<div className="plugin-site-jetpack__action plugin-action last-actions">
-					{ ! isMobileLayout && (
-						<>
-							<PluginUpdateIndicator site={ props.site } plugin={ props.plugin } expanded />
-							{ canToggleRemove && (
-								<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } />
-							) }
-						</>
+					{ ! isMobileLayout && canToggleRemove && (
+						<PluginRemoveButton plugin={ pluginOnSite } site={ props.site } />
 					) }
 					{ ( isMobileLayout || settingsLink ) && (
 						<EllipsisMenu position={ 'bottom' }>

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -42,6 +42,7 @@
 	}
 
 	.plugin-action {
+		display: flex;
 		flex: 1 1 0;
 		margin-top: 0;
 		color: var( --studio-gray-50 );

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -82,15 +82,21 @@ class PluginSiteUpdateIndicator extends Component {
 		}
 
 		return (
-			<div className="plugin-site-update-indicator__button-container">
-				<button
-					className="plugin-site-update-indicator__button button"
+			/* eslint-disable jsx-a11y/click-events-have-key-events */
+			/* eslint-disable jsx-a11y/anchor-is-valid */
+			<div className="plugin-site-update-indicator__link-container">
+				<a
+					className="plugin-site-update-indicator__link"
 					onClick={ this.updatePlugin }
 					disabled={ isUpdating }
+					role="button"
+					tabIndex="0"
 				>
 					{ message }
-				</button>
+				</a>
 			</div>
+			/* eslint-enable jsx-a11y/click-events-have-key-events */
+			/* eslint-enable jsx-a11y/anchor-is-valid */
 		);
 	};
 

--- a/client/my-sites/plugins/plugin-site-update-indicator/style.scss
+++ b/client/my-sites/plugins/plugin-site-update-indicator/style.scss
@@ -7,7 +7,19 @@
 	}
 }
 
-.plugin-site-update-indicator__button-container {
-	margin-top: 8px;
-	flex: 40%;
+.plugin-site-update-indicator__link-container {
+	margin-top: 1px;
+	text-align: center;
+}
+
+.plugin-site-update-indicator__link {
+	cursor: pointer;
+	color: var( --studio-gray-80 );
+	text-decoration: underline;
+	line-height: 18px;
+
+	&:hover, :focus {
+		color: var( --studio-gray-100 );
+		font-weight: bold;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the UpdateIndicator position and change the layout from button to anchor.
* Update distance from icon to text on Remove button.

#### Testing instructions
*  Install an old version of a plugin on a self-hosted jetpack site
* Go to `plugins/{plugin-slug}` page
* Check if the "update to" link matches the design below.

<img width="1081" alt="Screen Shot 2021-12-02 at 16 03 41" src="https://user-images.githubusercontent.com/5039531/144495091-e59c066f-7200-4faa-92f1-7efd5abfc599.png">



Fixes #58783