### PR TITLE
Config: Remove some always-on feature flags

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	isPersonal,
 	isPremium,
@@ -213,10 +212,6 @@ class ManagePurchase extends Component {
 	renderRenewButton() {
 		const { purchase, translate } = this.props;
 
-		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
-			return null;
-		}
-
 		if ( isPartnerPurchase( purchase ) || ! isRenewable( purchase ) || ! this.props.site ) {
 			return null;
 		}
@@ -268,10 +263,6 @@ class ManagePurchase extends Component {
 
 	renderRenewalNavItem( content, onClick ) {
 		const { purchase } = this.props;
-
-		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
-			return null;
-		}
 
 		if ( ! isRenewable( purchase ) || ! this.props.site ) {
 			return null;

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -180,7 +180,7 @@ class PurchaseNotice extends Component {
 	renderRenewNoticeAction( onClick ) {
 		const { changePaymentMethodPath, purchase, translate } = this.props;
 
-		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! this.props.selectedSite ) {
+		if ( ! this.props.selectedSite ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -1,6 +1,4 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-
-import config from '@automattic/calypso-config';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -141,7 +139,7 @@ export class List extends Component {
 							selectedSite={ this.props.selectedSite }
 							currentRoute={ this.props.currentRoute }
 						/>
-						{ this.optionsDomainButton() }
+						<OptionsDomainButton />
 					</div>
 				</div>
 
@@ -255,14 +253,6 @@ export class List extends Component {
 				.subtract( 30, 'minutes' )
 				.isBefore( this.props.moment( domain.registrationDate ) )
 		);
-	}
-
-	optionsDomainButton() {
-		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
-			return null;
-		}
-
-		return <OptionsDomainButton />;
 	}
 
 	setPrimaryDomain( domainName ) {

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -163,10 +162,6 @@ class ListAll extends Component {
 	};
 
 	headerButtons() {
-		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
-			return null;
-		}
-
 		return (
 			<Button primary compact className="list-all__add-a-domain" onClick={ this.clickAddDomain }>
 				{ this.props.translate( 'Add a domain' ) }

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -40,17 +39,10 @@ class ListHeader extends PureComponent {
 		}
 	};
 
-	renderAddDomainToThisSiteButton() {
-		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
-			return null;
-		}
-		return <OptionsDomainButton specificSiteActions={ true } />;
-	}
-
 	renderDefaultHeaderContent() {
 		return (
 			<SectionHeader label={ this.props.translate( 'Your site domains' ) }>
-				{ ! this.props.isManagingAllSites && this.renderAddDomainToThisSiteButton() }
+				{ ! this.props.isManagingAllSites && <OptionsDomainButton specificSiteActions /> }
 			</SectionHeader>
 		);
 	}

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
@@ -179,157 +178,155 @@ export default function () {
 		domainManagementController.domainManagementTransferIn
 	);
 
-	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
-		page(
-			'/domains/add',
-			siteSelection,
-			domainsController.domainsAddHeader,
-			domainsController.redirectToUseYourDomainIfVipSite(),
-			domainsController.jetpackNoDomainsWarning,
-			sites,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/domains/add',
+		siteSelection,
+		domainsController.domainsAddHeader,
+		domainsController.redirectToUseYourDomainIfVipSite(),
+		domainsController.jetpackNoDomainsWarning,
+		sites,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/domains/add/mapping',
-			siteSelection,
-			domainsController.domainsAddHeader,
-			domainsController.jetpackNoDomainsWarning,
-			sites,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/domains/add/mapping',
+		siteSelection,
+		domainsController.domainsAddHeader,
+		domainsController.jetpackNoDomainsWarning,
+		sites,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/domains/add/transfer',
-			siteSelection,
-			domainsController.domainsAddHeader,
-			domainsController.jetpackNoDomainsWarning,
-			sites,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/domains/add/transfer',
+		siteSelection,
+		domainsController.domainsAddHeader,
+		domainsController.jetpackNoDomainsWarning,
+		sites,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/domains/add/site-redirect',
-			siteSelection,
-			domainsController.domainsAddRedirectHeader,
-			domainsController.jetpackNoDomainsWarning,
-			sites,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/domains/add/site-redirect',
+		siteSelection,
+		domainsController.domainsAddRedirectHeader,
+		domainsController.jetpackNoDomainsWarning,
+		sites,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/domains/add/:domain',
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.redirectToUseYourDomainIfVipSite(),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.domainSearch,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/domains/add/:domain',
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add' ),
+		domainsController.redirectToUseYourDomainIfVipSite(),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.domainSearch,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/domains/add/:domain/email/:siteSlug',
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.emailUpsellForDomainRegistration,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/domains/add/:domain/email/:siteSlug',
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add' ),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.emailUpsellForDomainRegistration,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/domains/add/suggestion/:suggestion/:domain',
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.redirectToUseYourDomainIfVipSite(),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.redirectToDomainSearchSuggestion
-		);
+	page(
+		'/domains/add/suggestion/:suggestion/:domain',
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add' ),
+		domainsController.redirectToUseYourDomainIfVipSite(),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.redirectToDomainSearchSuggestion
+	);
 
-		page(
-			'/domains/add/mapping/:domain',
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add/mapping' ),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.mapDomain,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/domains/add/mapping/:domain',
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add/mapping' ),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.mapDomain,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			paths.domainMappingSetup( ':site', ':domain' ),
-			siteSelection,
-			navigation,
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.mapDomainSetup,
-			makeLayout,
-			clientRender
-		);
+	page(
+		paths.domainMappingSetup( ':site', ':domain' ),
+		siteSelection,
+		navigation,
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.mapDomainSetup,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/domains/add/site-redirect/:domain',
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add/site-redirect' ),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.siteRedirect,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/domains/add/site-redirect/:domain',
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add/site-redirect' ),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.siteRedirect,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			paths.domainTransferIn( ':domain' ),
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add/transfer' ),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.transferDomain,
-			makeLayout,
-			clientRender
-		);
+	page(
+		paths.domainTransferIn( ':domain' ),
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add/transfer' ),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.transferDomain,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			paths.domainUseYourDomain( ':site' ),
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.useYourDomain,
-			makeLayout,
-			clientRender
-		);
+	page(
+		paths.domainUseYourDomain( ':site' ),
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add' ),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.useYourDomain,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			paths.domainUseMyDomain( ':site' ),
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.useMyDomain,
-			makeLayout,
-			clientRender
-		);
+	page(
+		paths.domainUseMyDomain( ':site' ),
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add' ),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.useMyDomain,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			paths.domainManagementTransferInPrecheck( ':site', ':domain' ),
-			siteSelection,
-			navigation,
-			domainsController.redirectIfNoSite( '/domains/manage' ),
-			domainsController.jetpackNoDomainsWarning,
-			domainsController.transferDomainPrecheck,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		paths.domainManagementTransferInPrecheck( ':site', ':domain' ),
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/manage' ),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.transferDomainPrecheck,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/domains/:site',

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -46,7 +45,7 @@ class PlansNavigation extends Component {
 		const { site, shouldShowMyPlan, translate } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
-		const hasPinnedItems = isMobile() && config.isEnabled( 'upgrades/checkout' ) && site;
+		const hasPinnedItems = isMobile() && site;
 
 		return (
 			site && (
@@ -100,7 +99,7 @@ function CartToggleButton( {
 	path,
 	closeSectionNavMobilePanel,
 } ) {
-	if ( ! config.isEnabled( 'upgrades/checkout' ) || ! site ) {
+	if ( ! site ) {
 		return null;
 	}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { isBusiness, FEATURE_NO_BRANDING, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
 import languages from '@automattic/languages';
@@ -173,22 +172,25 @@ export class SiteSettingsFormGeneral extends Component {
 
 	blogAddress() {
 		const { site, siteIsJetpack, siteSlug, translate, isWPForTeamsSite } = this.props;
-		let customAddress = '';
-		let addressDescription = '';
-
 		if ( ! site || siteIsJetpack || isWPForTeamsSite ) {
 			return null;
 		}
 
-		if ( config.isEnabled( 'upgrades/domain-search' ) ) {
-			customAddress = (
-				<Button href={ '/domains/add/' + siteSlug } onClick={ this.trackUpgradeClick }>
-					<Gridicon icon="plus" />{ ' ' }
-					{ translate( 'Add custom address', { context: 'Site address, domain' } ) }
-				</Button>
-			);
-
-			addressDescription = (
+		return (
+			<FormFieldset className="site-settings__has-divider">
+				<FormLabel htmlFor="blogaddress">{ translate( 'Site address' ) }</FormLabel>
+				<div className="site-settings__blogaddress-settings">
+					<FormInput
+						name="blogaddress"
+						id="blogaddress"
+						value={ site.domain }
+						disabled="disabled"
+					/>
+					<Button href={ '/domains/add/' + siteSlug } onClick={ this.trackUpgradeClick }>
+						<Gridicon icon="plus" />{ ' ' }
+						{ translate( 'Add custom address', { context: 'Site address, domain' } ) }
+					</Button>
+				</div>
 				<FormSettingExplanation>
 					{ translate(
 						'Buy a {{domainSearchLink}}custom domain{{/domainSearchLink}}, ' +
@@ -221,22 +223,6 @@ export class SiteSettingsFormGeneral extends Component {
 						</a>
 					) }
 				</FormSettingExplanation>
-			);
-		}
-
-		return (
-			<FormFieldset className="site-settings__has-divider">
-				<FormLabel htmlFor="blogaddress">{ translate( 'Site address' ) }</FormLabel>
-				<div className="site-settings__blogaddress-settings">
-					<FormInput
-						name="blogaddress"
-						id="blogaddress"
-						value={ site.domain }
-						disabled="disabled"
-					/>
-					{ customAddress }
-				</div>
-				{ addressDescription }
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -78,11 +78,6 @@ class SiteTools extends Component {
 		const cloneTitle = translate( 'Clone', { context: 'verb' } );
 		const cloneText = translate( 'Clone your existing site and all its data to a new location.' );
 
-		let changeAddressText = translate( "Register a new domain or change your site's address." );
-		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
-			changeAddressText = translate( 'Change your site address.' );
-		}
-
 		return (
 			<div className="site-tools">
 				<QueryRewindState siteId={ siteId } />
@@ -92,7 +87,7 @@ class SiteTools extends Component {
 						href={ changeAddressLink }
 						onClick={ this.trackChangeAddress }
 						title={ changeSiteAddress }
-						description={ changeAddressText }
+						description={ translate( "Register a new domain or change your site's address." ) }
 					/>
 				) }
 				{ showClone && (

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -15,13 +15,6 @@ jest.mock(
 		}
 );
 
-jest.mock( '@automattic/calypso-config', () => {
-	const mock = jest.fn();
-	mock.isEnabled = jest.fn();
-
-	return mock;
-} );
-
 import {
 	PLAN_FREE,
 	PLAN_BLOGGER,
@@ -81,6 +74,7 @@ function renderWithRedux( ui ) {
 const props = {
 	site: {
 		plan: { product_slug: PLAN_FREE },
+		domain: 'example.wordpress.com',
 	},
 	selectedSite: {},
 	translate: ( x ) => x,
@@ -106,7 +100,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 					<SiteSettingsFormGeneral
 						{ ...props }
 						siteIsJetpack={ false }
-						site={ { plan: { product_slug: plan } } }
+						site={ { plan: { product_slug: plan }, domain: 'example.wordpress.com' } }
 					/>
 				);
 				expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
@@ -120,7 +114,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 					<SiteSettingsFormGeneral
 						{ ...props }
 						siteIsJetpack={ false }
-						site={ { plan: { product_slug: plan } } }
+						site={ { plan: { product_slug: plan }, domain: 'example.wordpress.com' } }
 					/>
 				);
 				expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
@@ -141,7 +135,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			testProps = {
 				...props,
 				siteIsJetpack: false,
-				site: { plan: { product_slug: PLAN_PERSONAL } },
+				site: { plan: { product_slug: PLAN_PERSONAL }, domain: 'example.wordpress.com' },
 				fields: {
 					blog_public: 1,
 					wpcom_coming_soon: 0,

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { mapValues, pickBy, flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
@@ -33,48 +32,44 @@ const identity = ( theme ) => theme;
 function getAllThemeOptions( { translate, blockEditorSettings } ) {
 	const isFSEActive = blockEditorSettings?.is_fse_active ?? false;
 
-	const purchase = config.isEnabled( 'upgrades/checkout' )
-		? {
-				label: translate( 'Purchase', {
-					context: 'verb',
-				} ),
-				extendedLabel: translate( 'Purchase this design' ),
-				header: translate( 'Purchase on:', {
-					context: 'verb',
-					comment: 'label for selecting a site for which to purchase a theme',
-				} ),
-				getUrl: getThemePurchaseUrl,
-				hideForTheme: ( state, themeId, siteId ) =>
-					isJetpackSite( state, siteId ) || // No individual theme purchase on a JP site
-					! isUserLoggedIn( state ) || // Not logged in
-					! isThemePremium( state, themeId ) || // Not a premium theme
-					isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
-					isThemeActive( state, themeId, siteId ), // Already active
-		  }
-		: {};
+	const purchase = {
+		label: translate( 'Purchase', {
+			context: 'verb',
+		} ),
+		extendedLabel: translate( 'Purchase this design' ),
+		header: translate( 'Purchase on:', {
+			context: 'verb',
+			comment: 'label for selecting a site for which to purchase a theme',
+		} ),
+		getUrl: getThemePurchaseUrl,
+		hideForTheme: ( state, themeId, siteId ) =>
+			isJetpackSite( state, siteId ) || // No individual theme purchase on a JP site
+			! isUserLoggedIn( state ) || // Not logged in
+			! isThemePremium( state, themeId ) || // Not a premium theme
+			isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
+			isThemeActive( state, themeId, siteId ), // Already active
+	};
 
-	const upgradePlan = config.isEnabled( 'upgrades/checkout' )
-		? {
-				label: translate( 'Upgrade to activate', {
-					comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
-				} ),
-				extendedLabel: translate( 'Upgrade to activate', {
-					comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
-				} ),
-				header: translate( 'Upgrade on:', {
-					context: 'verb',
-					comment: 'label for selecting a site for which to upgrade a plan',
-				} ),
-				getUrl: ( state, themeId, siteId ) =>
-					getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ),
-				hideForTheme: ( state, themeId, siteId ) =>
-					! isJetpackSite( state, siteId ) ||
-					! isUserLoggedIn( state ) ||
-					! isThemePremium( state, themeId ) ||
-					isThemeActive( state, themeId, siteId ) ||
-					isPremiumThemeAvailable( state, themeId, siteId ),
-		  }
-		: {};
+	const upgradePlan = {
+		label: translate( 'Upgrade to activate', {
+			comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
+		} ),
+		extendedLabel: translate( 'Upgrade to activate', {
+			comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
+		} ),
+		header: translate( 'Upgrade on:', {
+			context: 'verb',
+			comment: 'label for selecting a site for which to upgrade a plan',
+		} ),
+		getUrl: ( state, themeId, siteId ) =>
+			getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ),
+		hideForTheme: ( state, themeId, siteId ) =>
+			! isJetpackSite( state, siteId ) ||
+			! isUserLoggedIn( state ) ||
+			! isThemePremium( state, themeId ) ||
+			isThemeActive( state, themeId, siteId ) ||
+			isPremiumThemeAvailable( state, themeId, siteId ),
+	};
 
 	const activate = {
 		label: translate( 'Activate' ),

--- a/config/development.json
+++ b/config/development.json
@@ -151,7 +151,6 @@
 		"themes/premium": false,
 		"titan/iframe-control-panel": false,
 		"tools/migrate": true,
-		"upgrades/checkout": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/development.json
+++ b/config/development.json
@@ -152,7 +152,6 @@
 		"titan/iframe-control-panel": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
-		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -97,7 +97,6 @@
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,
-		"upgrades/checkout": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,7 +98,6 @@
 		"support-user": true,
 		"themes/premium": false,
 		"upgrades/checkout": true,
-		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -102,7 +102,6 @@
 		"support-user": true,
 		"themes/premium": false,
 		"tools/migrate": true,
-		"upgrades/checkout": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -103,7 +103,6 @@
 		"themes/premium": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
-		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -103,7 +103,6 @@
 		"support-user": true,
 		"themes/premium": false,
 		"tools/migrate": true,
-		"upgrades/checkout": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -104,7 +104,6 @@
 		"themes/premium": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
-		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/test.json
+++ b/config/test.json
@@ -78,7 +78,6 @@
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": true,
-		"upgrades/checkout": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/test.json
+++ b/config/test.json
@@ -79,7 +79,6 @@
 		"support-user": true,
 		"themes/premium": true,
 		"upgrades/checkout": true,
-		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -114,7 +114,6 @@
 		"themes/premium": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
-		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -113,7 +113,6 @@
 		"support-user": true,
 		"themes/premium": false,
 		"tools/migrate": true,
-		"upgrades/checkout": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up a couple of feature flags that have been around since the pre-OSS era, and are always enabled everywhere:

* `upgrades/checkout`
* `upgrades/domain-search`

This PR might be easier to review per commit. It contains 2 commits that remove usage, and 2 commits that remove the actual feature flags.

#### Testing instructions

Shouldn't be necessary, just verify changes make sense and flags are no longer used anywhere.