### PR TITLE
Fix domain step UI bug when navigating back from checkout

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -289,15 +289,6 @@ export default {
 		context.store.dispatch( setLayoutFocus( 'content' ) );
 		context.store.dispatch( setCurrentFlowName( flowName ) );
 
-		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
-		if (
-			! providesDependenciesInQuery?.includes( 'siteId' ) &&
-			! providesDependenciesInQuery?.includes( 'siteSlug' ) &&
-			! providesDependenciesInQuery?.includes( 'site' )
-		) {
-			context.store.dispatch( setSelectedSiteId( null ) );
-		}
-
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,
@@ -311,6 +302,17 @@ export default {
 			stepComponent,
 			pageTitle: getFlowPageTitle( flowName, userLoggedIn ),
 		} );
+
+		const signupDependencies = getSignupDependencyStore( context.store.getState() );
+		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
+		if (
+			! providesDependenciesInQuery?.includes( 'siteId' ) &&
+			! providesDependenciesInQuery?.includes( 'siteSlug' ) &&
+			! providesDependenciesInQuery?.includes( 'site' ) &&
+			! signupDependencies.isManageSiteFlow
+		) {
+			context.store.dispatch( setSelectedSiteId( null ) );
+		}
 
 		next();
 	},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -27,6 +27,12 @@ import { getDotBlogVerticalId } from './config/dotblog-verticals';
 import { getStepComponent } from './config/step-components';
 import SignupComponent from './main';
 import {
+	retrieveSignupDestination,
+	clearSignupDestinationCookie,
+	getSignupCompleteFlowName,
+	wasSignupCheckoutPageUnloaded,
+} from './storageUtils';
+import {
 	getStepUrl,
 	canResumeFlow,
 	getFlowName,
@@ -289,6 +295,32 @@ export default {
 		context.store.dispatch( setLayoutFocus( 'content' ) );
 		context.store.dispatch( setCurrentFlowName( flowName ) );
 
+		const searchParams = new URLSearchParams( window.location.search );
+		const isAddNewSiteFlow = searchParams.has( 'ref' );
+
+		if ( isAddNewSiteFlow ) {
+			clearSignupDestinationCookie();
+		}
+
+		// Checks if the user entered the signup flow via browser back from checkout page,
+		// and if they did, we'll show a modified domain step to prevent creating duplicate sites,
+		// check pau2Xa-1Io-p2#comment-6759.
+		const signupDestinationCookieExists = retrieveSignupDestination();
+		const isReEnteringFlow = getSignupCompleteFlowName() === flowName;
+		const isReEnteringSignupViaBrowserBack =
+			wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow;
+		const isManageSiteFlow = ! isAddNewSiteFlow && isReEnteringSignupViaBrowserBack;
+
+		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
+		if (
+			! providesDependenciesInQuery?.includes( 'siteId' ) &&
+			! providesDependenciesInQuery?.includes( 'siteSlug' ) &&
+			! providesDependenciesInQuery?.includes( 'site' ) &&
+			! isManageSiteFlow
+		) {
+			context.store.dispatch( setSelectedSiteId( null ) );
+		}
+
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,
@@ -301,18 +333,8 @@ export default {
 			stepSectionName,
 			stepComponent,
 			pageTitle: getFlowPageTitle( flowName, userLoggedIn ),
+			isManageSiteFlow,
 		} );
-
-		const signupDependencies = getSignupDependencyStore( context.store.getState() );
-		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
-		if (
-			! providesDependenciesInQuery?.includes( 'siteId' ) &&
-			! providesDependenciesInQuery?.includes( 'siteSlug' ) &&
-			! providesDependenciesInQuery?.includes( 'site' ) &&
-			! signupDependencies.isManageSiteFlow
-		) {
-			context.store.dispatch( setSelectedSiteId( null ) );
-		}
 
 		next();
 	},

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -70,13 +70,9 @@ import { addP2SignupClassName } from './controller';
 import SiteMockups from './site-mockup';
 import {
 	persistSignupDestination,
-	retrieveSignupDestination,
-	clearSignupDestinationCookie,
 	setSignupCompleteSlug,
 	getSignupCompleteSlug,
-	getSignupCompleteFlowName,
 	setSignupCompleteFlowName,
-	wasSignupCheckoutPageUnloaded,
 } from './storageUtils';
 import {
 	canResumeFlow,
@@ -160,17 +156,12 @@ class Signup extends Component {
 			providedDependencies = pick( queryObject, flow.providesDependenciesInQuery );
 		}
 
-		const searchParams = new URLSearchParams( window.location.search );
-		const isAddNewSiteFlow = searchParams.has( 'ref' );
-
-		if ( isAddNewSiteFlow ) {
-			clearSignupDestinationCookie();
-		}
-
 		// Prevent duplicate sites, check pau2Xa-1Io-p2#comment-6759.
-		if ( ! isAddNewSiteFlow && this.isReEnteringSignupViaBrowserBack() ) {
-			this.enableManageSiteFlow = true;
-			providedDependencies = { siteSlug: getSignupCompleteSlug(), isManageSiteFlow: true };
+		if ( this.props.isManageSiteFlow ) {
+			providedDependencies = {
+				siteSlug: getSignupCompleteSlug(),
+				isManageSiteFlow: this.props.isManageSiteFlow,
+			};
 		}
 
 		this.signupFlowController = new SignupFlowController( {
@@ -284,20 +275,6 @@ class Signup extends Component {
 
 	scrollToTop() {
 		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
-	}
-
-	/**
-	 * Checks if the user entered the signup flow via browser back from checkout page,
-	 * and if they did we will show a modified domain step to prevent creating duplicate sites.
-	 * Check pau2Xa-1Io-p2#comment-6759 for more context.
-	 */
-	isReEnteringSignupViaBrowserBack() {
-		const signupDestinationCookieExists = retrieveSignupDestination();
-		const isReEnteringFlow = getSignupCompleteFlowName() === this.props.flowName;
-		const isReEnteringSignupViaBrowserBack =
-			wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow;
-
-		return isReEnteringSignupViaBrowserBack;
 	}
 
 	completeP2FlowAfterLoggingIn() {
@@ -666,7 +643,7 @@ class Signup extends Component {
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		let propsForCurrentStep = propsFromConfig;
-		if ( this.enableManageSiteFlow ) {
+		if ( this.props.isManageSiteFlow ) {
 			propsForCurrentStep = {
 				...propsFromConfig,
 				showExampleSuggestions: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the following two issues:

(1) When you click browser back button from the checkout page, then the domains step skip option is missing the site address:

<img width="971" alt="Screenshot 2021-12-09 at 11 47 20 AM" src="https://user-images.githubusercontent.com/1269602/145559812-95ca4a95-68e2-47a3-9d6e-ec174ec54d81.png">

(2) The domains step fails to load suggestions when you perform the following steps:
        - Begin a fresh signup at `/start`
        - Click "View plans" button on the domains step
        - Select any paid plan and proceed to the checkout page
        - On the checkout page, click the browser back button
        - The domain step suggestions fail to load

<img width="1408" alt="Screenshot 2021-12-09 at 11 45 35 AM" src="https://user-images.githubusercontent.com/1269602/145560127-e2fb23d3-4670-4481-9d35-f5a7719ee34c.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the two issues described above are fixed.
* Verify that all test cases in https://github.com/Automattic/wp-calypso/pull/45040 pass.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


