### PR TITLE
Woop installer: remove 'on us' from domain warning

### DIFF
--- a/client/components/eligibility-warnings/domain-warning/index.tsx
+++ b/client/components/eligibility-warnings/domain-warning/index.tsx
@@ -18,7 +18,7 @@ const DomainEligibilityWarning = ( {
 			{ sprintf(
 				/* translators: %s: The wordpress domain (ex.: myawesomeblog.wordpress.com) */
 				__(
-					'By installing this product your subdomain will change. Your old subdomain (%s) will no longer work. You can change it to a custom domain on us at anytime in future.'
+					'By installing this product your subdomain will change. Your old subdomain (%s) will no longer work. You can change it to a custom domain at anytime in future.'
 				),
 				wpcomDomain
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* remove 'on us' from domain warning

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the `on us` has been removed when the site requires an upgrading

before | after
-----|------
![image](https://user-images.githubusercontent.com/77539/144674131-f5034650-8bb6-4244-b5f7-40618409ab06.png) | ![image](https://user-images.githubusercontent.com/77539/144674084-0ead144e-20b2-4bce-98ef-3181d812065f.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
