### PR TITLE
Site Settings: Use v1.4 endpoint

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -239,7 +239,6 @@ const mapDispatchToProps = {
 		saveSiteSettings( selectedSiteId, {
 			blog_public: 1,
 			wpcom_coming_soon: 0,
-			apiVersion: '1.4',
 		} ),
 };
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -174,7 +174,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			}
 
 			const siteFields = pick( fields, settingsFields.site );
-			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion: '1.4' } );
+			this.props.saveSiteSettings( siteId, siteFields );
 		};
 
 		handleRadio = ( event ) => {

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -59,7 +59,7 @@ export function requestSiteSettings( siteId ) {
 		} );
 
 		return wpcom.req
-			.get( `/sites/${ siteId }/settings` )
+			.get( `/sites/${ siteId }/settings`, { apiVersion: '1.4' } )
 			.then( ( { name, description, settings } ) => {
 				const savedSettings = {
 					...normalizeSettings( settings ),
@@ -90,10 +90,8 @@ export function saveSiteSettings( siteId, settings = {} ) {
 			siteId,
 		} );
 
-		const { apiVersion = '1.1', ...siteSettings } = settings;
-
 		return wpcom.req
-			.post( '/sites/' + siteId + '/settings', { apiVersion }, siteSettings )
+			.post( '/sites/' + siteId + '/settings', { apiVersion: '1.4' }, settings )
 			.then( ( body ) => {
 				dispatch( updateSiteSettings( siteId, normalizeSettings( body.updated ) ) );
 				dispatch( {

--- a/client/state/site-settings/test/actions.js
+++ b/client/state/site-settings/test/actions.js
@@ -58,13 +58,13 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( '/rest/v1.1/sites/2916284/settings' )
+				.get( '/rest/v1.4/sites/2916284/settings' )
 				.reply( 200, {
 					name: 'blog name',
 					description: 'blog description',
 					settings: { settingKey: 'cat' },
 				} )
-				.get( '/rest/v1.1/sites/2916285/settings' )
+				.get( '/rest/v1.4/sites/2916285/settings' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'User cannot access this private blog.',
@@ -120,11 +120,11 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( '/rest/v1.1/sites/2916284/settings' )
+				.post( '/rest/v1.4/sites/2916284/settings' )
 				.reply( 200, {
 					updated: { real_update: 'ribs' },
 				} )
-				.post( '/rest/v1.1/sites/2916285/settings' )
+				.post( '/rest/v1.4/sites/2916285/settings' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'User cannot access this private blog.',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up to #58901, particularly https://github.com/Automattic/wp-calypso/pull/58901#issuecomment-987825274.

We're updating all site settings calls to be to the `v1.4` endpoints that are the latest version.

#### Testing instructions

* Verify the test instructions in #58901 still work well.
* Try the following with a WP.com simple, Atomic and Jetpack sites with the highest tier plans.
* Test retrieving and saving settings in all settings sections, including `/marketing/traffic/:site:` and `/marketing/sharing-buttons/:site`.
* Verify tests still pass: `yarn run test-client client/state/site-settings`.