### PR TITLE
Plugin Details: Split the page structure into smaller components

### DIFF
--- a/client/my-sites/plugins/_placeholder.scss
+++ b/client/my-sites/plugins/_placeholder.scss
@@ -1,7 +1,0 @@
-%placeholder {
-	cursor: default;
-	color: transparent;
-	user-select: none;
-	background-color: var( --color-neutral-0 );
-	animation: loading-fade 1.6s ease-in-out infinite;
-}

--- a/client/my-sites/plugins/_placeholder.scss
+++ b/client/my-sites/plugins/_placeholder.scss
@@ -1,0 +1,7 @@
+%placeholder {
+	cursor: default;
+	color: transparent;
+	user-select: none;
+	background-color: var( --color-neutral-0 );
+	animation: loading-fade 1.6s ease-in-out infinite;
+}

--- a/client/my-sites/plugins/_variables.scss
+++ b/client/my-sites/plugins/_variables.scss
@@ -1,0 +1,20 @@
+$plugin-details-header-padding: 100px;
+
+%placeholder {
+	cursor: default;
+	color: transparent;
+	user-select: none;
+	background-color: var( --color-neutral-0 );
+	animation: loading-fade 1.6s ease-in-out infinite;
+}
+
+%plugin-header {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: $plugin-details-header-padding 0;
+
+	@media screen and ( max-width: 1040px ) {
+		padding: 0;
+	}
+}

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,26 +1,26 @@
 import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import page from 'page';
+import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { userCan } from 'calypso/lib/site/utils';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
-import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
-import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
-import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
 } from 'calypso/state/automated-transfer/selectors';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
+import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 const PluginDetailsCTA = ( props ) => {
-    const translate = useTranslate();
+	const translate = useTranslate();
 	const { pluginSlug, selectedSite, isPluginInstalledOnsite, siteIds } = props;
 
 	const requestingPluginsForSites = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,0 +1,164 @@
+import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
+import { Button, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import page from 'page';
+import { useSelector, useDispatch } from 'react-redux';
+import { userCan } from 'calypso/lib/site/utils';
+import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
+import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
+import {
+	getEligibility,
+	isEligibleForAutomatedTransfer,
+} from 'calypso/state/automated-transfer/selectors';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
+import './style.scss';
+
+const PluginDetailsCTA = ( props ) => {
+    const translate = useTranslate();
+	const { pluginSlug, selectedSite, isPluginInstalledOnsite, siteIds } = props;
+
+	const requestingPluginsForSites = useSelector( ( state ) =>
+		isRequestingForSites( state, siteIds )
+	);
+
+	// Site type
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
+	const isVip = useSelector( ( state ) => checkVipSite( state, selectedSite?.ID ) );
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
+	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
+
+	// Eligibilities for Simple Sites.
+	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>
+		getEligibility( state, selectedSite?.ID )
+	);
+	const isEligible = useSelector( ( state ) =>
+		isEligibleForAutomatedTransfer( state, selectedSite?.ID )
+	);
+	const hasEligibilityMessages =
+		! isJetpack && ( eligibilityHolds || eligibilityWarnings || isEligible );
+
+	if ( requestingPluginsForSites ) {
+		// Display nothing if we are still requesting the plugin status.
+		return null;
+	}
+	if ( ! isJetpackSelfHosted && ! isCompatiblePlugin( pluginSlug ) ) {
+		// Check for WordPress.com compatibility.
+		return null;
+	}
+
+	if ( ! selectedSite || ! userCan( 'manage_options', selectedSite ) ) {
+		// Check if user can manage plugins.
+		return null;
+	}
+
+	if ( isPluginInstalledOnsite ) {
+		// Check if already instlaled on the site
+		return null;
+	}
+
+	return (
+		<div className="plugin-details-CTA__container plugin-details__header">
+			<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
+			<div className="plugin-details-CTA__install">
+				<CTAButton
+					slug={ pluginSlug }
+					isPluginInstalledOnsite={ isPluginInstalledOnsite }
+					isJetpackSelfHosted={ isJetpackSelfHosted }
+					selectedSite={ selectedSite }
+					isJetpack={ isJetpack }
+					isVip={ isVip }
+					hasEligibilityMessages={ hasEligibilityMessages }
+				/>
+			</div>
+			<div className="plugin-details-CTA__t-and-c">
+				{ translate(
+					'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the Third-Party plugin Terms.',
+					{
+						components: {
+							a: <a target="_blank" rel="noopener noreferrer" href="https://wordpress.com/tos/" />,
+						},
+					}
+				) }
+			</div>
+		</div>
+	);
+};
+
+const CTAButton = ( { slug, selectedSite, isJetpack, isVip, hasEligibilityMessages } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const [ showEligibility, setShowEligibility ] = useState( false );
+
+	const shouldUpgrade = ! (
+		isBusiness( selectedSite.plan ) ||
+		isEnterprise( selectedSite.plan ) ||
+		isEcommerce( selectedSite.plan ) ||
+		isJetpack ||
+		isVip
+	);
+
+	return (
+		<>
+			<Dialog
+				isVisible={ showEligibility }
+				title={ translate( 'Eligibility' ) }
+				onClose={ () => setShowEligibility( false ) }
+			>
+				<EligibilityWarnings
+					standaloneProceed
+					onProceed={ () =>
+						onClickInstallPlugin( {
+							dispatch,
+							selectedSite,
+							slug,
+							upgradeAndInstall: shouldUpgrade,
+						} )
+					}
+				/>
+			</Dialog>
+			<Button
+				className="plugin-details-CTA__install-button"
+				onClick={ () => {
+					if ( hasEligibilityMessages ) {
+						return setShowEligibility( true );
+					}
+					onClickInstallPlugin( {
+						dispatch,
+						selectedSite,
+						slug,
+						upgradeAndInstall: shouldUpgrade,
+					} );
+				} }
+			>
+				{ shouldUpgrade ? translate( 'Upgrade and install' ) : translate( 'Install and activate' ) }
+			</Button>
+		</>
+	);
+};
+
+function onClickInstallPlugin( { dispatch, selectedSite, slug, upgradeAndInstall } ) {
+	dispatch( removePluginStatuses( 'completed', 'error' ) );
+
+	dispatch( recordGoogleEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', slug ) );
+	dispatch(
+		recordGoogleEvent( 'calypso_plugin_install_click_from_plugin_info', {
+			site: selectedSite?.ID,
+			plugin: slug,
+		} )
+	);
+
+	const installPluginURL = `/marketplace/${ slug }/install/${ selectedSite.slug }`;
+	if ( upgradeAndInstall ) {
+		page( `/checkout/${ selectedSite.slug }/business?redirect_to=${ installPluginURL }#step2` );
+	} else {
+		page( installPluginURL );
+	}
+}
+
+export default PluginDetailsCTA;

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -72,7 +72,7 @@ const PluginDetailsCTA = ( {
 	}
 
 	return (
-		<div className="plugin-details-CTA__container plugin-details__header">
+		<div className="plugin-details-CTA__container">
 			<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
 			<div className="plugin-details-CTA__install">
 				<CTAButton
@@ -101,7 +101,7 @@ const PluginDetailsCTA = ( {
 
 const PluginDetailsCTAPlaceholder = () => {
 	return (
-		<div className="plugin-details-CTA__container plugin-details__header is-placeholder">
+		<div className="plugin-details-CTA__container is-placeholder">
 			<div className="plugin-details-CTA__price">...</div>
 			<div className="plugin-details-CTA__install">...</div>
 			<div className="plugin-details-CTA__t-and-c">...</div>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -19,9 +19,14 @@ import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import './style.scss';
 
-const PluginDetailsCTA = ( props ) => {
+const PluginDetailsCTA = ( {
+	pluginSlug,
+	selectedSite,
+	isPluginInstalledOnsite,
+	siteIds,
+	isPlaceholder,
+} ) => {
 	const translate = useTranslate();
-	const { pluginSlug, selectedSite, isPluginInstalledOnsite, siteIds } = props;
 
 	const requestingPluginsForSites = useSelector( ( state ) =>
 		isRequestingForSites( state, siteIds )
@@ -42,6 +47,10 @@ const PluginDetailsCTA = ( props ) => {
 	);
 	const hasEligibilityMessages =
 		! isJetpack && ( eligibilityHolds || eligibilityWarnings || isEligible );
+
+	if ( isPlaceholder ) {
+		return <PluginDetailsCTAPlaceholder />;
+	}
 
 	if ( requestingPluginsForSites ) {
 		// Display nothing if we are still requesting the plugin status.
@@ -86,6 +95,16 @@ const PluginDetailsCTA = ( props ) => {
 					}
 				) }
 			</div>
+		</div>
+	);
+};
+
+const PluginDetailsCTAPlaceholder = () => {
+	return (
+		<div className="plugin-details-CTA__container plugin-details__header is-placeholder">
+			<div className="plugin-details-CTA__price">...</div>
+			<div className="plugin-details-CTA__install">...</div>
+			<div className="plugin-details-CTA__t-and-c">...</div>
 		</div>
 	);
 };

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -1,0 +1,31 @@
+.plugin-details-CTA__price {
+	font-family: $brand-serif;
+	font-size: $font-title-large;
+	color: var( --studio-gray-100 );
+	margin: 16px 0;
+}
+
+.plugin-details-CTA__install {
+	margin-bottom: 20px;
+
+	.plugin-details-CTA__install-button {
+		width: 100%;
+		padding: 12px 16px;
+		background-color: var( --color-accent-50 );
+		color: var( --studio-white );
+
+		&:focus,
+		&:hover {
+			background-color: var( --color-accent-60 );
+		}
+	}
+}
+
+.plugin-details-CTA__t-and-c {
+    font-size: $font-body-extra-small;
+    color: var( --studio-gray-50 );
+
+    @media screen and ( max-width: 1040px ) {
+        padding-bottom: 40px;
+    }
+}

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -1,3 +1,5 @@
+@use '../placeholder';
+
 .plugin-details-CTA__price {
 	font-family: $brand-serif;
 	font-size: $font-title-large;
@@ -28,4 +30,13 @@
     @media screen and ( max-width: 1040px ) {
         padding-bottom: 40px;
     }
+}
+
+.is-placeholder {
+	.plugin-details-CTA__price,
+	.plugin-details-CTA__install,
+	.plugin-details-CTA__t-and-c {
+		@extend %placeholder;
+	}
+
 }

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -1,4 +1,8 @@
-@use '../placeholder';
+@use '../variables';
+
+.plugin-details-CTA__container {
+	@extend %plugin-header;
+}
 
 .plugin-details-CTA__price {
 	font-family: $brand-serif;

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -18,7 +18,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 	return (
 		<>
 			<div className="plugin-details-header__tags">{ tags }</div>
-			<div className="plugin-details-header__container plugin-details__header">
+			<div className="plugin-details-header__container">
 				<div className="plugin-details-header__name">{ plugin.name }</div>
 				<div className="plugin-details-header__description">
 					{ plugin.short_description || plugin.description }
@@ -56,9 +56,9 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 
 const PluginDetailsHeaderPlaceholder = () => {
 	return (
-		<div className="is-placeholder">
+		<div className="plugin-details-header-wrapper is-placeholder">
 			<div className="plugin-details-header__tags">...</div>
-			<div className="plugin-details-header__container plugin-details__header">
+			<div className="plugin-details-header__container">
 				<div className="plugin-details-header__name">...</div>
 				<div className="plugin-details-header__description">...</div>
 				<div className="plugin-details-header__additional-info">...</div>

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -56,7 +56,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 
 const PluginDetailsHeaderPlaceholder = () => {
 	return (
-		<div className="plugin-details-header-wrapper is-placeholder">
+		<div className="plugin-details-header__wrapper is-placeholder">
 			<div className="plugin-details-header__tags">...</div>
 			<div className="plugin-details-header__container">
 				<div className="plugin-details-header__name">...</div>

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -3,15 +3,17 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import './style.scss';
 
-const PluginDetailsHeader = ( props ) => {
-	const { plugin } = props;
-
+const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
 	const tags = Object.values( plugin?.tags || {} )
 		.slice( 0, 3 )
 		.join( ' · ' );
+
+	if ( isPlaceholder ) {
+		return <PluginDetailsHeaderPlaceholder />;
+	}
 
 	return (
 		<>
@@ -49,6 +51,19 @@ const PluginDetailsHeader = ( props ) => {
 				</div>
 			</div>
 		</>
+	);
+};
+
+const PluginDetailsHeaderPlaceholder = () => {
+	return (
+		<div className="is-placeholder">
+			<div className="plugin-details-header__tags">...</div>
+			<div className="plugin-details-header__container plugin-details__header">
+				<div className="plugin-details-header__name">...</div>
+				<div className="plugin-details-header__description">...</div>
+				<div className="plugin-details-header__additional-info">...</div>
+			</div>
+		</div>
 	);
 };
 

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,0 +1,55 @@
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
+import './style.scss';
+
+const PluginDetailsHeader = ( props ) => {
+	const { plugin } = props;
+
+	const moment = useLocalizedMoment();
+	const translate = useTranslate();
+
+	const tags = Object.values( plugin?.tags || {} )
+		.slice( 0, 3 )
+		.join( ' · ' );
+
+	return (
+		<>
+			<div className="plugin-details-header__tags">{ tags }</div>
+			<div className="plugin-details-header__container plugin-details__header">
+				<div className="plugin-details-header__name">{ plugin.name }</div>
+				<div className="plugin-details-header__description">
+					{ plugin.short_description || plugin.description }
+				</div>
+				<div className="plugin-details-header__additional-info">
+					<div className="plugin-details-header__info">
+						<div className="plugin-details-header__info-title">{ translate( 'Developer' ) }</div>
+						<div className="plugin-details-header__info-value">
+							<a href={ plugin.author_url }>{ plugin.author_name }</a>
+						</div>
+					</div>
+					{ !! plugin.rating && (
+						<div className="plugin-details-header__info">
+							<div className="plugin-details-header__info-title">{ translate( 'Ratings' ) }</div>
+							<div className="plugin-details-header__info-value">
+								<PluginRatings rating={ plugin.rating } />
+							</div>
+						</div>
+					) }
+					<div className="plugin-details-header__info">
+						<div className="plugin-details-header__info-title">{ translate( 'Last updated' ) }</div>
+						<div className="plugin-details-header__info-value">
+							{ moment.utc( plugin.last_updated, 'YYYY-MM-DD hh:mma' ).format( 'LL' ) }
+						</div>
+					</div>
+					<div className="plugin-details-header__info">
+						<div className="plugin-details-header__info-title">{ translate( 'Version' ) }</div>
+						<div className="plugin-details-header__info-value">{ plugin.version }</div>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default PluginDetailsHeader;

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -19,6 +19,8 @@ $plugin-details-header-padding: 100px;
 
     .plugin-details-header__info {
         width: 25%;
+        box-sizing: border-box;
+        padding: 0 5px;
 
         @media screen and ( max-width: 1040px ) {
             width: 50%;

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -1,6 +1,10 @@
-@use '../placeholder';
+@use '../variables';
 
 $plugin-details-header-padding: 100px;
+
+.plugin-details-header__container {
+    @extend %plugin-header;
+}
 
 .plugin-details-header__name {
 	font-family: $brand-serif;

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -1,43 +1,45 @@
+@use '../placeholder';
+
 $plugin-details-header-padding: 100px;
 
 .plugin-details-header__name {
-    font-family: $brand-serif;
-    font-size: $font-title-large;
-    color: var( --studio-gray-100 );
-    margin: 16px 0;
+	font-family: $brand-serif;
+	font-size: $font-title-large;
+	color: var( --studio-gray-100 );
+	margin: 16px 0;
 }
 
 .plugin-details-header__description {
-    font-size: $font-title-small;
-    color: var( --studio-gray-70 );
-    margin-bottom: 30px;
+	font-size: $font-title-small;
+	color: var( --studio-gray-70 );
+	margin-bottom: 30px;
 }
 
 .plugin-details-header__additional-info {
-    display: flex;
-    flex-wrap: wrap;
+	display: flex;
+	flex-wrap: wrap;
 
-    .plugin-details-header__info {
-        width: 25%;
-        box-sizing: border-box;
-        padding: 0 5px;
+	.plugin-details-header__info {
+		width: 25%;
+		box-sizing: border-box;
+		padding: 0 5px;
 
-        @media screen and ( max-width: 1040px ) {
-            width: 50%;
-            padding-bottom: 12px;
-        }
-    }
+		@media screen and ( max-width: 1040px ) {
+			width: 50%;
+			padding-bottom: 12px;
+		}
+	}
 
-    .plugin-details-header__info-title {
-        font-size: $font-body-extra-small;
-        font-weight: 400;
-        color: var( --studio-gray-60 );
-    }
+	.plugin-details-header__info-title {
+		font-size: $font-body-extra-small;
+		font-weight: 400;
+		color: var( --studio-gray-60 );
+	}
 
-    .plugin-details-header__info-value {
-        font-size: $font-body;
-        color: var( --studio-gray-90 );
-    }
+	.plugin-details-header__info-value {
+		font-size: $font-body;
+		color: var( --studio-gray-90 );
+	}
 }
 
 .plugin-details-header__tags {
@@ -49,5 +51,18 @@ $plugin-details-header-padding: 100px;
 
 	@media screen and ( max-width: 1040px ) {
 		top: -5px;
+	}
+}
+
+.is-placeholder {
+	.plugin-details-header__name,
+	.plugin-details-header__description,
+	.plugin-details-header__additional-info {
+		@extend %placeholder;
+	}
+
+	.plugin-details-header__tags {
+		@extend %placeholder;
+		width: 50%;
 	}
 }

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -1,0 +1,51 @@
+$plugin-details-header-padding: 100px;
+
+.plugin-details-header__name {
+    font-family: $brand-serif;
+    font-size: $font-title-large;
+    color: var( --studio-gray-100 );
+    margin: 16px 0;
+}
+
+.plugin-details-header__description {
+    font-size: $font-title-small;
+    color: var( --studio-gray-70 );
+    margin-bottom: 30px;
+}
+
+.plugin-details-header__additional-info {
+    display: flex;
+    flex-wrap: wrap;
+
+    .plugin-details-header__info {
+        width: 25%;
+
+        @media screen and ( max-width: 1040px ) {
+            width: 50%;
+            padding-bottom: 12px;
+        }
+    }
+
+    .plugin-details-header__info-title {
+        font-size: $font-body-extra-small;
+        font-weight: 400;
+        color: var( --studio-gray-60 );
+    }
+
+    .plugin-details-header__info-value {
+        font-size: $font-body;
+        color: var( --studio-gray-90 );
+    }
+}
+
+.plugin-details-header__tags {
+	position: absolute;
+	font-size: $font-body-extra-small;
+	color: var( --studio-gray-60 );
+	top: calc( $plugin-details-header-padding - 15px );
+	left: 0;
+
+	@media screen and ( max-width: 1040px ) {
+		top: -5px;
+	}
+}

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -1,0 +1,31 @@
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+import { formatNumberMetric } from 'calypso/lib/format-number-compact';
+
+const PluginDetailsSidebar = ( props ) => {
+	const { plugin } = props;
+    
+    const translate = useTranslate();
+
+	return (
+		<>
+			<div className="plugin-details-sidebar__plugin-details-title">{ translate( 'Plugin details' ) }</div>
+			<div className="plugin-details-sidebar__plugin-details-content">
+				<div className="plugin-details-sidebar__active-installs">
+					<div className="plugin-details-sidebar__active-installs-text title">
+						{ translate( 'Active installations' ) }
+					</div>
+					<div className="plugin-details-sidebar__active-installs-value value">
+						{ formatNumberMetric( plugin.active_installs, 'en' ) }
+					</div>
+				</div>
+				<div className="plugin-details-sidebar__tested">
+					<div className="plugin-details-sidebar__tested-text title">{ translate( 'Tested up to' ) }</div>
+					<div className="plugin-details-sidebar__tested-value value">{ plugin.tested }</div>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default PluginDetailsSidebar;

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -4,12 +4,14 @@ import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 
 const PluginDetailsSidebar = ( props ) => {
 	const { plugin } = props;
-    
-    const translate = useTranslate();
+
+	const translate = useTranslate();
 
 	return (
 		<>
-			<div className="plugin-details-sidebar__plugin-details-title">{ translate( 'Plugin details' ) }</div>
+			<div className="plugin-details-sidebar__plugin-details-title">
+				{ translate( 'Plugin details' ) }
+			</div>
 			<div className="plugin-details-sidebar__plugin-details-content">
 				<div className="plugin-details-sidebar__active-installs">
 					<div className="plugin-details-sidebar__active-installs-text title">
@@ -20,7 +22,9 @@ const PluginDetailsSidebar = ( props ) => {
 					</div>
 				</div>
 				<div className="plugin-details-sidebar__tested">
-					<div className="plugin-details-sidebar__tested-text title">{ translate( 'Tested up to' ) }</div>
+					<div className="plugin-details-sidebar__tested-text title">
+						{ translate( 'Tested up to' ) }
+					</div>
 					<div className="plugin-details-sidebar__tested-value value">{ plugin.tested }</div>
 				</div>
 			</div>

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -1,0 +1,34 @@
+.plugin-details-sidebar__plugin-details-title {
+    padding: 15px 0;
+    display: none;
+    color: var( --studio-gray-100 );
+    font-size: $font-body-small;
+
+
+    @media screen and ( max-width: 1040px ) {
+        display: block;
+    }
+}
+
+
+.plugin-details-sidebar__plugin-details-content {
+    .title {
+        color: var( --studio-gray-60 );
+        font-size: $font-body-extra-small;
+    }
+
+    .value {
+        color: var( --studio-gray-90 );
+        font-size: $font-body-small;
+        padding-bottom: 16px;
+
+        &.plugin-details-sidebar__active-installs-value {
+            font-size: $font-body;
+        }
+    }
+
+    @media screen and ( max-width: 1040px ) {
+        display: flex;
+        justify-content: space-between;
+    }
+}

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -141,13 +141,11 @@ function PluginDetails( props ) {
 		return <NoPermissionsError title={ getPageTitle() } />;
 	}
 
-	if ( existingPlugin === 'unknown' ) {
-		return <PluginPlaceholder />;
-	}
-
 	if ( existingPlugin === false ) {
 		return <PluginDoesNotExistView />;
 	}
+
+	const showPlaceholder = existingPlugin === 'unknown';
 
 	return (
 		<MainComponent wideLayout>
@@ -166,7 +164,7 @@ function PluginDetails( props ) {
 			<div className="plugin-details__page">
 				<div className="plugin-details__layout plugin-details__top-section">
 					<div className="plugin-details__layout-col-left">
-						<PluginDetailsHeader plugin={ fullPlugin } />
+						<PluginDetailsHeader plugin={ fullPlugin } isPlaceholder={ showPlaceholder } />
 					</div>
 
 					<div className="plugin-details__layout-col-right">
@@ -175,48 +173,53 @@ function PluginDetails( props ) {
 							siteIds={ siteIds }
 							selectedSite={ selectedSite }
 							isPluginInstalledOnsite={ isPluginInstalledOnsite }
+							isPlaceholder={ showPlaceholder }
 						/>
 					</div>
 				</div>
 
-				{ ! isJetpackSelfHosted && ! isCompatiblePlugin( props.pluginSlug ) && (
-					<Notice
-						text={ translate(
-							'Incompatible plugin: This plugin is not supported on WordPress.com.'
+				{ ! showPlaceholder && (
+					<>
+						{ ! isJetpackSelfHosted && ! isCompatiblePlugin( props.pluginSlug ) && (
+							<Notice
+								text={ translate(
+									'Incompatible plugin: This plugin is not supported on WordPress.com.'
+								) }
+								status="is-warning"
+								showDismiss={ false }
+							>
+								<NoticeAction href="https://wordpress.com/support/incompatible-plugins/">
+									{ translate( 'More info' ) }
+								</NoticeAction>
+							</Notice>
 						) }
-						status="is-warning"
-						showDismiss={ false }
-					>
-						<NoticeAction href="https://wordpress.com/support/incompatible-plugins/">
-							{ translate( 'More info' ) }
-						</NoticeAction>
-					</Notice>
+
+						<SitesListArea
+							fullPlugin={ fullPlugin }
+							isPluginInstalledOnsite={ isPluginInstalledOnsite }
+							{ ...props }
+						/>
+
+						<div className="plugin-details__layout plugin-details__body">
+							<div className="plugin-details__layout-col-left">
+								{ fullPlugin.wporg ? (
+									<PluginSections
+										className="plugin-details__plugins-sections"
+										plugin={ fullPlugin }
+										isWpcom={ isWpcom }
+										addBanner
+										removeReadMore
+									/>
+								) : (
+									<PluginSectionsCustom plugin={ fullPlugin } />
+								) }
+							</div>
+							<div className="plugin-details__layout-col-right">
+								<PluginDetailsSidebar plugin={ fullPlugin } />
+							</div>
+						</div>
+					</>
 				) }
-
-				<SitesListArea
-					fullPlugin={ fullPlugin }
-					isPluginInstalledOnsite={ isPluginInstalledOnsite }
-					{ ...props }
-				/>
-
-				<div className="plugin-details__layout plugin-details__body">
-					<div className="plugin-details__layout-col-left">
-						{ fullPlugin.wporg ? (
-							<PluginSections
-								className="plugin-details__plugins-sections"
-								plugin={ fullPlugin }
-								isWpcom={ isWpcom }
-								addBanner
-								removeReadMore
-							/>
-						) : (
-							<PluginSectionsCustom plugin={ fullPlugin } />
-						) }
-					</div>
-					<div className="plugin-details__layout-col-right">
-						<PluginDetailsSidebar plugin={ fullPlugin } />
-					</div>
-				</div>
 			</div>
 		</MainComponent>
 	);
@@ -321,32 +324,6 @@ function PluginDoesNotExistView() {
 				action={ action }
 				illustration="/calypso/images/illustrations/illustration-404.svg"
 			/>
-		</MainComponent>
-	);
-}
-
-function PluginPlaceholder() {
-	return (
-		<MainComponent wideLayout>
-			<div className="plugin-details__page">
-				<div className="plugin-details__layout plugin-details__top-section is-placeholder">
-					<div className="plugin-details__layout-col-left">
-						<div className="plugin-details__tags">...</div>
-						<div className="plugin-details__header">
-							<div className="plugin-details__name">...</div>
-							<div className="plugin-details__description">...</div>
-							<div className="plugin-details__additional-info">...</div>
-						</div>
-					</div>
-					<div className="plugin-details__layout-col-right">
-						<div className="plugin-details__header">
-							<div className="plugin-details__price">...</div>
-							<div className="plugin-details__install">...</div>
-							<div className="plugin-details__t-and-c">...</div>
-						</div>
-					</div>
-				</div>
-			</div>
 		</MainComponent>
 	);
 }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -11,11 +11,11 @@ import MainComponent from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginDetailsCTA from 'calypso/my-sites/plugins/plugin-details-CTA';
 import PluginDetailsHeader from 'calypso/my-sites/plugins/plugin-details-header';
+import PluginDetailsSidebar from 'calypso/my-sites/plugins/plugin-details-sidebar';
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
@@ -222,25 +222,7 @@ function PluginDetails( props ) {
 						) }
 					</div>
 					<div className="plugin-details__layout-col plugin-details__layout-col-right">
-						<div className="plugin-details__plugin-details-title">
-							{ translate( 'Plugin details' ) }
-						</div>
-						<div className="plugin-details__plugin-details-content">
-							<div className="plugin-details__active-installs">
-								<div className="plugin-details__active-installs-text title">
-									{ translate( 'Active installations' ) }
-								</div>
-								<div className="plugin-details__active-installs-value value">
-									{ formatNumberMetric( fullPlugin.active_installs, 'en' ) }
-								</div>
-							</div>
-							<div className="plugin-details__tested">
-								<div className="plugin-details__tested-text title">
-									{ translate( 'Tested up to' ) }
-								</div>
-								<div className="plugin-details__tested-value value">{ fullPlugin.tested }</div>
-							</div>
-						</div>
+						<PluginDetailsSidebar plugin={ fullPlugin } />
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -163,21 +163,11 @@ function PluginDetails( props ) {
 
 			<div className="plugin-details__page">
 				<div className="plugin-details__layout plugin-details__top-section">
-					<div
-						className={ classNames(
-							'plugin-details__layout-col',
-							'plugin-details__layout-col-left'
-						) }
-					>
+					<div className="plugin-details__layout-col-left">
 						<PluginDetailsHeader plugin={ fullPlugin } />
 					</div>
 
-					<div
-						className={ classNames(
-							'plugin-details__layout-col',
-							'plugin-details__layout-col-right'
-						) }
-					>
+					<div className="plugin-details__layout-col-right">
 						<PluginDetailsCTA
 							pluginSlug={ props.pluginSlug }
 							siteIds={ siteIds }
@@ -208,7 +198,7 @@ function PluginDetails( props ) {
 				/>
 
 				<div className="plugin-details__layout plugin-details__body">
-					<div className="plugin-details__layout-col plugin-details__layout-col-left">
+					<div className="plugin-details__layout-col-left">
 						{ fullPlugin.wporg ? (
 							<PluginSections
 								className="plugin-details__plugins-sections"
@@ -221,7 +211,7 @@ function PluginDetails( props ) {
 							<PluginSectionsCustom plugin={ fullPlugin } />
 						) }
 					</div>
-					<div className="plugin-details__layout-col plugin-details__layout-col-right">
+					<div className="plugin-details__layout-col-right">
 						<PluginDetailsSidebar plugin={ fullPlugin } />
 					</div>
 				</div>
@@ -338,7 +328,7 @@ function PluginPlaceholder() {
 		<MainComponent wideLayout>
 			<div className="plugin-details__page">
 				<div className="plugin-details__layout plugin-details__top-section is-placeholder">
-					<div className="plugin-details__layout-col plugin-details__layout-col-left">
+					<div className="plugin-details__layout-col-left">
 						<div className="plugin-details__tags">...</div>
 						<div className="plugin-details__header">
 							<div className="plugin-details__name">...</div>
@@ -346,7 +336,7 @@ function PluginPlaceholder() {
 							<div className="plugin-details__additional-info">...</div>
 						</div>
 					</div>
-					<div className="plugin-details__layout-col plugin-details__layout-col-right">
+					<div className="plugin-details__layout-col-right">
 						<div className="plugin-details__header">
 							<div className="plugin-details__price">...</div>
 							<div className="plugin-details__install">...</div>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -201,7 +201,7 @@ function PluginDetails( props ) {
 					</Notice>
 				) }
 
-				<SitesList
+				<SitesListArea
 					fullPlugin={ fullPlugin }
 					isPluginInstalledOnsite={ isPluginInstalledOnsite }
 					{ ...props }
@@ -248,7 +248,7 @@ function PluginDetails( props ) {
 	);
 }
 
-function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) {
+function SitesListArea( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) {
 	const translate = useTranslate();
 
 	const selectedSite = useSelector( getSelectedSite );

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,11 +1,7 @@
-import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
-import { Button, Dialog } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -16,21 +12,15 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
-import { userCan } from 'calypso/lib/site/utils';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
+import PluginDetailsCTA from 'calypso/my-sites/plugins/plugin-details-CTA';
 import PluginDetailsHeader from 'calypso/my-sites/plugins/plugin-details-header';
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import {
-	getEligibility,
-	isEligibleForAutomatedTransfer,
-} from 'calypso/state/automated-transfer/selectors';
-import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import {
 	getPluginOnSite,
 	getPluginOnSites,
@@ -38,7 +28,6 @@ import {
 	getSitesWithoutPlugin,
 	isRequestingForSites,
 } from 'calypso/state/plugins/installed/selectors';
-import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import {
 	isFetching as isWporgPluginFetching,
@@ -49,7 +38,6 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
 import {
 	isJetpackSite,
 	isRequestingSites as checkRequestingSites,
@@ -91,20 +79,9 @@ function PluginDetails( props ) {
 
 	// Site type.
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
-	const isVip = useSelector( ( state ) => checkVipSite( state, selectedSite?.ID ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isWpcom = selectedSite && ! isJetpack;
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
-
-	// Eligibilities for Simple Sites.
-	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>
-		getEligibility( state, selectedSite?.ID )
-	);
-	const isEligible = useSelector( ( state ) =>
-		isEligibleForAutomatedTransfer( state, selectedSite?.ID )
-	);
-	const hasEligibilityMessages =
-		! isJetpack && ( eligibilityHolds || eligibilityWarnings || isEligible );
 
 	const fullPlugin = {
 		...plugin,
@@ -194,51 +171,20 @@ function PluginDetails( props ) {
 					>
 						<PluginDetailsHeader plugin={ fullPlugin } />
 					</div>
-					{ shouldDisplayCTA(
-						selectedSite,
-						props.pluginSlug,
-						isPluginInstalledOnsite,
-						isJetpackSelfHosted,
-						requestingPluginsForSites
-					) && (
-						<div
-							className={ classNames(
-								'plugin-details__layout-col',
-								'plugin-details__layout-col-right'
-							) }
-						>
-							<div className="plugin-details__header">
-								<div className="plugin-details__price">{ translate( 'Free' ) }</div>
-								<div className="plugin-details__install">
-									<CTA
-										slug={ props.pluginSlug }
-										isPluginInstalledOnsite={ isPluginInstalledOnsite }
-										isJetpackSelfHosted={ isJetpackSelfHosted }
-										selectedSite={ selectedSite }
-										isJetpack={ isJetpack }
-										isVip={ isVip }
-										hasEligibilityMessages={ hasEligibilityMessages }
-									/>
-								</div>
-								<div className="plugin-details__t-and-c">
-									{ translate(
-										'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the Third-Party plugin Terms.',
-										{
-											components: {
-												a: (
-													<a
-														target="_blank"
-														rel="noopener noreferrer"
-														href="https://wordpress.com/tos/"
-													/>
-												),
-											},
-										}
-									) }
-								</div>
-							</div>
-						</div>
-					) }
+
+					<div
+						className={ classNames(
+							'plugin-details__layout-col',
+							'plugin-details__layout-col-right'
+						) }
+					>
+						<PluginDetailsCTA
+							pluginSlug={ props.pluginSlug }
+							siteIds={ siteIds }
+							selectedSite={ selectedSite }
+							isPluginInstalledOnsite={ isPluginInstalledOnsite }
+						/>
+					</div>
 				</div>
 
 				{ ! isJetpackSelfHosted && ! isCompatiblePlugin( props.pluginSlug ) && (
@@ -300,103 +246,6 @@ function PluginDetails( props ) {
 			</div>
 		</MainComponent>
 	);
-}
-
-function shouldDisplayCTA(
-	selectedSite,
-	slug,
-	isPluginInstalledOnsite,
-	isJetpackSelfHosted,
-	requestingPluginsForSites
-) {
-	if ( requestingPluginsForSites ) {
-		// Display nothing if we are still requesting the plugin status.
-		return false;
-	}
-	if ( ! isJetpackSelfHosted && ! isCompatiblePlugin( slug ) ) {
-		// Check for WordPress.com compatibility.
-		return false;
-	}
-
-	if ( ! selectedSite || ! userCan( 'manage_options', selectedSite ) ) {
-		// Check if user can manage plugins.
-		return false;
-	}
-
-	return ! isPluginInstalledOnsite;
-}
-
-function CTA( { slug, selectedSite, isJetpack, isVip, hasEligibilityMessages } ) {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-	const [ showEligibility, setShowEligibility ] = useState( false );
-
-	const shouldUpgrade = ! (
-		isBusiness( selectedSite.plan ) ||
-		isEnterprise( selectedSite.plan ) ||
-		isEcommerce( selectedSite.plan ) ||
-		isJetpack ||
-		isVip
-	);
-
-	return (
-		<>
-			<Dialog
-				isVisible={ showEligibility }
-				title={ translate( 'Eligibility' ) }
-				onClose={ () => setShowEligibility( false ) }
-			>
-				<EligibilityWarnings
-					standaloneProceed
-					onProceed={ () =>
-						onClickInstallPlugin( {
-							dispatch,
-							selectedSite,
-							slug,
-							upgradeAndInstall: shouldUpgrade,
-						} )
-					}
-				/>
-			</Dialog>
-			<Button
-				className="plugin-details__install-button"
-				onClick={ () => {
-					if ( hasEligibilityMessages ) {
-						return setShowEligibility( true );
-					}
-					onClickInstallPlugin( {
-						dispatch,
-						selectedSite,
-						slug,
-						upgradeAndInstall: shouldUpgrade,
-					} );
-				} }
-			>
-				{ shouldUpgrade ? translate( 'Upgrade and install' ) : translate( 'Install and activate' ) }
-			</Button>
-		</>
-	);
-}
-
-function onClickInstallPlugin( { dispatch, selectedSite, slug, upgradeAndInstall } ) {
-	dispatch( removePluginStatuses( 'completed', 'error' ) );
-
-	dispatch( recordGoogleEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', slug ) );
-	dispatch(
-		recordGoogleEvent( 'calypso_plugin_install_click_from_plugin_info', {
-			site: selectedSite?.ID,
-			plugin: slug,
-		} )
-	);
-
-	dispatch( productToBeInstalled( null, slug, selectedSite.slug ) );
-
-	const installPluginURL = `/marketplace/${ slug }/install/${ selectedSite.slug }`;
-	if ( upgradeAndInstall ) {
-		page( `/checkout/${ selectedSite.slug }/business?redirect_to=${ installPluginURL }#step2` );
-	} else {
-		page( installPluginURL );
-	}
 }
 
 function SitesList( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -11,7 +11,6 @@ import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import MainComponent from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -20,7 +19,7 @@ import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { userCan } from 'calypso/lib/site/utils';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
-import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
+import PluginDetailsHeader from 'calypso/my-sites/plugins/plugin-details-header';
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
@@ -60,7 +59,6 @@ import NoPermissionsError from './no-permissions-error';
 
 function PluginDetails( props ) {
 	const dispatch = useDispatch();
-	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
 	// Site information.
@@ -112,10 +110,6 @@ function PluginDetails( props ) {
 		...plugin,
 		...wporgPlugin,
 	};
-
-	const tags = Object.values( fullPlugin?.tags || {} )
-		.slice( 0, 3 )
-		.join( ' · ' );
 
 	useEffect( () => {
 		if ( ! isFetched ) {
@@ -198,39 +192,7 @@ function PluginDetails( props ) {
 							'plugin-details__layout-col-left'
 						) }
 					>
-						<div className="plugin-details__tags">{ tags }</div>
-						<div className="plugin-details__header">
-							<div className="plugin-details__name">{ fullPlugin.name }</div>
-							<div className="plugin-details__description">
-								{ fullPlugin.short_description || fullPlugin.description }
-							</div>
-							<div className="plugin-details__additional-info">
-								<div className="plugin-details__info">
-									<div className="plugin-details__info-title">{ translate( 'Developer' ) }</div>
-									<div className="plugin-details__info-value">
-										<a href={ fullPlugin.author_url }>{ fullPlugin.author_name }</a>
-									</div>
-								</div>
-								{ !! fullPlugin.rating && (
-									<div className="plugin-details__info">
-										<div className="plugin-details__info-title">{ translate( 'Ratings' ) }</div>
-										<div className="plugin-details__info-value">
-											<PluginRatings rating={ fullPlugin.rating } />
-										</div>
-									</div>
-								) }
-								<div className="plugin-details__info">
-									<div className="plugin-details__info-title">{ translate( 'Last updated' ) }</div>
-									<div className="plugin-details__info-value">
-										{ moment.utc( fullPlugin.last_updated, 'YYYY-MM-DD hh:mma' ).format( 'LL' ) }
-									</div>
-								</div>
-								<div className="plugin-details__info">
-									<div className="plugin-details__info-title">{ translate( 'Version' ) }</div>
-									<div className="plugin-details__info-value">{ fullPlugin.version }</div>
-								</div>
-							</div>
-						</div>
+						<PluginDetailsHeader plugin={ fullPlugin } />
 					</div>
 					{ shouldDisplayCTA(
 						selectedSite,

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -83,10 +82,13 @@ function PluginDetails( props ) {
 	const isWpcom = selectedSite && ! isJetpack;
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 
-	const fullPlugin = {
-		...plugin,
-		...wporgPlugin,
-	};
+	const fullPlugin = useMemo(
+		() => ( {
+			...plugin,
+			...wporgPlugin,
+		} ),
+		[ plugin, wporgPlugin ]
+	);
 
 	useEffect( () => {
 		if ( ! isFetched ) {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -118,8 +118,6 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 }
 
-$plugin-details-header-padding: 100px;
-
 .plugin-details__layout {
 	@include grid-row( 4, 1 );
 	@include breakpoint-deprecated( '>1040px' ) {
@@ -146,17 +144,6 @@ $plugin-details-header-padding: 100px;
 .plugin-details__page {
 	@media screen and ( max-width: 1040px ) {
 		padding: 16px;
-	}
-}
-
-.plugin-details__header {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	padding: $plugin-details-header-padding 0;
-
-	@media screen and ( max-width: 1040px ) {
-		padding: 0;
 	}
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -189,13 +189,6 @@ $plugin-details-header-padding: 100px;
 .plugin-details__body {
 	border-top: 1px solid var( --studio-gray-5 );
 
-	.plugin-details__plugin-details-title {
-		padding: 15px 0;
-		display: none;
-		color: var( --studio-gray-100 );
-		font-size: $font-body-small;
-	}
-
 	.plugin-sections {
 		margin-top: 20px;
 
@@ -252,15 +245,6 @@ $plugin-details-header-padding: 100px;
 	@media screen and ( max-width: 1040px ) {
 		display: flex;
 		flex-direction: column;
-
-		.plugin-details__plugin-details-content {
-			display: flex;
-			justify-content: space-between;
-		}
-
-		.plugin-details__plugin-details-title {
-			display: block;
-		}
 
 		.plugin-details__layout-col-left {
 			order: 2;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -162,7 +162,7 @@ $plugin-details-header-padding: 100px;
 			@extend %placeholder;
 		}
 
-		.plugin-details__tags {
+		.plugin-details-header__tags {
 			@extend %placeholder;
 			width: 50%;
 		}
@@ -175,87 +175,44 @@ $plugin-details-header-padding: 100px;
 	}
 }
 
-.plugin-details__tags {
-	position: absolute;
-	font-size: $font-body-extra-small;
-	color: var( --studio-gray-60 );
-	top: calc( $plugin-details-header-padding - 15px );
-	left: 0;
+.plugin-details__price {
+	font-family: $brand-serif;
+	font-size: $font-title-large;
+	color: var( --studio-gray-100 );
+	margin: 16px 0;
+}
 
-	@media screen and ( max-width: 1040px ) {
-		top: -5px;
+.plugin-details__install {
+	margin-bottom: 20px;
+
+	.plugin-details__install-button {
+		width: 100%;
+		padding: 12px 16px;
+		background-color: var( --color-accent-50 );
+		color: var( --studio-white );
+
+		&:focus,
+		&:hover {
+			background-color: var( --color-accent-60 );
+		}
 	}
 }
+
+.plugin-details__t-and-c {
+    font-size: $font-body-extra-small;
+    color: var( --studio-gray-50 );
+
+    @media screen and ( max-width: 1040px ) {
+        padding-bottom: 40px;
+    }
+}
+
 
 .plugin-details__header {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	padding: $plugin-details-header-padding 0;
-
-	.plugin-details__name,
-	.plugin-details__price {
-		font-family: $brand-serif;
-		font-size: $font-title-large;
-		color: var( --studio-gray-100 );
-		margin: 16px 0;
-	}
-
-	.plugin-details__description {
-		font-size: $font-title-small;
-		color: var( --studio-gray-70 );
-		margin-bottom: 30px;
-	}
-
-	.plugin-details__additional-info {
-		display: flex;
-		flex-wrap: wrap;
-
-		.plugin-details__info {
-			width: 25%;
-
-			@media screen and ( max-width: 1040px ) {
-				width: 50%;
-				padding-bottom: 12px;
-			}
-		}
-
-		.plugin-details__info-title {
-			font-size: $font-body-extra-small;
-			font-weight: 400;
-			color: var( --studio-gray-60 );
-		}
-
-		.plugin-details__info-value {
-			font-size: $font-body;
-			color: var( --studio-gray-90 );
-		}
-	}
-
-	.plugin-details__install {
-		margin-bottom: 20px;
-
-		.plugin-details__install-button {
-			width: 100%;
-			padding: 12px 16px;
-			background-color: var( --color-accent-50 );
-			color: var( --studio-white );
-
-			&:focus,
-			&:hover {
-				background-color: var( --color-accent-60 );
-			}
-		}
-	}
-
-	.plugin-details__t-and-c {
-		font-size: $font-body-extra-small;
-		color: var( --studio-gray-50 );
-
-		@media screen and ( max-width: 1040px ) {
-			padding-bottom: 40px;
-		}
-	}
 
 	@media screen and ( max-width: 1040px ) {
 		padding: 0;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -143,32 +143,6 @@ $plugin-details-header-padding: 100px;
 	}
 }
 
-%placeholder {
-	cursor: default;
-	color: transparent;
-	user-select: none;
-	background-color: var( --color-neutral-0 );
-	animation: loading-fade 1.6s ease-in-out infinite;
-}
-
-.plugin-details__top-section {
-	&.is-placeholder {
-		.plugin-details__name,
-		.plugin-details__price,
-		.plugin-details__description,
-		.plugin-details__additional-info,
-		.plugin-details__install,
-		.plugin-details__t-and-c {
-			@extend %placeholder;
-		}
-
-		.plugin-details-header__tags {
-			@extend %placeholder;
-			width: 50%;
-		}
-	}
-}
-
 .plugin-details__page {
 	@media screen and ( max-width: 1040px ) {
 		padding: 16px;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -175,39 +175,6 @@ $plugin-details-header-padding: 100px;
 	}
 }
 
-.plugin-details__price {
-	font-family: $brand-serif;
-	font-size: $font-title-large;
-	color: var( --studio-gray-100 );
-	margin: 16px 0;
-}
-
-.plugin-details__install {
-	margin-bottom: 20px;
-
-	.plugin-details__install-button {
-		width: 100%;
-		padding: 12px 16px;
-		background-color: var( --color-accent-50 );
-		color: var( --studio-white );
-
-		&:focus,
-		&:hover {
-			background-color: var( --color-accent-60 );
-		}
-	}
-}
-
-.plugin-details__t-and-c {
-    font-size: $font-body-extra-small;
-    color: var( --studio-gray-50 );
-
-    @media screen and ( max-width: 1040px ) {
-        padding-bottom: 40px;
-    }
-}
-
-
 .plugin-details__header {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Turn PluginDetailsHeader into a component and use it on the PluginDetails page.
* Turn PluginDetailsCTA into a component and use it on the PluginDetails page.
* Turn PluginDetailsSidebar into a component and use it on the PluginDetails page.
* Rename SiteList component to SiteListArea. 
* Add padding to info divs.
* Remove unnecessary class.

#### Testing instructions
* Open the Plugin Details page (`/plugins/:plugin-slug`) in production.
* Open a new tab with the PluginDetails version of this PR.
* Both should look the same.
* Verify all the actions(CTA, Site list actions) on the also still working.

