### PR TITLE
Plugins Browser: Add missing info in the plugin browser item.

### DIFF
--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -64,7 +64,7 @@ export function fetchPluginsList( options ) {
 		'request[page]': page,
 		'request[per_page]': pageSize,
 		'request[fields]':
-			'icons,last_updated,-active_installs,-downloaded,-ratings,-rating,-requires,-requires_php,-tags,-tested,-contributors,-added,-donate_link,-homepage',
+			'icons,last_updated,rating,-active_installs,-downloaded,-ratings,-requires,-requires_php,-tags,-tested,-contributors,-added,-donate_link,-homepage',
 		'request[locale]': getWporgLocaleCode( options.locale ),
 	};
 

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -64,7 +64,7 @@ export function fetchPluginsList( options ) {
 		'request[page]': page,
 		'request[per_page]': pageSize,
 		'request[fields]':
-			'icons,-active_installs,-downloaded,-last_updated,-ratings,-rating,-requires,-requires_php,-tags,-tested,-contributors,-added,-donate_link,-homepage',
+			'icons,last_updated,-active_installs,-downloaded,-ratings,-rating,-requires,-requires_php,-tags,-tested,-contributors,-added,-donate_link,-homepage',
 		'request[locale]': getWporgLocaleCode( options.locale ),
 	};
 

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -64,7 +64,7 @@ export function fetchPluginsList( options ) {
 		'request[page]': page,
 		'request[per_page]': pageSize,
 		'request[fields]':
-			'icons,last_updated,rating,-active_installs,-downloaded,-ratings,-requires,-requires_php,-tags,-tested,-contributors,-added,-donate_link,-homepage',
+			'icons,last_updated,rating,active_installs,-downloaded,-ratings,-requires,-requires_php,-tags,-tested,-contributors,-added,-donate_link,-homepage',
 		'request[locale]': getWporgLocaleCode( options.locale ),
 	};
 

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -64,7 +64,7 @@ export function fetchPluginsList( options ) {
 		'request[page]': page,
 		'request[per_page]': pageSize,
 		'request[fields]':
-			'icons,last_updated,rating,active_installs,-downloaded,-ratings,-requires,-requires_php,-tags,-tested,-contributors,-added,-donate_link,-homepage',
+			'icons,last_updated,rating,active_installs,tested,-downloaded,-ratings,-requires,-requires_php,-tags,-contributors,-added,-donate_link,-homepage',
 		'request[locale]': getWporgLocaleCode( options.locale ),
 	};
 

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -90,7 +90,15 @@ class PluginRatings extends Component {
 	}
 
 	render() {
-		const { placeholder, ratings, rating, numRatings, downloaded } = this.props;
+		const {
+			placeholder,
+			ratings,
+			rating,
+			numRatings,
+			inlineNumRatings,
+			downloaded,
+			hideRatingValue,
+		} = this.props;
 
 		if ( placeholder ) {
 			return this.renderPlaceholder();
@@ -105,7 +113,10 @@ class PluginRatings extends Component {
 			<div className="plugin-ratings">
 				<div className="plugin-ratings__rating-stars">
 					<Rating rating={ rating } />
-					<span className="plugin-ratings__number">{ rating / 20 }</span>
+					{ inlineNumRatings && (
+						<span className="plugin-ratings__num-ratings">({ inlineNumRatings })</span>
+					) }
+					{ ! hideRatingValue && <span className="plugin-ratings__number">{ rating / 20 }</span> }
 				</div>
 				{ numRatings && (
 					<div className="plugin-ratings__rating-text">

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import Rating from 'calypso/components/rating';
@@ -97,7 +97,7 @@ class PluginRatings extends Component {
 			numRatings,
 			inlineNumRatings,
 			downloaded,
-			hideRatingValue,
+			hideRatingNumber,
 		} = this.props;
 
 		if ( placeholder ) {
@@ -113,12 +113,18 @@ class PluginRatings extends Component {
 			<div className="plugin-ratings">
 				<div className="plugin-ratings__rating-stars">
 					<Rating rating={ rating } />
-					{ inlineNumRatings && (
-						<span className="plugin-ratings__num-ratings">({ inlineNumRatings })</span>
+					{ inlineNumRatings && numRatings && (
+						<span className="plugin-ratings__num-ratings">
+							(
+							{ rating && Number.isInteger( numRatings )
+								? numRatings.toLocaleString( getLocaleSlug() )
+								: null }
+							)
+						</span>
 					) }
-					{ ! hideRatingValue && <span className="plugin-ratings__number">{ rating / 20 }</span> }
+					{ ! hideRatingNumber && <span className="plugin-ratings__number">{ rating / 20 }</span> }
 				</div>
-				{ numRatings && (
+				{ ! inlineNumRatings && numRatings && (
 					<div className="plugin-ratings__rating-text">
 						{ this.props.translate(
 							'Based on %(ratingsNumber)s rating',

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -22,7 +22,8 @@
 	}
 }
 
-.plugin-ratings__rating-text {
+.plugin-ratings__rating-text,
+.plugin-ratings__num-ratings {
 	font-size: $font-body-extra-small;
 	color: var( --color-neutral-light );
 	margin-bottom: 16px;
@@ -32,6 +33,10 @@
 		line-height: 24px;
 		vertical-align: top;
 	}
+}
+
+.plugin-ratings__num-ratings {
+	margin: 0;
 }
 
 .plugin-ratings__rating-tier-text,

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -6,6 +6,7 @@ import { useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
@@ -116,17 +117,27 @@ const PluginsBrowserListElement = ( props ) => {
 						/>
 					) }
 					<div className="plugins-browser-item__additional-info">
-						<div className="plugins-browser-item__ratings">
-							<PluginRatings
-								rating={ plugin.rating }
-								inlineNumRatings={
-									plugin.rating && Number.isInteger( plugin.num_ratings )
-										? plugin.num_ratings.toLocaleString( getLocaleSlug() )
-										: null
-								}
-								hideRatingValue
-							/>
-						</div>
+						{ !! plugin.rating && (
+							<div className="plugins-browser-item__ratings">
+								<PluginRatings
+									rating={ plugin.rating }
+									inlineNumRatings={
+										plugin.rating && Number.isInteger( plugin.num_ratings )
+											? plugin.num_ratings.toLocaleString( getLocaleSlug() )
+											: null
+									}
+									hideRatingValue
+								/>
+							</div>
+						) }
+						{ !! plugin.active_installs && (
+							<div className="plugins-browser-item__active-installs">
+								<span className="plugins-browser-item__active-installs-value">{ `${ formatNumberMetric(
+									plugin.active_installs
+								) }${ plugin.active_installs > 1000 && '+' }` }</span>
+								{ translate( ' Active Installs' ) }
+							</div>
+						) }
 					</div>
 				</div>
 			</a>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,9 +1,9 @@
 import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
-import { flowRight as compose, includes } from 'lodash';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { includes } from 'lodash';
+import { useMemo, useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
@@ -16,137 +16,137 @@ import './style.scss';
 
 const PREINSTALLED_PLUGINS = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPress' ];
 
-class PluginsBrowserListElement extends Component {
-	static defaultProps = {
-		iconSize: 40,
-		variant: PluginsBrowserElementVariant.Compact,
-	};
+const PluginsBrowserListElement = ( props ) => {
+	const {
+		isPlaceholder,
+		site,
+		plugin = {},
+		iconSize = 40,
+		variant = PluginsBrowserElementVariant.Compact,
+	} = props;
 
-	getPluginLink() {
-		if ( this.props.plugin.link ) {
-			return this.props.plugin.link;
+	const translate = useTranslate();
+
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSiteId ) );
+	const sitesWithPlugin = useSelector( ( state ) =>
+		isJetpack && currentSites
+			? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), plugin.slug )
+			: []
+	);
+
+	const pluginLink = useMemo( () => {
+		if ( plugin.link ) {
+			return plugin.link;
 		}
 
-		let url = '/plugins/' + this.props.plugin.slug;
-		if ( this.props.site ) {
-			url += '/' + this.props.site;
+		let url = '/plugins/' + plugin.slug;
+		if ( site ) {
+			url += '/' + site;
 		}
 		return url;
-	}
+	}, [ plugin] );
 
-	trackPluginLinkClick = () => {
+	const trackPluginLinkClick = useCallback( () => {
 		recordTracksEvent( 'calypso_plugin_browser_item_click', {
-			site: this.props.site,
-			plugin: this.props.plugin.slug,
-			list_name: this.props.listName,
+			site: site,
+			plugin: plugin.slug,
+			list_name: props.listName,
 		} );
-	};
+	}, [ site, plugin, props.listName ] );
 
-	isWpcomPreinstalled() {
-		if ( this.props.plugin.isPreinstalled ) {
+	const isWpcomPreinstalled = useMemo( () => {
+		if ( plugin.isPreinstalled ) {
 			return true;
 		}
 
-		if ( ! this.props.site ) {
+		if ( ! site ) {
 			return false;
 		}
 
-		return ! this.props.isJetpackSite && includes( PREINSTALLED_PLUGINS, this.props.plugin.name );
+		return ! isJetpack && includes( PREINSTALLED_PLUGINS, plugin.name );
+	}, [ isJetpack, site, plugin ] );
+
+	if ( isPlaceholder ) {
+		return <Placeholder iconSize={ iconSize } />;
 	}
 
-	renderInstalledInOrPricing() {
-		const { sitesWithPlugin, translate } = this.props;
-		if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || this.isWpcomPreinstalled() ) {
-			return (
-				/* eslint-disable wpcalypso/jsx-gridicon-size */
-				<div className="plugins-browser-item__installed">
-					<Gridicon icon="checkmark" size={ 14 } />
-					{ this.props.translate( 'Installed' ) }
+	const classNames = classnames( 'plugins-browser-item', variant );
+	return (
+		<li className={ classNames }>
+			<a
+				href={ pluginLink }
+				className="plugins-browser-item__link"
+				onClick={ trackPluginLinkClick }
+			>
+				<div className="plugins-browser-item__info">
+					<PluginIcon size={ iconSize } image={ plugin.icon } isPlaceholder={ isPlaceholder } />
+					<div className="plugins-browser-item__title">{ plugin.name }</div>
+					{ variant === PluginsBrowserElementVariant.Extended && (
+						<div className="plugins-browser-item__author">
+							{ translate( 'by ' ) }
+							<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
+						</div>
+					) }
+					<div className="plugins-browser-item__description">{ plugin.short_description }</div>
 				</div>
-				/* eslint-enable wpcalypso/jsx-gridicon-size */
-			);
-		}
+				{ variant === PluginsBrowserElementVariant.Extended && (
+					<InstalledInOrPricing
+						sitesWithPlugin={ sitesWithPlugin }
+						isWpcomPreinstalled={ isWpcomPreinstalled }
+					/>
+				) }
+			</a>
+			<UpgradeButton plugin={ plugin } />
+		</li>
+	);
+};
 
-		return <div className="plugins-browser-item__pricing">{ translate( 'Free' ) }</div>;
-	}
+const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled } ) => {
+	const translate = useTranslate();
 
-	renderUpgradeButton() {
-		const { isPreinstalled, upgradeLink } = this.props.plugin;
-		if ( isPreinstalled || ! upgradeLink ) {
-			return null;
-		}
-
+	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
 		return (
-			<Button className="plugins-browser-item__upgrade-button" compact primary href={ upgradeLink }>
-				{ this.props.translate( 'Upgrade' ) }
-			</Button>
+			/* eslint-disable wpcalypso/jsx-gridicon-size */
+			<div className="plugins-browser-item__installed">
+				<Gridicon icon="checkmark" size={ 14 } />
+				{ props.translate( 'Installed' ) }
+			</div>
+			/* eslint-enable wpcalypso/jsx-gridicon-size */
 		);
 	}
 
-	renderPlaceholder() {
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<li className="plugins-browser-item is-placeholder">
-				<span className="plugins-browser-item__link">
-					<div className="plugins-browser-item__info">
-						<PluginIcon size={ this.props.iconSize } isPlaceholder={ true } />
-						<div className="plugins-browser-item__title">…</div>
-						<div className="plugins-browser-item__author">…</div>
-						<div className="plugins-browser-item__description">…</div>
-					</div>
-				</span>
-			</li>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	return <div className="plugins-browser-item__pricing">{ translate( 'Free' ) }</div>;
+};
+
+const UpgradeButton = ( { plugin } ) => {
+	const { isPreinstalled, upgradeLink } = plugin;
+	if ( isPreinstalled || ! upgradeLink ) {
+		return null;
 	}
 
-	render() {
-		const { isPlaceholder, plugin, iconSize, variant, translate } = this.props;
-		if ( isPlaceholder ) {
-			return this.renderPlaceholder();
-		}
+	return (
+		<Button className="plugins-browser-item__upgrade-button" compact primary href={ upgradeLink }>
+			{ props.translate( 'Upgrade' ) }
+		</Button>
+	);
+};
 
-		const classNames = classnames( 'plugins-browser-item', variant );
+const Placeholder = ( { iconSize } ) => {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<li className="plugins-browser-item is-placeholder">
+			<span className="plugins-browser-item__link">
+				<div className="plugins-browser-item__info">
+					<PluginIcon size={ iconSize } isPlaceholder={ true } />
+					<div className="plugins-browser-item__title">…</div>
+					<div className="plugins-browser-item__author">…</div>
+					<div className="plugins-browser-item__description">…</div>
+				</div>
+			</span>
+		</li>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+};
 
-		return (
-			<li className={ classNames }>
-				<a
-					href={ this.getPluginLink() }
-					className="plugins-browser-item__link"
-					onClick={ this.trackPluginLinkClick }
-				>
-					<div className="plugins-browser-item__info">
-						<PluginIcon size={ iconSize } image={ plugin.icon } isPlaceholder={ isPlaceholder } />
-						<div className="plugins-browser-item__title">{ plugin.name }</div>
-						{ variant === PluginsBrowserElementVariant.Extended && (
-							<div className="plugins-browser-item__author">
-								{ translate( 'by ' ) }
-								<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
-							</div>
-						) }
-						<div className="plugins-browser-item__description">{ plugin.short_description }</div>
-					</div>
-					{ variant === PluginsBrowserElementVariant.Extended && this.renderInstalledInOrPricing() }
-				</a>
-				{ this.renderUpgradeButton() }
-			</li>
-		);
-	}
-}
-
-export default compose(
-	connect( ( state, { currentSites, plugin } ) => {
-		const selectedSiteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, selectedSiteId );
-		const sitesWithPlugin =
-			isJetpack && currentSites
-				? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), plugin.slug )
-				: [];
-
-		return {
-			isJetpackSite: isJetpack,
-			sitesWithPlugin,
-		};
-	} ),
-	localize
-)( PluginsBrowserListElement );
+export default PluginsBrowserListElement;

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,12 +1,13 @@
 import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { includes } from 'lodash';
 import { useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
+import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -103,12 +104,27 @@ const PluginsBrowserListElement = ( props ) => {
 					) }
 					<div className="plugins-browser-item__description">{ plugin.short_description }</div>
 				</div>
-				{ variant === PluginsBrowserElementVariant.Extended && (
-					<InstalledInOrPricing
-						sitesWithPlugin={ sitesWithPlugin }
-						isWpcomPreinstalled={ isWpcomPreinstalled }
-					/>
-				) }
+				<div className="plugins-browser-item__footer">
+					{ variant === PluginsBrowserElementVariant.Extended && (
+						<InstalledInOrPricing
+							sitesWithPlugin={ sitesWithPlugin }
+							isWpcomPreinstalled={ isWpcomPreinstalled }
+						/>
+					) }
+					<div className="plugins-browser-item__additional-info">
+						<div className="plugins-browser-item__ratings">
+							<PluginRatings
+								rating={ plugin.rating }
+								inlineNumRatings={
+									plugin.rating && Number.isInteger( plugin.num_ratings )
+										? plugin.num_ratings.toLocaleString( getLocaleSlug() )
+										: null
+								}
+								hideRatingValue
+							/>
+						</div>
+					</div>
+				</div>
 			</a>
 			<UpgradeButton plugin={ plugin } />
 		</li>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -25,6 +25,7 @@ const PluginsBrowserListElement = ( props ) => {
 		plugin = {},
 		iconSize = 40,
 		variant = PluginsBrowserElementVariant.Compact,
+		currentSites,
 	} = props;
 
 	const translate = useTranslate();
@@ -39,7 +40,8 @@ const PluginsBrowserListElement = ( props ) => {
 	);
 
 	const dateFromNow = useMemo(
-		() => moment.utc( plugin.last_updated, 'YYYY-MM-DD hh:mma' ).fromNow(),
+		() =>
+			plugin.last_updated ? moment.utc( plugin.last_updated, 'YYYY-MM-DD hh:mma' ).fromNow() : null,
 		[ plugin.last_updated ]
 	);
 
@@ -96,10 +98,12 @@ const PluginsBrowserListElement = ( props ) => {
 								{ translate( 'by ' ) }
 								<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
 							</div>
-							<div className="plugins-browser-item__last-updated">
-								{ translate( 'Last updated ' ) }
-								<span className="plugins-browser-item__last-updated-value">{ dateFromNow }</span>
-							</div>
+							{ dateFromNow && (
+								<div className="plugins-browser-item__last-updated">
+									{ translate( 'Last updated ' ) }
+									<span className="plugins-browser-item__last-updated-value">{ dateFromNow }</span>
+								</div>
+							) }
 						</>
 					) }
 					<div className="plugins-browser-item__description">{ plugin.short_description }</div>
@@ -139,7 +143,7 @@ const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled } ) => {
 			/* eslint-disable wpcalypso/jsx-gridicon-size */
 			<div className="plugins-browser-item__installed">
 				<Gridicon icon="checkmark" size={ 14 } />
-				{ props.translate( 'Installed' ) }
+				{ translate( 'Installed' ) }
 			</div>
 			/* eslint-enable wpcalypso/jsx-gridicon-size */
 		);
@@ -149,14 +153,16 @@ const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled } ) => {
 };
 
 const UpgradeButton = ( { plugin } ) => {
+	const translate = useTranslate();
 	const { isPreinstalled, upgradeLink } = plugin;
+
 	if ( isPreinstalled || ! upgradeLink ) {
 		return null;
 	}
 
 	return (
 		<Button className="plugins-browser-item__upgrade-button" compact primary href={ upgradeLink }>
-			{ props.translate( 'Upgrade' ) }
+			{ translate( 'Upgrade' ) }
 		</Button>
 	);
 };

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { includes } from 'lodash';
 import { useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
@@ -26,6 +27,7 @@ const PluginsBrowserListElement = ( props ) => {
 	} = props;
 
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSiteId ) );
@@ -33,6 +35,11 @@ const PluginsBrowserListElement = ( props ) => {
 		isJetpack && currentSites
 			? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), plugin.slug )
 			: []
+	);
+
+	const dateFromNow = useMemo(
+		() => moment.utc( plugin.last_updated, 'YYYY-MM-DD hh:mma' ).fromNow(),
+		[ plugin.last_updated ]
 	);
 
 	const pluginLink = useMemo( () => {
@@ -45,7 +52,7 @@ const PluginsBrowserListElement = ( props ) => {
 			url += '/' + site;
 		}
 		return url;
-	}, [ plugin] );
+	}, [ plugin ] );
 
 	const trackPluginLinkClick = useCallback( () => {
 		recordTracksEvent( 'calypso_plugin_browser_item_click', {
@@ -83,10 +90,16 @@ const PluginsBrowserListElement = ( props ) => {
 					<PluginIcon size={ iconSize } image={ plugin.icon } isPlaceholder={ isPlaceholder } />
 					<div className="plugins-browser-item__title">{ plugin.name }</div>
 					{ variant === PluginsBrowserElementVariant.Extended && (
-						<div className="plugins-browser-item__author">
-							{ translate( 'by ' ) }
-							<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
-						</div>
+						<>
+							<div className="plugins-browser-item__author">
+								{ translate( 'by ' ) }
+								<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
+							</div>
+							<div className="plugins-browser-item__last-updated">
+								{ translate( 'Last updated ' ) }
+								<span className="plugins-browser-item__last-updated-value">{ dateFromNow }</span>
+							</div>
+						</>
 					) }
 					<div className="plugins-browser-item__description">{ plugin.short_description }</div>
 				</div>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -111,12 +111,17 @@ const PluginsBrowserListElement = ( props ) => {
 								{ translate( 'by ' ) }
 								<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
 							</div>
-							{ dateFromNow && (
-								<div className="plugins-browser-item__last-updated">
-									{ translate( 'Last updated ' ) }
-									<span className="plugins-browser-item__last-updated-value">{ dateFromNow }</span>
-								</div>
-							) }
+
+							<div className="plugins-browser-item__last-updated">
+								{ dateFromNow && (
+									<>
+										{ translate( 'Last updated ' ) }
+										<span className="plugins-browser-item__last-updated-value">
+											{ dateFromNow }
+										</span>
+									</>
+								) }
+							</div>
 						</>
 					) }
 					<div className="plugins-browser-item__description">{ plugin.short_description }</div>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,8 +1,7 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
-import { useTranslate, getLocaleSlug } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -35,7 +34,7 @@ const PluginsBrowserListElement = ( props ) => {
 	const moment = useLocalizedMoment();
 
 	const selectedSite = useSelector( getSelectedSite );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.id ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const sitesWithPlugin = useSelector( ( state ) =>
 		isJetpack && currentSites
 			? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), plugin.slug )
@@ -77,7 +76,7 @@ const PluginsBrowserListElement = ( props ) => {
 			return false;
 		}
 
-		return ! isJetpack && includes( PREINSTALLED_PLUGINS, plugin.name );
+		return ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.name );
 	}, [ isJetpack, site, plugin ] );
 
 	const isUntestedVersion = useMemo( () => {
@@ -142,12 +141,9 @@ const PluginsBrowserListElement = ( props ) => {
 							<div className="plugins-browser-item__ratings">
 								<PluginRatings
 									rating={ plugin.rating }
-									inlineNumRatings={
-										plugin.rating && Number.isInteger( plugin.num_ratings )
-											? plugin.num_ratings.toLocaleString( getLocaleSlug() )
-											: null
-									}
-									hideRatingValue
+									numRatings={ plugin.num_ratings }
+									inlineNumRatings
+									hideRatingNumber
 								/>
 							</div>
 						) }
@@ -162,7 +158,6 @@ const PluginsBrowserListElement = ( props ) => {
 					</div>
 				</div>
 			</a>
-			<UpgradeButton plugin={ plugin } />
 		</li>
 	);
 };
@@ -182,21 +177,6 @@ const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled } ) => {
 	}
 
 	return <div className="plugins-browser-item__pricing">{ translate( 'Free' ) }</div>;
-};
-
-const UpgradeButton = ( { plugin } ) => {
-	const translate = useTranslate();
-	const { isPreinstalled, upgradeLink } = plugin;
-
-	if ( isPreinstalled || ! upgradeLink ) {
-		return null;
-	}
-
-	return (
-		<Button className="plugins-browser-item__upgrade-button" compact primary href={ upgradeLink }>
-			{ translate( 'Upgrade' ) }
-		</Button>
-	);
 };
 
 const Placeholder = ( { iconSize } ) => {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -56,7 +56,7 @@ const PluginsBrowserListElement = ( props ) => {
 			url += '/' + site;
 		}
 		return url;
-	}, [ plugin ] );
+	}, [ plugin, site ] );
 
 	const trackPluginLinkClick = useCallback( () => {
 		recordTracksEvent( 'calypso_plugin_browser_item_click', {
@@ -179,7 +179,6 @@ const UpgradeButton = ( { plugin } ) => {
 };
 
 const Placeholder = ( { iconSize } ) => {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<li className="plugins-browser-item is-placeholder">
 			<span className="plugins-browser-item__link">
@@ -192,7 +191,6 @@ const Placeholder = ( { iconSize } ) => {
 			</span>
 		</li>
 	);
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default PluginsBrowserListElement;

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -131,6 +131,17 @@
 	}
 }
 
+.plugins-browser-item__footer {
+	margin-top: auto;
+	display: flex;
+	justify-content: space-between;
+}
+
+.plugins-browser-item__rating-value {
+	color: var( --studio-gray-60 );
+	font-size: $font-body-extra-small;
+}
+
 .button.plugins-browser-item__upgrade-button {
 	position: absolute;
 	bottom: 16px;

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -105,15 +105,24 @@
 	color: $studio-blue-40;
 }
 
-.plugins-browser-item__last-updated {
+.plugins-browser-item__last-updated,
+.plugins-browser-item__rating-value,
+.plugins-browser-item__active-installs {
 	color: var( --studio-gray-60 );
 	font-size: $font-body-extra-small;
+}
+
+.plugins-browser-item__last-updated {
 	margin-top: 2px;
+}
+
+.plugins-browser-item__active-installs {
+	margin-top: 5px;
+	text-align: right;
 }
 
 .plugins-browser-item__pricing,
 .plugins-browser-item__installed {
-	margin-top: auto;
 	font-size: $font-body;
 	color: $studio-black;
 }
@@ -123,6 +132,7 @@
 	align-items: center;
 	color: var( --studio-green-30 );
 	animation: appear 0.15s ease-in;
+	margin-top: -10px;
 
 	.gridicon {
 		margin-right: 6px;
@@ -135,11 +145,6 @@
 	margin-top: auto;
 	display: flex;
 	justify-content: space-between;
-}
-
-.plugins-browser-item__rating-value {
-	color: var( --studio-gray-60 );
-	font-size: $font-body-extra-small;
 }
 
 .button.plugins-browser-item__upgrade-button {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -29,7 +29,8 @@
 	}
 
 	.plugins-browser-item__title,
-	.plugins-browser-item__author {
+	.plugins-browser-item__author,
+	.plugins-browser-item__last-updated {
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		margin-left: calc( 60px + 16px ); // icon width + margin
@@ -70,7 +71,8 @@
 	border: 1px solid var( --studio-gray-5 );
 	border-radius: 5px; /* stylelint-disable-line scales/radii */
 
-	&:focus, &:hover {
+	&:focus,
+	&:hover {
 		border-color: var( --studio-gray-30 );
 	}
 }
@@ -91,7 +93,7 @@
 	color: var( --color-neutral-70 );
 	font-weight: 600;
 	font-size: $font-body;
-	margin-top: 3px;
+	margin-top: -3px;
 }
 
 .plugins-browser-item__author {
@@ -101,6 +103,12 @@
 
 .plugins-browser-item__author-name {
 	color: $studio-blue-40;
+}
+
+.plugins-browser-item__last-updated {
+	color: var( --studio-gray-60 );
+	font-size: $font-body-extra-small;
+	margin-top: 2px;
 }
 
 .plugins-browser-item__pricing,

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -37,7 +37,7 @@
 	}
 
 	.plugins-browser-item__description {
-		margin: 32px 0 20px;
+		margin: 16px 0;
 		font-size: $font-body-small;
 		font-weight: 400;
 		color: $studio-gray-60;
@@ -110,6 +110,18 @@
 .plugins-browser-item__active-installs {
 	color: var( --studio-gray-60 );
 	font-size: $font-body-extra-small;
+}
+
+.plugins-browser-item__untested-notice {
+	display: flex;
+	color: var( --studio-gray-60 );
+	fill: var( --studio-gray-60 );
+	font-size: $font-body-small;
+	margin-bottom: 16px;
+
+	.plugins-browser-item__untested-text {
+		margin-left: 6px;
+	}
 }
 
 .plugins-browser-item__last-updated {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -126,6 +126,7 @@
 
 .plugins-browser-item__last-updated {
 	margin-top: 2px;
+	min-height: 18px;
 }
 
 .plugins-browser-item__active-installs {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -141,12 +141,11 @@
 
 .plugins-browser-item__installed {
 	display: flex;
-	align-items: center;
 	color: var( --studio-green-30 );
 	animation: appear 0.15s ease-in;
-	margin-top: -10px;
 
 	.gridicon {
+		margin-top: 3px;
 		margin-right: 6px;
 		border: 2px solid var( --studio-green-30 );
 		border-radius: 50%; /* stylelint-disable-line */
@@ -159,8 +158,3 @@
 	justify-content: space-between;
 }
 
-.button.plugins-browser-item__upgrade-button {
-	position: absolute;
-	bottom: 16px;
-	right: 16px;
-}

--- a/client/my-sites/plugins/plugins-browser-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/test/index.jsx
@@ -42,7 +42,7 @@ describe( 'PluginsBrowserList basic tests', () => {
 
 	test( 'should render a given number of list items when the size prop is set', () => {
 		const comp = shallow( <PluginsBrowserList { ...props } size={ 2 } /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)' ).length ).toBe( 2 );
+		expect( comp.find( 'PluginsBrowserListElement' ).length ).toBe( 2 );
 	} );
 } );
 
@@ -54,19 +54,19 @@ describe( 'InfiniteScroll variant', () => {
 
 	test( 'should show placeholders if there are no plugins', () => {
 		const comp = shallow( <PluginsBrowserList { ...infiniteScrollProps } plugins={ [] } /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 6 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 6 );
 	} );
 
 	test( 'should append placeholders if there are plugins and `showPlaceholders` is set', () => {
 		const comp = shallow( <PluginsBrowserList { ...infiniteScrollProps } showPlaceholders /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)' ).length ).toBe( 9 );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 6 );
+		expect( comp.find( 'PluginsBrowserListElement' ).length ).toBe( 9 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 6 );
 	} );
 
 	test( 'should not show placeholders if there are plugins and the `showPlaceholders` is not set', () => {
 		const comp = shallow( <PluginsBrowserList { ...infiniteScrollProps } /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)' ).length ).toBe( 3 );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 0 );
+		expect( comp.find( 'PluginsBrowserListElement' ).length ).toBe( 3 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 0 );
 	} );
 } );
 
@@ -78,18 +78,18 @@ describe( 'Paginated variant', () => {
 
 	test( 'should show placeholders if there are no plugins', () => {
 		const comp = shallow( <PluginsBrowserList { ...paginatedProps } plugins={ [] } /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 6 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 6 );
 	} );
 
 	test( 'should show placeholders if there are plugins and `showPlaceholders` is set', () => {
 		const comp = shallow( <PluginsBrowserList { ...paginatedProps } showPlaceholders /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 6 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 6 );
 	} );
 
 	test( 'should not show placeholders if there are plugins and the `showPlaceholders` is not set', () => {
 		const comp = shallow( <PluginsBrowserList { ...paginatedProps } /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)' ).length ).toBe( 3 );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 0 );
+		expect( comp.find( 'PluginsBrowserListElement' ).length ).toBe( 3 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 0 );
 	} );
 } );
 
@@ -101,14 +101,14 @@ describe( 'Fixed variant', () => {
 
 	test( 'should show placeholders if there are no plugins', () => {
 		const comp = shallow( <PluginsBrowserList { ...fixedProps } plugins={ [] } /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 6 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 6 );
 	} );
 
 	test( 'should not show placeholders regardless of the `showPlaceholders` prop', () => {
 		let comp = shallow( <PluginsBrowserList { ...fixedProps } showPlaceholders /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 0 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 0 );
 
 		comp = shallow( <PluginsBrowserList { ...fixedProps } /> );
-		expect( comp.find( 'Connect(PluginsBrowserListElement)[isPlaceholder]' ).length ).toBe( 0 );
+		expect( comp.find( 'PluginsBrowserListElement[isPlaceholder]' ).length ).toBe( 0 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Addition of the following information on the Plugins Browser Item:

- [x] Last updated
- [x] Rating
- [x] Active Installs
- [x] Untested version warning

#### Testing instructions
* Go to `/plugins` page
* Confirm each plugin card has last updated, rating, and active install informations. Ex:

![Screen Shot 2021-12-06 at 14 58 37](https://user-images.githubusercontent.com/5039531/144906993-4d5e288b-eadd-485f-94a1-4d0f24058ada.png)

* Go to `/plugins` page
* Search for a term where will be showed plugins with untested versions. ex: application
* Check if the warning is being properly showed

![Screen Shot 2021-12-08 at 11 20 45](https://user-images.githubusercontent.com/5039531/145234933-b5e3de94-a6a9-4058-a021-bacd15409c63.png)


---

Fixes  #58319