### PR TITLE
Jetpack pricing page: move Complete plan higher on mobile

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -43,6 +43,12 @@
 
 	list-style-type: none;
 
+	@include break-small {
+		grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
+	}
+}
+
+.product-grid__plan-grid {
 	> li.is-featured {
 		// Put featured item(s) in first position
 		order: -2;
@@ -51,10 +57,6 @@
 	> li:last-child {
 		// Put last item below featured items
 		order: -1;
-	}
-
-	@include break-small {
-		grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -44,7 +44,12 @@
 	list-style-type: none;
 
 	> li.is-featured {
-		// Put feature item(s) in first position
+		// Put featured item(s) in first position
+		order: -2;
+	}
+
+	> li:last-child {
+		// Put last item below featured items
 		order: -1;
 	}
 
@@ -59,6 +64,9 @@
 
 	// Considering there are 3 plans
 	> li {
+		// Reset mobile and tablet positions
+		order: 0;
+
 		&:first-child {
 			position: relative;
 			left: 8px;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR moves the _Complete_ plan higher on mobile in the pricing page. The order is now: Security > Complete > Backup.

### Testing instructions

- Download the PR and run Calypso or cloud
- Visit the plans/pricing page
- Check that the order of the plans matches the description above
- Check that the page looks the same on desktop as in production

### Screenshots

_Mobile_
<img width="501" alt="Screen Shot 2021-12-09 at 4 24 39 PM" src="https://user-images.githubusercontent.com/1620183/145478265-b9c31550-0c89-49e1-8011-0e640e190d44.png">


_Tablet_
<img width="964" alt="Screen Shot 2021-12-09 at 4 24 22 PM" src="https://user-images.githubusercontent.com/1620183/145478309-5172572b-baad-437e-b314-f7ad910d3ca2.png">

