### PR TITLE
Fix: consolidate importer E2E tests

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -16,7 +16,6 @@ const selectors = {
 	analyzeError: ( text: string ) => `div.capture__input-error-msg:text("${ text }")`,
 
 	// Headers
-	scanningHeader: 'h1:text("Scanning your site")',
 	setupHeader: 'h1:text("Themes")',
 	startBuildingHeader: ( text: string ) => `h1.onboarding-title:text("${ text }")`,
 
@@ -72,13 +71,6 @@ export class StartImportFlow {
 	 */
 	async validateErrorCapturePage( error: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.analyzeError( error ) );
-	}
-
-	/**
-	 * Validates that we've landed on the scanning page.
-	 */
-	async validateScanningPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.scanningHeader );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -1,4 +1,5 @@
 /**
+ * @group calypso-pr
  */
 
 import { DataHelper, LoginPage, setupHooks, StartImportFlow } from '@automattic/calypso-e2e';
@@ -37,7 +38,6 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		it( 'Start a WordPress import', async () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
-			await startImportFlow.validateScanningPage();
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
 
@@ -57,7 +57,6 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		it( `Start an invalid WordPress import (${ reason })`, async () => {
 			await startImportFlow.enterURL( url );
-			await startImportFlow.validateScanningPage();
 			await startImportFlow.validateBuildingPage( reason );
 			await startImportFlow.startBuilding();
 			await startImportFlow.validateSetupPage();
@@ -73,7 +72,6 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		it( 'Start an invalid WordPress import typo', async () => {
 			// 1.example.com is guaranteed never to be a valid DNS
 			await startImportFlow.enterURL( '1.example.com' );
-			await startImportFlow.validateScanningPage();
 			await startImportFlow.validateErrorCapturePage(
 				'The address you entered is not valid. Please try again.'
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the scanning page query selector

For more detailed information see https://github.com/Automattic/wp-calypso/pull/58491#issuecomment-985454796.

#### Testing instructions

Run `yarn jest specs/specs-playwright/wp-start__importer.ts`

Related to #58491, #58715
