### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` registrant verification to `wpcom.req`

### DIFF
--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -230,7 +230,7 @@ class RegistrantVerificationPage extends Component {
 		this.setState( this.getLoadingState() );
 
 		wp.req
-			.post( `/domains/${ domain }/resend-icann/` )
+			.post( `/domains/${ domain }/resend-icann` )
 			.then( () => {
 				this.setState( {
 					title: translate( 'Email sent!' ),

--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -9,8 +9,6 @@ import DomainsLandingContentCard from '../content-card';
 import DomainsLandingHeader from '../header';
 import { getMaintenanceMessageFromError } from '../utils';
 
-const wpcom = wp.undocumented();
-
 class RegistrantVerificationPage extends Component {
 	static propTypes = {
 		domain: PropTypes.string.isRequired,
@@ -23,14 +21,14 @@ class RegistrantVerificationPage extends Component {
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
 		const { domain, email, token } = this.props;
-		wpcom.domainsVerifyRegistrantEmail( domain, email, token ).then(
-			( response ) => {
+		wp.req
+			.get( `/domains/${ domain }/verify-email`, { email, token } )
+			.then( ( response ) => {
 				this.setState( this.getVerificationSuccessState( get( response, 'domains', [ domain ] ) ) );
-			},
-			( error ) => {
+			} )
+			.catch( ( error ) => {
 				this.setErrorState( error );
-			}
-		);
+			} );
 	}
 
 	getLoadingState() {
@@ -232,10 +230,9 @@ class RegistrantVerificationPage extends Component {
 
 		this.setState( this.getLoadingState() );
 
-		wpcom.resendIcannVerification( domain, ( error ) => {
-			if ( error ) {
-				this.setErrorState( { error: 'resend_email_failed' } );
-			} else {
+		wp.req
+			.post( `/domains/${ domain }/resend-icann/` )
+			.then( () => {
 				this.setState( {
 					title: translate( 'Email sent!' ),
 					message: translate( 'Check your email.' ),
@@ -244,8 +241,10 @@ class RegistrantVerificationPage extends Component {
 					footer: translate( "That's all for now. We'll see you again soon." ),
 					isLoading: false,
 				} );
-			}
-		} );
+			} )
+			.catch( () => {
+				this.setErrorState( { error: 'resend_email_failed' } );
+			} );
 	};
 
 	render() {

--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -18,8 +18,7 @@ class RegistrantVerificationPage extends Component {
 
 	state = this.getLoadingState();
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		const { domain, email, token } = this.props;
 		wp.req
 			.get( `/domains/${ domain }/verify-email`, { email, token } )

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -71,10 +71,6 @@ Undocumented.prototype.launchSite = function ( siteIdOrSlug, fn ) {
 	return this.wpcom.req.post( path, fn );
 };
 
-Undocumented.prototype.resendIcannVerification = function ( domain, callback ) {
-	return this.wpcom.req.post( '/domains/' + domain + '/resend-icann/', callback );
-};
-
 Undocumented.prototype.fetchDns = function ( domainName, fn ) {
 	return this.wpcom.req.get( '/domains/' + domainName + '/dns', fn );
 };
@@ -203,10 +199,6 @@ Undocumented.prototype.getDomainConnectSyncUxUrl = function (
 		{ redirect_uri: redirectUri },
 		callback
 	);
-};
-
-Undocumented.prototype.domainsVerifyRegistrantEmail = function ( domain, email, token ) {
-	return this.wpcom.req.get( `/domains/${ domain }/verify-email`, { email, token } );
 };
 
 Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` registrant verificataion methods to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

Also resolves part of #58453 as it removes one `UNSAFE_` lifecycle method.

#### Testing instructions

This can be tested by navigating to `/domain-services/registrant-verification?domain=DOMAIN&email=EMAIL&token=TOKEN` where `DOMAIN` is a domain, `EMAIL` is the email of the user and `TOKEN` is the verification token, however, I'm not sure how to generate the token, so I'd like to ask for some assistance from @Automattic/nomado on how to test this properly.