### PR TITLE
Checkout: Record transaction begin analytics directly in webPayProcessor

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
@@ -1,5 +1,6 @@
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
+import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import submitWpcomTransaction from './submit-wpcom-transaction';
@@ -29,11 +30,9 @@ export default async function webPayProcessor(
 	if ( ! isValidWebPayTransactionData( submitData ) ) {
 		throw new Error( 'Required purchase data is missing' );
 	}
-	const webPaymentEventType =
-		webPaymentType === 'google-pay'
-			? 'GOOGLE_PAY_TRANSACTION_BEGIN'
-			: 'APPLE_PAY_TRANSACTION_BEGIN';
-	transactionOptions.recordEvent( { type: webPaymentEventType } );
+	transactionOptions.reduxDispatch(
+		recordTransactionBeginAnalytics( { paymentMethodId: webPaymentType } )
+	);
 
 	const {
 		includeDomainDetails,

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -69,23 +69,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
 					);
 				}
-				case 'APPLE_PAY_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Web_Payment',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Web_Payment',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
-					);
-				}
 				default:
 					debug( 'unknown checkout event', action );
 					return reduxDispatch(

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -206,6 +206,9 @@ export interface WPCOMCart {
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 }
 
+// Payment method slugs which all map to a WPCOMPaymentMethod using
+// translateCheckoutPaymentMethodToWpcomPaymentMethod and
+// translateWpcomPaymentMethodToCheckoutPaymentMethod.
 export type CheckoutPaymentMethodSlug =
 	| 'alipay'
 	| 'web-pay'
@@ -224,7 +227,10 @@ export type CheckoutPaymentMethodSlug =
 	| 'free-purchase'
 	| 'full-credits'
 	| 'stripe-three-d-secure'
-	| 'wechat';
+	| 'wechat'
+	| `existingCard-${ string }`
+	| 'apple-pay'
+	| 'google-pay';
 
 /**
  * Payment method slugs as returned by the WPCOM backend.

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -228,9 +228,9 @@ export type CheckoutPaymentMethodSlug =
 	| 'full-credits'
 	| 'stripe-three-d-secure'
 	| 'wechat'
-	| `existingCard-${ string }`
-	| 'apple-pay'
-	| 'google-pay';
+	| `existingCard-${ string }` // a synonym for 'card'
+	| 'apple-pay' // a synonym for 'web-pay'
+	| 'google-pay'; // a synonym for 'web-pay'
 
 /**
  * Payment method slugs as returned by the WPCOM backend.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the web payment (Google Pay and Apple Pay) transaction start analytics from the checkout event handler directly into where the events occur.

This also adds a missing analytics event for Google Pay as it was not being handled.

#### Testing instructions

- You'll need to be able to see either Google Pay or Apple Pay. For both you'll need to be viewing a page over https. For Google Pay you can just use the calypso.live link on this PR, you'll need to be using the Chrome browser, you'll also need to have at least one active card in your Google Pay wallet. Testing Apple Pay is considerably more complex and is beyond the scope of this PR but Google Pay should be enough as they share the same processor.
- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`. For me, the Google Pay dialog won't actually work if devtools is open; if you have the same problem, you'll need to set the above debug variable, set devtools to "Preserve log", then close devtools to perform the payment, then open it again while the payment is processing to see the events 😩 .
- Add a plan to your cart and visit checkout.
- Next, select either Google Pay or Apple Pay as your payment method in checkout and submit the transaction. You'll need to confirm it in your browser to see the events. If your API is sandboxed, you should not be charged, but to be safe you can refund your purchase afterwards.
- Verify that you see the `calypso_checkout_form_submit` event triggered with `payment_method: 'WPCOM_Billing_Web_Payment'`.
- Verify that you see the `calypso_checkout_composite_google_pay_submit_clicked` event triggered for Google Pay (or `...apple_pay...` for Apple Pay).
<img width="622" alt="Screen Shot 2021-12-03 at 6 12 01 PM" src="https://user-images.githubusercontent.com/2036909/144684716-5524bcda-3ae5-4ec4-a0d1-a6effa2b39bf.png">

