### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` theme transfer status to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -222,20 +222,6 @@ Undocumented.prototype.getSiteConnectInfo = function ( inputUrl ) {
 	return this.wpcom.req.get( '/connect/site-info', { url: inputUrl } );
 };
 
-/**
- * Fetch the status of an Automated Transfer.
- *
- * @param {number} siteId -- the ID of the site being transferred
- * @param {number} transferId -- ID of the specific transfer
- * @returns {Promise} promise for handling result
- */
-Undocumented.prototype.transferStatus = function ( siteId, transferId ) {
-	debug( '/sites/:site_id/automated-transfers/status/:transfer_id' );
-	return this.wpcom.req.get( {
-		path: `/sites/${ siteId }/automated-transfers/status/${ transferId }`,
-	} );
-};
-
 Undocumented.prototype.getDomainConnectSyncUxUrl = function (
 	domain,
 	providerId,

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -160,9 +160,8 @@ export function pollThemeTransferStatus(
 				dispatch( transferStatusFailure( siteId, transferId, 'client timeout' ) );
 				return resolve();
 			}
-			return wpcom
-				.undocumented()
-				.transferStatus( siteId, transferId )
+			return wpcom.req
+				.get( `/sites/${ siteId }/automated-transfers/status/${ transferId }` )
 				.then( ( { status, message, uploaded_theme_slug } ) => {
 					dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
 					if ( status === 'complete' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` theme transfer status to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Go to `/themes/upload/:site` where `:site` is a WP.com simple site on a free plan.
* Buy a business plan from the prompt on that page.
* After purchasing, you'll end back there. Upload a theme.
* Verify theme upload works well.
* Verify tests pass: `yarn run test-client client/state/themes/test/actions.js`