### PR TITLE
Add keyboard event for the PluginSiteUpdateIndicator.

### DIFF
--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -82,7 +82,6 @@ class PluginSiteUpdateIndicator extends Component {
 		}
 
 		return (
-			/* eslint-disable jsx-a11y/click-events-have-key-events */
 			/* eslint-disable jsx-a11y/anchor-is-valid */
 			<div className="plugin-site-update-indicator__link-container">
 				<a
@@ -91,11 +90,11 @@ class PluginSiteUpdateIndicator extends Component {
 					disabled={ isUpdating }
 					role="button"
 					tabIndex="0"
+					onKeyDown={ ( e ) => e.key === 'Enter' && this.updatePlugin( e ) }
 				>
 					{ message }
 				</a>
 			</div>
-			/* eslint-enable jsx-a11y/click-events-have-key-events */
 			/* eslint-enable jsx-a11y/anchor-is-valid */
 		);
 	};

--- a/client/my-sites/plugins/plugin-site-update-indicator/style.scss
+++ b/client/my-sites/plugins/plugin-site-update-indicator/style.scss
@@ -18,7 +18,7 @@
 	text-decoration: underline;
 	line-height: 18px;
 
-	&:hover, :focus {
+	&:hover, &:focus {
 		color: var( --studio-gray-100 );
 		font-weight: bold;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add keyboard event for the PluginSiteUpdateIndicator.
* Fix the focus CSS rule.

#### Testing instructions
* Install an old version of a plugin on a self-hosted jetpack site
* Go to plugins/{plugin-slug} page
* Using the `tab` key, reach the "update to" link
* Verify if it matches the `hover` style
* Press `Enter` and see if you receive a notification on the screen about the update

<img width="1081" alt="Screen Shot 2021-12-03 at 10 14 34" src="https://user-images.githubusercontent.com/5039531/144616870-99d30223-9884-4a92-8535-fe6ae1f37d60.png">
 
---
Follow up of #58784
