### PR TITLE
Checkout: Auto-apply FIRSTYEAR50 to new yearly subs for Jetpack Search

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -21,7 +21,7 @@ const useMaybeJetpackIntroCouponCode = (
 			return undefined;
 		}
 
-		const isEligibleForFirstYear50 = products.filter(
+		const isEligibleForFirstYear50 = products.some(
 			( product ) => isNewPurchase( product ) && isYearly( product ) && isJetpackSearch( product )
 		);
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -1,18 +1,13 @@
-import {
-	isJetpackProductSlug,
-	isJetpackPlanSlug,
-	isJetpackSearch,
-} from '@automattic/calypso-products';
+import { isJetpackSearch } from '@automattic/calypso-products';
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const JETPACK_SEARCH_INTRO_COUPON_CODE = 'FIRSTYEAR50';
-const JETPACK_INTRO_COUPON_CODE = 'FRESHPACK';
 
-const isYearlySearch = ( product: RequestCartProduct ) =>
-	isJetpackSearch( product ) && ! product.product_slug.endsWith( '_monthly' );
+const isYearly = ( product: MinimalRequestCartProduct ) =>
+	! product.product_slug.endsWith( '_monthly' );
+const isNewPurchase = ( product: MinimalRequestCartProduct ) =>
+	product.extra?.purchaseType === 'renewal';
 
 // **NOTE**: This hook can be safely deleted when we no longer need to
 // rely on auto-applied coupons for introductory new purchase pricing.
@@ -20,44 +15,22 @@ const useMaybeJetpackIntroCouponCode = (
 	products: MinimalRequestCartProduct[],
 	isCouponApplied: boolean
 ): string | undefined => {
-	const jetpackSaleCoupon = useSelector( getJetpackSaleCoupon );
 	return useMemo( () => {
+		// If a coupon is already applied to this cart, don't try to apply another one.
 		if ( isCouponApplied ) {
 			return undefined;
 		}
-		const jetpackProducts = products.filter(
-			( product ) =>
-				isJetpackProductSlug( product.product_slug ) || isJetpackPlanSlug( product.product_slug )
+
+		const isEligibleForFirstYear50 = products.filter(
+			( product ) => isNewPurchase( product ) && isYearly( product ) && isJetpackSearch( product )
 		);
 
-		// Only apply FRESHPACK if there's a Jetpack
-		// product or plan present in the cart
-		if ( jetpackProducts.length < 1 ) {
-			return undefined;
-		}
-
-		// Only apply FRESHPACK for new purchases, not renewals.
-		if ( jetpackProducts.some( ( product ) => product.extra?.purchaseType === 'renewal' ) ) {
-			return undefined;
-		}
-
-		// Only apply FRESHPACK to monthly products if a sale is running
-		if (
-			jetpackSaleCoupon &&
-			! jetpackProducts.some( ( product ) => product.product_slug.endsWith( '_monthly' ) )
-		) {
-			return undefined;
-		}
-
-		// 2021-12-08: Tiered products like Search don't currently support introductory offers,
-		// so we simulate a 50%-off first year discount by auto-applying a coupon.
-		// This only applies to new subscriptions with yearly billing terms.
-		if ( jetpackProducts.some( isYearlySearch ) ) {
+		if ( isEligibleForFirstYear50 ) {
 			return JETPACK_SEARCH_INTRO_COUPON_CODE;
 		}
 
-		return JETPACK_INTRO_COUPON_CODE;
-	}, [ products, isCouponApplied, jetpackSaleCoupon ] );
+		return undefined;
+	}, [ products, isCouponApplied ] );
 };
 
 export default useMaybeJetpackIntroCouponCode;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -7,7 +7,7 @@ const JETPACK_SEARCH_INTRO_COUPON_CODE = 'FIRSTYEAR50';
 const isYearly = ( product: MinimalRequestCartProduct ) =>
 	! product.product_slug.endsWith( '_monthly' );
 const isNewPurchase = ( product: MinimalRequestCartProduct ) =>
-	product.extra?.purchaseType === 'renewal';
+	product.extra?.purchaseType !== 'renewal';
 
 // **NOTE**: This hook can be safely deleted when we no longer need to
 // rely on auto-applied coupons for introductory new purchase pricing.

--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -1,10 +1,18 @@
-import { isJetpackProductSlug, isJetpackPlanSlug } from '@automattic/calypso-products';
+import {
+	isJetpackProductSlug,
+	isJetpackPlanSlug,
+	isJetpackSearch,
+} from '@automattic/calypso-products';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
+const JETPACK_SEARCH_INTRO_COUPON_CODE = 'FIRSTYEAR50';
 const JETPACK_INTRO_COUPON_CODE = 'FRESHPACK';
+
+const isYearlySearch = ( product: RequestCartProduct ) =>
+	isJetpackSearch( product ) && ! product.product_slug.endsWith( '_monthly' );
 
 // **NOTE**: This hook can be safely deleted when we no longer need to
 // rely on auto-applied coupons for introductory new purchase pricing.
@@ -39,6 +47,13 @@ const useMaybeJetpackIntroCouponCode = (
 			! jetpackProducts.some( ( product ) => product.product_slug.endsWith( '_monthly' ) )
 		) {
 			return undefined;
+		}
+
+		// 2021-12-08: Tiered products like Search don't currently support introductory offers,
+		// so we simulate a 50%-off first year discount by auto-applying a coupon.
+		// This only applies to new subscriptions with yearly billing terms.
+		if ( jetpackProducts.some( isYearlySearch ) ) {
+			return JETPACK_SEARCH_INTRO_COUPON_CODE;
 		}
 
 		return JETPACK_INTRO_COUPON_CODE;


### PR DESCRIPTION
Resolves `1201295898168937-as-1201466911979525`.

This PR is meant to detect when people enter checkout with a new, annually-billed Jetpack Search subscription and apply an automatic 50% off their first year. This will eventually be supplanted by an introductory offer, but the WordPress.com store doesn't currently support introductory offers for tiered products like Search, so this is a temporary workaround until support is added.

#### Changes proposed in this Pull Request

* Add new logic to `use-maybe-jetpack-intro-coupon-code.ts` to auto-apply the `FIRSTYEAR50` coupon if a new yearly Jetpack Search subscription is in the cart, instead of `FRESHPACK`.
* Remove logic to auto-apply `FRESHPACK` to new subscriptions, which will be covered by a separate introductory offer.

#### Testing instructions

**NOTE:** Between each test case, please empty your cart to start each case fresh.

1. Load Calypso Blue and select a self-hosted Jetpack site.

##### Jetpack Search (yearly)

2. Attempt to purchase Jetpack Search with a yearly billing term.
3. Verify that when you're directed to checkout, the `FIRSTYEAR50` coupon is automatically applied and your subscription fee is reduced by 50%.

##### Jetpack Search (monthly)

4. Attempt to purchase Jetpack Search with a monthly billing term.
5. Verify that the `FIRSTYEAR50` coupon is not applied to your cart.

##### Any other Jetpack product (any billing term)

6. Attempt to purchase any other Jetpack plan or stand-alone product with a yearly billing term.
7. Verify your subscription fee is unchanged and no coupons have been applied.