### PR TITLE
Migrate wpcom.undocumented().oauth2ClientId() to wpcom.req

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -266,21 +266,6 @@ Undocumented.prototype.transferStatus = function ( siteId, transferId ) {
 	} );
 };
 
-/**
- * Get OAuth2 Client data for a given client ID
- *
- * @param {string}     clientId       The client ID
- * @param {Function}   fn             The callback function
- * @returns {Promise} A promise representing the request.
- */
-Undocumented.prototype.oauth2ClientId = function ( clientId, fn ) {
-	return this.wpcom.req.get(
-		`/oauth2/client-data/${ clientId }`,
-		{ apiNamespace: 'wpcom/v2' },
-		fn
-	);
-};
-
 Undocumented.prototype.getDomainConnectSyncUxUrl = function (
 	domain,
 	providerId,

--- a/client/state/oauth2-clients/actions.js
+++ b/client/state/oauth2-clients/actions.js
@@ -23,7 +23,9 @@ export const fetchOAuth2ClientData = ( clientId ) => async ( dispatch ) => {
 	try {
 		let data = cache.get( cacheKey );
 		if ( data === undefined ) {
-			data = await wpcom.undocumented().oauth2ClientId( clientId );
+			data = await wpcom.req.get( `/oauth2/client-data/${ clientId }`, {
+				apiNamespace: 'wpcom/v2',
+			} );
 			cache.set( cacheKey, data );
 		}
 


### PR DESCRIPTION
Part of #58458. To test, go to a login page that has `client_id` in the URL, like:
```
http://calypso.localhost:3000/log-in?client_id=58883&redirect_to=/%3Fclient_id=58883
```
(the `redirect_to` parameter must be engineered so that it passes all checks) and verify that the info for the OAuth client 58883 (or any other) is indeed fetched and that the app description is displayed as part of the UI copy:

<img width="445" alt="Screenshot 2021-12-07 at 9 48 23" src="https://user-images.githubusercontent.com/664258/144996663-fc1b1c54-6e0c-4b2c-914d-a44fca5f8eb3.png">

