### PR TITLE
Add availability message for reserved domain names.

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -24,6 +24,7 @@ export const registrar = {
 export const domainAvailability = {
 	AVAILABLE: 'available',
 	AVAILABLE_PREMIUM: 'available_premium',
+	AVAILABLE_RESERVED: 'available_reserved',
 	AVAILABILITY_CHECK_ERROR: 'availability_check_error',
 	CONFLICTING_CNAME_EXISTS: 'conflicting_cname_exists',
 	DISALLOWED: 'blacklisted_domain',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -366,6 +366,19 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			);
 			break;
 
+		case domainAvailability.AVAILABLE_RESERVED:
+			message = translate(
+				'Sorry, {{strong}}%(domain)s{{/strong}} is reserved by the .%(tld)s registry and cannot be registered without permission.',
+				{
+					args: { domain, tld },
+					components: {
+						strong: <strong />,
+						a: <a rel="noopener noreferrer" href={ domainMapping( site, domain ) } />,
+					},
+				}
+			);
+			break;
+
 		case domainAvailability.TRANSFERRABLE_PREMIUM:
 			message = translate(
 				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com, but if you are the owner of this domain, you can {{a}}map it to your site{{/a}}.",

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -373,7 +373,6 @@ function getAvailabilityNotice( domain, error, errorData ) {
 					args: { domain, tld },
 					components: {
 						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ domainMapping( site, domain ) } />,
 					},
 				}
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're going to start checking for reserved domain names, so we need to show a different message when a domain is reserved.

#### Testing instructions

Depends on D71225-code

Apply the back-end patch and test searching for domains as suggested in the patch. Make sure that the reserved domains show an error message as shown below and that reserved domains are stripped from the suggestions list.

<img width="1090" alt="Screen Shot 2021-12-08 at 3 11 53 PM" src="https://user-images.githubusercontent.com/1379730/145280883-d22555ac-a358-4dca-88da-89e8a8232d64.png">


