### PR TITLE
Disable concierge session upsell

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -157,7 +157,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"upsell/concierge-session": true,
+		"upsell/concierge-session": false,
 		"woocommerce/extension-referrers": true,
 		"woop": true,
 		"wordpress-action-search": false,

--- a/config/production.json
+++ b/config/production.json
@@ -109,7 +109,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"upsell/concierge-session": true,
+		"upsell/concierge-session": false,
 		"use-translation-chunks": true,
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -110,7 +110,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"upsell/concierge-session": true,
+		"upsell/concierge-session": false,
 		"use-translation-chunks": true,
 		"woocommerce/extension-referrers": false,
 		"woop": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"upsell/concierge-session": true,
+		"upsell/concierge-session": false,
 		"use-translation-chunks": true,
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,


### PR DESCRIPTION
See pc4ICr-mc-p2/#comment-692

#### Changes proposed in this Pull Request

* Disables concierge session upsell in all environments

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/checkout/offer-support-session` should not be accessible anymore

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


