### PR TITLE
Section loading indicator: fix centering and scrolling

### DIFF
--- a/client/layout/loader.scss
+++ b/client/layout/loader.scss
@@ -2,9 +2,9 @@
 .layout__loader {
 	background: transparent;
 	border-bottom: 1px solid transparent;
-	height: 46px;
+	height: var( --masterbar-height );
 	margin-left: -10%;
-	position: absolute;
+	position: fixed;
 	left: 50%;
 	top: 0;
 	width: 20%;


### PR DESCRIPTION
The loading dot indicator that shows in the middle of the masterbar whey you're navigating to a new section:

<img width="621" alt="Screenshot 2021-12-04 at 7 56 48" src="https://user-images.githubusercontent.com/664258/144723240-0ae8fd85-09a1-4228-a6eb-2225fa35dbb3.png">

is not vertically centered correctly, and also if you scroll down the page it scroll away, too, instead of being glued to the masterbar.

This PR fixes both. It uses the `--masterbar-height` CSS var to set `height`, and `position: fixed` (just like the masterbar itself is positioned) instead of `absolute`.

The result is proper vertical centering both in a wide, desktop view:

<img width="612" alt="Screenshot 2021-12-04 at 21 00 14" src="https://user-images.githubusercontent.com/664258/144723292-610a0374-8812-4b51-b3be-5028057c7e48.png">

and in the mobile view with thicker masterbar, too:

<img width="691" alt="Screenshot 2021-12-04 at 21 00 47" src="https://user-images.githubusercontent.com/664258/144723309-9a05f4e9-c24d-4105-b84b-014d60652734.png">

