### PR TITLE
Calypso build: Fix transpile babel path

### DIFF
--- a/packages/calypso-build/bin/transpile.js
+++ b/packages/calypso-build/bin/transpile.js
@@ -6,7 +6,7 @@ const path = require( 'path' );
 
 const dir = process.cwd();
 const root = path.dirname( __dirname );
-const babelPresetFile = path.join( root, 'babel', 'default.js' );
+const babelPresetFile = require.resolve( '@automattic/calypso-babel-config/presets/default.js' );
 
 const inputDir = path.join( dir, 'src' );
 const outputDirESM = path.join( dir, 'dist', 'esm' );


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Fix an error when using the `transpile` script from `calypso-build`.
It relied on a hard-coded path which changed in #58099. Update it to properly resolve the preset.

I came across this when publishing `interpolate-components`. There's still an issue where `transpile` script can't be found. The fix for this may be to add a devDependency on `calypso-build`, but that introduces a lot of peer dependencies and gets a bit messy. As a workaround, I locally changed transpile to point to the bin in the root node_modules directory.

You can reproduce these issues by running `yarn npm publish` in a package directory that uses `transpile`, e.g. `interpolate-components`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
