### PR TITLE
Dispatch action to recognize plugin click on installation flow.

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -12,6 +12,7 @@ import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
 } from 'calypso/state/automated-transfer/selectors';
+import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -171,6 +172,8 @@ function onClickInstallPlugin( { dispatch, selectedSite, slug, upgradeAndInstall
 			plugin: slug,
 		} )
 	);
+
+	dispatch( productToBeInstalled( null, slug, selectedSite.slug ) );
 
 	const installPluginURL = `/marketplace/${ slug }/install/${ selectedSite.slug }`;
 	if ( upgradeAndInstall ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Dispatch action to recognize plugin click on installation flow.

#### Testing instructions
* Go to `/plugins` page
* Select an uninstalled plugin
* Click on install and activate
* The plugin should be installed and you should be presented with the **Thank You** page

---

Related to #58923
