### PR TITLE
Update WP.me Shortlinks support info URL

### DIFF
--- a/client/my-sites/site-settings/shortlinks.jsx
+++ b/client/my-sites/site-settings/shortlinks.jsx
@@ -45,7 +45,7 @@ class Shortlinks extends Component {
 							text={ translate(
 								'Generates shorter links so you can have more space to write on social media sites.'
 							) }
-							link="https://jetpack.com/support/shortlinks/"
+							link="https://jetpack.com/support/wp-me-shortlinks/"
 						/>
 
 						<JetpackModuleToggle


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `jetpack-support-shortlinks` JP Redirect has already been updated from `https://jetpack.com/support/shortlinks` to `https://jetpack.com/support/wp-me-shortlinks/`. This PR updates that same URL in Calypso.

#### Testing instructions

- Minor change, proofread.
- In Calypso at `https://wordpress.com/marketing/traffic/__SITE_URL__` test that the `WP.me Shortlinks` support info URL goes to `https://jetpack.com/support/wp-me-shortlinks/`