### PR TITLE
Remove `test` from Stripe dashboard link in Earn > Payments

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -437,7 +437,7 @@ class MembershipsSection extends Component {
 				<PopoverMenuItem
 					target="_blank"
 					rel="noopener norefferer"
-					href={ `https://dashboard.stripe.com/test/search?query=metadata%3A${ subscriber.user.ID }` }
+					href={ `https://dashboard.stripe.com/search?query=metadata%3A${ subscriber.user.ID }` }
 				>
 					<Gridicon size={ 18 } icon={ 'external' } />
 					{ this.props.translate( 'See transactions in Stripe Dashboard' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes `\test\` from the user-facing Stripe dashboard link in Tools > Earn > Payments

#### Testing instructions

1. Switch to this branch.
2. On a site with Stripe transactions, navigate to Tools > Earn > Payments in Calypso.
3. Click the dot menu next to a Customer/Subcriber, and select "See transactions in Stripe Dashboard".
4. Ensure the dashboard loads with the link `https://dashboard.stripe.com/search?query=metadata%3ASUBSCRIBERID`, without `\test\` in the URL.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57804
