### PR TITLE
Enable Jetpack User-Licensing feature flag in production.

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -57,7 +57,7 @@
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
-		"jetpack/user-licensing": false,
+		"jetpack/user-licensing": true,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the `jetpack/user-licensing` feature-flag in production.

On Tuesday, Dec 7 we plan to ship the Jetpack License-based checkout project live to our users. This PR will enable all of the Calypso license-based checkout features in production.

License-based checkout project: p1HpG7-cSg-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Just a code review should be all thats needed.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #1201096622142517-as-1201454350867223