### PR TITLE
Videos UI: Count video play clicks from in the video player controls.

### DIFF
--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -24,6 +24,13 @@ const VideoPlayer = ( {
 		setShouldCheckForVideoComplete( false );
 	};
 
+	const trackPlayClick = () => {
+		recordTracksEvent( 'calypso_courses_video_player_play_click', {
+			course: course.slug,
+			video: videoData.slug,
+		} );
+	};
+
 	useEffect( () => {
 		if ( videoRef.current ) {
 			videoRef.current.onplay = () => {
@@ -53,6 +60,7 @@ const VideoPlayer = ( {
 				ref={ videoRef }
 				poster={ videoData.poster }
 				autoPlay={ isPlaying }
+				onPlay={ trackPlayClick }
 				onTimeUpdate={ shouldCheckForVideoComplete ? markVideoAsComplete : undefined }
 			>
 				<source src={ videoData.url } />{ ' ' }


### PR DESCRIPTION
This PR adds a handler to the synthetic `onPlay` event of the video player. This should allow us to capture play clicks from the video player controls (not just our buttons in the videos section).

<img width="600" alt="Screen Shot 2021-12-02 at 2 38 30 PM" src="https://user-images.githubusercontent.com/349751/144514474-3dcea6b2-b8e1-40cd-b8fd-819452f1de8d.png">

Fixes #58251 .