### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` migration to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -238,27 +238,6 @@ Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function (
 	} );
 };
 
-Undocumented.prototype.getMigrationStatus = function ( targetSiteId ) {
-	return this.wpcom.req.get( {
-		path: `/sites/${ targetSiteId }/migration-status`,
-		apiNamespace: 'wpcom/v2',
-	} );
-};
-
-Undocumented.prototype.resetMigration = function ( targetSiteId ) {
-	return this.wpcom.req.post( {
-		path: `/sites/${ targetSiteId }/reset-migration`,
-		apiNamespace: 'wpcom/v2',
-	} );
-};
-
-Undocumented.prototype.startMigration = function ( sourceSiteId, targetSiteId ) {
-	return this.wpcom.req.post( {
-		path: `/sites/${ targetSiteId }/migrate-from/${ sourceSiteId }`,
-		apiNamespace: 'wpcom/v2',
-	} );
-};
-
 /**
  * Look for a site belonging to the currently logged in user that matches the
  * anchor parameters specified.

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -115,6 +115,13 @@ class SectionMigrate extends Component {
 		this.props.navigateToSelectedSourceSite( this.state.selectedSiteSlug );
 	};
 
+	requestMigrationReset = ( targetSiteId ) => {
+		return wpcom.req.post( {
+			path: `/sites/${ targetSiteId }/reset-migration`,
+			apiNamespace: 'wpcom/v2',
+		} );
+	};
+
 	finishMigration = () => {
 		const { targetSiteId, targetSiteSlug } = this.props;
 
@@ -124,34 +131,28 @@ class SectionMigrate extends Component {
 		 */
 		this.props.requestSite( targetSiteId );
 
-		wpcom
-			.undocumented()
-			.resetMigration( targetSiteId )
-			.finally( () => {
-				page( `/home/${ targetSiteSlug }` );
-			} );
+		this.requestMigrationReset( targetSiteId ).finally( () => {
+			page( `/home/${ targetSiteSlug }` );
+		} );
 	};
 
 	resetMigration = () => {
 		const { targetSiteId, targetSiteSlug } = this.props;
 
-		wpcom
-			.undocumented()
-			.resetMigration( targetSiteId )
-			.finally( () => {
-				page( `/migrate/${ targetSiteSlug }` );
-				/**
-				 * Note this migrationStatus is local, thus the setState vs setMigrationState.
-				 * Call to updateFromAPI will update both local and non-local state.
-				 */
-				this.setState(
-					{
-						migrationStatus: 'inactive',
-						errorMessage: '',
-					},
-					this.updateFromAPI
-				);
-			} );
+		this.requestMigrationReset( targetSiteId ).finally( () => {
+			page( `/migrate/${ targetSiteSlug }` );
+			/**
+			 * Note this migrationStatus is local, thus the setState vs setMigrationState.
+			 * Call to updateFromAPI will update both local and non-local state.
+			 */
+			this.setState(
+				{
+					migrationStatus: 'inactive',
+					errorMessage: '',
+				},
+				this.updateFromAPI
+			);
+		} );
 	};
 
 	setMigrationState = ( state ) => {
@@ -241,9 +242,11 @@ class SectionMigrate extends Component {
 
 		this.props.recordTracksEvent( 'calypso_site_migration_start_migration' );
 
-		wpcom
-			.undocumented()
-			.startMigration( sourceSiteId, targetSiteId )
+		wpcom.req
+			.post( {
+				path: `/sites/${ targetSiteId }/migrate-from/${ sourceSiteId }`,
+				apiNamespace: 'wpcom/v2',
+			} )
 			.then( () => this.updateFromAPI() )
 			.catch( ( error ) => {
 				const { code = '', message = '' } = error;
@@ -271,9 +274,11 @@ class SectionMigrate extends Component {
 
 	updateFromAPI = () => {
 		const { targetSiteId, targetSite } = this.props;
-		wpcom
-			.undocumented()
-			.getMigrationStatus( targetSiteId )
+		wpcom.req
+			.get( {
+				path: `/sites/${ targetSiteId }/migration-status`,
+				apiNamespace: 'wpcom/v2',
+			} )
 			.then( ( response ) => {
 				const {
 					status: migrationStatus,

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -115,11 +115,13 @@ class SectionMigrate extends Component {
 		this.props.navigateToSelectedSourceSite( this.state.selectedSiteSlug );
 	};
 
-	requestMigrationReset = ( targetSiteId ) => {
-		return wpcom.req.post( {
-			path: `/sites/${ targetSiteId }/reset-migration`,
-			apiNamespace: 'wpcom/v2',
-		} );
+	requestMigrationReset = async ( targetSiteId ) => {
+		return await wpcom.req
+			.post( {
+				path: `/sites/${ targetSiteId }/reset-migration`,
+				apiNamespace: 'wpcom/v2',
+			} )
+			.catch( () => {} );
 	};
 
 	finishMigration = () => {

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -116,7 +116,7 @@ class SectionMigrate extends Component {
 	};
 
 	requestMigrationReset = async ( targetSiteId ) => {
-		return await wpcom.req
+		await wpcom.req
 			.post( {
 				path: `/sites/${ targetSiteId }/reset-migration`,
 				apiNamespace: 'wpcom/v2',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` site migration methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Verify all HTTP requests to the migration endpoints (`/migration-status`, `/reset-migration` and `/migrate-from/`) were successful and the flow works the same way as on production on the following steps.
* Go to `/migrate/:site` where `:site` is a WP.com simple site on a free plan.
* Input the a WP Jetpack site in the URL field and click "Continue".
* Pick "Everything" and upgrade to a business plan.
* Upgrade and continue.
* Confirm and start the import.
* When it finishes, click on "Start over" (if it succeeded) or "Try again" (if it failed).