### PR TITLE
Fix some translate calls that should have the textOnly flag

### DIFF
--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -17,6 +17,7 @@ import './style.scss';
 
 export class Gravatar extends Component {
 	static propTypes = {
+		className: PropTypes.string,
 		user: PropTypes.object,
 		size: PropTypes.number,
 		imgSize: PropTypes.number,
@@ -25,6 +26,7 @@ export class Gravatar extends Component {
 			PropTypes.string, // the temp image base64 string if it exists
 			PropTypes.bool, // or false if the temp image does not exist
 		] ),
+		alt: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -29,7 +29,10 @@ const Banner: React.FC = () => {
 
 			<img
 				className="intro-pricing-banner__badge"
-				alt={ translate( 'Money Back %(days)d-Day Guarantee', { args: { days: 14 } } ) }
+				alt={ translate( 'Money Back %(days)d-Day Guarantee', {
+					args: { days: 14 },
+					textOnly: true,
+				} ) }
 				src={ badgeIcon }
 			/>
 		</div>

--- a/client/components/jetpack/profile-dropdown/index.tsx
+++ b/client/components/jetpack/profile-dropdown/index.tsx
@@ -55,7 +55,7 @@ const ProfileDropdown: React.FC = () => {
 				<Gravatar
 					className="profile-dropdown__button-gravatar"
 					user={ user }
-					alt={ translate( 'My Profile' ) }
+					alt={ translate( 'My Profile', { textOnly: true } ) }
 					size={ 24 }
 				/>
 			</button>

--- a/client/components/jetpack/threat-item-subheader/index.tsx
+++ b/client/components/jetpack/threat-item-subheader/index.tsx
@@ -13,7 +13,7 @@ import './style.scss';
 
 interface Props {
 	threat: Threat;
-	isFixable: bool;
+	isFixable: boolean;
 }
 
 const entryActionClassNames = ( threat: Threat ) => {

--- a/client/components/promo-section/promo-card/index.tsx
+++ b/client/components/promo-section/promo-card/index.tsx
@@ -15,7 +15,7 @@ import './style.scss';
 export interface Image {
 	path: string;
 	className?: string;
-	alt?: string | TranslateResult;
+	alt?: string;
 	align?: 'left' | 'right';
 }
 

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -108,7 +108,8 @@ function windowConfirm() {
 		return true;
 	}
 	const confirmText = i18n.translate(
-		'You have unsaved changes. Are you sure you want to leave this page?'
+		'You have unsaved changes. Are you sure you want to leave this page?',
+		{ textOnly: true }
 	);
 	return window.confirm( confirmText );
 }


### PR DESCRIPTION
Fixes a few calls of `translate` that should have the `textOnly: true` option because the results are passed to places that accept only plain strings. Like `alt` attributes or `window.confirm`.

Should fix a few TypeScript errors.

As a drive-by I'm including one fix that changes `bool` (not a real TS type!) to `boolean`.