### PR TITLE
E2E: update steps for Support:Popover spec.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-support__popover-valid.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-valid.ts
@@ -23,7 +23,6 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 		{ siteType: 'Atomic', user: 'eCommerceUser' },
 	] )( 'Search and view a support article ($siteType)', function ( { user } ) {
 		let supportComponent: SupportComponent;
-		let supportArticlePage: Page;
 
 		it( 'Log in', async function () {
 			const loginPage = new LoginPage( page );
@@ -54,16 +53,13 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 			expect( results.length ).toBeGreaterThan( 0 );
 		} );
 
-		it( 'Click and visit first support article', async function () {
+		it( 'Click on first search result', async function () {
 			await supportComponent.clickResult( 'article', 1 );
 			await supportComponent.clickReadMore();
-			// Obtain handle to the popup page.
-			supportArticlePage = await supportComponent.visitArticle();
 		} );
 
-		it( 'Close article page and preview', async function () {
-			await supportArticlePage.close();
-			await supportComponent.closeArticle();
+		it( 'Close popover', async function () {
+			await supportComponent.closePopover;
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the test for clicking on the support article.

Details:
The step to click on the support article has been quite unreliable in the past and was the cause for this test to be quarantined.

This change result in testing slightly less of Calypso, but I feel the tradeoff is worthwhile.

With this change, once its stability is proven then this test can be restored to the regular lineup.

#### Testing instructions

- [x] mobile
- [x] desktop
- [x] pre-release
- [x] quarantine

Related to #58683
