### PR TITLE
Onboarding: update `start building` link

### DIFF
--- a/client/signup/steps/import/ready/index.tsx
+++ b/client/signup/steps/import/ready/index.tsx
@@ -92,7 +92,7 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( { goToStep } ) 
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ () => goToStep( 'design-setup-site', '', 'setup-site' ) }>
+						<NextButton onClick={ () => goToStep( 'intent', '', 'setup-site' ) }>
 							{ __( 'Start building' ) }
 						</NextButton>
 						<div>
@@ -190,7 +190,7 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ () => goToStep( 'design-setup-site', '', 'setup-site' ) }>
+						<NextButton onClick={ () => goToStep( 'intent', '', 'setup-site' ) }>
 							{ __( 'Start building' ) }
 						</NextButton>
 						<div>

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -60,7 +60,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.validateScanningPage();
 			await startImportFlow.validateBuildingPage( reason );
 			await startImportFlow.startBuilding();
-			await startImportFlow.validateDesignPage();
+			await startImportFlow.validateSetupPage();
 		} );
 	} );
 
@@ -122,20 +122,6 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'example.com' );
 			await startImportFlow.clickButton( 'Back to start' );
 			await startImportFlow.validateURLCapturePage();
-		} );
-	} );
-
-	// Go back from a importer error page
-	describe( 'Go back from building page', () => {
-		navigateToSetup();
-
-		// Back to setup page from the design page
-		it( 'Back to URL capture page from error page', async () => {
-			await startImportFlow.enterURL( 'example.com' );
-			await startImportFlow.startBuilding();
-			await startImportFlow.validateDesignPage();
-			await startImportFlow.goBackOneScreen();
-			await startImportFlow.validateSetupPage();
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Redirect to the `intent` screen instead of `design-setup-site`.
Fixes #58163

#### Testing instructions
* Go to `/start/importer?siteSlug={YOUR_SITE}.wordpress.com`
* Enter another WP.com website
* The screen`Your site is already on WordPress.com` will be shown
* Click on the `Start building` button
* Instead of `design-site-site`, `intent` screen will be shown

#### Screenshot
<img width="749" alt="Screenshot 2021-12-06 at 12 04 17" src="https://user-images.githubusercontent.com/1241413/144835426-df2d081f-404b-4433-b274-85ed9ee93e78.png">

Related to #58163
