### PR TITLE
Components: Migrate `LocaleSuggestions` away from `UNSAFE_` methods

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -28,8 +28,7 @@ export class LocaleSuggestions extends Component {
 		dismissed: false,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		let { locale } = this.props;
 
 		if ( ! locale && typeof navigator === 'object' && 'languages' in navigator ) {
@@ -45,10 +44,9 @@ export class LocaleSuggestions extends Component {
 		this.props.setLocale( locale );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.locale !== nextProps.locale ) {
-			this.props.setLocale( nextProps.locale );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.locale !== this.props.locale ) {
+			this.props.setLocale( this.props.locale );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `LocaleSuggestions` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions

* Go to `/log-in/new/link/es` as a logged out user.
* Verify you can see the locale suggestions (that this is also available in English)
* Click the English link to switch to English.
* Verify that once the page switches to English, the locale suggestions are no longer shown.