### PR TITLE
Design Picker: Turn on making Blank Canvas a button

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -95,7 +95,7 @@
 		"signup/reskin": true,
 		"signup/social": true,
 		"signup/design-picker-categories": true,
-		"signup/design-picker-use-featured-picks-buttons": false,
+		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/setup-site-after-checkout": true,
 		"signup/hero-flow": true,
 		"site-indicator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -98,7 +98,7 @@
 		"signup/reskin": true,
 		"signup/social": true,
 		"signup/design-picker-categories": true,
-		"signup/design-picker-use-featured-picks-buttons": false,
+		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/setup-site-after-checkout": true,
 		"signup/hero-flow": true,
 		"site-indicator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -100,7 +100,7 @@
 		"signup/reskin": true,
 		"signup/social": true,
 		"signup/design-picker-categories": true,
-		"signup/design-picker-use-featured-picks-buttons": false,
+		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/setup-site-after-checkout": true,
 		"signup/hero-flow": true,
 		"site-indicator": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As the user experience test p1638414432341200-slack-C029SB8JT8S looks good, turn on the feature to make the blank canvas a button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the Testing instructions from https://github.com/Automattic/wp-calypso/pull/58565

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/58429, https://github.com/Automattic/wp-calypso/pull/58565