### PR TITLE
PrecancellationChatButton: show only when enabled in server config

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	isGSuiteOrGoogleWorkspace,
 	isPlan,
@@ -99,23 +98,19 @@ class CancelPurchaseForm extends Component {
 		isVisible: false,
 	};
 
-	shouldShowChatButton = () => {
-		if ( ! config.isEnabled( 'upgrades/precancellation-chat' ) ) {
-			return false;
-		}
-
+	shouldShowChatButton() {
 		// Jetpack doesn't do Happychat support
 		// NOTE: The HappychatButton component may still decide not to render,
 		// based on agent availability and connection status.
 		return ! this.props.isJetpack;
-	};
+	}
 
-	shouldUseBlankCanvasLayout = () => {
+	shouldUseBlankCanvasLayout() {
 		const { isJetpack, purchase } = this.props;
 		return isPlan( purchase ) && ! isJetpack;
-	};
+	}
 
-	getAllSurveySteps = () => {
+	getAllSurveySteps() {
 		const { purchase, shouldRevertAtomicSite } = this.props;
 
 		if ( isPlan( purchase ) ) {
@@ -131,7 +126,7 @@ class CancelPurchaseForm extends Component {
 		}
 
 		return [ FINAL_STEP ];
-	};
+	}
 
 	initSurveyState() {
 		const [ firstStep ] = this.getAllSurveySteps();

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
@@ -7,6 +7,7 @@ import HappychatButton from 'calypso/components/happychat/button';
 import MaterialIcon from 'calypso/components/material-icon';
 import { hasIncludedDomain } from 'calypso/lib/purchases';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isPrecancellationChatAvailable from 'calypso/state/happychat/selectors/is-precancellation-chat-available';
 import './style.scss';
 
 class PrecancellationChatButton extends Component {
@@ -37,7 +38,11 @@ class PrecancellationChatButton extends Component {
 	};
 
 	render() {
-		const { icon, translate } = this.props;
+		const { isAvailable, icon, translate } = this.props;
+
+		if ( ! isAvailable ) {
+			return null;
+		}
 
 		return (
 			<HappychatButton
@@ -51,6 +56,9 @@ class PrecancellationChatButton extends Component {
 	}
 }
 
-export default connect( null, {
-	recordTracksEvent,
-} )( localize( PrecancellationChatButton ) );
+export default connect(
+	( state ) => ( {
+		isAvailable: isPrecancellationChatAvailable( state ),
+	} ),
+	{ recordTracksEvent }
+)( localize( PrecancellationChatButton ) );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	isDomainMapping,
 	isDomainRegistration,
@@ -185,19 +184,13 @@ class RemovePurchase extends Component {
 	}
 
 	renderDomainDialog() {
-		let chatButton = null;
-
-		if ( config.isEnabled( 'upgrades/precancellation-chat' ) ) {
-			chatButton = this.getChatButton();
-		}
-
 		return (
 			<RemoveDomainDialog
 				isRemoving={ this.state.isRemoving }
 				isDialogVisible={ this.state.isDialogVisible }
 				removePurchase={ this.removePurchase }
 				closeDialog={ this.closeDialog }
-				chatButton={ chatButton }
+				chatButton={ this.getChatButton() }
 				purchase={ this.props.purchase }
 			/>
 		);

--- a/config/development.json
+++ b/config/development.json
@@ -157,7 +157,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/precancellation-chat": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -104,7 +104,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/precancellation-chat": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"use-translation-chunks": true,

--- a/config/production.json
+++ b/config/production.json
@@ -109,7 +109,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/precancellation-chat": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -110,7 +110,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/precancellation-chat": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/precancellation-chat": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,


### PR DESCRIPTION
The `PrecancellationChatButton`, shown when removing or cancelling a plan or domain, should be shown only when enabled by the Happychat server config, fetched from the `/help/olark/mine` REST endpoint and stored in `state.happychat.user`. This PR adds that check because it was missing.

I'm also removing the related `upgrades/precancellation-chat` feature flag because it was always `true`.

**How to test:**
1. Start Calypso in development mode.
2. Log in to hud-staging.happychat.io and make yourself available for chats so that Calypso has someone to chat with.
3. Go to `/me/purchases` and try to remove one of the purchases, a plan or a domain.

In case of a plan, you'll see a screen like this, with a "chat with us" button at the bottom:
<img width="673" alt="Screenshot 2021-12-03 at 16 13 19" src="https://user-images.githubusercontent.com/664258/144626334-4fa81303-80d4-4e5b-a217-24f96fa19598.png">

Now, you'll need to patch the `PRESALE_PRECANCELLATION_CHAT_AVAILABILITY_SET` so that it never sets the `state.happychat.user.isPresalesPrecancellationEligible` state to the `true` values from server.

Now verify that the "chat with us" button is no longer shown on these screens. Before this PR, the server eligibility flag would be ignored and the button shown anyway.

In production, these flags are set in a Network Admin dashboard screen, to enable or disable these kinds of chats globally:

<img width="699" alt="Screenshot 2021-12-03 at 13 11 45" src="https://user-images.githubusercontent.com/664258/144626759-f6d96717-13ae-45c1-8b76-4cfcabd01f46.png">


