### PR TITLE
Migrate wpcom.undocumented().changeTheme() to wpcom.req

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -337,9 +337,10 @@ export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 
 	const theme = themeSlugWithRepo.split( '/' )[ 1 ];
 
-	wpcom.undocumented().changeTheme( siteSlug, { theme }, function ( errors ) {
-		callback( isEmpty( errors ) ? undefined : [ errors ] );
-	} );
+	wpcom.req
+		.post( `/sites/${ siteSlug }/themes/mine`, { theme } )
+		.then( () => callback() )
+		.catch( ( error ) => callback( [ error ] ) );
 }
 
 export function setDesignOnSite( callback, { siteSlug, selectedDesign } ) {
@@ -350,10 +351,8 @@ export function setDesignOnSite( callback, { siteSlug, selectedDesign } ) {
 
 	const { theme } = selectedDesign;
 
-	Promise.resolve()
-		.then( () =>
-			wpcom.undocumented().changeTheme( siteSlug, { theme, dont_change_homepage: true } )
-		)
+	wpcom.req
+		.post( `/sites/${ siteSlug }/themes/mine`, { theme, dont_change_homepage: true } )
 		.then( () =>
 			wpcom.req.post( {
 				path: `/sites/${ siteSlug }/theme-setup`,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -154,24 +154,6 @@ Undocumented.prototype.transferToSite = function ( siteId, domainName, targetSit
 	);
 };
 
-/*
- * Change the theme of a given site.
- *
- * @param {string} [siteSlug]
- * @param {string} [data]
- * @param {Function} fn
- */
-Undocumented.prototype.changeTheme = function ( siteSlug, data, fn ) {
-	debug( '/site/:site_id/themes/mine' );
-	return this.wpcom.req.post(
-		{
-			path: '/sites/' + siteSlug + '/themes/mine',
-			body: data,
-		},
-		fn
-	);
-};
-
 Undocumented.prototype.isSiteImportable = function ( site_url ) {
 	debug( `/wpcom/v2/imports/is-site-importable?${ site_url }` );
 


### PR DESCRIPTION
The `changeTheme` method is identical to `activateTheme` already migrated in #58239, except parameter order, and is used only in signup.

**How to test:**
Go to `/start/setup-site?siteSlug=example.blog` and start a signup flow to setup your (existing) site. One of the steps will be choosing and activating a theme. Verify that the `themes/mine` endpoint is indeed called and the selected theme is set.