### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` settings to `wpcom.req`

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -369,15 +369,17 @@ export function setOptionsOnSite( callback, { siteSlug, siteTitle, tagline } ) {
 		return;
 	}
 
-	const settings = {
-		apiVersion: '1.4',
-		blogname: siteTitle,
-		blogdescription: tagline,
-	};
-
-	wpcom.undocumented().settings( siteSlug, 'post', settings, function ( errors ) {
-		callback( isEmpty( errors ) ? undefined : [ errors ] );
-	} );
+	wpcom.req.post(
+		`/sites/${ siteSlug }/settings`,
+		{ apiVersion: '1.4' },
+		{
+			blogname: siteTitle,
+			blogdescription: tagline,
+		},
+		function ( errors ) {
+			callback( isEmpty( errors ) ? undefined : [ errors ] );
+		}
+	);
 }
 
 export function setIntentOnSite( callback, { siteSlug, intent } ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import { omit } from 'lodash';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?
@@ -21,34 +20,6 @@ Undocumented.prototype.jetpackIsUserConnected = function ( siteId ) {
 	debug( '/sites/:site_id:/jetpack-connect/is-user-connected query' );
 	const endpointUrl = '/sites/' + siteId + '/jetpack-connect/is-user-connected';
 	return this.wpcom.req.get( { path: endpointUrl, apiNamespace: 'wpcom/v2' } );
-};
-
-/**
- * GET/POST site settings
- *
- * @param {number|string} [siteId] The site ID
- * @param {string} [method] The request method
- * @param {object} [data] The POST data
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.settings = function ( siteId, method = 'get', data = {}, fn ) {
-	debug( '/sites/:site_id:/settings query' );
-	if ( 'function' === typeof method ) {
-		fn = method;
-		method = 'get';
-		data = {};
-	}
-
-	// If no apiVersion was specified, use the settings api version with the widest support (1.1)
-	const apiVersion = data.apiVersion || '1.1';
-	const body = omit( data, [ 'apiVersion' ] );
-	const path = '/sites/' + siteId + '/settings';
-
-	if ( 'get' === method ) {
-		return this.wpcom.req.get( path, { apiVersion }, fn );
-	}
-
-	return this.wpcom.req.post( { path }, { apiVersion }, body, fn );
 };
 
 /**

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -58,9 +58,8 @@ export function requestSiteSettings( siteId ) {
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.settings( siteId )
+		return wpcom.req
+			.get( `/sites/${ siteId }/settings` )
 			.then( ( { name, description, settings } ) => {
 				const savedSettings = {
 					...normalizeSettings( settings ),
@@ -84,16 +83,17 @@ export function requestSiteSettings( siteId ) {
 	};
 }
 
-export function saveSiteSettings( siteId, settings ) {
+export function saveSiteSettings( siteId, settings = {} ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: SITE_SETTINGS_SAVE,
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.settings( siteId, 'post', settings )
+		const { apiVersion = '1.1', ...siteSettings } = settings;
+
+		return wpcom.req
+			.post( '/sites/' + siteId + '/settings', { apiVersion }, siteSettings )
 			.then( ( body ) => {
 				dispatch( updateSiteSettings( siteId, normalizeSettings( body.updated ) ) );
 				dispatch( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` settings methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Go to `/start` as a logged in user.
* Pick some random test domain and select the free `.wordpress.com` domain.
* Click on "Start with a free site" to go with a free plan.
* On the setup site intent page, click "Start writing"
* Input blog name and tagline and click Continue.
* Click "Start Writing".
* Verify the `POST` request to `/sites/:siteSlug/settings` is successful.
* Navigate to `/settings/general/:siteSlug`
* Verify that the title and tagline are the ones you specified earlier.
* Go to `/settings/general/:site` and verify settings are retrieved correctly.
* Change the settings and click "Save settings".
* Verify settings are saved correctly.
* Upload a new site icon. Verify it's saved correctly after you select it.
* Keep an eye on the `apiVersion` part of the requests (sometimes it may be `1.1` - like for site icon, sometimes `1.4` - for title / tagline) and verify it's the same as before.
* Verify tests still pass: `yarn run test-client client/state/site-settings/test/actions.js`
