### PR TITLE
Declare TranslateResult as ReactNode, add textOnly overload

### DIFF
--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -51,17 +51,28 @@ declare namespace i18nCalypso {
 		original: string | { single: string; plural: string; count: number };
 	}
 
-	// Translate hooks force us to open up this type.
-	export type TranslateResult = string | React.ReactFragment;
+	export type TranslateOptionsText = TranslateOptions & { textOnly: true };
+	export type TranslateOptionsPlural = TranslateOptions & { count: number };
+	export type TranslateOptionsPluralText = TranslateOptionsPlural & { textOnly: true };
 
-	export function translate( options: DeprecatedTranslateOptions ): TranslateResult;
-	export function translate( original: string ): TranslateResult;
-	export function translate( original: string, options: TranslateOptions ): TranslateResult;
+	// Translate hooks, like component interpolation or highlighting untranslated strings,
+	// force us to declare the return type as a generic React node, not as just string.
+	export type TranslateResult = React.ReactNode;
+
+	export function translate( options: DeprecatedTranslateOptions ): React.ReactNode;
+	export function translate( original: string ): React.ReactNode;
+	export function translate( original: string, options: TranslateOptions ): React.ReactNode;
+	export function translate( original: string, options: TranslateOptionsText ): string;
 	export function translate(
 		original: string,
 		plural: string,
-		options: TranslateOptions & { count: number }
-	): TranslateResult;
+		options: TranslateOptionsPlural
+	): React.ReactNode;
+	export function translate(
+		original: string,
+		plural: string,
+		options: TranslateOptionsPluralText
+	): string;
 
 	export function setLocale( localeData: LocaleData ): void;
 	export function addTranslations( localeData: LocaleData ): void;
@@ -103,9 +114,9 @@ declare namespace i18nCalypso {
 	export function reRenderTranslations(): void;
 
 	export type TranslateHook = (
-		translation: TranslateResult,
+		translation: React.ReactNode,
 		options: NormalizedTranslateArgs
-	) => TranslateResult;
+	) => React.ReactNode;
 	export function registerTranslateHook( hook: TranslateHook ): void;
 
 	export type ComponentUpdateHook = ( ...args: any ) => any;


### PR DESCRIPTION
Improve the return type of `i18n.translate` to distinguish between `ReactNode` (generic React/HTML markup) and `string`, which is the only acceptable type for HTML attributes like `<img alt>`.

Inspired by discussion in https://github.com/Automattic/wp-calypso/pull/58761#discussion_r763863713

`translate` now has overloads when the `textOnly` option is specified:
```js
translate( 'Powered by Titan', { textOnly: true } )
```
and in that case the return type is inferred as `string`. That makes TypeScript happy when the result is passed to a prop that's declared as `string`:
```tsx
<img alt={ translate( 'Powered by Titan', { textOnly: true } ) } />
```

I'm also redeclaring `TranslateResult` to be `ReactNode` instead of the less general `string | ReactFragment`. `ReactNode` means anything that can be rendered with React as `<span>{ node }</span>`. And includes also `number`, `null`, `undefined`, ... The `translate` function, especially with translation hooks, can return any React markup.

Another idea I'm partially implementing is that the `TranslateResult` doesn't need to be declared as such. We can simply use `ReactNode` everywhere. That's why in my patch `translate` actually returns `ReactNode` and I'm declaring and exporting `TranslateResult` only for backward compatibility. And because Calypso has 200+ existing usages.

**How to test:**
Create a testing component like:
```tsx
function MyImage() {
  const translate = useTranslate();
  return <img alt={ translate( 'Hello', { textOnly: true } ) } />;
}
```
Before this PR, TypeScript would complain about incompatible types, but after this PR it will be happy.

You can also try to remove the `textOnly` option. That should make TypeScript report a type error again.