### PR TITLE
Migrate wpcom.undocumented().jetpackIsUserConnected() to wpcom.req

### DIFF
--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -22,7 +22,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
       <QuerySitePurchases
         siteId={98765}
       />
-      <Connect(QueryUserConnection)
+      <QueryUserConnection
         siteId={98765}
         siteIsOnSitesList={false}
       />

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -15,12 +15,6 @@ function Undocumented( wpcom ) {
 	this.wpcom = wpcom;
 }
 
-Undocumented.prototype.jetpackIsUserConnected = function ( siteId ) {
-	debug( '/sites/:site_id:/jetpack-connect/is-user-connected query' );
-	const endpointUrl = '/sites/' + siteId + '/jetpack-connect/is-user-connected';
-	return this.wpcom.req.get( { path: endpointUrl, apiNamespace: 'wpcom/v2' } );
-};
-
 /**
  * Get the inbound transfer status for this domain
  *

--- a/client/state/jetpack-connect/actions/is-user-connected.js
+++ b/client/state/jetpack-connect/actions/is-user-connected.js
@@ -30,7 +30,9 @@ export function isUserConnected( siteId, siteIsOnSitesList ) {
 			.then( ( site ) => {
 				accessibleSite = site;
 				debug( 'site is accessible! checking that user is connected', siteId );
-				return wpcom.undocumented().jetpackIsUserConnected( siteId );
+				return wpcom.req.get( `/sites/${ siteId }/jetpack-connect/is-user-connected`, {
+					apiNamespace: 'wpcom/v2',
+				} );
 			} )
 			.then( () => {
 				debug( 'user is connected to site.', accessibleSite );


### PR DESCRIPTION
Migrates the `jetpack-connect/is-user-connected` REST request, used by the `jetpack/connect/authorize` screen, and also migrates the `QueryUserConnection` component away from legacy lifecycles. Both are used together.

**How to test:**
1. Create a new Jetpack site, e.g., on `jurassic.ninja`
2. Start connecting it to your account.
3. When you're on the `wordpress.com/jetpack/connect/authorize` page (with a very very long query string), copy the path, replace the domain with `calypso.localhost` and test the URL on local dev Calypso.

Check that the screen issues the `is-user-connected` request. If the site is not already connected, you should be able to click on "Authorize" and proceed.

If the site is already connected, the `is-user-connected` endpoint will report success and you'll see a notice:

<img width="368" alt="Screenshot 2021-12-08 at 12 06 59" src="https://user-images.githubusercontent.com/664258/145198174-50fd1268-1f12-4d68-b8ed-3ab60a99ae64.png">

The notice is incorrectly worded, because it's connected as me, not "another user", but never mind.