### PR TITLE
Add block version of Blank Canvas to FSE design picker

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -21,6 +21,17 @@
 			"features": []
 		},
 		{
+			"title": "Blank Canvas",
+			"slug": "blank-canvas-blocks",
+			"template": "blank-canvas-blocks",
+			"theme": "blank-canvas-blocks",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"is_featured_picks": true,
+			"features": []
+		},
+		{
 			"title": "Arbutus",
 			"slug": "arbutus",
 			"template": "arbutus",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `available-designs-config.json` to include blank canvas block theme.
* Blank Canvas is a selectable theme in the /new FSE beta onboarding design picker

#### Blockers

- ✅  No `headstart` necessary
- ✅  No demo URL necessary
- ✅  Network-activated

#### Screenshots

![Screen Shot 2021-12-06 at 17 50 33](https://user-images.githubusercontent.com/26530524/144920882-34300f9d-5218-4193-958e-1ea282219891.png)

#### Testing instructions

* Apply branch to local calypso dev environment
* Visit http://calypso.localhost:3000/new/beta
* Enroll in the FSE beta
* Pick a free test domain
* Verify that `Blank Canvas` is a selectable theme
* Create a site with `Blank Canvas` enabled and smoke test the theme

Related to #58663.
