### PR TITLE
Add new string to constant of manual renewal reasons

### DIFF
--- a/client/state/immediate-login/constants.js
+++ b/client/state/immediate-login/constants.js
@@ -5,6 +5,7 @@ export const REASONS_FOR_MANUAL_RENEWAL = [
 	'bd_card-expiring',
 	'bd_missing-payment',
 	'bd_renewal-failure',
+	'bd_autorenew-disabled',
 	'expired-domain-notice',
 	'plan-expired',
 	'renew-domain-expiration-notice',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a new value to `REASONS_FOR_MANUAL_RENEWAL` constant.
* See D69707-code for reference

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that all client unit tests for immediate login pass: `yarn run test-client client/state/immediate-login`