### PR TITLE
Tour-kit: Use constrained tabbing utility from core

### DIFF
--- a/packages/tour-kit/src/hooks/use-focus-trap.ts
+++ b/packages/tour-kit/src/hooks/use-focus-trap.ts
@@ -1,8 +1,8 @@
 /**
  * External Dependencies
  */
+import { focus } from '@wordpress/dom';
 import { useEffect, useCallback, useState } from '@wordpress/element';
-
 /**
  * A hook that constraints tabbing/focus on focuable elements in the given element ref.
  *
@@ -39,23 +39,11 @@ const useFocusTrap = ( ref: React.MutableRefObject< null | HTMLElement > ): void
 	);
 
 	useEffect( () => {
-		const focusableElementSelectors = [
-			'a[href]:not([disabled])',
-			'button:not([disabled])',
-			'textarea:not([disabled])',
-			'input[type="text"]:not([disabled])',
-			'input[type="radio"]:not([disabled])',
-			'input[type="checkbox"]:not([disabled])',
-			'select:not([disabled])',
-		];
-
-		const focusableElements = ref.current?.querySelectorAll< HTMLElement >(
-			focusableElementSelectors.toString()
-		);
+		const focusableElements = focus.focusable.find( ref.current as HTMLElement );
 
 		if ( focusableElements && focusableElements.length ) {
-			setFirstFocusableElement( focusableElements[ 0 ] );
-			setLastFocusableElement( focusableElements[ focusableElements.length - 1 ] );
+			setFirstFocusableElement( focusableElements[ 0 ] as HTMLElement );
+			setLastFocusableElement( focusableElements[ focusableElements.length - 1 ] as HTMLElement );
 		}
 
 		document.addEventListener( 'keydown', handleTrapFocus );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In tour-kit, we provide our own custom hook for trapping focus within the tour (so tabbing does not escape to the rest of the page). (`use-focus-trap`)

Core has a hook that does similar things: [use-constrained-tabbing.](https://github.com/WordPress/gutenberg/tree/trunk/packages/compose/src/hooks/use-constrained-tabbing) and it uses `@wordpress/dom` to find tabbable elements. We could not manage to use `use-constrained-tabbing` directly, but we changed our implementation to take advantage of the use of `@wordpress/dom`


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  checkout branch
* `yarn dev --sync` from `apps/editing-toolkit` to sync the welcome tour to the sandbox
*  test that Welcome Tour tabbing works as usual ( tab has focus inside the tour when maximized, in all the page when minimized )

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57224
Related to #57224
