### PR TITLE
WPCOM: migrate wpcom.undocumented().wordAdsApprove() to wpcom.req

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -253,17 +253,6 @@ Undocumented.prototype.getSiteConnectInfo = function ( inputUrl ) {
 };
 
 /**
- * Requests streamlined approval to WordAds program
- *
- * @param {number}       siteId            The site ID
- * @returns {Promise} A promise representing the request
- */
-Undocumented.prototype.wordAdsApprove = function ( siteId ) {
-	debug( '/sites/:site:/wordads/approve' );
-	return this.wpcom.req.post( '/sites/' + siteId + '/wordads/approve' );
-};
-
-/**
  * Fetch the status of an Automated Transfer.
  *
  * @param {number} siteId -- the ID of the site being transferred

--- a/client/state/wordads/approve/actions.js
+++ b/client/state/wordads/approve/actions.js
@@ -15,9 +15,8 @@ export const requestWordAdsApproval = ( siteId ) => ( dispatch ) => {
 		siteId,
 	} );
 
-	return wpcom
-		.undocumented()
-		.wordAdsApprove( siteId )
+	return wpcom.req
+		.post( `/sites/${ siteId }/wordads/approve` )
 		.then( ( result ) => {
 			dispatch( {
 				type: WORDADS_SITE_APPROVE_REQUEST_SUCCESS,


### PR DESCRIPTION
Migrate `wpcom.undocumented().wordAdsApprove()` to `wpcom.req.post`. There's only one usage.

**How to test:**
On a site with a Premium+ plan, go to `/earn/ads-settings` an click the "Join WordAds" button:

<img width="605" alt="Screenshot 2021-12-06 at 16 13 27" src="https://user-images.githubusercontent.com/664258/144872149-c320222b-bf76-450c-a10c-7d3775040263.png">

Verify that it fired the `wordads/approve` request. You'll be queued for a (manual?) approval if your site is eligible to run WordAds.
