### PR TITLE
Plugin Upload: offer a WP Admin link in case of plugin already existing.

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -276,10 +276,10 @@ const MarketplacePluginInstall = ( {
 					line={ translate(
 						'This plugin already exists in your site. If you want to upgrade/ downgrade it please continue by uploading again from WP Admin.'
 					) }
-					action={ translate( 'Back' ) }
-					actionURL={ `/plugins/upload/${ selectedSiteSlug }` }
-					secondaryAction={ translate( 'Continue' ) }
-					secondaryActionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php` }
+					secondaryAction={ translate( 'Back' ) }
+					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
+					action={ translate( 'Continue' ) }
+					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php` }
 				/>
 			);
 		}

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -274,7 +274,7 @@ const MarketplacePluginInstall = ( {
 					illustration="/calypso/images/illustrations/error.svg"
 					title={ null }
 					line={ translate(
-						'This plugin already exists in your site. If you want to upgrade/ downgrade it please continue by uploading again from WP Admin.'
+						'This plugin already exists on your site. If you want to upgrade or downgrade the plugin, please continue by uploading the plugin again from WP Admin.'
 					) }
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -233,6 +233,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
+					title={ null }
 					line={ translate(
 						"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
 					) }
@@ -245,6 +246,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
+					title={ null }
 					line={ translate(
 						'This URL should not be accessed directly. Please try to upload the plugin again.'
 					) }
@@ -257,6 +259,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
+					title={ null }
 					line={ translate(
 						'This URL should not be accessed directly. Please click the Install button on the plugin page.'
 					) }
@@ -269,6 +272,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
+					title={ null }
 					line={ translate(
 						'This plugin already exists in your site. If you want to upgrade/ downgrade it please continue by uploading again from WP Admin.'
 					) }
@@ -288,6 +292,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
+					title={ null }
 					line={ translate( 'An error occurred while installing the plugin.' ) }
 					action={ translate( 'Back' ) }
 					actionURL={

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -53,7 +53,7 @@ const MarketplacePluginInstall = ( {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const pluginUploadProgress = useSelector( ( state ) => getPluginUploadProgress( state, siteId ) );
 	const pluginUploadError = useSelector( ( state ) => getPluginUploadError( state, siteId ) );
-	const pluginExists = pluginUploadError?.error === 'folder_exists' || false;
+	const pluginExists = pluginUploadError?.error === 'folder_exists';
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, productSlug ) );
 	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, productSlug ) );
 	const uploadedPluginSlug = useSelector( ( state ) =>

--- a/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-upload-status/index.tsx
@@ -53,6 +53,7 @@ const MarketplacePluginInstall = ( {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const pluginUploadProgress = useSelector( ( state ) => getPluginUploadProgress( state, siteId ) );
 	const pluginUploadError = useSelector( ( state ) => getPluginUploadError( state, siteId ) );
+	const pluginExists = pluginUploadError?.error === 'folder_exists' || false;
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, productSlug ) );
 	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, productSlug ) );
 	const uploadedPluginSlug = useSelector( ( state ) =>
@@ -232,7 +233,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
-					title={ translate(
+					line={ translate(
 						"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
 					) }
 					action={ translate( 'Upgrade to Business Plan' ) }
@@ -244,7 +245,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
-					title={ translate(
+					line={ translate(
 						'This URL should not be accessed directly. Please try to upload the plugin again.'
 					) }
 					action={ translate( 'Go to the upload page' ) }
@@ -256,7 +257,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
-					title={ translate(
+					line={ translate(
 						'This URL should not be accessed directly. Please click the Install button on the plugin page.'
 					) }
 					action={ translate( 'Go to the plugin page' ) }
@@ -264,6 +265,21 @@ const MarketplacePluginInstall = ( {
 				/>
 			);
 		}
+		if ( pluginExists ) {
+			return (
+				<EmptyContent
+					illustration="/calypso/images/illustrations/error.svg"
+					line={ translate(
+						'This plugin already exists in your site. If you want to upgrade/ downgrade it please continue by uploading again from WP Admin.'
+					) }
+					action={ translate( 'Back' ) }
+					actionURL={ `/plugins/upload/${ selectedSiteSlug }` }
+					secondaryAction={ translate( 'Continue' ) }
+					secondaryActionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php` }
+				/>
+			);
+		}
+		// Catch the rest of the error cases.
 		if (
 			pluginUploadError ||
 			pluginInstallStatus.error ||
@@ -272,7 +288,7 @@ const MarketplacePluginInstall = ( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
-					title={ translate( 'An error occurred while installing the plugin.' ) }
+					line={ translate( 'An error occurred while installing the plugin.' ) }
 					action={ translate( 'Back' ) }
 					actionURL={
 						isUploadFlow


### PR DESCRIPTION

#### Changes proposed in this Pull Request

This PR attempts to:
- better explain the plugin upload error in case of folder already existing
- allow the user to get self serviced by offering a WP Admin link to upload the plugin
- change all error messages to use `line` prop instead of `title`. Line seems having a better font-size.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1597" alt="SS 2021-12-08 at 15 58 23" src="https://user-images.githubusercontent.com/12430020/145220765-cc4c0844-6a2a-4e34-95cf-e69625f41cbd.png">|<img width="1598" alt="SS 2021-12-08 at 16 14 20" src="https://user-images.githubusercontent.com/12430020/145223223-8da72002-0727-47f8-abd0-102240c9ffa8.png">|

**Folder Exists Scenario**
- visit `/plugins/upload/[domain]` of an Atomic site
- drop a zip of an already uploaded plugin
- you should get the new screen
- click `Continue`, you should be redirected to WP Admin `Add New` screen

**Regression Testing, Other Upload error**
- visit `/plugins/upload/[domain]` of an Atomic site
- drop a zip which is not a plugin
- you should get the `An error occurred while installing the plugin` screen

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58508 
