### PR TITLE
FSE Beta: increase opt-in percentage to 20%

### DIFF
--- a/client/landing/gutenboarding/hooks/use-fse-beta-eligibility.ts
+++ b/client/landing/gutenboarding/hooks/use-fse-beta-eligibility.ts
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { USER_STORE } from '../stores/user';
 
-const FSE_BETA_ROLLOUT_PERCENTAGE = 10;
+const FSE_BETA_ROLLOUT_PERCENTAGE = 20;
 
 export default function useFseBetaEligibility(): boolean {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Increase the percentage of existing users that get the FSE Beta opt-in during new site creation to 20%.

#### Testing instructions

Same as #56585.


