### PR TITLE
Videos UI - Adding internationatlization hooks for blogging quickstart card

### DIFF
--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
@@ -13,7 +13,7 @@ const BloggingQuickStart = () => {
 		<EducationalContent
 			title={ translate( 'Blog like an expert from day one' ) }
 			description={ translate(
-				"Learn the fundamentals from our bite-sized video course &mdash; you'll be up and running in just nine minutes."
+				"Learn the fundamentals from our bite-sized video course — you'll be up and running in just nine minutes."
 			) }
 			modalLinks={ [
 				{

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import playImage from 'calypso/assets/images/customer-home/plain-play.png';
@@ -7,18 +6,15 @@ import EducationalContent from '../educational-content';
 import BloggingQuickStartModal from './blogging-quick-start-modal';
 
 const BloggingQuickStart = () => {
-	const { localeSlug } = useTranslate();
-	const isEnglish = config( 'english_locales' ).includes( localeSlug );
+	const translate = useTranslate();
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
-
-	if ( ! isEnglish ) {
-		return null;
-	}
 
 	return (
 		<EducationalContent
-			title="Blog like an expert from day one"
-			description="Learn the fundamentals from our bite-sized video course &mdash; you'll be up and running in just nine minutes."
+			title={ translate( 'Blog like an expert from day one' ) }
+			description={ translate(
+				"Learn the fundamentals from our bite-sized video course &mdash; you'll be up and running in just nine minutes."
+			) }
 			modalLinks={ [
 				{
 					ModalComponent: BloggingQuickStartModal,
@@ -30,7 +26,7 @@ const BloggingQuickStart = () => {
 						},
 					},
 					onClick: () => setIsModalVisible( true ),
-					text: 'Start learning',
+					text: translate( 'Start learning' ),
 				},
 			] }
 			illustration={ playImage }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the Blogging Quickstart front page card to have internationalized text since we are planning to open it for all users instead of just English-speaking ones.

<img width="784" alt="Screen Shot 2021-12-08 at 1 50 34 PM" src="https://user-images.githubusercontent.com/349751/145290177-8d8733cb-49b4-45ab-b483-9f605e919400.png">


#### Testing instructions
* Check out this PR to local.
* Sandbox the API, and comment out lines 98-100 of `wp-content/lib/home/cards.php` (which hides the card for non-English speakers).
* Verify that the text displays on the Blogging Quickstart card properly - in English at first, and then in all Mag16 languages once the translations have gone through after merge.

Fixes #57852
