### PR TITLE
Update premium theme selectors and restore isPremiumThemeAvailable tests

### DIFF
--- a/client/state/themes/selectors/is-premium-theme-available.js
+++ b/client/state/themes/selectors/is-premium-theme-available.js
@@ -1,3 +1,5 @@
+import { FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
+import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 
 import 'calypso/state/themes/init';
@@ -11,5 +13,8 @@ import 'calypso/state/themes/init';
  * @returns {boolean}         True if the premium theme is available for the given site
  */
 export function isPremiumThemeAvailable( state, themeId, siteId ) {
-	return isThemePurchased( state, themeId, siteId );
+	return (
+		isThemePurchased( state, themeId, siteId ) ||
+		hasFeature( state, siteId, FEATURE_PREMIUM_THEMES )
+	);
 }

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1,4 +1,9 @@
-import { PLAN_FREE } from '@automattic/calypso-products';
+import {
+	PLAN_FREE,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+} from '@automattic/calypso-products';
 import { expect } from 'chai';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 import {
@@ -2295,6 +2300,116 @@ describe( 'themes selectors', () => {
 			);
 
 			expect( isAvailable ).to.be.false;
+		} );
+
+		test( 'given a premium squared theme and a site without the premium upgrade, should return false', () => {
+			const isAvailable = isPremiumThemeAvailable(
+				{
+					sites: {
+						items: {
+							2916284: {},
+						},
+						plans: {
+							2916284: {
+								data: [
+									{
+										currentPlan: true,
+										productSlug: PLAN_FREE,
+									},
+								],
+							},
+						},
+					},
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { mood },
+							} ),
+						},
+					},
+					purchases: {
+						data: [],
+					},
+				},
+				'mood',
+				2916284
+			);
+
+			expect( isAvailable ).to.be.false;
+		} );
+
+		test( 'given a premium squared theme and a site with the premium upgrade, should return true', () => {
+			const isAvailable = isPremiumThemeAvailable(
+				{
+					sites: {
+						items: {
+							2916284: {},
+						},
+						plans: {
+							2916284: {
+								data: [
+									{
+										currentPlan: true,
+										productSlug: PLAN_PREMIUM,
+									},
+								],
+							},
+						},
+					},
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { mood },
+							} ),
+						},
+					},
+					purchases: {
+						data: [],
+					},
+				},
+				'mood',
+				2916284
+			);
+
+			expect( isAvailable ).to.be.true;
+		} );
+
+		test( 'given a site with the unlimited premium themes bundle, should return true', () => {
+			[ PLAN_BUSINESS, PLAN_ECOMMERCE ].forEach( ( plan ) => {
+				const isAvailable = isPremiumThemeAvailable(
+					{
+						sites: {
+							items: {
+								2916284: {},
+							},
+							plans: {
+								2916284: {
+									data: [
+										{
+											currentPlan: true,
+											productSlug: plan,
+										},
+									],
+								},
+							},
+						},
+						themes: {
+							queries: {
+								wpcom: new ThemeQueryManager( {
+									items: { mood },
+								} ),
+							},
+						},
+						purchases: {
+							data: [],
+						},
+					},
+					'mood',
+					2916284
+				);
+
+				expect( isAvailable ).to.be.true;
+			} );
 		} );
 	} );
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -451,16 +451,14 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			PREMIUM_DESIGN_FOR_STORES,
 		].filter( isValueTruthy ),
 	// Features not displayed but used for checking plan abilities
-	getIncludedFeatures: () =>
-		[
-			FEATURE_AUDIO_UPLOADS,
-			FEATURE_GOOGLE_MY_BUSINESS,
-			FEATURE_CLOUDFLARE_ANALYTICS,
-			FEATURE_UPLOAD_THEMES_PLUGINS,
-			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
-			FEATURE_SEO_PREVIEW_TOOLS,
-			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
-		].filter( isValueTruthy ),
+	getIncludedFeatures: () => [
+		FEATURE_AUDIO_UPLOADS,
+		FEATURE_GOOGLE_MY_BUSINESS,
+		FEATURE_CLOUDFLARE_ANALYTICS,
+		FEATURE_UPLOAD_THEMES_PLUGINS,
+		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
+		FEATURE_SEO_PREVIEW_TOOLS,
+	],
 	getInferiorFeatures: () => [],
 } );
 
@@ -639,7 +637,6 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,
 		FEATURE_GOOGLE_MY_BUSINESS,
-		isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
 		FEATURE_CLOUDFLARE_ANALYTICS,
 		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 		FEATURE_SEO_PREVIEW_TOOLS,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -454,12 +454,12 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 	getIncludedFeatures: () =>
 		[
 			FEATURE_AUDIO_UPLOADS,
-			FEATURE_GOOGLE_MY_BUSINESS,
 			FEATURE_CLOUDFLARE_ANALYTICS,
-			FEATURE_UPLOAD_THEMES_PLUGINS,
 			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
-			FEATURE_SEO_PREVIEW_TOOLS,
+			FEATURE_GOOGLE_MY_BUSINESS,
 			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+			FEATURE_SEO_PREVIEW_TOOLS,
+			FEATURE_UPLOAD_THEMES_PLUGINS,
 		].filter( isValueTruthy ),
 	getInferiorFeatures: () => [],
 } );
@@ -639,10 +639,10 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 	getIncludedFeatures: () =>
 		[
 			FEATURE_AUDIO_UPLOADS,
-			FEATURE_GOOGLE_MY_BUSINESS,
-			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
 			FEATURE_CLOUDFLARE_ANALYTICS,
 			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
+			FEATURE_GOOGLE_MY_BUSINESS,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
 			FEATURE_SEO_PREVIEW_TOOLS,
 		].filter( isValueTruthy ),
 	getInferiorFeatures: () => [],

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -636,15 +636,14 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SFTP_DATABASE,
 		].filter( isValueTruthy ),
 	// Features not displayed but used for checking plan abilities
-	getIncludedFeatures: () =>
-		[
-			FEATURE_AUDIO_UPLOADS,
-			FEATURE_GOOGLE_MY_BUSINESS,
-			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
-			FEATURE_CLOUDFLARE_ANALYTICS,
-			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
-			FEATURE_SEO_PREVIEW_TOOLS,
-		].filter( isValueTruthy ),
+	getIncludedFeatures: () => [
+		FEATURE_AUDIO_UPLOADS,
+		FEATURE_GOOGLE_MY_BUSINESS,
+		isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+		FEATURE_CLOUDFLARE_ANALYTICS,
+		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
+		FEATURE_SEO_PREVIEW_TOOLS,
+	],
 	getInferiorFeatures: () => [],
 } );
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -636,14 +636,15 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SFTP_DATABASE,
 		].filter( isValueTruthy ),
 	// Features not displayed but used for checking plan abilities
-	getIncludedFeatures: () => [
-		FEATURE_AUDIO_UPLOADS,
-		FEATURE_GOOGLE_MY_BUSINESS,
-		isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
-		FEATURE_CLOUDFLARE_ANALYTICS,
-		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
-		FEATURE_SEO_PREVIEW_TOOLS,
-	],
+	getIncludedFeatures: () =>
+		[
+			FEATURE_AUDIO_UPLOADS,
+			FEATURE_GOOGLE_MY_BUSINESS,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+			FEATURE_CLOUDFLARE_ANALYTICS,
+			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
+			FEATURE_SEO_PREVIEW_TOOLS,
+		].filter( isValueTruthy ),
 	getInferiorFeatures: () => [],
 } );
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -451,14 +451,16 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			PREMIUM_DESIGN_FOR_STORES,
 		].filter( isValueTruthy ),
 	// Features not displayed but used for checking plan abilities
-	getIncludedFeatures: () => [
-		FEATURE_AUDIO_UPLOADS,
-		FEATURE_GOOGLE_MY_BUSINESS,
-		FEATURE_CLOUDFLARE_ANALYTICS,
-		FEATURE_UPLOAD_THEMES_PLUGINS,
-		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
-		FEATURE_SEO_PREVIEW_TOOLS,
-	],
+	getIncludedFeatures: () =>
+		[
+			FEATURE_AUDIO_UPLOADS,
+			FEATURE_GOOGLE_MY_BUSINESS,
+			FEATURE_CLOUDFLARE_ANALYTICS,
+			FEATURE_UPLOAD_THEMES_PLUGINS,
+			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
+			FEATURE_SEO_PREVIEW_TOOLS,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+		].filter( isValueTruthy ),
 	getInferiorFeatures: () => [],
 } );
 
@@ -637,6 +639,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,
 		FEATURE_GOOGLE_MY_BUSINESS,
+		isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
 		FEATURE_CLOUDFLARE_ANALYTICS,
 		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 		FEATURE_SEO_PREVIEW_TOOLS,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -454,12 +454,12 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 	getIncludedFeatures: () =>
 		[
 			FEATURE_AUDIO_UPLOADS,
-			FEATURE_CLOUDFLARE_ANALYTICS,
-			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 			FEATURE_GOOGLE_MY_BUSINESS,
-			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
-			FEATURE_SEO_PREVIEW_TOOLS,
+			FEATURE_CLOUDFLARE_ANALYTICS,
 			FEATURE_UPLOAD_THEMES_PLUGINS,
+			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
+			FEATURE_SEO_PREVIEW_TOOLS,
+			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
 		].filter( isValueTruthy ),
 	getInferiorFeatures: () => [],
 } );
@@ -639,10 +639,10 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 	getIncludedFeatures: () =>
 		[
 			FEATURE_AUDIO_UPLOADS,
-			FEATURE_CLOUDFLARE_ANALYTICS,
-			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 			FEATURE_GOOGLE_MY_BUSINESS,
 			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
+			FEATURE_CLOUDFLARE_ANALYTICS,
+			FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 			FEATURE_SEO_PREVIEW_TOOLS,
 		].filter( isValueTruthy ),
 	getInferiorFeatures: () => [],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restore `isPremiumThemeAvailable` tests
  * These were removed in ec2e8e501cb81cecc14956991826aea5f6983611
  * We added a different version of these changes back in  #58747 with some changes without the tests.
* Allow `isPremiumThemeAvailable` to check if your current plan has `FEATURE_PREMIUM_THEMES`

**NOTE**
Edit: It seems to be working now. Old note follows below.
~~These tests are failing which shows that we're currently missing something.~~

~~Even when I disable the feature flag checking, the tests are failing, so we need to figure out what.~~


#### Testing instructions

* `yarn run jest -c=test/client/jest.config.js client/state/themes/test/selectors.js`