### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` get domain price to `wpcom.req`

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -847,7 +847,7 @@ class RegisterDomainStep extends Component {
 				pending: false,
 				is_premium: data.is_premium,
 				cost: data.cost,
-				is_price_limit_exceeded: data?.is_price_limit_exceeded,
+				is_price_limit_exceeded: data.is_price_limit_exceeded,
 			} ) )
 			.catch( ( error ) => ( {
 				pending: true,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -674,7 +674,7 @@ class RegisterDomainStep extends Component {
 		this.save();
 
 		Object.keys( this.state.premiumDomains ).map( ( premiumDomain ) => {
-			this.fetchDomainPricePromise( premiumDomain )
+			this.fetchDomainPrice( premiumDomain )
 				.catch( () => [] )
 				.then( ( domainPrice ) => {
 					this.setState( ( state ) => {
@@ -842,25 +842,19 @@ class RegisterDomainStep extends Component {
 			.catch( noop );
 	};
 
-	fetchDomainPricePromise = ( domain ) => {
-		return new Promise( ( resolve ) => {
-			wpcom.req
-				.get( `/domains/${ encodeURIComponent( domain ) }/price` )
-				.then( ( data ) => {
-					resolve( {
-						pending: false,
-						is_premium: data.is_premium,
-						cost: data.cost,
-						is_price_limit_exceeded: data?.is_price_limit_exceeded,
-					} );
-				} )
-				.catch( ( error ) => {
-					resolve( {
-						pending: true,
-						error,
-					} );
-				} );
-		} );
+	fetchDomainPrice = ( domain ) => {
+		return wpcom.req
+			.get( `/domains/${ encodeURIComponent( domain ) }/price` )
+			.then( ( data ) => ( {
+				pending: false,
+				is_premium: data.is_premium,
+				cost: data.cost,
+				is_price_limit_exceeded: data?.is_price_limit_exceeded,
+			} ) )
+			.catch( ( error ) => ( {
+				pending: true,
+				error,
+			} ) );
 	};
 
 	preCheckDomainAvailability = ( domain ) => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -674,17 +674,15 @@ class RegisterDomainStep extends Component {
 		this.save();
 
 		Object.keys( this.state.premiumDomains ).map( ( premiumDomain ) => {
-			this.fetchDomainPrice( premiumDomain )
-				.catch( () => [] )
-				.then( ( domainPrice ) => {
-					this.setState( ( state ) => {
-						const newPremiumDomains = { ...state.premiumDomains };
-						newPremiumDomains[ premiumDomain ] = domainPrice;
-						return {
-							premiumDomains: newPremiumDomains,
-						};
-					} );
+			this.fetchDomainPrice( premiumDomain ).then( ( domainPrice ) => {
+				this.setState( ( state ) => {
+					const newPremiumDomains = { ...state.premiumDomains };
+					newPremiumDomains[ premiumDomain ] = domainPrice;
+					return {
+						premiumDomains: newPremiumDomains,
+					};
 				} );
+			} );
 		} );
 	};
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -844,22 +844,22 @@ class RegisterDomainStep extends Component {
 
 	fetchDomainPricePromise = ( domain ) => {
 		return new Promise( ( resolve ) => {
-			wpcom.undocumented().getDomainPrice( domain, ( serverError, result ) => {
-				if ( serverError ) {
+			wpcom.req
+				.get( `/domains/${ encodeURIComponent( domain ) }/price` )
+				.then( ( data ) => {
+					resolve( {
+						pending: false,
+						is_premium: data.is_premium,
+						cost: data.cost,
+						is_price_limit_exceeded: data?.is_price_limit_exceeded,
+					} );
+				} )
+				.catch( ( error ) => {
 					resolve( {
 						pending: true,
-						error: serverError,
+						error,
 					} );
-					return;
-				}
-
-				resolve( {
-					pending: false,
-					is_premium: result.is_premium,
-					cost: result.cost,
-					is_price_limit_exceeded: result?.is_price_limit_exceeded,
 				} );
-			} );
 		} );
 	};
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -106,21 +106,6 @@ Undocumented.prototype.startInboundTransfer = function ( siteId, domain, authCod
 };
 
 /**
- *
- * @param domain {string}
- * @param fn {function}
- */
-Undocumented.prototype.getDomainPrice = function ( domain, fn ) {
-	return this.wpcom.req.get(
-		`/domains/${ encodeURIComponent( domain ) }/price`,
-		{
-			apiVersion: '1.1',
-		},
-		fn
-	);
-};
-
-/**
  * Launches a private site
  *
  * @param {string} siteIdOrSlug - ID or slug of the site to be launched


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` domain price retrieval method to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Go to `/domains/add/:site` where `:site` is a WP.com site.
* Input `image.blog` in the search form.
* Verify price is retrieved and displayed correctly.