### PR TITLE
FSE Beta: direct new sites to the Site editor

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -110,7 +110,13 @@ export default function useOnSiteCreation(): void {
 			clearLastNonEditorRoute();
 			setSelectedSite( newSite.blogid );
 
-			window.location.href = `/home/${ newSite.site_slug }/`;
+			let destination;
+			if ( design?.is_fse ) {
+				destination = `/site-editor/${ newSite.site_slug }/`;
+			} else {
+				destination = `/home/${ newSite.site_slug }/`;
+			}
+			window.location.href = destination;
 		}
 	}, [
 		flow,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the landing location to new FSE sites to go direction to the Site editor
* Non-FSE site still go to My Home

#### Testing instructions

* Create a new site using the `/new` flow, enrolling in the FSE beta
* See that you are taken to the Site editor after the site is created
* Try again without enrolling in the beta
* You should end up on My Home for the site (the current behavior)

Related to p1638990744138800-slack-CHN6J22MP