### PR TITLE
Add padding between two columns in horizontal signup steps

### DIFF
--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -136,6 +136,10 @@
 		.step-wrapper__header {
 			display: block;
 			margin-top: 0;
+
+			@include break-small {
+				padding-right: 20px;
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the step heading copy is very long (which can happen in some translations) we don't want the text to butt right against the step controls. We never noticed this in English because coincidentally none of the English copy wrapped in a way that made it notice-able.

Reported pdtkmj-1y-p2#comment-26

Adds 20px padding between the columns, which matches the amount of padding on the left and right of the step wrapper.

**Before** (Dutch / `nl`)
<img width="1584" alt="Screenshot 2021-12-09 at 12 19 07 PM" src="https://user-images.githubusercontent.com/1500769/145306916-d18ea60a-a7df-44c0-976e-edd065f46168.png">

**After**
<img width="1584" alt="Screenshot 2021-12-09 at 12 19 27 PM" src="https://user-images.githubusercontent.com/1500769/145306971-293dcc12-0763-4aaa-becd-2509a8ac5618.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on `calypso.localhost:3000` so that the Hero Flow is enabled for languages other than English

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58859