### PR TITLE
Payment Methods: Do not display backup checkbox for non-cards

### DIFF
--- a/client/lib/checkout/payment-methods.ts
+++ b/client/lib/checkout/payment-methods.ts
@@ -13,20 +13,33 @@ export const PARTNER_PAYPAL_EXPRESS = 'paypal_express';
 export const PAYMENT_AGREEMENTS_PARTNERS = [ PARTNER_PAYPAL_EXPRESS ];
 
 export interface PaymentMethod {
-	card?: string;
+	added: string;
+	card: string;
+	card_type: string;
 	email: string;
-	card_type?: string;
-	payment_partner: string;
-	name: string;
 	expiry: string;
+	is_expired: boolean;
+	last_service: string;
+	last_used: string;
+	meta: PaymentMethodMeta[];
+	mp_ref: string;
+	name: string;
+	payment_partner: string;
+	remember: '1' | '0';
 	stored_details_id: string;
-	is_expired?: boolean;
+	user_id: string;
 }
 
-export const isPaymentAgreement = ( method: PaymentMethod ) =>
+export interface PaymentMethodMeta {
+	meta_key: string;
+	meta_value: string;
+	stored_details_id: string;
+}
+
+export const isPaymentAgreement = ( method: PaymentMethod ): boolean =>
 	PAYMENT_AGREEMENTS_PARTNERS.includes( method.payment_partner );
 
-export const isCreditCard = ( method: PaymentMethod ) => ! isPaymentAgreement( method );
+export const isCreditCard = ( method: PaymentMethod ): boolean => ! isPaymentAgreement( method );
 
 interface ImagePathsMap {
 	[ key: string ]: string;

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -12,7 +12,7 @@ import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {
 	lastDigits?: string;
-	cardType: string;
+	cardType?: string;
 	name: string;
 	expiry?: string;
 	email?: string;

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -1,11 +1,12 @@
 import { CompactCard } from '@automattic/components';
-import { FunctionComponent, ComponentProps } from 'react';
+import { FunctionComponent } from 'react';
 import PaymentMethodDetails from './payment-method-details';
+import type { PaymentMethod as PaymentMethodType } from 'calypso/lib/checkout/payment-methods';
 
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {
-	card: ComponentProps< typeof PaymentMethodDetails >;
+	card?: PaymentMethodType;
 }
 
 const PaymentMethod: FunctionComponent< Props > = ( { card, children } ) => {

--- a/client/my-sites/checkout/composite-checkout/types/stored-cards.ts
+++ b/client/my-sites/checkout/composite-checkout/types/stored-cards.ts
@@ -1,22 +1,4 @@
-export interface StoredCard {
-	added: string;
-	card: string;
-	card_type: string;
-	email: string;
-	expiry: string;
-	last_service: string;
-	last_used: string;
-	mp_ref: string;
-	name: string;
-	payment_partner: string;
-	remember: string;
-	stored_details_id: string;
-	user_id: string;
-	meta: StoredCardMeta[];
-}
-
-export interface StoredCardMeta {
-	meta_key: string;
-	meta_value: string;
-	stored_details_id: string;
-}
+export type {
+	PaymentMethod as StoredCard,
+	PaymentMethodMeta as StoredCardMeta,
+} from 'calypso/lib/checkout/payment-methods';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This prevents a backup checkbox being displayed (and subsequently showing an error) for PayPal billing agreements in the payment method list. (An accidental regression from https://github.com/Automattic/wp-calypso/pull/56665)

Before:
<img width="1012" alt="before-pp-backup-error-2" src="https://user-images.githubusercontent.com/2036909/145077045-0857f142-662f-4734-b9aa-c721fd827140.png">

After:

<img width="1007" alt="after-pp-backup-error-2" src="https://user-images.githubusercontent.com/2036909/145077057-eca8f8c3-bfa2-498b-950a-ddfa0ed2a7df.png">




Fixes 599-gh-Automattic/payments-shilling

#### Testing instructions

- Add a PayPal billing agreement to your account by purchasing something with PayPal.
- Visit `/me/purchases/payment-methods`
- Verify that there is neither a checkbox nor an error next to the PayPal agreement but the checkbox remains next to the credit cards.