### PR TITLE
Add premium theme ref to checkout thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -1,9 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { isPremium, isGSuiteOrExtraLicenseOrGoogleWorkspace } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
 import analyticsImage from 'calypso/assets/images/illustrations/google-analytics.svg';
+import themeImage from 'calypso/assets/images/illustrations/themes.svg';
 import customizeThemeImage from 'calypso/assets/images/upgrades/customize-theme.svg';
 import mediaPostImage from 'calypso/assets/images/upgrades/media-post.svg';
 import advertisingRemovedImage from 'calypso/assets/images/upgrades/removed-advertising.svg';
@@ -73,6 +75,18 @@ const PremiumPlanDetails = ( {
 				buttonText={ translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug }
 			/>
+
+			{ isEnabled( 'themes/premium' ) && (
+				<PurchaseDetail
+					icon={ <img alt="" src={ themeImage } /> }
+					title={ translate( 'Try a New Theme' ) }
+					description={ translate(
+						"You've now got access to every premium theme, at no extra cost. Give one a try!"
+					) }
+					buttonText={ translate( 'Browse premium themes' ) }
+					href={ '/themes/' + selectedSite.slug }
+				/>
+			) }
 
 			{ ! selectedFeature && (
 				<PurchaseDetail


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Premium themes reference to the Checkout Thank you page under the themes/premium feature-flag

From my tests, Business and E-commerce plans don't use the thank you page, even though there is the code for that.
The e-commerce go straight to its configuration and the business opens the new post page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Choose Premium plan
* On the Thank you page, under the feature flag:
 
![image](https://user-images.githubusercontent.com/3801502/144499745-b013f725-0324-43a0-b6f1-b2a6b3cc723a.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58616
