### PR TITLE
Woo Installer: Convert transfer step to use v2 endpoint data-layer

### DIFF
--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
-import { useSelector } from 'react-redux';
 import Image01 from 'calypso/assets/images/woocommerce/woop-cta-image01.jpeg';
 import Image02 from 'calypso/assets/images/woocommerce/woop-cta-image02.jpeg';
 import Image03 from 'calypso/assets/images/woocommerce/woop-cta-image03.jpeg';
@@ -14,7 +13,6 @@ import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import MasonryWave from 'calypso/components/masonry-wave';
 import WarningCard from 'calypso/components/warning-card';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 import './style.scss';
 
@@ -35,10 +33,9 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 	const ctaRef = useRef( null );
 
 	const { hasBlockers, wpcomDomain, isDataReady } = useWooCommerceOnPlansEligibility( siteId );
-	const isAtomic = !! useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
 	function onCTAClickHandler() {
-		if ( isEnabled( 'woop' ) && ! isAtomic ) {
+		if ( isEnabled( 'woop' ) ) {
 			return page( `/start/woocommerce-install/?site=${ wpcomDomain }` );
 		}
 

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -93,7 +93,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		if ( isDataReady && ( isAtomicSite || isReadyForTransfer ) ) {
 			return goToStep( 'transfer' );
 		}
-	}, [ goToStep, isDataReady, isAtomicSite, isReadyForTransfer, wpcomDomain ] );
+	}, [ goToStep, isDataReady, isAtomicSite, isReadyForTransfer ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import page from 'page';
 import { ReactElement, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
@@ -90,17 +89,11 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	} = useWooCommerceOnPlansEligibility( siteId );
 
 	useEffect( () => {
-		if ( ! isAtomicSite ) {
-			// Automatically start the transfer process when it's ready.
-			if ( isReadyForTransfer ) {
-				return goToStep( 'transfer' );
-			}
-
-			return;
+		// Automatically start the transfer process when it's ready.
+		if ( isDataReady && ( isAtomicSite || isReadyForTransfer ) ) {
+			return goToStep( 'transfer' );
 		}
-
-		page.redirect( `/woocommerce-installation/${ wpcomDomain }` );
-	}, [ goToStep, isAtomicSite, isReadyForTransfer, wpcomDomain ] );
+	}, [ goToStep, isDataReady, isAtomicSite, isReadyForTransfer, wpcomDomain ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {
@@ -156,7 +149,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					<ActionSection>
 						<SupportLink />
 						<StyledNextButton
-							disabled={ hasBlockers || ! isDataReady || isAtomicSite }
+							disabled={ hasBlockers || ! isDataReady }
 							onClick={ () => {
 								if ( siteUpgrading.required ) {
 									return ( window.location.href = siteUpgrading.checkoutUrl );
@@ -172,7 +165,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		);
 	}
 
-	if ( ! siteId || ! isDataReady || isAtomicSite ) {
+	if ( ! siteId || ! isDataReady || isAtomicSite || isReadyForTransfer ) {
 		return (
 			<div className="confirm__info-section">
 				<LoadingEllipsis />

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -126,7 +126,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 			);
 		}
 
-		if ( warnings.length || isAtomicSite ) {
+		if ( warnings.length ) {
 			return (
 				<WarningsOrHoldsSection>
 					<Divider />

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -63,7 +63,7 @@ function SupportLink() {
 	return (
 		<SupportLinkContainer>
 			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
-				a: <SupportLinkStyle href="#support-link" />,
+				a: <SupportLinkStyle href="/help/contact" />,
 			} ) }
 		</SupportLinkContainer>
 	);

--- a/client/signup/steps/woocommerce-install/index.tsx
+++ b/client/signup/steps/woocommerce-install/index.tsx
@@ -1,8 +1,9 @@
-import type { GoToStep } from '../../types';
+import type { GoToStep, GoToNextStep } from '../../types';
 
 export interface WooCommerceInstallProps {
 	siteId: number;
 	goToStep: GoToStep;
+	goToNextStep: GoToNextStep;
 	stepName: string;
 	stepSectionName: string;
 	isReskinned: boolean;

--- a/client/signup/steps/woocommerce-install/transfer/error.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/error.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import { ReactElement } from 'react';
+import WarningCard from 'calypso/components/warning-card';
+import StepContent from './step-content';
+
+const WarningsOrHoldsSection = styled.div`
+	margin-bottom: 40px;
+`;
+
+export default function Error( { message }: { message: string } ): ReactElement {
+	const { __ } = useI18n();
+	// todo: both messages sort of say the same thing, refer to figma and fix
+	return (
+		<StepContent
+			title={ __( "We've hit a snag" ) }
+			subtitle={ __(
+				'It looks like something went wrong while setting up your store. If this is unexpected, please contact support so that we can help you out.'
+			) }
+		>
+			<WarningsOrHoldsSection>
+				<WarningCard
+					message={
+						message ||
+						__(
+							'There is an error that is stopping us from being able to install this product, please contact support.'
+						)
+					}
+				/>
+			</WarningsOrHoldsSection>
+		</StepContent>
+	);
+}

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -1,145 +1,23 @@
-import { Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactElement, useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
-import {
-	isFetchingAutomatedTransferStatus,
-	getAutomatedTransferStatus,
-} from 'calypso/state/automated-transfer/selectors';
-import { getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
-import { initiateThemeTransfer } from 'calypso/state/themes/actions';
-import { hasUploadFailed } from 'calypso/state/themes/upload-theme/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import InstallPlugins from './install-plugins';
+import TransferSite from './transfer-site';
 import type { WooCommerceInstallProps } from '../';
 
 import './style.scss';
 
 export default function Transfer( props: WooCommerceInstallProps ): ReactElement | null {
-	const { goToStep, isReskinned } = props;
+	const { isReskinned } = props;
 	const { __ } = useI18n();
-	const dispatch = useDispatch();
-
-	const [ progress, setProgress ] = useState( 0.1 );
-	const [ error, setError ] = useState( { transferFailed: false, transferStatus: null } );
-	const [ step, setStep ] = useState( __( 'Building your store' ) );
 
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const fetchingTransferStatus = !! useSelector( ( state ) =>
-		isFetchingAutomatedTransferStatus( state, siteId )
-	);
-	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
-	const transferFailed = useSelector( ( state ) => hasUploadFailed( state, siteId ) );
 
-	const wcAdmin = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) ) ?? '/';
-
-	// Initiate Atomic transfer
-	useEffect( () => {
-		if ( ! siteId ) {
-			return;
-		}
-
-		dispatch( fetchAutomatedTransferStatus( siteId ) );
-		dispatch( initiateThemeTransfer( siteId, null, 'woocommerce' ) );
-	}, [ siteId, dispatch ] );
-
-	// Watch transfer status
-	useEffect( () => {
-		if ( ! siteId ) {
-			goToStep( 'confirm' );
-			return;
-		}
-
-		if ( fetchingTransferStatus ) {
-			return;
-		}
-
-		// Note: most of these states are never seen and the ones you do see will
-		// sometimes be missed from transfer to transfer due to polling request timing.
-		switch ( transferStatus ) {
-			case transferStates.NONE:
-			case transferStates.PENDING:
-			case transferStates.INQUIRING:
-			case transferStates.PROVISIONED:
-			case transferStates.FAILURE:
-			case transferStates.START:
-			case transferStates.REVERTED:
-				setProgress( 0.2 );
-				break;
-			case transferStates.SETUP:
-			case transferStates.CONFLICTS:
-			case transferStates.ACTIVE:
-				setProgress( 0.5 );
-				break;
-			case transferStates.UPLOADING:
-			case transferStates.BACKFILLING:
-				setProgress( 0.6 );
-				break;
-			case transferStates.COMPLETE:
-				setProgress( 1 );
-				break;
-		}
-
-		if (
-			transferFailed ||
-			transferStatus === transferStates.ERROR ||
-			transferStatus === transferStates.FAILURE ||
-			transferStatus === transferStates.REQUEST_FAILURE ||
-			transferStatus === transferStates.CONFLICTS
-		) {
-			setProgress( 1 );
-			setError( { transferFailed, transferStatus } );
-		}
-	}, [ siteId, goToStep, fetchingTransferStatus, transferStatus, transferFailed, wcAdmin, __ ] );
-
-	// Progress smoothing, works out to be around 40seconds unless transfer step polling dictates otherwise
-	const [ simulatedProgress, setSimulatedProgress ] = useState( 0.01 );
-	useEffect( () => {
-		const timeOutReference = setTimeout( () => {
-			if ( progress > simulatedProgress || progress === 1 ) {
-				setSimulatedProgress( progress );
-			} else if ( simulatedProgress < 1 ) {
-				setSimulatedProgress( ( previousProgress ) => {
-					let newProgress = previousProgress + Math.random() * 0.05;
-					// Stall at 95%, allow complete to finish up
-					if ( newProgress >= 0.95 ) {
-						newProgress = 0.95;
-					}
-					return newProgress;
-				} );
-			}
-		}, 1000 );
-
-		if ( simulatedProgress >= 0.8 ) {
-			setStep( __( 'Turning on the lights' ) );
-		} else if ( simulatedProgress >= 0.6 ) {
-			setStep( __( 'Last paint touchups' ) );
-		} else if ( simulatedProgress >= 0 ) {
-			setStep( __( 'Building your store' ) );
-		}
-
-		return () => clearTimeout( timeOutReference );
-	}, [ simulatedProgress, progress, __ ] );
-
-	useEffect( () => {
-		if ( simulatedProgress < 1 ) {
-			return;
-		}
-
-		const timer = setTimeout( () => {
-			window.location.href = wcAdmin;
-		}, 5000 );
-
-		return function () {
-			if ( ! timer ) {
-				return;
-			}
-			window.clearTimeout( timer );
-		};
-	}, [ simulatedProgress, wcAdmin ] );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
 	return (
 		<StepWrapper
@@ -153,19 +31,8 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			isWideLayout={ isReskinned }
 			stepContent={
 				<>
-					<div className="transfer__heading-wrapper woocommerce-install__heading-wrapper">
-						<div className="transfer__heading woocommerce-install__heading">
-							<Title>{ step }</Title>
-						</div>
-					</div>
-					<div className="transfer__content woocommerce-install__content">
-						{ error.transferFailed && 'error...' /* todo */ }
-						{ error.transferFailed && error.transferStatus }
-						<div
-							className="transfer__progress-bar"
-							style={ { '--progress': simulatedProgress } as React.CSSProperties }
-						/>
-					</div>
+					{ isAtomic && <InstallPlugins /> }
+					{ ! isAtomic && <TransferSite /> }
 				</>
 			}
 			{ ...props }

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -1,4 +1,3 @@
-import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -11,24 +10,19 @@ import type { WooCommerceInstallProps } from '../';
 import './style.scss';
 
 export default function Transfer( props: WooCommerceInstallProps ): ReactElement | null {
-	const { isReskinned } = props;
-	const { __ } = useI18n();
-
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
-
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
 	return (
 		<StepWrapper
-			flowName="woocommerce-install"
-			hideSkip={ true }
-			nextLabelText={ __( 'Confirm' ) }
-			allowBackFirstStep={ true }
-			backUrl="/woocommerce-installation"
-			hideFormattedHeader={ true }
 			className="transfer__step-wrapper"
-			isWideLayout={ isReskinned }
+			flowName="woocommerce-install"
+			hideBack={ true }
+			hideNext={ true }
+			hideSkip={ true }
+			hideFormattedHeader={ true }
+			isWideLayout={ props.isReskinned }
 			stepContent={
 				<>
 					{ isAtomic && <InstallPlugins /> }

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -18,6 +18,7 @@ export default function InstallPlugins(): ReactElement | null {
 	const softwareStatus = useSelector( ( state ) =>
 		getAtomicSoftwareStatus( state, siteId, 'woo-on-plans' )
 	);
+	const softwareApplied = softwareStatus?.applied;
 	const wcAdmin = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) ) ?? '/';
 
 	const [ progress, setProgress ] = useState( 0.6 );
@@ -39,7 +40,7 @@ export default function InstallPlugins(): ReactElement | null {
 			setProgress( progress + 0.2 );
 			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
 		},
-		softwareStatus.applied ? null : 3000
+		softwareApplied ? null : 3000
 	);
 
 	// Redirect to wc-admin once software installation is confirmed.
@@ -48,14 +49,14 @@ export default function InstallPlugins(): ReactElement | null {
 			return;
 		}
 
-		if ( softwareStatus.applied ) {
+		if ( softwareApplied ) {
 			setProgress( 1 );
 			// Allow progress bar to complete
 			setTimeout( () => {
 				window.location.href = wcAdmin;
-			}, 1000 );
+			}, 500 );
 		}
-	}, [ siteId, softwareStatus, wcAdmin ] );
+	}, [ siteId, softwareApplied, wcAdmin ] );
 
 	// todo: Need error handling on these requests
 	return <Progress progress={ progress } />;

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -1,4 +1,3 @@
-import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -15,7 +14,6 @@ import StepContent from './step-content';
 import './style.scss';
 
 export default function InstallPlugins(): ReactElement | null {
-	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -60,7 +58,7 @@ export default function InstallPlugins(): ReactElement | null {
 	return (
 		<>
 			{
-				<StepContent title={ __( 'Building your store' ) }>
+				<StepContent>
 					<LoadingEllipsis />
 				</StepContent>
 			}

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -1,6 +1,5 @@
-import { ReactElement, useEffect } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import {
 	requestAtomicSoftwareStatus,
@@ -9,8 +8,7 @@ import {
 import { getAtomicSoftwareStatus } from 'calypso/state/atomic/software/selectors';
 import { getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import StepContent from './step-content';
-
+import Progress from './progress';
 import './style.scss';
 
 export default function InstallPlugins(): ReactElement | null {
@@ -22,6 +20,7 @@ export default function InstallPlugins(): ReactElement | null {
 	);
 	const wcAdmin = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) ) ?? '/';
 
+	const [ progress, setProgress ] = useState( 0.6 );
 	// Install Woo on plans software set
 	useEffect( () => {
 		if ( ! siteId ) {
@@ -37,7 +36,7 @@ export default function InstallPlugins(): ReactElement | null {
 			if ( ! siteId ) {
 				return;
 			}
-
+			setProgress( progress + 0.2 );
 			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
 		},
 		softwareStatus.applied ? null : 3000
@@ -50,18 +49,14 @@ export default function InstallPlugins(): ReactElement | null {
 		}
 
 		if ( softwareStatus.applied ) {
-			window.location.href = wcAdmin;
+			setProgress( 1 );
+			// Allow progress bar to complete
+			setTimeout( () => {
+				window.location.href = wcAdmin;
+			}, 1000 );
 		}
 	}, [ siteId, softwareStatus, wcAdmin ] );
 
 	// todo: Need error handling on these requests
-	return (
-		<>
-			{
-				<StepContent>
-					<LoadingEllipsis />
-				</StepContent>
-			}
-		</>
-	);
+	return <Progress progress={ progress } />;
 }

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -1,0 +1,69 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { ReactElement, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { useInterval } from 'calypso/lib/interval/use-interval';
+import {
+	requestAtomicSoftwareStatus,
+	requestAtomicSoftwareInstall,
+} from 'calypso/state/atomic/software/actions';
+import { getAtomicSoftwareStatus } from 'calypso/state/atomic/software/selectors';
+import { getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import StepContent from './step-content';
+
+import './style.scss';
+
+export default function InstallPlugins(): ReactElement | null {
+	const { __ } = useI18n();
+	const dispatch = useDispatch();
+	// selectedSiteId is set by the controller whenever site is provided as a query param.
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const softwareStatus = useSelector( ( state ) =>
+		getAtomicSoftwareStatus( state, siteId, 'woo-on-plans' )
+	);
+	const wcAdmin = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) ) ?? '/';
+
+	// Install Woo on plans software set
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		dispatch( requestAtomicSoftwareInstall( siteId, 'woo-on-plans' ) );
+	}, [ dispatch, siteId ] );
+
+	// Poll for status of installation
+	useInterval(
+		() => {
+			if ( ! siteId ) {
+				return;
+			}
+
+			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
+		},
+		softwareStatus.applied ? null : 3000
+	);
+
+	// Redirect to wc-admin once software installation is confirmed.
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		if ( softwareStatus.applied ) {
+			window.location.href = wcAdmin;
+		}
+	}, [ siteId, softwareStatus, wcAdmin ] );
+
+	// todo: Need error handling on these requests
+	return (
+		<>
+			{
+				<StepContent title={ __( 'Building your store' ) }>
+					<LoadingEllipsis />
+				</StepContent>
+			}
+		</>
+	);
+}

--- a/client/signup/steps/woocommerce-install/transfer/progress.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/progress.tsx
@@ -39,7 +39,7 @@ export default function Progress( { progress }: { progress: number } ): ReactEle
 		<StepContent title={ step }>
 			<div
 				className="transfer__progress-bar"
-				style={ { '--progress': progress } as React.CSSProperties }
+				style={ { '--progress': simulatedProgress } as React.CSSProperties }
 			/>
 		</StepContent>
 	);

--- a/client/signup/steps/woocommerce-install/transfer/progress.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/progress.tsx
@@ -1,0 +1,46 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { ReactElement, useState, useEffect } from 'react';
+import StepContent from './step-content';
+
+export default function Progress( { progress }: { progress: number } ): ReactElement {
+	const { __ } = useI18n();
+	const [ step, setStep ] = useState( __( 'Building your store' ) );
+
+	// Progress smoothing, works out to be around 40seconds unless transfer step polling dictates otherwise
+	const [ simulatedProgress, setSimulatedProgress ] = useState( 0.01 );
+	useEffect( () => {
+		const timeoutReference = setTimeout( () => {
+			if ( progress > simulatedProgress || progress === 1 ) {
+				setSimulatedProgress( progress );
+			} else if ( simulatedProgress < 1 ) {
+				setSimulatedProgress( ( previousProgress ) => {
+					let newProgress = previousProgress + Math.random() * 0.04;
+					// Stall at 95%, allow complete to finish up
+					if ( newProgress >= 0.95 ) {
+						newProgress = 0.95;
+					}
+					return newProgress;
+				} );
+			}
+		}, 1000 );
+
+		if ( simulatedProgress >= 0.8 ) {
+			setStep( __( 'Turning on the lights' ) );
+		} else if ( simulatedProgress >= 0.6 ) {
+			setStep( __( 'Last paint touchups' ) );
+		} else if ( simulatedProgress >= 0 ) {
+			setStep( __( 'Building your store' ) );
+		}
+
+		return () => clearTimeout( timeoutReference );
+	}, [ simulatedProgress, progress, __ ] );
+
+	return (
+		<StepContent title={ step }>
+			<div
+				className="transfer__progress-bar"
+				style={ { '--progress': progress } as React.CSSProperties }
+			/>
+		</StepContent>
+	);
+}

--- a/client/signup/steps/woocommerce-install/transfer/progress.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/progress.tsx
@@ -24,9 +24,9 @@ export default function Progress( { progress }: { progress: number } ): ReactEle
 			}
 		}, 1000 );
 
-		if ( simulatedProgress >= 0.8 ) {
+		if ( simulatedProgress >= 0.8 || progress >= 0.8 ) {
 			setStep( __( 'Turning on the lights' ) );
-		} else if ( simulatedProgress >= 0.6 ) {
+		} else if ( simulatedProgress >= 0.6 || progress >= 0.6 ) {
 			setStep( __( 'Last paint touchups' ) );
 		} else if ( simulatedProgress >= 0 ) {
 			setStep( __( 'Building your store' ) );
@@ -39,7 +39,9 @@ export default function Progress( { progress }: { progress: number } ): ReactEle
 		<StepContent title={ step }>
 			<div
 				className="transfer__progress-bar"
-				style={ { '--progress': simulatedProgress } as React.CSSProperties }
+				style={
+					{ '--progress': simulatedProgress > 1 ? 1 : simulatedProgress } as React.CSSProperties
+				}
 			/>
 		</StepContent>
 	);

--- a/client/signup/steps/woocommerce-install/transfer/progress.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/progress.tsx
@@ -6,7 +6,7 @@ export default function Progress( { progress }: { progress: number } ): ReactEle
 	const { __ } = useI18n();
 	const [ step, setStep ] = useState( __( 'Building your store' ) );
 
-	// Progress smoothing, works out to be around 40seconds unless transfer step polling dictates otherwise
+	// Progress smoothing, works out to be around 40seconds unless step polling dictates otherwise
 	const [ simulatedProgress, setSimulatedProgress ] = useState( 0.01 );
 	useEffect( () => {
 		const timeoutReference = setTimeout( () => {

--- a/client/signup/steps/woocommerce-install/transfer/step-content.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/step-content.tsx
@@ -1,0 +1,24 @@
+import { Title, SubTitle } from '@automattic/onboarding';
+import { ReactElement } from 'react';
+
+export default function StepContent( {
+	title,
+	subtitle,
+	children,
+}: {
+	title: string;
+	subtitle?: string;
+	children: ReactElement | null;
+} ): ReactElement {
+	return (
+		<>
+			<div className="transfer__heading-wrapper woocommerce-install__heading-wrapper">
+				<div className="transfer__heading woocommerce-install__heading">
+					<Title>{ title }</Title>
+					{ subtitle && <SubTitle>{ subtitle }</SubTitle> }
+				</div>
+			</div>
+			<div className="transfer__content woocommerce-install__content">{ children }</div>
+		</>
+	);
+}

--- a/client/signup/steps/woocommerce-install/transfer/step-content.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/step-content.tsx
@@ -6,7 +6,7 @@ export default function StepContent( {
 	subtitle,
 	children,
 }: {
-	title: string;
+	title?: string;
 	subtitle?: string;
 	children: ReactElement | null;
 } ): ReactElement {
@@ -14,7 +14,7 @@ export default function StepContent( {
 		<>
 			<div className="transfer__heading-wrapper woocommerce-install__heading-wrapper">
 				<div className="transfer__heading woocommerce-install__heading">
-					<Title>{ title }</Title>
+					{ title && <Title>{ title }</Title> }
 					{ subtitle && <SubTitle>{ subtitle }</SubTitle> }
 				</div>
 			</div>

--- a/client/signup/steps/woocommerce-install/transfer/style.scss
+++ b/client/signup/steps/woocommerce-install/transfer/style.scss
@@ -3,6 +3,15 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
+.transfer__step-wrapper {
+	.step-wrapper__content {
+		padding: 1em;
+		max-width: 540px;
+		text-align: center;
+		margin: 32vh auto;
+	}
+}
+
 $progress-duration: 800ms;
 
 .transfer__progress-bar {
@@ -23,42 +32,5 @@ $progress-duration: 800ms;
 		right: 0;
 		bottom: 0;
 		transition: transform $progress-duration ease-out;
-	}
-}
-
-.transfer__step-wrapper {
-	.step-wrapper__content {
-		padding: 1em;
-		max-width: 540px;
-		text-align: center;
-		margin: 32vh auto;
-
-		&.is-force-centered {
-			position: fixed;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-		}
-
-		.transfer__progress-steps {
-			margin-top: 0.7em;
-			padding: 1em;
-			text-align: center;
-			color: var( --studio-gray-40 );
-		}
-
-		.transfer__progress-step {
-			@include onboarding-font-recoleta;
-			/* stylelint-disable-next-line scales/font-sizes */
-			font-size: 1.625rem;
-			line-height: 40px;
-			text-align: center;
-			vertical-align: middle;
-			margin: 0;
-		}
 	}
 }

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -1,0 +1,97 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { ReactElement, useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useInterval } from 'calypso/lib/interval/use-interval';
+import { requestAtomicSoftwareStatus } from 'calypso/state/atomic/software/actions';
+import { getAtomicSoftwareStatus } from 'calypso/state/atomic/software/selectors';
+import {
+	initiateAtomicTransfer,
+	requestLatestAtomicTransfer,
+} from 'calypso/state/atomic/transfers/actions';
+import { transferStates } from 'calypso/state/atomic/transfers/constants';
+import { getLatestAtomicTransfer } from 'calypso/state/atomic/transfers/selectors';
+import { getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import Error from './error';
+import Progress from './progress';
+
+import './style.scss';
+
+export default function TransferSite(): ReactElement | null {
+	const { __ } = useI18n();
+	const dispatch = useDispatch();
+
+	const [ progress, setProgress ] = useState( 0.1 );
+
+	// selectedSiteId is set by the controller whenever site is provided as a query param.
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const transfer = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
+	const transferStatus = transfer?.status;
+	const transferFailed = !! transfer?.error;
+	const softwareStatus = useSelector( ( state ) =>
+		getAtomicSoftwareStatus( state, siteId, 'woo-on-plans' )
+	);
+	const wcAdmin = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) ) ?? '/';
+
+	// Initiate Atomic transfer
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+		dispatch( initiateAtomicTransfer( siteId, { softwareSet: 'woo-on-plans' } ) );
+	}, [ dispatch, siteId ] );
+
+	// Poll for transfer status
+	useInterval(
+		() => {
+			dispatch( requestLatestAtomicTransfer( siteId ) );
+		},
+		transferStatus === transferStates.COMPLETED || transferFailed ? null : 3000
+	);
+
+	// Poll for software status
+	useInterval(
+		() => {
+			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
+		},
+		softwareStatus?.applied ? null : 3000
+	);
+
+	// Watch transfer status
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		switch ( transferStatus ) {
+			case transferStates.PENDING:
+				setProgress( 0.2 );
+				break;
+			case transferStates.ACTIVE:
+				setProgress( 0.4 );
+				break;
+			case transferStates.PROVISIONED:
+				setProgress( 0.6 );
+				break;
+			case transferStates.COMPLETED:
+				if ( softwareStatus?.applied ) {
+					setProgress( 1 );
+					window.location.href = wcAdmin;
+				}
+				setProgress( 0.9 );
+				break;
+		}
+
+		if ( transferFailed || transferStatus === transferStates.ERROR ) {
+			setProgress( 1 );
+		}
+	}, [ siteId, transferStatus, transferFailed, softwareStatus, wcAdmin, __ ] );
+
+	// todo: transferFailed states need testing and if required, pass the message through correctly
+	return (
+		<>
+			{ transferFailed && <Error message={ transferStatus || '' } /> }
+			{ ! transferFailed && <Progress progress={ progress } /> }
+		</>
+	);
+}

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -26,9 +26,10 @@ export default function TransferSite(): ReactElement | null {
 	const transfer = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
 	const transferStatus = transfer?.status;
 	const transferFailed = !! transfer?.error;
-	const softwareStatus = useSelector( ( state ) =>
+	const software = useSelector( ( state ) =>
 		getAtomicSoftwareStatus( state, siteId, 'woo-on-plans' )
 	);
+	const softwareApplied = software?.applied;
 	const wcAdmin = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) ) ?? '/';
 
 	// Initiate Atomic transfer or software install
@@ -52,7 +53,7 @@ export default function TransferSite(): ReactElement | null {
 		() => {
 			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
 		},
-		softwareStatus?.applied ? null : 3000
+		softwareApplied ? null : 3000
 	);
 
 	// Watch transfer status
@@ -87,14 +88,14 @@ export default function TransferSite(): ReactElement | null {
 			return;
 		}
 
-		if ( softwareStatus?.applied ) {
+		if ( softwareApplied ) {
 			setProgress( 1 );
 			// Allow progress bar to complete
 			setTimeout( () => {
 				window.location.href = wcAdmin;
-			}, 1000 );
+			}, 500 );
 		}
-	}, [ siteId, softwareStatus, wcAdmin ] );
+	}, [ siteId, softwareApplied, wcAdmin ] );
 
 	// todo: transferFailed states need testing and if required, pass the message through correctly
 	return (

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -17,3 +17,5 @@ export interface Flow {
 }
 
 export type GoToStep = ( stepName: string, stepSectionName?: string, flowName?: string ) => void;
+
+export type GoToNextStep = ( nextFlowName?: string ) => void;

--- a/client/state/atomic/software/reducer.js
+++ b/client/state/atomic/software/reducer.js
@@ -12,6 +12,7 @@ function software( state = {}, action ) {
 				...action?.status,
 			};
 	}
+	return state;
 }
 
 export default withStorageKey(

--- a/client/state/atomic/transfers/reducer.js
+++ b/client/state/atomic/transfers/reducer.js
@@ -7,6 +7,7 @@ function transfers( state = {}, action ) {
 		case ATOMIC_TRANSFER_SET_LATEST:
 			return { ...state, siteId: action.siteId, ...action.transfer };
 	}
+	return state;
 }
 
 export default withStorageKey( 'atomicTransfers', keyedReducer( 'siteId', transfers ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reworking transfer step for making use of:
* https://github.com/Automattic/wp-calypso/pull/58709 (merged)
* ~D70860-code~ - software endpoint
* ~D71460-code~ ~D70856-code~ - transfer endpoint
* ~D71447-code~ ~D70867-code~ - transfer endpoint software install job
* Rework error handling to close out #58331

#### Testing instructions

- Start an install flow with a simple site via /woocommerce-installation, it should kick off a transfer and install WooCommerce and Woo Payments. It will also require an upgrade if needed.
- Start an install flow with an Atomic site from /woocommerce-installation, it should install WooCommerce and Woo Payments.

Related to #58227