### PR TITLE
Woop installer: restore autotransferring handling

### DIFF
--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -86,15 +86,21 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		isDataReady,
 		warnings,
 		isAtomicSite,
+		isReadyForTransfer,
 	} = useWooCommerceOnPlansEligibility( siteId );
 
 	useEffect( () => {
 		if ( ! isAtomicSite ) {
+			// Automatically start the transfer process when it's ready.
+			if ( isReadyForTransfer ) {
+				return goToStep( 'transfer' );
+			}
+
 			return;
 		}
 
 		page.redirect( `/woocommerce-installation/${ wpcomDomain }` );
-	}, [ isAtomicSite, wpcomDomain ] );
+	}, [ goToStep, isAtomicSite, isReadyForTransfer, wpcomDomain ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -80,7 +80,6 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 				break;
 			case transferStates.COMPLETE:
 				setProgress( 1 );
-				window.location.href = wcAdmin;
 				break;
 		}
 
@@ -124,6 +123,23 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 
 		return () => clearTimeout( timeOutReference );
 	}, [ simulatedProgress, progress, __ ] );
+
+	useEffect( () => {
+		if ( simulatedProgress < 1 ) {
+			return;
+		}
+
+		const timer = setTimeout( () => {
+			window.location.href = wcAdmin;
+		}, 5000 );
+
+		return function () {
+			if ( ! timer ) {
+				return;
+			}
+			window.clearTimeout( timer );
+		};
+	}, [ simulatedProgress, wcAdmin ] );
 
 	return (
 		<StepWrapper

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -3,6 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement, useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import {
 	isFetchingAutomatedTransferStatus,
@@ -41,6 +42,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			return;
 		}
 
+		dispatch( fetchAutomatedTransferStatus( siteId ) );
 		dispatch( initiateThemeTransfer( siteId, null, 'woocommerce' ) );
 	}, [ siteId, dispatch ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR restores the automatic skip to the transfer step when the site has the proper state.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Confirm that when:

* It's a Simple site
* With a custom domain
* With a Biz plan
* Without blockers

... it skips the confirm step transferring the site on the fly.


https://user-images.githubusercontent.com/77539/144620505-e7ffbb28-97c2-4e1c-8753-a33f623e3e18.mov


https://user-images.githubusercontent.com/77539/144668546-5b5974af-cea0-4153-9a7a-0329c6b13794.mov


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
