### PR TITLE
i18n: Localize the support docs link on the Start Over page

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import ActionPanel from 'calypso/components/action-panel';
@@ -11,6 +12,7 @@ import { EMPTY_SITE } from 'calypso/lib/url/support';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const StartOver = ( { translate, selectedSiteSlug } ) => {
+	const localizeUrl = useLocalizeUrl();
 	return (
 		<div
 			className="main main-column" // eslint-disable-line wpcalypso/jsx-classname-namespace
@@ -46,7 +48,7 @@ const StartOver = ( { translate, selectedSiteSlug } ) => {
 				<ActionPanelFooter>
 					<Button
 						className="action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace
-						href={ EMPTY_SITE }
+						href={ localizeUrl( EMPTY_SITE ) }
 					>
 						{ translate( 'Follow the steps' ) }
 						<Gridicon icon="external" size={ 48 } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wraps the URL used in the "Follow the steps" support docs link on the Start Over page in `localizeUrl`.

![Markup on 2021-12-03 at 13:05:27](https://user-images.githubusercontent.com/75777864/144599842-3faded30-2b4d-49f7-a3f5-e85045b2e7b9.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-English Mag-16 locale.
* Go to Settings > General > Delete your content.
* Verify that the "Follow the steps" link is localized correctly.
* Switch your UI to English and repeat.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 353-gh-Automattic/i18n-issues
