### PR TITLE
Fix react warning: ref used on function component

### DIFF
--- a/client/components/forms/form-label/index.tsx
+++ b/client/components/forms/form-label/index.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { Children, FunctionComponent, LabelHTMLAttributes } from 'react';
+import { Children, FunctionComponent, LabelHTMLAttributes, forwardRef } from 'react';
 
 import './style.scss';
 
@@ -11,28 +11,36 @@ interface Props {
 
 type LabelProps = LabelHTMLAttributes< HTMLLabelElement >;
 
-const FormLabel: FunctionComponent< Props & LabelProps > = ( {
-	children,
-	required,
-	optional,
-	className, // Via LabelProps
-	...labelProps
-} ) => {
-	const translate = useTranslate();
+const FormLabel: FunctionComponent< Props & LabelProps > = forwardRef<
+	HTMLLabelElement,
+	Props & LabelProps
+>(
+	(
+		{
+			children,
+			required,
+			optional,
+			className, // Via LabelProps
+			...labelProps
+		},
+		ref
+	) => {
+		const translate = useTranslate();
 
-	const hasChildren: boolean = Children.count( children ) > 0;
+		const hasChildren: boolean = Children.count( children ) > 0;
 
-	return (
-		<label { ...labelProps } className={ classnames( className, 'form-label' ) }>
-			{ children }
-			{ hasChildren && required && (
-				<small className="form-label__required">{ translate( 'Required' ) }</small>
-			) }
-			{ hasChildren && optional && (
-				<small className="form-label__optional">{ translate( 'Optional' ) }</small>
-			) }
-		</label>
-	);
-};
+		return (
+			<label ref={ ref } { ...labelProps } className={ classnames( className, 'form-label' ) }>
+				{ children }
+				{ hasChildren && required && (
+					<small className="form-label__required">{ translate( 'Required' ) }</small>
+				) }
+				{ hasChildren && optional && (
+					<small className="form-label__optional">{ translate( 'Optional' ) }</small>
+				) }
+			</label>
+		);
+	}
+);
 
 export default FormLabel;


### PR DESCRIPTION
On  `DeleteUser` component a `ref` is added to the `FormLabel` component.

```
...
   <FormFieldset>
      <FormLabel ref={ this.setReassignLabel }>
         <FormRadio
...
```

But `FormLabel` is a function component, so `ref`s don't work out of the box.

![image](https://user-images.githubusercontent.com/3801502/139489770-1d5e6bc3-d8c5-4463-8aa7-71ff0ea3cc91.png)

This PR uses `React.forwardRef()` to forward the ref to `FormLabel`'s child DOM element, a `<label />`

By doing this, the error disappears and, in this specific use case, the intended behavior is set: when clicking the label, the popover doesn't close.

![image](https://user-images.githubusercontent.com/3801502/139490995-0388e11c-e001-4079-8702-0c5296263776.png)


#### Testing instructions

- Open Calypso on any site.
- Go to Users
- Click on a member from the list
- Check the browser log