### PR TITLE
Revert "Videos UI: Count video play clicks from in the video player controls."

### DIFF
--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -19,13 +19,6 @@ const VideoPlayer = ( {
 		setShouldCheckForVideoComplete( false );
 	};
 
-	const trackPlayClick = () => {
-		recordTracksEvent( 'calypso_courses_video_player_play_click', {
-			course: course.slug,
-			video: videoData.slug,
-		} );
-	};
-
 	useEffect( () => {
 		if ( videoRef.current ) {
 			videoRef.current.onplay = () => {
@@ -55,7 +48,6 @@ const VideoPlayer = ( {
 				ref={ videoRef }
 				poster={ videoData.poster }
 				autoPlay={ isPlaying }
-				onPlay={ trackPlayClick }
 				onTimeUpdate={ shouldCheckForVideoComplete ? markVideoAsComplete : undefined }
 			>
 				<source src={ videoData.url } />{ ' ' }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#58794. We're getting console errors about `recordTracksEvent` not being defined.