### PR TITLE
Move wpcom.undocumented().getAtomicSiteMediaViaProxy to a separate module

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -2,8 +2,8 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
+import { getAtomicSiteMediaViaProxyRetry } from 'calypso/lib/get-atomic-site-media';
 import { mediaURLToProxyConfig, canvasToBlob } from 'calypso/lib/media/utils';
-import wpcom from 'calypso/lib/wp';
 import {
 	setImageEditorCropBounds,
 	setImageEditorImageHasLoaded,
@@ -92,7 +92,7 @@ export class ImageEditorCanvas extends Component {
 		const useProxy = isPrivateAtomic && filePath && isRelativeToSiteRoot;
 
 		if ( useProxy ) {
-			return wpcom.undocumented().getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, { query } );
+			return getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, { query } );
 		}
 
 		if ( ! src.startsWith( 'blob' ) ) {

--- a/client/lib/get-atomic-site-media/index.js
+++ b/client/lib/get-atomic-site-media/index.js
@@ -1,0 +1,53 @@
+import wpcom from 'calypso/lib/wp';
+
+export function getAtomicSiteMediaViaProxy( siteId, mediaPath, { query = '', maxSize } ) {
+	const safeQuery = query.replace( /^\?/, '' );
+	const params = {
+		path: `/sites/${ siteId }/atomic-auth-proxy/file?path=${ mediaPath }&${ safeQuery }`,
+		apiNamespace: 'wpcom/v2',
+	};
+
+	return new Promise( ( resolve, reject ) => {
+		const fetchMedia = () =>
+			wpcom.req.get( { ...params, responseType: 'blob' }, ( error, data ) => {
+				if ( error || ! ( data instanceof globalThis.Blob ) ) {
+					reject( error );
+				} else {
+					resolve( data );
+				}
+			} );
+
+		if ( ! maxSize ) {
+			return fetchMedia();
+		}
+
+		return wpcom.req.get( { ...params, method: 'HEAD' }, ( err, data, headers ) => {
+			if ( headers[ 'Content-Length' ] > maxSize ) {
+				reject( { message: 'exceeded_max_size' } );
+				return;
+			}
+
+			fetchMedia();
+		} );
+	} );
+}
+
+export function getAtomicSiteMediaViaProxyRetry( siteId, mediaPath, options ) {
+	let retries = 0;
+	const request = () =>
+		getAtomicSiteMediaViaProxy( siteId, mediaPath, options ).catch( ( error ) => {
+			// Retry three times with exponential backoff times
+			if ( retries < 3 ) {
+				return new Promise( ( resolve ) => {
+					++retries;
+					setTimeout( () => {
+						resolve( request() );
+					}, ( retries * retries * 1000 ) / 2 );
+				} );
+			}
+
+			return Promise.reject( error );
+		} );
+
+	return request();
+}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2,7 +2,6 @@ import debugFactory from 'debug';
 import { omit } from 'lodash';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
-const { Blob } = globalThis; // The linter complains if I don't do this...?
 
 /**
  * Create an `Undocumented` instance
@@ -331,66 +330,6 @@ Undocumented.prototype.startMigration = function ( sourceSiteId, targetSiteId ) 
 		path: `/sites/${ targetSiteId }/migrate-from/${ sourceSiteId }`,
 		apiNamespace: 'wpcom/v2',
 	} );
-};
-
-Undocumented.prototype.getAtomicSiteMediaViaProxy = function (
-	siteIdOrSlug,
-	mediaPath,
-	{ query = '', maxSize }
-) {
-	const safeQuery = query.replace( /^\?/, '' );
-	const params = {
-		path: `/sites/${ siteIdOrSlug }/atomic-auth-proxy/file?path=${ mediaPath }&${ safeQuery }`,
-		apiNamespace: 'wpcom/v2',
-	};
-
-	return new Promise( ( resolve, _reject ) => {
-		const fetchMedia = () =>
-			this.wpcom.req.get( { ...params, responseType: 'blob' }, ( error, data ) => {
-				if ( error || ! ( data instanceof Blob ) ) {
-					_reject( error );
-				} else {
-					resolve( data );
-				}
-			} );
-
-		if ( ! maxSize ) {
-			return fetchMedia();
-		}
-
-		return this.wpcom.req.get( { ...params, method: 'HEAD' }, ( err, data, headers ) => {
-			if ( headers[ 'Content-Length' ] > maxSize ) {
-				_reject( { message: 'exceeded_max_size' } );
-				return;
-			}
-
-			fetchMedia();
-		} );
-	} );
-};
-
-Undocumented.prototype.getAtomicSiteMediaViaProxyRetry = function (
-	siteIdOrSlug,
-	mediaPath,
-	options
-) {
-	let retries = 0;
-	const request = () =>
-		this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, options ).catch( ( error ) => {
-			// Retry three times with exponential backoff times
-			if ( retries < 3 ) {
-				return new Promise( ( resolve ) => {
-					++retries;
-					setTimeout( () => {
-						resolve( request() );
-					}, ( retries * retries * 1000 ) / 2 );
-				} );
-			}
-
-			return Promise.reject( error );
-		} );
-
-	return request();
 };
 
 /**

--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -1,7 +1,7 @@
 import debugFactory from 'debug';
 import { useEffect, useState } from 'react';
-import * as React from 'react';
-import wpcom from 'calypso/lib/wp';
+import { getAtomicSiteMediaViaProxyRetry } from 'calypso/lib/get-atomic-site-media';
+import type { ComponentType, FC, ReactElement, ReactNode } from 'react';
 
 const debug = debugFactory( 'calypso:my-sites:media-library:proxied-image' );
 
@@ -9,13 +9,13 @@ type RenderedComponentProps = {
 	src: string;
 	[ key: string ]: any;
 };
-export type RenderedComponent = string | React.ComponentType< RenderedComponentProps >;
+export type RenderedComponent = string | ComponentType< RenderedComponentProps >;
 
 export interface ProxiedImageProps {
 	query: string;
 	filePath: string;
 	siteSlug: string;
-	placeholder: React.ReactNode | null;
+	placeholder: ReactNode;
 	component: RenderedComponent;
 	maxSize: number | null;
 	onError?: ( err: Error ) => any;
@@ -39,7 +39,7 @@ const cacheResponse = ( requestId: string, blob: Blob, freshness = 60000 ) => {
 	}, freshness );
 };
 
-const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
+const ProxiedImage: FC< ProxiedImageProps > = function ProxiedImage( {
 	siteSlug,
 	filePath,
 	query,
@@ -64,9 +64,7 @@ const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
 			if ( maxSize !== null ) {
 				options.maxSize = maxSize;
 			}
-			wpcom
-				.undocumented()
-				.getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, options )
+			getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, options )
 				.then( ( data: Blob ) => {
 					cacheResponse( requestId, data );
 					setImageObjectUrl( URL.createObjectURL( data ) );
@@ -84,7 +82,7 @@ const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
 	}, [ siteSlug, filePath, query ] );
 
 	if ( ! imageObjectUrl ) {
-		return placeholder as React.ReactElement;
+		return placeholder as ReactElement;
 	}
 
 	/* eslint-disable-next-line jsx-a11y/alt-text */


### PR DESCRIPTION
Part of #58458. Moves the `wpcom.undocumented().getAtomicSiteMediaViaProxy` methods to a new `calypso/lib/get-atomic-site-media` module. It's used at two places.

As a drive-by, I'm also fixing up React type imports in `ProxiedImage` component.

**How to test:**
1. Have a private Atomic site.
2. Go to Media library (Calypso version) for this site.
3. Verify that the images are loaded using the proxy endpoint, with requests like:
```
https://public-api.wordpress.com/wpcom/v2/sites/example.blog/atomic-auth-proxy/file?path=/wp-content/uploads/picture.png
```
Fetching them directly from `example.blog` wouldn't work because the cross-origin requests wouldn't be property authenticated.