### PR TITLE
Domains: Update domains list status ordering

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -112,7 +112,7 @@ export function resolveDomainStatus(
 					return {
 						statusText: translate( 'Connection error' ),
 						statusClass: 'status-alert',
-						status: translate( 'Verifying' ),
+						status: translate( 'Error' ),
 						icon: 'info',
 						listStatusText: status,
 						listStatusClass: 'alert',
@@ -133,7 +133,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Verifying connection' ),
 					statusClass: 'status-verifying',
-					status: translate( 'Verifying' ),
+					status: translate( 'Complete setup' ),
 					icon: 'verifying',
 					listStatusText: status,
 					listStatusClass: 'verifying',
@@ -147,6 +147,7 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Action required' ),
 					icon: 'info',
+					listStatusWeight: 600,
 				};
 			}
 
@@ -186,6 +187,7 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Action required' ),
 					icon: 'info',
+					listStatusWeight: 600,
 				};
 			}
 
@@ -195,6 +197,7 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Suspended' ),
 					icon: 'info',
+					listStatusWeight: 800,
 				};
 			}
 
@@ -204,6 +207,7 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Action required' ),
 					icon: 'info',
+					listStatusWeight: 600,
 				};
 			}
 
@@ -271,6 +275,7 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Action required' ),
 					icon: 'info',
+					listStatusWeight: 600,
 				};
 			}
 
@@ -332,6 +337,7 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Action required' ),
 					icon: 'info',
+					listStatusWeight: 600,
 				};
 			}
 

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -137,7 +137,7 @@ export function resolveDomainStatus(
 					icon: 'verifying',
 					listStatusText: status,
 					listStatusClass: 'verifying',
-					listStatusWeight: 200,
+					listStatusWeight: 600,
 				};
 			}
 
@@ -168,7 +168,7 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusText: pendingRenewalMessage,
 					listStatusClass: 'warning',
-					listStatusWeight: 800,
+					listStatusWeight: 400,
 				};
 			}
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -54,6 +54,7 @@
 	}
 
 	&__status-neutral-dot,
+	&__status-verifying-dot,
 	&__status-alert-dot,
 	&__status-warning-dot,
 	&__status-error-dot {


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the site domains list and all domains list pages, there were some "Action required" domain statuses that were not ordered correctly. This PR updates some of the status weights and labels so that all yellow statuses are chunked together. The following screenshot shows how some statuses are ordered now:

![Markup on 2021-12-09 at 16:46:13](https://user-images.githubusercontent.com/5324818/145466184-916d3fd0-80e8-407d-a79f-2149bce4e09f.png)

### Testing instructions

- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/management-list-redesign` to your URL to enable the appropriate feature flag
- Go to the "All domains" page (the fastest way is by pointing your browser's URL to `/domains/manage`) 
- Order the table by the "Status" column
- Ensure all the yellow domain statuses are grouped together and ordered according to the screenshot above