### PR TITLE
Analytics: Migrate `TrackComponentView` away from `UNSAFE_` methods

### DIFF
--- a/client/lib/analytics/track-component-view/index.jsx
+++ b/client/lib/analytics/track-component-view/index.jsx
@@ -23,7 +23,7 @@ class TrackComponentView extends Component {
 	};
 
 	componentDidMount() {
-		debug( 'Component will mount.' );
+		debug( 'Component did mount.' );
 		const { eventName, eventProperties } = this.props;
 		if ( eventName ) {
 			debug( `Recording Tracks event "${ eventName }".` );

--- a/client/lib/analytics/track-component-view/index.jsx
+++ b/client/lib/analytics/track-component-view/index.jsx
@@ -22,8 +22,7 @@ class TrackComponentView extends Component {
 		bumpStat: () => {},
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		debug( 'Component will mount.' );
 		const { eventName, eventProperties } = this.props;
 		if ( eventName ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `TrackComponentView` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions

* Type `localStorage.setItem( 'debug', 'calypso:analytics' )` in your console.
* Go to `/plans/:site` and verify you can see a `Record event "calypso_plans_view" called with props ...` message in the console.