### PR TITLE
E2E: Quarantine Notifications spec.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-user__notifications.ts
+++ b/test/e2e/specs/specs-playwright/wp-user__notifications.ts
@@ -1,5 +1,5 @@
 /**
- * @group calypso-pr
+ * @group quarantined
  */
 
 import {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The spec `wp-user__notifications.ts` is too flakey.

See: #58968.

#### Testing instructions

- [ ] Ensure test is no longer running as part of regular e2e.
- [ ] Ensure test is running in Quarantined build.


Related to #58968
