### PR TITLE
Onboarding: Fix checkmark alignment for multiline plan feature items

### DIFF
--- a/packages/plans-grid/src/plans-feature-list/index.tsx
+++ b/packages/plans-grid/src/plans-feature-list/index.tsx
@@ -155,11 +155,11 @@ const PlansFeatureListItem: React.FunctionComponent< FeatureListItemProps > = (
 			) }
 		>
 			<ItemWrapper className="plans-feature-list__item-content-wrapper">
-				<BulletIcon className="plans-feature-list__item-bullet-icon" />
+				{ requiresAnnuallyBilledPlan && (
+					<FeatureAnnualDiscountNudge billingPeriod={ billingPeriod } __={ __ } />
+				) }
 				<span className="plans-feature-list__item-text">
-					{ requiresAnnuallyBilledPlan && (
-						<FeatureAnnualDiscountNudge billingPeriod={ billingPeriod } __={ __ } />
-					) }
+					<BulletIcon className="plans-feature-list__item-bullet-icon" />
 					<span className="plans-feature-list__item-description">{ textNode }</span>
 				</span>
 			</ItemWrapper>

--- a/packages/plans-grid/src/plans-feature-list/style.scss
+++ b/packages/plans-grid/src/plans-feature-list/style.scss
@@ -40,8 +40,8 @@ ul.plans-feature-list__item-group {
 
 	// If the 'INCLUDED WITH ANNUAL PLANS` text is rendered
 	// the item needs more margin top
-	& + &--requires-annual-enabled,
-	& + &--requires-annual-disabled {
+	&--requires-annual-enabled,
+	&--requires-annual-disabled {
 		margin-top: 8px;
 	}
 
@@ -60,8 +60,7 @@ ul.plans-feature-list__item-group {
 // Content wrapper. Can be a <button> in case of the domain feature item
 .plans-feature-list__item-content-wrapper,
 .plans-feature-list__item-content-wrapper.components-button.is-link {
-	display: flex;
-	align-items: flex-end;
+	display: block;
 	padding: 0;
 	text-decoration: none;
 
@@ -75,6 +74,7 @@ ul.plans-feature-list__item-group {
 	flex-grow: 0;
 	flex-shrink: 0;
 	margin-right: 6px;
+	margin-top: 1px;
 
 	color: var( --studio-gray-100 );
 
@@ -97,23 +97,20 @@ ul.plans-feature-list__item-group {
 
 // Wrapper for the feature item's text content
 .plans-feature-list__item-text {
-	// Item tends to occupy all available space, but without exceeding parent's width
-	flex: 1;
-	max-width: 100%;
-
-	// Makes the tick/cross icon align better with the text
-	margin-bottom: 1px;
+	display: flex;
+	align-items: flex-start;
 }
 
 // Optional text informing the user that a specific feature is only available with the annual version of a plan
 .plans-feature-list__item-annual-nudge {
 	display: block;
 	text-transform: uppercase;
-	font-size: 10px; /* stylelint-disable-line scales/font-size */
+	font-size: 10px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	font-weight: 700;
 	letter-spacing: 0.02em;
 	line-height: 1;
 	margin-bottom: 6px;
+	padding-left: 24px;
 
 	.plans-feature-list__item--requires-annual-enabled & {
 		color: var( --studio-green-60 );
@@ -126,8 +123,13 @@ ul.plans-feature-list__item-group {
 
 // The text describing the feature
 .plans-feature-list__item-description {
+	// Item tends to occupy all available space, but without exceeding parent's width
+	flex: 1;
+	max-width: 100%;
+
+	padding-top: 1px;
 	font-size: $font-body-small;
-	line-height: 1.2;
+	line-height: 1.35;
 	letter-spacing: 0.2px;
 	font-weight: 400;
 	color: var( --studio-gray-70 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the alignment of the checkmark icon for multiline feature items on the onboarding select plan flow.

**Before:**
![CleanShot 2021-12-08 at 16 05 43](https://user-images.githubusercontent.com/2722412/145222484-12d3e85c-ed2f-417b-9ea2-535f8d40284f.png)

**After:**
![CleanShot 2021-12-08 at 16 05 22](https://user-images.githubusercontent.com/2722412/145222551-7c36bac5-9cfa-4748-b01d-49b8a2319969.png)


#### Testing instructions

* Go to `/new/plans/` and select locale (e.g. Russian) that would cause the feature text on some items to wrap on multiple lines.
* Confirm the checkmark icons are aligned with the first line of the feature description text.

Related to 354-gh-Automattic/i18n-issues
