### PR TITLE
`InvitesListEnd`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/people/people-invites/invites-list-end.jsx
+++ b/client/my-sites/people/people-invites/invites-list-end.jsx
@@ -1,51 +1,45 @@
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { PureComponent, Fragment } from 'react';
-import { connect } from 'react-redux';
+import { Fragment, useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import ListEnd from 'calypso/components/list-end';
 import { bumpStat } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 
-class InvitesListEnd extends PureComponent {
-	static propTypes = {
-		shown: PropTypes.number,
-		found: PropTypes.number,
-	};
+function InvitesListEnd( { shown, found } ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const bumped = useRef( false );
 
-	constructor( props ) {
-		super( props );
-		this.bumpedStat = false;
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.found > nextProps.shown && ! this.bumpedStat ) {
-			this.props.bumpStat( 'calypso_people_invite_list', 'displayed_max' );
-			this.bumpedStat = true;
+	useEffect( () => {
+		if ( found > shown && ! bumped.current ) {
+			dispatch( bumpStat( 'calypso_people_invite_list', 'displayed_max' ) );
+			bumped.current = true;
 		}
-	}
+	}, [ dispatch, bumped, found, shown ] );
 
-	render() {
-		const { shown, found, translate } = this.props;
-
-		return (
-			<Fragment>
-				{ shown < found && (
-					<div className="people-invites__max-items-notice">
-						{ translate(
-							'Showing %(shown)d invite of %(found)d.',
-							'Showing %(shown)d invites of %(found)d.',
-							{ args: { shown, found } }
-						) }
-						<br />
-						{ translate( 'To view more invites, clear some of your existing invites first.' ) }
-					</div>
-				) }
-				<ListEnd />
-			</Fragment>
-		);
-	}
+	return (
+		<Fragment>
+			{ shown < found && (
+				<div className="people-invites__max-items-notice">
+					{ translate(
+						'Showing %(shown)d invite of %(found)d.',
+						'Showing %(shown)d invites of %(found)d.',
+						{ args: { shown, found } }
+					) }
+					<br />
+					{ translate( 'To view more invites, clear some of your existing invites first.' ) }
+				</div>
+			) }
+			<ListEnd />
+		</Fragment>
+	);
 }
 
-export default connect( null, { bumpStat } )( localize( InvitesListEnd ) );
+InvitesListEnd.propTypes = {
+	shown: PropTypes.number,
+	found: PropTypes.number,
+};
+
+export default InvitesListEnd;

--- a/client/my-sites/people/people-invites/invites-list-end.jsx
+++ b/client/my-sites/people/people-invites/invites-list-end.jsx
@@ -26,7 +26,10 @@ function InvitesListEnd( { shown, found } ) {
 					{ translate(
 						'Showing %(shown)d invite of %(found)d.',
 						'Showing %(shown)d invites of %(found)d.',
-						{ args: { shown, found } }
+						{
+							count: shown,
+							args: { shown, found },
+						}
 					) }
 					<br />
 					{ translate( 'To view more invites, clear some of your existing invites first.' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `InvitesListEnd`: refactor away from `UNSAFE_*`
* Also refactor to functional component

#### Testing instructions

* Go to `/people/invites/<siteSlug>` for a site with > 100 invites
* You should see an action dispatched as shown below
* To properly test the `bumped` flag, in React devtools change the value of either `shown | found` but leave the condition intact (`found > shown`); then make sure you don't see another action dispatched



<img width="339" alt="Screenshot 2021-12-07 at 14 32 28" src="https://user-images.githubusercontent.com/9202899/145040399-055b007a-ca74-4843-8ef3-540ed627971a.png">
Related to #58453 
