### PR TITLE
CI: Use Playwright 1.17

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,7 +43,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "1.17",
+		"playwright": "^1.17",
 		"postcss": "^8.3.11",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,7 +43,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "1.14.0",
+		"playwright": "1.17",
 		"postcss": "^8.3.11",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -19,7 +19,7 @@
 		"@types/totp-generator": "^0.0.2",
 		"config": "^3.3.6",
 		"mailosaur": "^7.3.1",
-		"playwright": "1.14.0",
+		"playwright": "1.17",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -19,7 +19,7 @@
 		"@types/totp-generator": "^0.0.2",
 		"config": "^3.3.6",
 		"mailosaur": "^7.3.1",
-		"playwright": "1.17",
+		"playwright": "^1.17",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -78,12 +78,16 @@ export async function newPage( { context }: { context?: BrowserContext } = {} ):
  * @param {BrowserType} browserType Type of browser to use.
  * @returns {Promise<Browser>} New Browser instance.
  */
-export async function startBrowser( browserType: BrowserType ): Promise< Browser > {
+export async function startBrowser(
+	browserType: BrowserType,
+	options?: { channel?: string }
+): Promise< Browser > {
 	if ( browser ) {
 		return browser;
 	}
 
 	browser = await browserType.launch( {
+		...options,
 		headless: getHeadless(),
 		args: [ '--window-position=0,0' ],
 	} );

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -41,7 +41,7 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 		const loggingConfiguration = await getDefaultLoggerConfiguration( artifactPath );
 
 		// Start the browser
-		await startBrowser( chromium );
+		await startBrowser( chromium, { channel: 'chrome' } );
 
 		// Launch context with logging.
 		context = await newBrowserContext( loggingConfiguration );

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -61,7 +61,7 @@
 		"mocha-junit-reporter": "^2.0.0",
 		"mocha-multi-reporters": "^1.5.1",
 		"mocha-teamcity-reporter": "^3.0.0",
-		"playwright": "1.17",
+		"playwright": "^1.17",
 		"png-itxt": "^1.3.0",
 		"push-receiver": "^2.0.0",
 		"react": "^17.0.2",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -61,7 +61,7 @@
 		"mocha-junit-reporter": "^2.0.0",
 		"mocha-multi-reporters": "^1.5.1",
 		"mocha-teamcity-reporter": "^3.0.0",
-		"playwright": "1.14.0",
+		"playwright": "1.17",
 		"png-itxt": "^1.3.0",
 		"push-receiver": "^2.0.0",
 		"react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,7 +244,7 @@ __metadata:
     config: ^3.3.6
     mailosaur: ^7.3.1
     node-fetch: ^2.6.1
-    playwright: 1.17
+    playwright: ^1.17
     totp-generator: ^0.0.12
     typescript: ^4.4.4
   languageName: unknown
@@ -9493,7 +9493,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: 1.17
+    playwright: ^1.17
     postcss: ^8.3.11
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -28373,7 +28373,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"playwright@npm:1.17":
+"playwright@npm:^1.17":
   version: 1.17.1
   resolution: "playwright@npm:1.17.1"
   dependencies:
@@ -38442,7 +38442,7 @@ testarmada-magellan@11.0.10:
     mocha-junit-reporter: ^2.0.0
     mocha-multi-reporters: ^1.5.1
     mocha-teamcity-reporter: ^3.0.0
-    playwright: 1.17
+    playwright: ^1.17
     png-itxt: ^1.3.0
     postcss: ^8.3.11
     push-receiver: ^2.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -9663,12 +9663,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6":
-  version: 6.0.1
-  resolution: "agent-base@npm:6.0.1"
+"agent-base@npm:6, agent-base@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
   dependencies:
     debug: 4
-  checksum: fe25d6bdc5767ed7483587cc74e7b6b5d15c765d5d73c8f37709e34dd4311b952b8db839d768d7128c272c2beb81687311017fc4b366ab4b6010c8f9de00081d
+  checksum: dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
   languageName: node
   linkType: hard
 
@@ -9678,15 +9678,6 @@ __metadata:
   dependencies:
     es6-promisify: ^5.0.0
   checksum: a618d4e4ca7c0c2023b2664346570773455c501a930718764f65016a8a9eea6d2ab5ba54255589e46de529bab4026a088523dce17f94e34ba385af1f644febe1
-  languageName: node
-  linkType: hard
-
-"agent-base@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "agent-base@npm:6.0.2"
-  dependencies:
-    debug: 4
-  checksum: dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
   languageName: node
   linkType: hard
 
@@ -34047,17 +34038,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.3.3":
-  version: 2.5.1
-  resolution: "socks@npm:2.5.1"
-  dependencies:
-    ip: ^1.1.5
-    smart-buffer: ^4.1.0
-  checksum: db7bb7072196b2233a80a706d0cb247341bc592f354073a3224a2d813b5dab0d73d3327247a094ccf61aa77ccf2186bec73d3b71ffb9f672563b726300156d39
-  languageName: node
-  linkType: hard
-
-"socks@npm:^2.6.1":
+"socks@npm:^2.3.3, socks@npm:^2.6.1":
   version: 2.6.1
   resolution: "socks@npm:2.6.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,7 +244,7 @@ __metadata:
     config: ^3.3.6
     mailosaur: ^7.3.1
     node-fetch: ^2.6.1
-    playwright: 1.14.0
+    playwright: 1.17
     totp-generator: ^0.0.12
     typescript: ^4.4.4
   languageName: unknown
@@ -9493,7 +9493,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: 1.14.0
+    playwright: 1.17
     postcss: ^8.3.11
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -9678,6 +9678,15 @@ __metadata:
   dependencies:
     es6-promisify: ^5.0.0
   checksum: a618d4e4ca7c0c2023b2664346570773455c501a930718764f65016a8a9eea6d2ab5ba54255589e46de529bab4026a088523dce17f94e34ba385af1f644febe1
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: 4
+  checksum: dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
   languageName: node
   linkType: hard
 
@@ -13230,7 +13239,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^6.1.0, commander@npm:^6.2.1":
+"commander@npm:^6.2.1":
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: 85748abd9d18c8bc88febed58b98f66b7c591d9b5017cad459565761d7b29ca13b7783ea2ee5ce84bf235897333706c4ce29adf1ce15c8252780e7000e2ce9ea
@@ -13241,6 +13250,13 @@ __metadata:
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
+  languageName: node
+  linkType: hard
+
+"commander@npm:^8.2.0":
+  version: 8.3.0
+  resolution: "commander@npm:8.3.0"
+  checksum: 8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
   languageName: node
   linkType: hard
 
@@ -28340,11 +28356,11 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"playwright@npm:1.14.0":
-  version: 1.14.0
-  resolution: "playwright@npm:1.14.0"
+"playwright-core@npm:=1.17.1":
+  version: 1.17.1
+  resolution: "playwright-core@npm:1.17.1"
   dependencies:
-    commander: ^6.1.0
+    commander: ^8.2.0
     debug: ^4.1.1
     extract-zip: ^2.0.1
     https-proxy-agent: ^5.0.0
@@ -28355,12 +28371,25 @@ fsevents@~2.1.2:
     proper-lockfile: ^4.1.1
     proxy-from-env: ^1.1.0
     rimraf: ^3.0.2
+    socks-proxy-agent: ^6.1.0
     stack-utils: ^2.0.3
     ws: ^7.4.6
+    yauzl: ^2.10.0
     yazl: ^2.5.1
   bin:
-    playwright: lib/cli/cli.js
-  checksum: 12241c08c121ccfebd913de3d923e8edcf07a5f0c720a6a9aaf1c4ff8fd3578e8450adad832488c3208b0d9627a4990ac25e90fc9ef55840a672208b842b418e
+    playwright: cli.js
+  checksum: 9356bf82a936c7fbbce3d880f7d53a9f48fd5667f13a4cf049c5d50530427e4fa67b0cea7bc8d273704c2156314ae3be820571c36265768f3d6eb2e315aa6719
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.17":
+  version: 1.17.1
+  resolution: "playwright@npm:1.17.1"
+  dependencies:
+    playwright-core: =1.17.1
+  bin:
+    playwright: cli.js
+  checksum: 9f616070e24b0e0af171f32459fa6148b4daf0ebb5654f67c397a0474730a4384867d7e4d22a1189b3ab4206468c8006046ade7a9e58eb822a6852a9a3037d03
   languageName: node
   linkType: hard
 
@@ -34007,6 +34036,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"socks-proxy-agent@npm:^6.1.0":
+  version: 6.1.1
+  resolution: "socks-proxy-agent@npm:6.1.1"
+  dependencies:
+    agent-base: ^6.0.2
+    debug: ^4.3.1
+    socks: ^2.6.1
+  checksum: 4d2ff6af0a4c49aa0f5aa3847468a75667795bc72c8271f85ee4c0a121f13f610674da43a6cbe77275e51596022f59da744d58f57d722dafbd1f54208cfa427d
+  languageName: node
+  linkType: hard
+
 "socks@npm:^2.3.3":
   version: 2.5.1
   resolution: "socks@npm:2.5.1"
@@ -34014,6 +34054,16 @@ resolve@^2.0.0-next.3:
     ip: ^1.1.5
     smart-buffer: ^4.1.0
   checksum: db7bb7072196b2233a80a706d0cb247341bc592f354073a3224a2d813b5dab0d73d3327247a094ccf61aa77ccf2186bec73d3b71ffb9f672563b726300156d39
+  languageName: node
+  linkType: hard
+
+"socks@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "socks@npm:2.6.1"
+  dependencies:
+    ip: ^1.1.5
+    smart-buffer: ^4.1.0
+  checksum: e992192c7837bfa9093251abf3e78849741f332881900f481dcb3267d18b16595e93519f63dce29f39e4135789a7ed379d210dd68e98465564a40e81ccf9082a
   languageName: node
   linkType: hard
 
@@ -38411,7 +38461,7 @@ testarmada-magellan@11.0.10:
     mocha-junit-reporter: ^2.0.0
     mocha-multi-reporters: ^1.5.1
     mocha-teamcity-reporter: ^3.0.0
-    playwright: 1.14.0
+    playwright: 1.17
     png-itxt: ^1.3.0
     postcss: ^8.3.11
     push-receiver: ^2.0.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the version of Playwright used to 1.17.

Due to issues with the version of Chromium contained in Playwright 1.17, this PR also forces the usage of the `Chrome` channel. [Playwright 1.17 comes bundled with Chrome 96](https://github.com/microsoft/playwright/releases/tag/v1.17.0).

Use of a more up-to-date version of Playwright has the following benefits:
- APIs introduced since 1.14
- Trace file supports rich page previews again.
- test against the current version of Chrome, the dominant browser used by our customers.
