### PR TITLE
Playwright: use Locator to check that item/subitem is selected in SidebarComponent.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -82,13 +82,9 @@ export class SidebarComponent {
 		}
 
 		// Verify the expected item or subitem is selected.
-		await Promise.all( [
-			this.page.waitForSelector( selectedMenuItem, {
-				timeout: 10000,
-				state: 'attached',
-			} ),
-			this.page.waitForSelector( '.focus-content' ),
-		] );
+		await this.page.waitForSelector( '.focus-content' );
+		const locator = this.page.locator( selectedMenuItem );
+		await locator.elementHandle();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -82,9 +82,8 @@ export class SidebarComponent {
 		}
 
 		// Verify the expected item or subitem is selected.
-		await this.page.waitForSelector( '.focus-content' );
 		const locator = this.page.locator( selectedMenuItem );
-		await locator.elementHandle();
+		await locator.waitFor( { state: 'attached' } );
 	}
 
 	/**


### PR DESCRIPTION
 #### Changes proposed in this Pull Request

This PR replaces the use of `page.waitForSelector` with `locator.elementHandle`.

Details:
Intermittently (as documented in https://github.com/Automattic/wp-calypso/issues/58720) there have been failures in the SidebarComponent when navigating to the Media gallery.

Looking at the trace file and the logs, the issue appears to be that `waitForSelector` locates the target element on page, but still fails regardless.

The proposal here is to instead use Locator API, which attempts to resolve to an ElementHandle immediately prior to the called action being executed in the hopes that it would lower false positive rate. Combine this with the `timeout`value being removed will allow all the framework to locate the element for all but the worst case scenario.

#### Testing instructions

- [x] mobile e2e
- [x] desktop e2e
- [x] pre-relese tests
- [x] quarantined tests

Closes #58720