### PR TITLE
Migrate wpcom.undocumented().startInboundTransfer() to wpcom.req

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -297,14 +297,14 @@ class TransferDomainStep extends Component {
 	startPendingInboundTransfer = ( domain, authCode ) => {
 		const { selectedSite, translate } = this.props;
 
-		startInboundTransfer( selectedSite.ID, domain, authCode, ( error, result ) => {
-			if ( result ) {
+		startInboundTransfer( selectedSite.ID, domain, authCode )
+			.then( () => {
 				this.props.fetchSiteDomains( selectedSite.ID );
 				page( domainManagementTransferIn( selectedSite.slug, domain ) );
-			} else {
+			} )
+			.catch( () => {
 				this.props.errorNotice( translate( 'We were unable to start the transfer.' ) );
-			}
-		} );
+			} );
 	};
 
 	getTransferDomainPrecheck() {

--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -78,9 +78,10 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 
 		const startInboundTransferAndReload = async () => {
 			try {
-				const result = await wpcom
-					.undocumented()
-					.startInboundTransfer( selectedSite.ID, domain, authCode );
+				const result = await wpcom.req.get(
+					`/domains/${ encodeURIComponent( domain ) }/inbound-transfer-start/${ selectedSite.ID }`,
+					authCode ? { auth_code: authCode } : {}
+				);
 				if ( result.success ) {
 					page( domainManagementTransferIn( selectedSite.slug, domain ) );
 				} else {

--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -11,6 +11,7 @@ import {
 } from 'calypso/components/domains/connect-domain-step/types';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { domainTransfer, updatePrivacyForDomain } from 'calypso/lib/cart-values/cart-items';
+import { startInboundTransfer } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import wpcom from 'calypso/lib/wp';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
@@ -78,21 +79,10 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 
 		const startInboundTransferAndReload = async () => {
 			try {
-				const result = await wpcom.req.get(
-					`/domains/${ encodeURIComponent( domain ) }/inbound-transfer-start/${ selectedSite.ID }`,
-					authCode ? { auth_code: authCode } : {}
-				);
-				if ( result.success ) {
-					page( domainManagementTransferIn( selectedSite.slug, domain ) );
-				} else {
-					return onDone( {
-						message: transferDomainError.GENERIC_ERROR,
-					} );
-				}
+				await startInboundTransfer( selectedSite.ID, domain, authCode );
+				page( domainManagementTransferIn( selectedSite.slug, domain ) );
 			} catch ( error ) {
-				return onDone( {
-					message: transferDomainError.GENERIC_ERROR,
-				} );
+				onDone( { message: transferDomainError.GENERIC_ERROR } );
 			}
 		};
 

--- a/client/lib/domains/start-inbound-transfer.js
+++ b/client/lib/domains/start-inbound-transfer.js
@@ -1,19 +1,12 @@
 import wpcom from 'calypso/lib/wp';
 
-export function startInboundTransfer( siteId, domainName, authCode, onComplete ) {
-	if ( ! domainName || ! siteId ) {
-		onComplete( null );
-		return;
+export function startInboundTransfer( siteId, domain, authCode ) {
+	if ( ! domain || ! siteId ) {
+		return Promise.reject( new Error( 'Missing siteId or domain' ) );
 	}
 
-	wpcom
-		.undocumented()
-		.startInboundTransfer( siteId, domainName, authCode, function ( serverError, result ) {
-			if ( serverError ) {
-				onComplete( serverError.error );
-				return;
-			}
-
-			onComplete( null, result );
-		} );
+	return wpcom.req.get(
+		`/domains/${ encodeURIComponent( domain ) }/inbound-transfer-start/${ siteId }`,
+		authCode ? { auth_code: authCode } : {}
+	);
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -31,28 +31,6 @@ Undocumented.prototype.checkAuthCode = function ( domain, authCode, fn ) {
 	);
 };
 
-/**
- * Starts an inbound domain transfer that is in the pending_start state.
- *
- * @param {number|string} siteId The site ID
- * @param {string} domain The domain name
- * @param {string} authCode The auth code for the transfer
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.startInboundTransfer = function ( siteId, domain, authCode, fn ) {
-	let query = {};
-	if ( authCode && authCode !== '' ) {
-		query = { auth_code: authCode };
-	}
-
-	return this.wpcom.req.get(
-		`/domains/${ encodeURIComponent( domain ) }/inbound-transfer-start/${ siteId }`,
-		query,
-		fn
-	);
-};
-
 Undocumented.prototype.fetchDns = function ( domainName, fn ) {
 	return this.wpcom.req.get( '/domains/' + domainName + '/dns', fn );
 };


### PR DESCRIPTION
Migrates `wpcom.undocumented().startInboundTransfer()` to wpcom.req.get` (another REST endpoint that should be POST instead!) and promisifies the `startInboundTransfer` helper that calls it.

I'm not sure if `authCode` is always present: the server implementation considers it optional, and there are multiple implementations for different domain registrar types. So I'm adding it conditionally.