### PR TITLE
Tests: Remove unnecessary store mocks

### DIFF
--- a/client/components/domains/registrant-extra-info/test/ca-form.js
+++ b/client/components/domains/registrant-extra-info/test/ca-form.js
@@ -1,8 +1,6 @@
 import { shallow } from 'enzyme';
 import { RegistrantExtraInfoCaForm } from '../ca-form';
 
-jest.mock( 'store', () => ( { get: () => {}, set: () => {} } ) );
-
 const mockProps = {
 	translate: ( string ) => string,
 	updateContactDetailsCache: () => {},

--- a/client/components/domains/registrant-extra-info/test/index.js
+++ b/client/components/domains/registrant-extra-info/test/index.js
@@ -5,8 +5,6 @@ import RegistrantExtraInfoFrForm from '../fr-form';
 import RegistrantExtraInfoForm from '../index';
 import RegistrantExtraInfoUkForm from '../uk-form';
 
-jest.mock( 'store', () => ( { get: () => {}, set: () => {} } ) );
-
 describe( 'Switcher Form', () => {
 	test( 'should render correct form for fr', () => {
 		const wrapper = shallow( <RegistrantExtraInfoForm tld="fr" /> );

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -2,11 +2,6 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'store', () => ( {
-	get: () => {},
-	User: () => {},
-} ) );
-
 jest.mock(
 	'calypso/blocks/upsell-nudge',
 	() =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on fixing the tests for #58996, I noticed we still mock `store` here and there, without the need to do so anymore. This PR removes those mocks.

#### Testing instructions

Verify all tests pass.