### PR TITLE
Emails: Price badge improvements in styling and use

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -38,7 +38,7 @@ const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) =
 	const toggleVisibility = ( event: React.MouseEvent ): void => {
 		event.preventDefault();
 
-		onExpandedChange( providerKey ?? '', ! detailsExpanded );
+		onExpandedChange( providerKey, ! detailsExpanded );
 	};
 
 	const header = (

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -1,10 +1,8 @@
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
-import { translate } from 'i18n-calypso';
 import { FunctionComponent, useState } from 'react';
 import PromoCard from 'calypso/components/promo-section/promo-card';
-import PromoCardPrice from 'calypso/components/promo-section/promo-card/price';
 import EmailProviderFeaturesToggleButton from 'calypso/my-sites/email/email-provider-features/toggle-button';
 import EmailProviderStackedFeatures from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features';
 import type { ProviderCard } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props';
@@ -16,20 +14,16 @@ const noop = () => {};
 
 const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) => {
 	const {
-		additionalPriceInformation,
-		buttonLabel,
 		children,
 		description,
-		discount,
 		detailsExpanded,
 		expandButtonLabel,
 		features,
 		footerBadge,
-		formattedPrice,
 		formFields,
 		logo,
-		onButtonClick = noop,
 		onExpandedChange = noop,
+		priceBadge = null,
 		productName,
 		providerKey,
 		showExpandButton = true,
@@ -44,27 +38,8 @@ const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) =
 	const toggleVisibility = ( event: React.MouseEvent ): void => {
 		event.preventDefault();
 
-		onExpandedChange( providerKey, ! detailsExpanded );
+		onExpandedChange( providerKey ?? '', ! detailsExpanded );
 	};
-
-	const labelForExpandButton = expandButtonLabel ? expandButtonLabel : buttonLabel;
-
-	const price = (
-		<div className="email-provider-stacked-card__title-price-badge">
-			<div className="email-provider-stacked-card__discount badge badge--info-green">
-				{ translate( '3 months free' ) }
-			</div>
-			<PromoCardPrice
-				formattedPrice={ formattedPrice }
-				discount={ discount }
-				additionalPriceInformation={
-					<span className="email-provider-stacked-card__provider-additional-price-information">
-						{ additionalPriceInformation }
-					</span>
-				}
-			/>
-		</div>
-	);
 
 	const header = (
 		<div className="email-provider-stacked-card__header">
@@ -72,20 +47,7 @@ const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) =
 				<h2 className="email-provider-stacked-card__title wp-brand-font"> { productName } </h2>
 				<p>{ description }</p>
 			</div>
-			{ price }
-		</div>
-	);
-
-	return (
-		<PromoCard
-			className={ classnames( 'email-providers-stacked-comparison__provider-card', {
-				'is-expanded': detailsExpanded,
-				'is-forwarding': providerKey === 'forwarding',
-			} ) }
-			image={ logo }
-			titleComponent={ header }
-			icon={ '' }
-		>
+			<div className="email-provider-stacked-card__title-price-badge">{ priceBadge }</div>
 			<div className="email-provider-stacked-card__provider-card-main-details">
 				{ showExpandButton && (
 					<Button
@@ -93,11 +55,22 @@ const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) =
 						onClick={ toggleVisibility }
 						className="email-provider-stacked-card__provider-expand-cta"
 					>
-						{ labelForExpandButton }
+						{ expandButtonLabel }
 					</Button>
 				) }
 			</div>
+		</div>
+	);
 
+	return (
+		<PromoCard
+			className={ classnames( 'email-providers-stacked-comparison__provider-card', {
+				'is-expanded': detailsExpanded,
+			} ) }
+			image={ logo }
+			titleComponent={ header }
+			icon={ '' }
+		>
 			<div className="email-provider-stacked-card__provider-price-and-button">
 				{ showFeaturesToggleButton && (
 					<EmailProviderFeaturesToggleButton
@@ -108,15 +81,7 @@ const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) =
 			</div>
 
 			<div className="email-provider-stacked-card__provider-form-and-right-panel">
-				<div className="email-provider-stacked-card__provider-form">
-					{ formFields }
-
-					{ buttonLabel && (
-						<Button primary onClick={ onButtonClick }>
-							{ buttonLabel }
-						</Button>
-					) }
-				</div>
+				<div className="email-provider-stacked-card__provider-form">{ formFields }</div>
 				<div className="email-provider-stacked-card__provider-right-panel">
 					{ ( ! showFeaturesToggleButton || areFeaturesExpanded ) && (
 						<>

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -177,11 +177,6 @@ h2.action-panel__title {
 	width: $width-right-panel-card;
 }
 
-.email-provider-stacked-card__provider-additional-price-information {
-	color: var( --studio-gray-60 );
-	margin-left: 4px;
-}
-
 .email-provider-stacked-card__provider-form-and-right-panel {
 	display: none;
 }

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -1,8 +1,8 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-$width-right-panel-card: 40%;
-$width-left-panel-card: calc( 60% - 48px );
+$width-right-panel-card: calc( 45% - 130px );
+$width-left-panel-card: calc( 55% );
 
 .email-provider-stacked-features__whats-included {
 	color: var( --studio-gray-20 );
@@ -194,9 +194,10 @@ h2.action-panel__title {
 	.email-provider-stacked-card__provider-form-and-right-panel {
 		display: flex;
 		flex-direction: column-reverse;
-		justify-content: space-between;
+		justify-content: start;
 		margin-top: 1em;
 		line-height: 1.5;
+		padding-right: 20px;
 
 		@include breakpoint-deprecated( '>1040px' ) {
 			flex-direction: row;
@@ -205,6 +206,7 @@ h2.action-panel__title {
 
 	.email-provider-stacked-card__provider-form {
 		margin-bottom: 20px;
+		margin-right: 20px;
 		width: $width-left-panel-card;
 
 		@include breakpoint-deprecated( '>1040px' ) {
@@ -257,6 +259,10 @@ h2.action-panel__title {
 	flex-direction: row;
 	flex-wrap: wrap;
 	justify-content: space-between;
+}
+
+.email-provider-stacked-card__provider-card-main-details {
+	width: 120px;
 }
 
 .email-provider-stacked-card__title-container {

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -66,7 +66,7 @@ const googleWorkspaceCardInformation: ProviderCard = {
 
 const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > = ( props ) => {
 	const { currencyCode = '', domain, gSuiteProduct, selectedDomainName } = props;
-	const googleWorkspace: ProviderCard = googleWorkspaceCardInformation;
+	const googleWorkspace: ProviderCard = { ...googleWorkspaceCardInformation };
 
 	const isUpgrading = () => {
 		const { domain, hasCartDomain } = props;
@@ -255,7 +255,6 @@ const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > =
 			description={ googleWorkspace.description }
 			detailsExpanded={ googleWorkspace.detailsExpanded }
 			discount={ discount }
-			additionalPriceInformation={ googleWorkspace.additionalPriceInformation }
 			onExpandedChange={ googleWorkspace.onExpandedChange }
 			priceBadge={ priceBadge }
 			formFields={ formFields }

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -241,9 +241,7 @@ const ProfessionalEmailCard: FunctionComponent< EmailProvidersStackedCardProps >
 			productName={ professionalEmail.productName }
 			description={ professionalEmail.description }
 			detailsExpanded={ professionalEmail.detailsExpanded }
-			additionalPriceInformation={ professionalEmail.additionalPriceInformation }
 			onExpandedChange={ professionalEmail.onExpandedChange }
-			formattedPrice={ formattedPrice }
 			formFields={ formFields }
 			isDomainEligibleForTitanFreeTrial={ isDomainEligibleForTitanFreeTrial( domain ) }
 			showExpandButton={ professionalEmail.showExpandButton }

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -21,7 +21,7 @@ export interface ProviderCard {
 	onButtonClick?: ( event: React.MouseEvent ) => void;
 	priceBadge?: ReactElement | TranslateResult;
 	productName?: TranslateResult;
-	providerKey?: string;
+	providerKey: string;
 	showExpandButton?: boolean;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request adds minimal code to show a working control modifying the underneath provider cards that will swap from annual billing to monthly billing.

This pull request also refactors, remove duplicated code, and cleans the previous code. Please, pair with me if you need help on reviewing this PR, as it became very big.

#### Testing instructions

1. Go to a site with domains without email subscription *
2. Click on 'Add email' for the desired site
3. Once you are in the comparison page, add at the end the following flag: `?flags=emails/new-email-comparison`
4. The provider cards should render correctly

**Remarks**
You can also go through the path /email/{domain}/purchase/{site}?flags=emails/new-email-comparison
This change the product type yet, but products are not ready yet?.

![image](https://user-images.githubusercontent.com/5689927/145075525-b8e1c68f-6def-4013-a86a-6c38ac6097e8.png)

**Related to**
{1200182182542585-as-1201481434846122}