### PR TITLE
Simplify usages of TranslateResult

### DIFF
--- a/client/blocks/jetpack-benefits/benefit-card.tsx
+++ b/client/blocks/jetpack-benefits/benefit-card.tsx
@@ -3,7 +3,7 @@ import { TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 
 interface Props {
-	stat?: TranslateResult | string | number | null;
+	stat?: TranslateResult;
 	headline: TranslateResult;
 	description: TranslateResult;
 	placeholder?: boolean | null;

--- a/client/components/backup-storage-space/hooks.ts
+++ b/client/components/backup-storage-space/hooks.ts
@@ -19,7 +19,7 @@ const bytesToUnit = ( bytes: number, unit: StorageUnits ) => bytes / unit;
 export const useStorageUsageText = (
 	bytesUsed: number | undefined,
 	bytesAvailable: number | undefined
-): TranslateResult | null => {
+): TranslateResult => {
 	const translate = useTranslate();
 
 	return useMemo( () => {

--- a/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
+++ b/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
@@ -2,7 +2,7 @@ import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { StorageUsageLevels } from '../storage-usage-levels';
 
-const useStorageStatusText = ( usageLevel: StorageUsageLevels ): TranslateResult | null => {
+const useStorageStatusText = ( usageLevel: StorageUsageLevels ): TranslateResult => {
 	const translate = useTranslate();
 
 	// TODO: For StorageUsageLevels.Warning, estimate how many days until

--- a/client/components/jetpack/backup-card/hooks.ts
+++ b/client/components/jetpack/backup-card/hooks.ts
@@ -8,7 +8,7 @@ import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
-type GetDisplayDateHook = () => ( date: Moment ) => TranslateResult | undefined;
+type GetDisplayDateHook = () => ( date: Moment ) => TranslateResult;
 
 // We format a bit differently here than in
 // calypso/components/jetpack/daily-backup-status

--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -8,7 +8,6 @@ import Paid from './paid';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
 import type { TranslateResult } from 'i18n-calypso';
 import type { Moment } from 'moment';
-import type { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -27,7 +26,7 @@ type OwnProps = {
 	showAbovePriceText?: boolean;
 	originalPrice: number;
 	productName: TranslateResult;
-	tooltipText?: TranslateResult | ReactNode;
+	tooltipText?: TranslateResult;
 };
 
 const DisplayPrice: React.FC< OwnProps > = ( {

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -8,7 +8,6 @@ import { getJetpackSaleCouponDiscountRatio } from 'calypso/state/marketing/selec
 import TimeFrame from './time-frame';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
 import type { Moment } from 'moment';
-import type { ReactNode } from 'react';
 
 type OwnProps = {
 	discountedPrice?: number;
@@ -16,7 +15,7 @@ type OwnProps = {
 	billingTerm: Duration;
 	currencyCode?: string | null;
 	displayFrom?: boolean;
-	tooltipText?: TranslateResult | ReactNode;
+	tooltipText?: TranslateResult;
 	expiryDate?: Moment;
 	hideSavingLabel?: boolean;
 };

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -33,10 +33,10 @@ type OwnProps = {
 	isDeprecated?: boolean;
 	isAligned?: boolean;
 	isDisabled?: boolean;
-	disabledMessage?: TranslateResult | null;
+	disabledMessage?: TranslateResult;
 	displayFrom?: boolean;
-	tooltipText?: TranslateResult | ReactNode;
-	aboveButtonText?: TranslateResult | ReactNode;
+	tooltipText?: TranslateResult;
+	aboveButtonText?: TranslateResult;
 	featuredLabel?: TranslateResult;
 	hideSavingLabel?: boolean;
 	showAbovePriceText?: boolean;

--- a/client/components/jetpack/log-item/index.tsx
+++ b/client/components/jetpack/log-item/index.tsx
@@ -8,12 +8,12 @@ import './style.scss';
 export interface Props {
 	children?: ReactNode;
 	className?: string;
-	header: string | i18nCalypso.TranslateResult;
-	subheader?: string | ReactNode;
+	header: ReactNode;
+	subheader?: ReactNode;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;
-	summary?: string | ReactNode;
-	expandedSummary?: string | ReactNode;
+	summary?: ReactNode;
+	expandedSummary?: ReactNode;
 	clickableHeader?: boolean;
 	onClick?: () => void;
 }

--- a/client/components/jetpack/server-credentials-wizard-dialog/index.tsx
+++ b/client/components/jetpack/server-credentials-wizard-dialog/index.tsx
@@ -18,7 +18,7 @@ interface Props {
 	children: React.ReactNode;
 	buttons?: React.ReactNode;
 	baseDialogClassName?: string;
-	title: i18nCalypso.TranslateResult;
+	title: React.ReactNode;
 	titleClassName?: string;
 }
 

--- a/client/components/jetpack/threat-description/index.tsx
+++ b/client/components/jetpack/threat-description/index.tsx
@@ -1,4 +1,4 @@
-import { translate, TranslateResult } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { PureComponent, ReactNode } from 'react';
 import DiffViewer from 'calypso/components/diff-viewer';
 import { ThreatStatus } from 'calypso/components/jetpack/threat-item/types';
@@ -20,7 +20,7 @@ export interface Props {
 }
 
 class ThreatDescription extends PureComponent< Props > {
-	renderTextOrNode( content: string | TranslateResult | ReactNode ) {
+	renderTextOrNode( content: ReactNode ) {
 		return <>{ content }</>;
 	}
 
@@ -30,7 +30,6 @@ class ThreatDescription extends PureComponent< Props > {
 		switch ( status ) {
 			case 'fixed':
 				return translate( 'How did Jetpack fix it?' );
-				break;
 
 			case 'current':
 				if ( isFixable ) {
@@ -38,11 +37,8 @@ class ThreatDescription extends PureComponent< Props > {
 				}
 				return translate( 'Resolving the threat' );
 
-				break;
-
 			default:
 				return translate( 'How we will fix it?' );
-				break;
 		}
 	}
 

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import classnames from 'classnames';
-import { translate } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
@@ -70,7 +70,7 @@ const ThreatItem: React.FC< Props > = ( {
 		[ isFixing, onFixThreat, threat ]
 	);
 
-	const getFix = React.useCallback( (): i18nCalypso.TranslateResult | undefined => {
+	const getFix = React.useCallback( (): TranslateResult => {
 		if ( threat.status === 'fixed' ) {
 			return;
 		}

--- a/client/components/jetpack/threat-item/utils.ts
+++ b/client/components/jetpack/threat-item/utils.ts
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 import { Threat, ThreatFix, ThreatType } from './types';
 
 export function getThreatType( threat: Threat ): ThreatType {
@@ -29,7 +29,7 @@ export function getThreatType( threat: Threat ): ThreatType {
 	return 'none';
 }
 
-export const getThreatVulnerability = ( threat: Threat ): string | i18nCalypso.TranslateResult => {
+export const getThreatVulnerability = ( threat: Threat ): TranslateResult => {
 	switch ( getThreatType( threat ) ) {
 		case 'core':
 			return translate( 'Vulnerability found in WordPress' );
@@ -56,7 +56,7 @@ export const getThreatVulnerability = ( threat: Threat ): string | i18nCalypso.T
 	}
 };
 
-export const getThreatFix = ( fixable: ThreatFix ): i18nCalypso.TranslateResult => {
+export const getThreatFix = ( fixable: ThreatFix ): TranslateResult => {
 	switch ( fixable.fixer ) {
 		case 'replace':
 			return translate( 'Jetpack Scan will replace the affected file or directory.' );

--- a/client/components/jetpack/upsell/index.tsx
+++ b/client/components/jetpack/upsell/index.tsx
@@ -5,14 +5,14 @@ import { FunctionComponent, ReactNode } from 'react';
 import './style.scss';
 
 interface Props {
-	bodyText: TranslateResult | ReactNode;
-	buttonLink?: TranslateResult;
+	bodyText: TranslateResult;
+	buttonLink?: string;
 	buttonText?: TranslateResult;
 	headerText: TranslateResult;
 	iconComponent?: ReactNode;
 	onClick?: () => void;
 	openButtonLinkOnNewTab?: boolean;
-	secondaryButtonLink?: TranslateResult;
+	secondaryButtonLink?: string;
 	secondaryButtonText?: TranslateResult;
 	secondaryOnClick?: () => void;
 }

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -37,7 +37,7 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, purchase, ..
 	const dispatch = useDispatch();
 	const [ cancellationStep, setCancellationStep ] = useState( steps.FEATURES_LOST_STEP ); // set initial state
 	const [ surveyAnswerId, setSurveyAnswerId ] = useState< string | null >( null );
-	const [ surveyAnswerText, setSurveyAnswerText ] = useState< TranslateResult | string >( '' );
+	const [ surveyAnswerText, setSurveyAnswerText ] = useState< TranslateResult >( '' );
 
 	const isAtomicSite = useSelector( ( state ) =>
 		isSiteAutomatedTransfer( state, purchase.siteId )
@@ -145,10 +145,7 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, purchase, ..
 		recordEvent( 'calypso_purchases_cancel_form_submit' );
 	};
 
-	const onSurveyAnswerChange = (
-		answerId: string | null,
-		answerText: TranslateResult | string
-	) => {
+	const onSurveyAnswerChange = ( answerId: string | null, answerText: TranslateResult ) => {
 		if ( answerId !== surveyAnswerId ) {
 			recordTracksEvent( 'calypso_purchases_cancel_jetpack_survey_answer_change', {
 				answer_id: answerId,

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -14,7 +14,7 @@ interface Choice {
 
 interface JetpackCancellationSurveyProps {
 	selectedAnswerId: string | null;
-	onAnswerChange: ( answerId: string | null, answerText: TranslateResult | string ) => void;
+	onAnswerChange: ( answerId: string | null, answerText: TranslateResult ) => void;
 }
 
 export default function JetpackCancellationSurvey( {

--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -5,7 +5,7 @@ import PromoCard, { Props as PromoCardProps } from './promo-card';
 import PromoCardCta, { Props as PromoCardCtaProps } from './promo-card/cta';
 
 interface PromoSectionCardProps extends PromoCardProps {
-	body: string | TranslateResult;
+	body: TranslateResult;
 	actions?: PromoCardCtaProps;
 }
 

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -17,7 +17,7 @@ interface CtaAction {
 }
 
 export interface CtaButton {
-	text: string | TranslateResult;
+	text: TranslateResult;
 	action: URL | ClickCallback | CtaAction;
 	component?: JSX.Element;
 }

--- a/client/components/promo-section/promo-card/index.tsx
+++ b/client/components/promo-section/promo-card/index.tsx
@@ -22,7 +22,7 @@ export interface Image {
 export interface Props {
 	icon: string;
 	image?: Image | ReactElement;
-	title?: string | TranslateResult;
+	title?: TranslateResult;
 	titleComponent?: ReactElement;
 	isPrimary?: boolean;
 	badge?: string | ReactElement;

--- a/client/components/promo-section/promo-card/price.tsx
+++ b/client/components/promo-section/promo-card/price.tsx
@@ -1,13 +1,12 @@
 import classnames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
-import type { ReactElement } from 'react';
+import type { FunctionComponent } from 'react';
 
 export interface Props {
 	/** Should be of the format: <span>$price</span> /interval, e.g. <span>$1</span> /year */
-	formattedPrice?: string | TranslateResult;
-	discount?: string | TranslateResult | null;
-	additionalPriceInformation?: string | TranslateResult | ReactElement;
+	formattedPrice?: TranslateResult;
+	discount?: TranslateResult;
+	additionalPriceInformation?: TranslateResult;
 }
 
 const PromoCardPrice: FunctionComponent< Props > = ( {

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -39,10 +39,10 @@ export type ThankYouProps = {
 	showSupportSection?: boolean;
 	customSupportSection?: ThankYouSupportSectionProps;
 	thankYouImage: {
-		alt: string | TranslateResult;
+		alt: string;
 		src: string;
 	};
-	thankYouTitle?: string | TranslateResult;
-	thankYouSubtitle?: string | TranslateResult;
+	thankYouTitle?: TranslateResult;
+	thankYouSubtitle?: TranslateResult;
 	thankYouNotice?: ThankYouNoticeProps;
 };

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
@@ -2,7 +2,7 @@ import { translate, TranslateResult } from 'i18n-calypso';
 
 export interface LinkAndInfo {
 	info?: TranslateResult;
-	link?: string | TranslateResult;
+	link?: TranslateResult;
 }
 
 enum InfoTypes {

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -14,7 +14,7 @@ import type { IncompleteRequestCartProduct } from 'calypso/lib/cart-values/cart-
 // exporting these in the big export below causes trouble
 export interface GSuiteNewUserField {
 	value: string;
-	error: TranslateResult | null;
+	error: TranslateResult;
 }
 
 export interface GSuiteNewUser {

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -192,7 +192,7 @@ function onPaymentSelectComplete( {
 }: {
 	successCallback: () => void;
 	translate: ReturnType< typeof useTranslate >;
-	showSuccessMessage: ( message: string | TranslateResult ) => void;
+	showSuccessMessage: ( message: TranslateResult ) => void;
 	purchase?: Purchase | undefined;
 } ) {
 	if ( purchase ) {
@@ -211,9 +211,7 @@ function CurrentPaymentMethodNotAvailableNotice( {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const storedPaymentAgreements = useSelector( getStoredPaymentAgreements );
-	const noticeProps: Record< string, boolean | string | number | TranslateResult > = {
-		showDismiss: false,
-	};
+	const noticeProps: Record< string, TranslateResult > = { showDismiss: false };
 
 	if ( purchase.payment.creditCard && creditCardHasAlreadyExpired( purchase ) ) {
 		noticeProps.text = translate(

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -29,7 +29,7 @@ interface Props {
 	isVisible: boolean;
 	onClose: () => void;
 	onConfirm: ( purchases: Purchase[] ) => void;
-	submitButtonText?: string | TranslateResult;
+	submitButtonText?: TranslateResult;
 	showManagePurchaseLinks?: boolean;
 	getManagePurchaseUrlFor?: ( siteSlug: string, purchaseId: number ) => string;
 }

--- a/client/my-sites/backup/rewind-flow/rewind-flow-notice/check-your-email.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-flow-notice/check-your-email.tsx
@@ -1,9 +1,9 @@
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import Notice, { RewindFlowNoticeLevel } from './index';
 
 interface Props {
-	message: i18nCalypso.TranslateResult;
+	message: TranslateResult;
 }
 
 const RewindFlowCheckYourEmail: FunctionComponent< Props > = ( { message } ) => {

--- a/client/my-sites/backup/rewind-flow/rewind-flow-notice/index.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-flow-notice/index.tsx
@@ -1,5 +1,5 @@
 import { Gridicon } from '@automattic/components';
-import { FunctionComponent } from 'react';
+import type { FunctionComponent, ReactNode } from 'react';
 
 enum RewindFlowNoticeLevel {
 	NOTICE,
@@ -10,8 +10,8 @@ enum RewindFlowNoticeLevel {
 interface Props {
 	gridicon: string;
 	link?: string;
-	message?: i18nCalypso.TranslateResult;
-	title: i18nCalypso.TranslateResult;
+	message?: ReactNode;
+	title: ReactNode;
 	type: RewindFlowNoticeLevel;
 }
 

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -123,7 +123,7 @@ function getMessagePrettifier(
 	translate: ReturnType< typeof useTranslate >,
 	selectedSiteSlug: string | null | undefined
 ) {
-	return function getPrettyMessage( message: ResponseCartMessage ): TranslateResult | string {
+	return function getPrettyMessage( message: ResponseCartMessage ): TranslateResult {
 		switch ( message.code ) {
 			case 'chargeback':
 				return getChargebackErrorMessage( { translate, selectedSiteSlug } );

--- a/client/my-sites/checkout/checkout-thank-you/use-get-jetpack-activation-confirmation-info.ts
+++ b/client/my-sites/checkout/checkout-thank-you/use-get-jetpack-activation-confirmation-info.ts
@@ -8,7 +8,7 @@ import {
 	JETPACK_VIDEOPRESS_PRODUCTS,
 } from '@automattic/calypso-products';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { createElement, ReactNode } from 'react';
+import { createElement } from 'react';
 import { useSelector } from 'react-redux';
 import successImageAntiSpam from 'calypso/assets/images/jetpack/licensing-activation-success-Anti-Spam.png';
 import successImageComplete from 'calypso/assets/images/jetpack/licensing-activation-success-Complete.png';
@@ -19,7 +19,7 @@ import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
 
 type ActivationConfirmationInfo = {
 	image: string;
-	text: TranslateResult | ReactNode;
+	text: TranslateResult;
 	buttonUrl: string;
 };
 

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -242,7 +242,7 @@ export function isValid( arg: ManagedValue ): boolean {
 function getInitialManagedValue( initialProperties?: {
 	value?: string;
 	isTouched?: boolean;
-	errors?: Array< string | TranslateResult >;
+	errors?: Array< TranslateResult >;
 } ): ManagedValue {
 	return {
 		value: '',
@@ -283,10 +283,7 @@ function setValueUnlessTouched(
 	return oldData.isTouched ? oldData : { ...oldData, value: newValue, errors: [] };
 }
 
-function setErrors(
-	errors: string[] | TranslateResult[] | undefined,
-	oldData: ManagedValue
-): ManagedValue {
+function setErrors( errors: TranslateResult[] | undefined, oldData: ManagedValue ): ManagedValue {
 	return undefined === errors ? { ...oldData, errors: [] } : { ...oldData, errors };
 }
 
@@ -459,7 +456,7 @@ function prepareUkDomainContactExtraDetailsErrors(
 ): UkDomainContactExtraDetailsErrors | null {
 	if ( details.tldExtraFields?.uk ) {
 		// Needed for compatibility with existing component props
-		const toErrorPayload = ( errorMessage: string | TranslateResult, index: number ) => {
+		const toErrorPayload = ( errorMessage: TranslateResult, index: number ) => {
 			return { errorCode: index.toString(), errorMessage };
 		};
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -19,7 +19,7 @@ export interface ProviderCard {
 	logo?: ReactElement | { path: string; className?: string };
 	onExpandedChange?: ( providerKey: string, expanded: boolean ) => void;
 	onButtonClick?: ( event: React.MouseEvent ) => void;
-	priceBadge?: ReactElement | TranslateResult;
+	priceBadge?: TranslateResult;
 	productName?: TranslateResult;
 	providerKey: string;
 	showExpandButton?: boolean;

--- a/client/my-sites/jetpack-search/content.tsx
+++ b/client/my-sites/jetpack-search/content.tsx
@@ -6,8 +6,8 @@ import JetpackUpsell from 'calypso/components/jetpack/upsell';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 interface Props {
-	bodyText: TranslateResult | ReactNode;
-	buttonLink?: TranslateResult;
+	bodyText: TranslateResult;
+	buttonLink?: string;
 	buttonText?: TranslateResult;
 	headerText: TranslateResult;
 	iconComponent?: ReactNode;

--- a/client/my-sites/plans/jetpack-plans/more-info-box/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/more-info-box/index.tsx
@@ -3,13 +3,12 @@ import * as React from 'react';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { PLAN_COMPARISON_PAGE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import type { TranslateResult } from 'i18n-calypso';
-import type { ReactNode } from 'react';
 
 import './style.scss';
 
 type MoreInfoProps = {
 	headline: TranslateResult;
-	buttonLabel: TranslateResult | ReactNode;
+	buttonLabel: TranslateResult;
 	onButtonClick?: () => void;
 };
 

--- a/client/my-sites/plans/jetpack-plans/product-card/product-above-button-text.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-above-button-text.ts
@@ -7,7 +7,7 @@ export default function productAboveButtonText(
 	siteProduct?: SiteProduct,
 	isOwned?: boolean,
 	isIncludedInPlan?: boolean
-): TranslateResult | null {
+): TranslateResult {
 	if (
 		! isOwned &&
 		! isIncludedInPlan &&

--- a/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
@@ -14,7 +14,7 @@ import type { PriceTierEntry } from '@automattic/calypso-products';
 export default function productTooltip(
 	product: SelectorProduct,
 	tiers: PriceTierEntry[]
-): null | TranslateResult {
+): TranslateResult {
 	if ( ! ( JETPACK_SEARCH_PRODUCTS as ReadonlyArray< string > ).includes( product.productSlug ) ) {
 		return null;
 	}

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -102,12 +102,12 @@ export interface SelectorProduct extends SelectorProductCost {
 	shortName: TranslateResult;
 	subheader?: TranslateResult;
 	tagline: TranslateResult;
-	description: TranslateResult | ReactNode;
+	description: TranslateResult;
 	children?: ReactNode;
 	term: Duration;
 	buttonLabel?: TranslateResult;
 	features: SelectorProductFeatures;
-	infoText?: TranslateResult | ReactNode;
+	infoText?: TranslateResult;
 	legacy?: boolean;
 	hidePrice?: boolean;
 	externalUrl?: string;

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, ProgressBar, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import { translate } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -72,7 +72,7 @@ class ScanPage extends Component< Props > {
 		);
 	}
 
-	renderHeader( text: i18nCalypso.TranslateResult ) {
+	renderHeader( text: TranslateResult ) {
 		return <h1 className="scan__header">{ text }</h1>;
 	}
 

--- a/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
+++ b/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
@@ -8,10 +8,7 @@ import type { TranslateResult } from 'i18n-calypso';
  * @param {Product} product Product purchase object
  * @returns {TranslateResult} Product display name
  */
-export function getJetpackProductCallToAction( product: Product ): TranslateResult | undefined {
-	const jetpackProductsCallToActions = getJetpackProductsCallToAction() as Record<
-		string,
-		TranslateResult
-	>;
+export function getJetpackProductCallToAction( product: Product ): TranslateResult {
+	const jetpackProductsCallToActions = getJetpackProductsCallToAction();
 	return jetpackProductsCallToActions[ product.product_slug ];
 }

--- a/packages/calypso-products/src/get-jetpack-product-description.ts
+++ b/packages/calypso-products/src/get-jetpack-product-description.ts
@@ -5,10 +5,7 @@ import type { TranslateResult } from 'i18n-calypso';
 /**
  * Get Jetpack product description based on the product purchase object.
  */
-export function getJetpackProductDescription( product: Product ): TranslateResult | undefined {
-	const jetpackProductsDescriptions = getJetpackProductsDescriptions() as Record<
-		string,
-		TranslateResult
-	>;
+export function getJetpackProductDescription( product: Product ): TranslateResult {
+	const jetpackProductsDescriptions = getJetpackProductsDescriptions();
 	return jetpackProductsDescriptions[ product.product_slug ];
 }

--- a/packages/calypso-products/src/get-jetpack-product-display-name.ts
+++ b/packages/calypso-products/src/get-jetpack-product-display-name.ts
@@ -5,7 +5,7 @@ import type { TranslateResult } from 'i18n-calypso';
 /**
  * Get Jetpack product display name based on the product purchase object.
  */
-export function getJetpackProductDisplayName( product: Product ): TranslateResult | undefined {
+export function getJetpackProductDisplayName( product: Product ): TranslateResult {
 	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
 	return jetpackProductsDisplayNames[ product.product_slug ];
 }

--- a/packages/calypso-products/src/get-jetpack-product-short-name.ts
+++ b/packages/calypso-products/src/get-jetpack-product-short-name.ts
@@ -5,7 +5,7 @@ import type { TranslateResult } from 'i18n-calypso';
 /**
  * Get Jetpack product short name based on the product purchase object.
  */
-export function getJetpackProductShortName( product: Product ): TranslateResult | undefined {
+export function getJetpackProductShortName( product: Product ): TranslateResult {
 	const jetpackProductShortNames = getJetpackProductsShortNames();
 	return jetpackProductShortNames[ product.product_slug ];
 }

--- a/packages/calypso-products/src/get-jetpack-product-tagline.ts
+++ b/packages/calypso-products/src/get-jetpack-product-tagline.ts
@@ -7,7 +7,7 @@ import type { TranslateResult } from 'i18n-calypso';
 export function getJetpackProductTagline(
 	product: { product_slug: string },
 	isOwned = false
-): TranslateResult | undefined {
+): TranslateResult {
 	const jetpackProductsTaglines = getJetpackProductsTaglines();
 	const productTagline = jetpackProductsTaglines[ product.product_slug ];
 	return isOwned ? productTagline?.owned || productTagline?.default : productTagline?.default;

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -324,7 +324,7 @@ export const useJetpack1TbStorageAmountText = (): TranslateResult => {
 
 export const useJetpackStorageAmountTextByProductSlug = (
 	productSlug: string
-): TranslateResult | undefined => {
+): TranslateResult => {
 	const TEN_GIGABYTES = useJetpack10GbStorageAmountText();
 	const ONE_TERABYTE = useJetpack1TbStorageAmountText();
 

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -144,20 +144,20 @@ export type PossiblyCompleteDomainContactDetails = {
 };
 
 export type DomainContactDetailsErrors = {
-	firstName?: string | TranslateResult;
-	lastName?: string | TranslateResult;
-	organization?: string | TranslateResult;
-	email?: string | TranslateResult;
-	alternateEmail?: string | TranslateResult;
-	phone?: string | TranslateResult;
-	address1?: string | TranslateResult;
-	address2?: string | TranslateResult;
-	city?: string | TranslateResult;
-	state?: string | TranslateResult;
-	postalCode?: string | TranslateResult;
-	countryCode?: string | TranslateResult;
-	fax?: string | TranslateResult;
-	vatId?: string | TranslateResult;
+	firstName?: TranslateResult;
+	lastName?: TranslateResult;
+	organization?: TranslateResult;
+	email?: TranslateResult;
+	alternateEmail?: TranslateResult;
+	phone?: TranslateResult;
+	address1?: TranslateResult;
+	address2?: TranslateResult;
+	city?: TranslateResult;
+	state?: TranslateResult;
+	postalCode?: TranslateResult;
+	countryCode?: TranslateResult;
+	fax?: TranslateResult;
+	vatId?: TranslateResult;
 	extra?: DomainContactDetailsErrorsExtra;
 };
 
@@ -168,22 +168,22 @@ type DomainContactDetailsErrorsExtra = {
 };
 
 export type CaDomainContactExtraDetailsErrors = {
-	lang?: string | TranslateResult;
-	legalType?: string | TranslateResult;
-	ciraAgreementAccepted?: string | TranslateResult;
+	lang?: TranslateResult;
+	legalType?: TranslateResult;
+	ciraAgreementAccepted?: TranslateResult;
 };
 
 export type UkDomainContactExtraDetailsErrors = {
-	registrantType?: { errorCode: string; errorMessage: string | TranslateResult }[];
-	registrationNumber?: { errorCode: string; errorMessage: string | TranslateResult }[];
-	tradingName?: { errorCode: string; errorMessage: string | TranslateResult }[];
+	registrantType?: { errorCode: string; errorMessage: TranslateResult }[];
+	registrationNumber?: { errorCode: string; errorMessage: TranslateResult }[];
+	tradingName?: { errorCode: string; errorMessage: TranslateResult }[];
 };
 
 export type FrDomainContactExtraDetailsErrors = {
-	registrantType?: string[] | TranslateResult[];
-	registrantVatId?: string[] | TranslateResult[];
-	trademarkNumber?: string[] | TranslateResult[];
-	sirenSiret?: string[] | TranslateResult[];
+	registrantType?: TranslateResult[];
+	registrantVatId?: TranslateResult[];
+	trademarkNumber?: TranslateResult[];
+	sirenSiret?: TranslateResult[];
 };
 
 export type PayPalExpressEndpoint = (
@@ -306,7 +306,7 @@ export type ManagedContactDetailsTldExtraFieldsShape< T > = {
 export type ManagedContactDetails = ManagedContactDetailsShape< ManagedValue >;
 
 export type ManagedContactDetailsErrors = ManagedContactDetailsShape<
-	undefined | string[] | TranslateResult[]
+	undefined | TranslateResult[]
 >;
 
 /*
@@ -324,7 +324,7 @@ export type ManagedContactDetailsUpdate = ManagedContactDetailsShape< string >;
 export interface ManagedValue {
 	value: string;
 	isTouched: boolean; // Has value been edited by the user?
-	errors: string[] | TranslateResult[]; // Has value passed validation?
+	errors: TranslateResult[]; // Has value passed validation?
 }
 
 export type WpcomStoreState = {


### PR DESCRIPTION
Remove all superflous `TranslateResult | something` types.