### PR TITLE
Videos UI: use `duration_seconds`

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -1,8 +1,8 @@
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { cloneElement, useEffect, useState } from 'react';
 import moment from 'moment';
+import { cloneElement, useEffect, useState } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import useUpdateUserCourseProgressionMutation from 'calypso/data/courses/use-update-user-course-progression-mutation';

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -156,7 +156,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 												{ i + 1 }. { videoInfo.title }{ ' ' }
 											</span>
 											<span className="videos-ui__duration"> 
-												{ moment.unix( videoInfo.duration_seconds ).format('m:ss') } 
+												{ moment.unix( videoInfo.duration_seconds ).format( 'm:ss' ) }
 											</span>
 											{ isVideoCompleted && (
 												<span className="videos-ui__completed-checkmark">

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { cloneElement, useEffect, useState } from 'react';
+import moment from 'moment';
 import { useSelector, shallowEqual } from 'react-redux';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import useUpdateUserCourseProgressionMutation from 'calypso/data/courses/use-update-user-course-progression-mutation';
@@ -154,7 +155,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 											<span className="videos-ui__video-title">
 												{ i + 1 }. { videoInfo.title }{ ' ' }
 											</span>
-											<span className="videos-ui__duration"> { videoInfo.duration } </span>{ ' ' }
+											<span className="videos-ui__duration"> { moment.unix( videoInfo.duration_seconds ).format('m:ss') } </span>{ ' ' }
 											{ isVideoCompleted && (
 												<span className="videos-ui__completed-checkmark">
 													<Gridicon icon="checkmark" size={ 12 } />

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -155,7 +155,9 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 											<span className="videos-ui__video-title">
 												{ i + 1 }. { videoInfo.title }{ ' ' }
 											</span>
-											<span className="videos-ui__duration"> { moment.unix( videoInfo.duration_seconds ).format('m:ss') } </span>{ ' ' }
+											<span className="videos-ui__duration"> 
+												{ moment.unix( videoInfo.duration_seconds ).format('m:ss') } 
+											</span>
 											{ isVideoCompleted && (
 												<span className="videos-ui__completed-checkmark">
 													<Gridicon icon="checkmark" size={ 12 } />

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -155,7 +155,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 											<span className="videos-ui__video-title">
 												{ i + 1 }. { videoInfo.title }{ ' ' }
 											</span>
-											<span className="videos-ui__duration"> 
+											<span className="videos-ui__duration">
 												{ moment.unix( videoInfo.duration_seconds ).format( 'm:ss' ) }
 											</span>
 											{ isVideoCompleted && (


### PR DESCRIPTION
This PR uses the attribute introduced in D71068-code. It also formats the value to show it in the UI.

#### Testing
1. Apply D71068-code to your sandbox if not merged.
2. Open the Videos UI.
2. Verify videos durations are the same as in this screenshot:
![image](https://user-images.githubusercontent.com/375980/144873470-86f32544-6dfc-410d-be7d-4b2bfb2f8468.png)

Related to https://github.com/Automattic/wp-calypso/issues/58775