### PR TITLE
Videos UI: Get completions from the courses endpoint.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -2,11 +2,9 @@ import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { cloneElement, useEffect, useState } from 'react';
-import { useSelector, shallowEqual } from 'react-redux';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import useUpdateUserCourseProgressionMutation from 'calypso/data/courses/use-update-user-course-progression-mutation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import getOriginalUserSetting from 'calypso/state/selectors/get-original-user-setting';
 import VideoPlayer from './video-player';
 import './style.scss';
 
@@ -17,10 +15,8 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	const { data: course } = useCourseQuery( courseSlug, { retry: false } );
 	const { updateUserCourseProgression } = useUpdateUserCourseProgressionMutation();
 
-	const initialUserCourseProgression = useSelector( ( state ) => {
-		const courses = getOriginalUserSetting( state, 'courses' );
-		return courses !== null && courseSlug in courses ? courses[ courseSlug ] : [];
-	}, shallowEqual );
+	const initialUserCourseProgression = course?.completions ?? [];
+
 	const [ userCourseProgression, setUserCourseProgression ] = useState( [] );
 	useEffect( () => {
 		setUserCourseProgression( initialUserCourseProgression );


### PR DESCRIPTION
**This should be merged after D71027-code**

This PR makes the Video UI consume user progress information from the `/courses` endpoint instead of getting it from the user settings.

#### Testing
1. Apply D71027-code to your sandbox if not merged.
2. Open the UI.
3. Complete a video.
4. Close the UI.
5. Open the UI without reloading and verify the completed video in `3.` is marked as complete.

Closes https://github.com/Automattic/wp-calypso/issues/58774