### PR TITLE
Turn PluginsBrowser into a functional component

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -65,8 +65,14 @@ import './style.scss';
 const SHORT_LIST_LENGTH = 6;
 const SEARCH_RESULTS_LIST_LENGTH = 12;
 
-export const PluginsBrowser = ( props ) => {
-	const { trackPageViews = true, category, search } = props;
+export const PluginsBrowser = ( {
+	trackPageViews = true,
+	category,
+	search,
+	searchTitle,
+	hideHeader,
+	doSearch,
+} ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
@@ -161,7 +167,7 @@ export const PluginsBrowser = ( props ) => {
 	];
 
 	useEffect( () => {
-		if ( search && props.searchTitle ) {
+		if ( search && searchTitle ) {
 			dispatch(
 				recordTracksEvent( 'calypso_plugins_search_noresults_recommendations_show', {
 					search_query: search,
@@ -221,31 +227,30 @@ export const PluginsBrowser = ( props ) => {
 			/>
 			<DocumentHead title={ translate( 'Plugins' ) } />
 			<SidebarNavigation />
-		
-				<AnnouncementModal
-					announcementId="plugins-page-revamp"
-					pages={ annoncementPages }
-					finishButtonText={ translate( "Let's explore!" ) }
-				/>
-			{ ! props.hideHeader && (
+
+			<AnnouncementModal
+				announcementId="plugins-page-revamp"
+				pages={ annoncementPages }
+				finishButtonText={ translate( "Let's explore!" ) }
+			/>
+			{ ! hideHeader && (
 				<FixedNavigationHeader
 					className="plugins-browser__header"
 					navigationItems={ navigationItems }
 				>
 					<div className="plugins-browser__main-buttons">
-					
-							<ManageButton
-								shouldShowManageButton={ shouldShowManageButton }
-								siteAdminUrl={ siteAdminUrl }
-								siteSlug={ siteSlug }
-								jetpackNonAtomic={ jetpackNonAtomic }
-							/>
-						
+						<ManageButton
+							shouldShowManageButton={ shouldShowManageButton }
+							siteAdminUrl={ siteAdminUrl }
+							siteSlug={ siteSlug }
+							jetpackNonAtomic={ jetpackNonAtomic }
+						/>
+
 						<UploadPluginButton isMobile={ isMobile } siteSlug={ siteSlug } />
 					</div>
 
 					<div className="plugins-browser__searchbox">
-						{ <SearchBox isMobile={ isMobile } doSearch={ props.doSearch } search={ search } /> }
+						{ <SearchBox isMobile={ isMobile } doSearch={ doSearch } search={ search } /> }
 					</div>
 				</FixedNavigationHeader>
 			) }
@@ -276,7 +281,7 @@ export const PluginsBrowser = ( props ) => {
 				recommendedPlugins={ recommendedPlugins }
 				isRequestingRecommendedPlugins={ isRequestingRecommendedPlugins }
 				sites={ sites }
-				searchTitle={ props.searchTitle }
+				searchTitle={ searchTitle }
 				siteSlug={ siteSlug }
 				isRecommendedPluginsEnabled={ isRecommendedPluginsEnabled }
 			/>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -65,7 +65,7 @@ import './style.scss';
 const SHORT_LIST_LENGTH = 6;
 const SEARCH_RESULTS_LIST_LENGTH = 12;
 
-export const PluginsBrowser = ( {
+const PluginsBrowser = ( {
 	trackPageViews = true,
 	category,
 	search,

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -3,7 +3,6 @@ import {
 	isBusiness,
 	isEcommerce,
 	isEnterprise,
-	isPremium,
 	findFirstSimilarPlanKey,
 	FEATURE_UPLOAD_PLUGINS,
 	TYPE_BUSINESS,
@@ -12,11 +11,9 @@ import { Button } from '@automattic/components';
 import Search from '@automattic/search';
 import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
 import { Icon, upload } from '@wordpress/icons';
-import { localize } from 'i18n-calypso';
-import { flow, get } from 'lodash';
-import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import announcementImage from 'calypso/assets/images/marketplace/plugins-revamp.png';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -29,7 +26,7 @@ import MainComponent from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
 import { PaginationVariant } from 'calypso/components/pagination/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import urlSearch from 'calypso/lib/url-search';
+import UrlSearch from 'calypso/lib/url-search';
 import NoResults from 'calypso/my-sites/no-results';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -59,11 +56,7 @@ import {
 	isRequestingSites,
 	getSiteAdminUrl,
 } from 'calypso/state/sites/selectors';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 /**
@@ -71,72 +64,128 @@ import './style.scss';
  */
 const SHORT_LIST_LENGTH = 6;
 const SEARCH_RESULTS_LIST_LENGTH = 12;
-const VISIBLE_CATEGORIES = [ 'new', 'popular', 'featured' ];
-const VISIBLE_CATEGORIES_FOR_RECOMMENDATIONS = [ 'new', 'popular' ];
 
-export class PluginsBrowser extends Component {
-	static propTypes = {
-		isRequestingRecommendedPlugins: PropTypes.bool.isRequired,
-		recommendedPlugins: PropTypes.arrayOf( PropTypes.object ),
-		selectedSite: PropTypes.object,
-		trackPageView: PropTypes.bool,
-		hideHeader: PropTypes.bool,
-	};
+const PluginsBrowser = ( props ) => {
+	const { trackPageViews = true, category, search } = props;
+	const selectedSite = useSelector( getSelectedSite );
+	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
-	static defaultProps = {
-		trackPageViews: true,
-	};
+	const hasBusinessPlan =
+		sitePlan && ( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
+	const recommendedPlugins =
+		useSelector( ( state ) => getRecommendedPlugins( state, selectedSite?.ID ) ) || [];
+	const popularPlugins = useSelector( ( state ) => getPluginsListByCategory( state, 'popular' ) );
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			isMobile: isWithinBreakpoint( '<960px' ),
-		};
-	}
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
+	const jetpackNonAtomic = useSelector(
+		( state ) =>
+			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
+	);
+	const isVip = useSelector( ( state ) => isVipSite( state, selectedSite?.ID ) );
+	const hasJetpack = useSelector( hasJetpackSites );
+	const isRequestingSitesData = useSelector( isRequestingSites );
+	const noPermissionsError = useSelector(
+		( state ) =>
+			!! selectedSite?.ID && ! canCurrentUser( state, selectedSite?.ID, 'manage_options' )
+	);
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
+	const isRequestingRecommendedPlugins = ! Array.isArray( recommendedPlugins );
+	const pluginsByCategory = useSelector( ( state ) => getPluginsListByCategory( state, category ) );
+	const pluginsByCategoryNew = useSelector( ( state ) => getPluginsListByCategory( state, 'new' ) );
+	const pluginsByCategoryFeatured = useSelector( ( state ) =>
+		getPluginsListByCategory( state, 'featured' )
+	);
+	const pluginsByCategoryPopular = filterPopularPlugins(
+		popularPlugins,
+		pluginsByCategoryFeatured
+	);
+	const pluginsBySearchTerm = useSelector( ( state ) =>
+		getPluginsListBySearchTerm( state, search )
+	);
+	const pluginsPagination = useSelector( ( state ) => getPluginsListPagination( state, search ) );
+	const isFetchingPluginsByCategory = useSelector( ( state ) =>
+		isFetchingPluginsList( state, category )
+	);
+	const isFetchingPluginsByCategoryNew = useSelector( ( state ) =>
+		isFetchingPluginsList( state, 'new' )
+	);
+	const isFetchingPluginsByCategoryPopular = useSelector( ( state ) =>
+		isFetchingPluginsList( state, 'popular' )
+	);
+	const isFetchingPluginsByCategoryFeatured = useSelector( ( state ) =>
+		isFetchingPluginsList( state, 'featured' )
+	);
+	const isFetchingPluginsBySearchTerm = useSelector( ( state ) =>
+		isFetchingPluginsList( state, null, search )
+	);
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, selectedSite?.ID ) );
 
-	reinitializeSearch() {
-		this.WrappedSearch = ( props ) => <Search { ...props } />;
-	}
+	const dispatch = useDispatch();
+	const translate = useTranslate();
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.reinitializeSearch();
+	const [ isMobile, setIsMobile ] = useState();
+	const isRecommendedPluginsEnabled = useMemo(
+		() => isEnabled( 'recommend-plugins' ) && !! selectedSite?.ID && selectedSite?.jetpack,
+		[ selectedSite ]
+	);
 
-		if ( typeof this.unsubscribe === 'function' ) {
-			this.unsubscribe();
+	const shouldShowManageButton = useMemo( () => {
+		if ( isJetpack ) {
+			return true;
 		}
-	}
+		return ! selectedSite?.ID && hasJetpack;
+	}, [ isJetpack, selectedSite, hasJetpack ] );
 
-	componentDidMount() {
-		if ( this.props.search && this.props.searchTitle ) {
-			this.props.recordTracksEvent( 'calypso_plugins_search_noresults_recommendations_show', {
-				search_query: this.props.search,
+	const navigationItems = useMemo( () => {
+		const items = [ { label: translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }` } ];
+		if ( search ) {
+			items.push( {
+				label: translate( 'Search Results' ),
+				href: `/plugins/${ siteSlug || '' }?s=${ search }`,
 			} );
 		}
 
-		// Change the isMobile state when the size of the browser changes.
-		this.unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobile ) => {
-			this.setState( { isMobile } );
-		} );
-	}
+		return items;
+	}, [ search, siteSlug ] );
 
-	getVisibleCategories() {
-		if ( ! this.isRecommendedPluginsEnabled() ) {
-			return VISIBLE_CATEGORIES;
+	const annoncementPages = [
+		{
+			headline: translate( 'ITS NEW!' ),
+			heading: translate( 'All the plugins and more' ),
+			content: translate(
+				'This page may look different as we’ve made some changes to improve the experience for you. Stay tuned for even more exciting updates to come!'
+			),
+			featureImage: announcementImage,
+		},
+	];
+
+	useEffect( () => {
+		if ( search && props.searchTitle ) {
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_noresults_recommendations_show', {
+					search_query: search,
+				} )
+			);
 		}
-		return VISIBLE_CATEGORIES_FOR_RECOMMENDATIONS;
-	}
+	}, [] );
 
-	isRecommendedPluginsEnabled() {
-		return (
-			isEnabled( 'recommend-plugins' ) &&
-			!! this.props.selectedSiteId &&
-			get( this.props.selectedSite, 'jetpack' )
+	useEffect( () => {
+		if ( isWithinBreakpoint( '<960px' ) ) {
+			setIsMobile( true );
+		}
+		const unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobileLayout ) =>
+			setIsMobile( isMobileLayout )
 		);
-	}
 
-	fetchNextPagePlugins = () => {
-		const { category, isFetchingPluginsByCategory } = this.props;
+		return () => {
+			if ( typeof unsubscribe === 'function' ) {
+				unsubscribe();
+			}
+		};
+	}, [] );
+
+	const fetchNextPagePlugins = useCallback( () => {
 		if ( ! category ) {
 			return;
 		}
@@ -146,402 +195,429 @@ export class PluginsBrowser extends Component {
 			return;
 		}
 
-		this.props.fetchPluginsCategoryNextPage( category );
-	};
+		dispatch( fetchPluginsCategoryNextPage( category ) );
+	}, [ category, isFetchingPluginsByCategory ] );
 
-	getPluginBrowserContent() {
-		if ( this.props.search ) {
-			return this.getSearchListView();
-		}
-		if ( this.props.category ) {
-			return this.getFullListView();
-		}
-		return this.getShortListsView();
+	if ( ! isRequestingSitesData && noPermissionsError ) {
+		return <NoPermissionsError title={ translate( 'Plugins', { textOnly: true } ) } />;
 	}
 
-	translateCategory( category ) {
-		const { translate } = this.props;
-
-		const recommendedText = translate( 'Recommended', {
-			context: 'Category description for the plugin browser.',
-		} );
-
-		switch ( category ) {
-			case 'new':
-				return translate( 'New', {
-					context: 'Category description for the plugin browser.',
-				} );
-			case 'popular':
-				return translate( 'Popular', {
-					context: 'Category description for the plugin browser.',
-				} );
-			case 'featured':
-				return translate( 'Featured', {
-					context: 'Category description for the plugin browser.',
-				} );
-			case 'recommended':
-				return recommendedText;
-		}
-	}
-
-	getFullListView() {
-		const { category, isFetchingPluginsByCategory, pluginsByCategory } = this.props;
-		if ( pluginsByCategory.length > 0 || isFetchingPluginsByCategory ) {
-			return (
-				<PluginsBrowserList
-					plugins={ pluginsByCategory }
-					listName={ category }
-					title={ this.translateCategory( category ) }
-					site={ this.props.siteSlug }
-					showPlaceholders={ isFetchingPluginsByCategory }
-					currentSites={ this.props.sites }
-					variant={ PluginsBrowserListVariant.InfiniteScroll }
-					extended
-				/>
-			);
-		}
-	}
-
-	getSearchListView() {
-		const {
-			search: searchTerm,
-			isFetchingPluginsBySearchTerm,
-			pluginsBySearchTerm,
-			pluginsPagination,
-			fetchPluginsList: fetchPlugins,
-		} = this.props;
-		if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
-			const searchTitle =
-				this.props.searchTitle ||
-				this.props.translate( 'Search results for {{b}}%(searchTerm)s{{/b}}', {
-					textOnly: true,
-					args: {
-						searchTerm,
-					},
-					components: {
-						b: <b />,
-					},
-				} );
-
-			const subtitle =
-				pluginsPagination &&
-				this.props.translate( '%(total)s plugin', '%(total)s plugins', {
-					count: pluginsPagination.results,
-					textOnly: true,
-					args: {
-						total: pluginsPagination.results,
-					},
-				} );
-
-			return (
+	return (
+		<MainComponent wideLayout>
+			{ category && <QueryWporgPlugins category={ category } /> }
+			{ search && <QueryWporgPlugins searchTerm={ search } /> }
+			{ ! category && ! search && (
 				<>
-					<PluginsBrowserList
-						plugins={ pluginsBySearchTerm }
-						listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
-						title={ searchTitle }
-						subtitle={ subtitle }
-						site={ this.props.siteSlug }
-						showPlaceholders={ isFetchingPluginsBySearchTerm }
-						size={ SEARCH_RESULTS_LIST_LENGTH }
-						currentSites={ this.props.sites }
-						variant={ PluginsBrowserListVariant.Paginated }
-						extended
-					/>
-					{ pluginsPagination && (
-						<Pagination
-							page={ pluginsPagination.page }
-							perPage={ SEARCH_RESULTS_LIST_LENGTH }
-							total={ pluginsPagination.results }
-							pageClick={ ( page ) => {
-								fetchPlugins( null, page, searchTerm, SEARCH_RESULTS_LIST_LENGTH );
-							} }
-							variant={ PaginationVariant.minimal }
-						/>
-					) }
+					<QueryWporgPlugins category="new" />
+					<QueryWporgPlugins category="popular" />
+					<QueryWporgPlugins category="featured" />
 				</>
-			);
-		}
-		return (
-			<NoResults
-				text={ this.props.translate( 'No plugins match your search for {{searchTerm/}}.', {
-					textOnly: true,
-					components: { searchTerm: <em>{ searchTerm }</em> },
-				} ) }
+			) }
+			{ isRecommendedPluginsEnabled && <QuerySiteRecommendedPlugins siteId={ selectedSite?.ID } /> }
+			<PageViewTrackerWrapper
+				category={ category }
+				selectedSiteId={ selectedSite?.ID }
+				trackPageViews={ trackPageViews }
 			/>
-		);
-	}
+			<DocumentHead title={ translate( 'Plugins' ) } />
+			<SidebarNavigation />
+		
+				<AnnouncementModal
+					announcementId="plugins-page-revamp"
+					pages={ annoncementPages }
+					finishButtonText={ translate( "Let's explore!" ) }
+				/>
+			{ ! props.hideHeader && (
+				<FixedNavigationHeader
+					className="plugins-browser__header"
+					navigationItems={ navigationItems }
+				>
+					<div className="plugins-browser__main-buttons">
+					
+							<ManageButton
+								shouldShowManageButton={ shouldShowManageButton }
+								siteAdminUrl={ siteAdminUrl }
+								siteSlug={ siteSlug }
+								jetpackNonAtomic={ jetpackNonAtomic }
+							/>
+						
+						<UploadPluginButton isMobile={ isMobile } siteSlug={ siteSlug } />
+					</div>
 
-	getPluginSingleListView( category ) {
-		let plugins;
-		let isFetching;
-		if ( category === 'new' ) {
-			plugins = this.props.pluginsByCategoryNew;
-			isFetching = this.props.isFetchingPluginsByCategoryNew;
-		} else if ( category === 'popular' ) {
-			plugins = this.props.pluginsByCategoryPopular;
-			isFetching = this.props.isFetchingPluginsByCategoryPopular;
-		} else if ( category === 'featured' ) {
-			plugins = this.props.pluginsByCategoryFeatured;
-			isFetching = this.props.isFetchingPluginsByCategoryFeatured;
-		} else {
-			return;
-		}
+					<div className="plugins-browser__searchbox">
+						{ <SearchBox isMobile={ isMobile } doSearch={ props.doSearch } search={ search } /> }
+					</div>
+				</FixedNavigationHeader>
+			) }
 
-		const listLink = '/plugins/' + category + '/';
-		return (
-			<PluginsBrowserList
-				plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
-				listName={ category }
-				title={ this.translateCategory( category ) }
-				site={ this.props.siteSlug }
-				expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? listLink : false }
-				size={ SHORT_LIST_LENGTH }
-				showPlaceholders={ isFetching }
-				currentSites={ this.props.sites }
-				variant={ PluginsBrowserListVariant.Fixed }
-				extended
+			<UpgradeNudge
+				selectedSite={ selectedSite }
+				sitePlan={ sitePlan }
+				isVip={ isVip }
+				jetpackNonAtomic={ jetpackNonAtomic }
+				hasBusinessPlan={ hasBusinessPlan }
+				siteSlug={ siteSlug }
 			/>
-		);
-	}
 
-	getRecommendedPluginListView() {
-		const { recommendedPlugins } = this.props;
-		if ( recommendedPlugins && recommendedPlugins.length === 0 ) {
-			return;
-		}
-
-		return (
-			<PluginsBrowserList
-				currentSites={ this.props.sites }
-				expandedListLink={ false }
-				listName="recommended"
-				plugins={ recommendedPlugins }
-				showPlaceholders={ this.props.isRequestingRecommendedPlugins }
-				site={ this.props.siteSlug }
-				size={ SHORT_LIST_LENGTH }
-				title={ this.translateCategory( 'recommended' ) }
-				variant={ PluginsBrowserListVariant.Fixed }
-				extended
+			<PluginBrowserContent
+				pluginsByCategoryNew={ pluginsByCategoryNew }
+				isFetchingPluginsByCategoryNew={ isFetchingPluginsByCategoryNew }
+				pluginsByCategoryPopular={ pluginsByCategoryPopular }
+				isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }
+				pluginsByCategoryFeatured={ pluginsByCategoryFeatured }
+				isFetchingPluginsByCategoryFeatured={ isFetchingPluginsByCategoryFeatured }
+				search={ search }
+				isFetchingPluginsBySearchTerm={ isFetchingPluginsBySearchTerm }
+				pluginsBySearchTerm={ pluginsBySearchTerm }
+				pluginsPagination={ pluginsPagination }
+				category={ category }
+				isFetchingPluginsByCategory={ isFetchingPluginsByCategory }
+				pluginsByCategory={ pluginsByCategory }
+				recommendedPlugins={ recommendedPlugins }
+				isRequestingRecommendedPlugins={ isRequestingRecommendedPlugins }
+				sites={ sites }
+				searchTitle={ props.searchTitle }
+				siteSlug={ siteSlug }
+				isRecommendedPluginsEnabled={ isRecommendedPluginsEnabled }
 			/>
-		);
-	}
+			<InfiniteScroll nextPageMethod={ fetchNextPagePlugins } />
+		</MainComponent>
+	);
+};
 
-	getShortListsView() {
+const WrappedSearch = ( props ) => <Search { ...props } />;
+
+const SearchListView = ( {
+	search: searchTerm,
+	isFetchingPluginsBySearchTerm,
+	pluginsBySearchTerm,
+	pluginsPagination,
+	searchTitle: searchTitleTerm,
+	siteSlug,
+	sites,
+} ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
+		const searchTitle =
+			searchTitleTerm ||
+			translate( 'Search results for {{b}}%(searchTerm)s{{/b}}', {
+				textOnly: true,
+				args: {
+					searchTerm,
+				},
+				components: {
+					b: <b />,
+				},
+			} );
+
+		const subtitle =
+			pluginsPagination &&
+			translate( '%(total)s plugin', '%(total)s plugins', {
+				count: pluginsPagination.results,
+				textOnly: true,
+				args: {
+					total: pluginsPagination.results,
+				},
+			} );
+
 		return (
 			<>
-				{ this.isRecommendedPluginsEnabled()
-					? this.getRecommendedPluginListView()
-					: this.getPluginSingleListView( 'featured' ) }
-
-				{ this.getPluginSingleListView( 'popular' ) }
-				{ this.getPluginSingleListView( 'new' ) }
+				<PluginsBrowserList
+					plugins={ pluginsBySearchTerm }
+					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
+					title={ searchTitle }
+					subtitle={ subtitle }
+					site={ siteSlug }
+					showPlaceholders={ isFetchingPluginsBySearchTerm }
+					size={ SEARCH_RESULTS_LIST_LENGTH }
+					currentSites={ sites }
+					variant={ PluginsBrowserListVariant.Paginated }
+					extended
+				/>
+				{ pluginsPagination && (
+					<Pagination
+						page={ pluginsPagination.page }
+						perPage={ SEARCH_RESULTS_LIST_LENGTH }
+						total={ pluginsPagination.results }
+						pageClick={ ( page ) => {
+							dispatch( fetchPluginsList( null, page, searchTerm, SEARCH_RESULTS_LIST_LENGTH ) );
+						} }
+						variant={ PaginationVariant.minimal }
+					/>
+				) }
 			</>
 		);
 	}
 
-	recordSearchEvent = ( eventName ) => this.props.recordGoogleEvent( 'PluginsBrowser', eventName );
+	return (
+		<NoResults
+			text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
+				textOnly: true,
+				components: { searchTerm: <em>{ searchTerm }</em> },
+			} ) }
+		/>
+	);
+};
 
-	getSearchBox( isMobile ) {
-		const { WrappedSearch } = this;
+const translateCategory = ( { category, translate } ) => {
+	const recommendedText = translate( 'Recommended', {
+		context: 'Category description for the plugin browser.',
+	} );
 
+	switch ( category ) {
+		case 'new':
+			return translate( 'New', {
+				context: 'Category description for the plugin browser.',
+			} );
+		case 'popular':
+			return translate( 'Popular', {
+				context: 'Category description for the plugin browser.',
+			} );
+		case 'featured':
+			return translate( 'Featured', {
+				context: 'Category description for the plugin browser.',
+			} );
+		case 'recommended':
+			return recommendedText;
+	}
+};
+
+const FullListView = ( {
+	category,
+	isFetchingPluginsByCategory,
+	pluginsByCategory,
+	siteSlug,
+	sites,
+} ) => {
+	const translate = useTranslate();
+
+	if ( pluginsByCategory.length > 0 || isFetchingPluginsByCategory ) {
 		return (
-			<WrappedSearch
-				pinned={ isMobile }
-				fitsContainer={ isMobile }
-				onSearch={ this.props.doSearch }
-				initialValue={ this.props.search }
-				placeholder={ this.props.translate( 'Try searching ‘ecommerce’' ) }
-				delaySearch={ true }
-				recordEvent={ this.recordSearchEvent }
+			<PluginsBrowserList
+				plugins={ pluginsByCategory }
+				listName={ category }
+				title={ translateCategory( { category, translate } ) }
+				site={ siteSlug }
+				showPlaceholders={ isFetchingPluginsByCategory }
+				currentSites={ sites }
+				variant={ PluginsBrowserListVariant.InfiniteScroll }
+				extended
 			/>
 		);
 	}
+};
 
-	handleSuggestedSearch = ( term ) => () => {
-		this.reinitializeSearch();
-		this.props.doSearch( term );
-	};
+const PluginSingleListView = ( {
+	category,
+	pluginsByCategoryNew,
+	isFetchingPluginsByCategoryNew,
+	pluginsByCategoryPopular,
+	isFetchingPluginsByCategoryPopular,
+	pluginsByCategoryFeatured,
+	isFetchingPluginsByCategoryFeatured,
+	siteSlug,
+	sites,
+} ) => {
+	const translate = useTranslate();
 
-	shouldShowManageButton() {
-		if ( this.props.isJetpackSite ) {
-			return true;
-		}
-		return ! this.props.selectedSiteId && this.props.hasJetpackSites;
-	}
-
-	renderManageButton() {
-		if ( ! this.shouldShowManageButton() ) {
-			return null;
-		}
-
-		const { siteAdminUrl, siteSlug, translate } = this.props;
-		const site = siteSlug ? '/' + siteSlug : '';
-
-		// When no site is selected eg `/plugins` or when Jetpack is self hosted
-		// show the Calypso Plugins Manage page.
-		// In any other case, redirect to current site WP Admin.
-		const managePluginsDestination =
-			! siteAdminUrl || this.props.jetpackNonAtomic
-				? `/plugins/manage${ site }`
-				: `${ siteAdminUrl }plugins.php`;
-
-		return (
-			<Button className="plugins-browser__button" href={ managePluginsDestination }>
-				<span className="plugins-browser__button-text">{ translate( 'Manage plugins' ) }</span>
-			</Button>
-		);
-	}
-
-	handleUploadPluginButtonClick = () => {
-		this.props.recordTracksEvent( 'calypso_click_plugin_upload' );
-		this.props.recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' );
-	};
-
-	renderUploadPluginButton( isMobile ) {
-		const { siteSlug, translate } = this.props;
-		const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
-
-		return (
-			<Button
-				className="plugins-browser__button"
-				onClick={ this.handleUploadPluginButtonClick }
-				href={ uploadUrl }
-			>
-				<Icon className="plugins-browser__button-icon" icon={ upload } width={ 18 } height={ 18 } />
-				{ ! isMobile && (
-					<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
-				) }
-			</Button>
-		);
-	}
-
-	renderUpgradeNudge() {
-		if (
-			! this.props.selectedSiteId ||
-			! this.props.sitePlan ||
-			this.props.isVipSite ||
-			this.props.jetpackNonAtomic ||
-			this.props.hasBusinessPlan
-		) {
-			return null;
-		}
-
-		const { translate, siteSlug } = this.props;
-		const bannerURL = `/checkout/${ siteSlug }/business`;
-		const plan = findFirstSimilarPlanKey( this.props.sitePlan.product_slug, {
-			type: TYPE_BUSINESS,
-		} );
-		const title = translate( 'Upgrade to the Business plan to install plugins.' );
-
-		return (
-			<UpsellNudge
-				event="calypso_plugins_browser_upgrade_nudge"
-				showIcon={ true }
-				href={ bannerURL }
-				feature={ FEATURE_UPLOAD_PLUGINS }
-				plan={ plan }
-				title={ title }
-			/>
-		);
-	}
-
-	renderPageViewTracker() {
-		const { category, selectedSiteId, trackPageViews } = this.props;
-
-		const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
-		let analyticsPath = category ? `/plugins/${ category }` : '/plugins';
-
-		if ( selectedSiteId ) {
-			analyticsPath += '/:site';
-		}
-
-		if ( trackPageViews ) {
-			return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
-		}
-
+	let plugins;
+	let isFetching;
+	if ( category === 'new' ) {
+		plugins = pluginsByCategoryNew;
+		isFetching = isFetchingPluginsByCategoryNew;
+	} else if ( category === 'popular' ) {
+		plugins = pluginsByCategoryPopular;
+		isFetching = isFetchingPluginsByCategoryPopular;
+	} else if ( category === 'featured' ) {
+		plugins = pluginsByCategoryFeatured;
+		isFetching = isFetchingPluginsByCategoryFeatured;
+	} else {
 		return null;
 	}
 
-	getNavigationItems() {
-		const { search, siteSlug } = this.props;
-		const navigationItems = [
-			{ label: this.props.translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }` },
-		];
-		if ( search ) {
-			navigationItems.push( {
-				label: this.props.translate( 'Search Results' ),
-				href: `/plugins/${ siteSlug || '' }?s=${ search }`,
-			} );
-		}
+	const listLink = '/plugins/' + category + '/';
+	return (
+		<PluginsBrowserList
+			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
+			listName={ category }
+			title={ translateCategory( { category, translate } ) }
+			site={ siteSlug }
+			expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? listLink : false }
+			size={ SHORT_LIST_LENGTH }
+			showPlaceholders={ isFetching }
+			currentSites={ sites }
+			variant={ PluginsBrowserListVariant.Fixed }
+			extended
+		/>
+	);
+};
 
-		return navigationItems;
+const RecommendedPluginListView = ( {
+	recommendedPlugins,
+	isRequestingRecommendedPlugins,
+	sites,
+	siteSlug,
+} ) => {
+	const translate = useTranslate();
+
+	if ( recommendedPlugins && recommendedPlugins.length === 0 ) {
+		return null;
 	}
 
-	getAnnoncementPages() {
-		const { translate } = this.props;
-		return [
-			{
-				headline: translate( 'ITS NEW!' ),
-				heading: translate( 'All the plugins and more' ),
-				content: translate(
-					'This page may look different as we’ve made some changes to improve the experience for you. Stay tuned for even more exciting updates to come!'
-				),
-				featureImage: announcementImage,
-			},
-		];
+	return (
+		<PluginsBrowserList
+			currentSites={ sites }
+			expandedListLink={ false }
+			listName="recommended"
+			plugins={ recommendedPlugins }
+			showPlaceholders={ isRequestingRecommendedPlugins }
+			site={ siteSlug }
+			size={ SHORT_LIST_LENGTH }
+			title={ translateCategory( { category: 'recommended', translate } ) }
+			variant={ PluginsBrowserListVariant.Fixed }
+			extended
+		/>
+	);
+};
+
+const PluginBrowserContent = ( props ) => {
+	if ( props.search ) {
+		return <SearchListView { ...props } />;
+	}
+	if ( props.category ) {
+		return <FullListView { ...props } />;
 	}
 
-	render() {
-		const { category, search, translate } = this.props;
+	return (
+		<>
+			{ props.isRecommendedPluginsEnabled ? (
+				<RecommendedPluginListView { ...props } />
+			) : (
+				<PluginSingleListView { ...props } category="featured" />
+			) }
 
-		if ( ! this.props.isRequestingSites && this.props.noPermissionsError ) {
-			return <NoPermissionsError title={ translate( 'Plugins', { textOnly: true } ) } />;
-		}
+			<PluginSingleListView { ...props } category="popular" />
+			<PluginSingleListView { ...props } category="new" />
+		</>
+	);
+};
 
-		return (
-			<MainComponent wideLayout>
-				{ category && <QueryWporgPlugins category={ category } /> }
-				{ search && <QueryWporgPlugins searchTerm={ search } /> }
-				{ ! category && ! search && (
-					<Fragment>
-						<QueryWporgPlugins category="new" />
-						<QueryWporgPlugins category="popular" />
-						<QueryWporgPlugins category="featured" />
-					</Fragment>
-				) }
-				{ this.isRecommendedPluginsEnabled() && (
-					<QuerySiteRecommendedPlugins siteId={ this.props.selectedSiteId } />
-				) }
-				{ this.renderPageViewTracker() }
-				<DocumentHead title={ translate( 'Plugins' ) } />
-				<SidebarNavigation />
-				<AnnouncementModal
-					announcementId="plugins-page-revamp"
-					pages={ this.getAnnoncementPages() }
-					finishButtonText={ translate( "Let's explore!" ) }
-				/>
-				{ ! this.props.hideHeader && (
-					<FixedNavigationHeader
-						className="plugins-browser__header"
-						navigationItems={ this.getNavigationItems() }
-					>
-						<div className="plugins-browser__main-buttons">
-							{ this.renderManageButton() }
-							{ this.renderUploadPluginButton( this.state.isMobile ) }
-						</div>
+const UpgradeNudge = ( {
+	selectedSite,
+	sitePlan,
+	isVip,
+	jetpackNonAtomic,
+	hasBusinessPlan,
+	siteSlug,
+} ) => {
+	const translate = useTranslate();
 
-						<div className="plugins-browser__searchbox">
-							{ this.getSearchBox( this.state.isMobile ) }
-						</div>
-					</FixedNavigationHeader>
-				) }
-				{ this.renderUpgradeNudge() }
-				{ this.getPluginBrowserContent() }
-				<InfiniteScroll nextPageMethod={ this.fetchNextPagePlugins } />
-			</MainComponent>
-		);
+	if ( ! selectedSite?.ID || ! sitePlan || isVip || jetpackNonAtomic || hasBusinessPlan ) {
+		return null;
 	}
-}
+
+	const bannerURL = `/checkout/${ siteSlug }/business`;
+	const plan = findFirstSimilarPlanKey( sitePlan.product_slug, {
+		type: TYPE_BUSINESS,
+	} );
+	const title = translate( 'Upgrade to the Business plan to install plugins.' );
+
+	return (
+		<UpsellNudge
+			event="calypso_plugins_browser_upgrade_nudge"
+			showIcon={ true }
+			href={ bannerURL }
+			feature={ FEATURE_UPLOAD_PLUGINS }
+			plan={ plan }
+			title={ title }
+		/>
+	);
+};
+
+const UploadPluginButton = ( { isMobile, siteSlug } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
+
+	const handleUploadPluginButtonClick = () => {
+		dispatch( recordTracksEvent( 'calypso_click_plugin_upload' ) );
+		dispatch( recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' ) );
+	};
+
+	return (
+		<Button
+			className="plugins-browser__button"
+			onClick={ handleUploadPluginButtonClick }
+			href={ uploadUrl }
+		>
+			<Icon className="plugins-browser__button-icon" icon={ upload } width={ 18 } height={ 18 } />
+			{ ! isMobile && (
+				<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
+			) }
+		</Button>
+	);
+};
+
+const SearchBox = ( { isMobile, doSearch, search } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const recordSearchEvent = ( eventName ) =>
+		dispatch( recordGoogleEvent( 'PluginsBrowser', eventName ) );
+
+	return (
+		<WrappedSearch
+			pinned={ isMobile }
+			fitsContainer={ isMobile }
+			onSearch={ doSearch }
+			initialValue={ search }
+			placeholder={ translate( 'Try searching ‘ecommerce’' ) }
+			delaySearch={ true }
+			recordEvent={ recordSearchEvent }
+		/>
+	);
+};
+
+const ManageButton = ( { shouldShowManageButton, siteAdminUrl, siteSlug, jetpackNonAtomic } ) => {
+	const translate = useTranslate();
+
+	if ( ! shouldShowManageButton ) {
+		return null;
+	}
+
+	const site = siteSlug ? '/' + siteSlug : '';
+
+	// When no site is selected eg `/plugins` or when Jetpack is self hosted
+	// show the Calypso Plugins Manage page.
+	// In any other case, redirect to current site WP Admin.
+	const managePluginsDestination =
+		! siteAdminUrl || jetpackNonAtomic
+			? `/plugins/manage${ site }`
+			: `${ siteAdminUrl }plugins.php`;
+
+	return (
+		<Button className="plugins-browser__button" href={ managePluginsDestination }>
+			<span className="plugins-browser__button-text">{ translate( 'Manage plugins' ) }</span>
+		</Button>
+	);
+};
+
+const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) => {
+	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
+	let analyticsPath = category ? `/plugins/${ category }` : '/plugins';
+
+	if ( selectedSiteId ) {
+		analyticsPath += '/:site';
+	}
+
+	if ( trackPageViews ) {
+		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
+	}
+
+	return null;
+};
 
 /**
  * Filter the popular plugins list.
@@ -565,59 +641,4 @@ function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 	);
 }
 
-export default flow(
-	localize,
-	urlSearch,
-	connect(
-		( state, { category, search } ) => {
-			const selectedSiteId = getSelectedSiteId( state );
-			const sitePlan = getSitePlan( state, selectedSiteId );
-
-			const hasBusinessPlan =
-				sitePlan &&
-				( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
-			const hasPremiumPlan = sitePlan && ( hasBusinessPlan || isPremium( sitePlan ) );
-			const recommendedPlugins = getRecommendedPlugins( state, selectedSiteId );
-			const featuredPlugins = getPluginsListByCategory( state, 'featured' );
-			const popularPlugins = getPluginsListByCategory( state, 'popular' );
-
-			return {
-				selectedSiteId,
-				sitePlan,
-				hasPremiumPlan,
-				hasBusinessPlan,
-				isJetpackSite: isJetpackSite( state, selectedSiteId ),
-				jetpackNonAtomic:
-					isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),
-				isVipSite: isVipSite( state, selectedSiteId ),
-				hasJetpackSites: hasJetpackSites( state ),
-				isRequestingSites: isRequestingSites( state ),
-				noPermissionsError:
-					!! selectedSiteId && ! canCurrentUser( state, selectedSiteId, 'manage_options' ),
-				selectedSite: getSelectedSite( state ),
-				siteSlug: getSelectedSiteSlug( state ),
-				sites: getSelectedOrAllSitesJetpackCanManage( state ),
-				isRequestingRecommendedPlugins: ! Array.isArray( recommendedPlugins ),
-				recommendedPlugins: recommendedPlugins || [],
-				pluginsByCategory: getPluginsListByCategory( state, category ),
-				pluginsByCategoryNew: getPluginsListByCategory( state, 'new' ),
-				pluginsByCategoryPopular: filterPopularPlugins( popularPlugins, featuredPlugins ),
-				pluginsByCategoryFeatured: featuredPlugins,
-				pluginsBySearchTerm: getPluginsListBySearchTerm( state, search ),
-				pluginsPagination: getPluginsListPagination( state, search ),
-				isFetchingPluginsByCategory: isFetchingPluginsList( state, category ),
-				isFetchingPluginsByCategoryNew: isFetchingPluginsList( state, 'new' ),
-				isFetchingPluginsByCategoryPopular: isFetchingPluginsList( state, 'popular' ),
-				isFetchingPluginsByCategoryFeatured: isFetchingPluginsList( state, 'featured' ),
-				isFetchingPluginsBySearchTerm: isFetchingPluginsList( state, null, search ),
-				siteAdminUrl: getSiteAdminUrl( state, selectedSiteId ),
-			};
-		},
-		{
-			fetchPluginsList,
-			fetchPluginsCategoryNextPage,
-			recordTracksEvent,
-			recordGoogleEvent,
-		}
-	)
-)( PluginsBrowser );
+export default UrlSearch( PluginsBrowser );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -65,7 +65,7 @@ import './style.scss';
 const SHORT_LIST_LENGTH = 6;
 const SEARCH_RESULTS_LIST_LENGTH = 12;
 
-const PluginsBrowser = ( props ) => {
+export const PluginsBrowser = ( props ) => {
 	const { trackPageViews = true, category, search } = props;
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -1,12 +1,25 @@
 /** @jest-environment jsdom */
 
+jest.mock( 'calypso/lib/wporg', () => ( {
+	getWporgLocaleCode: () => 'it_US',
+	fetchPluginsList: () => Promise.resolve( [] ),
+} ) );
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'calypso/components/main', () => 'MainComponent' );
-jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => 'upsell-nudge' );
 jest.mock( 'calypso/components/notice', () => 'Notice' );
 jest.mock( 'calypso/components/notice/notice-action', () => 'NoticeAction' );
+
+jest.mock( '@automattic/languages', () => [
+	{
+		value: 1,
+		langSlug: 'it',
+		name: 'Italian English',
+		wpLocale: 'it_US',
+		popular: 1,
+		territories: [ '019' ],
+	},
+] );
 
 import {
 	PLAN_FREE,
@@ -19,117 +32,73 @@ import {
 	PLAN_BLOGGER,
 	PLAN_BLOGGER_2_YEARS,
 } from '@automattic/calypso-products';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
+import { merge } from 'lodash';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import { PluginsBrowser } from '../';
 
-const props = {
-	isRequestingRecommendedPlugins: false,
-	pluginsByCategory: [],
-	pluginsByCategoryNew: [],
-	pluginsByCategoryPopular: [],
-	pluginsByCategoryFeatured: [],
-	pluginsBySearchTerm: [],
-	site: {
-		plan: PLAN_FREE,
+window.__i18n_text_domain__ = JSON.stringify( 'default' );
+const initialReduxState = {
+	plugins: {
+		wporg: {
+			lists: {},
+			fetchingLists: {},
+		},
 	},
-	selectedSite: {},
-	selectedSiteId: 123,
-	translate: ( x ) => x,
+	ui: { selectedSiteId: 1 },
+	sites: { items: { 1: { ID: 1, plan: { productSlug: PLAN_FREE } } } },
+	currentUser: { capabilities: { 1: { manage_options: true } } },
+	media: {
+		queries: {
+			'[]': {
+				itemKeys: [ 1 ],
+				found: 1,
+			},
+		},
+	},
+	documentHead: {},
 };
 
-describe( 'PluginsBrowser basic tests', () => {
-	test( 'should not blow up and have proper CSS class', () => {
-		const comp = shallow( <PluginsBrowser { ...props } /> );
-		expect( comp.find( 'MainComponent' ).length ).toBe( 1 );
+function mountWithRedux( ui, overrideState ) {
+	const store = createStore(
+		( state ) => state,
+		merge( initialReduxState, overrideState ),
+		applyMiddleware( thunkMiddleware )
+	);
+	return mount( <Provider store={ store }>{ ui }</Provider> );
+}
+
+describe( 'Search view', () => {
+	const myProps = {
+		search: 'searchterm',
+	};
+
+	test( 'should show NoResults when there are no results', () => {
+		const comp = mountWithRedux( <PluginsBrowser { ...myProps } /> );
+		expect( comp.find( 'NoResults' ).length ).toBe( 1 );
 	} );
-	test( 'should show upsell nudge when appropriate', () => {
-		const comp = shallow(
-			<PluginsBrowser
-				{ ...props }
-				selectedSiteId={ 12 }
-				sitePlan={ PLAN_PREMIUM }
-				isJetpackSite={ false }
-				hasBusinessPlan={ false }
-			/>
-		);
-		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
-			1
-		);
-	} );
-	test( 'should not show upsell nudge if no site is selected', () => {
-		const comp = shallow(
-			<PluginsBrowser
-				{ ...props }
-				selectedSiteId={ null }
-				sitePlan={ { product_slug: PLAN_PREMIUM } }
-				isJetpackSite={ false }
-				hasBusinessPlan={ false }
-			/>
-		);
-		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
-			0
-		);
-	} );
-	test( 'should not show upsell nudge if no sitePlan', () => {
-		const comp = shallow(
-			<PluginsBrowser
-				{ ...props }
-				selectedSiteId={ 10 }
-				sitePlan={ null }
-				isJetpackSite={ true }
-				hasBusinessPlan={ false }
-			/>
-		);
-		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
-			0
-		);
-	} );
-	test( 'should not show upsell nudge if non-atomic jetpack site', () => {
-		const comp = shallow(
-			<PluginsBrowser
-				{ ...props }
-				selectedSiteId={ 10 }
-				sitePlan={ { product_slug: PLAN_PREMIUM } }
-				jetpackNonAtomic={ true }
-				hasBusinessPlan={ false }
-			/>
-		);
-		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
-			0
-		);
-	} );
-	test( 'should not show upsell nudge has business plan', () => {
-		const comp = shallow(
-			<PluginsBrowser
-				{ ...props }
-				selectedSiteId={ 10 }
-				sitePlan={ { product_slug: PLAN_PREMIUM } }
-				isJetpackSite={ false }
-				hasBusinessPlan={ true }
-			/>
-		);
-		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
-			0
-		);
+
+	test( 'should show plugin list when there are results', () => {
+		const comp = mountWithRedux( <PluginsBrowser { ...myProps } />, {
+			plugins: { wporg: { lists: { search: { searchterm: [ {} ] } } } },
+		} );
+		expect( comp.find( 'PluginsBrowserList' ).length ).toBe( 1 );
 	} );
 } );
 
 describe( 'Upsell Nudge should get appropriate plan constant', () => {
-	const myProps = {
-		...props,
-		showUpgradeNudge: true,
-		isJetpackSite: false,
-		hasBusinessPlan: false,
-	};
-
 	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( ( product_slug ) => {
 		test( `Business 1 year for (${ product_slug })`, () => {
-			const comp = shallow( <PluginsBrowser { ...myProps } sitePlan={ { product_slug } } /> );
+			const comp = mountWithRedux( <PluginsBrowser />, {
+				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
+			} );
 			expect(
-				comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+				comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
 			).toBe( 1 );
 			expect(
-				comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
+				comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
 			).toBe( PLAN_BUSINESS );
 		} );
 	} );
@@ -137,36 +106,60 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach(
 		( product_slug ) => {
 			test( `Business 2 year for (${ product_slug })`, () => {
-				const comp = shallow( <PluginsBrowser { ...myProps } sitePlan={ { product_slug } } /> );
+				const comp = mountWithRedux( <PluginsBrowser />, {
+					sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
+				} );
 				expect(
-					comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+					comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
 				).toBe( 1 );
 				expect(
-					comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
+					comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
 				).toBe( PLAN_BUSINESS_2_YEARS );
 			} );
 		}
 	);
 } );
 
-describe( 'Search view', () => {
-	const myProps = {
-		...props,
-		search: 'test searchterm',
-	};
-
-	test( 'should show NoResults when there are no results', () => {
-		const comp = shallow( <PluginsBrowser { ...myProps } /> );
-		expect( comp.find( 'NoResults' ).length ).toBe( 1 );
+describe( 'PluginsBrowser basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = mountWithRedux( <PluginsBrowser /> );
+		expect( comp.find( 'main' ).length ).toBe( 1 );
 	} );
-
-	test( 'should show plugin list when there are results', () => {
-		const myProps2 = {
-			...myProps,
-			pluginsBySearchTerm: [ { name: 'plugin1', slug: 'test-plugin' } ],
-		};
-
-		const comp = shallow( <PluginsBrowser { ...myProps2 } /> );
-		expect( comp.find( 'Localized(PluginsBrowserList)' ).length ).toBe( 1 );
+	test( 'should show upsell nudge when appropriate', () => {
+		const comp = mountWithRedux( <PluginsBrowser /> );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 1 );
+	} );
+	test( 'should not show upsell nudge if no site is selected', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, { ui: { selectedSiteId: null } } );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 0 );
+	} );
+	test( 'should not show upsell nudge if no sitePlan', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, {
+			ui: { selectedSiteId: 10 },
+			sites: { items: { 10: { ID: 10, plan: null } } },
+		} );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 0 );
+	} );
+	test( 'should not show upsell nudge if non-atomic jetpack site', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, {
+			sites: { items: { 1: { jetpack: true } } },
+		} );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 0 );
+	} );
+	test( 'should not show upsell nudge has business plan', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, {
+			sites: { items: { 1: { jetpack: true, plan: { productSlug: PLAN_PREMIUM } } } },
+		} );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 0 );
 	} );
 } );

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -37,7 +37,7 @@ import { merge } from 'lodash';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import { PluginsBrowser } from '../';
+import PluginsBrowser from '../';
 
 window.__i18n_text_domain__ = JSON.stringify( 'default' );
 const initialReduxState = {
@@ -59,6 +59,7 @@ const initialReduxState = {
 		},
 	},
 	documentHead: {},
+	preferences: { remoteValues: {} },
 };
 
 function mountWithRedux( ui, overrideState ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Turn PluginsBrowser into a functional component

#### Testing instructions
No visual change should be seen.

1. Go to `/plugins` page without a selected site.
1. Click on the breadcrumbs to see if it still works.
1. Search for a plugin and check if the list gets filtered.
1. Verify if clicking the **Manage plugins** button redirects you to `/plugins/manage`.
1. Verify if clicking the **Upload** button redirects you to `/plugins/upload`.
1. Select a site and redo the steps from **2** to **5**.

---

Fixes #59002
Also related to #58453 by removing all lifecycle methods.