### PR TITLE
Hide remove product button from premium product line item when DIFM is in the cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -85,7 +85,7 @@ export function WPOrderReviewLineItems( {
 					<WPOrderReviewListItem key={ product.uuid }>
 						<LineItem
 							product={ product }
-							hasDeleteButton={ canItemBeDeleted( product ) }
+							hasDeleteButton={ canItemBeDeleted( product, responseCart.products ) }
 							removeProductFromCart={ removeProductFromCart }
 							isSummary={ isSummary }
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -142,7 +142,20 @@ WPOrderReviewLineItems.propTypes = {
 	createUserAndSiteBeforeTransaction: PropTypes.bool,
 };
 
-function canItemBeDeleted( item: ResponseCartProduct ): boolean {
+function canItemBeDeleted(
+	item: ResponseCartProduct,
+	cartProducts: Array< ResponseCartProduct >
+): boolean {
 	const itemTypesThatCannotBeDeleted = [ 'domain_redemption' ];
-	return ! itemTypesThatCannotBeDeleted.includes( item.product_slug );
+	if ( itemTypesThatCannotBeDeleted.includes( item.product_slug ) ) {
+		return false;
+	}
+
+	// The Premium plan cannot be deleted when in combination with the DIFM lite product
+	const isPremiumPlanProduct = item.product_slug === 'value_bundle';
+	const hasDifmLiteProductInCart = cartProducts.some( ( p ) => p.product_slug === 'wp_difm_lite' );
+	if ( isPremiumPlanProduct && hasDifmLiteProductInCart ) {
+		return false;
+	}
+	return true;
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -82,7 +82,10 @@ export function WPOrderReviewLineItems( {
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ responseCart.products.map( ( product ) => {
 				const isRenewal = isWpComProductRenewal( product );
-				const shouldShowVariantSelector = onChangePlanLength && ! isRenewal;
+				const shouldShowVariantSelector =
+					onChangePlanLength &&
+					! isRenewal &&
+					! isPremiumPlanWithDIFMInTheCart( product, responseCart );
 				return (
 					<WPOrderReviewListItem key={ product.uuid }>
 						<LineItem
@@ -144,14 +147,25 @@ WPOrderReviewLineItems.propTypes = {
 	createUserAndSiteBeforeTransaction: PropTypes.bool,
 };
 
+/**
+ * Checks if the given item is the premium plan product and the DIFM product exists in the provided shopping cart object
+ *
+ * @param item The shopping basket line item
+ * @param cartProducts The shopping cart object
+ * @returns boolean
+ */
+function isPremiumPlanWithDIFMInTheCart( item: ResponseCartProduct, cartProducts: ResponseCart ) {
+	return isPremium( item ) && hasDIFMProduct( cartProducts );
+}
+
 function canItemBeDeleted( item: ResponseCartProduct, cartProducts: ResponseCart ): boolean {
 	const itemTypesThatCannotBeDeleted = [ 'domain_redemption' ];
 	if ( itemTypesThatCannotBeDeleted.includes( item.product_slug ) ) {
 		return false;
 	}
 
-	// The Premium plan cannot be deleted when in combination with the DIFM lite product
-	if ( isPremium( item ) && hasDIFMProduct( cartProducts ) ) {
+	// The Premium plan cannot be removed from the cart when in combination with the DIFM lite product
+	if ( isPremiumPlanWithDIFMInTheCart( item, cartProducts ) ) {
 		return false;
 	}
 	return true;

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,3 +1,4 @@
+import { isPremium } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import {
 	getCouponLineItemFromCart,
@@ -10,6 +11,7 @@ import {
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import * as React from 'react';
+import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
@@ -85,7 +87,7 @@ export function WPOrderReviewLineItems( {
 					<WPOrderReviewListItem key={ product.uuid }>
 						<LineItem
 							product={ product }
-							hasDeleteButton={ canItemBeDeleted( product, responseCart.products ) }
+							hasDeleteButton={ canItemBeDeleted( product, responseCart ) }
 							removeProductFromCart={ removeProductFromCart }
 							isSummary={ isSummary }
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -142,19 +144,14 @@ WPOrderReviewLineItems.propTypes = {
 	createUserAndSiteBeforeTransaction: PropTypes.bool,
 };
 
-function canItemBeDeleted(
-	item: ResponseCartProduct,
-	cartProducts: Array< ResponseCartProduct >
-): boolean {
+function canItemBeDeleted( item: ResponseCartProduct, cartProducts: ResponseCart ): boolean {
 	const itemTypesThatCannotBeDeleted = [ 'domain_redemption' ];
 	if ( itemTypesThatCannotBeDeleted.includes( item.product_slug ) ) {
 		return false;
 	}
 
 	// The Premium plan cannot be deleted when in combination with the DIFM lite product
-	const isPremiumPlanProduct = item.product_slug === 'value_bundle';
-	const hasDifmLiteProductInCart = cartProducts.some( ( p ) => p.product_slug === 'wp_difm_lite' );
-	if ( isPremiumPlanProduct && hasDifmLiteProductInCart ) {
+	if ( isPremium( item ) && hasDIFMProduct( cartProducts ) ) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
Hide remove product button from premium product line item when DIFM is in the cart

#### Changes proposed in this Pull Request

* Add to function which decides when the remove product from cart button is shown
* Hide plan variant

#### Testing instructions
- Go through the DIFM lite flow `/start/do-it-for-me`
- Make sure the remove product from cart button is not available at checkout
