### PR TITLE
Domains: Restrict "Transfer to other site" new styles to the new component

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
@@ -2,7 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/colors';
 
-.transfer-to-other-site {
+.transfer-domain-to-other-site {
 	background: var( --studio-white );
 
 	.formatted-header__title {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -122,7 +122,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	render(): JSX.Element {
 		const { selectedSite, selectedDomainName, currentRoute, translate } = this.props;
 		const { slug } = selectedSite;
-		const componentClassName = 'transfer-to-other-site';
+		const componentClassName = 'transfer-domain-to-other-site';
 		if ( ! this.isDataReady() ) {
 			return (
 				<DomainMainPlaceholder
@@ -182,7 +182,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	};
 
 	renderSection(): JSX.Element {
-		const { translate, currentUserCanManage, selectedDomainName } = this.props;
+		const { currentUserCanManage, selectedDomainName } = this.props;
 		const { children, ...propsWithoutChildren } = this.props;
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...propsWithoutChildren } />;
@@ -190,14 +190,13 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 
 		return (
 			<div>
-				<Card className="transfer-to-other-site__card">
+				<Card className="transfer-domain-to-other-site__card">
 					<p>{ this.getMessage() }</p>
 					<SiteSelector
-						className={ 'transfer-to-other-site__site-selector' }
+						className={ 'transfer-domain-to-other-site__site-selector' }
 						filter={ this.isSiteEligible }
 						sites={ this.props.sites }
 						onSiteSelect={ this.handleSiteSelect }
-						searchPlaceholder={ translate( 'Search' ) }
 					/>
 				</Card>
 				{ this.state.targetSiteId && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request
#58554 added styles for the new "Transfer to other site" component. 
But even though the previous component didn't load/import the `style.scss` file, it got bundled to the final `domains.scss`, thus wrongly applying styles to the old component. This PR fixes it by changing the `className` of the new component and changing it in the styles.

#### Testing instructions
- Build this branch locally or open the live Calypso link;
- Go to "Upgrades > Domains";
- Select one of your registered domains;
- Select "Transfer your domain" > "To another WordPress.com site";
- Make sure that the old screen still looks the same;
- Add the `domains/transfers-redesign` flag and make sure that the screen looks like the new one described in #58554.