### PR TITLE
Site Editor: Display editor menu item by default for block themes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -26,8 +26,16 @@ function is_core_fse_active() {
 		return false;
 	}
 
-	// Now we just check for our own option.
-	return (bool) get_option( ACTIVATE_FSE_OPTION_NAME );
+	// For universal themes, we check for our own option.
+	if ( 'pub/blockase' === get_option( 'template' ) ) {
+		return (bool) get_option( ACTIVATE_FSE_OPTION_NAME );
+	}
+
+	// Universal themes can use the customizer to customize the site, regardless of whether or
+	// not the full site editor is activated. Block themes, however, don't have access to the
+	// customizer. If the site editor is disabled for them, it will severely limit site
+	// customizability. Because of this we always activate FSE for block themes.
+	return true;
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -26,9 +26,7 @@ function is_core_fse_active() {
 		return false;
 	}
 
-	// To identify universal themes, we assume that child themes will all use blockbase as
-	// their default template. If it is universal, we check for our own option.
-	if ( 'blockbase' === basename( get_template() ) ) {
+	if ( is_universal_theme() ) {
 		return (bool) get_option( ACTIVATE_FSE_OPTION_NAME );
 	}
 
@@ -48,6 +46,17 @@ function is_core_fse_active() {
  */
 function is_fse_theme() {
 	return function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
+}
+
+/**
+ * To identify universal themes, we assume that child themes will
+ * all use blockbase as their default theme template. This
+ * function checks if the current template is a blockbase template.
+ *
+ * @return boolean
+ */
+function is_universal_theme() {
+	return 'blockbase' === basename( get_template() );
 }
 
 /**
@@ -122,8 +131,13 @@ function load_helpers() {
 	if ( apply_filters( 'a8c_hide_core_fse_activation', false ) ) {
 		return;
 	}
+	// This menu toggles site editor visibility for universal themes.
+	// It's unnecessary for block themes because the site editor
+	// will always be visible.
+	if ( is_universal_theme() ) {
+		add_action( 'admin_menu', __NAMESPACE__ . '\add_submenu' );
+	}
 	add_action( 'admin_notices', __NAMESPACE__ . '\theme_nag' );
-	add_action( 'admin_menu', __NAMESPACE__ . '\add_submenu' );
 	add_action( 'admin_init', __NAMESPACE__ . '\init_settings' );
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -26,8 +26,12 @@ function is_core_fse_active() {
 		return false;
 	}
 
+	$universal_theme_template = defined( 'IS_ATOMIC' ) && IS_ATOMIC
+		? 'blockase'
+		: 'pub/blockase';
+
 	// For universal themes, we check for our own option.
-	if ( 'pub/blockase' === get_option( 'template' ) ) {
+	if ( get_option( 'template' ) === $universal_theme_template ) {
 		return (bool) get_option( ACTIVATE_FSE_OPTION_NAME );
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -27,8 +27,8 @@ function is_core_fse_active() {
 	}
 
 	$universal_theme_template = defined( 'IS_ATOMIC' ) && IS_ATOMIC
-		? 'blockase'
-		: 'pub/blockase';
+		? 'blockbase'
+		: 'pub/blockbase';
 
 	// For universal themes, we check for our own option.
 	if ( get_option( 'template' ) === $universal_theme_template ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -26,8 +26,8 @@ function is_core_fse_active() {
 		return false;
 	}
 
-	// For universal themes, we check for our own option. To identify universal themes, we
-	// assume that they will all use blockbase as their default template.
+	// To identify universal themes, we assume that child themes will all use blockbase as
+	// their default template. If it is universal, we check for our own option.
 	if ( 'blockbase' === basename( get_template() ) ) {
 		return (bool) get_option( ACTIVATE_FSE_OPTION_NAME );
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -26,6 +26,8 @@ function is_core_fse_active() {
 		return false;
 	}
 
+	// We identify universal themes by assuming that they will all use blockbase as the
+	// default template.
 	$universal_theme_template = defined( 'IS_ATOMIC' ) && IS_ATOMIC
 		? 'blockbase'
 		: 'pub/blockbase';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -26,14 +26,9 @@ function is_core_fse_active() {
 		return false;
 	}
 
-	// We identify universal themes by assuming that they will all use blockbase as the
-	// default template.
-	$universal_theme_template = defined( 'IS_ATOMIC' ) && IS_ATOMIC
-		? 'blockbase'
-		: 'pub/blockbase';
-
-	// For universal themes, we check for our own option.
-	if ( get_option( 'template' ) === $universal_theme_template ) {
+	// For universal themes, we check for our own option. To identify universal themes, we
+	// assume that they will all use blockbase as their default template.
+	if ( 'blockbase' === basename( get_template() ) ) {
 		return (bool) get_option( ACTIVATE_FSE_OPTION_NAME );
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Universal themes can use the customizer to customize the site, regardless of whether or not the full site editor is activated. Block themes, however, don't have access to the customizer. If the site editor is disabled for them, it will severely limit site
customizability. Because of this we always activate FSE for block themes.

* If the current FSE theme is a block theme, always activate FSE (don't check `wpcom_is_fse_activated` option)

## Screenshots
<img width="1496" alt="Screen Shot 2021-12-14 at 6 07 21 PM" src="https://user-images.githubusercontent.com/5414230/146110030-985a5bb4-8555-4571-b145-b42050a3c0ba.png">

## Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
We do not test simple sites that aren't enrolled in the FSE beta because, initially, TT2 will only be shown to enrolled sites D71156-code

**Simple Sites enrolled in FSE beta**
* Create an [FSE eligible site](https://horizon.wordpress.com/new/beta) with a universal theme like Quadrat or Zoologist
* Ensure that Gutenberg v12.1 or higher is installed. If not, update it.
* Verify that the Appearance > Editor is a menu item
* As a proxied user, disable the site editor in Appearance > Site Editor
* Verify that Appearance > Editor is no longer a menu item
* Install the TwentyTwentyTwo block theme from your sandbox (wp theme activate pub/twentytwentytwo --url=YOUR_URL_HERE)
* Verify that Appearance > Editor is still not a selectable menu item
* Sandbox the site _and_ public api
* Apply the changes in this PR by running `yarn dev --sync`
* You may have to comment out code in newspack blocks to get the ETK build working. Specifically, `apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/index.php` lines 53-60 and 78-85. I'm planning to touch base with the team about this soon.
* Refresh the page
* Verify that Appearance > Editor is a selectable menu item again for the TwentyTwentyTwo theme

**Atomic Sites**
* Set up an atomic site
* Ensure that Gutenberg v12.1 or higher is installed. If not, update it.
* Install the [TwentyTwentyTwo block theme](https://github.com/WordPress/twentytwentytwo)
* Verify that Appearance > Editor is still not a selectable menu item
* Upload and activate our build for the Editing Toolkit Plugin to apply changes from this PR to the atomic site ([editing-toolkit-plugin.zip](https://github.com/Automattic/wp-calypso/files/7715556/editing-toolkit-plugin.zip))
* Refresh the page
* Verify that Appearance > Editor is a selectable menu item for the TwentyTwentyTwo theme

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/58675