### PR TITLE
Add script for yarnrc maintinence

### DIFF
--- a/bin/update-yarnrc.sh
+++ b/bin/update-yarnrc.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
+YELLOW=$(tput setaf 3)
+RESET=$(tput sgr0)
+
+# sed -i behaves differently between macos and linux platforms.
+# See https://stackoverflow.com/a/51060063
+# To use this, do `sed "${sedi[@]}" -e $sed_expression`
+sedi=(-i)
+# macOS version of sed doesn't support `--version` param and exits with code 1
+if ! sed --version > /dev/null 2>&1 ; then
+	# For macOS, use two parameters
+	sedi=(-i "")
+fi
+
+# Can enter as many packages as you want, space deliminated.
+packages="${1-}"
+
+# If no packages were entered, we'll generate a list of packages based on the 
+# incorrect peer dependency warnings.
+if [ -z "$packages" ] ; then
+	echo "Since no packages were passed, we'll generate a list from the yarn output."
+	yarn_out="yarn-json-output.json"
+	yarn --json > "$yarn_out"
+
+	# Yarn --json saves as newline-delimited JSON. To make the JSON file valid,
+	# we add brackets at the beginning and end and commas on each entry in between.
+	# Inspired by https://stackoverflow.com/a/35021663.
+	sed "${sedi[@]}" -e '1s/^/[/; $!s/$/,/; $s/$/]/' "$yarn_out"
+
+	# 1. Send the yarn output (in JSON format) to the jq command.
+	# 2. Filter for the YN002 error code, the "$package doesn't provide $peer" warning.
+	# 3. Select the warning message for each error code.
+	# 4. Select just the package portion of the warning, which is just any character
+	#    until the "@npm:version" portion of the string.
+	# 5. Since each package can have multiple warnings, remove duplicates.
+	broken_packages=$( cat "$yarn_out" | jq --raw-output '.[] | select(.name == 2) | .data' | sed -E "s/^(@?.[^@]*).*/\1/g" | uniq )
+
+	# Change from newline to spaces for delimination. This makes it easy to loop through.
+	packages="${broken_packages//$'\n'/ }"
+fi
+
+if [ -z "$packages" ] ; then
+	echo "Nothing to do, as no peer warnings were found and no package was passed."
+	exit
+fi
+
+echo -e "Checking these packages: $packages\n"
+
+for package in $packages ; do
+	echo "Checking package ${GREEN}$package${RESET}"
+
+	# Finds versions of the package overridden in yarnrc.yml. It saves as a newline
+	# deliminated string. So an input of @wordpress/components will find each package
+	# like '@wordpress/components@12.0.9', and then save all the versions in the order
+	# it finds them, like "12.0.9\n11.1.9\n13.1.1".
+	available_versions=$( sed -nE "s|^[[:space:]]+'$package@(.*)'.*|\1|gp" .yarnrc.yml)
+	
+	# Sorts by version (-V) and then saves the newest version found in yarnrc.yml. This
+	# entry is the one we need to update with the newest version update. The other
+	# entries do not need to be updated, because they likely match stale packages.
+	current_version=$( sort -rV <<< "$available_versions" | head -n1 )
+
+	# Double check that the package is actually installed.
+	if ! yarn info "$package" -AR > /dev/null ; then
+		echo -e "\tNo match for $package, skipping."
+		continue
+	fi
+
+	# 1. Gets the package info from yarn, including transitive dependencies.
+	# 2. Outputs the "version" of the package.
+	# 3. Sorts the list of versions in order, since multiple different versions
+	#    for a package could be installed.
+	# 4. Take the largest version number from the list.
+	update_version=$( yarn info "$package" -AR --json | jq --raw-output ".children.Version" | sort -Vr | head -n1 )
+
+	# Helpful colors to show out-of-date yarnrc versions.
+	[[ "$current_version" = "$update_version" ]] && yarnrc_color=${GREEN} || yarnrc_color=${YELLOW}
+
+	echo -e "\t.yarnrc.yml override version:\t${yarnrc_color}$current_version${RESET}"
+	echo -e "\tpackage version from yarn:\t${GREEN}$update_version${RESET}"
+
+	if [ "$current_version" == "$update_version" ] ; then
+		continue
+	fi
+
+	# Finally, replace the package version entry in yarnrc.yml with the new version.
+	sed "${sedi[@]}" -E "s|'$package@$current_version'|'$package@$update_version'|" ".yarnrc.yml"
+	echo -e "\tUpdated yarnrc entry!"
+done


### PR DESCRIPTION
### Changes proposed in this Pull Request
In a few different cases (mainly WordPress monorepo updates), we need to go through and patch all of the versions in `.yarnrc.yml`. This was getting annoying, so I scripted a solution to the main part of the problem.

It makes one big assumption: if there are multiple versions of a package (either installed locally or entries in the yarnrc file), then it will always use the most recent version. I think this makes sense for this use case. The problem happens when updating to a new version, and the entry in yarnrc which needs to updated is usually the most recent one. In other words:

- If there are multiple entries for the package in `.yarnrc.yml`, then it will change the version number the most recent entry.
- If it finds multiple versions in the yarn dependency tree, then it will choose the most recent version. (And this version is what will go into the yarnrc file.)

Usage:
- `./bin/update-yarnrc.sh` with no args will run yarn install, and then find peer dep warnings. It'll then try to update the yarnrc.yml file if there are matches.
- `./bin/update-yarnrc.sh $package` will run it just for the package passed -- checking the yarnrc file and seeing if it needs to be updated to the latest version in the dep tree.

Here's the command output:
```
$ ./bin/update-yarnrc.sh
Since no packages were passed, we'll generate a list from the yarn output.
Checking these packages: @wordpress/block-editor @wordpress/block-library @wordpress/edit-post @wordpress/edit-site @wordpress/editor @wordpress/format-library @wordpress/interface @wordpress/nux @wordpress/reusable-blocks @wordpress/server-side-render

Checking package @wordpress/block-editor
	.yarnrc.yml override version:	8.0.7
	package version from yarn:	8.0.9
	Updated yarnrc entry!
Checking package @wordpress/block-library
	.yarnrc.yml override version:	6.0.11
	package version from yarn:	6.0.13
	Updated yarnrc entry!
Checking package @wordpress/edit-post
	.yarnrc.yml override version:	5.0.13
	package version from yarn:	5.0.15
	Updated yarnrc entry!
Checking package @wordpress/edit-site
	.yarnrc.yml override version:	3.0.13
	package version from yarn:	3.0.15
	Updated yarnrc entry!
Checking package @wordpress/editor
	.yarnrc.yml override version:	12.0.10
	package version from yarn:	12.0.12
	Updated yarnrc entry!
Checking package @wordpress/format-library
	.yarnrc.yml override version:	3.0.13
	package version from yarn:	3.0.15
	Updated yarnrc entry!
Checking package @wordpress/interface
	.yarnrc.yml override version:	4.1.9
	package version from yarn:	4.1.11
	Updated yarnrc entry!
Checking package @wordpress/nux
	.yarnrc.yml override version:	5.0.11
	package version from yarn:	5.0.13
	Updated yarnrc entry!
Checking package @wordpress/reusable-blocks
	.yarnrc.yml override version:	3.0.13
	package version from yarn:	3.0.15
	Updated yarnrc entry!
Checking package @wordpress/server-side-render
	.yarnrc.yml override version:	3.0.11
	package version from yarn:	3.0.13
	Updated yarnrc entry!
```

### Testing instructions
I've tested this with #58884. The commit updating the yarnrc file was made with changes from `./bin/update-yarnrc.sh`