### PR TITLE
Allow the ThemeCard to detect if your site supports premium themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1,5 +1,10 @@
 import config from '@automattic/calypso-config';
-import { FEATURE_UPLOAD_THEMES, PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
+import {
+	FEATURE_PREMIUM_THEMES,
+	FEATURE_UPLOAD_THEMES,
+	PLAN_BUSINESS,
+	PLAN_PREMIUM,
+} from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
@@ -630,6 +635,7 @@ class ThemeSheet extends Component {
 			siteId,
 			siteSlug,
 			retired,
+			hasUnlimitedPremiumThemes,
 			isPremium,
 			isJetpack,
 			isWpcomTheme,
@@ -680,7 +686,9 @@ class ThemeSheet extends Component {
 
 		let pageUpsellBanner;
 		let previewUpsellBanner;
-		const hasWpComThemeUpsellBanner = ! isJetpack && isPremium && ! isVip && ! retired;
+
+		const hasWpComThemeUpsellBanner =
+			! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip && ! retired;
 		const hasWpOrgThemeUpsellBanner =
 			! isWpcomTheme && ( ! siteId || ( ! isJetpack && ! canUserUploadThemes ) );
 		const hasUpsellBanner = hasWpComThemeUpsellBanner || hasWpOrgThemeUpsellBanner;
@@ -844,6 +852,7 @@ export default connect(
 			isPremium: isThemePremium( state, id ),
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
 			forumUrl: getThemeForumUrl( state, id, siteId ),
+			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_PREMIUM_THEMES ),
 			canUserUploadThemes: hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),

--- a/client/state/themes/selectors/is-premium-theme-available.js
+++ b/client/state/themes/selectors/is-premium-theme-available.js
@@ -1,3 +1,5 @@
+import { FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
+import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 
 import 'calypso/state/themes/init';
@@ -11,5 +13,8 @@ import 'calypso/state/themes/init';
  * @returns {boolean}         True if the premium theme is available for the given site
  */
 export function isPremiumThemeAvailable( state, themeId, siteId ) {
-	return isThemePurchased( state, themeId, siteId );
+	return (
+		isThemePurchased( state, themeId, siteId ) ||
+		hasFeature( state, siteId, FEATURE_PREMIUM_THEMES )
+	);
 }

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1,4 +1,9 @@
-import { PLAN_FREE } from '@automattic/calypso-products';
+import {
+	PLAN_FREE,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+} from '@automattic/calypso-products';
 import { expect } from 'chai';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 import {
@@ -2295,6 +2300,116 @@ describe( 'themes selectors', () => {
 			);
 
 			expect( isAvailable ).to.be.false;
+		} );
+
+		test( 'given a premium squared theme and a site without the premium upgrade, should return false', () => {
+			const isAvailable = isPremiumThemeAvailable(
+				{
+					sites: {
+						items: {
+							2916284: {},
+						},
+						plans: {
+							2916284: {
+								data: [
+									{
+										currentPlan: true,
+										productSlug: PLAN_FREE,
+									},
+								],
+							},
+						},
+					},
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { mood },
+							} ),
+						},
+					},
+					purchases: {
+						data: [],
+					},
+				},
+				'mood',
+				2916284
+			);
+
+			expect( isAvailable ).to.be.false;
+		} );
+
+		test( 'given a premium squared theme and a site with the premium upgrade, should return true', () => {
+			const isAvailable = isPremiumThemeAvailable(
+				{
+					sites: {
+						items: {
+							2916284: {},
+						},
+						plans: {
+							2916284: {
+								data: [
+									{
+										currentPlan: true,
+										productSlug: PLAN_PREMIUM,
+									},
+								],
+							},
+						},
+					},
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { mood },
+							} ),
+						},
+					},
+					purchases: {
+						data: [],
+					},
+				},
+				'mood',
+				2916284
+			);
+
+			expect( isAvailable ).to.be.true;
+		} );
+
+		test( 'given a site with the unlimited premium themes bundle, should return true', () => {
+			[ PLAN_BUSINESS, PLAN_ECOMMERCE ].forEach( ( plan ) => {
+				const isAvailable = isPremiumThemeAvailable(
+					{
+						sites: {
+							items: {
+								2916284: {},
+							},
+							plans: {
+								2916284: {
+									data: [
+										{
+											currentPlan: true,
+											productSlug: plan,
+										},
+									],
+								},
+							},
+						},
+						themes: {
+							queries: {
+								wpcom: new ThemeQueryManager( {
+									items: { mood },
+								} ),
+							},
+						},
+						purchases: {
+							data: [],
+						},
+					},
+					'mood',
+					2916284
+				);
+
+				expect( isAvailable ).to.be.true;
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
## ---> Warning: This builds upon PR #58816, which needs to be merged before this PR is reviewed. <--
  * This PR also includes the changes from #58816.

#### Changes proposed in this Pull Request

* ThemeCard: `hasWpComThemeUpsellBanner` now requires `! hasUnlimitedPremiumThemes` to be true. If you have unlimited premium themes, you can no longer see the banner. 

#### Testing instructions

* Follow the directions in "Hacks to see premium themes when none exist" pdgA0m-8p-p2
* Go to theme showcase and filter for premium themes
* Use two sites to visit the "Info" page of a theme, one with Premium plan or above, another with Free plan
* The Free plan should display an upsell banner and the button should say to "Pick" this design, which brings you to the shopping cart. The Premium plan should have no banner and the button should say "Activate" this design, which tries to activate the theme directly without going to the shopping cart.
![2021-12-03_16-44](https://user-images.githubusercontent.com/937354/144682785-dc2aa4bd-25d4-46a3-acf6-d104a798c2fe.png)
![2021-12-03_16-43](https://user-images.githubusercontent.com/937354/144682806-a5f5a539-f7a9-4e7c-9a29-7b0d36dcfcb1.png)
![2021-12-03_16-45](https://user-images.githubusercontent.com/937354/144682818-533f1a83-288d-4b6c-9f77-63c6ae7679c1.png)
