### PR TITLE
Remove moment from notifications

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -34,7 +34,6 @@
 		"classnames": "^2.3.1",
 		"debug": "^4.1.1",
 		"i18n-calypso": "workspace:^",
-		"moment": "^2.26.0",
 		"page": "^1.11.5",
 		"prop-types": "^15.7.2",
 		"react": "^17.0.2",

--- a/apps/notifications/src/panel/templates/block-user.jsx
+++ b/apps/notifications/src/panel/templates/block-user.jsx
@@ -1,10 +1,15 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import moment from 'moment';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import getIsNoteApproved from '../state/selectors/get-is-note-approved';
 import FollowLink from './follow-link';
 import { linkProps } from './functions';
+
+const aSecond = 1000;
+const aMinute = aSecond * 60;
+const anHour = aMinute * 60;
+const aDay = anHour * 24;
 
 function getDisplayURL( url ) {
 	const parser = document.createElement( 'a' );
@@ -12,23 +17,119 @@ function getDisplayURL( url ) {
 	return ( parser.hostname + parser.pathname ).replace( /\/$/, '' );
 }
 
+/**
+ * Get localized relative time string for past timestamp.
+ *
+ * @param {number} timestamp Web timestamp (milliseconds since Epoch)
+ * @param {string} locale Locale slug
+ * @param {Date} now The date to be used for "now" in the relative calculation
+ * @returns {string} Formatted relative date string, e.g. '2 min. ago'.
+ *   Returns '' for future dates and errors.
+ */
+function getRelativeTimeString( timestamp, locale = 'en', now = Date.now() ) {
+	const delta = now - timestamp;
+
+	if ( delta < 0 ) {
+		return '';
+	}
+
+	try {
+		const formatter = new Intl.RelativeTimeFormat( locale, { style: 'narrow' } );
+
+		if ( delta < aSecond ) {
+			// Super-accurate timing is not critical; pretend a second has elapsed.
+			return formatter.format( -1, 'seconds' );
+		}
+
+		if ( delta < aMinute ) {
+			return formatter.format( -1 * Math.round( delta / aSecond ), 'seconds' );
+		}
+
+		if ( delta < anHour ) {
+			return formatter.format( -1 * Math.round( delta / aMinute ), 'minutes' );
+		}
+
+		if ( delta < aDay ) {
+			return formatter.format( -1 * Math.round( delta / anHour ), 'hours' );
+		}
+
+		return formatter.format( -1 * Math.round( delta / aDay ), 'days' );
+	} catch ( error ) {
+		return '';
+	}
+}
+
+/**
+ * Get localized short date format for timestamp.
+ *
+ * @param {number} timestamp Web timestamp (milliseconds since Epoch)
+ * @param {string} locale Locale slug
+ * @returns {string} Formatted localized date, e.g. 'Dec 20, 2021' for US English.
+ *   Falls back to ISO date string if anything goes wrong.
+ */
+function getShortDateString( timestamp, locale = 'en' ) {
+	try {
+		const formatter = new Intl.DateTimeFormat( locale, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+		} );
+		return formatter.format( new Date( timestamp ) );
+	} catch ( error ) {
+		return getISODateString( timestamp, locale );
+	}
+}
+
+/**
+ * Get localized numeric date format for timestamp.
+ *
+ * @param {number} timestamp Web timestamp (milliseconds since Epoch)
+ * @param {string} locale Locale slug
+ * @returns {string} Formatted localized date, e.g. '12/20/2021' for US English
+ *   Falls back to ISO date string if anything goes wrong.
+ */
+function getNumericDateString( timestamp, locale = 'en' ) {
+	try {
+		const formatter = new Intl.DateTimeFormat( locale, {
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+		} );
+		return formatter.format( new Date( timestamp ) );
+	} catch ( error ) {
+		return getISODateString( timestamp, locale );
+	}
+}
+
+/**
+ * Get ISO date format for timestamp.
+ *
+ * @param {number} timestamp Web timestamp (milliseconds since Epoch)
+ * @returns {string} Formatted ISO date, e.g. '2020-12-20'
+ */
+function getISODateString( timestamp ) {
+	return new Date( timestamp ).toISOString().split( 'T' )[ 0 ];
+}
+
 export class UserBlock extends Component {
 	/**
-	 * Format a timestamp for showing how long
-	 * ago an event occurred. Specifically here
-	 * for showing when a comment was made.
+	 * Format a timestamp for showing how long ago an event occurred.
+	 * Specifically here for showing when a comment was made.
 	 *
 	 * If within the past five days, a relative time
-	 *   e.g. "23 sec", "15 min", "4 hours", "1 day"
+	 *   e.g. "23 sec. ago", "15 min. ago", "4 hrs. ago", "1 day ago"
 	 *
 	 * If older than five days, absolute date
 	 *   e.g. "30 Apr 2015"
 	 *
-	 * @param {string} timestamp - Time stamp in Date.parse()'able format
-	 * @returns {string} - Time stamp formatted for display or '' if input invalid
+	 * If anything goes wrong, ISO date
+	 *   e.g. "2020-12-20"
+	 * Localized dates are always better, but ISO dates should be broadly recognizable.
+	 *
+	 * @param {string} timestamp - Timestamp in Date.parse()'able format
+	 * @returns {string} - Timestamp formatted for display or '' if input invalid
 	 */
 	getTimeString = ( timestamp ) => {
-		const DAY_IN_SECONDS = 3600 * 24;
 		const MAX_LENGTH = 15;
 		const parsedTime = Date.parse( timestamp );
 		let timeString;
@@ -38,19 +139,27 @@ export class UserBlock extends Component {
 		}
 
 		const localeSlug = getLocaleSlug();
-		const momentTime = moment( timestamp ).locale( localeSlug );
 
-		if ( Date.now() - parsedTime > 1000 * DAY_IN_SECONDS * 5 ) {
-			// 30 Apr 2015
-			timeString = momentTime.format( 'll' );
+		timeString = getShortDateString( parsedTime, localeSlug );
 
-			if ( timeString.length > MAX_LENGTH ) {
-				// 2015/4/30 if 'll' is too long, e.g. "30 de abr. de 2015"
-				timeString = momentTime.format( 'l' );
+		// If the localized short date format is too long, use numeric one.
+		if ( timeString.length > MAX_LENGTH ) {
+			timeString = getNumericDateString( parsedTime, localeSlug );
+		}
+
+		// If the localized numeric date format is still too long, use ISO one.
+		if ( timeString.length > MAX_LENGTH ) {
+			timeString = getISODateString( parsedTime );
+		}
+
+		// Use relative time strings (e.g. '2 min. ago') for recent dates.
+		if ( Date.now() - parsedTime < 5 * aDay ) {
+			const relativeTimeString = getRelativeTimeString( parsedTime, localeSlug );
+
+			// Only use relative date if it makes sense and is not too long.
+			if ( relativeTimeString && relativeTimeString.length <= MAX_LENGTH ) {
+				timeString = relativeTimeString;
 			}
-		} else {
-			// simplified units, no "ago", e.g. 7 min, 4 hours, 2 days
-			timeString = momentTime.fromNow( true );
 		}
 
 		return timeString;
@@ -102,7 +211,7 @@ export class UserBlock extends Component {
 
 		if ( home_title ) {
 			const homeClassName =
-				timeIndicator != '' ? 'wpnc__user__meta wpnc__user__bulleted' : 'wpnc__user__meta';
+				timeIndicator !== '' ? 'wpnc__user__meta wpnc__user__bulleted' : 'wpnc__user__meta';
 			homeTemplate = (
 				<p className={ homeClassName }>
 					<span className="wpnc__user__ago">{ timeIndicator }</span>
@@ -125,7 +234,11 @@ export class UserBlock extends Component {
 			);
 		}
 
-		if ( this.props.block.actions && 'undefined' != this.props.block.meta.ids.site ) {
+		if (
+			this.props.block.actions &&
+			this.props.block.meta.ids.site !== undefined &&
+			this.props.block.meta.ids.site !== 'undefined'
+		) {
 			followLink = (
 				<FollowLink
 					site={ this.props.block.meta.ids.site }
@@ -138,11 +251,11 @@ export class UserBlock extends Component {
 		if ( home_url ) {
 			return (
 				<div className="wpnc__user">
-					<a className="wpnc__user__site" href={ home_url } target="_blank">
-						<img src={ grav.url } height={ grav.height } width={ grav.width } />
+					<a className="wpnc__user__site" href={ home_url } target="_blank" rel="noreferrer">
+						<img src={ grav.url } height={ grav.height } width={ grav.width } alt="Avatar" />
 					</a>
 					<span className="wpnc__user__username">
-						<a className="wpnc__user__home" href={ home_url } target="_blank">
+						<a className="wpnc__user__home" href={ home_url } target="_blank" rel="noreferrer">
 							{ this.props.block.text }
 						</a>
 					</span>
@@ -153,7 +266,7 @@ export class UserBlock extends Component {
 		}
 		return (
 			<div className="wpnc__user">
-				<img src={ grav.url } height={ grav.height } width={ grav.width } />
+				<img src={ grav.url } height={ grav.height } width={ grav.width } alt="Avatar" />
 				<span className="wpnc__user__username">{ this.props.block.text }</span>
 				{ homeTemplate }
 				{ followLink }

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,7 +830,6 @@ __metadata:
     html-webpack-plugin: ^5.0.0-beta.4
     i18n-calypso: "workspace:^"
     jest: ^27.3.1
-    moment: ^2.26.0
     page: ^1.11.5
     postcss: ^8.3.11
     postcss-custom-properties: ^11.0.0


### PR DESCRIPTION
The large `moment` library is being imported into notifications for a single use in a single place. That's not very reasonable, so this PR reimplements that functionality using native browser APIs.

The dates will not be displayed exactly the same as they were, but they should be displayed in a reasonable, readable format for a given locale.

This probably doesn't have much of an impact in the Calypso app, but it should save around 57KB (18KB gzipped) in the notifications app.

#### Changes proposed in this Pull Request

* Reimplement date strings in notifications without `moment`
* Fix some lint issues

#### Testing instructions

The code is the same for standalone or Calypso notifications, so it should be enough to test one of them.

* Open your list of notifications.
* Click a notification that includes a timestamp (e.g. someone replying to one of your posts).
* Verify that the displayed date makes sense and looks reasonable for your locale.

Try testing several different notifications; newer ones (< 5 days) will display as relative dates, whereas older ones will display as absolute dates.
