### PR TITLE
Sidebar: add WooCommerce item when woop flag is enabled

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -741,7 +741,10 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( ! isBusiness( site.plan ) || ! canUserUseWooCommerceCoreStore ) {
+		if (
+			( ! isBusiness( site.plan ) || ! canUserUseWooCommerceCoreStore ) &&
+			! isEnabled( 'woop' )
+		) {
 			// Right now, we only use the "WooCommerce" label for Business plan sites.
 			// eCommerce sites continue to use the "Store" label for now
 			// (see handling in `store()` above.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the WooCoomerce item into the sidebar when the `woop` flag is enabled.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
