### PR TITLE
Site Editor: don't hide nav after Gutenberg 12.2

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -339,7 +339,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  */
 function load_wpcom_site_editor() {
 	// This is no longer needed after Gutenberg 12.1 due to the Navigation menu no longer being inscrutable.
-	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '12.1.0', '>=' ) ) {
+	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '12.2.0', '>=' ) ) {
 		return;
 	}
 	require_once __DIR__ . '/wpcom-site-editor/index.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -338,7 +338,8 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  * (Core Full Site Editing)
  */
 function load_wpcom_site_editor() {
-	// This is no longer needed after Gutenberg 12.1 due to the Navigation menu no longer being inscrutable.
+	// This is no longer needed after Gutenberg 12.2 due to the Navigation menu no longer being inscrutable.
+	// This should be deleted along with the files that would be loaded after 12.2 is in production.
 	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '12.2.0', '>=' ) ) {
 		return;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -338,6 +338,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  * (Core Full Site Editing)
  */
 function load_wpcom_site_editor() {
+	// This is no longer needed after Gutenberg 12.1 due to the Navigation menu no longer being inscrutable.
+	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '12.1.0', '>=' ) ) {
+		return;
+	}
 	require_once __DIR__ . '/wpcom-site-editor/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_site_editor', 11 ); // load just after the Gutenberg plugin.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Unhide the Navigation menu (under the top left W)

Gutenberg 12.2 (ahead of and for WP 5.9) has a new, drastically scaled-back Navigation Sidebar. The `< Dashboard` link is no longer nested-away-by-default, so we can stop hijacking the (W) menu to go back to the Dashboard directly.

This also prevents the weird state in which you could open the nav sidebar by picking "browse templates" from the top middle template dropdown without being able to close it again. There was probably an issue about that.

#### Testing instructions
1. Ensure your test sandboxed site has the `gutenberg-edge` sticker. 
2. Wait until WordPress/gutenberg/pull/36488 is merged and released (in a RC2?), or build it yourself and extract the built artifact from `npm run build:plugin-zip` in the `gutenberg-core/v12.1.0-rc.1` directory on your sandbox to overwrite it. (If you sync a working repo without building, you won't have the required `GUTENBERG_VERSION` PHP constant.)
3. This ETK build is running on your sandbox
4. Once that patched Gutenberg is running, and the ETK is patched, et voila. The Navigation Sidebar is now working just like Core and the `< Dashboard` link takes you back to Calypso home.
