### PR TITLE
Shopping Cart: Reject action promises if an error occurs

### DIFF
--- a/client/components/forms/form-fieldset/index.jsx
+++ b/client/components/forms/form-fieldset/index.jsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 
 import './style.scss';
 
-const FormFieldset = ( { className, children, ...otherProps } ) => (
+const FormFieldset = ( { className = '', children, ...otherProps } ) => (
 	<fieldset { ...otherProps } className={ classnames( className, 'form-fieldset' ) }>
 		{ children }
 	</fieldset>

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -70,7 +70,11 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 			.forCartKey( cartKey )
 			.actions.replaceProductsInCart( domainChoiceCart )
 			.then( () => callback( undefined, providedDependencies ) )
-			.catch( ( error ) => callback( error, providedDependencies ) );
+			.catch( ( error ) => {
+				debug( 'product replace request had an error', error );
+				reduxStore.dispatch( errorNotice( error.message ) );
+				callback( error, providedDependencies );
+			} );
 	} else if ( designType === 'existing-site' ) {
 		const providedDependencies = {
 			siteId,
@@ -84,7 +88,11 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 			.forCartKey( siteId )
 			.actions.replaceProductsInCart( products )
 			.then( () => callback( undefined, providedDependencies ) )
-			.catch( ( error ) => callback( error, providedDependencies ) );
+			.catch( ( error ) => {
+				debug( 'product replace request had an error', error );
+				reduxStore.dispatch( errorNotice( error.message ) );
+				callback( error, providedDependencies );
+			} );
 	} else {
 		const newSiteData = {
 			cartItem,

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -464,15 +464,6 @@ function processItemCart(
 				.actions.addProductsToCart( newCartItemsToAdd )
 				.then( ( updatedCart ) => {
 					debug( 'product add request complete', updatedCart );
-					// Even if the cart request succeeds, there may be errors
-					if ( updatedCart.messages?.errors && updatedCart.messages.errors.length > 0 ) {
-						throw new Error( updatedCart.messages.errors[ 0 ].message );
-					}
-					const error = cartManagerClient.forCartKey( siteSlug ).getState().loadingError;
-					if ( error ) {
-						throw new Error( error );
-					}
-					debug( 'product add request successful' );
 					callback( undefined, providedDependencies );
 				} )
 				.catch( ( error ) => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -2,14 +2,14 @@ import { isJetpackProductSlug, isJetpackPlanSlug } from '@automattic/calypso-pro
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
-import type { RequestCartProduct } from '@automattic/shopping-cart';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const JETPACK_INTRO_COUPON_CODE = 'FRESHPACK';
 
 // **NOTE**: This hook can be safely deleted when we no longer need to
 // rely on auto-applied coupons for introductory new purchase pricing.
 const useMaybeJetpackIntroCouponCode = (
-	products: RequestCartProduct[],
+	products: MinimalRequestCartProduct[],
 	isCouponApplied: boolean
 ): string | undefined => {
 	const jetpackSaleCoupon = useSelector( getJetpackSaleCoupon );
@@ -29,7 +29,7 @@ const useMaybeJetpackIntroCouponCode = (
 		}
 
 		// Only apply FRESHPACK for new purchases, not renewals.
-		if ( jetpackProducts.some( ( product ) => product.extra.purchaseType === 'renewal' ) ) {
+		if ( jetpackProducts.some( ( product ) => product.extra?.purchaseType === 'renewal' ) ) {
 			return undefined;
 		}
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -238,14 +238,8 @@ class EmailProvidersComparison extends Component {
 			.then( () => {
 				if ( this.isMounted ) {
 					this.setState( { addingToCart: false } );
+					page( '/checkout/' + selectedSite.slug );
 				}
-				const { errors } = this.props?.cart?.messages;
-				if ( errors && errors.length ) {
-					// Stay on the page to show the relevant error(s)
-					return;
-				}
-
-				this.isMounted && page( '/checkout/' + selectedSite.slug );
 			} );
 	};
 
@@ -304,16 +298,8 @@ class EmailProvidersComparison extends Component {
 			.then( () => {
 				if ( this.isMounted ) {
 					this.setState( { addingToCart: false } );
+					page( '/checkout/' + selectedSite.slug );
 				}
-
-				const { errors } = this.props?.cart?.messages;
-
-				if ( errors && errors.length ) {
-					// Stay on the page to show the relevant error(s)
-					return;
-				}
-
-				this.isMounted && page( '/checkout/' + selectedSite.slug );
 			} );
 	};
 

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -172,6 +172,11 @@ class TitanAddMailboxes extends Component {
 					}
 
 					return this.isMounted && page( '/checkout/' + selectedSite.slug );
+				} )
+				.catch( () => {
+					if ( this.isMounted ) {
+						this.setState( { isAddingToCart: false } );
+					}
 				} );
 		}
 	};

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -164,14 +164,8 @@ class TitanAddMailboxes extends Component {
 				.then( () => {
 					if ( this.isMounted ) {
 						this.setState( { isAddingToCart: false } );
+						page( '/checkout/' + selectedSite.slug );
 					}
-					const { errors } = this.props?.cart?.messages;
-					if ( errors && errors.length ) {
-						// Stay on the page to show the relevant error
-						return;
-					}
-
-					return this.isMounted && page( '/checkout/' + selectedSite.slug );
 				} )
 				.catch( () => {
 					if ( this.isMounted ) {

--- a/client/state/products-list/selectors/get-product-by-slug.js
+++ b/client/state/products-list/selectors/get-product-by-slug.js
@@ -7,7 +7,7 @@ import 'calypso/state/products-list/init';
  *
  * @param {object} state - global state tree
  * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
- * @returns {?object} the corresponding product, or null if not found
+ * @returns {import('./get-products-list').ProductListItem|null} the corresponding product, or null if not found
  */
 export function getProductBySlug( state, productSlug ) {
 	return get( state, [ 'productsList', 'items', productSlug ], null );

--- a/client/state/products-list/selectors/get-product-price-tiers.ts
+++ b/client/state/products-list/selectors/get-product-price-tiers.ts
@@ -3,10 +3,6 @@ import type { PriceTierEntry } from '@automattic/calypso-products';
 import type { AppState } from 'calypso/types';
 import 'calypso/state/products-list/init';
 
-type Product = {
-	price_tier_list: PriceTierEntry[];
-};
-
 /**
  * Returns the price tiers of the specified product.
  *
@@ -15,7 +11,7 @@ type Product = {
  * @returns {PriceTierEntry[]} The price tiers.
  */
 export function getProductPriceTierList( state: AppState, productSlug: string ): PriceTierEntry[] {
-	const product = getProductBySlug( state, productSlug ) as Product;
+	const product = getProductBySlug( state, productSlug );
 
 	if ( ! product || ! product.price_tier_list ) {
 		return [];

--- a/client/state/products-list/selectors/get-products-list.js
+++ b/client/state/products-list/selectors/get-products-list.js
@@ -1,5 +1,0 @@
-import 'calypso/state/products-list/init';
-
-export function getProductsList( state ) {
-	return state.productsList.items;
-}

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -1,0 +1,23 @@
+import type { PriceTierEntry } from '@automattic/calypso-products';
+import type { AppState } from 'calypso/types';
+import 'calypso/state/products-list/init';
+
+export interface ProductListItem {
+	product_id: number;
+	product_name: string;
+	product_slug: string;
+	description: string;
+	product_type: string;
+	available: boolean;
+	is_domain_registration: boolean;
+	cost_display: string;
+	cost: number;
+	currency_code: string;
+	price_tier_list: PriceTierEntry[];
+	price_tier_usage_quantity: null | number;
+	price_tier_slug: string;
+}
+
+export function getProductsList( state: AppState ): Record< string, ProductListItem > {
+	return state.productsList.items;
+}

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -32,9 +32,9 @@ The `UseShoppingCart` object contains the following properties. Note that the ac
 - `loadingErrorType: ShoppingCartError | undefined`. If fetching or updating the cart causes an error, this will contain a string that explains what type of error.
 - `couponStatus: 'fresh' | 'pending' | 'applied' | 'rejected'. A string that can be used to determine if a coupon is applied.
 
-The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
+The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete). If there are errors returned by the cart endpoint (the `responseCart.messages.errors`), or if there is an error during the request (`loadingError`), the Promise will be rejected.
 
-**Note that the Promise returned by cart actions will never be rejected.** If there are errors returned by the shopping-cart response, they will be in the `messages.errors` property of the returned `ResponseCart`. If the cart request itself fails, the `loadingError` property will be set on the cart manager.
+Regardless, it's a good idea to always check `responseCart.messages.errors` and the `loadingError` property on the cart manager on any state change!
 
 - `addProductsToCart: ( products: RequestCartProduct[] ) => Promise<ResponseCart>`. A function that requests adding new products to the cart. May cause the cart to be replaced instead, depending on the RequestCartProducts (mostly renewals and non-renewals cannot co-exist in the cart at the same time).
 - `removeProductFromCart: ( uuidToRemove: string ) => Promise<ResponseCart>`. A function that requests removing a product from the cart.

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -34,7 +34,7 @@ The `UseShoppingCart` object contains the following properties. Note that the ac
 
 The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
 
-If there are errors returned by the cart endpoint (the `responseCart.messages.errors`), or if there is an error during the request (`loadingError`), the Promise will be rejected. The argument passed to the rejection will an instance of `CartActionError` with a `code` and a `message` property.
+If there are errors returned by the cart endpoint (the `responseCart.messages.errors`), or if there is an error during the request (`loadingError`), the Promise will be rejected. The argument passed to the rejection will an instance of `CartActionConnectionError` or `CartActionResponseError` (both subclasses of `CartActionError`) with a `code` and a `message` property.
 
 Regardless, it's a good idea to always check `responseCart.messages.errors` and the `loadingError` property on the cart manager after any state change!
 

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -34,7 +34,7 @@ The `UseShoppingCart` object contains the following properties. Note that the ac
 
 The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
 
-If there are errors returned by the cart endpoint (the `responseCart.messages.errors`), or if there is an error during the request (`loadingError`), the Promise will be rejected. The argument passed to the rejection will an instance of `ActionPromiseError` with a `code` and a `message` property.
+If there are errors returned by the cart endpoint (the `responseCart.messages.errors`), or if there is an error during the request (`loadingError`), the Promise will be rejected. The argument passed to the rejection will an instance of `CartActionError` with a `code` and a `message` property.
 
 Regardless, it's a good idea to always check `responseCart.messages.errors` and the `loadingError` property on the cart manager after any state change!
 

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -32,9 +32,11 @@ The `UseShoppingCart` object contains the following properties. Note that the ac
 - `loadingErrorType: ShoppingCartError | undefined`. If fetching or updating the cart causes an error, this will contain a string that explains what type of error.
 - `couponStatus: 'fresh' | 'pending' | 'applied' | 'rejected'. A string that can be used to determine if a coupon is applied.
 
-The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete). If there are errors returned by the cart endpoint (the `responseCart.messages.errors`), or if there is an error during the request (`loadingError`), the Promise will be rejected.
+The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
 
-Regardless, it's a good idea to always check `responseCart.messages.errors` and the `loadingError` property on the cart manager on any state change!
+If there are errors returned by the cart endpoint (the `responseCart.messages.errors`), or if there is an error during the request (`loadingError`), the Promise will be rejected. The argument passed to the rejection will an instance of `ActionPromiseError` with a `code` and a `message` property.
+
+Regardless, it's a good idea to always check `responseCart.messages.errors` and the `loadingError` property on the cart manager after any state change!
 
 - `addProductsToCart: ( products: RequestCartProduct[] ) => Promise<ResponseCart>`. A function that requests adding new products to the cart. May cause the cart to be replaced instead, depending on the RequestCartProducts (mostly renewals and non-renewals cannot co-exist in the cart at the same time).
 - `removeProductFromCart: ( uuidToRemove: string ) => Promise<ResponseCart>`. A function that requests removing a product from the cart.

--- a/packages/shopping-cart/src/action-promise-error.ts
+++ b/packages/shopping-cart/src/action-promise-error.ts
@@ -1,0 +1,9 @@
+export class ActionPromiseError extends Error {
+	code: string;
+
+	constructor( message: string, code: string ) {
+		super( message );
+		Object.setPrototypeOf( this, ActionPromiseError.prototype );
+		this.code = code;
+	}
+}

--- a/packages/shopping-cart/src/action-promise-error.ts
+++ b/packages/shopping-cart/src/action-promise-error.ts
@@ -1,9 +1,0 @@
-export class ActionPromiseError extends Error {
-	code: string;
-
-	constructor( message: string, code: string ) {
-		super( message );
-		Object.setPrototypeOf( this, ActionPromiseError.prototype );
-		this.code = code;
-	}
-}

--- a/packages/shopping-cart/src/errors.ts
+++ b/packages/shopping-cart/src/errors.ts
@@ -6,3 +6,7 @@ export class CartActionError extends Error {
 		this.code = code;
 	}
 }
+
+export class CartActionConnectionError extends CartActionError {}
+
+export class CartActionResponseError extends CartActionError {}

--- a/packages/shopping-cart/src/errors.ts
+++ b/packages/shopping-cart/src/errors.ts
@@ -1,0 +1,8 @@
+export class CartActionError extends Error {
+	code: string;
+
+	constructor( message: string, code: string ) {
+		super( message );
+		this.code = code;
+	}
+}

--- a/packages/shopping-cart/src/index.ts
+++ b/packages/shopping-cart/src/index.ts
@@ -5,4 +5,5 @@ export { default as createRequestCartProduct } from './create-request-cart-produ
 export * from './shopping-cart-manager';
 export * from './empty-carts';
 export * from './types';
+export * from './action-promise-error';
 export { convertResponseCartToRequestCart } from './cart-functions';

--- a/packages/shopping-cart/src/index.ts
+++ b/packages/shopping-cart/src/index.ts
@@ -5,5 +5,5 @@ export { default as createRequestCartProduct } from './create-request-cart-produ
 export * from './shopping-cart-manager';
 export * from './empty-carts';
 export * from './types';
-export * from './action-promise-error';
+export * from './errors';
 export { convertResponseCartToRequestCart } from './cart-functions';

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -44,7 +44,7 @@ function createDispatchAndWaitForValid(
 
 function getErrorFromState( state: ShoppingCartState ): undefined | ActionPromiseError {
 	if ( state.loadingError ) {
-		return new ActionPromiseError( state.loadingError, state.loadingErrorType ?? 'Unknown type' );
+		return new ActionPromiseError( state.loadingError, state.loadingErrorType );
 	}
 	const errorMessages = state.responseCart.messages?.errors ?? [];
 	if ( errorMessages.length > 0 ) {
@@ -74,12 +74,7 @@ function createShoppingCartManager(
 		state = newState;
 
 		if ( state.cacheStatus === 'error' ) {
-			actionPromises.reject(
-				new ActionPromiseError(
-					state.loadingError ?? 'Unknown error',
-					state.loadingErrorType ?? 'Unknown type'
-				)
-			);
+			actionPromises.reject( new ActionPromiseError( state.loadingError, state.loadingErrorType ) );
 		}
 
 		if ( ! isStatePendingUpdateOrQueuedAction( state ) ) {

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { CartActionError } from './errors';
+import { CartActionError, CartActionConnectionError, CartActionResponseError } from './errors';
 import {
 	getShoppingCartManagerState,
 	createSubscriptionManager,
@@ -44,12 +44,12 @@ function createDispatchAndWaitForValid(
 
 function getErrorFromState( state: ShoppingCartState ): undefined | CartActionError {
 	if ( state.loadingError ) {
-		return new CartActionError( state.loadingError, state.loadingErrorType );
+		return new CartActionConnectionError( state.loadingError, state.loadingErrorType );
 	}
 	const errorMessages = state.responseCart.messages?.errors ?? [];
 	if ( errorMessages.length > 0 ) {
 		const firstMessage = errorMessages[ 0 ];
-		return new CartActionError( firstMessage.message, firstMessage.code );
+		return new CartActionResponseError( firstMessage.message, firstMessage.code );
 	}
 	return undefined;
 }
@@ -74,7 +74,9 @@ function createShoppingCartManager(
 		state = newState;
 
 		if ( state.cacheStatus === 'error' ) {
-			actionPromises.reject( new CartActionError( state.loadingError, state.loadingErrorType ) );
+			actionPromises.reject(
+				new CartActionConnectionError( state.loadingError, state.loadingErrorType )
+			);
 		}
 
 		if ( ! isStatePendingUpdateOrQueuedAction( state ) ) {

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { ActionPromiseError } from './action-promise-error';
+import { CartActionError } from './errors';
 import {
 	getShoppingCartManagerState,
 	createSubscriptionManager,
@@ -42,14 +42,14 @@ function createDispatchAndWaitForValid(
 	};
 }
 
-function getErrorFromState( state: ShoppingCartState ): undefined | ActionPromiseError {
+function getErrorFromState( state: ShoppingCartState ): undefined | CartActionError {
 	if ( state.loadingError ) {
-		return new ActionPromiseError( state.loadingError, state.loadingErrorType );
+		return new CartActionError( state.loadingError, state.loadingErrorType );
 	}
 	const errorMessages = state.responseCart.messages?.errors ?? [];
 	if ( errorMessages.length > 0 ) {
 		const firstMessage = errorMessages[ 0 ];
-		return new ActionPromiseError( firstMessage.message, firstMessage.code );
+		return new CartActionError( firstMessage.message, firstMessage.code );
 	}
 	return undefined;
 }
@@ -74,7 +74,7 @@ function createShoppingCartManager(
 		state = newState;
 
 		if ( state.cacheStatus === 'error' ) {
-			actionPromises.reject( new ActionPromiseError( state.loadingError, state.loadingErrorType ) );
+			actionPromises.reject( new CartActionError( state.loadingError, state.loadingErrorType ) );
 		}
 
 		if ( ! isStatePendingUpdateOrQueuedAction( state ) ) {

--- a/packages/shopping-cart/src/shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/shopping-cart-reducer.ts
@@ -124,11 +124,21 @@ function shoppingCartReducer(
 			};
 
 		case 'FETCH_INITIAL_RESPONSE_CART':
-			return { ...state, cacheStatus: 'fresh-pending' };
+			return {
+				...state,
+				cacheStatus: 'fresh-pending',
+				loadingError: undefined,
+				loadingErrorType: undefined,
+			};
 
 		case 'CART_RELOAD':
 			debug( 'reloading cart from server' );
-			return { ...state, cacheStatus: 'fresh' };
+			return {
+				...state,
+				cacheStatus: 'fresh',
+				loadingError: undefined,
+				loadingErrorType: undefined,
+			};
 
 		case 'CLEAR_QUEUED_ACTIONS':
 			return { ...state, queuedActions: [] };
@@ -140,6 +150,8 @@ function shoppingCartReducer(
 				...state,
 				responseCart: removeItemFromResponseCart( state.responseCart, uuidToRemove ),
 				cacheStatus: 'invalid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 		}
 
@@ -149,6 +161,8 @@ function shoppingCartReducer(
 				...state,
 				responseCart: addItemsToResponseCart( state.responseCart, action.products ),
 				cacheStatus: 'invalid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 
 		case 'CART_PRODUCTS_REPLACE_ALL':
@@ -157,6 +171,8 @@ function shoppingCartReducer(
 				...state,
 				responseCart: replaceAllItemsInResponseCart( state.responseCart, action.products ),
 				cacheStatus: 'invalid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 
 		case 'CART_PRODUCT_REPLACE': {
@@ -179,6 +195,8 @@ function shoppingCartReducer(
 					action.productPropertiesToChange
 				),
 				cacheStatus: 'invalid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 		}
 
@@ -193,6 +211,8 @@ function shoppingCartReducer(
 				responseCart: removeCouponFromResponseCart( state.responseCart ),
 				couponStatus: 'fresh',
 				cacheStatus: 'invalid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 
 		case 'ADD_COUPON': {
@@ -210,6 +230,8 @@ function shoppingCartReducer(
 				responseCart: addCouponToResponseCart( state.responseCart, newCoupon ),
 				couponStatus: 'pending',
 				cacheStatus: 'invalid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 		}
 
@@ -220,6 +242,8 @@ function shoppingCartReducer(
 				responseCart: response,
 				couponStatus: getUpdatedCouponStatus( couponStatus, response ),
 				cacheStatus: 'valid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 		}
 
@@ -227,6 +251,8 @@ function shoppingCartReducer(
 			return {
 				...state,
 				cacheStatus: 'pending',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 
 		case 'RECEIVE_UPDATED_RESPONSE_CART': {
@@ -242,6 +268,8 @@ function shoppingCartReducer(
 				responseCart: response,
 				couponStatus: newCouponStatus,
 				cacheStatus: 'valid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
 			};
 		}
 
@@ -281,6 +309,8 @@ function shoppingCartReducer(
 					...state,
 					responseCart: addLocationToResponseCart( state.responseCart, action.location ),
 					cacheStatus: 'invalid',
+					loadingError: undefined,
+					loadingErrorType: undefined,
 				};
 			}
 			debug( 'cart location is the same; not updating' );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -135,25 +135,23 @@ export interface ShoppingCartManagerActions {
 
 export type ShoppingCartError = 'GET_SERVER_CART_ERROR' | 'SET_SERVER_CART_ERROR';
 
-export type ShoppingCartState =
+export type ShoppingCartState = {
+	responseCart: TempResponseCart;
+	lastValidResponseCart: ResponseCart;
+	couponStatus: CouponStatus;
+	queuedActions: ShoppingCartAction[];
+} & (
 	| {
-			responseCart: TempResponseCart;
-			lastValidResponseCart: ResponseCart;
-			couponStatus: CouponStatus;
 			cacheStatus: Exclude< CacheStatus, 'error' >;
 			loadingError?: undefined;
 			loadingErrorType?: undefined;
-			queuedActions: ShoppingCartAction[];
 	  }
 	| {
-			responseCart: TempResponseCart;
-			lastValidResponseCart: ResponseCart;
-			couponStatus: CouponStatus;
-			cacheStatus: Extract< CacheStatus, 'error' >;
+			cacheStatus: 'error';
 			loadingError: string;
 			loadingErrorType: ShoppingCartError;
-			queuedActions: ShoppingCartAction[];
-	  };
+	  }
+ );
 
 export interface WithShoppingCartProps {
 	shoppingCartManager: UseShoppingCart;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -1,4 +1,4 @@
-import type { ActionPromiseError } from './action-promise-error';
+import type { CartActionError } from './errors';
 import type { Dispatch } from 'react';
 
 export type ShoppingCartReducerDispatch = ( action: ShoppingCartAction ) => void;
@@ -166,12 +166,12 @@ export type DispatchAndWaitForValid = ( action: ShoppingCartAction ) => Promise<
 
 export type SavedActionPromise = {
 	resolve: ( responseCart: ResponseCart ) => void;
-	reject: ( error: ActionPromiseError ) => void;
+	reject: ( error: CartActionError ) => void;
 };
 
 export interface ActionPromises {
 	resolve: ( tempResponseCart: TempResponseCart ) => void;
-	reject: ( error: ActionPromiseError ) => void;
+	reject: ( error: CartActionError ) => void;
 	add: ( actionPromise: SavedActionPromise ) => void;
 }
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -135,15 +135,25 @@ export interface ShoppingCartManagerActions {
 
 export type ShoppingCartError = 'GET_SERVER_CART_ERROR' | 'SET_SERVER_CART_ERROR';
 
-export type ShoppingCartState = {
-	responseCart: TempResponseCart;
-	lastValidResponseCart: ResponseCart;
-	couponStatus: CouponStatus;
-	cacheStatus: CacheStatus;
-	loadingError?: string;
-	loadingErrorType?: ShoppingCartError;
-	queuedActions: ShoppingCartAction[];
-};
+export type ShoppingCartState =
+	| {
+			responseCart: TempResponseCart;
+			lastValidResponseCart: ResponseCart;
+			couponStatus: CouponStatus;
+			cacheStatus: Exclude< CacheStatus, 'error' >;
+			loadingError?: undefined;
+			loadingErrorType?: undefined;
+			queuedActions: ShoppingCartAction[];
+	  }
+	| {
+			responseCart: TempResponseCart;
+			lastValidResponseCart: ResponseCart;
+			couponStatus: CouponStatus;
+			cacheStatus: Extract< CacheStatus, 'error' >;
+			loadingError: string;
+			loadingErrorType: ShoppingCartError;
+			queuedActions: ShoppingCartAction[];
+	  };
 
 export interface WithShoppingCartProps {
 	shoppingCartManager: UseShoppingCart;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -1,3 +1,4 @@
+import type { ActionPromiseError } from './action-promise-error';
 import type { Dispatch } from 'react';
 
 export type ShoppingCartReducerDispatch = ( action: ShoppingCartAction ) => void;
@@ -155,12 +156,12 @@ export type DispatchAndWaitForValid = ( action: ShoppingCartAction ) => Promise<
 
 export type SavedActionPromise = {
 	resolve: ( responseCart: ResponseCart ) => void;
-	reject: ( error: string ) => void;
+	reject: ( error: ActionPromiseError ) => void;
 };
 
 export interface ActionPromises {
 	resolve: ( tempResponseCart: TempResponseCart ) => void;
-	reject: ( error: string ) => void;
+	reject: ( error: ActionPromiseError ) => void;
 	add: ( actionPromise: SavedActionPromise ) => void;
 }
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -153,9 +153,15 @@ export type CartValidCallback = ( cart: ResponseCart ) => void;
 
 export type DispatchAndWaitForValid = ( action: ShoppingCartAction ) => Promise< ResponseCart >;
 
+export type SavedActionPromise = {
+	resolve: ( responseCart: ResponseCart ) => void;
+	reject: ( error: string ) => void;
+};
+
 export interface ActionPromises {
 	resolve: ( tempResponseCart: TempResponseCart ) => void;
-	add: ( resolve: ( value: ResponseCart ) => void ) => void;
+	reject: ( error: string ) => void;
+	add: ( actionPromise: SavedActionPromise ) => void;
 }
 
 export interface CartSyncManager {

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -43,10 +43,11 @@ describe( 'ShoppingCartManager', () => {
 	} );
 
 	it( 'addProductsToCart rejects its promise if there are error messages in the response', async () => {
+		const errorCode = 'test-error';
 		const errorMessage = 'test error message';
 		const mockSetCart = jest.fn().mockResolvedValue( {
 			...getEmptyResponseCart(),
-			messages: { errors: [ { code: 'test-error', message: errorMessage } ] },
+			messages: { errors: [ { code: errorCode, message: errorMessage } ] },
 		} );
 		const cartManagerClient = createShoppingCartManagerClient( {
 			getCart,
@@ -54,11 +55,15 @@ describe( 'ShoppingCartManager', () => {
 		} );
 		const manager = cartManagerClient.forCartKey( mainCartKey );
 		await manager.fetchInitialCart();
-		const p1 = manager.actions.addProductsToCart( [ planOne ] );
-		return expect( p1 ).rejects.toEqual( errorMessage );
+		expect.assertions( 2 );
+		return manager.actions.addProductsToCart( [ planOne ] ).catch( ( error ) => {
+			expect( error.message ).toEqual( errorMessage );
+			expect( error.code ).toEqual( errorCode );
+		} );
 	} );
 
 	it( 'addProductsToCart rejects its promise if there is a connection error', async () => {
+		const errorCode = 'SET_SERVER_CART_ERROR';
 		const errorMessage = 'test error message';
 		const mockSetCart = jest.fn().mockRejectedValue( { message: errorMessage } );
 		const cartManagerClient = createShoppingCartManagerClient( {
@@ -67,8 +72,11 @@ describe( 'ShoppingCartManager', () => {
 		} );
 		const manager = cartManagerClient.forCartKey( mainCartKey );
 		await manager.fetchInitialCart();
-		const p1 = manager.actions.addProductsToCart( [ planOne ] );
-		return expect( p1 ).rejects.toEqual( errorMessage );
+		expect.assertions( 2 );
+		return manager.actions.addProductsToCart( [ planOne ] ).catch( ( error ) => {
+			expect( error.message ).toEqual( errorMessage );
+			expect( error.code ).toEqual( errorCode );
+		} );
 	} );
 
 	it( 'addProductsToCart adds the products to the cart if queued', async () => {

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -44,9 +44,10 @@ describe( 'ShoppingCartManager', () => {
 
 	it( 'addProductsToCart rejects its promise if there are error messages in the response', async () => {
 		const errorMessage = 'test error message';
-		const mockSetCart = jest
-			.fn()
-			.mockResolvedValue( { ...getEmptyResponseCart(), messages: { errors: [ errorMessage ] } } );
+		const mockSetCart = jest.fn().mockResolvedValue( {
+			...getEmptyResponseCart(),
+			messages: { errors: [ { code: 'test-error', message: errorMessage } ] },
+		} );
 		const cartManagerClient = createShoppingCartManagerClient( {
 			getCart,
 			setCart: mockSetCart,
@@ -59,7 +60,7 @@ describe( 'ShoppingCartManager', () => {
 
 	it( 'addProductsToCart rejects its promise if there is a connection error', async () => {
 		const errorMessage = 'test error message';
-		const mockSetCart = jest.fn().mockRejectedValue( errorMessage );
+		const mockSetCart = jest.fn().mockRejectedValue( { message: errorMessage } );
 		const cartManagerClient = createShoppingCartManagerClient( {
 			getCart,
 			setCart: mockSetCart,

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -42,6 +42,34 @@ describe( 'ShoppingCartManager', () => {
 		expect( responseCart.products[ 0 ].product_slug ).toBe( planOne.product_slug );
 	} );
 
+	it( 'addProductsToCart rejects its promise if there are error messages in the response', async () => {
+		const errorMessage = 'test error message';
+		const mockSetCart = jest
+			.fn()
+			.mockResolvedValue( { ...getEmptyResponseCart(), messages: { errors: [ errorMessage ] } } );
+		const cartManagerClient = createShoppingCartManagerClient( {
+			getCart,
+			setCart: mockSetCart,
+		} );
+		const manager = cartManagerClient.forCartKey( mainCartKey );
+		await manager.fetchInitialCart();
+		const p1 = manager.actions.addProductsToCart( [ planOne ] );
+		return expect( p1 ).rejects.toEqual( errorMessage );
+	} );
+
+	it( 'addProductsToCart rejects its promise if there is a connection error', async () => {
+		const errorMessage = 'test error message';
+		const mockSetCart = jest.fn().mockRejectedValue( errorMessage );
+		const cartManagerClient = createShoppingCartManagerClient( {
+			getCart,
+			setCart: mockSetCart,
+		} );
+		const manager = cartManagerClient.forCartKey( mainCartKey );
+		await manager.fetchInitialCart();
+		const p1 = manager.actions.addProductsToCart( [ planOne ] );
+		return expect( p1 ).rejects.toEqual( errorMessage );
+	} );
+
 	it( 'addProductsToCart adds the products to the cart if queued', async () => {
 		const cartManagerClient = createShoppingCartManagerClient( {
 			getCart,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The shopping cart manager in the `@automattic/shopping-cart` package returns a Promise when calling any of its actions. The Promise resolves, not when the action is complete, but when the cart next becomes "valid"; this means that several actions may be batched together and the Promise won't resolve until all of them complete. However, the Promise never rejects, which can be confusing because it breaks the typical Promise contract. 

An action can certainly fail, but it's not always easy to know what "failure" is since many errors still return a valid cart (with error messages included), and if there are multiple batched actions, which action failed? The original intention was that consumers would check for errors on the response themselves, but I believe that this will only create bugs (eg: https://github.com/Automattic/wp-calypso/pull/58428).

This PR changes the action Promise behavior so that it will now reject if one of two things occurs:

1. If any currently batched action experiences a connection issue, setting `loadingError` to a string. In this case, the `loadingError` and `loadingErrorType` will be passed as the rejection argument as an instance of `CartActionConnectionError`.
2. If the cart becomes "valid" after any number of batched actions, and the response contains a non-zero number of values in `responseCart.messages.errors`. The first error in that array will be passed as the rejection argument as an instance of `CartActionResponseError`.

In most cases this will not have any notable effect because most places that use cart actions already display errors from the cart to the user (via `CalypsoShoppingCartProvider` which includes `CartMessages`). The biggest difference will be that if an action fails before, say, a redirect to checkout, the error message will appear on the source page rather than the destination page.

#### Testing instructions

Unit tests are included.

Since this obviates the need for additional guards in most cases, this also reverts the guards added in https://github.com/Automattic/wp-calypso/pull/58428. Therefore, we should test that the functionality of that PR remains unchanged:

- You'll need to modify the shopping-cart endpoint to always return an error; D70551-code should do it.
- Visit `/start` and proceed through the signup flow, adding a paid plan to the cart.
- Verify that you are returned to the plan step.
- Verify that you see an error message displayed.