### PR TITLE
WPCOM: Migrate `wpcom.undocumented().checkAuthCode()` to `wpcom.req`

### DIFF
--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -33,10 +33,11 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 	if ( ! selectedSite ) return onDone( { message: transferDomainError.NO_SELECTED_SITE } );
 
 	try {
-		const wpcomDomain = wpcom.domain( domain );
 		const authCode = verificationData.ownership_verification_data.verification_data;
-
-		const authCodeCheckResult = await wpcomDomain.checkAuthCode( authCode );
+		const authCodeCheckResult = await wpcom.req.get(
+			`/domains/${ encodeURIComponent( domain ) }/inbound-transfer-check-auth-code`,
+			{ auth_code: authCode }
+		);
 
 		if ( ! authCodeCheckResult.success )
 			return onDone( {

--- a/client/lib/domains/check-auth-code.js
+++ b/client/lib/domains/check-auth-code.js
@@ -6,12 +6,10 @@ export function checkAuthCode( domainName, authCode, onComplete ) {
 		return;
 	}
 
-	wpcom.undocumented().checkAuthCode( domainName, authCode, function ( serverError, result ) {
-		if ( serverError ) {
-			onComplete( { error: serverError.error, message: serverError.message } );
-			return;
-		}
-
-		onComplete( null, result );
-	} );
+	wpcom.req
+		.get( `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-check-auth-code`, {
+			auth_code: authCode,
+		} )
+		.then( ( data ) => onComplete( null, data ) )
+		.catch( ( error ) => onComplete( { error: error.error, message: error.message } ) );
 }

--- a/client/lib/domains/check-auth-code.js
+++ b/client/lib/domains/check-auth-code.js
@@ -11,5 +11,5 @@ export function checkAuthCode( domainName, authCode, onComplete ) {
 			auth_code: authCode,
 		} )
 		.then( ( data ) => onComplete( null, data ) )
-		.catch( ( error ) => onComplete( { error: error.error, message: error.message } ) );
+		.catch( ( error ) => onComplete( error ) );
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -11,22 +11,6 @@ function Undocumented( wpcom ) {
 	this.wpcom = wpcom;
 }
 
-/**
- * Get the inbound transfer status for this domain
- *
- * @param {string} domain - The domain name to check.
- * @param {string} authCode - The auth code for the given domain to check.
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.checkAuthCode = function ( domain, authCode, fn ) {
-	return this.wpcom.req.get(
-		`/domains/${ encodeURIComponent( domain ) }/inbound-transfer-check-auth-code`,
-		{ auth_code: authCode },
-		fn
-	);
-};
-
 Undocumented.prototype.applyDnsTemplateSyncFlow = function (
 	domain,
 	provider,

--- a/packages/wpcom.js/src/lib/domain.js
+++ b/packages/wpcom.js/src/lib/domain.js
@@ -188,21 +188,6 @@ class Domain {
 		const body = { mode };
 		return this.wpcom.req.post( root + this._id + '/mapping-status', query, body, fn );
 	}
-
-	/**
-	 * Checks the auth code for transferring this domain
-	 *
-	 * @param {string} authCode - The auth code for the given domain to check.
-	 * @param {Function} fn The callback function
-	 * @returns {Promise} A promise that resolves when the request completes
-	 */
-	checkAuthCode = function ( authCode, fn ) {
-		return this.wpcom.req.get(
-			`${ root + encodeURIComponent( this._id ) }/inbound-transfer-check-auth-code`,
-			{ auth_code: authCode },
-			fn
-		);
-	};
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the wpcom.undocumented() domain transfer authorization code check to wpcom.req.

Testing instructions

Because this method handles the actual authorization check, testing it will require a valid auth code for an unlocked domain name at another registrar.

#### Testing instructions

**Test `undocumented().checkAuthCode()` refactor:**
_Note: this is an outdated flow that's due to be removed, and the only actual implementation of this method, but I'm refactoring it anyway so we can clean up `wpcom.undocumented()` while keeping this flow functional for as long as it's still around._

- Start at `/domains/manage/[DOMAIN]/transfer/precheck/[SITE]`
- If your domain is already unlocked, the flow should register that. If it isn't, go unlock it and collect the auth code from your registrar
- To test the error state, modify `client/lib/domains/check-auth-code.js`, line 10 to point to a modified domain (example: `.get( /domains/${ encodeURIComponent( domainName ) }/inbound-transfer-check-auth-code-ERROR, {`). Then enter any auth code and verify an error message is presented (in this case it'll be a 404)
- To test an invalid auth code, return the previously edited line to its original state. On the 'Get a domain authorization code' step, enter an *invalid* auth code. Confirm that's recognized as being the incorrect code.
- Now test your actual auth code and confirm that it's successfully recognized.

**Test `wpcom.domain().checkAuthCode()` refactor:**
- Start at `/domains/add/use-my-domain/[SITE]`
- Enter your domain and click 'Next'. If your domain is already unlocked, the flow should register that. If it isn't, go unlock it and collect the auth code from your registrar
- To test the error state, modify `client/lib/domains/check-auth-code.js`, line 10 to point to a modified domain (example: `.get( /domains/${ encodeURIComponent( domainName ) }/inbound-transfer-check-auth-code-ERROR, {`). Then enter any auth code and verify an error message is presented (in this case it'll be a 404)
- To test an invalid auth code, return the previously edited line to its original state. On the 'Get a domain authorization code' step, enter an *invalid* auth code. Confirm that's recognized as being the incorrect code.
- Now test your actual auth code and confirm that it's successfully recognized. If it is, you'll be sent directly to the checkout page, where you can remove the transfer from your cart.

Don't forget to go and lock your domain when you're done testing 😄 

Related to https://github.com/Automattic/wp-calypso/issues/58458
