### PR TITLE
Fix showing presales chat button on checkout page

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -12,7 +12,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
-import { HappychatButton as HappychatButtonUnstyled } from 'calypso/components/happychat/button';
+import HappychatButtonUnstyled from 'calypso/components/happychat/button';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';


### PR DESCRIPTION
When buying a premium plan, the checkout page is supposed to show a pre-sales chat button like this:

<img width="480" alt="Screenshot 2021-12-03 at 13 06 45" src="https://user-images.githubusercontent.com/664258/144607432-d283e5bf-ddad-4ee1-aed7-89d8596c0a8f.png">

but it never does because the `CheckoutHelpLink` component is rendering an _unconnected_ `HappychatButton` where props like `isChatAvailable` are always `undefined`. This PR fixes that by importing the Redux-connected version instead.

Found this bug when testing the changes in #58657.

**How to test:**
1. Start Calypso development server.
2. Log in to `hud-staging.happychat.io` and make yourself available for chats so that Calypso has someone to chat with.
3. Pick a Premium (or Businness or eCommerce) plan for your site and go to the checkout page.
4. Verify that the chat button is there under the checkout summary box.