### PR TITLE
Components: Refactor away from `UNSAFE_` in `FormPhoneInput`

### DIFF
--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -84,12 +84,12 @@
 				align-items: center;
 			}
 
-			.form-fieldset__country {
+			.form-phone-input__country {
 				flex: 0;
 				padding-right: 24px;
 			}
 
-			.form-fieldset__phone-number {
+			.form-phone-input__phone-number {
 				flex: 1;
 			}
 		}

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -48,7 +48,7 @@ export class FormPhoneInput extends Component {
 	render() {
 		return (
 			<div className={ classnames( this.props.className, 'form-phone-input' ) }>
-				<FormFieldset className="form-fieldset__country">
+				<FormFieldset className="form-phone-input__country">
 					<FormLabel htmlFor="country_code">
 						{ this.props.translate( 'Country code', {
 							context: 'The country code for the phone for the user.',
@@ -64,7 +64,7 @@ export class FormPhoneInput extends Component {
 					/>
 				</FormFieldset>
 
-				<FormFieldset className="form-fieldset__phone-number">
+				<FormFieldset className="form-phone-input__phone-number">
 					<FormLabel htmlFor="phone_number">{ this.props.translate( 'Phone number' ) }</FormLabel>
 					<FormTelInput
 						{ ...this.props.phoneInputProps }

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -36,8 +36,7 @@ export class FormPhoneInput extends Component {
 		phoneNumber: this.props.initialPhoneNumber || '',
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.maybeSetCountryStateFromList();
 	}
 

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -113,7 +113,7 @@
 		margin-bottom: 0;
 	}
 
-	.form-fieldset__phone-number {
+	.form-phone-input__phone-number {
 		margin-top: 20px;
 
 		@include breakpoint-deprecated( '>480px' ) {

--- a/client/me/security-2fa-sms-settings/style.scss
+++ b/client/me/security-2fa-sms-settings/style.scss
@@ -11,7 +11,7 @@
 	}
 }
 
-.security-2fa-sms-settings__fieldset-container .form-fieldset__country {
+.security-2fa-sms-settings__fieldset-container .form-phone-input__country {
 	flex: 1;
 	padding-right: 0;
 
@@ -26,7 +26,7 @@
 	overflow: ellipsis;
 }
 
-.security-2fa-sms-settings__fieldset-container .form-fieldset__phone-number {
+.security-2fa-sms-settings__fieldset-container .form-phone-input__phone-number {
 	flex: 2;
 	margin-bottom: 5px;
 }

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -11,7 +11,7 @@
 	}
 }
 
-.security-account-recovery-contact__detail .form-fieldset__country {
+.security-account-recovery-contact__detail .form-phone-input__country {
 	padding-right: 0;
 
 	@include breakpoint-deprecated( '>480px' ) {
@@ -30,7 +30,7 @@
 	}
 }
 
-.security-account-recovery-contact__detail .form-fieldset__phone-number {
+.security-account-recovery-contact__detail .form-phone-input__phone-number {
 	margin-bottom: 0;
 
 	@include breakpoint-deprecated( '>480px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `FormPhoneInput` component away from the `UNSAFE_` deprecated React component methods.

We also use the opportunity to fix a couple of class names that were not following the `wpcalypso/jsx-classname-namespace` ESLint rule.

Part of #58453.

#### Testing instructions

* Go to `/devdocs/design/form-fields`
* Scroll down to the "Form Phone Input"
* Verify that it still has a pre-selected value and works the same way as before.