### PR TITLE
Domains: Fix domain-only flow adding `siteUrl` missing dependency

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -325,7 +325,7 @@ export function generateSteps( {
 		},
 		'domain-only': {
 			stepName: 'domain-only',
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ], // note: siteId, siteSlug are not provided when used in domain flow
+			providesDependencies: [ 'siteId', 'siteSlug', 'siteUrl', 'domainItem' ], // note: siteId, siteSlug are not provided when used in domain flow
 			props: {
 				isDomainOnly: true,
 				forceHideFreeDomainExplainerAndStrikeoutUi: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
`siteUrl` is currently used as a provided dependency on the domain-only step - but it was not passed on the `providedDependencies` array at `client/signup/config/steps-pure.js`, which would break the domain-only flow when coming from https://wordpress.com/domains/get/com page. This PR fixes it by adding it as one of the dependencies 😸 

#### Testing instructions
- Go to `/start/domain/domain-only?new=test-new-test.com` and check that the flow is able to proceed without breaking;
- Also make sure that the domain-only flow isn't broken when going to `/start/domain/domain-only` - confirm that you're able to finish the flow.

Related to #58836 - it will be fixed after deployment.
