### PR TITLE
Plugins: Migrate `SinglePlugin` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -44,14 +44,11 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
 
 class SinglePlugin extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( ! this.isFetched() ) {
 			this.props.wporgFetchPluginData( this.props.pluginSlug );
 		}
-	}
 
-	componentDidMount() {
 		this.hasAlreadyShownTheTour = false;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `SinglePlugin` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions

* Go to `/plugins/:site` where `:site` is a Jetpack site.
* Click on a plugin.
* Verify that a request to `https://api.wordpress.org/plugins/info/1.2/?action=plugin_information...` is performed and the plugin is loaded correctly.