### PR TITLE
Add premium themes upsell message

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,8 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
-	PLAN_BUSINESS,
-	FEATURE_UPLOAD_THEMES,
 	FEATURE_PREMIUM_THEMES,
+	FEATURE_UPLOAD_THEMES,
+	PLAN_BUSINESS,
+	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -29,7 +30,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 				className="themes__showcase-banner"
 				event="calypso_themes_list_premium_themes"
 				feature={ FEATURE_PREMIUM_THEMES }
-				plan={ PLAN_BUSINESS }
+				plan={ PLAN_PREMIUM }
 				title={ translate(
 					'Unlock all premium themes with our Premium, Business and eCommerce plans!'
 				) }

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,4 +1,9 @@
-import { PLAN_BUSINESS, FEATURE_UPLOAD_THEMES } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	PLAN_BUSINESS,
+	FEATURE_UPLOAD_THEMES,
+	FEATURE_PREMIUM_THEMES,
+} from '@automattic/calypso-products';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import Main from 'calypso/components/main';
@@ -19,7 +24,19 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;
 	if ( displayUpsellBanner ) {
-		upsellBanner = (
+		upsellBanner = isEnabled( 'themes/premium' ) ? (
+			<UpsellNudge
+				className="themes__showcase-banner"
+				event="calypso_themes_list_premium_themes"
+				feature={ FEATURE_PREMIUM_THEMES }
+				plan={ PLAN_BUSINESS }
+				title={ translate(
+					'Unlock all premium themes with our Premium, Business and eCommerce plans!'
+				) }
+				forceHref={ true }
+				showIcon={ true }
+			/>
+		) : (
 			<UpsellNudge
 				className="themes__showcase-banner"
 				event="calypso_themes_list_install_themes"

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -3,6 +3,8 @@ import {
 	FEATURE_PREMIUM_THEMES,
 	FEATURE_UPLOAD_THEMES,
 	PLAN_BUSINESS,
+	PLAN_FREE,
+	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { connect } from 'react-redux';
@@ -25,29 +27,47 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;
 	if ( displayUpsellBanner ) {
-		upsellBanner = isEnabled( 'themes/premium' ) ? (
-			<UpsellNudge
-				className="themes__showcase-banner"
-				event="calypso_themes_list_premium_themes"
-				feature={ FEATURE_PREMIUM_THEMES }
-				plan={ PLAN_PREMIUM }
-				title={ translate(
-					'Unlock all premium themes with our Premium, Business and eCommerce plans!'
-				) }
-				forceHref={ true }
-				showIcon={ true }
-			/>
-		) : (
-			<UpsellNudge
-				className="themes__showcase-banner"
-				event="calypso_themes_list_install_themes"
-				feature={ FEATURE_UPLOAD_THEMES }
-				plan={ PLAN_BUSINESS }
-				title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
-				forceHref={ true }
-				showIcon={ true }
-			/>
-		);
+		if ( isEnabled( 'themes/premium' ) ) {
+			if ( [ PLAN_PERSONAL, PLAN_FREE ].includes( currentPlan.productSlug ) ) {
+				upsellBanner = (
+					<UpsellNudge
+						className="themes__showcase-banner"
+						event="calypso_themes_list_premium_themes"
+						feature={ FEATURE_PREMIUM_THEMES }
+						plan={ PLAN_PREMIUM }
+						title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
+						forceHref={ true }
+						showIcon={ true }
+					/>
+				);
+			}
+
+			if ( currentPlan.productSlug === PLAN_PREMIUM ) {
+				upsellBanner = (
+					<UpsellNudge
+						className="themes__showcase-banner"
+						event="calypso_themes_list_install_themes"
+						feature={ FEATURE_UPLOAD_THEMES }
+						plan={ PLAN_BUSINESS }
+						title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
+						forceHref={ true }
+						showIcon={ true }
+					/>
+				);
+			}
+		} else {
+			upsellBanner = (
+				<UpsellNudge
+					className="themes__showcase-banner"
+					event="calypso_themes_list_install_themes"
+					feature={ FEATURE_UPLOAD_THEMES }
+					plan={ PLAN_BUSINESS }
+					title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
+					forceHref={ true }
+					showIcon={ true }
+				/>
+			);
+		}
 	}
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Premium themes upsell message to the themes page under the `themes/premium` feature-flag.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the `/themes/<site>` page using a free site (using the feature-flag)
![image](https://user-images.githubusercontent.com/3801502/144640405-7976cff7-e7d5-4bb1-9943-cffedf986a98.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58616
