### PR TITLE
Videos UI: Record Tracks events for video player control play clicks.

### DIFF
--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,4 +1,5 @@
 import { createRef, useEffect, useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const VideoPlayer = ( {
 	videoData,
@@ -41,6 +42,13 @@ const VideoPlayer = ( {
 		setShouldCheckForVideoComplete( true );
 	}, [ course?.slug, videoData?.slug ] );
 
+	const trackPlayClick = () => {
+		recordTracksEvent( 'calypso_courses_video_player_play_click', {
+			course: course.slug,
+			video: videoData.slug,
+		} );
+	};
+
 	return (
 		<div key={ videoData.url } className="videos-ui__video">
 			<video
@@ -48,6 +56,7 @@ const VideoPlayer = ( {
 				ref={ videoRef }
 				poster={ videoData.poster }
 				autoPlay={ isPlaying }
+				onPlay={ trackPlayClick }
 				onTimeUpdate={ shouldCheckForVideoComplete ? markVideoAsComplete : undefined }
 			>
 				<source src={ videoData.url } />{ ' ' }


### PR DESCRIPTION
_I had to revert #58794 because of a missing import; this PR repeats that PR with the fixed import._

This PR adds a handler to the synthetic `onPlay` event of the video player. This should allow us to capture play clicks from the video player controls (not just our buttons in the videos section).

<img width="600" alt="Screen Shot 2021-12-02 at 2 38 30 PM" src="https://user-images.githubusercontent.com/349751/144514474-3dcea6b2-b8e1-40cd-b8fd-819452f1de8d.png">

Fixes #58251 .

**Testing Instructions**
* Open this PR's calypso.live branch on My Home and enter `localStorage.setItem( 'debug', 'calypso:analytics*' )` into the console – refresh the page.
* Open the videos UI by clicking on "Start learning", and play videos with both the big white play buttons, and the the play button within the player controls.
* Verify both `calypso_courses_play_click` and `calypso_courses_video_player_play_click` events when clicking the white buttons, and only a `calypso_courses_video_player_play_click` event when using the video controls.