### PR TITLE
Migrate wpcom.undocumented().getMatchingAnchorSite() to wpcom.req

### DIFF
--- a/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
@@ -1,5 +1,4 @@
 import { useSelect } from '@wordpress/data';
-import page from 'page';
 import { useState, useEffect } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useIsAnchorFm, useAnchorFmParams } from '../path';
@@ -34,22 +33,23 @@ export default function useDetectMatchingAnchorSite(): boolean {
 		}
 
 		setIsLoading( true );
-		wpcom
-			.undocumented()
-			.getMatchingAnchorSite(
-				anchorFmPodcastId,
-				anchorFmEpisodeId,
-				anchorFmSpotifyUrl,
-				anchorFmSite,
-				anchorFmPost
-			)
+
+		// construct query object from entries that are not null
+		const query = Object.fromEntries(
+			[
+				[ 'podcast', anchorFmPodcastId ],
+				[ 'episode', anchorFmEpisodeId ],
+				[ 'spotify_url', anchorFmSpotifyUrl ],
+				[ 'site', anchorFmSite ],
+				[ 'post', anchorFmPost ],
+			].filter( ( [ , value ] ) => value != null )
+		);
+
+		wpcom.req
+			.get( { path: '/anchor', apiNamespace: 'wpcom/v2' }, query )
 			.then( ( result: AnchorEndpointResult ) => {
-				if ( result?.location ) {
-					try {
-						page( result.location );
-					} catch ( err ) {
-						window.location.href = result.location;
-					}
+				if ( result.location ) {
+					window.location.href = result.location;
 				} else {
 					setIsLoading( false );
 				}

--- a/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/gutenboarding/hooks/use-detect-matching-anchor-site.ts
@@ -34,7 +34,7 @@ export default function useDetectMatchingAnchorSite(): boolean {
 
 		setIsLoading( true );
 
-		// construct query object from entries that are not null
+		// construct query object from entries that are not null or undefined
 		const query = Object.fromEntries(
 			[
 				[ 'podcast', anchorFmPodcastId ],

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -70,47 +70,4 @@ Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function (
 	} );
 };
 
-/**
- * Look for a site belonging to the currently logged in user that matches the
- * anchor parameters specified.
- *
- * @param anchorFmPodcastId {string | null}  Example: 22b6608
- * @param anchorFmEpisodeId {string | null}  Example: e324a06c-3148-43a4-85d8-34c0d8222138
- * @param anchorFmSpotifyUrl {string | null} Example: https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
- * @param anchorFmSite {string | null} Example: 181129564
- * @param anchorFmPost {string | null} Example: 5
- * @returns {Promise} A promise
- *    The promise should resolve to a json object containing ".location" key as {string|false} type.
- *    False - There were no matching sites detected, the user should create a new one.
- *    String - The URL to redirect the user to, to edit a new or existing post on that site.
- */
-Undocumented.prototype.getMatchingAnchorSite = function (
-	anchorFmPodcastId,
-	anchorFmEpisodeId,
-	anchorFmSpotifyUrl,
-	anchorFmSite,
-	anchorFmPost
-) {
-	const queryParts = {
-		podcast: anchorFmPodcastId,
-		episode: anchorFmEpisodeId,
-		spotify_url: anchorFmSpotifyUrl,
-		site: anchorFmSite,
-		post: anchorFmPost,
-	};
-	Object.keys( queryParts ).forEach( ( k ) => {
-		if ( queryParts[ k ] === null ) {
-			delete queryParts[ k ];
-		}
-	} );
-	return this.wpcom.req.get(
-		{
-			path: '/anchor',
-			method: 'GET',
-			apiNamespace: 'wpcom/v2',
-		},
-		queryParts
-	);
-};
-
 export default Undocumented;


### PR DESCRIPTION
The endpoint is used in Gutenboarding.

My PR also removes an usage of `page( location )` call that's completely wrong here. Gutenboarding doesn't use page.js, the library is not even initialized, and therefore the `page()` call will always throw an error. I changed that to assigning `window.location.href` directly. A nice consequence is that the `page` package is no longer bundled with Gutenboarding.

I experimented with React Router's `useHistory().push( location )` for a while, but it doesn't work here. `history.push` works only for locations that are inside the `/new` app, not outside. When calling `history.push( '/new' )`, the path is considered relative the base `/new` path and becomes `/new/new`. And the `/anchor` endpoint can also return `/post` URLs (redirecting to post editor), which also wouldn't work with `history.push`.

**How to test:**
Go to this URL (I copied it from @mreishus' #48065):
```
http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138
```
and verify that the Gutenboarding app calls the `/anchor` endpoint, gets a `/new` location with a `anchor_is_new_site=true` query param appended, and navigates to that new URL. Your site title will be pre-filled with the podcast name.

Part of #58458.