### PR TITLE
Playwright: Update documentation, Part 2.

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -76,10 +76,11 @@ cd wp-calypso
 yarn install
 ```
 
-9. [decrypt](docs/test_environment.md) the secrets file.
+9. export required [environment variables](docs/test_environment.md).
 
 ```
-npm run decryptconfig
+export NODE_CONFIG_ENV=<name_of_decrypted_config_to_use>
+export CONFIG_KEY=<decryption_key_from_a8c_store>
 ```
 
 10. navigate to e2e directory.
@@ -88,13 +89,19 @@ npm run decryptconfig
 cd test/e2e
 ```
 
-11. transpile the `@automattic/calypso-e2e` package.
+11. [decrypt](docs/test_environment.md) the secrets file.
+
+```
+npm run decryptconfig
+```
+
+12. transpile the `@automattic/calypso-e2e` package.
 
 ```
 yarn workspace @automattic/calypso-e2e build
 ```
 
-12. run test.
+13. run test.
 
 ```
 yarn jest specs/specs-playwright/<spec_name>
@@ -106,7 +113,7 @@ Please refer to the [Advanced Setup](docs/setup.md) page.
 
 ## Contribute to E2E tests
 
-Please refer to the [] pages.
+Please refer to the [Writing Tests](docs/writing_tests.md) and [Style Guide](docs/style_guide.md) pages.
 
 ## Troubleshooting
 

--- a/test/e2e/docs/config_values.md
+++ b/test/e2e/docs/config_values.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Config Values
 
 This list may be out of date as configuration value are added/removed.

--- a/test/e2e/docs/debugging.md
+++ b/test/e2e/docs/debugging.md
@@ -1,6 +1,6 @@
 <div style="width: 45%; float:left" align="left"><a href="./style_guide.md"><-- Style Guide</a> </div>
 <div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
-<div style="width: 45%; float:right"align="right"><a href="./troubleshooting.md">St --> Troubleshooting</a> </div>
+<div style="width: 45%; float:right"align="right"><a href="./troubleshooting.md">--> Troubleshooting</a> </div>
 
 <br><br>
 

--- a/test/e2e/docs/debugging.md
+++ b/test/e2e/docs/debugging.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Debugging
 
 The Playwright [project page](https://playwright.dev/docs/debug/) has in-depth coverage of various debugging tools. This page will cover debugging scenarios unique to WordPress.com and Calypso.

--- a/test/e2e/docs/debugging.md
+++ b/test/e2e/docs/debugging.md
@@ -1,4 +1,8 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><a href="./style_guide.md"><-- Style Guide</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./troubleshooting.md">St --> Troubleshooting</a> </div>
+
+<br><br>
 
 # Debugging
 

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Environment Variables
 
 Environment Variables are values that are defined at the system level to serve as configuration for programs.

--- a/test/e2e/docs/library_objects.md
+++ b/test/e2e/docs/library_objects.md
@@ -1,4 +1,8 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><a href="./writing_tests.md"><-- Writing tests</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./style_guide.md">Style Guide --></a> </div>
+
+<br><br>
 
 # Library Objects
 

--- a/test/e2e/docs/library_objects.md
+++ b/test/e2e/docs/library_objects.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Library Objects
 
 The `@automattic/calypso-e2e` package offers a robust set of library objects patterned after the Page Object Model. When developing a new test spec, try to leverage these objects as much as possible for a seamless experience.

--- a/test/e2e/docs/overview.md
+++ b/test/e2e/docs/overview.md
@@ -1,11 +1,13 @@
+Return to [Top Page](../README.md).
+
 # Overview
 
 <!-- TOC -->
 
 - [Overview](#overview)
-  - [What is this?](#what-is-this)
-  - [Our Goals](#our-goals)
-  - [What is tested?](#what-is-tested)
+    - [What is this?](#what-is-this)
+    - [Our Goals](#our-goals)
+    - [What is tested?](#what-is-tested)
 
 <!-- /TOC -->
 
@@ -33,3 +35,4 @@ At the high level, each test file (or `spec`) fall under one of the following fl
 | Jetpack              | `specs/specs-jetpack`    |
 
 Core code for Jetpack, WooCommerce and Gutenberg are hosted in other repositories and they have separate e2e testing infrastructure. Tests within `test/e2e` are meant to test interactions between their respective components and Calypso/WordPress.com.
+

--- a/test/e2e/docs/overview.md
+++ b/test/e2e/docs/overview.md
@@ -1,13 +1,17 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><p></p> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./setup.md">Setup --></a> </div>
+
+<br><br>
 
 # Overview
 
 <!-- TOC -->
 
 - [Overview](#overview)
-    - [What is this?](#what-is-this)
-    - [Our Goals](#our-goals)
-    - [What is tested?](#what-is-tested)
+  - [What is this?](#what-is-this)
+  - [Our Goals](#our-goals)
+  - [What is tested?](#what-is-tested)
 
 <!-- /TOC -->
 
@@ -35,4 +39,3 @@ At the high level, each test file (or `spec`) fall under one of the following fl
 | Jetpack              | `specs/specs-jetpack`    |
 
 Core code for Jetpack, WooCommerce and Gutenberg are hosted in other repositories and they have separate e2e testing infrastructure. Tests within `test/e2e` are meant to test interactions between their respective components and Calypso/WordPress.com.
-

--- a/test/e2e/docs/setup.md
+++ b/test/e2e/docs/setup.md
@@ -1,4 +1,8 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><a href="./overview.md"><-- Overview</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./test_environment.md">Test Environment --></a> </div>
+
+<br><br>
 
 # Setup
 

--- a/test/e2e/docs/setup.md
+++ b/test/e2e/docs/setup.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Setup
 
 <!-- TOC -->

--- a/test/e2e/docs/style_guide.md
+++ b/test/e2e/docs/style_guide.md
@@ -1,4 +1,8 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><a href="./library_objects.md"><-- Library objects</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./debugging.md">Debugging --></a> </div>
+
+<br><br>
 
 # Style Guide
 

--- a/test/e2e/docs/style_guide.md
+++ b/test/e2e/docs/style_guide.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Style Guide
 
 <!-- TOC -->

--- a/test/e2e/docs/test_environment.md
+++ b/test/e2e/docs/test_environment.md
@@ -1,15 +1,19 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><a href="./setup.md"><-- Setup</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./tests_local.md">Running tests on your machine --></a> </div>
+
+<br><br>
 
 # Test Environment
 
 <!-- TOC -->
 
 - [Test Environment](#test-environment)
-    - [Environment Variables](#environment-variables)
-    - [Secrets file](#secrets-file)
-    - [Non-secret configuration file](#non-secret-configuration-file)
-        - [Default config](#default-config)
-        - [Custom configs](#custom-configs)
+  - [Environment Variables](#environment-variables)
+  - [Secrets file](#secrets-file)
+  - [Non-secret configuration file](#non-secret-configuration-file)
+    - [Default config](#default-config)
+    - [Custom configs](#custom-configs)
 
 <!-- /TOC -->
 
@@ -67,5 +71,3 @@ The `local-` prefix ensures that custom configurations [will be ignored][https:/
 Values found in the local configuration file will override ones found in `default.json`.
 
 For the full list of possible configuration values, refer to the following page: [config values](config_values.md).
-
-<p align="left"><a href="./setup.md"><-- Setup</a></p>

--- a/test/e2e/docs/test_environment.md
+++ b/test/e2e/docs/test_environment.md
@@ -1,13 +1,15 @@
+Return to [Top Page](../README.md).
+
 # Test Environment
 
 <!-- TOC -->
 
 - [Test Environment](#test-environment)
-  - [Environment Variables](#environment-variables)
-  - [Secrets file](#secrets-file)
-  - [Non-secret configuration file](#non-secret-configuration-file)
-    - [Default config](#default-config)
-    - [Custom configs](#custom-configs)
+    - [Environment Variables](#environment-variables)
+    - [Secrets file](#secrets-file)
+    - [Non-secret configuration file](#non-secret-configuration-file)
+        - [Default config](#default-config)
+        - [Custom configs](#custom-configs)
 
 <!-- /TOC -->
 
@@ -65,3 +67,5 @@ The `local-` prefix ensures that custom configurations [will be ignored][https:/
 Values found in the local configuration file will override ones found in `default.json`.
 
 For the full list of possible configuration values, refer to the following page: [config values](config_values.md).
+
+<p align="left"><a href="./setup.md"><-- Setup</a></p>

--- a/test/e2e/docs/tests_ci.md
+++ b/test/e2e/docs/tests_ci.md
@@ -1,4 +1,4 @@
-<div style="width: 45%; float:left" align="left"><a href="./tests_ci.md"><-- Running tests on CI</a> </div>
+<div style="width: 45%; float:left" align="left"><a href="./tests_local.md"><-- Running tests on your machine</a> </div>
 <div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
 <div style="width: 45%; float:right"align="right"><a href="./writing_tests.md">Writing Tests --></a> </div>
 

--- a/test/e2e/docs/tests_ci.md
+++ b/test/e2e/docs/tests_ci.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Running tests on CI
 
 <!-- TOC -->

--- a/test/e2e/docs/tests_ci.md
+++ b/test/e2e/docs/tests_ci.md
@@ -1,4 +1,8 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><a href="./tests_ci.md"><-- Running tests on CI</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./writing_tests.md">Writing Tests --></a> </div>
+
+<br><br>
 
 # Running tests on CI
 

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -1,4 +1,8 @@
-Return to [Top Page](../README.md).
+<div style="width:454%; float:left" align="left"><a href="./test_environment.md"><-- Test Environment</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./tests_ci.md">Running tests on CI --></a> </div>
+
+<br><br>
 
 # Running tests on your machine
 

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Running tests on your machine
 
 <!-- TOC -->
@@ -11,6 +13,7 @@
     - [Save authentication cookies](#save-authentication-cookies)
     - [Target local webapp](#target-local-webapp)
     - [Debug mode](#debug-mode)
+      - [Notes on TypeScript](#notes-on-typescript)
 
 <!-- /TOC -->
 

--- a/test/e2e/docs/troubleshooting.md
+++ b/test/e2e/docs/troubleshooting.md
@@ -1,4 +1,7 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><a href="./debugging.md"><-- Debugging</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+
+<br><br>
 
 # Troubleshooting & Debugging
 

--- a/test/e2e/docs/troubleshooting.md
+++ b/test/e2e/docs/troubleshooting.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Troubleshooting & Debugging
 
 <!-- TOC -->

--- a/test/e2e/docs/troubleshooting.md
+++ b/test/e2e/docs/troubleshooting.md
@@ -3,11 +3,11 @@
 
 <br><br>
 
-# Troubleshooting & Debugging
+# Troubleshooting
 
 <!-- TOC -->
 
-- [Troubleshooting & Debugging](#troubleshooting--debugging)
+- [Troubleshooting](#troubleshooting)
   - [git pre-commit hook/husky](#git-pre-commit-hookhusky)
   - [Chromium binary is not available for arm64](#chromium-binary-is-not-available-for-arm64)
   - [Package 'lcms2', required by 'vips', not found](#package-lcms2-required-by-vips-not-found)

--- a/test/e2e/docs/writing_tests.md
+++ b/test/e2e/docs/writing_tests.md
@@ -1,3 +1,5 @@
+Return to [Top Page](../README.md).
+
 # Writing Tests
 
 <!-- TOC -->

--- a/test/e2e/docs/writing_tests.md
+++ b/test/e2e/docs/writing_tests.md
@@ -1,4 +1,8 @@
-Return to [Top Page](../README.md).
+<div style="width: 45%; float:left" align="left"><a href="./tests_ci.md"><-- Running tests on CI</a> </div>
+<div style="width: 5%; float:left" align="center"><a href="./../README.md">Top</a></div>
+<div style="width: 45%; float:right"align="right"><a href="./library_objects.md">Library Objects --></a> </div>
+
+<br><br>
 
 # Writing Tests
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After the [previous round of updates](https://github.com/Automattic/wp-calypso/pull/58610) there are some minor tweaks that should be made to the documentation.

Key changes:
- fill in missing links to pages under `Writing Tests` section.
- add step referring to exporting the environment variable, used for secrets decryption.

#### Testing instructions

Navigate [from the top page](https://github.com/Automattic/wp-calypso/tree/pw/update-documentation-2/test/e2e) to ensure the changes are present.

Related to #58610, https://github.com/Automattic/wp-calypso/issues/58370.
