### PR TITLE
Add getSignupCompareAvailableFeatures to getAllFeaturesForPlan

### DIFF
--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -150,6 +150,9 @@ export function getAllFeaturesForPlan( plan: Plan | string ): TranslateResult[] 
 		...( 'getSignupFeatures' in planObj && planObj.getSignupFeatures
 			? planObj.getSignupFeatures()
 			: [] ),
+		...( 'getSignupCompareAvailableFeatures' in planObj && planObj.getSignupCompareAvailableFeatures
+			? planObj.getSignupCompareAvailableFeatures()
+			: [] ),
 		...( 'getBlogSignupFeatures' in planObj && planObj.getBlogSignupFeatures
 			? planObj.getBlogSignupFeatures()
 			: [] ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* plans-list.tsx has many different feature subsections for plans: https://github.com/Automattic/wp-calypso/blob/157ea8c498f2c8f5c9195f6ab9d76ec0f57bf743/packages/calypso-products/src/plans-list.tsx#L315-L343
* `getAllFeaturesForPlan()`, gets all of a plan's features by looking in these various sections, but does not look into `getSignupCompareAvailableFeatures()`, a section that was added earlier this year.
  * It was added in #49877, which does not add it to the available features list at the time. I don't think this is intentional.
    * Here was the code back then: https://github.com/Automattic/wp-calypso/blob/406b50c47ab16532e065c11decb66f52568e345d/client/lib/plans/index.js#L137-L144
* Make getAllFeaturesForPlan() get features from getSignupCompareAvailableFeatures()

#### Testing instructions

* `yarn run test-client` - Is same before and after PR
