### PR TITLE
Checkout: Record existing card analytics events directly

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -78,7 +78,9 @@ export const recordTransactionBeginAnalytics = ( {
 				payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
 			} )
 		);
-		const paymentMethodIdForTracks = paymentMethodId.replace( /-/, '_' ).toLowerCase();
+		const paymentMethodIdForTracks = paymentMethodId.startsWith( 'existingCard' )
+			? 'existing_card'
+			: paymentMethodId.replace( /-/, '_' ).toLowerCase();
 		dispatch(
 			recordTracksEvent(
 				`calypso_checkout_composite_${ paymentMethodIdForTracks }_submit_clicked`,

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -6,6 +6,7 @@ import {
 } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import submitWpcomTransaction from './submit-wpcom-transaction';
@@ -44,6 +45,7 @@ export default async function existingCardProcessor(
 	if ( ! stripe ) {
 		throw new Error( 'Stripe is required to submit an existing card payment' );
 	}
+	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'existingCard' } ) );
 
 	const domainDetails = getDomainDetails( contactDetails, {
 		includeDomainDetails,

--- a/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
@@ -12,6 +12,11 @@ export default function isPaymentMethodEnabled(
 		return true;
 	}
 
+	// If new cards are supported, so are existing cards.
+	if ( slug.startsWith( 'existingCard' ) && allowedPaymentMethods?.includes( 'card' ) ) {
+		return true;
+	}
+
 	// Some country-specific payment methods should only be available if that
 	// country is selected in the contact information.
 	if ( slug === 'netbanking' && countryCode !== 'IN' ) {

--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -54,9 +54,11 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 ): WPCOMPaymentMethod | null {
 	// existing cards have unique paymentMethodIds
 	if ( paymentMethod.startsWith( 'existingCard' ) ) {
-		paymentMethod = 'card';
+		paymentMethod = 'existingCard';
 	}
 	switch ( paymentMethod ) {
+		case 'existingCard':
+			return 'WPCOM_Billing_MoneyPress_Stored';
 		case 'ebanx':
 			return 'WPCOM_Billing_Ebanx';
 		case 'brazil-tef':
@@ -123,7 +125,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 }
 
 export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMethodSlug | null {
-	if ( slug.startsWith( 'existingCard-' ) ) {
+	if ( slug.startsWith( 'existingCard' ) ) {
 		slug = 'card';
 	}
 	switch ( slug ) {

--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -45,6 +45,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'netbanking';
 		case 'WPCOM_Billing_Web_Payment':
 			return 'web-pay';
+		case 'WPCOM_Billing_MoneyPress_Stored':
+			return 'existingCard';
 	}
 	throw new Error( `Unknown payment method '${ paymentMethod }'` );
 }
@@ -124,9 +126,12 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 	return null;
 }
 
+/**
+ * Return the passed CheckoutPaymentMethodSlug if valid
+ */
 export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMethodSlug | null {
 	if ( slug.startsWith( 'existingCard' ) ) {
-		slug = 'card';
+		slug = 'existingCard';
 	}
 	switch ( slug ) {
 		case 'ebanx':
@@ -135,6 +140,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'paypal-direct':
 		case 'paypal':
 		case 'card':
+		case 'existingCard':
 		case 'alipay':
 		case 'bancontact':
 		case 'eps':

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -52,23 +52,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 					);
 				}
-				case 'EXISTING_CARD_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_MoneyPress_Stored',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_MoneyPress_Stored',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
-					);
-				}
 				default:
 					debug( 'unknown checkout event', action );
 					return reduxDispatch(

--- a/packages/wpcom-checkout/src/payment-methods/existing-credit-card.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/existing-credit-card.tsx
@@ -1,10 +1,4 @@
-import {
-	Button,
-	FormStatus,
-	useLineItems,
-	useFormStatus,
-	useEvents,
-} from '@automattic/composite-checkout';
+import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -142,7 +136,6 @@ function ExistingCardPayButton( {
 } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -158,7 +151,6 @@ function ExistingCardPayButton( {
 			disabled={ disabled }
 			onClick={ () => {
 				debug( 'submitting existing card payment' );
-				onEvent( { type: 'EXISTING_CARD_TRANSACTION_BEGIN' } );
 				onClick( 'existing-card', {
 					items,
 					name: cardholderName,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -228,7 +228,7 @@ export type CheckoutPaymentMethodSlug =
 	| 'full-credits'
 	| 'stripe-three-d-secure'
 	| 'wechat'
-	| `existingCard-${ string }` // a synonym for 'card'
+	| `existingCard-${ string }`
 	| 'apple-pay' // a synonym for 'web-pay'
 	| 'google-pay'; // a synonym for 'web-pay'
 

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -228,7 +228,7 @@ export type CheckoutPaymentMethodSlug =
 	| 'full-credits'
 	| 'stripe-three-d-secure'
 	| 'wechat'
-	| `existingCard-${ string }`
+	| `existingCard${ string }`
 	| 'apple-pay' // a synonym for 'web-pay'
 	| 'google-pay'; // a synonym for 'web-pay'
 

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -239,6 +239,7 @@ export type CheckoutPaymentMethodSlug =
  */
 export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_WPCOM'
+	| 'WPCOM_Billing_MoneyPress_Stored'
 	| 'WPCOM_Billing_Ebanx'
 	| 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef'
 	| 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the existing card transaction start analytics from the checkout event handler directly into where the events occur.

This involves adjusting some payment method types because up until now, existing cards were being treated in some cases the same as new cards. However, the analytics and transactions should actually be unaffected.

#### Testing instructions

- You'll need an account with at least one stored card.
- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- Add a plan to your cart and visit checkout.
- Next, select any existing card as your payment method in checkout and submit the transaction.
- Verify that you see the `calypso_checkout_form_submit` event triggered with `payment_method: 'WPCOM_Billing_MoneyPress_Stored'`.
- Verify that you see the `calypso_checkout_composite_existing_card_submit_clicked` event triggered.
<img width="621" alt="Screen Shot 2021-12-03 at 7 18 20 PM" src="https://user-images.githubusercontent.com/2036909/144688698-11ef8563-88e8-46f9-8306-de85ff876d21.png">


