### PR TITLE
Checkout: Record stripe and ebanx transaction start analytics directly

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -59,8 +59,10 @@ export const recordCompositeCheckoutErrorDuringAnalytics = ( {
 
 export const recordTransactionBeginAnalytics = ( {
 	paymentMethodId,
+	useForAllSubscriptions,
 }: {
 	paymentMethodId: CheckoutPaymentMethodSlug;
+	useForAllSubscriptions?: boolean;
 } ) => ( dispatch: CalypsoDispatch ): void => {
 	try {
 		if ( isRedirectPaymentMethod( paymentMethodId ) ) {
@@ -70,12 +72,14 @@ export const recordTransactionBeginAnalytics = ( {
 			recordTracksEvent( 'calypso_checkout_form_submit', {
 				credits: null,
 				payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
+				...( useForAllSubscriptions ? { use_for_all_subs: useForAllSubscriptions } : undefined ),
 			} )
 		);
 		dispatch(
 			recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 				credits: null,
 				payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
+				...( useForAllSubscriptions ? { use_for_all_subs: useForAllSubscriptions } : undefined ),
 			} )
 		);
 		const paymentMethodIdForTracks = paymentMethodId.startsWith( 'existingCard' )

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -7,6 +7,7 @@ import {
 import debugFactory from 'debug';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import submitWpcomTransaction from './submit-wpcom-transaction';
@@ -72,6 +73,12 @@ async function stripeCardProcessor(
 		contactDetails,
 		reduxDispatch,
 	} = transactionOptions;
+	reduxDispatch(
+		recordTransactionBeginAnalytics( {
+			paymentMethodId: 'stripe',
+			useForAllSubscriptions: submitData.useForAllSubscriptions,
+		} )
+	);
 
 	let paymentMethodToken;
 	try {
@@ -148,7 +155,9 @@ async function ebanxCardProcessor(
 		responseCart,
 		siteId,
 		contactDetails,
+		reduxDispatch,
 	} = transactionOptions;
+	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'ebanx' } ) );
 
 	let paymentMethodToken;
 	try {

--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -71,6 +71,7 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return 'WPCOM_Billing_PayPal_Direct';
 		case 'paypal':
 			return 'WPCOM_Billing_PayPal_Express';
+		case 'stripe':
 		case 'card':
 			return 'WPCOM_Billing_Stripe_Payment_Method';
 		case 'alipay':
@@ -140,6 +141,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'paypal-direct':
 		case 'paypal':
 		case 'card':
+		case 'stripe':
 		case 'existingCard':
 		case 'alipay':
 		case 'bancontact':

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -1,10 +1,4 @@
-import {
-	Button,
-	FormStatus,
-	useLineItems,
-	useEvents,
-	useFormStatus,
-} from '@automattic/composite-checkout';
+import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
 import { useElements, CardNumberElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -31,7 +25,6 @@ export default function CreditCardPayButton( {
 	);
 	const cardholderName = fields.cardholderName;
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const paymentPartner = shouldUseEbanx ? 'ebanx' : 'stripe';
 	const elements = useElements();
 	const cardNumberElement = elements?.getElement( CardNumberElement ) ?? undefined;
@@ -43,7 +36,6 @@ export default function CreditCardPayButton( {
 				if ( isCreditCardFormValid( store, paymentPartner, __ ) ) {
 					if ( paymentPartner === 'stripe' ) {
 						debug( 'submitting stripe payment' );
-						onEvent( { type: 'STRIPE_TRANSACTION_BEGIN', payload: { useForAllSubscriptions } } );
 						onClick( 'card', {
 							stripe,
 							name: cardholderName?.value,
@@ -61,7 +53,6 @@ export default function CreditCardPayButton( {
 					}
 					if ( paymentPartner === 'ebanx' ) {
 						debug( 'submitting ebanx payment' );
-						onEvent( { type: 'EBANX_TRANSACTION_BEGIN' } );
 						onClick( 'card', {
 							name: cardholderName?.value || '',
 							countryCode: fields?.countryCode?.value || '',

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -16,42 +16,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
-				case 'STRIPE_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
-							use_for_all_subs: action.payload?.useForAllSubscriptions,
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
-							use_for_all_subs: action.payload?.useForAllSubscriptions,
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
-					);
-				}
-				case 'EBANX_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Ebanx',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Ebanx',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
-					);
-				}
 				default:
 					debug( 'unknown checkout event', action );
 					return reduxDispatch(

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -229,6 +229,7 @@ export type CheckoutPaymentMethodSlug =
 	| 'stripe-three-d-secure'
 	| 'wechat'
 	| `existingCard${ string }`
+	| 'stripe' // a synonym for 'card'
 	| 'apple-pay' // a synonym for 'web-pay'
 	| 'google-pay'; // a synonym for 'web-pay'
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the `useEvents` hook (#48282), this PR moves the stripe and ebanx card transaction start analytics from the checkout event handler directly into where the events occur.

The only significant change this should cause is that, previously, the "submit" Tracks event for Ebanx transactions was `calypso_checkout_composite_stripe_submit_clicked`, and now it will be `calypso_checkout_composite_ebanx_submit_clicked`. I believe this was a mistake in the original implementation of this event so I'm taking the opportunity to correct it here.

This change leaves the `createAnalyticsEventHandler` without any events and the `useEvents` hook with no uses, but I'd like to remove these in separate PRs to keep things tidy and safe.

#### Testing instructions

- These instructions assume that you have the API and the store sandboxed so you can use test cards.
- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.

To test Stripe:

- Add a plan to your cart and visit checkout.
- Next, select "Credit or debit card" as your payment method in checkout.
- Complete the form using a [Stripe test card](https://stripe.com/docs/testing), and submit the transaction. Use `4000000000009995` if you want the transaction to fail but still trigger the events.
- Verify that you see the `calypso_checkout_form_submit` event triggered with `payment_method: 'WPCOM_Billing_Stripe_Payment_Method'`.
- Verify that you see the `calypso_checkout_composite_stripe_submit_clicked` event triggered.
<img width="599" alt="Screen Shot 2021-12-07 at 1 39 12 PM" src="https://user-images.githubusercontent.com/2036909/145087318-243b4f6e-7e44-4e21-ad4a-71b0e7ffab7a.png">

To test Ebanx:

- Make sure your account currency is set to BRL.
- Add a product to your cart and visit checkout. 
- Select Brazil in the contact form with a postal code of `68900-000`.
- Next, select "Credit or debit card" as your payment method in checkout.
- Verify that the form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.)
- Use an [ebanx test card](https://developer.ebanx.com/docs/resources/testCreditCards/) (use `4716909774636285` if you want the payment to fail but still trigger the events) and [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/) (CPF is the "Taxpayer Identification Number" and CEP is the postal code).
- Verify that you see the `calypso_checkout_form_submit` event triggered with `payment_method: 'WPCOM_Billing_Ebanx'`.
- Verify that you see the `calypso_checkout_composite_ebanx_submit_clicked` event triggered.
<img width="598" alt="Screen Shot 2021-12-07 at 1 44 31 PM" src="https://user-images.githubusercontent.com/2036909/145088035-24e5c547-5467-47fc-997c-aa67b38c595f.png">


