### PR TITLE
Migrate wpcom.undocumented().launchSite() to wpcom.req

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -532,7 +532,7 @@ export function launchSiteApi( callback, dependencies ) {
 
 	wpcom.req
 		.post( `/sites/${ siteSlug }/launch` )
-		.then( () => callback() )
+		.then( () => callback( null ) )
 		.catch( ( error ) => callback( error ) );
 }
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -530,15 +530,10 @@ function addPrivacyProtectionIfSupported( item, state ) {
 export function launchSiteApi( callback, dependencies ) {
 	const { siteSlug } = dependencies;
 
-	wpcom.undocumented().launchSite( siteSlug, function ( error ) {
-		if ( error ) {
-			callback( error );
-
-			return;
-		}
-
-		callback();
-	} );
+	wpcom.req
+		.post( `/sites/${ siteSlug }/launch` )
+		.then( () => callback() )
+		.catch( ( error ) => callback( error ) );
 }
 
 export function createAccount(

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -53,18 +53,6 @@ Undocumented.prototype.startInboundTransfer = function ( siteId, domain, authCod
 	);
 };
 
-/**
- * Launches a private site
- *
- * @param {string} siteIdOrSlug - ID or slug of the site to be launched
- * @param {Function} fn - Function to invoke when request is complete
- */
-Undocumented.prototype.launchSite = function ( siteIdOrSlug, fn ) {
-	const path = `/sites/${ siteIdOrSlug }/launch`;
-	debug( path );
-	return this.wpcom.req.post( path, fn );
-};
-
 Undocumented.prototype.fetchDns = function ( domainName, fn ) {
 	return this.wpcom.req.get( '/domains/' + domainName + '/dns', fn );
 };


### PR DESCRIPTION
The `wpcom.undocumented().launchSite()` method was used only at one place: when launching a site from the Signup framework.

**How to test:**
1. Have a private site
2. Go to `/start/launch-only?siteSlug=your.site.slug`
3. Check that the launch succeeds, redirects to `/home` and the site is no longer private.

Verify also that this was really the only place where the `undocumented()` method was used. There is plenty other places where we launch sites, but they use different implementations: a data layer handler, a `@wordpress/data` store, ...