### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` is site importable to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,7 +1,3 @@
-import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
-
 /**
  * Create an `Undocumented` instance
  *
@@ -84,15 +80,6 @@ Undocumented.prototype.getDnsTemplateRecords = function (
 		'/domains/' + domain + '/dns/providers/' + provider + '/services/' + service + '/preview',
 		{ variables },
 		callback
-	);
-};
-
-Undocumented.prototype.isSiteImportable = function ( site_url ) {
-	debug( `/wpcom/v2/imports/is-site-importable?${ site_url }` );
-
-	return this.wpcom.req.get(
-		{ path: '/imports/is-site-importable', apiNamespace: 'wpcom/v2' },
-		{ site_url }
 	);
 };
 

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -8,13 +8,11 @@ import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import HeaderCake from 'calypso/components/header-cake';
 import Notice from 'calypso/components/notice';
-import wpLib from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import SitesBlock from 'calypso/my-sites/migrate/components/sites-block';
 import { getImportSectionLocation, redirectTo } from 'calypso/my-sites/migrate/helpers';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import './section-migrate.scss';
-
-const wpcom = wpLib.undocumented();
 
 class StepSourceSelect extends Component {
 	static propTypes = {
@@ -47,8 +45,11 @@ class StepSourceSelect extends Component {
 		const validEngines = [ 'wordpress', 'blogger', 'medium', 'wix', 'godaddy', 'squarespace' ];
 
 		this.setState( { error: null, isLoading: true }, () => {
-			wpcom
-				.isSiteImportable( this.props.url )
+			wpcom.req
+				.get(
+					{ path: '/imports/is-site-importable', apiNamespace: 'wpcom/v2' },
+					{ site_url: this.props.url }
+				)
 				.then( ( result ) => {
 					const importUrl = `/import/${ this.props.targetSiteSlug }?not-wp=1&engine=${ result.site_engine }&from-site=${ result.site_url }`;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` method that checks whether a site is importable to `wpcom.req`. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Go to `/migrate/:site` where `:site` is a WP.com simple site.
* In the `Import from…` field, input the URL of a Jetpack site.
* Click the `Continue` button.
* Verify the request to `/imports/is-site-importable` is successful and you're presented with the next step that asks you what to import, and the site name and URL are properly populated in the site card above.