### PR TITLE
Themes Showcase: Stop redirects for site slugs beginning with tier slugs.

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -115,7 +115,7 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
 }
 
 export function redirectTiers( { res, originalUrl }, next ) {
-	const redirectUrl = originalUrl.replace( /\/(free|premium|type)/g, '' );
+	const redirectUrl = originalUrl.replace( /\/(free|premium|type)\/?$/g, '' );
 	if ( redirectUrl === originalUrl ) {
 		return next();
 	}

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -118,13 +118,13 @@ export function redirectTiers( { res, originalUrl, params: { tier } }, next ) {
 	if ( tier === undefined ) {
 		return next();
 	}
-	const typeTierRegex = new RegExp( `/type/${ tier }$`, 'g' );
-	const tierRegex = new RegExp( `/${ tier }(/|$)`, 'g' );
 
-	const redirectUrl = originalUrl.replace( typeTierRegex, '' ).replace( tierRegex, '' );
-	if ( redirectUrl === originalUrl ) {
-		return next();
-	}
+	const typeTierRegex = new RegExp( `/type/${ tier }$`, 'g' );
+	const inlineOrPostfixTierRegex = new RegExp( `(?<=/)${ tier }/|/${ tier }$`, 'g' );
+
+	const redirectUrl = originalUrl
+		.replace( typeTierRegex, '' )
+		.replace( inlineOrPostfixTierRegex, '' );
 
 	res.redirect( 301, redirectUrl );
 }

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -114,8 +114,14 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
 	res.redirect( '/theme/' + [ theme, redirectedSection, site ].filter( Boolean ).join( '/' ) );
 }
 
-export function redirectTiers( { res, originalUrl }, next ) {
-	const redirectUrl = originalUrl.replace( /\/(free|premium|type)\/?$/g, '' );
+export function redirectTiers( { res, originalUrl, params: { tier } }, next ) {
+	if ( tier === undefined ) {
+		return next();
+	}
+	const typeTierRegex = new RegExp( `/type/${ tier }$`, 'g' );
+	const tierRegex = new RegExp( `/${ tier }(/|$)`, 'g' );
+
+	const redirectUrl = originalUrl.replace( typeTierRegex, '' ).replace( tierRegex, '' );
 	if ( redirectUrl === originalUrl ) {
 		return next();
 	}

--- a/client/my-sites/themes/test/controller.js
+++ b/client/my-sites/themes/test/controller.js
@@ -1,0 +1,82 @@
+import { redirectTiers } from '../controller';
+
+describe( 'redirectTiers()', () => {
+	const res = { redirect: jest.fn() };
+	const next = () => {};
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'when a :tier is present in the path', () => {
+		test.each( [
+			[ 'en/themes/free', 'free', 'en/themes' ],
+			[ 'en/themes/premium', 'premium', 'en/themes' ],
+
+			[ 'en/themes/filter/free/foofilter', 'free', 'en/themes/filter/foofilter' ],
+			[ 'en/themes/filter/premium/foofilter', 'premium', 'en/themes/filter/foofilter' ],
+
+			[ 'en/themes/foovertical/free', 'free', 'en/themes/foovertical' ],
+			[ 'en/themes/foovertical/premium', 'premium', 'en/themes/foovertical' ],
+
+			[
+				'en/themes/foovertical/free/filter/foofilter',
+				'free',
+				'en/themes/foovertical/filter/foofilter',
+			],
+			[
+				'en/themes/foovertical/premium/filter/foofilter',
+				'premium',
+				'en/themes/foovertical/filter/foofilter',
+			],
+
+			[ '/themes/type/free', 'free', '/themes' ],
+			[ '/themes/type/premium', 'premium', '/themes' ],
+			[ '/themes/blog.example/type/free', 'free', '/themes/blog.example' ],
+			[ '/themes/blog.example/type/premium', 'premium', '/themes/blog.example' ],
+
+			[ '/themes/search/searchquery/type/free', 'free', '/themes/search/searchquery' ],
+			[ '/themes/search/searchquery/type/premium', 'premium', '/themes/search/searchquery' ],
+			[
+				'/themes/blog.example/search/searchquery/type/free',
+				'free',
+				'/themes/blog.example/search/searchquery',
+			],
+			[
+				'/themes/blog.example/search/searchquery/type/premium',
+				'premium',
+				'/themes/blog.example/search/searchquery',
+			],
+
+			[ '/themes/filter/somefilter/type/free', 'free', '/themes/filter/somefilter' ],
+			[ '/themes/filter/somefilter/type/premium', 'premium', '/themes/filter/somefilter' ],
+			[
+				'/themes/blog.example/filter/somefilter/type/free',
+				'free',
+				'/themes/blog.example/filter/somefilter',
+			],
+			[
+				'/themes/blog.example/filter/somefilter/type/premium',
+				'premium',
+				'/themes/blog.example/filter/somefilter',
+			],
+		] )( '%s', ( originalUrl, tier, redirectTo ) => {
+			redirectTiers( { res, originalUrl, params: { tier } }, next );
+			expect( res.redirect ).toBeCalledWith( 301, redirectTo );
+		} );
+	} );
+
+	describe( 'when a :tier is *not* present in the path', () => {
+		test.each( [
+			[ 'en/themes' ],
+			[ 'en/themes/filter/foofilter' ],
+			[ '/themes/search/searchquery' ],
+			[ '/themes/blog.example/search/searchquery' ],
+			[ '/themes/filter/somefilter' ],
+			[ '/themes/blog.example/filter/somefilter' ],
+		] )( '%s', ( originalUrl ) => {
+			redirectTiers( { res, originalUrl, params: { tier: undefined } }, next );
+			expect( res.redirect ).not.toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
As part of removing premium themes from the Theme Showcase, a redirect for `/themes/premium` to `/themes` was added in #56430. Unfortunately, this also captures paths with site slugs that begin with `premium`, `free`, or `type`, like `/themes/premiumsite.wordpress.com`, resulting in a 404 after redirecting to `/themessite.wordpress.com`. This PR updates the regex to only remove the tier when followed by nothing, or only a slash (so no following characters that could represent a site domain).

| Production | PR |
| --- | --- |
| <img width="1393" alt="Screen Shot 2021-12-08 at 12 48 26 PM" src="https://user-images.githubusercontent.com/349751/145282237-61d39fd0-2533-4c09-a6cb-aee206f9b761.png"> | <img width="1397" alt="Screen Shot 2021-12-08 at 12 47 59 PM" src="https://user-images.githubusercontent.com/349751/145282252-1025c309-7c8a-44c3-9d2f-79420899248b.png"> |


Fixes #58704 .

**Testing Instructions**
* Start Calypso locally.
* In a new tab, open the URL `calypso.localhost:3000/themes/premiumsite.wordpress.com`, and notice it forwards to `calypso.localhost:3000/themessite.wordpress.com` (which 404s).
* Switch to this branch.
* Restart Calypso.
* Open `calypso.localhost:3000/themes/premiumsite.wordpress.com` again in a new tab, and verify the redirect doesn't happen (instead, assuming you don't have that site, the site selector will appear).