### PR TITLE
Checkout: Add modal to close button with option to clear cart

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -78,6 +78,10 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 			console.error( 'Error getting query string in close button' );
 		}
 
+		if ( closeUrl.startsWith( '/' ) ) {
+			page( closeUrl );
+			return;
+		}
 		window.location.href = closeUrl;
 	}, [ siteSlug, checkoutBackUrl, previousPath, dispatch ] );
 

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -91,14 +91,10 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 		leaveCheckout();
 	};
 
-	const modalTitleText = String(
-		translate( 'You are about to leave checkout with items in your cart' )
-	);
-	const modalBodyText = String(
-		translate( 'You can leave the items in the cart or clear your cart.' )
-	);
-	const modalPrimaryText = String( translate( 'Continue' ) );
-	const modalSecondaryText = String( translate( 'Clear cart' ) );
+	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );
+	const modalBodyText = translate( 'You can leave the items in the cart or clear your cart.' );
+	const modalPrimaryText = translate( 'Continue' );
+	const modalSecondaryText = translate( 'Clear cart' );
 	const clearCartAndLeave = () => {
 		replaceProductsInCart( [] );
 		leaveCheckout();

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -1,8 +1,9 @@
+import { checkoutTheme, CheckoutModal } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { FunctionComponent, useCallback, useState } from 'react';
-import ReactModal from 'react-modal';
 import { useDispatch } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
@@ -102,7 +103,6 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	const clearCartAndLeave = () => {
 		replaceProductsInCart( [] );
 		leaveCheckout();
-		// No need to close the modal since we will be redirected
 	};
 	return (
 		<Masterbar>
@@ -120,17 +120,16 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			<Item className="masterbar__item-title">{ title }</Item>
-			<ReactModal
-				isOpen={ isModalVisible }
-				onRequestClose={ () => {
-					setIsModalVisible( false );
-				} }
-			>
-				<h2>{ modalTitleText }</h2>
-				<div>{ modalBodyText }</div>
-				<button onClick={ clearCartAndLeave }>{ modalSecondaryText }</button>
-				<button onClick={ leaveCheckout }>{ modalPrimaryText }</button>
-			</ReactModal>
+			<CheckoutModal
+				title={ modalTitleText }
+				copy={ modalBodyText }
+				closeModal={ () => setIsModalVisible( false ) }
+				isVisible={ isModalVisible }
+				buttonCTA={ modalPrimaryText }
+				primaryAction={ leaveCheckout }
+				secondaryButtonCTA={ modalSecondaryText }
+				secondaryAction={ clearCartAndLeave }
+			/>
 		</Masterbar>
 	);
 };
@@ -138,7 +137,9 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 export default function CheckoutMasterbarWrapper( props: Props ): JSX.Element {
 	return (
 		<CalypsoShoppingCartProvider>
-			<CheckoutMasterbar { ...props } />
+			<ThemeProvider theme={ checkoutTheme }>
+				<CheckoutMasterbar { ...props } />
+			</ThemeProvider>
 		</CalypsoShoppingCartProvider>
 	);
 }

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -97,12 +97,12 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	};
 
 	const modalTitleText = String(
-		translate( 'You are about to leave Checkout with items in your cart' )
+		translate( 'You are about to leave checkout with items in your cart' )
 	);
 	const modalBodyText = String(
 		translate( 'You can leave the items in the cart or clear your cart.' )
 	);
-	const modalPrimaryText = String( translate( 'Leave items in cart' ) );
+	const modalPrimaryText = String( translate( 'Continue' ) );
 	const modalSecondaryText = String( translate( 'Clear cart' ) );
 	const clearCartAndLeave = () => {
 		replaceProductsInCart( [] );

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -2,11 +2,11 @@ import { checkoutTheme, CheckoutModal } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { FunctionComponent, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
+import { navigate } from 'calypso/lib/navigate';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -40,11 +40,11 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 		dispatch( recordTracksEvent( 'calypso_masterbar_close_clicked' ) );
 
 		if ( checkoutBackUrl ) {
-			window.location.href = checkoutBackUrl;
-			return;
+			closeUrl = checkoutBackUrl;
 		}
 
 		if (
+			! checkoutBackUrl &&
 			previousPath &&
 			'' !== previousPath &&
 			previousPath !== window.location.href &&
@@ -64,12 +64,11 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 			// user there after checkout by putting the previous page's path in the
 			// `redirect_to` query param. When leaving checkout via the close button,
 			// we probably want to return to that location also.
-			if ( searchParams.has( 'redirect_to' ) ) {
+			if ( ! checkoutBackUrl && searchParams.has( 'redirect_to' ) ) {
 				const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
 				// Only allow redirecting to relative paths.
 				if ( redirectPath.startsWith( '/' ) ) {
-					page( redirectPath );
-					return;
+					closeUrl = redirectPath;
 				}
 			}
 		} catch ( error ) {
@@ -78,11 +77,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 			console.error( 'Error getting query string in close button' );
 		}
 
-		if ( closeUrl.startsWith( '/' ) ) {
-			page( closeUrl );
-			return;
-		}
-		window.location.href = closeUrl;
+		navigate( closeUrl );
 	}, [ siteSlug, checkoutBackUrl, previousPath, dispatch ] );
 
 	const cartKey = useCartKey();

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -93,7 +93,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 
 	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );
 	const modalBodyText = translate( 'You can leave the items in the cart or clear your cart.' );
-	const modalPrimaryText = translate( 'Continue' );
+	const modalPrimaryText = translate( 'Do not clear' );
 	const modalSecondaryText = translate( 'Clear cart' );
 	const clearCartAndLeave = () => {
 		replaceProductsInCart( [] );

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -92,9 +92,11 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	};
 
 	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );
-	const modalBodyText = translate( 'You can leave the items in the cart or clear your cart.' );
-	const modalPrimaryText = translate( 'Do not clear' );
-	const modalSecondaryText = translate( 'Clear cart' );
+	const modalBodyText = translate( 'You can leave the items in the cart or empty the cart.' );
+	/* translators: The label to a button that will exit checkout without removing items from the shopping cart. */
+	const modalPrimaryText = translate( 'Leave items' );
+	/* translators: The label to a button that will remove all items from the shopping cart. */
+	const modalSecondaryText = translate( 'Empty cart' );
 	const clearCartAndLeave = () => {
 		replaceProductsInCart( [] );
 		leaveCheckout();

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -119,9 +119,8 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 				title={ modalTitleText }
 				copy={ modalBodyText }
 				closeModal={ () => setIsModalVisible( false ) }
-				hideCancelButton
 				isVisible={ isModalVisible }
-				buttonCTA={ modalPrimaryText }
+				primaryButtonCTA={ modalPrimaryText }
 				primaryAction={ leaveCheckout }
 				secondaryButtonCTA={ modalSecondaryText }
 				secondaryAction={ clearCartAndLeave }

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -119,6 +119,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 				title={ modalTitleText }
 				copy={ modalBodyText }
 				closeModal={ () => setIsModalVisible( false ) }
+				hideCancelButton
 				isVisible={ isModalVisible }
 				buttonCTA={ modalPrimaryText }
 				primaryAction={ leaveCheckout }

--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -168,6 +168,7 @@ const CheckoutModalTitle = styled.h1`
 
 const CheckoutModalCopy = styled.p`
 	margin: 0;
+	color: ${ ( props ) => props.theme.colors.textColor };
 `;
 
 const CheckoutModalActions = styled.div`

--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -14,11 +14,13 @@ export default function CheckoutModal( {
 	title,
 	copy,
 	primaryAction,
+	secondaryAction,
 	cancelAction = noop,
 	closeModal,
 	isVisible,
 	buttonCTA,
 	cancelButtonCTA,
+	secondaryButtonCTA,
 }: CheckoutModalProps ): JSX.Element | null {
 	const { __ } = useI18n();
 	useModalScreen( isVisible, closeModal );
@@ -34,7 +36,7 @@ export default function CheckoutModal( {
 			role="dialog"
 			aria-labelledby={ titleId }
 			className={ joinClasses( [ className, 'checkout-modal' ] ) }
-			onClick={ () => handleCancelAction( cancelAction, closeModal ) }
+			onClick={ () => handleActionAndClose( cancelAction, closeModal ) }
 		>
 			<CheckoutModalContent className="checkout-modal__content" onClick={ preventClose }>
 				<CheckoutModalTitle id={ titleId } className="checkout-modal__title">
@@ -43,13 +45,22 @@ export default function CheckoutModal( {
 				<CheckoutModalCopy className="checkout-modal__copy">{ copy }</CheckoutModalCopy>
 
 				<CheckoutModalActions>
-					<Button onClick={ () => handleCancelAction( cancelAction, closeModal ) }>
+					<Button onClick={ () => handleActionAndClose( cancelAction, closeModal ) }>
 						{ cancelButtonCTA || __( 'Cancel' ) }
 					</Button>
+					{ secondaryAction && secondaryButtonCTA && (
+						<Button
+							onClick={ () => {
+								handleActionAndClose( secondaryAction, closeModal );
+							} }
+						>
+							{ secondaryButtonCTA }
+						</Button>
+					) }
 					<Button
 						buttonType="primary"
 						onClick={ () => {
-							handlePrimaryAction( primaryAction, closeModal );
+							handleActionAndClose( primaryAction, closeModal );
 						} }
 					>
 						{ buttonCTA || __( 'Continue' ) }
@@ -79,11 +90,13 @@ interface CheckoutModalProps {
 	title: string;
 	copy: string;
 	primaryAction: Callback;
+	secondaryAction?: Callback;
 	cancelAction?: Callback;
 	isVisible: boolean;
 	className?: string;
 	buttonCTA?: string;
 	cancelButtonCTA?: string;
+	secondaryButtonCTA?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -160,25 +173,12 @@ const CheckoutModalCopy = styled.p`
 const CheckoutModalActions = styled.div`
 	display: flex;
 	justify-content: flex-end;
+	gap: 8px;
 	margin-top: 24px;
-
-	button:first-of-type {
-		margin-right: 8px;
-
-		.rtl & {
-			margin-right: 0;
-			margin-left: 8px;
-		}
-	}
 `;
 
-function handlePrimaryAction( primaryAction: Callback, closeModal: Callback ) {
-	primaryAction();
-	closeModal();
-}
-
-function handleCancelAction( cancelAction: Callback, closeModal: Callback ) {
-	cancelAction();
+function handleActionAndClose( action: Callback, closeModal: Callback ) {
+	action();
 	closeModal();
 }
 

--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -1,7 +1,6 @@
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import joinClasses from '../lib/join-classes';
 import Button from './button';
@@ -29,7 +28,9 @@ export default function CheckoutModal( {
 		return null;
 	}
 
-	const titleId = `${ title.toLowerCase().replace( /[^a-z0-9_-]/g, '-' ) }-modal-title`;
+	const titleId = `${ String( title )
+		.toLowerCase()
+		.replace( /[^a-z0-9_-]/g, '-' ) }-modal-title`;
 
 	return (
 		<CheckoutModalWrapper
@@ -71,32 +72,20 @@ export default function CheckoutModal( {
 	);
 }
 
-CheckoutModal.propTypes = {
-	closeModal: PropTypes.func.isRequired,
-	title: PropTypes.string.isRequired,
-	copy: PropTypes.string.isRequired,
-	primaryAction: PropTypes.func.isRequired,
-	cancelAction: PropTypes.func,
-	isVisible: PropTypes.bool.isRequired,
-	className: PropTypes.string,
-	buttonCTA: PropTypes.string,
-	cancelButtonCTA: PropTypes.string,
-};
-
 type Callback = () => void;
 
 interface CheckoutModalProps {
 	closeModal: Callback;
-	title: string;
-	copy: string;
+	title: React.ReactNode;
+	copy: React.ReactNode;
 	primaryAction: Callback;
 	secondaryAction?: Callback;
 	cancelAction?: Callback;
 	isVisible: boolean;
 	className?: string;
-	buttonCTA?: string;
-	cancelButtonCTA?: string;
-	secondaryButtonCTA?: string;
+	buttonCTA?: React.ReactNode;
+	cancelButtonCTA?: React.ReactNode;
+	secondaryButtonCTA?: React.ReactNode;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -18,9 +18,7 @@ export default function CheckoutModal( {
 	closeModal,
 	isVisible,
 	buttonCTA,
-	cancelButtonCTA,
 	secondaryButtonCTA,
-	hideCancelButton,
 }: CheckoutModalProps ): JSX.Element | null {
 	const { __ } = useI18n();
 	useModalScreen( isVisible, closeModal );
@@ -47,11 +45,6 @@ export default function CheckoutModal( {
 				<CheckoutModalCopy className="checkout-modal__copy">{ copy }</CheckoutModalCopy>
 
 				<CheckoutModalActions>
-					{ hideCancelButton ? undefined : (
-						<Button onClick={ () => handleActionAndClose( cancelAction, closeModal ) }>
-							{ cancelButtonCTA || __( 'Cancel' ) }
-						</Button>
-					) }
 					{ secondaryAction && secondaryButtonCTA && (
 						<Button
 							onClick={ () => {
@@ -87,9 +80,7 @@ interface CheckoutModalProps {
 	isVisible: boolean;
 	className?: string;
 	buttonCTA?: React.ReactNode;
-	cancelButtonCTA?: React.ReactNode;
 	secondaryButtonCTA?: React.ReactNode;
-	hideCancelButton?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -20,6 +20,7 @@ export default function CheckoutModal( {
 	buttonCTA,
 	cancelButtonCTA,
 	secondaryButtonCTA,
+	hideCancelButton,
 }: CheckoutModalProps ): JSX.Element | null {
 	const { __ } = useI18n();
 	useModalScreen( isVisible, closeModal );
@@ -46,9 +47,11 @@ export default function CheckoutModal( {
 				<CheckoutModalCopy className="checkout-modal__copy">{ copy }</CheckoutModalCopy>
 
 				<CheckoutModalActions>
-					<Button onClick={ () => handleActionAndClose( cancelAction, closeModal ) }>
-						{ cancelButtonCTA || __( 'Cancel' ) }
-					</Button>
+					{ hideCancelButton ? undefined : (
+						<Button onClick={ () => handleActionAndClose( cancelAction, closeModal ) }>
+							{ cancelButtonCTA || __( 'Cancel' ) }
+						</Button>
+					) }
 					{ secondaryAction && secondaryButtonCTA && (
 						<Button
 							onClick={ () => {
@@ -86,6 +89,7 @@ interface CheckoutModalProps {
 	buttonCTA?: React.ReactNode;
 	cancelButtonCTA?: React.ReactNode;
 	secondaryButtonCTA?: React.ReactNode;
+	hideCancelButton?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -17,7 +17,7 @@ export default function CheckoutModal( {
 	cancelAction = noop,
 	closeModal,
 	isVisible,
-	buttonCTA,
+	primaryButtonCTA,
 	secondaryButtonCTA,
 }: CheckoutModalProps ): JSX.Element | null {
 	const { __ } = useI18n();
@@ -60,7 +60,7 @@ export default function CheckoutModal( {
 							handleActionAndClose( primaryAction, closeModal );
 						} }
 					>
-						{ buttonCTA || __( 'Continue' ) }
+						{ primaryButtonCTA || __( 'Continue' ) }
 					</Button>
 				</CheckoutModalActions>
 			</CheckoutModalContent>
@@ -79,7 +79,7 @@ interface CheckoutModalProps {
 	cancelAction?: Callback;
 	isVisible: boolean;
 	className?: string;
-	buttonCTA?: React.ReactNode;
+	primaryButtonCTA?: React.ReactNode;
 	secondaryButtonCTA?: React.ReactNode;
 }
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -213,9 +213,13 @@ function WPNonProductLineItem( {
 						closeModal={ () => {
 							setIsModalVisible( false );
 						} }
+						secondaryAction={ () => {
+							setIsModalVisible( false );
+						} }
 						primaryAction={ () => {
 							removeProductFromCart();
 						} }
+						secondaryButtonCTA={ String( 'Cancel' ) }
 						title={ modalCopy.title }
 						copy={ modalCopy.description }
 					/>
@@ -800,6 +804,10 @@ function WPLineItem( {
 						cancelAction={ () => {
 							onRemoveProductCancel?.( label );
 						} }
+						secondaryAction={ () => {
+							onRemoveProductCancel?.( label );
+						} }
+						secondaryButtonCTA={ String( translate( 'Cancel' ) ) }
 						title={ modalCopy.title }
 						copy={ modalCopy.description }
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a modal confirmation dialog that appears when you click the "X" button in the checkout header; the dialog gives the user the option to clear the cart before leaving.

<img width="737" alt="checkout-close-button" src="https://user-images.githubusercontent.com/2036909/144523407-a016871a-3a50-45ce-b332-d10c63e26ece.png">

<img width="453" alt="Screen Shot 2021-12-08 at 7 20 04 PM" src="https://user-images.githubusercontent.com/2036909/145312672-8e4349be-c1f0-4a57-9764-316164149d7f.png">


Fixes https://github.com/Automattic/wp-calypso/issues/51556

#### Testing instructions

- Add a product to your cart and visit checkout.
- Click the "X" close button in the upper-left.
- Verify that you see the modal.
- Click outside the modal or press escape. Verify that you are returned to checkout unchanged.
- Click the close button again.
- Click "Do not clear". Verify that you are returned to the previous page (or the plans page) and that the cart still contains the same products.
- Return to checkout.
- Click the close button again.
- Click "Clear cart". Verify that you are returned to the previous page (or the plans page) and that the cart is now empty.