### PR TITLE
Enable the Hero Flow for non-en users in the wpcalypso environment

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { englishLocales } from '@automattic/i18n-utils';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
@@ -73,7 +74,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 	}
 
 	// Initially ship to English users only, then ship to all users when translations complete
-	if ( englishLocales.includes( localeSlug ) ) {
+	if ( englishLocales.includes( localeSlug ) || isEnabled( 'signup/hero-flow-non-en' ) ) {
 		return addQueryArgs( queryParam, '/start/setup-site' );
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -147,6 +147,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
+		"signup/hero-flow-non-en": true,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -110,6 +110,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
+		"signup/hero-flow-non-en": true,
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Working on enabling Hero Flow for non-English users #58859. Deploying this to `wpcalypso` will make it easier to get help with testing.

* Create `signup/hero-flow-non-en`
* Enable `signup/hero-flow-non-en` in development and wpcalypso environments
* Enable the Hero Flow if `signup/hero-flow-non-en` is enabled, regardless of the user's locale

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch user account to something non-English
* Restart development environment
* Test that Hero Flow is enabled on `calypso.localhost:3000`
* During deployment ensure that Hero Flow is still disabled in staging environment.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58859
