### PR TITLE
Add breadcrumbs to domain settings page

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,21 +1,54 @@
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
+import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import { SettingsPageProps } from './types';
 
-const Settings = (): JSX.Element => {
+const Settings = ( props: SettingsPageProps ): JSX.Element => {
+	const translate = useTranslate();
+
+	const renderBreadcrumbs = () => {
+		const { selectedSite, currentRoute, selectedDomainName } = props;
+
+		const previousPath = domainManagementEdit(
+			selectedSite?.slug,
+			selectedDomainName,
+			currentRoute
+		);
+
+		const items = [
+			{
+				label: translate( 'Domains' ),
+				href: domainManagementList( selectedSite?.slug, selectedDomainName ),
+			},
+			{ label: selectedDomainName },
+		];
+
+		const mobileItem = {
+			label: translate( 'Back' ),
+			href: previousPath,
+			showBackArrow: true,
+		};
+
+		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
+	};
+
 	return (
 		<Main wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+			{ renderBreadcrumbs() }
 			Page goes here.
 		</Main>
 	);
 };
 
-export default connect( ( state, ownProps ) => {
+export default connect( ( state, ownProps: SettingsPageProps ) => {
 	return {
 		currentRoute: getCurrentRoute( state ),
-		hasDomainOnlySite: isDomainOnlySite( state, ownProps.selectedSite.ID ),
+		hasDomainOnlySite: isDomainOnlySite( state, ownProps.selectedSite!.ID ),
 	};
 } )( Settings );

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -1,0 +1,8 @@
+import { SiteData } from 'calypso/state/ui/selectors/site-data';
+
+export type SettingsPageProps = {
+	currentRoute: string;
+	selectedDomainName: string;
+	selectedSite: SiteData | null;
+	hasDomainOnlySite: boolean | null;
+};

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -3,6 +3,6 @@ import { SiteData } from 'calypso/state/ui/selectors/site-data';
 export type SettingsPageProps = {
 	currentRoute: string;
 	selectedDomainName: string;
-	selectedSite: SiteData | null;
-	hasDomainOnlySite: boolean | null;
+	selectedSite: SiteData;
+	hasDomainOnlySite: boolean;
 };


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR add Breadcrumbs component to the new Domain Setting page.

This is part of the domain management redesign project described in pcYYhz-m2-p2.

<img width="1764" alt="Schermata 2021-12-07 alle 09 30 03" src="https://user-images.githubusercontent.com/2797601/144995210-dd6ac832-57e9-46df-a660-e8edaf7fdfdc.png">

## Testing instructions

Build this branch locally or open the live Calypso link
* Go to `Upgrades > Domains`
* Select one of your domains
* If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
* Ensure Breadcrumbs component is rendered