### PR TITLE
Domains: Redesigned domain list updates

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -94,7 +94,7 @@ class DomainRow extends PureComponent {
 			return (
 				<div className="domain-row__site-cell">
 					<Button href={ createSiteFromDomainOnly( site?.slug, site?.siteId ) } plain>
-						{ translate( 'Create site' ) } <MaterialIcon icon="add" />
+						<MaterialIcon icon="add" /> { translate( 'Create site' ) }
 					</Button>
 				</div>
 			);
@@ -284,7 +284,7 @@ class DomainRow extends PureComponent {
 
 		return (
 			<a href="#" onClick={ this.addEmailClick }>
-				{ translate( 'Add +', { context: 'Button label' } ) }
+				{ translate( '+ Add', { context: 'Button label' } ) }
 			</a>
 		);
 	};

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -69,7 +69,11 @@ function EmptyDomainsListCard( {
 	);
 
 	return (
-		<Card className="empty-domains-list-card">
+		<Card
+			className={ classNames( 'empty-domains-list-card', {
+				'has-non-wpcom-domains': hasNonWpcomDomains,
+			} ) }
+		>
 			<div
 				className={ classNames( 'empty-domains-list-card__wrapper', {
 					'is-compact': isCompact,

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -166,14 +166,6 @@ export class SiteDomains extends Component {
 			<>
 				{ ! hasProductsList && <QueryProductsList /> }
 
-				{ ! this.isLoading() && nonWpcomDomains.length === 0 && ! selectedFilter && (
-					<EmptyDomainsListCard
-						selectedSite={ selectedSite }
-						hasDomainCredit={ this.props.hasDomainCredit }
-						hasNonWpcomDomains={ false }
-					/>
-				) }
-
 				{ ! this.isLoading() && <GoogleSaleBanner domains={ domains } /> }
 
 				<div className="domain-management-list__items">
@@ -195,6 +187,14 @@ export class SiteDomains extends Component {
 						hasLoadedPurchases={ ! isFetchingPurchases }
 					/>
 				</div>
+
+				{ ! this.isLoading() && nonWpcomDomains.length === 0 && ! selectedFilter && (
+					<EmptyDomainsListCard
+						selectedSite={ selectedSite }
+						hasDomainCredit={ this.props.hasDomainCredit }
+						hasNonWpcomDomains={ false }
+					/>
+				) }
 
 				{ ! this.isLoading() && nonWpcomDomains.length > 0 && ! selectedFilter && (
 					<EmptyDomainsListCard

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -256,7 +256,7 @@ export class SiteDomains extends Component {
 			{
 				label: 'All my domains',
 				value: 'all-my-domains',
-				path: domainManagementRoot(),
+				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-me' } ),
 				count: null,
 			},
 		];

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -298,6 +298,10 @@
 	}
 }
 
+.empty-domains-list-card:not( .has-non-wpcom-domains ) {
+	box-shadow: none;
+}
+
 .domain-management-list__items + .empty-domains-list-card {
 	margin-top: 16px;
 	margin-bottom: 32px;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -484,11 +484,11 @@
 		display: flex;
 		width: 20px;
 		background: #d67709;
-		border-radius: 16px;
+		border-radius: 16px; /* stylelint-disable-line */
 		justify-content: center;
 		align-items: center;
 		color: #ffffff;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		height: 18px;
 		margin: 0 4px;
 		line-height: 20px;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -299,6 +299,15 @@
 }
 
 .domain-management-list__items + .empty-domains-list-card {
+	margin-top: 16px;
+	margin-bottom: 32px;
+
+	@include break-small {
+		margin-top: 0;
+	}
+}
+
+.domain-management-list__items + .empty-domains-list-card.has-non-wpcom-domains {
 	margin-top: 32px;
 	margin-bottom: 32px;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR addresses the design review issues pointed out in pcYYhz-pX-p2#comment-388, pcYYhz-pX-p2#comment-389 and pcYYhz-pX-p2#comment-390, which were:

1. "Get your domain" card appearing above the domain filters dropdown

![Markup on 2021-12-08 at 20:12:27](https://user-images.githubusercontent.com/5324818/145305977-6f55fae5-7e88-47fd-93c1-ea26012e6b05.png)

2. When clicking the "All my domains" option in the domain filters dropdown, the user was sent to the "All domains" page with the "All domains" filter selected instead of the "Owned by me" filter
3. Switch the position of the "+" sign in the "Create site +" and "Add +" (email) links in the domains list

![Markup on 2021-12-08 at 20:03:51](https://user-images.githubusercontent.com/5324818/145305984-a64144ae-f02f-4fd5-9d86-2a44fc561f42.png)

![Markup on 2021-12-08 at 20:09:32](https://user-images.githubusercontent.com/5324818/145306002-1d991ae0-340e-4a02-83ce-c76c03a78480.png)

You can compare them with the previous designs:

<img width="395" alt="Screen Shot 2021-12-08 at 20 36 00" src="https://user-images.githubusercontent.com/5324818/145313328-55715024-a9e9-495a-ab84-ae1f958026a8.png">

![Markup on 2021-12-08 at 20:38:06](https://user-images.githubusercontent.com/5324818/145313433-8ad11258-19e2-4f7b-b04f-5f88a7d52bb8.png)

![Markup on 2021-12-08 at 20:39:17](https://user-images.githubusercontent.com/5324818/145313453-0cf07bb5-98f4-4443-acca-7d67b5d5e7bb.png)

### Testing instructions

- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/management-list-redesign` to your URL to enable the appropriate feature flag

Points to verify:
1. "Get your domain" card position
  - Select a site with a plan where you haven't used domain credits yet, i.e. you didn't claim your free domain
  - Go to "Upgrades > Domains"
  - Check if the "Get your domain" card appears in the correct location in mobile view
2. Clicking "All my domains" filter option
  - In the domains filter dropdown, select "All my domains" and ensure you're taken to the "All domains" page with the "Owned by me" filter selected
3. "+ Create site" and "+ Add" links
  - In the "All domains" page, ensure that the "Create site +" link reads "+ Create site" now - this link appears for domain-only sites
  - Select a site where you have domains without email configured, go to "Upgrades > Domains" and ensure the "Add +" link in the "Email" column reads "+ Add" now
