### PR TITLE
Experiment : Plans: Add billed as wording on mobile

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -301,7 +301,7 @@ export class PlanFeaturesHeader extends Component {
 				args: { discountRate },
 			} );
 
-			return <span className="plan-features__header-discounted-info">{ annualDiscountText }</span>;
+			return <div className="plan-features__header-discounted-info">{ annualDiscountText }</div>;
 		}
 		return null;
 	}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -126,6 +126,7 @@ export class PlanFeaturesHeader extends Component {
 			title,
 			audience,
 			translate,
+			isBillingWordingExperiment,
 		} = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
@@ -150,9 +151,8 @@ export class PlanFeaturesHeader extends Component {
 					) }
 				</header>
 				<div className="plan-features__pricing">
-					{ this.getPlanFeaturesPrices() }
-					{ this.getBillingTimeframe() }
-					{ this.getDiscountInfo() }
+					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
+					{ isBillingWordingExperiment && this.getDiscountInfo() }
 					{ this.getIntervalDiscount() }
 				</div>
 			</span>
@@ -198,8 +198,7 @@ export class PlanFeaturesHeader extends Component {
 					<ProductIcon slug={ planType } />
 				</div>
 				<div className="plan-features__pricing">
-					{ this.getPlanFeaturesPrices() }
-					{ this.getBillingTimeframe() }
+					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
 					{ this.getIntervalDiscount() }
 				</div>
 			</div>
@@ -237,6 +236,7 @@ export class PlanFeaturesHeader extends Component {
 			isMonthlyPlan,
 			relatedYearlyPlan,
 			isLoggedInMonthlyPricing,
+			isBillingWordingExperiment,
 		} = this.props;
 
 		if ( ( isInSignup || isLoggedInMonthlyPricing ) && isMonthlyPlan && relatedYearlyPlan ) {
@@ -251,9 +251,12 @@ export class PlanFeaturesHeader extends Component {
 			planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } ) &&
 			relatedYearlyPlan
 		) {
-			return translate( 'billed as %(price)s annually', {
-				args: { price: relatedYearlyPlan.formatted_price },
-			} );
+			if ( isBillingWordingExperiment ) {
+				return translate( 'billed as %(price)s annually', {
+					args: { price: relatedYearlyPlan.formatted_price },
+				} );
+			}
+			return translate( 'billed annually' );
 		}
 
 		if (

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -313,6 +313,7 @@ export class PlanFeatures extends Component {
 			showPlanCreditsApplied,
 			isLaunchPage,
 			isInVerticalScrollingPlansExperiment,
+			isBillingWordingExperiment,
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -398,6 +399,7 @@ export class PlanFeatures extends Component {
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={ this.props.isLoggedInMonthlyPricing }
 						isInSignup={ isInSignup }
+						isBillingWordingExperiment={ isBillingWordingExperiment }
 					/>
 					<p className="plan-features__description">{ planDescription }</p>
 					<PlanFeaturesActions

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -425,6 +425,8 @@ $plan-features-sidebar-width: 272px;
 .plan-features__header-discounted-info {
 	color: var( --studio-green-60 );
 	font-weight: 600;
+	margin-top: -16px;
+	margin-bottom: 12px;
 }
 
 .plan-features__header-credit-label {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -422,6 +422,11 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+.plan-features__header-discounted-info {
+	color: var( --studio-green-60 );
+	font-weight: 600;
+}
+
 .plan-features__header-credit-label {
 	font-size: $font-body-extra-small;
 	line-height: 20px;

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -15,10 +15,6 @@
 		margin-left: 8px;
 		vertical-align: super;
 	}
-
-	@include breakpoint-deprecated( '<960px' ) {
-		font-size: $font-title-medium;
-	}
 }
 
 .plan-price.is-original {
@@ -70,7 +66,6 @@
 .plan-price__integer {
 	margin: 0 1px;
 	font-weight: 400;
-	font-size: $font-title-large;
 }
 
 .plan-price__fraction {

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -70,6 +70,7 @@
 .plan-price__integer {
 	margin: 0 1px;
 	font-weight: 400;
+	font-size: $font-title-large;
 }
 
 .plan-price__fraction {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -168,12 +168,12 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			isInVerticalScrollingPlansExperiment,
+			isBillingWordingExperiment,
 			redirectToAddDomainFlow,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
-
 		return (
 			<div
 				className={ classNames(
@@ -212,6 +212,7 @@ export class PlansFeaturesMain extends Component {
 					} ) }
 					siteId={ siteId }
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+					isBillingWordingExperiment={ isBillingWordingExperiment }
 					kindOfPlanTypeSelector={ this.getKindOfPlanTypeSelector( this.props ) }
 				/>
 			</div>

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isMobile } from '@automattic/viewport';
 import { isEmpty } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';
@@ -333,11 +334,11 @@ export default {
 
 		// Pre-fetching the experiment
 		if ( flowName === 'onboarding' || flowName === 'launch-site' ) {
-			await loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' );
+			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' );
 		}
 
-		if ( 'onboarding' === flowName ) {
-			await loadExperimentAssignment( 'calypso_mobile_plans_page_with_billing' );
+		if ( isMobile() && 'onboarding' === flowName ) {
+			loadExperimentAssignment( 'calypso_mobile_plans_page_with_billing' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -336,6 +336,10 @@ export default {
 			await loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' );
 		}
 
+		if ( 'onboarding' === flowName ) {
+			await loadExperimentAssignment( 'calypso_mobile_plans_page_with_billing' );
+		}
+
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -146,53 +146,52 @@ export class PlansStep extends Component {
 			);
 		}
 
-		if ( isMobile() && 'onboarding' === this.props.flowName ) {
-			return (
-				<ProvideExperimentData name="calypso_mobile_plans_page_with_billing">
-					{ ( isLoading, experimentAssignment ) => {
-						if ( isLoading ) {
-							return this.renderLoading();
-						}
+		return (
+			<ProvideExperimentData
+				name="calypso_mobile_plans_page_with_billing"
+				options={ { isEligible: isMobile() && 'onboarding' === this.props.flowName } }
+			>
+				{ ( isLoading, experimentAssignment ) => {
+					if ( isLoading ) {
+						return this.renderLoading();
+					}
 
-						// This allows us to continue with the other experiments.
-						if ( experimentAssignment?.variationName === null ) {
-							return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
-						}
+					// This allows us to continue with the other experiments.
+					if ( experimentAssignment?.variationName === null ) {
+						return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
+					}
 
-						return (
-							<div>
-								{ errorDisplay }
-								<QueryPlans />
-								<PlansFeaturesMain
-									site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-									hideFreePlan={ hideFreePlan }
-									isInSignup={ true }
-									isLaunchPage={ isLaunchPage }
-									intervalType={ this.getIntervalType( false ) }
-									isBillingWordingExperiment={ experimentAssignment?.variationName !== null }
-									onUpgradeClick={ this.onSelectPlan }
-									showFAQ={ false }
-									domainName={ this.getDomainName() }
-									customerType={ this.getCustomerType() }
-									disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-									plansWithScroll={ this.state.isDesktop }
-									planTypes={ planTypes }
-									flowName={ flowName }
-									showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-									isAllPaidPlansShown={ true }
-									isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-									shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-									isReskinned={ isReskinned }
-									disableMonthlyExperiment={ false }
-								/>
-							</div>
-						);
-					} }
-				</ProvideExperimentData>
-			);
-		}
-
-		return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
+					return (
+						<div>
+							{ errorDisplay }
+							<QueryPlans />
+							<PlansFeaturesMain
+								site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+								hideFreePlan={ hideFreePlan }
+								isInSignup={ true }
+								isLaunchPage={ isLaunchPage }
+								intervalType={ this.getIntervalType( false ) }
+								isBillingWordingExperiment={ experimentAssignment?.variationName !== null }
+								onUpgradeClick={ this.onSelectPlan }
+								showFAQ={ false }
+								domainName={ this.getDomainName() }
+								customerType={ this.getCustomerType() }
+								disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+								plansWithScroll={ this.state.isDesktop }
+								planTypes={ planTypes }
+								flowName={ flowName }
+								showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+								isAllPaidPlansShown={ true }
+								isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+								shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+								isReskinned={ isReskinned }
+								disableMonthlyExperiment={ false }
+							/>
+						</div>
+					);
+				} }
+			</ProvideExperimentData>
+		);
 	}
 
 	renderSignUpMonthlyPlansExperiment( errorDisplay ) {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -10,9 +10,9 @@ import { parse as parseQs } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
-import PulsingDot from 'calypso/components/pulsing-dot';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
 import { ProvideExperimentData } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
@@ -151,7 +151,7 @@ export class PlansStep extends Component {
 				<ProvideExperimentData name="calypso_mobile_plans_page_with_billing">
 					{ ( isLoading, experimentAssignment ) => {
 						if ( isLoading ) {
-							return <PulsingDot active />;
+							return this.renderLoading();
 						}
 
 						// This allows us to continue with the other experiments.
@@ -216,7 +216,7 @@ export class PlansStep extends Component {
 			>
 				{ ( isLoading, experimentAssignment ) => {
 					if ( isLoading ) {
-						return <PulsingDot active />;
+						return this.renderLoading();
 					}
 					const isTreatmentMonthlyDefault = experimentAssignment?.variationName !== null;
 
@@ -249,6 +249,14 @@ export class PlansStep extends Component {
 					);
 				} }
 			</ProvideExperimentData>
+		);
+	}
+
+	renderLoading() {
+		return (
+			<div className="plans__loading">
+				<LoadingEllipsis active />
+			</div>
 		);
 	}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,7 +1,7 @@
 import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
-import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
+import { isDesktop, subscribeIsDesktop, isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { intersection } from 'lodash';
@@ -144,6 +144,45 @@ export class PlansStep extends Component {
 					</Notice>
 				</div>
 			);
+		}
+
+		if ( isMobile() && 'onboarding' === this.props.flowName ) {
+			<ProvideExperimentData name="calypso_mobile_plans_page_with_billing">
+				{ ( isLoading, experimentAssignment ) => {
+					if ( isLoading ) {
+						return <PulsingDot active />;
+					}
+
+					return (
+						<div>
+							{ errorDisplay }
+							<QueryPlans />
+							<PlansFeaturesMain
+								site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+								hideFreePlan={ hideFreePlan }
+								isInSignup={ true }
+								isLaunchPage={ isLaunchPage }
+								intervalType={ this.getIntervalType( false ) }
+								isBillingWordingExperiment={ experimentAssignment?.variationName !== null }
+								onUpgradeClick={ this.onSelectPlan }
+								showFAQ={ false }
+								domainName={ this.getDomainName() }
+								customerType={ this.getCustomerType() }
+								disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+								plansWithScroll={ this.state.isDesktop }
+								planTypes={ planTypes }
+								flowName={ flowName }
+								showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+								isAllPaidPlansShown={ true }
+								isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+								shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+								isReskinned={ isReskinned }
+								disableMonthlyExperiment={ false }
+							/>
+						</div>
+					);
+				} }
+			</ProvideExperimentData>;
 		}
 
 		return (

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -147,44 +147,66 @@ export class PlansStep extends Component {
 		}
 
 		if ( isMobile() && 'onboarding' === this.props.flowName ) {
-			<ProvideExperimentData name="calypso_mobile_plans_page_with_billing">
-				{ ( isLoading, experimentAssignment ) => {
-					if ( isLoading ) {
-						return <PulsingDot active />;
-					}
+			return (
+				<ProvideExperimentData name="calypso_mobile_plans_page_with_billing">
+					{ ( isLoading, experimentAssignment ) => {
+						if ( isLoading ) {
+							return <PulsingDot active />;
+						}
 
-					return (
-						<div>
-							{ errorDisplay }
-							<QueryPlans />
-							<PlansFeaturesMain
-								site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-								hideFreePlan={ hideFreePlan }
-								isInSignup={ true }
-								isLaunchPage={ isLaunchPage }
-								intervalType={ this.getIntervalType( false ) }
-								isBillingWordingExperiment={ experimentAssignment?.variationName !== null }
-								onUpgradeClick={ this.onSelectPlan }
-								showFAQ={ false }
-								domainName={ this.getDomainName() }
-								customerType={ this.getCustomerType() }
-								disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-								plansWithScroll={ this.state.isDesktop }
-								planTypes={ planTypes }
-								flowName={ flowName }
-								showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-								isAllPaidPlansShown={ true }
-								isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-								shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-								isReskinned={ isReskinned }
-								disableMonthlyExperiment={ false }
-							/>
-						</div>
-					);
-				} }
-			</ProvideExperimentData>;
+						// This allows us to continue with the other experiments.
+						if ( experimentAssignment?.variationName === null ) {
+							return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
+						}
+
+						return (
+							<div>
+								{ errorDisplay }
+								<QueryPlans />
+								<PlansFeaturesMain
+									site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+									hideFreePlan={ hideFreePlan }
+									isInSignup={ true }
+									isLaunchPage={ isLaunchPage }
+									intervalType={ this.getIntervalType( false ) }
+									isBillingWordingExperiment={ experimentAssignment?.variationName !== null }
+									onUpgradeClick={ this.onSelectPlan }
+									showFAQ={ false }
+									domainName={ this.getDomainName() }
+									customerType={ this.getCustomerType() }
+									disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+									plansWithScroll={ this.state.isDesktop }
+									planTypes={ planTypes }
+									flowName={ flowName }
+									showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+									isAllPaidPlansShown={ true }
+									isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+									shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+									isReskinned={ isReskinned }
+									disableMonthlyExperiment={ false }
+								/>
+							</div>
+						);
+					} }
+				</ProvideExperimentData>
+			);
 		}
 
+		return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
+	}
+
+	renderSignUpMonthlyPlansExperiment( errorDisplay ) {
+		const {
+			disableBloggerPlanWithNonBlogDomain,
+			hideFreePlan,
+			isLaunchPage,
+			selectedSite,
+			planTypes,
+			flowName,
+			showTreatmentPlansReorderTest,
+			isInVerticalScrollingPlansExperiment,
+			isReskinned,
+		} = this.props;
 		return (
 			<ProvideExperimentData
 				name="calypso_signup_monthly_plans_default_202201_v2"
@@ -208,6 +230,7 @@ export class PlansStep extends Component {
 								isInSignup={ true }
 								isLaunchPage={ isLaunchPage }
 								intervalType={ this.getIntervalType( isTreatmentMonthlyDefault ) }
+								isBillingWordingExperiment={ false }
 								onUpgradeClick={ this.onSelectPlan }
 								showFAQ={ false }
 								domainName={ this.getDomainName() }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -157,7 +157,7 @@ export class PlansStep extends Component {
 					}
 
 					// This allows us to continue with the other experiments.
-					if ( experimentAssignment?.variationName === null ) {
+					if ( ! experimentAssignment?.variationName ) {
 						return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
 					}
 

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -48,3 +48,11 @@
 	line-height: inherit;
 	text-decoration: underline;
 }
+
+.plans__loading {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	position: relative;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is intended as an A/B experiment to show that adding more clear wording ( as it currently exists on desktop) to the signup page on mobile, will result in an improved mobile conversion rate.

This change is intended to make the plans page line up more with the desktop side of things by making sure that we display the same info on both screen sizes. 


Desktop:
<img width="600" src="https://user-images.githubusercontent.com/115071/145316349-07eb2b16-bde0-478e-8258-695880f66535.png" />

Before: Mobile also the control in the experiment
/start/plans
<img width="300" src="https://user-images.githubusercontent.com/115071/145316421-43a5a9d4-7b1b-4feb-83d3-11faa6ab6ac5.png" />

After: Mobile & variation
/start/plans
<img width="300" src="https://user-images.githubusercontent.com/115071/145318674-6a4bace6-f780-4d12-9cbf-bebeefcd1eb0.png" />

#### Testing instructions

* Visit /start/plans on a smaller windows size ( mobile ) 
* Notice that now we have the wording that tells you about what you are expecting to pay as well as the discount info. 

* Visit /plans/yearly/example.wordpress.com
* Notice that there is no change on that page. It should show the same content as before.

To test the variation vs control 
Please use the bookmarklet to assign yourself a variation. 


Fixes https://github.com/Automattic/wp-calypso/issues/58982

Experiment proposal pbxNRc-1an-p2, 
Experiment pbxNRc-1fu-p2