### PR TITLE
Fix FormattedHeader proptypes

### DIFF
--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -40,11 +40,12 @@ FormattedHeader.propTypes = {
 	id: PropTypes.string,
 	className: PropTypes.string,
 	brandFont: PropTypes.bool,
-	headerText: PropTypes.node.isRequired,
+	headerText: PropTypes.node,
 	subHeaderText: PropTypes.node,
 	compactOnMobile: PropTypes.bool,
 	isSecondary: PropTypes.bool,
 	align: PropTypes.oneOf( [ 'center', 'left', 'right' ] ),
+	hasScreenOptions: PropTypes.bool,
 };
 
 FormattedHeader.defaultProps = {


### PR DESCRIPTION
Fixes `FormattedHeader` proptypes to:
- remove the `.isRequired` flag from `headerText`. With the flag, the prop value can't be `undefined` and we can't pass a value with TypeScript type `ReactNode` because that type includes `undefined`. Generally, the `PropTypes.node.isRequired` type is self-contradictory and should be never used.
- add the `hasScreenOptions` boolean prop

The outcome I expect from this is that the number of TypeScript errors decreases. After it increased in #58938, see the issues reported there by @scinos.