### PR TITLE
Clean up dependencies

### DIFF
--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -42,6 +42,11 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@types/cookie": "^0.4.1",
+		"@types/debug": "^4.1.7",
+		"@types/lodash": "^4.14.177",
+		"@types/node": "^16.11.10",
+		"@types/uuid": "^8.3.3",
 		"typescript": "^4.5.4"
 	}
 }

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -67,5 +67,13 @@
 	"peerDependencies": {
 		"postcss": "^8.4.5",
 		"webpack": "^5.65.0"
+	},
+	"peerDependenciesMeta": {
+		"postcss": {
+			"optional": true
+		},
+		"webpack": {
+			"optional": true
+		}
 	}
 }

--- a/packages/calypso-codemods/package.json
+++ b/packages/calypso-codemods/package.json
@@ -4,9 +4,6 @@
 	"description": "jscodeshift transforms used to upgrade calypso code",
 	"main": "./api.js",
 	"bin": "./index.js",
-	"scripts": {
-		"test": "jest"
-	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",

--- a/packages/calypso-config/package.json
+++ b/packages/calypso-config/package.json
@@ -41,6 +41,8 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@types/cookie": "^0.4.1",
+		"@types/node": "^16.11.10",
 		"typescript": "^4.5.4"
 	}
 }

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -38,7 +38,6 @@
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json",
-		"test": "yarn jest"
+		"build": "tsc --build ./tsconfig.json"
 	}
 }

--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -39,9 +39,12 @@
 	"dependencies": {
 		"@stripe/react-stripe-js": "^1.4.1",
 		"@stripe/stripe-js": "^1.17.1",
+		"@types/debug": "^4.1.7",
+		"@types/react": "^17.0.36",
 		"debug": "^4.1.1",
 		"react": "^17.0.2",
-		"react-dom": "^17.0.2"
+		"react-dom": "^17.0.2",
+		"tslib": "^2.3.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/calypso-url/package.json
+++ b/packages/calypso-url/package.json
@@ -37,6 +37,9 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/calypso-url#readme",
 	"private": true,
+	"dependencies": {
+		"tslib": "^2.3.0"
+	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"typescript": "^4.5.4"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,6 +29,7 @@
 	],
 	"types": "dist/types",
 	"dependencies": {
+		"@types/react-modal": "^3.13.1",
 		"@wordpress/base-styles": "^4.0.4",
 		"classnames": "^2.3.1",
 		"gridicons": "^3.4.0",
@@ -43,6 +44,7 @@
 		"react-dom": "^17.0.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -40,6 +40,7 @@
 	"dependencies": {
 		"@emotion/react": "^11.4.1",
 		"@emotion/styled": "^11.3.0",
+		"@types/debug": "^4.1.7",
 		"@wordpress/i18n": "^4.2.4",
 		"@wordpress/react-i18n": "^3.0.4",
 		"debug": "^4.1.1",

--- a/packages/create-calypso-config/package.json
+++ b/packages/create-calypso-config/package.json
@@ -33,6 +33,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@types/node": "^16.11.10",
 		"cookie": "^0.4.0",
 		"tslib": "^2.3.0"
 	},

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -34,6 +34,9 @@
 	},
 	"dependencies": {
 		"@automattic/format-currency": "workspace:^",
+		"@types/qs": "^6.9.7",
+		"@types/wordpress__data": "^4.6.10",
+		"@types/wordpress__data-controls": "^2.2.0",
 		"@wordpress/api-fetch": "^5.2.6",
 		"@wordpress/data-controls": "^2.2.7",
 		"@wordpress/deprecated": "^3.2.3",
@@ -51,6 +54,7 @@
 		"react": "^17.0.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/validator": "^13.7.0",
 		"jest-fetch-mock": "^3.0.3",

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -35,6 +35,9 @@
 		"@automattic/js-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
+		"@types/debug": "^4.1.7",
+		"@types/react-router-dom": "^5.3.2",
+		"@types/wordpress__components": "^14.0.4",
 		"@wordpress/components": "^19.1.5",
 		"@wordpress/react-i18n": "^3.0.4",
 		"@wordpress/url": "^3.3.1",
@@ -57,6 +60,7 @@
 		"webpack": "^5.65.0"
 	},
 	"peerDependencies": {
+		"@types/debug": "^4.1.7",
 		"@wordpress/data": "^6.1.4",
 		"@wordpress/element": "^4.0.4",
 		"@wordpress/i18n": "^4.2.4",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -37,6 +37,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
+		"@types/wordpress__components": "^14.0.4",
 		"@wordpress/base-styles": "^4.0.4",
 		"@wordpress/components": "^19.1.5",
 		"@wordpress/compose": "^5.0.6",
@@ -49,6 +50,7 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/jest-dom": "^5.16.1",
 		"@testing-library/react": "^12.1.2",

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -19,8 +19,7 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"prepack": "yarn run clean && yarn run build",
-		"test": "yarn jest"
+		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {
 		"@automattic/explat-client": "workspace:^",

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -19,8 +19,7 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"prepack": "yarn run clean && yarn run build",
-		"test": "yarn jest"
+		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {
 		"tslib": "^2.3.0"
@@ -28,6 +27,7 @@
 	"devDependencies": {
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@types/node": "^16.11.10",
 		"typescript": "^4.5.4"
 	}
 }

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -36,6 +36,7 @@
 		"react": "^17.0.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^"
 	},
 	"types": "types"

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -32,6 +32,7 @@
 		"use-subscription": "^1.5.1"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -18,9 +18,7 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
-		"watch": "tsc --build ./tsconfig.json --watch",
-		"download": "node bin/download.js",
-		"test": "yarn jest"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"@wordpress/compose": "^5.0.6",

--- a/packages/interpolate-components/package.json
+++ b/packages/interpolate-components/package.json
@@ -21,6 +21,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/interpolate-components#readme",
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"react-dom": "^17.0.2"
 	},

--- a/packages/js-utils/package.json
+++ b/packages/js-utils/package.json
@@ -32,6 +32,9 @@
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
+	"dependencies": {
+		"tslib": "^2.3.0"
+	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"typescript": "^4.5.4"

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -32,6 +32,7 @@
 		"@automattic/languages": "workspace:^",
 		"@automattic/search": "workspace:^",
 		"@babel/runtime": "^7.16.5",
+		"@types/wordpress__components": "^14.0.4",
 		"@wordpress/base-styles": "^4.0.4",
 		"@wordpress/components": "^19.1.5",
 		"@wordpress/i18n": "^4.2.4",

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -19,8 +19,7 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"prepare": "yarn run build",
-		"download": "node bin/download.js",
-		"test": "yarn jest"
+		"download": "node bin/download.js"
 	},
 	"dependencies": {
 		"tslib": "^2.3.0"

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -49,6 +49,7 @@
 		"use-debounce": "^3.1.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@testing-library/react": "^12.1.2",

--- a/packages/launch/tsconfig.json
+++ b/packages/launch/tsconfig.json
@@ -18,7 +18,6 @@
 	"references": [
 		{ "path": "../shopping-cart" },
 		{ "path": "../data-stores" },
-		{ "path": "../components" },
 		{ "path": "../onboarding" },
 		{ "path": "../domain-picker" },
 		{ "path": "../plans-grid" },

--- a/packages/load-script/package.json
+++ b/packages/load-script/package.json
@@ -33,6 +33,7 @@
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^"
 	}
 }

--- a/packages/mocha-debug-reporter/package.json
+++ b/packages/mocha-debug-reporter/package.json
@@ -16,7 +16,8 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
-		"@types/mocha": "^9.0.0"
+		"@types/mocha": "^9.0.0",
+		"@types/node": "^16.11.10"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -32,6 +32,8 @@
 	},
 	"dependencies": {
 		"@automattic/data-stores": "workspace:^",
+		"@types/react-router-dom": "^5.3.2",
+		"@types/wordpress__components": "^14.0.4",
 		"@wordpress/components": "^19.1.5",
 		"@wordpress/data": "^6.1.4",
 		"@wordpress/icons": "^6.1.1",
@@ -41,6 +43,7 @@
 		"tslib": "^2.3.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@testing-library/react": "^12.1.2",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -31,6 +31,7 @@
 	"dependencies": {
 		"@automattic/design-picker": "workspace:^",
 		"@automattic/typography": "workspace:^",
+		"@types/wordpress__blocks": "^6.4.12",
 		"@wordpress/blocks": "^11.1.4",
 		"@wordpress/components": "^19.1.5",
 		"@wordpress/compose": "^5.0.6",
@@ -41,6 +42,7 @@
 		"lodash": "^4.17.21"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/react": "^12.1.2",
 		"jest": "^27.3.1",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -37,6 +37,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"dependencies": {
+		"@types/debug": "^4.1.7",
 		"@types/seed-random": "^2.2.1",
 		"crc32": "^0.2.2",
 		"debug": "^4.0.0",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -43,6 +43,7 @@
 		"seed-random": "^2.2.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"typescript": "^4.5.4"
 	},

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -34,6 +34,7 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
+		"@types/debug": "^4.1.7",
 		"@wordpress/components": "^19.1.5",
 		"@wordpress/compose": "^5.0.6",
 		"@wordpress/icons": "^6.1.1",
@@ -46,6 +47,7 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@wordpress/base-styles": "^4.0.4",

--- a/packages/popup-monitor/package.json
+++ b/packages/popup-monitor/package.json
@@ -37,6 +37,7 @@
 		"lodash": "^4.17.21"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"chai": "^4.3.4"
 	}

--- a/packages/request-external-access/package.json
+++ b/packages/request-external-access/package.json
@@ -38,6 +38,7 @@
 		"@automattic/popup-monitor": "workspace:^"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^"
 	}
 }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -31,6 +31,7 @@
 	"dependencies": {
 		"@automattic/typography": "workspace:^",
 		"@babel/runtime": "^7.16.5",
+		"@types/wordpress__components": "^14.0.4",
 		"@wordpress/base-styles": "^4.0.4",
 		"@wordpress/components": "^19.1.5",
 		"@wordpress/compose": "^5.0.6",
@@ -46,6 +47,7 @@
 		"react-dom": "^17.0.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -37,7 +37,10 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/shopping-cart#readme",
 	"dependencies": {
-		"debug": "^4.1.1"
+		"@types/debug": "^4.1.7",
+		"@types/react": "^17.0.36",
+		"debug": "^4.1.1",
+		"tslib": "^2.3.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.2",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -47,6 +47,7 @@
 		"prop-types": "^15.7.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"enzyme": "^3.11.0",
 		"react": "^17.0.2",

--- a/packages/state-utils/package.json
+++ b/packages/state-utils/package.json
@@ -32,6 +32,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@types/lodash": "^4.14.177",
+		"@types/node": "^16.11.10",
 		"@wordpress/is-shallow-equal": "^4.2.1",
 		"@wordpress/warning": "^2.2.2",
 		"lodash": "^4.17.21",

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -40,6 +40,7 @@
 		"react-popper": "^2.2.5"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/react": "^6.4.9",

--- a/packages/viewport-react/package.json
+++ b/packages/viewport-react/package.json
@@ -27,6 +27,7 @@
 		"react-dom": "^17.0.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^"
 	},
 	"scripts": {

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -31,6 +31,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"typescript": "^4.5.4"
 	}

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -53,6 +53,7 @@
 		"redux": "^4.1.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^"
 	}
 }

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -18,10 +18,6 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"bin": "./cli.js",
-	"scripts": {
-		"start": "./cli.js",
-		"test": "rm -rf test/output && jest"
-	},
 	"dependencies": {
 		"@automattic/babel-plugin-i18n-calypso": "workspace:^",
 		"@babel/cli": "^7.16.0",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -43,6 +43,7 @@
 		"@automattic/shopping-cart": "workspace:^",
 		"@emotion/styled": "^11.3.0",
 		"@stripe/stripe-js": "^1.17.1",
+		"@types/wordpress__data": "^4.6.10",
 		"@wordpress/data": "^6.1.4",
 		"@wordpress/i18n": "^4.2.4",
 		"@wordpress/react-i18n": "^3.0.4",
@@ -51,6 +52,7 @@
 		"prop-types": "^15.7.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/jest-dom": "^5.16.1",
 		"@testing-library/react": "^12.1.2",

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -47,6 +47,7 @@
 		"wp-error": "^1.3.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"chai": "^4.3.4"

--- a/packages/wpcom-xhr-request/package.json
+++ b/packages/wpcom-xhr-request/package.json
@@ -45,6 +45,7 @@
 		"wp-error": "^1.3.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^"
 	}
 }

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -43,6 +43,7 @@
 		"qs": "^6.5.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@babel/core": "^7.16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,6 +177,11 @@ __metadata:
   peerDependencies:
     postcss: ^8.4.5
     webpack: ^5.65.0
+  peerDependenciesMeta:
+    postcss:
+      optional: true
+    webpack:
+      optional: true
   bin:
     calypso-build: ./bin/calypso-build.js
     copy-assets: ./bin/copy-assets.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,6 +89,11 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/load-script": "workspace:^"
+    "@types/cookie": ^0.4.1
+    "@types/debug": ^4.1.7
+    "@types/lodash": ^4.14.177
+    "@types/node": ^16.11.10
+    "@types/uuid": ^8.3.3
     cookie: ^0.4.0
     debug: ^4.1.1
     hash.js: ^1.1.7
@@ -199,7 +204,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/create-calypso-config": "workspace:^"
     "@types/cookie": ^0.4.1
-    "@types/node": ^16.11.13
+    "@types/node": ^16.11.10
     cookie: ^0.4.0
     tslib: ^2.3.0
     typescript: ^4.5.4
@@ -325,9 +330,12 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@stripe/react-stripe-js": ^1.4.1
     "@stripe/stripe-js": ^1.17.1
+    "@types/debug": ^4.1.7
+    "@types/react": ^17.0.36
     debug: ^4.1.1
     react: ^17.0.2
     react-dom: ^17.0.2
+    tslib: ^2.3.0
     typescript: ^4.5.4
   languageName: unknown
   linkType: soft
@@ -343,6 +351,7 @@ __metadata:
   resolution: "@automattic/calypso-url@workspace:packages/calypso-url"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    tslib: ^2.3.0
     typescript: ^4.5.4
   languageName: unknown
   linkType: soft
@@ -358,10 +367,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/components@workspace:packages/components"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@storybook/react": ^6.4.9
+    "@types/react-modal": ^3.13.1
     "@wordpress/base-styles": ^4.0.4
     classnames: ^2.3.1
     gridicons: ^3.4.0
@@ -388,6 +399,7 @@ __metadata:
     "@storybook/react": ^6.4.9
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
+    "@types/debug": ^4.1.7
     "@wordpress/i18n": ^4.2.4
     "@wordpress/react-i18n": ^3.0.4
     debug: ^4.1.1
@@ -406,6 +418,7 @@ __metadata:
   resolution: "@automattic/create-calypso-config@workspace:packages/create-calypso-config"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@types/node": ^16.11.10
     cookie: ^0.4.0
     tslib: ^2.3.0
     typescript: ^4.5.4
@@ -416,9 +429,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/data-stores@workspace:packages/data-stores"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/format-currency": "workspace:^"
+    "@types/qs": ^6.9.7
     "@types/validator": ^13.7.0
+    "@types/wordpress__data": ^4.6.10
+    "@types/wordpress__data-controls": ^2.2.0
     "@wordpress/api-fetch": ^5.2.6
     "@wordpress/data-controls": ^2.2.7
     "@wordpress/deprecated": ^3.2.3
@@ -453,6 +470,9 @@ __metadata:
     "@automattic/typography": "workspace:^"
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
+    "@types/debug": ^4.1.7
+    "@types/react-router-dom": ^5.3.2
+    "@types/wordpress__components": ^14.0.4
     "@wordpress/components": ^19.1.5
     "@wordpress/react-i18n": ^3.0.4
     "@wordpress/url": ^3.3.1
@@ -468,6 +488,7 @@ __metadata:
     utility-types: ^3.10.0
     webpack: ^5.65.0
   peerDependencies:
+    "@types/debug": ^4.1.7
     "@wordpress/data": ^6.1.4
     "@wordpress/element": ^4.0.4
     "@wordpress/i18n": ^4.2.4
@@ -484,6 +505,7 @@ __metadata:
   resolution: "@automattic/domain-picker@workspace:packages/domain-picker"
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
@@ -492,6 +514,7 @@ __metadata:
     "@automattic/typography": "workspace:^"
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
+    "@types/wordpress__components": ^14.0.4
     "@wordpress/base-styles": ^4.0.4
     "@wordpress/components": ^19.1.5
     "@wordpress/compose": ^5.0.6
@@ -551,6 +574,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-polyfills": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@types/node": ^16.11.10
     tslib: ^2.3.0
     typescript: ^4.5.4
   languageName: unknown
@@ -560,6 +584,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/format-currency@workspace:packages/format-currency"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     i18n-calypso: "workspace:^"
   peerDependencies:
@@ -590,6 +615,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/interpolate-components@workspace:packages/interpolate-components"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     react-dom: ^17.0.2
   peerDependencies:
@@ -676,6 +702,7 @@ __metadata:
   resolution: "@automattic/js-utils@workspace:packages/js-utils"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    tslib: ^2.3.0
     typescript: ^4.5.4
   languageName: unknown
   linkType: soft
@@ -688,6 +715,7 @@ __metadata:
     "@automattic/languages": "workspace:^"
     "@automattic/search": "workspace:^"
     "@babel/runtime": ^7.16.5
+    "@types/wordpress__components": ^14.0.4
     "@wordpress/base-styles": ^4.0.4
     "@wordpress/components": ^19.1.5
     "@wordpress/i18n": ^4.2.4
@@ -736,6 +764,7 @@ __metadata:
   resolution: "@automattic/launch@workspace:packages/launch"
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/domain-picker": "workspace:^"
@@ -771,6 +800,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/load-script@workspace:packages/load-script"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@babel/runtime": ^7.16.5
     debug: ^4.0.0
@@ -792,6 +822,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@types/mocha": ^9.0.0
+    "@types/node": ^16.11.10
     typescript: ^4.5.4
   peerDependencies:
     mocha: ">=8.0.0"
@@ -905,10 +936,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/onboarding@workspace:packages/onboarding"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@testing-library/react": ^12.1.2
+    "@types/react-router-dom": ^5.3.2
+    "@types/wordpress__components": ^14.0.4
     "@wordpress/base-styles": ^4.0.4
     "@wordpress/components": ^19.1.5
     "@wordpress/data": ^6.1.4
@@ -934,10 +968,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/page-pattern-modal@workspace:packages/page-pattern-modal"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/design-picker": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@testing-library/react": ^12.1.2
+    "@types/wordpress__blocks": ^6.4.12
     "@wordpress/blocks": ^11.1.4
     "@wordpress/components": ^19.1.5
     "@wordpress/compose": ^5.0.6
@@ -962,11 +998,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/plans-grid@workspace:packages/plans-grid"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/onboarding": "workspace:^"
     "@automattic/typography": "workspace:^"
+    "@types/debug": ^4.1.7
     "@wordpress/base-styles": ^4.0.4
     "@wordpress/components": ^19.1.5
     "@wordpress/compose": ^5.0.6
@@ -995,6 +1033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/popup-monitor@workspace:packages/popup-monitor"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     chai: ^4.3.4
     lodash: ^4.17.21
@@ -1019,6 +1058,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/request-external-access@workspace:packages/request-external-access"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/popup-monitor": "workspace:^"
   languageName: unknown
@@ -1028,6 +1068,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/search@workspace:packages/search"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -1037,6 +1078,7 @@ __metadata:
     "@testing-library/dom": ^8.11.1
     "@testing-library/react": ^12.1.2
     "@testing-library/user-event": ^13.5.0
+    "@types/wordpress__components": ^14.0.4
     "@wordpress/base-styles": ^4.0.4
     "@wordpress/components": ^19.1.5
     "@wordpress/compose": ^5.0.6
@@ -1066,7 +1108,10 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
+    "@types/debug": ^4.1.7
+    "@types/react": ^17.0.36
     debug: ^4.1.1
+    tslib: ^2.3.0
     typescript: ^4.5.4
   peerDependencies:
     react: ^17.0.2
@@ -1078,6 +1123,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/social-previews@workspace:packages/social-previews"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@wordpress/components": ^19.1.5
     "@wordpress/i18n": ^4.2.4
@@ -1101,6 +1147,8 @@ __metadata:
   resolution: "@automattic/state-utils@workspace:packages/state-utils"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@types/lodash": ^4.14.177
+    "@types/node": ^16.11.10
     "@wordpress/is-shallow-equal": ^4.2.1
     "@wordpress/warning": ^2.2.2
     lodash: ^4.17.21
@@ -1131,6 +1179,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/tour-kit@workspace:packages/tour-kit"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/viewport-react": "workspace:^"
@@ -1168,6 +1217,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/viewport-react@workspace:packages/viewport-react"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@wordpress/compose": ^5.0.6
@@ -1181,6 +1231,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/viewport@workspace:packages/viewport"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     typescript: ^4.5.4
   languageName: unknown
@@ -1241,6 +1292,7 @@ __metadata:
   resolution: "@automattic/whats-new@workspace:packages/whats-new"
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -1332,6 +1384,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/wpcom-checkout@workspace:packages/wpcom-checkout"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-stripe": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -1341,6 +1394,7 @@ __metadata:
     "@stripe/stripe-js": ^1.17.1
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
+    "@types/wordpress__data": ^4.6.10
     "@wordpress/data": ^6.1.4
     "@wordpress/i18n": ^4.2.4
     "@wordpress/react-i18n": ^3.0.4
@@ -6593,7 +6647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:*, @types/lodash@npm:^4.14.172, @types/lodash@npm:^4.14.178":
+"@types/lodash@npm:*, @types/lodash@npm:^4.14.172, @types/lodash@npm:^4.14.177, @types/lodash@npm:^4.14.178":
   version: 4.14.178
   resolution: "@types/lodash@npm:4.14.178"
   checksum: 820e33578a084aba2ca66fc83728c14d82813b91f3f14f281621b36904533c3d1681992b5e2719579b8beb52e1a77cfa914283a145f66dfa71b5e02a7cec5a37
@@ -6702,6 +6756,13 @@ __metadata:
   version: 15.14.9
   resolution: "@types/node@npm:15.14.9"
   checksum: fe5b69cffd20f97c814d568c1d791b3c367f9efa6567a18d2c15cd73c5437f47bcff73a2e10bdfe59f90ce7df47e6cc3c6d431c76d2213bf6099e8ab5d16d355
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^16.11.10":
+  version: 16.11.12
+  resolution: "@types/node@npm:16.11.12"
+  checksum: 941afac5fc5816106521f9846be969ce7460b2ad8e72eb1d675666d6418eb3cc0254085b4d0a5e85b64a155eac8b83bba8689416a1faf94a9b40bbc219d3eb8c
   languageName: node
   linkType: hard
 
@@ -7099,7 +7160,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/wordpress__blocks@npm:*":
+"@types/wordpress__blocks@npm:*, @types/wordpress__blocks@npm:^6.4.12":
   version: 6.4.12
   resolution: "@types/wordpress__blocks@npm:6.4.12"
   dependencies:
@@ -20330,6 +20391,7 @@ fsevents@~2.1.2:
   version: 0.0.0-use.local
   resolution: "i18n-calypso@workspace:packages/i18n-calypso"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/interpolate-components": "workspace:^"
     "@babel/runtime": ^7.16.5
@@ -28053,6 +28115,7 @@ fsevents@~2.1.2:
   version: 0.0.0-use.local
   resolution: "photon@workspace:packages/photon"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@types/seed-random": ^2.2.1
     crc32: ^0.2.2
@@ -37998,6 +38061,7 @@ testarmada-magellan@11.0.10:
   version: 0.0.0-use.local
   resolution: "wpcom-proxy-request@workspace:packages/wpcom-proxy-request"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     chai: ^4.3.4
@@ -38012,6 +38076,7 @@ testarmada-magellan@11.0.10:
   version: 0.0.0-use.local
   resolution: "wpcom-xhr-request@workspace:packages/wpcom-xhr-request"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@babel/runtime": ^7.16.5
     debug: ^4.1.1
@@ -38024,6 +38089,7 @@ testarmada-magellan@11.0.10:
   version: 0.0.0-use.local
   resolution: "wpcom@workspace:packages/wpcom.js"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@babel/core": ^7.16.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -28122,6 +28122,7 @@ fsevents@~2.1.2:
   dependencies:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@types/debug": ^4.1.7
     "@types/seed-random": ^2.2.1
     crc32: ^0.2.2
     debug: ^4.0.0


### PR DESCRIPTION
### Changes

Add missing dependencies to each package.

Missing dependencies have been found by running `yarn workspaces focus` on each package, and then trying to run each script declared in `package.json` (https://gist.github.com/scinos/f125ea2c36effd7c1dfa2d2c47421218)

### Notes

Many packages depend on `@automattic/calypso-build` because they use `transpile` or `copy-assets` scripts. However, `calypso-build` requires many heavy peer dependencies, which I have not added. I'll work on extracting those scripts to a smaller separate package. Once that is extracted, I'll update this PR.

Some other packages had a `test` command which, AFAIK, is not supported. The official way to test packages is to run `yarn test:package <name>` in the root of the repo. While this is not ideal and I rather have each package bein able to test itself, I think we should keep consistent for now.

### Tasks

- [ ] Extract build scripts from calypso-build