### PR TITLE
Design Picker: Make Blank Canvas button is easier to translate

### DIFF
--- a/packages/design-picker/src/components/featured-picks-buttons/index.tsx
+++ b/packages/design-picker/src/components/featured-picks-buttons/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import React from 'react';
+import { isBlankCanvasDesign } from '../..';
 import type { Design } from '../../types';
 import './style.scss';
 
@@ -28,10 +28,10 @@ const FeaturedPicksButtons: React.FC< Props > = ( { className, designs, onSelect
 					isSecondary
 					onClick={ () => onSelect( design ) }
 				>
-					{
-						/* translators: %s is the title of design */
-						sprintf( __( 'Use %s' ), design.title )
-					}
+					{ isBlankCanvasDesign( design )
+						? __( 'Use a blank theme' )
+						: /* translators: %s is the title of design */
+						  sprintf( __( 'Use %s' ), design.title ) }
 				</Button>
 			) ) }
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request



The "Use %s" label is working correctly, but since we don't translate
theme names, it means non-English readers won't understand what type of
theme they're selecting.

By using a custom label without the theme name placeholder, we allow
translators to fully localise this button so that users will understand
what sort of theme they're selecting.

<img width="1584" alt="Screenshot 2021-12-09 at 2 12 21 PM" src="https://user-images.githubusercontent.com/1500769/145316320-506d0a87-74d0-4270-b596-4ebe735ef9bd.png">

Reported: pdtkmj-1y-p2#comment-9
Wording discussed: p1638934056466400-slack-C029SB8JT8S

I'll apply the [String Freeze] label once I think we're at consensus on the wording. It's not worth doing the `hasTranslation()` trick to ship earlier because "Use Blank Canvas" is fine for English.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using `calypso.localhost:3000` otherwise Hero Flow won't be enabled for non-English languages

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58859