### PR TITLE
Remove unused puppeteer dependency

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -102,7 +102,6 @@
 		"moment": "^2.26.0",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.3.11",
-		"puppeteer": "^3.0.4",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"react-popper": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,7 +1411,6 @@ __metadata:
     moment: ^2.26.0
     npm-run-all: ^4.1.5
     postcss: ^8.3.11
-    puppeteer: ^3.0.4
     react: ^17.0.2
     react-dom: ^17.0.2
     react-popper: ^2.2.5


### PR DESCRIPTION
### Changes proposed in this Pull Request
In #52469, I removed the e2e suite from ETK, because it was never used and never worked. Puppeteer can be removed then as well :)

Though there are a few scattered references to puppeteer in the codebase, ETK is the only place it's declared as a dependency. So I don't think it is used elsewhere. CI should figure that out pretty quickly, though.

However, puppeteer is still brought along as a transitive dependency via the `@wordpress/scripts` and `capture-website` packages.

### Testing instructions
- ci should pass
