### PR TITLE
Migrate to using UNIX TS to store the event date and respect the sites timezone

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
@@ -18,6 +18,7 @@ const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
  * @returns a moment instance
  */
 function assignTimezone( date, offset, format = TIMEZONELESS_FORMAT ) {
+	// passing the `true` flag to `utcOffset` keeps the date unaltered, only adds a tz
 	return moment( date, format ).utcOffset( offset * 60, true );
 }
 
@@ -30,6 +31,7 @@ const edit = ( { attributes, setAttributes, className } ) => {
 	if ( attributes.eventTimestamp ) {
 		label = dateI18n(
 			settings.formats.datetimeAbbreviated,
+			// eventTimestamp is UNIX (in seconds), Date expect milliseconds
 			new Date( attributes.eventTimestamp * 1000 )
 		);
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
@@ -5,14 +5,48 @@
 import { Button, DateTimePicker, Dropdown, Placeholder } from '@wordpress/components';
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
+import moment from 'moment';
 import { EventCountdownIcon } from './icon';
+
+const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
+/**
+ * Assigns timezone to a date without altering it
+ *
+ * @param {string} date a date in YYYY-MM-DDTHH:mm:ss format
+ * @param {number} offset the offset in hours
+ * @returns a moment instance
+ */
+function assignTimezone( date, offset, format = TIMEZONELESS_FORMAT ) {
+	return moment( date, format ).utcOffset( offset * 60, true );
+}
 
 const edit = ( { attributes, setAttributes, className } ) => {
 	const settings = __experimentalGetSettings();
 
 	let label = __( 'Choose Date', 'full-site-editing' );
-	if ( attributes.eventDate ) {
-		label = dateI18n( settings.formats.datetimeAbbreviated, attributes.eventDate );
+	let eventDate;
+
+	if ( attributes.eventTimestamp ) {
+		label = dateI18n(
+			settings.formats.datetimeAbbreviated,
+			new Date( attributes.eventTimestamp * 1000 )
+		);
+
+		// the DateTimePicker requires the date to be in this format
+		// we offset the date by the site timezone settings to counteract the Datepicker automatic adjustment to the client-side timezone
+		eventDate = moment( attributes.eventTimestamp * 1000 )
+			.utcOffset( settings.timezone.offset * 60 )
+			.format( TIMEZONELESS_FORMAT );
+	} else if ( attributes.eventDate ) {
+		// backwards compatibility
+		const siteTimeZoneAdjustedTime = assignTimezone(
+			attributes.eventDate,
+			Number.parseFloat( settings.timezone.offset ) // offset can be a string if a manual timezone is selected
+		);
+
+		label = dateI18n( settings.formats.datetimeAbbreviated, siteTimeZoneAdjustedTime );
+		eventDate = attributes.eventDate;
 	}
 
 	return (
@@ -50,8 +84,12 @@ const edit = ( { attributes, setAttributes, className } ) => {
 					renderContent={ () => (
 						<DateTimePicker
 							key="event-countdown-picker"
-							onChange={ ( eventDate ) => setAttributes( { eventDate } ) }
-							currentDate={ attributes.eventDate }
+							onChange={ ( date ) =>
+								setAttributes( {
+									eventTimestamp: assignTimezone( date, settings.timezone.offset ).unix(),
+								} )
+							}
+							currentDate={ eventDate }
 						/>
 					) }
 				/>

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/index.js
@@ -20,7 +20,7 @@ registerBlockType( 'jetpack/event-countdown', {
 	},
 	example: {
 		attributes: {
-			eventDate: '2024-04-08T11:38:32',
+			eventTimestamp: 1318874398,
 			eventTitle: 'Total Solar Eclipse',
 		},
 	},
@@ -30,8 +30,8 @@ registerBlockType( 'jetpack/event-countdown', {
 			source: 'text',
 			selector: '.event-countdown__event-title',
 		},
-		eventDate: {
-			type: 'string',
+		eventTimestamp: {
+			type: 'number',
 		},
 	},
 
@@ -41,6 +41,21 @@ registerBlockType( 'jetpack/event-countdown', {
 		}
 		return view( { ...props, isEditView: true } );
 	},
-
 	save: view,
+	deprecated: [
+		{
+			attributes: {
+				eventTitle: {
+					type: 'string',
+					source: 'text',
+					selector: '.event-countdown__event-title',
+				},
+				eventDate: {
+					type: 'string',
+				},
+			},
+			// the new `view` function can handle the deprecated attributes
+			save: view,
+		},
+	],
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/view.js
@@ -10,11 +10,16 @@ const view = ( { attributes, className, isEditView } ) => {
 	let hours = '&nbsp;';
 	let mins = '&nbsp;';
 	let secs = '&nbsp;';
-
 	if ( isEditView ) {
 		// Zero out.
 		days = hours = mins = secs = 0;
-		const eventTime = new Date( attributes.eventDate ).getTime();
+		let eventTime;
+		if ( attributes.eventTimestamp ) {
+			eventTime = attributes.eventTimestamp * 1000;
+		} else {
+			// backwards compatibility
+			eventTime = new Date( attributes.eventDate ).getTime();
+		}
 		const now = Date.now();
 		const diff = eventTime - now;
 
@@ -37,7 +42,9 @@ const view = ( { attributes, className, isEditView } ) => {
 
 	return (
 		<div className={ className }>
-			<div className="event-countdown__date">{ attributes.eventDate }</div>
+			<div className="event-countdown__date">
+				{ attributes.eventTimestamp || attributes.eventDate }
+			</div>
 			<div className="event-countdown__counter">
 				<p>
 					<strong className="event-countdown__day">{ days }</strong>{ ' ' }

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/event-countdown.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/event-countdown.js
@@ -1,6 +1,9 @@
 // Event Countdown Block
 // JavaScript that loads on front-end to update the block
 ( function () {
+	function isUnixTimestamp( dtstr ) {
+		return /^[0-9]+$/.test( dtstr );
+	}
 	// loop through all event countdown blocks on page
 	const intervalIds = [];
 	const cals = document.getElementsByClassName( 'wp-block-jetpack-event-countdown' );
@@ -16,11 +19,11 @@
 		const dtstr = eventDateElem[ 0 ].innerHTML;
 
 		let eventTime;
-		if ( ! Number.isNaN( dtstr ) ) {
+		if ( isUnixTimestamp( dtstr ) ) {
 			eventTime = eventDateElem[ 0 ].innerHTML * 1000;
 		} else {
 			// backwards compatibility, event date was stored as YYYY-MM-DDTHH:mm:ss
-			// parse date into unix time
+			// parse date into unix time (but in ms)
 			eventTime = new Date( dtstr ).getTime();
 		}
 		if ( isNaN( eventTime ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/event-countdown.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/event-countdown.js
@@ -13,9 +13,16 @@
 			continue;
 		}
 
-		// parse date into unix time
 		const dtstr = eventDateElem[ 0 ].innerHTML;
-		const eventTime = new Date( dtstr ).getTime();
+
+		let eventTime;
+		if ( ! Number.isNaN( dtstr ) ) {
+			eventTime = eventDateElem[ 0 ].innerHTML * 1000;
+		} else {
+			// backwards compatibility, event date was stored as YYYY-MM-DDTHH:mm:ss
+			// parse date into unix time
+			eventTime = new Date( dtstr ).getTime();
+		}
 		if ( isNaN( eventTime ) ) {
 			continue;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR moves the event-countdown block to use a unix timestamp to store the date instead of `YYYY-MM-DDTHH:mm:ss`. The old format didn't contain a timezone and left it to the client's browser interpretation, so each viewer parsed it against their timezone, causing an error range of 24h in the event countdown. 

I deprecated `eventDate` attribute in favor of `eventTimestamp`.

### Testing instructions

#### Before sandboxing or anything

1. In a wpcom simple site, go to settings and set the site timezone to something different from your own (I strongly recommend New York).
2. Create a post in the same site with a countdown event block. Set the event date to something easily memorable, like New Year's Eve in the city you picked. Like NYE in NYC (Jan 1, 2022 00:00).
3. You'll see that the button in the countdown block has a different date than you pick in the date picker, it adjusts it to your local time, which is also a bug.
4. Publish the post. 
5. View the post in an incognito window, the countdown should be off, to compare, visit this [countdown](https://www.timeanddate.com/countdown/newyear?p0=179&msg=NYE+in+NYC&font=cursive) I made for you.

#### Now testing the fix.

1. In calypso repo, go to `apps/editing-toolkit`. 
2. Run `yarn dev --sync`.
3. Sandbox the same site from above.
4. Refresh the editor's page, the component should render successfully and have the same date you entered. This is important because it tests backwards compat. And the button should also have the same date as the datepicker.
5. Change the date to 00:01 (instead of 00:00) just to trigger creating the new HTML and publish again.
6. Go to the same incognito window, refresh, the countdown should be the same as [this](https://www.timeanddate.com/countdown/newyear?p0=179&msg=NYE+in+NYC&font=cursive).

Fixes 148-gh-Automattic/wpcom-blocks and 149-gh-Automattic/wpcom-blocks