### PR TITLE
Reader: check that post.tags exists before using it in x-post helper

### DIFF
--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -4,7 +4,7 @@ import displayTypes from 'calypso/state/reader/posts/display-types';
 const { X_POST } = displayTypes;
 
 export function isXPost( post ) {
-	return post && ( post.display_type & X_POST || post.tags.hasOwnProperty( 'p2-xpost' ) );
+	return post && ( post.display_type & X_POST || post.tags?.hasOwnProperty( 'p2-xpost' ) );
 }
 
 const exported = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In p5PDj3-4ZM-p2 @csonnek reports that searching for terms like "honduras" or "el salvador" in Reader search currently leads to a blank white page being rendered.

This seems to be caused by a malformed post. This PR improves the resilence of the x-post helper in this situation, making sure post.tags is available before accessing it.

#### Testing instructions

* Go to Reader at http://calypso.localhost:3000/read
* In the search input, search for "honduras" or "el salvador"
* Ensure that search results are displayed and you aren't shown a blank white page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->