### PR TITLE
Checkout: Record stored card error and card invalid field error directly

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -330,9 +330,13 @@ export default function CompositeCheckout( {
 	);
 
 	useActOnceOnStrings( [ storedCardsError ].filter( isValueTruthy ), ( messages ) => {
-		messages.forEach( ( message ) =>
-			recordEvent( { type: 'STORED_CARD_ERROR', payload: message } )
-		);
+		messages.forEach( ( message ) => {
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_stored_card_error', {
+					error_message: String( message ),
+				} )
+			);
+		} );
 	} );
 
 	const {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -23,14 +23,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							error_message: String( action.payload ),
 						} )
 					);
-				case 'a8c_checkout_stripe_field_invalid_error':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_stripe_field_invalid_error', {
-							error_type: action.payload.type,
-							error_field: action.payload.field,
-							error_message: action.payload.message,
-						} )
-					);
 				case 'STRIPE_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -16,13 +16,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'STORED_CARD_ERROR':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_stored_card_error', {
-							error_type: action.payload.type,
-							error_message: String( action.payload ),
-						} )
-					);
 				case 'STRIPE_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -31,10 +31,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							error_message: action.payload.message,
 						} )
 					);
-				case 'a8c_checkout_add_coupon_button_clicked':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} )
-					);
 				case 'STRIPE_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves a couple of checkout analytics from the checkout event handler directly into where the events occur. Specifically, it moves the stored card error and the card invalid field analytics.

#### Testing instructions

- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- In order to test the stored cards error, you'll need to break the stored cards endpoint. D70968-code should do it. 
- Add a plan to your cart and visit checkout.
- Verify that you see the `calypso_checkout_composite_stored_card_error` event triggered.
- Next, select "Credit or debit card" as your payment method in checkout and enter an invalid card number, like `2523 4525 2352 3452`.
- Verify that you see the `calypso_checkout_composite_stripe_field_invalid_error` event triggered.


<img width="622" alt="Screen Shot 2021-12-02 at 3 28 00 PM" src="https://user-images.githubusercontent.com/2036909/144497926-0cb130a9-941b-477c-8fd0-1d8ede7c8d99.png">

<img width="623" alt="Screen Shot 2021-12-02 at 3 21 51 PM" src="https://user-images.githubusercontent.com/2036909/144497385-02c6f5bf-9109-44a2-90dc-059f89fb9c6e.png">


