### PR TITLE
Removed setup option for premium themes from theme sheet

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -154,7 +154,11 @@ class ThemeSheet extends Component {
 	getValidSections = () => {
 		const validSections = [];
 		validSections.push( '' ); // Default section
-		this.props.supportDocumentation && validSections.push( 'setup' );
+
+		if ( ! this.props.isPremium && this.props.supportDocumentation ) {
+			validSections.push( 'setup' );
+		}
+
 		validSections.push( 'support' );
 		return validSections;
 	};

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -22,7 +22,6 @@ import {
 	getThemeHelpUrl,
 	getThemePurchaseUrl,
 	getThemeSignupUrl,
-	getThemeSupportUrl,
 	isPremiumThemeAvailable,
 	isThemeActive,
 	isThemeGutenbergFirst,
@@ -172,13 +171,6 @@ function getAllThemeOptions( { translate, blockEditorSettings } ) {
 		getUrl: getThemeDetailsUrl,
 	};
 
-	const support = {
-		label: translate( 'Setup' ),
-		icon: 'help',
-		getUrl: getThemeSupportUrl,
-		hideForTheme: ( state, themeId ) => ! isThemePremium( state, themeId ),
-	};
-
 	const help = {
 		label: translate( 'Support' ),
 		getUrl: getThemeHelpUrl,
@@ -195,7 +187,6 @@ function getAllThemeOptions( { translate, blockEditorSettings } ) {
 		signup,
 		separator,
 		info,
-		support,
 		help,
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove "Setup" option for premium themes on the theme sheet page `/theme/<theme>/<site>`
* Remove "Setup" option for premium themes on the themes page `/themes/<site>`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Theme sheet:
- Open calypso using the `themes/premium` feature flag
- List premium themes
- Click on one of them. 
![image](https://user-images.githubusercontent.com/3801502/145090145-1d968b65-8807-4e24-ab50-771551cc61c6.png)


2) Themes list
- Open calypso using the `themes/premium` feature flag
- List premium themes
- There shouldn't be any "Setup" option
![image](https://user-images.githubusercontent.com/3801502/145090330-47b143ea-c21d-443b-b9a9-dba3ddc68ce6.png)

The same logic is applied to the current theme:
![image](https://user-images.githubusercontent.com/3801502/145090504-caec9a85-a745-4133-8b89-a1224d667a64.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58706
