### PR TITLE
Notifications: Remove superfluous args from `getISODateString`

### DIFF
--- a/apps/notifications/src/panel/templates/block-user.jsx
+++ b/apps/notifications/src/panel/templates/block-user.jsx
@@ -76,7 +76,7 @@ function getShortDateString( timestamp, locale = 'en' ) {
 		} );
 		return formatter.format( new Date( timestamp ) );
 	} catch ( error ) {
-		return getISODateString( timestamp, locale );
+		return getISODateString( timestamp );
 	}
 }
 
@@ -97,7 +97,7 @@ function getNumericDateString( timestamp, locale = 'en' ) {
 		} );
 		return formatter.format( new Date( timestamp ) );
 	} catch ( error ) {
-		return getISODateString( timestamp, locale );
+		return getISODateString( timestamp );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While looking at #58906, I noticed we're passing superfluous arguments to `getISODateString` in the notifications app. This PR cleans them up.

#### Testing instructions

Not needed, just verify that the `getISODateString` function doesn't need the second argument.