### PR TITLE
Purchases: fix alignment of purchase meta

### DIFF
--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -46,9 +46,12 @@ export default function PaymentInfoBlock( {
 		const logoType = paymentLogoType( purchase );
 		const willNotBeBilled = !! ( isExpiring( purchase ) && purchase.payment.creditCard );
 		return (
-			<PaymentInfoBlockWrapper willNotBeBilled={ willNotBeBilled }>
-				<PaymentLogo type={ logoType } disabled={ isExpiring( purchase ) } />
-				{ purchase.payment.creditCard?.number ?? '' }
+			<PaymentInfoBlockWrapper>
+				<span className="manage-purchase__payment-method">
+					<PaymentLogo type={ logoType } disabled={ isExpiring( purchase ) } />
+					{ purchase.payment.creditCard?.number ?? '' }
+				</span>
+				{ willNotBeBilled && <WillNotBeBilledNotice /> }
 				{ isBackupMethodAvailable && ! willNotBeBilled && <BackupPaymentMethodNotice /> }
 			</PaymentInfoBlockWrapper>
 		);
@@ -62,13 +65,16 @@ export default function PaymentInfoBlock( {
 		const logoType = paymentLogoType( purchase );
 		const willNotBeBilled = isExpiring( purchase );
 		return (
-			<PaymentInfoBlockWrapper willNotBeBilled={ willNotBeBilled }>
-				<PaymentLogo type={ logoType } disabled={ willNotBeBilled } />
+			<PaymentInfoBlockWrapper>
+				<span className="manage-purchase__payment-method">
+					<PaymentLogo type={ logoType } disabled={ willNotBeBilled } />
+				</span>
 				{ translate( 'expiring %(cardExpiry)s', {
 					args: {
 						cardExpiry: moment( purchase.payment.expiryDate, 'MM/YY' ).format( 'MMMM YYYY' ),
 					},
 				} ) }
+				{ willNotBeBilled && <WillNotBeBilledNotice /> }
 				{ isBackupMethodAvailable && ! willNotBeBilled && <BackupPaymentMethodNotice /> }
 			</PaymentInfoBlockWrapper>
 		);
@@ -78,8 +84,9 @@ export default function PaymentInfoBlock( {
 		const logoType = paymentLogoType( purchase );
 		const willNotBeBilled = isExpiring( purchase );
 		return (
-			<PaymentInfoBlockWrapper willNotBeBilled={ willNotBeBilled }>
+			<PaymentInfoBlockWrapper>
 				<PaymentLogo type={ logoType } disabled={ willNotBeBilled } />
+				{ willNotBeBilled && <WillNotBeBilledNotice /> }
 				{ isBackupMethodAvailable && ! willNotBeBilled && <BackupPaymentMethodNotice /> }
 			</PaymentInfoBlockWrapper>
 		);
@@ -88,24 +95,22 @@ export default function PaymentInfoBlock( {
 	return <PaymentInfoBlockWrapper>{ translate( 'None' ) }</PaymentInfoBlockWrapper>;
 }
 
-function PaymentInfoBlockWrapper( {
-	children,
-	willNotBeBilled,
-}: {
-	children: ReactNode;
-	willNotBeBilled?: boolean;
-} ) {
+function PaymentInfoBlockWrapper( { children }: { children: ReactNode } ) {
 	const translate = useTranslate();
 	return (
 		<aside aria-label={ String( translate( 'Payment method' ) ) }>
 			<em className="manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
-			{ willNotBeBilled && (
-				<div className="manage-purchase__detail-label-subtitle">
-					{ translate( '(this will not be billed)' ) }
-				</div>
-			) }
 			<span className="manage-purchase__detail">{ children }</span>
 		</aside>
+	);
+}
+
+function WillNotBeBilledNotice() {
+	const translate = useTranslate();
+	return (
+		<div className="manage-purchase__detail-label-subtitle">
+			{ translate( '(this will not be billed)' ) }
+		</div>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -283,17 +283,28 @@
 }
 
 .manage-purchase__detail {
-	@include breakpoint-deprecated( '<660px' ) {
-		text-align: right;
-	}
-
 	display: block;
+	text-align: right;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		text-align: left;
+	}
 
 	.components-toggle-control {
 		display: inline-block;
 
 		.components-form-toggle {
 			margin-right: initial;
+		}
+	}
+
+	.manage-purchase__payment-method {
+		display: flex;
+		justify-content: flex-end;
+		margin-bottom: 6px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			justify-content: flex-start;
 		}
 	}
 
@@ -304,10 +315,6 @@
 	a {
 		display: block;
 		cursor: pointer;
-	}
-
-	.manage-purchase__backup-payment-method-notice {
-		margin-top: 6px;
 	}
 
 	.manage-purchase__backup-payment-method-notice a {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -306,6 +306,10 @@
 		cursor: pointer;
 	}
 
+	.manage-purchase__backup-payment-method-notice {
+		margin-top: 6px;
+	}
+
 	.manage-purchase__backup-payment-method-notice a {
 		display: inline;
 	}
@@ -319,26 +323,8 @@
 	margin-right: 0;
 }
 
-@include breakpoint-deprecated( '>660px' ) {
-	.manage-purchase__auto-renew {
-		display: flex;
-		flex-wrap: wrap-reverse;
-		justify-content: space-between;
-		gap: 8px;
-
-		.manage-purchase__auto-renew-text {
-			white-space: nowrap;
-			line-height: 1.5rem;
-		}
-
-		.manage-purchase__auto-renew-toggle {
-			order: 2;
-
-			.components-base-control__field {
-				margin: initial;
-			}
-		}
-	}
+.manage-purchase__auto-renew-toggle .components-base-control__field {
+	margin-bottom: 6px;
 }
 
 .manage-purchase__expiring-credit-card-notice.notice,

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -18,15 +18,24 @@
 .purchases-layout__information {
 	margin-right: 16px;
 	flex: 1 1 250px;
-	
+
 	@include breakpoint-deprecated( '>960px' ) {
 		flex: 1 1 462px;
 	}
 }
 
 .purchases-layout__status {
-	margin: 16px 16px 0 52px;
+	margin: 16px 16px 0 0;
 	flex: 1 1 200px;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		margin: 16px 16px 0 52px;
+	}
+
+	@include breakpoint-deprecated( '>960px' ) {
+		flex: 0 1 300px;
+		margin: 0 16px 0 0;
+	}
 
 	.subscriptions__list & {
 		margin: 16px 16px 0 0;
@@ -34,11 +43,6 @@
 		@include breakpoint-deprecated( '>960px' ) {
 			margin: 0 16px 0 0;
 		}
-	}
-
-	@include breakpoint-deprecated( '>960px' ) {
-		flex: 0 1 300px;
-		margin: 0 16px 0 0;
 	}
 }
 
@@ -103,7 +107,7 @@
 		border-radius: 2px;
 	}
 
-	.site-icon, 
+	.site-icon,
 	.site-icon__img {
 		border-radius: 2px;
 		width: 36px;
@@ -159,7 +163,7 @@
 	color: var( --color-neutral-80 );
 	line-height: 1.3em;
 
-	.purchase-item__is-error, 
+	.purchase-item__is-error,
 	.purchase-item__is-warning {
 		color: var( --color-error-50 );
 		position: relative;


### PR DESCRIPTION
In #58300, some changes were introduced to the purchase meta layout that broke the auto-renew toggle's alignment on desktop and caused the payment method and auto-renew blocks to be misaligned. This tries to find a balance between the two.

Fixes: #58916

| Auto-Renew On: | Auto-Renew Off: |
| ----------- | ----------- |
| <img width="891" alt="Screen Shot 2021-12-07 at 2 56 27 PM" src="https://user-images.githubusercontent.com/942359/145115549-c35ce3f3-e64a-429b-a4a8-44a40baa726a.png"> | <img width="838" alt="Screen Shot 2021-12-07 at 5 20 30 PM" src="https://user-images.githubusercontent.com/942359/145115630-68904724-830d-4d90-942a-e5e08131a839.png"> |
| <img width="335" alt="Screen Shot 2021-12-07 at 2 56 45 PM" src="https://user-images.githubusercontent.com/942359/145115568-aa7d2cb8-a396-4d90-8f7c-de82629c15e1.png"> | <img width="337" alt="Screen Shot 2021-12-07 at 5 20 13 PM" src="https://user-images.githubusercontent.com/942359/145115646-1b5049d6-6572-4c4d-8a6d-7089892f32c1.png"> |

**To test:**
- visit a purchase with auto-renew on
- verify that the toggle aligns with the payment method icon on desktop and both are right aligned to their section titles on mobile
- visit a purchase with auto-renew off
- verify that the toggle aligns with the payment method icon on desktop and both are right aligned to their section titles on mobile
- visit a purchase made with credits
- verify that the different meta looks okay