### PR TITLE
Updating styles to make sure that the free plan link is white instead of gray

### DIFF
--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -39,12 +39,17 @@
 	margin-top: 25px;
 }
 
-.signup__step.is-plans .formatted-header__subtitle .button.is-borderless,
-.signup__step.is-plans-launch .formatted-header__subtitle .button.is-borderless {
-	padding: 0;
-	color: inherit;
-	font-size: inherit;
-	font-weight: inherit;
-	line-height: inherit;
-	text-decoration: underline;
+.signup__step {
+	&.is-plans,
+	&.is-plans-launch,
+	&.is-plans-import, {
+		.formatted-header__subtitle .button.is.borderless {
+			padding: 0;
+			color: inherit;
+			font-size: inherit;
+			font-weight: inherit;
+			line-height: inherit;
+			text-decoration: underline;
+		}
+	}
 }

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -43,7 +43,7 @@
 	&.is-plans,
 	&.is-plans-launch,
 	&.is-plans-import, {
-		.formatted-header__subtitle .button.is.borderless {
+		.formatted-header__subtitle .button.is-borderless {
 			padding: 0;
 			color: inherit;
 			font-size: inherit;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The link to the free plan shows on the blue plans grid is displaying in gray instead of white, making it hard to read. These changes update styling to address this issue. See: https://github.com/Automattic/wp-calypso/issues/58806

#### Testing instructions

- Start at https://wordpress.com/start/import/from-url?ref=compare%2Fwix-lp
- Add in the URL https://mikael393.wixsite.com/website-8 or other sample site
- Pick any free domain
- See the plans grid & free link on top
- Ensure that link to free plan is white


- Visit https://wordpress.com/start/plans 
- Ensure that there has been no change to the free plan link 
<img width="836" alt="Screen Shot 2021-12-08 at 10 38 41 AM" src="https://user-images.githubusercontent.com/48809176/145256838-7425602f-1637-425d-acff-a3f1e001c7d4.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Related to #58806
