### PR TITLE
Jetpack product card: reduce height

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -1,12 +1,17 @@
+@import '@automattic/onboarding/styles/mixins';
+
 .jetpack-product-card .display-price {
 	.is-disabled & {
 		opacity: 0.4;
 	}
 
 	&.is-free {
-		min-height: 130px;
 		margin-block-start: -4px;
 		padding-block-start: 24px;
+
+		@include break-medium {
+			min-height: 130px;
+		}
 
 		// Adjust leading margin so that different UI fonts
 		// still align to the price the same way

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -1,3 +1,5 @@
+@import '@automattic/onboarding/styles/mixins';
+
 .jetpack-product-card {
 	position: relative;
 
@@ -80,7 +82,7 @@
 }
 
 .jetpack-product-card__product-name {
-	margin: 12px 0 20px;
+	margin: 8px 0 12px;
 
 	color: var( --studio-gray-100 );
 
@@ -170,15 +172,19 @@
 }
 
 .jetpack-product-card__features-list {
-	margin: 0 16px 32px;
+	margin: 0 16px 12px;
 
 	em {
 		font-style: normal;
 	}
+
+	@include break-medium {
+		margin-block-end: 2rem;
+	}
 }
 
 .jetpack-product-card__features-item {
-	margin: 14px 0;
+	margin: 12px 0;
 	padding-inline-start: 8px;
 	color: var( --studio-gray-60 );
 

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -3,8 +3,8 @@
 
 .product-grid__section {
 	margin-bottom: 70px;
-	padding-left: 20px;
-	padding-right: 20px;
+	padding-left: 16px;
+	padding-right: 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		padding-left: 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR reduces slightly the height of the Jetpack product card, to improve the mobile experience. #58919 will help make it smaller too.

### Testing instructions

- Download the PR and run Calypso or cloud
- Visit the plans/pricing page
- Check that the product cards are smaller than in production (see captures below)

### Screenshots

| Before | After |
|--------|------|
|<img width="426" alt="Screen Shot 2021-12-09 at 4 07 31 PM" src="https://user-images.githubusercontent.com/1620183/145476456-59ab47dd-c0af-49fb-bef2-beb33baa2d61.png">|<img width="428" alt="Screen Shot 2021-12-09 at 4 07 37 PM" src="https://user-images.githubusercontent.com/1620183/145476506-82ce0a58-29b1-41e3-81d1-388d8f6d8e14.png">|

