### PR TITLE
Update storybook

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -61,7 +61,7 @@ logFilters:
     level: discard
   - pattern: "@automattic/wpcom-editing-toolkit@workspace:apps/editing-toolkit provides react (pa6835) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
     level: discard
-  
+
   # Depends on
   #   react-dates: https://github.com/airbnb/react-dates/issues/2105
   #   react-with-direction: https://github.com/airbnb/react-with-direction/issues/20

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -119,17 +119,6 @@ packageExtensions:
     peerDependencies:
       '@emotion/core': '*'
       react: '*'
-  '@storybook/csf-tools@6.3.12':
-    peerDependencies:
-      webpack: '*'
-      '@babel/core': '*'
-  '@storybook/core-server@6.3.12':
-    peerDependencies:
-      '@babel/core': '*'
-  '@storybook/core@6.3.12':
-    peerDependencies:
-      '@babel/core': '*'
-      'webpack': '*'
   '@types/wordpress__block-editor@6.0.4':
     peerDependencies:
       react: '*'

--- a/bin/storybook-default-config.js
+++ b/bin/storybook-default-config.js
@@ -1,10 +1,3 @@
-const { dirname } = require( 'path' );
-
-// Using `require.resolve` by itself gives a path to a file in /dist. Instead,
-// resolve `/package.json` and then get the containing directory to find the root
-// of the given module.
-const findModule = ( module ) => dirname( require.resolve( module + '/package.json' ) );
-
 module.exports = function storybookDefaultConfig( {
 	stories,
 	plugins = [],
@@ -14,35 +7,24 @@ module.exports = function storybookDefaultConfig( {
 		core: {
 			builder: 'webpack5',
 		},
+		features: {
+			/**
+			 * Can probably be removed after the next major storybook release with emotion 11 support.
+			 *
+			 * @see https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#emotion11-quasi-compatibility
+			 */
+			emotionAlias: false,
+			babelModeV7: true,
+		},
 		stories: stories && stories.length ? stories : [ '../src/**/*.stories.{js,jsx,ts,tsx}' ],
 		addons: [ '@storybook/addon-actions', '@storybook/preset-scss' ],
 		typescript: {
 			check: false,
 			reactDocgen: false,
 		},
-		babel: {
-			presets: [
-				[ '@babel/preset-env', { targets: { browsers: 'last 2 versions' } } ],
-				[ '@babel/preset-react', { runtime: 'automatic' } ],
-			],
-			plugins: [ [ '@babel/plugin-proposal-private-property-in-object', { loose: false } ] ],
-		},
 		webpackFinal: async ( config ) => {
 			config.resolve.alias = {
 				...config.resolve.alias,
-				/**
-				 * Storybook manually resolves emotion 10 internally. To render
-				 * a package using Emotion 11, we must manually alias Emotion
-				 * imports to use the v11 packages instead of v10.
-				 *
-				 * @todo Remove once Storybook supports Emotion 11.
-				 * @see https://github.com/storybookjs/storybook/issues/12262
-				 * @see https://github.com/storybookjs/storybook/pull/13300#issuecomment-783268111
-				 */
-				'@emotion/styled': findModule( '@emotion/styled' ),
-				'@emotion/core': findModule( '@emotion/react' ),
-				'@emotion-theming': findModule( '@emotion/react' ),
-				'@emotion/react': findModule( '@emotion/react' ),
 				...webpackAliases,
 			};
 			config.resolve.mainFields = [ 'browser', 'calypso:src', 'module', 'main' ];

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 		"@babel/register": "^7.16.0",
 		"@babel/runtime": "^7.16.3",
 		"@signal-noise/stylelint-scales": "^2.0.0",
-		"@storybook/react": "^6.3.12",
+		"@storybook/react": "^6.4.8",
 		"@typeform/embed-react": "^1.1.0",
 		"@types/cookie": "^0.4.1",
 		"@types/debug": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 		"@babel/register": "^7.16.0",
 		"@babel/runtime": "^7.16.3",
 		"@signal-noise/stylelint-scales": "^2.0.0",
-		"@storybook/react": "^6.4.8",
+		"@storybook/react": "^6.4.9",
 		"@typeform/embed-react": "^1.1.0",
 		"@types/cookie": "^0.4.1",
 		"@types/debug": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -125,10 +125,10 @@
 		"whybundled": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run build-client && whybundled client/stats.json",
 		"whybundled:server": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run build-server && whybundled client/stats-server.json",
 		"composite-checkout-demo": "echo 'Deprecated, run `yarn run composite-checkout:storybook:start` instead'",
-		"components:storybook:start": "start-storybook -c packages/components/.storybook",
-		"search:storybook:start": "start-storybook -c packages/search/.storybook",
-		"composite-checkout:storybook:start": "start-storybook -c packages/composite-checkout/.storybook",
-		"tour-kit:storybook:start": "start-storybook -c packages/tour-kit/.storybook"
+		"components:storybook:start": "BABEL_ENV=storybook start-storybook -c packages/components/.storybook",
+		"search:storybook:start": "BABEL_ENV=storybook start-storybook -c packages/search/.storybook",
+		"composite-checkout:storybook:start": "BABEL_ENV=storybook start-storybook -c packages/composite-checkout/.storybook",
+		"tour-kit:storybook:start": "BABEL_ENV=storybook start-storybook -c packages/tour-kit/.storybook"
 	},
 	"dependencies": {
 		"@automattic/calypso-babel-config": "workspace:^",

--- a/packages/calypso-babel-config/config.js
+++ b/packages/calypso-babel-config/config.js
@@ -25,5 +25,14 @@ module.exports = ( { isBrowser = true, outputPOT = 'build' } = {} ) => ( {
 			presets: [ [ '@babel/preset-env', { targets: { node: 'current' } } ] ],
 			plugins: [ 'babel-plugin-dynamic-import-node' ],
 		},
+		storybook: {
+			// Forces some plugins to load in loose mode, used by Storybook.
+			// See https://github.com/storybookjs/storybook/issues/14805
+			plugins: [
+				[ require.resolve( '@babel/plugin-proposal-private-property-in-object' ), { loose: true } ],
+				[ require.resolve( '@babel/plugin-proposal-class-properties' ), { loose: true } ],
+				[ require.resolve( '@babel/plugin-proposal-private-methods' ), { loose: true } ],
+			],
+		},
 	},
 } );

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,7 +45,7 @@
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@storybook/addon-actions": "^6.3.12",
+		"@storybook/addon-actions": "^6.4.8",
 		"@storybook/preset-scss": "^1.0.3",
 		"css-loader": "^3.6.0",
 		"enzyme": "^3.11.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,7 +45,7 @@
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@storybook/addon-actions": "^6.4.8",
+		"@storybook/addon-actions": "^6.4.9",
 		"@storybook/preset-scss": "^1.0.3",
 		"css-loader": "^3.6.0",
 		"enzyme": "^3.11.0",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -47,7 +47,7 @@
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@storybook/addon-actions": "^6.3.12",
+		"@storybook/addon-actions": "^6.4.8",
 		"@storybook/preset-scss": "^1.0.3",
 		"@testing-library/jest-dom": "^5.16.1",
 		"@testing-library/react": "^12.1.2",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -47,7 +47,7 @@
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@storybook/addon-actions": "^6.4.8",
+		"@storybook/addon-actions": "^6.4.9",
 		"@storybook/preset-scss": "^1.0.3",
 		"@testing-library/jest-dom": "^5.16.1",
 		"@testing-library/react": "^12.1.2",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -48,9 +48,9 @@
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@storybook/addon-actions": "^6.3.12",
-		"@storybook/builder-webpack5": "^6.3.12",
-		"@storybook/manager-webpack5": "^6.3.12",
+		"@storybook/addon-actions": "^6.4.8",
+		"@storybook/builder-webpack5": "^6.4.8",
+		"@storybook/manager-webpack5": "^6.4.8",
 		"@storybook/preset-scss": "^1.0.3",
 		"@testing-library/dom": "^8.11.1",
 		"@testing-library/react": "^12.1.2",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -48,9 +48,9 @@
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@storybook/addon-actions": "^6.4.8",
-		"@storybook/builder-webpack5": "^6.4.8",
-		"@storybook/manager-webpack5": "^6.4.8",
+		"@storybook/addon-actions": "^6.4.9",
+		"@storybook/builder-webpack5": "^6.4.9",
+		"@storybook/manager-webpack5": "^6.4.9",
 		"@storybook/preset-scss": "^1.0.3",
 		"@testing-library/dom": "^8.11.1",
 		"@testing-library/react": "^12.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,7 +339,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@storybook/addon-actions": ^6.4.8
+    "@storybook/addon-actions": ^6.4.9
     "@storybook/preset-scss": ^1.0.3
     "@wordpress/base-styles": ^4.0.4
     classnames: ^2.3.1
@@ -369,7 +369,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
-    "@storybook/addon-actions": ^6.4.8
+    "@storybook/addon-actions": ^6.4.9
     "@storybook/preset-scss": ^1.0.3
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
@@ -1026,9 +1026,9 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@babel/runtime": ^7.16.3
-    "@storybook/addon-actions": ^6.4.8
-    "@storybook/builder-webpack5": ^6.4.8
-    "@storybook/manager-webpack5": ^6.4.8
+    "@storybook/addon-actions": ^6.4.9
+    "@storybook/builder-webpack5": ^6.4.9
+    "@storybook/manager-webpack5": ^6.4.9
     "@storybook/preset-scss": ^1.0.3
     "@testing-library/dom": ^8.11.1
     "@testing-library/react": ^12.1.2
@@ -4965,16 +4965,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:^6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/addon-actions@npm:6.4.8"
+"@storybook/addon-actions@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/addon-actions@npm:6.4.9"
   dependencies:
-    "@storybook/addons": 6.4.8
-    "@storybook/api": 6.4.8
-    "@storybook/components": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/api": 6.4.9
+    "@storybook/components": 6.4.9
+    "@storybook/core-events": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.8
+    "@storybook/theming": 6.4.9
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -4995,21 +4995,21 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 2d75ba4caaf019b9473d1090d84a4537112778bbd610814ad1808b22a1f1e3091b2312c11c18409fbc309ffd7762ec800284a6f3a14227bada673f045e04c75c
+  checksum: cb4724ecaeedd0ee79be80a64712ec997377b3e8013c8d681537ebda67a59eed7ce034564ebfea99b7a37eae77534e33e42a62ed0ff050da7fde89263cacc102
   languageName: node
   linkType: hard
 
-"@storybook/addons@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/addons@npm:6.4.8"
+"@storybook/addons@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/addons@npm:6.4.9"
   dependencies:
-    "@storybook/api": 6.4.8
-    "@storybook/channels": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/api": 6.4.9
+    "@storybook/channels": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/core-events": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.8
-    "@storybook/theming": 6.4.8
+    "@storybook/router": 6.4.9
+    "@storybook/theming": 6.4.9
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -5017,21 +5017,21 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 09301982512525c27e94fb93056638cbc2211a2e01d888a454daa923e2a1bc4a688634f6d610eecf878df5f1a1027c3233ffb5ef8f5e67074fd5e6060cd0adb2
+  checksum: 567e20d96cc954126a51fd41b93cc9f384224199451dcd61eeb4164de4da3c5c9cd56f3423466b7a0277fd4d22f09f30c73ada816fcf9f8a5216ea190f573ab5
   languageName: node
   linkType: hard
 
-"@storybook/api@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/api@npm:6.4.8"
+"@storybook/api@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/api@npm:6.4.9"
   dependencies:
-    "@storybook/channels": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/channels": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/core-events": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.8
+    "@storybook/router": 6.4.9
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.8
+    "@storybook/theming": 6.4.9
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -5045,13 +5045,13 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 6cfb9f2e25003869c225288636a0037c42da97da7acf5023c71ec0cb771edc9b5fdcb7acf9992fd8b4cfea091712efa8146e7d489191617c83435d5925c1fc42
+  checksum: 6f8ac4be827bacb850c00e1517378765e34ef58ad8d456a1cc5e5271d91b0f0b1a0a6a48dc7e234b18487fc82e106c7cf67f7ecdfe8ce181b675deaf17646da2
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack4@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/builder-webpack4@npm:6.4.8"
+"@storybook/builder-webpack4@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/builder-webpack4@npm:6.4.9"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -5074,22 +5074,22 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.4.8
-    "@storybook/api": 6.4.8
-    "@storybook/channel-postmessage": 6.4.8
-    "@storybook/channels": 6.4.8
-    "@storybook/client-api": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/components": 6.4.8
-    "@storybook/core-common": 6.4.8
-    "@storybook/core-events": 6.4.8
-    "@storybook/node-logger": 6.4.8
-    "@storybook/preview-web": 6.4.8
-    "@storybook/router": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/api": 6.4.9
+    "@storybook/channel-postmessage": 6.4.9
+    "@storybook/channels": 6.4.9
+    "@storybook/client-api": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/components": 6.4.9
+    "@storybook/core-common": 6.4.9
+    "@storybook/core-events": 6.4.9
+    "@storybook/node-logger": 6.4.9
+    "@storybook/preview-web": 6.4.9
+    "@storybook/router": 6.4.9
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.8
-    "@storybook/theming": 6.4.8
-    "@storybook/ui": 6.4.8
+    "@storybook/store": 6.4.9
+    "@storybook/theming": 6.4.9
+    "@storybook/ui": 6.4.9
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     autoprefixer: ^9.8.6
@@ -5129,13 +5129,13 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 3e19126f11904c1f609d2706987915da1429cd0f8bbab7a446816a0cf8d4e795938c91e3e5753af82063412268a6e5b8391b11d89948a84e555497164f9832ad
+  checksum: 55e5def76345d6eed06d93262f71b8c4a9a3b2b8252f702ba2b2adb132a301cc6095e4fc60b7368643629257f59846a6b07711c56a35896f0f2bf362c3429f67
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack5@npm:^6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/builder-webpack5@npm:6.4.8"
+"@storybook/builder-webpack5@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/builder-webpack5@npm:6.4.9"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -5157,21 +5157,21 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.4.8
-    "@storybook/api": 6.4.8
-    "@storybook/channel-postmessage": 6.4.8
-    "@storybook/channels": 6.4.8
-    "@storybook/client-api": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/components": 6.4.8
-    "@storybook/core-common": 6.4.8
-    "@storybook/core-events": 6.4.8
-    "@storybook/node-logger": 6.4.8
-    "@storybook/preview-web": 6.4.8
-    "@storybook/router": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/api": 6.4.9
+    "@storybook/channel-postmessage": 6.4.9
+    "@storybook/channels": 6.4.9
+    "@storybook/client-api": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/components": 6.4.9
+    "@storybook/core-common": 6.4.9
+    "@storybook/core-events": 6.4.9
+    "@storybook/node-logger": 6.4.9
+    "@storybook/preview-web": 6.4.9
+    "@storybook/router": 6.4.9
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.8
-    "@storybook/theming": 6.4.8
+    "@storybook/store": 6.4.9
+    "@storybook/theming": 6.4.9
     "@types/node": ^14.0.10
     babel-loader: ^8.0.0
     babel-plugin-macros: ^3.0.1
@@ -5200,60 +5200,60 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 66e80755047a381064ee905f6ccf4f6d37360694ab2e08716151b604e726602fbfb4526f430876ef20bde9aad325d014d3d2d02e32176283d64dfff47b514ad5
+  checksum: 160f0f8ec4b342b868b4fdf403ecda8d4b7ed7cbf6fd9460345f28958f47157f39e48343ab0346aad95f9ab046782c329e8020d4877ebd9aea306bb2a4d15dbd
   languageName: node
   linkType: hard
 
-"@storybook/channel-postmessage@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/channel-postmessage@npm:6.4.8"
+"@storybook/channel-postmessage@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/channel-postmessage@npm:6.4.9"
   dependencies:
-    "@storybook/channels": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/channels": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/core-events": 6.4.9
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
     telejson: ^5.3.2
-  checksum: b34b5838e58d8eadb6c96c3f59dc7fb3db9464486e756ed8018c7b6021e33171992439f9aeab8ef3d0fed027422440aac47e269b65287a59e5f8f958517c87af
+  checksum: eb5534ce0438600fadafcc8053a6a661b0c24326f424848a951ad54ac2562ccd2cc34a724f1c1f30768f34172b38cf13314d1d303ce64b43d675054deb750b1d
   languageName: node
   linkType: hard
 
-"@storybook/channel-websocket@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/channel-websocket@npm:6.4.8"
+"@storybook/channel-websocket@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/channel-websocket@npm:6.4.9"
   dependencies:
-    "@storybook/channels": 6.4.8
-    "@storybook/client-logger": 6.4.8
+    "@storybook/channels": 6.4.9
+    "@storybook/client-logger": 6.4.9
     core-js: ^3.8.2
     global: ^4.4.0
     telejson: ^5.3.2
-  checksum: c9ef7d68ec133efa85ce50fedce1ed5759d941499795c42e543e4164d705d71e1a85e4dfcd4f6fce33964fc5ecd58b8a184e12ab07df6ab2301fd3ba2cbbc415
+  checksum: eb2227344084a6a33b39b66b9be0e756ae9a4381a67c0dc2dcd8c10d0361b8c3948783a3aea3b54b883482e5591f926c271da7c829f8919f7defc6ab25d27ec2
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/channels@npm:6.4.8"
+"@storybook/channels@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/channels@npm:6.4.9"
   dependencies:
     core-js: ^3.8.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  checksum: da25834d686f6616810edf5dfa3da0b69e01111a6f88f3d93c00273cbc22e3ab210a85a0dd28377db46031f9aaa34a71fafb87386adef91eceb954e9e60d9200
+  checksum: 3c3feae20f697ca691612dcca6d492a0f1337fbdcdcc7fa1b3117c45ee8249ce6ef13c4783ce47b9354a1e153754f210f913934232c1fdbf103276321ce02e04
   languageName: node
   linkType: hard
 
-"@storybook/client-api@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/client-api@npm:6.4.8"
+"@storybook/client-api@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/client-api@npm:6.4.9"
   dependencies:
-    "@storybook/addons": 6.4.8
-    "@storybook/channel-postmessage": 6.4.8
-    "@storybook/channels": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/channel-postmessage": 6.4.9
+    "@storybook/channels": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/core-events": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.8
+    "@storybook/store": 6.4.9
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -5270,28 +5270,28 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 04cf7dd9b77b0a8fd57a46e12cd0867e5627a3d917a39f7a5cc6bbb3a2452ff412ab788525adb2ddb16db2cbd6c303edf53598b5c8bc32fcfbd97e76572c9905
+  checksum: c77da28b1d5d5652c39c21ddcad2d03c42091e151d02894333a008a958741b3212a895b170e529b585094bebf6686a334704c13e1747213a6ca599a5e3a5f642
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/client-logger@npm:6.4.8"
+"@storybook/client-logger@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/client-logger@npm:6.4.9"
   dependencies:
     core-js: ^3.8.2
     global: ^4.4.0
-  checksum: f672822f81db018eb721c5ef834e904d4f3fc69db36913520308bea45495e49854b7016ddb071d0e4643264c401b1ee2db60f3afc8b267714073f492bae60050
+  checksum: 32e2a9cd94b1cf732ace64e9ad9f75819c58e99022da0c17cdc1e77e99712cf6a249ab691b8afa59af0f26ff083b14711c8b87e53088879c2ed6d61c375506d6
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/components@npm:6.4.8"
+"@storybook/components@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/components@npm:6.4.9"
   dependencies:
     "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.4.8
+    "@storybook/client-logger": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.8
+    "@storybook/theming": 6.4.9
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -5315,24 +5315,24 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 4df4022f61867ffcfd591a70840ebe5ce773381193c45eb7c2cc9f220a750140ec364a49c0c5f385b5e74ac17796a3dd42f6ca3ccee6deeeb533a4d63c250c91
+  checksum: dbd8438baa00c6fdc228667344cd7f622cad50026827cbd65c17d23502cf1f0289d083d7325c29238a79fa5d3f287a2b795cee505e8f759eab2b26c331324ba6
   languageName: node
   linkType: hard
 
-"@storybook/core-client@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/core-client@npm:6.4.8"
+"@storybook/core-client@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/core-client@npm:6.4.9"
   dependencies:
-    "@storybook/addons": 6.4.8
-    "@storybook/channel-postmessage": 6.4.8
-    "@storybook/channel-websocket": 6.4.8
-    "@storybook/client-api": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/channel-postmessage": 6.4.9
+    "@storybook/channel-websocket": 6.4.9
+    "@storybook/client-api": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/core-events": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/preview-web": 6.4.8
-    "@storybook/store": 6.4.8
-    "@storybook/ui": 6.4.8
+    "@storybook/preview-web": 6.4.9
+    "@storybook/store": 6.4.9
+    "@storybook/ui": 6.4.9
     airbnb-js-shims: ^2.2.1
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
@@ -5350,13 +5350,13 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: c700c744e27256f2860f5e23a4faebb6e4a3e1c9e45d6d98dbf7f5fc1bc1545e26eb20a66ee5e43ea9d2faceb4ef47050c6525461949a14be48f5dec376671e7
+  checksum: f39525e174b23c0dffd88988c59c48fd4f3b617ab9cab1138eabe36aabac7f4843fa63c06e409b169a42c3e0f8d09b1710f5ef1d56e3ab03d604e4eef8ef2769
   languageName: node
   linkType: hard
 
-"@storybook/core-common@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/core-common@npm:6.4.8"
+"@storybook/core-common@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/core-common@npm:6.4.9"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -5379,7 +5379,7 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.4.8
+    "@storybook/node-logger": 6.4.9
     "@storybook/semver": ^7.3.2
     "@types/node": ^14.0.10
     "@types/pretty-hrtime": ^1.0.0
@@ -5413,34 +5413,34 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: b687d2a3c66fb93330f21812a267adb6c37d857563728a6fe1df4c1d9d43d58709eccd8f4ada6381dee6194094f9ae4e84c5d0aa14dc01ca042db1457f0d4b87
+  checksum: f20885204cce8b89139289aaf26175b024573b8ba37e363dc8dfc7ee44fdc3456deb7cda9de35a4662d1adde005647b91b4b633fcab243f1629c4bcd0a11b01c
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/core-events@npm:6.4.8"
+"@storybook/core-events@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/core-events@npm:6.4.9"
   dependencies:
     core-js: ^3.8.2
-  checksum: ee347f40833146041b1095e2398f24a04a3bdf987077cf6a7171dc6cdd85bea29cf77c806e4734422a497cbf21612e7bcfac9f21d694e41a6eb2d20fd91b41cb
+  checksum: a2d6651c12e64b731b9c3e910896a3a53680e61bf02551b566517dc930d86ebffe1750cf5c8da5885af625866f83407b6fe19b43be9df2f0741ef4c43021f861
   languageName: node
   linkType: hard
 
-"@storybook/core-server@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/core-server@npm:6.4.8"
+"@storybook/core-server@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/core-server@npm:6.4.9"
   dependencies:
     "@discoveryjs/json-ext": ^0.5.3
-    "@storybook/builder-webpack4": 6.4.8
-    "@storybook/core-client": 6.4.8
-    "@storybook/core-common": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/builder-webpack4": 6.4.9
+    "@storybook/core-client": 6.4.9
+    "@storybook/core-common": 6.4.9
+    "@storybook/core-events": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/csf-tools": 6.4.8
-    "@storybook/manager-webpack4": 6.4.8
-    "@storybook/node-logger": 6.4.8
+    "@storybook/csf-tools": 6.4.9
+    "@storybook/manager-webpack4": 6.4.9
+    "@storybook/node-logger": 6.4.9
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.8
+    "@storybook/store": 6.4.9
     "@types/node": ^14.0.10
     "@types/node-fetch": ^2.5.7
     "@types/pretty-hrtime": ^1.0.0
@@ -5473,8 +5473,8 @@ __metadata:
     webpack: 4
     ws: ^8.2.3
   peerDependencies:
-    "@storybook/builder-webpack5": 6.4.8
-    "@storybook/manager-webpack5": 6.4.8
+    "@storybook/builder-webpack5": 6.4.9
+    "@storybook/manager-webpack5": 6.4.9
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -5484,18 +5484,18 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: e3cd758fd603adbb8d386a0abf74c2c18df7bda8b4dacd64fc191fe7fb1ab85ff783a2788f79fdaf9b45223022949c802987b6fd2f5a093679ce08d4ab3211e2
+  checksum: 5f9f2198a116ed530fb11a9bf0b4faa25288f2cb71f57687ca80c159c993720d6782c4af97df2511635559f82f6b8ae751295af3faa138a9deff89db127ecda1
   languageName: node
   linkType: hard
 
-"@storybook/core@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/core@npm:6.4.8"
+"@storybook/core@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/core@npm:6.4.9"
   dependencies:
-    "@storybook/core-client": 6.4.8
-    "@storybook/core-server": 6.4.8
+    "@storybook/core-client": 6.4.9
+    "@storybook/core-server": 6.4.9
   peerDependencies:
-    "@storybook/builder-webpack5": 6.4.8
+    "@storybook/builder-webpack5": 6.4.9
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
     webpack: "*"
@@ -5504,13 +5504,13 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 57463e7307411f2bb683562ebc87b7b2fbfef4e39f2879bb5f7a31106a09c868a81640122d0c17a8d159d8530691b62f14324cb6916139d31aff07d178cb4d87
+  checksum: 3d5a9731e052a59f215f38a43c2bfaeb72963ea5f7d6f757612157fb29eca659c33efbd58960d64bebd4ceff2303add05119dfd175944907112195f335abef9a
   languageName: node
   linkType: hard
 
-"@storybook/csf-tools@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/csf-tools@npm:6.4.8"
+"@storybook/csf-tools@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/csf-tools@npm:6.4.9"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/generator": ^7.12.11
@@ -5529,7 +5529,7 @@ __metadata:
     prettier: ^2.2.1
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
-  checksum: fc5589c5c977f2cd0e8895965db15138e2fc7cb9a0012356b9431956b9eebb3c5bf66acf995b292627acf81dd9ed5a2625c816b7c999e523f6d53ac759b57968
+  checksum: aa6e17828368e0e48ca66227dfc2a68bc0f7d148e8c23bf9bdd949c191391049c3589b1d75003d98ca822bb5f93d7250460a9909d7846a0aaadfeb2db44b5d06
   languageName: node
   linkType: hard
 
@@ -5542,19 +5542,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack4@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/manager-webpack4@npm:6.4.8"
+"@storybook/manager-webpack4@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/manager-webpack4@npm:6.4.9"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.4.8
-    "@storybook/core-client": 6.4.8
-    "@storybook/core-common": 6.4.8
-    "@storybook/node-logger": 6.4.8
-    "@storybook/theming": 6.4.8
-    "@storybook/ui": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/core-client": 6.4.9
+    "@storybook/core-common": 6.4.9
+    "@storybook/node-logger": 6.4.9
+    "@storybook/theming": 6.4.9
+    "@storybook/ui": 6.4.9
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     babel-loader: ^8.0.0
@@ -5588,23 +5588,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: f8dfe8cdedbc30da4248d28743fd58f9645603b61e4dc11ad1737ce29b3139c22b30ee3e431774c3a0960c1ab4878852c8705187e261e224833f0f2d07eefc8a
+  checksum: 1570acfcb6c787694501e79b51d9099c47dd146852fd37411685afa55abf613747a409e4937d9632adabcdf9fe78378b3df5b2a4ea8648300e80d506af3ae007
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack5@npm:^6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/manager-webpack5@npm:6.4.8"
+"@storybook/manager-webpack5@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/manager-webpack5@npm:6.4.9"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.4.8
-    "@storybook/core-client": 6.4.8
-    "@storybook/core-common": 6.4.8
-    "@storybook/node-logger": 6.4.8
-    "@storybook/theming": 6.4.8
-    "@storybook/ui": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/core-client": 6.4.9
+    "@storybook/core-common": 6.4.9
+    "@storybook/node-logger": 6.4.9
+    "@storybook/theming": 6.4.9
+    "@storybook/ui": 6.4.9
     "@types/node": ^14.0.10
     babel-loader: ^8.0.0
     case-sensitive-paths-webpack-plugin: ^2.3.0
@@ -5634,20 +5634,20 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: a8f539e9a3f15e4625894d26a53b1a660b23ab2dee7914d7cdee766ddb44da19ed38f59b7dacc48718b779194317257ece6034d8dbbaf4157a2d66fddb26f3a4
+  checksum: 2ff7da906ba96deeb7ea14c4ea5aaf7cde1bf718b9602e9316f88fd2ba3fb332136c10d658276cdd30f2f9b2f4631bd1c04a24b5643c18a63196047faed4694a
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/node-logger@npm:6.4.8"
+"@storybook/node-logger@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/node-logger@npm:6.4.9"
   dependencies:
     "@types/npmlog": ^4.1.2
     chalk: ^4.1.0
     core-js: ^3.8.2
     npmlog: ^5.0.1
     pretty-hrtime: ^1.0.3
-  checksum: 255bd55cbcd4b92023202a856eb7a712cce461439a6765f51fa8b23682065a0b856a2d9b1ebe2b4e4fcf7a2023be4cfad36c9c6276a8fd1292c29bd42ab1c98c
+  checksum: ced92cd7b5177e5cddca45f2730bb9c5ded69ed8d8e04559424bae14f1af57c729f08b1391be37c6085911532593b9c4bb38e2e57cb8ddca4e82e9fcd80344b3
   languageName: node
   linkType: hard
 
@@ -5662,16 +5662,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/preview-web@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/preview-web@npm:6.4.8"
+"@storybook/preview-web@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/preview-web@npm:6.4.9"
   dependencies:
-    "@storybook/addons": 6.4.8
-    "@storybook/channel-postmessage": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/channel-postmessage": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/core-events": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.8
+    "@storybook/store": 6.4.9
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
@@ -5685,7 +5685,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 583ec5b0505387c113a715bb3f7c19efe21d461308cf283f1342224d3801b9db890b2d0df6001696181aa3e6a52cfc0eb18c015c07d7e32de2456599e0720ef4
+  checksum: 21bf3eb7c58ca5540984e2b6d2ab723879ca9e92b964803538c93e85ec2314cedc3f117b95885d717c29d197e240eaddf237425b7d06300a1b5bb62683c8a34d
   languageName: node
   linkType: hard
 
@@ -5707,21 +5707,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:^6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/react@npm:6.4.8"
+"@storybook/react@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/react@npm:6.4.9"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.1
-    "@storybook/addons": 6.4.8
-    "@storybook/core": 6.4.8
-    "@storybook/core-common": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/core": 6.4.9
+    "@storybook/core-common": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/node-logger": 6.4.8
+    "@storybook/node-logger": 6.4.9
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.8
+    "@storybook/store": 6.4.9
     "@types/webpack-env": ^1.16.0
     babel-plugin-add-react-displayname: ^0.0.5
     babel-plugin-named-asset-import: ^0.3.1
@@ -5749,15 +5749,15 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 0b4dc8fe28a7ffea8f0260543c6a3946b90760a5bd58b3ccd4bddb749c162ed3eef6c95ab3a5e5f927f734e88c1094c5e6d6e6f4782bffccaff8ee26ab33bbd3
+  checksum: 13391e6dcd3b4e002dc78e52d10fdf2c0d3b32e69dd04d908ba18fa5ec7f372f42a34face9b7134fcc16e199a5da82e2ad1871c6535ca3d933222d9cbe991a7e
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/router@npm:6.4.8"
+"@storybook/router@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/router@npm:6.4.9"
   dependencies:
-    "@storybook/client-logger": 6.4.8
+    "@storybook/client-logger": 6.4.9
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -5771,7 +5771,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 05e2e884a9a59acf10399cccfef57e8b60d061372a5108f4918fff5f08c3c7ba768f9ac882b7c4cb69972fd38dd1193152dbe55ae8e50c36d7e41dc5322ed9ed
+  checksum: 831f2728655f862202de735a639d4a8e2f096fb4e7493cdcdad00a94a6987ed1b023359aa7a177995ab11b451d14acbbed3c0fac38ce7e70502beedd369eb9ad
   languageName: node
   linkType: hard
 
@@ -5787,13 +5787,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/store@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/store@npm:6.4.8"
+"@storybook/store@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/store@npm:6.4.9"
   dependencies:
-    "@storybook/addons": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/core-events": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/core-events": 6.4.9
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -5809,18 +5809,18 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 9e3319c2fcbb9815496e51aecf47af6d8f8e4dfe0d817750879496ed758f090e8b504304e8cfc84b70cf50ec87c2e79683db0b919b943565e37d7746fb981421
+  checksum: 2ff4156a1b2985b928542d78ec0e5a3f1cc837ab0a908bc16b7bef8c5b57b12f07cc2e224140e04c03699e20f38d5fec8e9d5718748b80ac0524ad5d30126bd2
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/theming@npm:6.4.8"
+"@storybook/theming@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/theming@npm:6.4.9"
   dependencies:
     "@emotion/core": ^10.1.1
     "@emotion/is-prop-valid": ^0.8.6
     "@emotion/styled": ^10.0.27
-    "@storybook/client-logger": 6.4.8
+    "@storybook/client-logger": 6.4.9
     core-js: ^3.8.2
     deep-object-diff: ^1.1.0
     emotion-theming: ^10.0.27
@@ -5832,24 +5832,24 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: df424e264dd4ead7ba6387965f63abad62f8a2b82322f60ed3c0d2826034cd1a3a18b09371a15ec80dcd591dd34b5f856381a3a218c1eba88ff3e43d1db01682
+  checksum: 815f44a9c4386fce63c9aed79de3d0109d3bee4b46317f55cf521b914ea7c6b724f19c67f1508a0d2a32e572b0f1ca327c04fd74358acf5810ba1ae027272718
   languageName: node
   linkType: hard
 
-"@storybook/ui@npm:6.4.8":
-  version: 6.4.8
-  resolution: "@storybook/ui@npm:6.4.8"
+"@storybook/ui@npm:6.4.9":
+  version: 6.4.9
+  resolution: "@storybook/ui@npm:6.4.9"
   dependencies:
     "@emotion/core": ^10.1.1
-    "@storybook/addons": 6.4.8
-    "@storybook/api": 6.4.8
-    "@storybook/channels": 6.4.8
-    "@storybook/client-logger": 6.4.8
-    "@storybook/components": 6.4.8
-    "@storybook/core-events": 6.4.8
-    "@storybook/router": 6.4.8
+    "@storybook/addons": 6.4.9
+    "@storybook/api": 6.4.9
+    "@storybook/channels": 6.4.9
+    "@storybook/client-logger": 6.4.9
+    "@storybook/components": 6.4.9
+    "@storybook/core-events": 6.4.9
+    "@storybook/router": 6.4.9
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.8
+    "@storybook/theming": 6.4.9
     copy-to-clipboard: ^3.3.1
     core-js: ^3.8.2
     core-js-pure: ^3.8.2
@@ -5871,7 +5871,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: c24702589a3c5462003eb824d7a7faa3d4e08989a775a269021bca98535f1e5c942d9fa921fab0360b8b9cf8bb839928ffc70f8bcc6d5e246c5d6ce71e4e07f5
+  checksum: bab91b98a3597dd388375f0382a1a3e5eea5964d9da45e346ac7039cb26aabe874baf81ff0f3a630845950169abd28aa151f94a903c7f6bc683969c95736b1ef
   languageName: node
   linkType: hard
 
@@ -37609,7 +37609,7 @@ testarmada-magellan@11.0.10:
     "@babel/runtime": ^7.16.3
     "@bartekbp/typescript-checkstyle": ^5.0.0
     "@signal-noise/stylelint-scales": ^2.0.0
-    "@storybook/react": ^6.4.8
+    "@storybook/react": ^6.4.9
     "@typeform/embed-react": ^1.1.0
     "@types/cookie": ^0.4.1
     "@types/debug": ^4.1.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,7 +339,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@storybook/addon-actions": ^6.3.12
+    "@storybook/addon-actions": ^6.4.8
     "@storybook/preset-scss": ^1.0.3
     "@wordpress/base-styles": ^4.0.4
     classnames: ^2.3.1
@@ -369,7 +369,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
-    "@storybook/addon-actions": ^6.3.12
+    "@storybook/addon-actions": ^6.4.8
     "@storybook/preset-scss": ^1.0.3
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
@@ -1026,9 +1026,9 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@babel/runtime": ^7.16.3
-    "@storybook/addon-actions": ^6.3.12
-    "@storybook/builder-webpack5": ^6.3.12
-    "@storybook/manager-webpack5": ^6.3.12
+    "@storybook/addon-actions": ^6.4.8
+    "@storybook/builder-webpack5": ^6.4.8
+    "@storybook/manager-webpack5": ^6.4.8
     "@storybook/preset-scss": ^1.0.3
     "@testing-library/dom": ^8.11.1
     "@testing-library/react": ^12.1.2
@@ -4373,23 +4373,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pmmmwh/react-refresh-webpack-plugin@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.4.3"
+"@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.1":
+  version: 0.5.3
+  resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.5.3"
   dependencies:
-    ansi-html: ^0.0.7
+    ansi-html-community: ^0.0.8
+    common-path-prefix: ^3.0.0
+    core-js-pure: ^3.8.1
     error-stack-parser: ^2.0.6
-    html-entities: ^1.2.1
-    native-url: ^0.2.6
-    schema-utils: ^2.6.5
+    find-up: ^5.0.0
+    html-entities: ^2.1.0
+    loader-utils: ^2.0.0
+    schema-utils: ^3.0.0
     source-map: ^0.7.3
   peerDependencies:
-    "@types/webpack": 4.x
-    react-refresh: ">=0.8.3 <0.10.0"
+    "@types/webpack": 4.x || 5.x
+    react-refresh: ">=0.10.0 <1.0.0"
     sockjs-client: ^1.4.0
-    type-fest: ^0.13.1
+    type-fest: ">=0.17.0 <3.0.0"
     webpack: ">=4.43.0 <6.0.0"
-    webpack-dev-server: 3.x
+    webpack-dev-server: 3.x || 4.x
     webpack-hot-middleware: 2.x
     webpack-plugin-serve: 0.x || 1.x
   peerDependenciesMeta:
@@ -4405,7 +4408,7 @@ __metadata:
       optional: true
     webpack-plugin-serve:
       optional: true
-  checksum: c59979ebc3c0dbbfdc37eb53e238d050c519ba3c99e50ecc2953c5243fbc3ae4260956d79282aeaca0e33043564d345f8fc140788846d33257e905c2470c5f60
+  checksum: b33fc7c02c7f45682407813c747ba5fce44d14f05eac48724b8a910abace0a4774bbb9c090fc75d10779a77368581d7d22e30ac39ee2c8186e1aafddf5f28208
   languageName: node
   linkType: hard
 
@@ -4493,21 +4496,6 @@ __metadata:
   version: 1.1.0
   resolution: "@protobufjs/utf8@npm:1.1.0"
   checksum: a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
-  languageName: node
-  linkType: hard
-
-"@reach/router@npm:^1.3.4":
-  version: 1.3.4
-  resolution: "@reach/router@npm:1.3.4"
-  dependencies:
-    create-react-context: 0.3.0
-    invariant: ^2.2.3
-    prop-types: ^15.6.1
-    react-lifecycles-compat: ^3.0.4
-  peerDependencies:
-    react: 15.x || 16.x || 16.4.0-alpha.0911da3
-    react-dom: 15.x || 16.x || 16.4.0-alpha.0911da3
-  checksum: 083fcb658ae5cd0de2b7ebe56bbb8c1b4aa6ec035038d41916afcdd2f31ffd7ccdd6848f7ee8e53d562c31fc4c1b1953fd7007eb9d57daf65779f344ca5a5373
   languageName: node
   linkType: hard
 
@@ -4977,24 +4965,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:^6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/addon-actions@npm:6.3.12"
+"@storybook/addon-actions@npm:^6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/addon-actions@npm:6.4.8"
   dependencies:
-    "@storybook/addons": 6.3.12
-    "@storybook/api": 6.3.12
-    "@storybook/client-api": 6.3.12
-    "@storybook/components": 6.3.12
-    "@storybook/core-events": 6.3.12
-    "@storybook/theming": 6.3.12
+    "@storybook/addons": 6.4.8
+    "@storybook/api": 6.4.8
+    "@storybook/components": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/theming": 6.4.8
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     polished: ^4.0.5
     prop-types: ^15.7.2
     react-inspector: ^5.1.0
     regenerator-runtime: ^0.13.7
+    telejson: ^5.3.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
     uuid-browser: ^3.1.0
@@ -5006,49 +4995,48 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 0fe515697d03691c02b91245e0160055a5e438ec2ba26b3b5a85115ed5bdfe6989de0719dcdd9e92bf146fbebde2637792ba96c39cc1230d92ce7d91bb10b063
+  checksum: 2d75ba4caaf019b9473d1090d84a4537112778bbd610814ad1808b22a1f1e3091b2312c11c18409fbc309ffd7762ec800284a6f3a14227bada673f045e04c75c
   languageName: node
   linkType: hard
 
-"@storybook/addons@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/addons@npm:6.3.12"
+"@storybook/addons@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/addons@npm:6.4.8"
   dependencies:
-    "@storybook/api": 6.3.12
-    "@storybook/channels": 6.3.12
-    "@storybook/client-logger": 6.3.12
-    "@storybook/core-events": 6.3.12
-    "@storybook/router": 6.3.12
-    "@storybook/theming": 6.3.12
+    "@storybook/api": 6.4.8
+    "@storybook/channels": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/router": 6.4.8
+    "@storybook/theming": 6.4.8
+    "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
     regenerator-runtime: ^0.13.7
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 88b7507f878f0c3a3c18caa07ce1034c10a9e2f5ee3f768323c2d029d46de6a48ee8ccff3de2a5cf402c7ac54012c36e79c58098d3dee8a6fb6c925b25efe83c
+  checksum: 09301982512525c27e94fb93056638cbc2211a2e01d888a454daa923e2a1bc4a688634f6d610eecf878df5f1a1027c3233ffb5ef8f5e67074fd5e6060cd0adb2
   languageName: node
   linkType: hard
 
-"@storybook/api@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/api@npm:6.3.12"
+"@storybook/api@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/api@npm:6.4.8"
   dependencies:
-    "@reach/router": ^1.3.4
-    "@storybook/channels": 6.3.12
-    "@storybook/client-logger": 6.3.12
-    "@storybook/core-events": 6.3.12
-    "@storybook/csf": 0.0.1
-    "@storybook/router": 6.3.12
+    "@storybook/channels": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/router": 6.4.8
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.12
-    "@types/reach__router": ^1.3.7
+    "@storybook/theming": 6.4.8
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     memoizerific: ^1.11.3
-    qs: ^6.10.0
     regenerator-runtime: ^0.13.7
     store2: ^2.12.0
     telejson: ^5.3.2
@@ -5057,13 +5045,13 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 20bb18b83d6c0fd6840df7d27689f0da3aa036f8e4c039e6cabde985152c23784a7b7f6790151393494931f60b2d6e2ce8296dd9dfbc3613af47ce3eaebda11d
+  checksum: 6cfb9f2e25003869c225288636a0037c42da97da7acf5023c71ec0cb771edc9b5fdcb7acf9992fd8b4cfea091712efa8146e7d489191617c83435d5925c1fc42
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack4@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/builder-webpack4@npm:6.3.12"
+"@storybook/builder-webpack4@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/builder-webpack4@npm:6.4.8"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -5086,34 +5074,34 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.3.12
-    "@storybook/api": 6.3.12
-    "@storybook/channel-postmessage": 6.3.12
-    "@storybook/channels": 6.3.12
-    "@storybook/client-api": 6.3.12
-    "@storybook/client-logger": 6.3.12
-    "@storybook/components": 6.3.12
-    "@storybook/core-common": 6.3.12
-    "@storybook/core-events": 6.3.12
-    "@storybook/node-logger": 6.3.12
-    "@storybook/router": 6.3.12
+    "@storybook/addons": 6.4.8
+    "@storybook/api": 6.4.8
+    "@storybook/channel-postmessage": 6.4.8
+    "@storybook/channels": 6.4.8
+    "@storybook/client-api": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/components": 6.4.8
+    "@storybook/core-common": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/node-logger": 6.4.8
+    "@storybook/preview-web": 6.4.8
+    "@storybook/router": 6.4.8
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.12
-    "@storybook/ui": 6.3.12
+    "@storybook/store": 6.4.8
+    "@storybook/theming": 6.4.8
+    "@storybook/ui": 6.4.8
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     autoprefixer: ^9.8.6
-    babel-loader: ^8.2.2
+    babel-loader: ^8.0.0
     babel-plugin-macros: ^2.8.0
     babel-plugin-polyfill-corejs3: ^0.1.0
     case-sensitive-paths-webpack-plugin: ^2.3.0
     core-js: ^3.8.2
     css-loader: ^3.6.0
-    dotenv-webpack: ^1.8.0
     file-loader: ^6.2.0
     find-up: ^5.0.0
     fork-ts-checker-webpack-plugin: ^4.1.6
-    fs-extra: ^9.0.1
     glob: ^7.1.6
     glob-promise: ^3.4.0
     global: ^4.4.0
@@ -5123,7 +5111,7 @@ __metadata:
     postcss-flexbugs-fixes: ^4.2.1
     postcss-loader: ^4.2.0
     raw-loader: ^4.0.2
-    react-dev-utils: ^11.0.3
+    react-dev-utils: ^11.0.4
     stable: ^0.1.8
     style-loader: ^1.3.0
     terser-webpack-plugin: ^4.2.3
@@ -5133,7 +5121,7 @@ __metadata:
     webpack: 4
     webpack-dev-middleware: ^3.7.3
     webpack-filter-warnings-plugin: ^1.2.1
-    webpack-hot-middleware: ^2.25.0
+    webpack-hot-middleware: ^2.25.1
     webpack-virtual-modules: ^0.2.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -5141,13 +5129,13 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: b17e9a0a0f547c5e2064a4fdd99db5ef18d219757306027063618a2aa7ccf97c05a39b96fff3bdf62c9c84b28344f245790072fc3dcf223973ee5457e8cb6701
+  checksum: 3e19126f11904c1f609d2706987915da1429cd0f8bbab7a446816a0cf8d4e795938c91e3e5753af82063412268a6e5b8391b11d89948a84e555497164f9832ad
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack5@npm:^6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/builder-webpack5@npm:6.3.12"
+"@storybook/builder-webpack5@npm:^6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/builder-webpack5@npm:6.4.8"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -5169,33 +5157,34 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.3.12
-    "@storybook/api": 6.3.12
-    "@storybook/channel-postmessage": 6.3.12
-    "@storybook/channels": 6.3.12
-    "@storybook/client-api": 6.3.12
-    "@storybook/client-logger": 6.3.12
-    "@storybook/components": 6.3.12
-    "@storybook/core-common": 6.3.12
-    "@storybook/core-events": 6.3.12
-    "@storybook/node-logger": 6.3.12
-    "@storybook/router": 6.3.12
+    "@storybook/addons": 6.4.8
+    "@storybook/api": 6.4.8
+    "@storybook/channel-postmessage": 6.4.8
+    "@storybook/channels": 6.4.8
+    "@storybook/client-api": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/components": 6.4.8
+    "@storybook/core-common": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/node-logger": 6.4.8
+    "@storybook/preview-web": 6.4.8
+    "@storybook/router": 6.4.8
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.12
+    "@storybook/store": 6.4.8
+    "@storybook/theming": 6.4.8
     "@types/node": ^14.0.10
-    babel-loader: ^8.2.2
+    babel-loader: ^8.0.0
     babel-plugin-macros: ^3.0.1
     babel-plugin-polyfill-corejs3: ^0.1.0
     case-sensitive-paths-webpack-plugin: ^2.3.0
     core-js: ^3.8.2
     css-loader: ^5.0.1
-    dotenv-webpack: ^7.0.0
     fork-ts-checker-webpack-plugin: ^6.0.4
-    fs-extra: ^9.0.1
     glob: ^7.1.6
     glob-promise: ^3.4.0
     html-webpack-plugin: ^5.0.0
-    react-dev-utils: ^11.0.3
+    path-browserify: ^1.0.1
+    react-dev-utils: ^11.0.4
     stable: ^0.1.8
     style-loader: ^2.0.0
     terser-webpack-plugin: ^5.0.3
@@ -5203,7 +5192,7 @@ __metadata:
     util-deprecate: ^1.0.2
     webpack: ^5.9.0
     webpack-dev-middleware: ^4.1.0
-    webpack-hot-middleware: ^2.25.0
+    webpack-hot-middleware: ^2.25.1
     webpack-virtual-modules: ^0.4.1
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -5211,83 +5200,98 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: ddd2d9f1a6385c70df1c8ba07e6400c97dad62989f8870cc18d6692f03dde3f01ec449b5c52f9e3fb767ea78c038187f31d9409f7548e1d04ad058f0dde26578
+  checksum: 66e80755047a381064ee905f6ccf4f6d37360694ab2e08716151b604e726602fbfb4526f430876ef20bde9aad325d014d3d2d02e32176283d64dfff47b514ad5
   languageName: node
   linkType: hard
 
-"@storybook/channel-postmessage@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/channel-postmessage@npm:6.3.12"
+"@storybook/channel-postmessage@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/channel-postmessage@npm:6.4.8"
   dependencies:
-    "@storybook/channels": 6.3.12
-    "@storybook/client-logger": 6.3.12
-    "@storybook/core-events": 6.3.12
+    "@storybook/channels": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/core-events": 6.4.8
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
     telejson: ^5.3.2
-  checksum: 9194e7e4f805c09dd25c3d4e6eca1a52d36d769724f39f39b22cfe108c8109ddc0c2924fd2ad02af7c04f64171e0e829001cce66c112aa8b43453e4a207e5f28
+  checksum: b34b5838e58d8eadb6c96c3f59dc7fb3db9464486e756ed8018c7b6021e33171992439f9aeab8ef3d0fed027422440aac47e269b65287a59e5f8f958517c87af
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/channels@npm:6.3.12"
+"@storybook/channel-websocket@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/channel-websocket@npm:6.4.8"
+  dependencies:
+    "@storybook/channels": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    core-js: ^3.8.2
+    global: ^4.4.0
+    telejson: ^5.3.2
+  checksum: c9ef7d68ec133efa85ce50fedce1ed5759d941499795c42e543e4164d705d71e1a85e4dfcd4f6fce33964fc5ecd58b8a184e12ab07df6ab2301fd3ba2cbbc415
+  languageName: node
+  linkType: hard
+
+"@storybook/channels@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/channels@npm:6.4.8"
   dependencies:
     core-js: ^3.8.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  checksum: 78802068a1b508b5382faf1cd35dd8e6d647d6f1f7c516304572bb1039913d6d64249cd91f888a86b4c6bb9cfb5377074e4d1f348d2264a00bd715d7c2f50187
+  checksum: da25834d686f6616810edf5dfa3da0b69e01111a6f88f3d93c00273cbc22e3ab210a85a0dd28377db46031f9aaa34a71fafb87386adef91eceb954e9e60d9200
   languageName: node
   linkType: hard
 
-"@storybook/client-api@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/client-api@npm:6.3.12"
+"@storybook/client-api@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/client-api@npm:6.4.8"
   dependencies:
-    "@storybook/addons": 6.3.12
-    "@storybook/channel-postmessage": 6.3.12
-    "@storybook/channels": 6.3.12
-    "@storybook/client-logger": 6.3.12
-    "@storybook/core-events": 6.3.12
-    "@storybook/csf": 0.0.1
+    "@storybook/addons": 6.4.8
+    "@storybook/channel-postmessage": 6.4.8
+    "@storybook/channels": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/store": 6.4.8
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     memoizerific: ^1.11.3
     qs: ^6.10.0
     regenerator-runtime: ^0.13.7
-    stable: ^0.1.8
     store2: ^2.12.0
+    synchronous-promise: ^2.0.15
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 08d643bf6fe7d47a587a3bc6fbcbdc470bc88bc87e8dd1f2d34761eacfc6242c17faf2028ae8019ff457cc15468cfe63bb017ae70ce70209a02626e8a6b9c47a
+  checksum: 04cf7dd9b77b0a8fd57a46e12cd0867e5627a3d917a39f7a5cc6bbb3a2452ff412ab788525adb2ddb16db2cbd6c303edf53598b5c8bc32fcfbd97e76572c9905
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/client-logger@npm:6.3.12"
+"@storybook/client-logger@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/client-logger@npm:6.4.8"
   dependencies:
     core-js: ^3.8.2
     global: ^4.4.0
-  checksum: 7e6b0a1752e16bd1551d45833e12a1b2eda0d355728ee15720cc9b48acb94afe87d8492a0ac3ab1f107c1d9349baf1cd9c5fb71fb34ab29afdd342acb7f6b43e
+  checksum: f672822f81db018eb721c5ef834e904d4f3fc69db36913520308bea45495e49854b7016ddb071d0e4643264c401b1ee2db60f3afc8b267714073f492bae60050
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/components@npm:6.3.12"
+"@storybook/components@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/components@npm:6.4.8"
   dependencies:
     "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.3.12
-    "@storybook/csf": 0.0.1
-    "@storybook/theming": 6.3.12
+    "@storybook/client-logger": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/theming": 6.4.8
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -5295,7 +5299,7 @@ __metadata:
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     markdown-to-jsx: ^7.1.3
     memoizerific: ^1.11.3
     overlayscrollbars: ^1.13.1
@@ -5311,26 +5315,29 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 23dc9374a6951c9b492558a29a9451dc1084771f4483e26338e242ac4d42a4cf8b4649830f7b7b44347d1b9f8597544f1c18f8b067113aa98a69a9682dc52744
+  checksum: 4df4022f61867ffcfd591a70840ebe5ce773381193c45eb7c2cc9f220a750140ec364a49c0c5f385b5e74ac17796a3dd42f6ca3ccee6deeeb533a4d63c250c91
   languageName: node
   linkType: hard
 
-"@storybook/core-client@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/core-client@npm:6.3.12"
+"@storybook/core-client@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/core-client@npm:6.4.8"
   dependencies:
-    "@storybook/addons": 6.3.12
-    "@storybook/channel-postmessage": 6.3.12
-    "@storybook/client-api": 6.3.12
-    "@storybook/client-logger": 6.3.12
-    "@storybook/core-events": 6.3.12
-    "@storybook/csf": 0.0.1
-    "@storybook/ui": 6.3.12
+    "@storybook/addons": 6.4.8
+    "@storybook/channel-postmessage": 6.4.8
+    "@storybook/channel-websocket": 6.4.8
+    "@storybook/client-api": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/preview-web": 6.4.8
+    "@storybook/store": 6.4.8
+    "@storybook/ui": 6.4.8
     airbnb-js-shims: ^2.2.1
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     qs: ^6.10.0
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
@@ -5343,13 +5350,13 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: d46016f8b525a07783b948a63aab42266c2b135ccde1adc6c69afca0c701e73e4d57f32c7d8338dd120ab1ae7e4071c3dbb1d56929142a555f76e539b158dff9
+  checksum: c700c744e27256f2860f5e23a4faebb6e4a3e1c9e45d6d98dbf7f5fc1bc1545e26eb20a66ee5e43ea9d2faceb4ef47050c6525461949a14be48f5dec376671e7
   languageName: node
   linkType: hard
 
-"@storybook/core-common@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/core-common@npm:6.3.12"
+"@storybook/core-common@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/core-common@npm:6.4.8"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -5372,13 +5379,11 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.3.12
+    "@storybook/node-logger": 6.4.8
     "@storybook/semver": ^7.3.2
-    "@types/glob-base": ^0.3.0
-    "@types/micromatch": ^4.0.1
     "@types/node": ^14.0.10
     "@types/pretty-hrtime": ^1.0.0
-    babel-loader: ^8.2.2
+    babel-loader: ^8.0.0
     babel-plugin-macros: ^3.0.1
     babel-plugin-polyfill-corejs3: ^0.1.0
     chalk: ^4.1.0
@@ -5387,15 +5392,18 @@ __metadata:
     file-system-cache: ^1.0.5
     find-up: ^5.0.0
     fork-ts-checker-webpack-plugin: ^6.0.4
+    fs-extra: ^9.0.1
     glob: ^7.1.6
-    glob-base: ^0.3.0
+    handlebars: ^4.7.7
     interpret: ^2.2.0
     json5: ^2.1.3
     lazy-universal-dotenv: ^3.0.1
-    micromatch: ^4.0.2
+    picomatch: ^2.3.0
     pkg-dir: ^5.0.0
     pretty-hrtime: ^1.0.3
     resolve-from: ^5.0.0
+    slash: ^3.0.0
+    telejson: ^5.3.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
     webpack: 4
@@ -5405,60 +5413,68 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 12a234392b1722828d6cf90795839eefbae6bce7cfdce9c421d4d34fbdb81acd22780451cb2406bb3cd66c953e73b7afbac654630c3d0577be079c934c492788
+  checksum: b687d2a3c66fb93330f21812a267adb6c37d857563728a6fe1df4c1d9d43d58709eccd8f4ada6381dee6194094f9ae4e84c5d0aa14dc01ca042db1457f0d4b87
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/core-events@npm:6.3.12"
+"@storybook/core-events@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/core-events@npm:6.4.8"
   dependencies:
     core-js: ^3.8.2
-  checksum: 7d43191c0ecf1d5e83b7ddda731bc1ebc6687bfcdaf2e32f60ef1d0cb5c78f686547b7ed5b55253a7c16f02f75e6e74fc292bc7ea364c150a01908ffeb294b4e
+  checksum: ee347f40833146041b1095e2398f24a04a3bdf987077cf6a7171dc6cdd85bea29cf77c806e4734422a497cbf21612e7bcfac9f21d694e41a6eb2d20fd91b41cb
   languageName: node
   linkType: hard
 
-"@storybook/core-server@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/core-server@npm:6.3.12"
+"@storybook/core-server@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/core-server@npm:6.4.8"
   dependencies:
     "@discoveryjs/json-ext": ^0.5.3
-    "@storybook/builder-webpack4": 6.3.12
-    "@storybook/core-client": 6.3.12
-    "@storybook/core-common": 6.3.12
-    "@storybook/csf-tools": 6.3.12
-    "@storybook/manager-webpack4": 6.3.12
-    "@storybook/node-logger": 6.3.12
+    "@storybook/builder-webpack4": 6.4.8
+    "@storybook/core-client": 6.4.8
+    "@storybook/core-common": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/csf-tools": 6.4.8
+    "@storybook/manager-webpack4": 6.4.8
+    "@storybook/node-logger": 6.4.8
     "@storybook/semver": ^7.3.2
+    "@storybook/store": 6.4.8
     "@types/node": ^14.0.10
     "@types/node-fetch": ^2.5.7
     "@types/pretty-hrtime": ^1.0.0
     "@types/webpack": ^4.41.26
     better-opn: ^2.1.1
-    boxen: ^4.2.0
+    boxen: ^5.1.2
     chalk: ^4.1.0
     cli-table3: 0.6.0
     commander: ^6.2.1
     compression: ^1.7.4
     core-js: ^3.8.2
-    cpy: ^8.1.1
+    cpy: ^8.1.2
     detect-port: ^1.3.0
     express: ^4.17.1
     file-system-cache: ^1.0.5
     fs-extra: ^9.0.1
     globby: ^11.0.2
     ip: ^1.1.5
+    lodash: ^4.17.21
     node-fetch: ^2.6.1
     pretty-hrtime: ^1.0.3
     prompts: ^2.4.0
     regenerator-runtime: ^0.13.7
     serve-favicon: ^2.5.0
+    slash: ^3.0.0
+    telejson: ^5.3.3
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
+    watchpack: ^2.2.0
     webpack: 4
+    ws: ^8.2.3
   peerDependencies:
-    "@storybook/builder-webpack5": 6.3.12
-    "@storybook/manager-webpack5": 6.3.12
+    "@storybook/builder-webpack5": 6.4.8
+    "@storybook/manager-webpack5": 6.4.8
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -5468,33 +5484,35 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: c3acf55586d79607b1b0055aea638e9128aaea72442bca0aed26e1e1737ea2ca2e34913ce0d76d582fa15622402739fca282aacc600d473286d2ade5f940586d
+  checksum: e3cd758fd603adbb8d386a0abf74c2c18df7bda8b4dacd64fc191fe7fb1ab85ff783a2788f79fdaf9b45223022949c802987b6fd2f5a093679ce08d4ab3211e2
   languageName: node
   linkType: hard
 
-"@storybook/core@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/core@npm:6.3.12"
+"@storybook/core@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/core@npm:6.4.8"
   dependencies:
-    "@storybook/core-client": 6.3.12
-    "@storybook/core-server": 6.3.12
+    "@storybook/core-client": 6.4.8
+    "@storybook/core-server": 6.4.8
   peerDependencies:
-    "@storybook/builder-webpack5": 6.3.12
+    "@storybook/builder-webpack5": 6.4.8
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
+    webpack: "*"
   peerDependenciesMeta:
     "@storybook/builder-webpack5":
       optional: true
     typescript:
       optional: true
-  checksum: 7e45acd7ca41b8ebc34363721db773a028fd7b1b73bd584cbb76173c4e666efac51de6bf8c334199815b9599e480738f2a1695538a0bb92379d8775ab962e2db
+  checksum: 57463e7307411f2bb683562ebc87b7b2fbfef4e39f2879bb5f7a31106a09c868a81640122d0c17a8d159d8530691b62f14324cb6916139d31aff07d178cb4d87
   languageName: node
   linkType: hard
 
-"@storybook/csf-tools@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/csf-tools@npm:6.3.12"
+"@storybook/csf-tools@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/csf-tools@npm:6.4.8"
   dependencies:
+    "@babel/core": ^7.12.10
     "@babel/generator": ^7.12.11
     "@babel/parser": ^7.12.11
     "@babel/plugin-transform-react-jsx": ^7.12.12
@@ -5502,47 +5520,48 @@ __metadata:
     "@babel/traverse": ^7.12.11
     "@babel/types": ^7.12.11
     "@mdx-js/mdx": ^1.6.22
-    "@storybook/csf": ^0.0.1
+    "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     fs-extra: ^9.0.1
+    global: ^4.4.0
     js-string-escape: ^1.0.1
-    lodash: ^4.17.20
-    prettier: ~2.2.1
+    lodash: ^4.17.21
+    prettier: ^2.2.1
     regenerator-runtime: ^0.13.7
-  checksum: ef3e515e3a7a2e8242662f7312a9a0b75a996eb85b2b1aeb3e9d2af5ee62d3b9ac5fc0d8c05252b56f15d5c1b0440390ee715aba862c2b8852700718680450ab
+    ts-dedent: ^2.0.0
+  checksum: fc5589c5c977f2cd0e8895965db15138e2fc7cb9a0012356b9431956b9eebb3c5bf66acf995b292627acf81dd9ed5a2625c816b7c999e523f6d53ac759b57968
   languageName: node
   linkType: hard
 
-"@storybook/csf@npm:0.0.1, @storybook/csf@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@storybook/csf@npm:0.0.1"
+"@storybook/csf@npm:0.0.2--canary.87bc651.0":
+  version: 0.0.2--canary.87bc651.0
+  resolution: "@storybook/csf@npm:0.0.2--canary.87bc651.0"
   dependencies:
     lodash: ^4.17.15
-  checksum: 7b0f75763415f9147692a460b44417ee56ea9639433716a1fd4d1df4c8b0221cbc71b8da0fbed4dcecb3ccd6c7ed64be39f5c255c713539a6088a1d6488aaa24
+  checksum: 0e7c378b358666ddae637ffba4c4345bed0a2603138528cbc5049f416a62a74cd8ab917856d444bf0b7b3dc0ba52186456c24b21ccb1f028dc5cd43e7f2509dc
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack4@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/manager-webpack4@npm:6.3.12"
+"@storybook/manager-webpack4@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/manager-webpack4@npm:6.4.8"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.3.12
-    "@storybook/core-client": 6.3.12
-    "@storybook/core-common": 6.3.12
-    "@storybook/node-logger": 6.3.12
-    "@storybook/theming": 6.3.12
-    "@storybook/ui": 6.3.12
+    "@storybook/addons": 6.4.8
+    "@storybook/core-client": 6.4.8
+    "@storybook/core-common": 6.4.8
+    "@storybook/node-logger": 6.4.8
+    "@storybook/theming": 6.4.8
+    "@storybook/ui": 6.4.8
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
-    babel-loader: ^8.2.2
+    babel-loader: ^8.0.0
     case-sensitive-paths-webpack-plugin: ^2.3.0
     chalk: ^4.1.0
     core-js: ^3.8.2
     css-loader: ^3.6.0
-    dotenv-webpack: ^1.8.0
     express: ^4.17.1
     file-loader: ^6.2.0
     file-system-cache: ^1.0.5
@@ -5569,32 +5588,30 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: e15ef840b4049715a6778b4d788b462e531ed39b75b1eb63777aff00467182c6c3718a85627825951e435b56853da9f3b14af40f7c480cb850d41e40f4e449c1
+  checksum: f8dfe8cdedbc30da4248d28743fd58f9645603b61e4dc11ad1737ce29b3139c22b30ee3e431774c3a0960c1ab4878852c8705187e261e224833f0f2d07eefc8a
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack5@npm:^6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/manager-webpack5@npm:6.3.12"
+"@storybook/manager-webpack5@npm:^6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/manager-webpack5@npm:6.4.8"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.3.12
-    "@storybook/core-client": 6.3.12
-    "@storybook/core-common": 6.3.12
-    "@storybook/node-logger": 6.3.12
-    "@storybook/theming": 6.3.12
-    "@storybook/ui": 6.3.12
+    "@storybook/addons": 6.4.8
+    "@storybook/core-client": 6.4.8
+    "@storybook/core-common": 6.4.8
+    "@storybook/node-logger": 6.4.8
+    "@storybook/theming": 6.4.8
+    "@storybook/ui": 6.4.8
     "@types/node": ^14.0.10
-    babel-loader: ^8.2.2
+    babel-loader: ^8.0.0
     case-sensitive-paths-webpack-plugin: ^2.3.0
     chalk: ^4.1.0
     core-js: ^3.8.2
     css-loader: ^5.0.1
-    dotenv-webpack: ^7.0.0
     express: ^4.17.1
-    file-loader: ^6.2.0
     file-system-cache: ^1.0.5
     find-up: ^5.0.0
     fs-extra: ^9.0.1
@@ -5607,7 +5624,6 @@ __metadata:
     telejson: ^5.3.2
     terser-webpack-plugin: ^5.0.3
     ts-dedent: ^2.0.0
-    url-loader: ^4.1.1
     util-deprecate: ^1.0.2
     webpack: ^5.9.0
     webpack-dev-middleware: ^4.1.0
@@ -5618,20 +5634,20 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 11a26a54a0533cbde2672adfd0520b3385a0d3a00cd55c275b3df26141faa463cb3feaae6620706e839e89213d29faff2f28fd7bd39b09be67835a214b932998
+  checksum: a8f539e9a3f15e4625894d26a53b1a660b23ab2dee7914d7cdee766ddb44da19ed38f59b7dacc48718b779194317257ece6034d8dbbaf4157a2d66fddb26f3a4
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/node-logger@npm:6.3.12"
+"@storybook/node-logger@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/node-logger@npm:6.4.8"
   dependencies:
     "@types/npmlog": ^4.1.2
     chalk: ^4.1.0
     core-js: ^3.8.2
-    npmlog: ^4.1.2
+    npmlog: ^5.0.1
     pretty-hrtime: ^1.0.3
-  checksum: 967ae92a4ab6a81070a2d1dda0d05b949e82bcf0e5b20b986eb571305476ffbca5183a43571846dab605f6668273d58b7b7e6eb83a058a4173ac366ab2ce193b
+  checksum: 255bd55cbcd4b92023202a856eb7a712cce461439a6765f51fa8b23682065a0b856a2d9b1ebe2b4e4fcf7a2023be4cfad36c9c6276a8fd1292c29bd42ab1c98c
   languageName: node
   linkType: hard
 
@@ -5643,6 +5659,33 @@ __metadata:
     sass-loader: "*"
     style-loader: "*"
   checksum: 6df3a8edb0d9ff36ad20954355ebda979b5cf32f3e3c24fea995cf22edbff6efbf349f96cbd867b3afb39af069e7e15e347fa15b7caed34a8e06a9e8cfe7eb60
+  languageName: node
+  linkType: hard
+
+"@storybook/preview-web@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/preview-web@npm:6.4.8"
+  dependencies:
+    "@storybook/addons": 6.4.8
+    "@storybook/channel-postmessage": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/store": 6.4.8
+    ansi-to-html: ^0.6.11
+    core-js: ^3.8.2
+    global: ^4.4.0
+    lodash: ^4.17.21
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+    synchronous-promise: ^2.0.15
+    ts-dedent: ^2.0.0
+    unfetch: ^4.2.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 583ec5b0505387c113a715bb3f7c19efe21d461308cf283f1342224d3801b9db890b2d0df6001696181aa3e6a52cfc0eb18c015c07d7e32de2456599e0720ef4
   languageName: node
   linkType: hard
 
@@ -5664,29 +5707,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:^6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/react@npm:6.3.12"
+"@storybook/react@npm:^6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/react@npm:6.4.8"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@pmmmwh/react-refresh-webpack-plugin": ^0.4.3
-    "@storybook/addons": 6.3.12
-    "@storybook/core": 6.3.12
-    "@storybook/core-common": 6.3.12
-    "@storybook/node-logger": 6.3.12
+    "@pmmmwh/react-refresh-webpack-plugin": ^0.5.1
+    "@storybook/addons": 6.4.8
+    "@storybook/core": 6.4.8
+    "@storybook/core-common": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/node-logger": 6.4.8
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
     "@storybook/semver": ^7.3.2
+    "@storybook/store": 6.4.8
     "@types/webpack-env": ^1.16.0
     babel-plugin-add-react-displayname: ^0.0.5
     babel-plugin-named-asset-import: ^0.3.1
     babel-plugin-react-docgen: ^4.2.1
     core-js: ^3.8.2
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     prop-types: ^15.7.2
-    react-dev-utils: ^11.0.3
-    react-refresh: ^0.8.3
+    react-dev-utils: ^11.0.4
+    react-refresh: ^0.10.0
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
@@ -5704,28 +5749,29 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: b875596c8c4fb0bd5de9a935771e08de35f1edef94e1f2a4e98ae8325e4bf5f4fc0d81b26998613f1d2b56239c8c1084d1df8652c779821863b406303526a3c9
+  checksum: 0b4dc8fe28a7ffea8f0260543c6a3946b90760a5bd58b3ccd4bddb749c162ed3eef6c95ab3a5e5f927f734e88c1094c5e6d6e6f4782bffccaff8ee26ab33bbd3
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/router@npm:6.3.12"
+"@storybook/router@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/router@npm:6.4.8"
   dependencies:
-    "@reach/router": ^1.3.4
-    "@storybook/client-logger": 6.3.12
-    "@types/reach__router": ^1.3.7
+    "@storybook/client-logger": 6.4.8
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    history: 5.0.0
+    lodash: ^4.17.21
     memoizerific: ^1.11.3
     qs: ^6.10.0
+    react-router: ^6.0.0
+    react-router-dom: ^6.0.0
     ts-dedent: ^2.0.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 665e7702e292bbd22a05ed887882120532e116b4007fccf3d415214ebdc3fa4a78e963102c0dc4c1b429c9aa9c7235f5a15c551e9efc0c2947e817bfe32efa8c
+  checksum: 05e2e884a9a59acf10399cccfef57e8b60d061372a5108f4918fff5f08c3c7ba768f9ac882b7c4cb69972fd38dd1193152dbe55ae8e50c36d7e41dc5322ed9ed
   languageName: node
   linkType: hard
 
@@ -5741,14 +5787,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/theming@npm:6.3.12"
+"@storybook/store@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/store@npm:6.4.8"
+  dependencies:
+    "@storybook/addons": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    slash: ^3.0.0
+    stable: ^0.1.8
+    synchronous-promise: ^2.0.15
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 9e3319c2fcbb9815496e51aecf47af6d8f8e4dfe0d817750879496ed758f090e8b504304e8cfc84b70cf50ec87c2e79683db0b919b943565e37d7746fb981421
+  languageName: node
+  linkType: hard
+
+"@storybook/theming@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/theming@npm:6.4.8"
   dependencies:
     "@emotion/core": ^10.1.1
     "@emotion/is-prop-valid": ^0.8.6
     "@emotion/styled": ^10.0.27
-    "@storybook/client-logger": 6.3.12
+    "@storybook/client-logger": 6.4.8
     core-js: ^3.8.2
     deep-object-diff: ^1.1.0
     emotion-theming: ^10.0.27
@@ -5760,25 +5832,24 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: d4bfa1951e4fcdd275ab3c54ce0d03fea6dc409bf47bc83ca2ac05131778e73210017033be03ee4579e7eeec0861fa7c64a3cc61c5e798c850b7e7de13712420
+  checksum: df424e264dd4ead7ba6387965f63abad62f8a2b82322f60ed3c0d2826034cd1a3a18b09371a15ec80dcd591dd34b5f856381a3a218c1eba88ff3e43d1db01682
   languageName: node
   linkType: hard
 
-"@storybook/ui@npm:6.3.12":
-  version: 6.3.12
-  resolution: "@storybook/ui@npm:6.3.12"
+"@storybook/ui@npm:6.4.8":
+  version: 6.4.8
+  resolution: "@storybook/ui@npm:6.4.8"
   dependencies:
     "@emotion/core": ^10.1.1
-    "@storybook/addons": 6.3.12
-    "@storybook/api": 6.3.12
-    "@storybook/channels": 6.3.12
-    "@storybook/client-logger": 6.3.12
-    "@storybook/components": 6.3.12
-    "@storybook/core-events": 6.3.12
-    "@storybook/router": 6.3.12
+    "@storybook/addons": 6.4.8
+    "@storybook/api": 6.4.8
+    "@storybook/channels": 6.4.8
+    "@storybook/client-logger": 6.4.8
+    "@storybook/components": 6.4.8
+    "@storybook/core-events": 6.4.8
+    "@storybook/router": 6.4.8
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.12
-    "@types/markdown-to-jsx": ^6.11.3
+    "@storybook/theming": 6.4.8
     copy-to-clipboard: ^3.3.1
     core-js: ^3.8.2
     core-js-pure: ^3.8.2
@@ -5786,8 +5857,8 @@ __metadata:
     emotion-theming: ^10.0.27
     fuse.js: ^3.6.1
     global: ^4.4.0
-    lodash: ^4.17.20
-    markdown-to-jsx: ^6.11.4
+    lodash: ^4.17.21
+    markdown-to-jsx: ^7.1.3
     memoizerific: ^1.11.3
     polished: ^4.0.5
     qs: ^6.10.0
@@ -5800,7 +5871,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 058ed895d08b26a5e03f3a7acf38c2ebab2d6ea368872476907942e67787dcd45061e75491261b569a86469362d335539fd8e3cdb4eff9e66fe1091d1f780826
+  checksum: c24702589a3c5462003eb824d7a7faa3d4e08989a775a269021bca98535f1e5c942d9fa921fab0360b8b9cf8bb839928ffc70f8bcc6d5e246c5d6ce71e4e07f5
   languageName: node
   linkType: hard
 
@@ -6356,13 +6427,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/glob-base@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@types/glob-base@npm:0.3.0"
-  checksum: 2c0cb3b7bb7c8661b9421194c0fd90a36e1c786a4124375749df9dc1dd8ade536c8eb2ac93b217db24ed3a427755def9a54bc86c2b6bf64a81fb82e7e6f44cc7
-  languageName: node
-  linkType: hard
-
 "@types/glob@npm:*, @types/glob@npm:^7.1.1":
   version: 7.1.3
   resolution: "@types/glob@npm:7.1.3"
@@ -6517,15 +6581,6 @@ __metadata:
   version: 4.0.1
   resolution: "@types/long@npm:4.0.1"
   checksum: 5ce2ecb4d14d29f0f25eff2e2fdb4e5d2ad2a7613094722bc06514d4aaeaa60fc4819465a438aa8e7f987c2649f50da18755d87ac30e5241a127251ad06b2c80
-  languageName: node
-  linkType: hard
-
-"@types/markdown-to-jsx@npm:^6.11.3":
-  version: 6.11.3
-  resolution: "@types/markdown-to-jsx@npm:6.11.3"
-  dependencies:
-    "@types/react": "*"
-  checksum: a14520d501430beb22e429ce330605aa84f3f3344e00d2329ff0724e876864c75c841354b503afcb99e2b79f71af85dfcfefc0f63b145b375ec0588e884764b4
   languageName: node
   linkType: hard
 
@@ -6720,15 +6775,6 @@ __metadata:
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 157eb05f4c75790b0ebdcf7b0547ff117feabc8cda03c3cac3d3ea82bb19a1912e76a411df3eb0bdd01026a9770f07bc0e7e3fbe39ebb31c1be4564c16be35f1
-  languageName: node
-  linkType: hard
-
-"@types/reach__router@npm:^1.3.7":
-  version: 1.3.9
-  resolution: "@types/reach__router@npm:1.3.9"
-  dependencies:
-    "@types/react": "*"
-  checksum: 9145be1aca1f6bd34f99971381c8066a23e238452e39e76ec0549d0b240f6a39232d425f5c5425761e7e56562ae7f003e08a2291d724d503bdbc29686eb509d2
   languageName: node
   linkType: hard
 
@@ -9805,15 +9851,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-html@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "ansi-html@npm:0.0.7"
-  bin:
-    ansi-html: ./bin/ansi-html
-  checksum: f6d3072422dc8d4c795142fd4ee8ee596538ddd02ac23676ec6c61dc61c1149f61acfc651b28ff49e7828a6372d4adab2d94d14e95feff73f656388803e13929
-  languageName: node
-  linkType: hard
-
 "ansi-regex@npm:^2.0.0, ansi-regex@npm:^2.1.1":
   version: 2.1.1
   resolution: "ansi-regex@npm:2.1.1"
@@ -9974,6 +10011,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aproba@npm:^1.0.3 || ^2.0.0":
+  version: 2.0.0
+  resolution: "aproba@npm:2.0.0"
+  checksum: d06e26384a8f6245d8c8896e138c0388824e259a329e0c9f196b4fa533c82502a6fd449586e3604950a0c42921832a458bb3aa0aa9f0ba449cfd4f50fd0d09b5
+  languageName: node
+  linkType: hard
+
 "aproba@npm:^1.0.3, aproba@npm:^1.1.1":
   version: 1.2.0
   resolution: "aproba@npm:1.2.0"
@@ -10011,6 +10055,16 @@ __metadata:
     tar-stream: ^2.1.0
     zip-stream: ^2.1.2
   checksum: cbe672f5abcafcf5018241e65e186839b4d5881a5ea7e3829a5946a12ca9a053bd7af1817791e14e518e391b7255b5ccf4f443a0f743d312ec2583263a74b493
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "are-we-there-yet@npm:2.0.0"
+  dependencies:
+    delegates: ^1.0.0
+    readable-stream: ^3.6.0
+  checksum: 375f753c10329153c8d66dc95e8f8b6c7cc2aa66e05cb0960bd69092b10dae22900cacc7d653ad11d26b3ecbdbfe1e8bfb6ccf0265ba8077a7d979970f16b99c
   languageName: node
   linkType: hard
 
@@ -10625,7 +10679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:^8.2.2, babel-loader@npm:^8.2.3":
+"babel-loader@npm:^8.0.0, babel-loader@npm:^8.2.3":
   version: 8.2.3
   resolution: "babel-loader@npm:8.2.3"
   dependencies:
@@ -11247,23 +11301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"boxen@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "boxen@npm:4.2.0"
-  dependencies:
-    ansi-align: ^3.0.0
-    camelcase: ^5.3.1
-    chalk: ^3.0.0
-    cli-boxes: ^2.2.0
-    string-width: ^4.1.0
-    term-size: ^2.1.0
-    type-fest: ^0.8.1
-    widest-line: ^3.1.0
-  checksum: 64898cf3c0d79a84be1f4d93267d5ed5ed1082df9a62f8a5a80ee46112743ad32c9aba02ac5c280b37da5f452d351eb63a05b90482cdbe2ef49000cec20ff709
-  languageName: node
-  linkType: hard
-
-"boxen@npm:^5.0.0":
+"boxen@npm:^5.0.0, boxen@npm:^5.1.2":
   version: 5.1.2
   resolution: "boxen@npm:5.1.2"
   dependencies:
@@ -12694,7 +12732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-boxes@npm:^2.2.0, cli-boxes@npm:^2.2.1":
+"cli-boxes@npm:^2.2.1":
   version: 2.2.1
   resolution: "cli-boxes@npm:2.2.1"
   checksum: 6111352edbb2f62dbc7bfd58f2d534de507afed7f189f13fa894ce5a48badd94b2aa502fda28f1d7dd5f1eb456e7d4033d09a76660013ef50c7f66e7a034f050
@@ -13001,6 +13039,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-support@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "color-support@npm:1.1.3"
+  bin:
+    color-support: bin.js
+  checksum: 8ffeaa270a784dc382f62d9be0a98581db43e11eee301af14734a6d089bd456478b1a8b3e7db7ca7dc5b18a75f828f775c44074020b51c05fc00e6d0992b1cc6
+  languageName: node
+  linkType: hard
+
 "color@npm:3.0.x":
   version: 3.0.0
   resolution: "color@npm:3.0.0"
@@ -13188,6 +13235,13 @@ __metadata:
   version: 0.7.6
   resolution: "comment-parser@npm:0.7.6"
   checksum: 7b9b19f81faaffc0e477958a017195fda37b7b48ef063d139d729b98dd68843b9133e723137b8e8c35cef9f44e529de3d7291374a4bbb78c3796b0866aeb32ec
+  languageName: node
+  linkType: hard
+
+"common-path-prefix@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "common-path-prefix@npm:3.0.0"
+  checksum: c4a74294e1b1570f4a8ab435285d185a03976c323caa16359053e749db4fde44e3e6586c29cd051100335e11895767cbbd27ea389108e327d62f38daf4548fdb
   languageName: node
   linkType: hard
 
@@ -13453,7 +13507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"console-control-strings@npm:^1.0.0, console-control-strings@npm:~1.1.0":
+"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0, console-control-strings@npm:~1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 7ab51d30b52d461412cd467721bb82afe695da78fff8f29fe6f6b9cbaac9a2328e27a22a966014df9532100f6dd85370460be8130b9c677891ba36d96a343f50
@@ -13629,10 +13683,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-pure@npm:^3.0.0, core-js-pure@npm:^3.8.2":
-  version: 3.17.1
-  resolution: "core-js-pure@npm:3.17.1"
-  checksum: 0f411802c7ed009bdf396556a59adaa8905d8fc94cc0a6e0d0654d9c436c179b097ff7e6ff23f8a353ee77e79b241b20e9d100d814c3e9dd7622eb4e5374b9e8
+"core-js-pure@npm:^3.0.0, core-js-pure@npm:^3.8.1, core-js-pure@npm:^3.8.2":
+  version: 3.19.3
+  resolution: "core-js-pure@npm:3.19.3"
+  checksum: 688478e76faff18e28872e647100b79fd031f11f5ead16c44e60eab8d939ff42a548ddf936067bafae74ff859feff7952373bffd7fb8d3ab4142e5e19bdec65a
   languageName: node
   linkType: hard
 
@@ -13721,9 +13775,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cpy@npm:^8.1.1":
-  version: 8.1.1
-  resolution: "cpy@npm:8.1.1"
+"cpy@npm:^8.1.2":
+  version: 8.1.2
+  resolution: "cpy@npm:8.1.2"
   dependencies:
     arrify: ^2.0.1
     cp-file: ^7.0.0
@@ -13734,7 +13788,7 @@ __metadata:
     p-all: ^2.1.0
     p-filter: ^2.1.0
     p-map: ^3.0.0
-  checksum: efbaa7bc83f196cf3db8625b6d55eae47091b2cbb892c9ff766822cd5cc0c194b971c6cbcae71cf211c83f2db4763d457c8d206346055749d2aeed93d3bd58ea
+  checksum: 84611fdd526a0582ae501a0fa1e1d55e16348c69110eb17be5fc0c087b7b2aa6caec014286b669e4f123750d01e0c4db77d32fdcdb9840c3df4d161a137a345a
   languageName: node
   linkType: hard
 
@@ -13812,19 +13866,6 @@ __metadata:
     safe-buffer: ^5.0.1
     sha.js: ^2.4.8
   checksum: 24332bab51011652a9a0a6d160eed1e8caa091b802335324ae056b0dcb5acbc9fcf173cf10d128eba8548c3ce98dfa4eadaa01bd02f44a34414baee26b651835
-  languageName: node
-  linkType: hard
-
-"create-react-context@npm:0.3.0":
-  version: 0.3.0
-  resolution: "create-react-context@npm:0.3.0"
-  dependencies:
-    gud: ^1.0.0
-    warning: ^4.0.3
-  peerDependencies:
-    prop-types: ^15.0.0
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0
-  checksum: 3f9dfde23da59e3f748b5f1b06c7ff8cbf48095cf2d62212427195860f1ee4b2b0b475280c19592f7fffb9fd100fd739af687281d7c5c93806d519bf66f6dd86
   languageName: node
   linkType: hard
 
@@ -15468,24 +15509,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv-defaults@npm:^1.0.2":
-  version: 1.1.1
-  resolution: "dotenv-defaults@npm:1.1.1"
-  dependencies:
-    dotenv: ^6.2.0
-  checksum: c1304b7c83cbc310b0fa2a9256cf60caa0221d8b240b9e520f59bcdf3dfcfcf6a6d322250e787b6b770e21a17e7fdf56b6371e0b9a515d58d1159e7042a7caef
-  languageName: node
-  linkType: hard
-
-"dotenv-defaults@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "dotenv-defaults@npm:2.0.2"
-  dependencies:
-    dotenv: ^8.2.0
-  checksum: 14b7b8f6c21a30404106384398728746e63405bfeabe47ef7aadd0e81de49986d5896a612e5b1acddf655af6472a24947b7b113aa3ef3270a2877afa9c5bd287
-  languageName: node
-  linkType: hard
-
 "dotenv-expand@npm:^5.1.0":
   version: 5.1.0
   resolution: "dotenv-expand@npm:5.1.0"
@@ -15493,36 +15516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv-webpack@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "dotenv-webpack@npm:1.8.0"
-  dependencies:
-    dotenv-defaults: ^1.0.2
-  peerDependencies:
-    webpack: ^1 || ^2 || ^3 || ^4
-  checksum: 64ec3b4c2fcb6cc65195c2a44778d47d5b38478ec3663b95a465b3cb392a6436def96393eff92780dc53f4b35bef67589d0fc19812503acbc9ec015a6bf45b3b
-  languageName: node
-  linkType: hard
-
-"dotenv-webpack@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "dotenv-webpack@npm:7.0.3"
-  dependencies:
-    dotenv-defaults: ^2.0.2
-  peerDependencies:
-    webpack: ^4 || ^5
-  checksum: 1209f72c980989a4de550e6be7fab9efe7c34f56496760e8b91cd577ddba461b36acbb7de3a56416e60af9ef67c9b7d224bdf6a61e4dca60e23dc8e1673a16eb
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "dotenv@npm:6.2.0"
-  checksum: 56886938622c34255c89ec24d584460668a5ca035afe37da7b16bfbac36f8b352d20a6dde51000b30db04fa5cac7b03caf165919fe5e9bd8c91a2735fd61c649
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:^8.0.0, dotenv@npm:^8.2.0":
+"dotenv@npm:^8.0.0":
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 6750431dea8efbd54b9f2d9681b04e1ccc7989486461dcf058bb708d9e3d63b04115fcdf8840e38ad1e24a4a2e1e7c1560626c5e3ac7bc09371b127c49e2d45f
@@ -18540,6 +18534,23 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"gauge@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "gauge@npm:3.0.1"
+  dependencies:
+    aproba: ^1.0.3 || ^2.0.0
+    color-support: ^1.1.2
+    console-control-strings: ^1.0.0
+    has-unicode: ^2.0.1
+    object-assign: ^4.1.1
+    signal-exit: ^3.0.0
+    string-width: ^1.0.1 || ^2.0.0
+    strip-ansi: ^3.0.1 || ^4.0.0
+    wide-align: ^1.1.2
+  checksum: 8c857554961ddf59cf27fdf7a752314a6054b4069c54e4fdcf4c64024246bbf2ceb5cf23b7fa146925374f082c24669314aa68db6f8966cde54e90e8bc109c27
+  languageName: node
+  linkType: hard
+
 "gauge@npm:~2.7.3":
   version: 2.7.4
   resolution: "gauge@npm:2.7.4"
@@ -18734,25 +18745,6 @@ fsevents@~2.1.2:
   version: 0.0.0
   resolution: "github-from-package@npm:0.0.0"
   checksum: 737ee3f52d0a27e26332cde85b533c21fcdc0b09fb716c3f8e522cfaa9c600d4a631dec9fcde179ec9d47cca89017b7848ed4d6ae6b6b78f936c06825b1fcc12
-  languageName: node
-  linkType: hard
-
-"glob-base@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "glob-base@npm:0.3.0"
-  dependencies:
-    glob-parent: ^2.0.0
-    is-glob: ^2.0.0
-  checksum: 4ce785c1dac2ff1e4660c010fa43ed2f1b38993dfd004023a3e7080b20bc61f29fbfe5d265b7e64cc84096ecf44e8ca876c7c1aad8f1f995d4c0f33034f3ae8c
-  languageName: node
-  linkType: hard
-
-"glob-parent@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "glob-parent@npm:2.0.0"
-  dependencies:
-    is-glob: ^2.0.0
-  checksum: b9d59dc532d47aaaa4841046ff631b325a707f738445300b83b7a1ee603dd060c041a378e8a195c887d479bb703685cee4725c8f54b8dacef65355375f57d32a
   languageName: node
   linkType: hard
 
@@ -19223,13 +19215,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"gud@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "gud@npm:1.0.0"
-  checksum: a4db6edc18e2c4e3a22dc9e639e40a4e5650d53dae9cf384a96d5380dfa17ddda376cf6b7797a5c30d140d2532e5a69d167bdb70c2c151dd673253bac6b027f3
-  languageName: node
-  linkType: hard
-
 "gzip-size@npm:5.1.1":
   version: 5.1.1
   resolution: "gzip-size@npm:5.1.1"
@@ -19253,6 +19238,24 @@ fsevents@~2.1.2:
   version: 2.0.1
   resolution: "handle-thing@npm:2.0.1"
   checksum: 7ae34ba286a3434f1993ebd1cc9c9e6b6d8ea672182db28b1afc0a7119229552fa7031e3e5f3cd32a76430ece4e94b7da6f12af2eb39d6239a7693e4bd63a998
+  languageName: node
+  linkType: hard
+
+"handlebars@npm:^4.7.7":
+  version: 4.7.7
+  resolution: "handlebars@npm:4.7.7"
+  dependencies:
+    minimist: ^1.2.5
+    neo-async: ^2.6.0
+    source-map: ^0.6.1
+    uglify-js: ^3.1.4
+    wordwrap: ^1.0.0
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 4c0913fc0018a2a2e358ee94e4fe83f071762b8bec51a473d187e6642e94e569843adcf550ffe329554c63ad450c062f3a05447bd2e3fff5ebfe698e214225c6
   languageName: node
   linkType: hard
 
@@ -19358,7 +19361,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.0":
+"has-unicode@npm:^2.0.0, has-unicode@npm:^2.0.1":
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: ebdb2f4895c26bb08a8a100b62d362e49b2190bcfd84b76bc4be1a3bd4d254ec52d0dd9f2fbcc093fc5eb878b20c52146f9dfd33e2686ed28982187be593b47c
@@ -19585,6 +19588,15 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"history@npm:5.0.0":
+  version: 5.0.0
+  resolution: "history@npm:5.0.0"
+  dependencies:
+    "@babel/runtime": ^7.7.6
+  checksum: 6e1a0880c1d67a9040117e5b426e71bc35642488485354d378cb635f194c2177979558b6fb537972840c6993d92c1ae971ab6c33bf77be1b1f135349ea65cde0
+  languageName: node
+  linkType: hard
+
 "history@npm:^4.9.0":
   version: 4.10.1
   resolution: "history@npm:4.10.1"
@@ -19599,12 +19611,12 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"history@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "history@npm:5.0.0"
+"history@npm:^5.0.0, history@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "history@npm:5.1.0"
   dependencies:
     "@babel/runtime": ^7.7.6
-  checksum: 6e1a0880c1d67a9040117e5b426e71bc35642488485354d378cb635f194c2177979558b6fb537972840c6993d92c1ae971ab6c33bf77be1b1f135349ea65cde0
+  checksum: f76cd11b905cd947e9db371d7bf6e6c403d52e081ae88953c1ba6208d741470fd8f85f22acfb0d9fb11ef7d8811e6fbd20d0a7b87f05263e2cc80393ba1be315
   languageName: node
   linkType: hard
 
@@ -19719,13 +19731,6 @@ fsevents@~2.1.2:
   dependencies:
     whatwg-encoding: ^1.0.5
   checksum: 6dc3aa2d35a8f0c8c7906ffb665dd24a88f7004f913fafdd3541d24a4da6182ab30c4a0a81387649a1234ecb90182c4136220ed12ae3dc1a57ed68e533dea416
-  languageName: node
-  linkType: hard
-
-"html-entities@npm:^1.2.1":
-  version: 1.4.0
-  resolution: "html-entities@npm:1.4.0"
-  checksum: eb2de616fb5948e681157805687672ea90e67c8a4f21a3215888ab422a984cab61fec96860708dca3bde0ae52577515683c8e28157ac8637220bb6a57a031b85
   languageName: node
   linkType: hard
 
@@ -20498,7 +20503,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.3, invariant@npm:^2.2.4":
+"invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
@@ -20836,13 +20841,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"is-extglob@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-extglob@npm:1.0.0"
-  checksum: 1ce5366d19958f36069a45ca996c1e51ab607f42a01eb0505f0ccffe8f9c91f5bcba6e971605efd8b4d4dfd0111afa3c8df3e1746db5b85b9a8f933f5e7286b7
-  languageName: node
-  linkType: hard
-
 "is-extglob@npm:^2.1.0, is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -20909,15 +20907,6 @@ fsevents@~2.1.2:
     is-obj: ^1.0.1
     multimatch: ^2.1.0
   checksum: dc44689ce4f12cc825f3b5c7e319b1d30493265edcd549000603af68fe726961aac5784559b64147e2235f3ef92cab121a48414a9c1337290e9a3c8e24490d43
-  languageName: node
-  linkType: hard
-
-"is-glob@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "is-glob@npm:2.0.1"
-  dependencies:
-    is-extglob: ^1.0.0
-  checksum: ef156806af0924983325c9218a8b8a838fa50e1a104ed2a11fe94829a5b27c1b05a4c8cf98d96cb3a7fea539c21f14ae2081e1a248f3d5a9eea62f2d4e9f8b0c
   languageName: node
   linkType: hard
 
@@ -24541,18 +24530,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"markdown-to-jsx@npm:^6.11.4":
-  version: 6.11.4
-  resolution: "markdown-to-jsx@npm:6.11.4"
-  dependencies:
-    prop-types: ^15.6.2
-    unquote: ^1.1.0
-  peerDependencies:
-    react: ">= 0.14.0"
-  checksum: 72b9f877f001604413ec089e4873bc034f8e1c17042f1421ab75938c97a1ad53ef8948656eeec234e3b1621613c37b13daad81db4fa895ac6b7f4cc4720dfcc6
-  languageName: node
-  linkType: hard
-
 "markdown-to-jsx@npm:^7.1.3":
   version: 7.1.3
   resolution: "markdown-to-jsx@npm:7.1.3"
@@ -26039,15 +26016,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"native-url@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "native-url@npm:0.2.6"
-  dependencies:
-    querystring: ^0.2.0
-  checksum: d29d4a96ce20c107da0febcfd402665a2033f46075a51b3d70c97b0fadf6b102658b573aa04e33e82b7d8ec7686a760a4af96991653ee848ee3a57e30202d205
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -26116,7 +26084,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.5.0, neo-async@npm:^2.6.1, neo-async@npm:^2.6.2":
+"neo-async@npm:^2.5.0, neo-async@npm:^2.6.0, neo-async@npm:^2.6.1, neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
@@ -26695,6 +26663,18 @@ fsevents@~2.1.2:
     gauge: ~2.7.3
     set-blocking: ~2.0.0
   checksum: d6a26cb362277c65e24a70ebdaff31f81184ceb5415fd748abaaf26417bf0794a17ba849116e4f454a0370b9067ae320834cc78d74527dbeadf6e9d19a959046
+  languageName: node
+  linkType: hard
+
+"npmlog@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "npmlog@npm:5.0.1"
+  dependencies:
+    are-we-there-yet: ^2.0.0
+    console-control-strings: ^1.1.0
+    gauge: ^3.0.0
+    set-blocking: ^2.0.0
+  checksum: 489ba519031013001135c463406f55491a17fc7da295c18a04937fe3a4d523fd65e88dd418a28b967ab743d913fdeba1e29838ce0ad8c75557057c481f7d49fa
   languageName: node
   linkType: hard
 
@@ -27950,7 +27930,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3, picomatch@npm:^2.3.0":
   version: 2.3.0
   resolution: "picomatch@npm:2.3.0"
   checksum: a65bde78212368e16afb82429a0ea033d20a836270446acb53ec6e31d939bccf1213f788bc49361f7aff47b67c1fb74d898f99964f67f26ca07a3cd815ddbcbb
@@ -28951,21 +28931,21 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"prettier@npm:^2.2.1":
+  version: 2.5.1
+  resolution: "prettier@npm:2.5.1"
+  bin:
+    prettier: bin-prettier.js
+  checksum: fa9750193b3fcdb4bd54ba4e57996d335de4cd492d277539b6ffb6d146c8b6d3c3dc264b75021914c99c91574643637f607da08ef4588ef30a7b78d14326f470
+  languageName: node
+  linkType: hard
+
 "prettier@npm:wp-prettier@2.2.1-beta-1":
   version: 2.2.1-beta-1
   resolution: "wp-prettier@npm:2.2.1-beta-1"
   bin:
     prettier: bin-prettier.js
   checksum: 24287cada8e2320683c12e0b0ca2079db1f8bf1314b564cb59aa5cbfff6c326722d04960e04db2dae3270de7f651114f6fe9d930e493c6e9ba8758e16f6de6ec
-  languageName: node
-  linkType: hard
-
-"prettier@npm:~2.2.1":
-  version: 2.2.1
-  resolution: "prettier@npm:2.2.1"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 4041ff87d6cba9134a8e0eb74a9e7f50f7091de6b95f5a6fb1928795c7d0584ae46806e0d75588fbc912b2cda2439d28a14fb84416946384cf71d60f5a0a68a6
   languageName: node
   linkType: hard
 
@@ -29766,7 +29746,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-dev-utils@npm:^11.0.3":
+"react-dev-utils@npm:^11.0.4":
   version: 11.0.4
   resolution: "react-dev-utils@npm:11.0.4"
   dependencies:
@@ -30180,17 +30160,17 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"react-refresh@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "react-refresh@npm:0.10.0"
+  checksum: 616e82bed3787bf4e55dcc1c9836f251b93523dd4b0ffb1c24c2dcf5d09f686fbf3cffc7d489cd7f12429f76ddf66eb431748fc07df56b18a888a7705cbc079e
+  languageName: node
+  linkType: hard
+
 "react-refresh@npm:^0.4.0":
   version: 0.4.3
   resolution: "react-refresh@npm:0.4.3"
   checksum: 2b4e4b14b54bfbdfdd6d1c16b8476151b3e61083387061d4e5923b0342c678f6d0f23705835c3a04ab151bd92551d437395da3fb52ea7461a408f457d11ac6fa
-  languageName: node
-  linkType: hard
-
-"react-refresh@npm:^0.8.3":
-  version: 0.8.3
-  resolution: "react-refresh@npm:0.8.3"
-  checksum: 74ad7a7e2f29163163b9e13c9aa868faba58d76113acf910f165c18c022086a590750fd93bc8d9468e73cacc3874ad5c061ded7e931ef299aa3dfa3a663fe665
   languageName: node
   linkType: hard
 
@@ -30220,6 +30200,19 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"react-router-dom@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "react-router-dom@npm:6.0.2"
+  dependencies:
+    history: ^5.1.0
+    react-router: 6.0.2
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: f34d30742631813ff5a9bff2dc20adc0ae3932c956cf5b1ecaeeb5287f41c4dcb612e2eb2a98244ee5cc6f6c6827ebc91c771ebb3beb7eca103c5e4b8d251f24
+  languageName: node
+  linkType: hard
+
 "react-router@npm:5.2.0":
   version: 5.2.0
   resolution: "react-router@npm:5.2.0"
@@ -30237,6 +30230,17 @@ fsevents@~2.1.2:
   peerDependencies:
     react: ">=15"
   checksum: 3225ca136f0e95a972d3698f05d83e48733b0ea1248b28e1051727cf12e7e13700ee638141a076ebad4dea2b9e915f65aac097d33da785d64e8a08f23cdd34e9
+  languageName: node
+  linkType: hard
+
+"react-router@npm:6.0.2, react-router@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "react-router@npm:6.0.2"
+  dependencies:
+    history: ^5.1.0
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 60f9b079c03b6d213740cda937ba7265c2b6ce31d3e9cd9155fa64fb5b62fa5b15cfa9a487fb272809d935e4238697833d5910bb9aaed89b948c0071e3e5c399
   languageName: node
   linkType: hard
 
@@ -33909,6 +33913,16 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"string-width@npm:^1.0.1 || ^2.0.0, string-width@npm:^1.0.2 || 2, string-width@npm:^2.0.0, string-width@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "string-width@npm:2.1.1"
+  dependencies:
+    is-fullwidth-code-point: ^2.0.0
+    strip-ansi: ^4.0.0
+  checksum: e5f2b169fcf8a4257a399f95d069522f056e92ec97dbdcb9b0cdf14d688b7ca0b1b1439a1c7b9773cd79446cbafd582727279d6bfdd9f8edd306ea5e90e5b610
+  languageName: node
+  linkType: hard
+
 "string-width@npm:^1.0.1, string-width@npm:^1.0.2":
   version: 1.0.2
   resolution: "string-width@npm:1.0.2"
@@ -33920,13 +33934,14 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2, string-width@npm:^2.0.0, string-width@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "string-width@npm:2.1.1"
+"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
   dependencies:
-    is-fullwidth-code-point: ^2.0.0
-    strip-ansi: ^4.0.0
-  checksum: e5f2b169fcf8a4257a399f95d069522f056e92ec97dbdcb9b0cdf14d688b7ca0b1b1439a1c7b9773cd79446cbafd582727279d6bfdd9f8edd306ea5e90e5b610
+    emoji-regex: ^8.0.0
+    is-fullwidth-code-point: ^3.0.0
+    strip-ansi: ^6.0.1
+  checksum: 1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
   languageName: node
   linkType: hard
 
@@ -33938,17 +33953,6 @@ resolve@^2.0.0-next.3:
     is-fullwidth-code-point: ^2.0.0
     strip-ansi: ^5.1.0
   checksum: 85fa0d4f106e7999bb68c1c640c76fa69fb8c069dab75b009e29c123914e2d3b532e6cfa4b9d1bd913176fc83dedd7a2d7bf40d21a81a8a1978432cedfb65b91
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "string-width@npm:4.2.2"
-  dependencies:
-    emoji-regex: ^8.0.0
-    is-fullwidth-code-point: ^3.0.0
-    strip-ansi: ^6.0.0
-  checksum: 3874075d5b9c29f4260a338bf3d8152f266a8e6cf27538fd5c89f9dee0a5148d602df5c07c1308707b8a20029aac7842aebb6f861a84e24e79b3d97531894c23
   languageName: node
   linkType: hard
 
@@ -34084,7 +34088,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^4.0.0":
+"strip-ansi@npm:^3.0.1 || ^4.0.0, strip-ansi@npm:^4.0.0":
   version: 4.0.0
   resolution: "strip-ansi@npm:4.0.0"
   dependencies:
@@ -34677,6 +34681,13 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
+"synchronous-promise@npm:^2.0.15":
+  version: 2.0.15
+  resolution: "synchronous-promise@npm:2.0.15"
+  checksum: 967778e7570dc496d7630a89db3bada38876574797c9b272ee50f6ecd7afcebf450268b4bb48a84274d213ab9fd4865dbcc6edeb279f9ecaddf189d5446cbe43
+  languageName: node
+  linkType: hard
+
 "table@npm:^5.2.3":
   version: 5.4.6
   resolution: "table@npm:5.4.6"
@@ -34802,7 +34813,7 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"telejson@npm:^5.3.2":
+"telejson@npm:^5.3.2, telejson@npm:^5.3.3":
   version: 5.3.3
   resolution: "telejson@npm:5.3.3"
   dependencies:
@@ -34844,13 +34855,6 @@ swiper@4.5.1:
   dependencies:
     rimraf: ~2.6.2
   checksum: 7f071c963031bfece37e13c5da11e9bb451e4ddfc4653e23e327a2f91594102dc826ef6a693648e09a6e0eb856f507967ec759ae55635e0878091eccf411db37
-  languageName: node
-  linkType: hard
-
-"term-size@npm:^2.1.0":
-  version: 2.2.0
-  resolution: "term-size@npm:2.2.0"
-  checksum: 351864912bdf315b97ead6189c1d083d957b2a549ab2150eab1c60ae79ee6077cd12853a0ae27acac8703833b122901232d35db2fa3c72a96838ec4036ac7298
   languageName: node
   linkType: hard
 
@@ -35946,6 +35950,15 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
+"uglify-js@npm:^3.1.4":
+  version: 3.14.4
+  resolution: "uglify-js@npm:3.14.4"
+  bin:
+    uglifyjs: bin/uglifyjs
+  checksum: 0e75348ae340665179dd28b25e868bcb5b5b6e4f50c580488192c54f6bba87fd9ceb268f02ce3223fb8985eb8713be27d27a47b7aa5b98a504b4afe5a50aa4a3
+  languageName: node
+  linkType: hard
+
 "ultron@npm:1.0.x":
   version: 1.0.2
   resolution: "ultron@npm:1.0.2"
@@ -36306,7 +36319,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"unquote@npm:^1.1.0, unquote@npm:^1.1.1, unquote@npm:~1.1.1":
+"unquote@npm:^1.1.1, unquote@npm:~1.1.1":
   version: 1.1.1
   resolution: "unquote@npm:1.1.1"
   checksum: de59fb48cbaadc636002c6563dcb6b1bce95c91ebecb92addbc9bb47982cb03e7d8a8371c9617267b9e5746bbcb4403394139bc1310106b9ac4c26790ed57859
@@ -36900,7 +36913,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.3.1":
+"watchpack@npm:^2.2.0, watchpack@npm:^2.3.1":
   version: 2.3.1
   resolution: "watchpack@npm:2.3.1"
   dependencies:
@@ -37110,7 +37123,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"webpack-hot-middleware@npm:^2.25.0, webpack-hot-middleware@npm:^2.25.1":
+"webpack-hot-middleware@npm:^2.25.1":
   version: 2.25.1
   resolution: "webpack-hot-middleware@npm:2.25.1"
   dependencies:
@@ -37454,12 +37467,21 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"wide-align@npm:1.1.3, wide-align@npm:^1.1.0":
+"wide-align@npm:1.1.3":
   version: 1.1.3
   resolution: "wide-align@npm:1.1.3"
   dependencies:
     string-width: ^1.0.2 || 2
   checksum: 9bf69ad55f7bcccd5a7af2ebbb8115aebf1b17e6d4f0a2a40a84f5676e099153b9adeab331e306661bf2a8419361bacba83057a62163947507473ce7ac4116b7
+  languageName: node
+  linkType: hard
+
+"wide-align@npm:^1.1.0, wide-align@npm:^1.1.2":
+  version: 1.1.5
+  resolution: "wide-align@npm:1.1.5"
+  dependencies:
+    string-width: ^1.0.2 || 2 || 3 || 4
+  checksum: 1d9c2a3e36dfb09832f38e2e699c367ef190f96b82c71f809bc0822c306f5379df87bab47bed27ea99106d86447e50eb972d3c516c2f95782807a9d082fbea95
   languageName: node
   linkType: hard
 
@@ -37531,6 +37553,13 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
+"wordwrap@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "wordwrap@npm:1.0.0"
+  checksum: 7ed2e44f3c33c5c3e3771134d2b0aee4314c9e49c749e37f464bf69f2bcdf0cbf9419ca638098e2717cff4875c47f56a007532f6111c3319f557a2ca91278e92
+  languageName: node
+  linkType: hard
+
 "worker-farm@npm:^1.7.0":
   version: 1.7.0
   resolution: "worker-farm@npm:1.7.0"
@@ -37580,7 +37609,7 @@ testarmada-magellan@11.0.10:
     "@babel/runtime": ^7.16.3
     "@bartekbp/typescript-checkstyle": ^5.0.0
     "@signal-noise/stylelint-scales": ^2.0.0
-    "@storybook/react": ^6.3.12
+    "@storybook/react": ^6.4.8
     "@typeform/embed-react": ^1.1.0
     "@types/cookie": ^0.4.1
     "@types/debug": ^4.1.7
@@ -38021,9 +38050,9 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.1.0":
-  version: 8.2.3
-  resolution: "ws@npm:8.2.3"
+"ws@npm:^8.1.0, ws@npm:^8.2.3":
+  version: 8.3.0
+  resolution: "ws@npm:8.3.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -38032,7 +38061,7 @@ testarmada-magellan@11.0.10:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 5ef0f81cc5b8776fb5dd5504c83b4f49be5aa610f9319ff774158bba7db495127e69763d73085288223061e7a5d104d022e2e264346b36b046322f50057e7945
+  checksum: 3e9d2faf128435f0b8ab272d731d8460c6c23d126503a920f14f81f9ae4a213624bfc2ca79e891b87ae84fe45b187754048df93b46c3ce55f8501528790380ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Seeing #55736, I was motivated to try this cleanup ourselves.

Interestingly, storybook 6.4 has a lot of changes to prep for the future v7 release.
- Peer dependency issues are resolved, so we can remove our override. 🎉 
- It adds a flag to access modern emotion versions. This allows us to remove the hack which aliases them ourselves.
- There is a new `babelModeV7` feature. This opts-in to a feature which will be default in the next major update. Basically, Storybook is going to use your default babel config instead of whatever you pass directly. This allowed me to delete our custom babel stuff in the storybook config file.

However, there is one oddity:

```sh
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
to the "plugins" section of your Babel config.
```

Now, we saw this same error previously, and I was able to fix it by adding `loose: false` for one of the babel plugins directly in the storybook config. However, **even if I use the config file from trunk**, this warning shows up. So it's not happening because of the new babel feature flag being enabled, or because of any of the other config changes.

From some research, the group of babel plugins related to class properties _should_ have loose set to `false`. This is the default set in `preset/env`. However, somewhere in our dependency tree, something is setting loose to true for one of the related plugins. I tried several things in our "default" babel preset in the babel config package we have. I wasn't able to find anything which worked, though, even setting all of the plugins to `loose: false`. (At some point, I was able to get the build to fail entirely with these changes, so Storybook is certainly reading our root babel config file now.)

I think we should continue without solving it for now, unless anyone has any good ideas :)

#### Testing instructions
Run the various storybooks locally, and make sure the components render. 

Side note: maybe we should just have one storybook project? It seems we are making new ones for each project, instead of adding all projects to the same one.
