### PR TITLE
Checkout: add Tracks events for step completion

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -48,6 +48,7 @@ import type { OnChangeItemVariant } from '../components/item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, RequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -302,7 +303,15 @@ export default function WPCheckout( {
 					isStepActive={ isOrderReviewActive }
 					isStepComplete={ true }
 					goToThisStep={ () => setIsOrderReviewActive( ! isOrderReviewActive ) }
-					goToNextStep={ () => setIsOrderReviewActive( ! isOrderReviewActive ) }
+					goToNextStep={ () => {
+						setIsOrderReviewActive( ! isOrderReviewActive )
+						reduxDispatch(
+							recordTracksEvent( 'calypso_checkout_composite_step_complete', {
+								step: 0,
+								step_name: "review-order-step",
+							} )
+						);
+					}}
 					activeStepContent={
 						<WPCheckoutOrderReview
 							removeProductFromCart={ removeProductFromCart }
@@ -349,7 +358,18 @@ export default function WPCheckout( {
 									reduxDispatch,
 									translate,
 									true
-								);
+								).then((response) => {
+									if (response) {
+										reduxDispatch(
+											recordTracksEvent( 'calypso_checkout_composite_step_complete', {
+												step: 1,
+												step_name: "contact-form",
+											} )
+										);
+									}
+									return response;
+									
+								});;
 							} }
 							activeStepContent={
 								<WPContactForm

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -30,6 +30,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import useUpdateCartLocationWhenPaymentMethodChanges from '../hooks/use-update-cart-location-when-payment-method-changes';
 import { validateContactDetails } from '../lib/contact-validation';
@@ -48,7 +49,6 @@ import type { OnChangeItemVariant } from '../components/item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, RequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -304,14 +304,14 @@ export default function WPCheckout( {
 					isStepComplete={ true }
 					goToThisStep={ () => setIsOrderReviewActive( ! isOrderReviewActive ) }
 					goToNextStep={ () => {
-						setIsOrderReviewActive( ! isOrderReviewActive )
+						setIsOrderReviewActive( ! isOrderReviewActive );
 						reduxDispatch(
 							recordTracksEvent( 'calypso_checkout_composite_step_complete', {
 								step: 0,
-								step_name: "review-order-step",
+								step_name: 'review-order-step',
 							} )
 						);
-					}}
+					} }
 					activeStepContent={
 						<WPCheckoutOrderReview
 							removeProductFromCart={ removeProductFromCart }
@@ -358,18 +358,17 @@ export default function WPCheckout( {
 									reduxDispatch,
 									translate,
 									true
-								).then((response) => {
-									if (response) {
+								).then( ( response ) => {
+									if ( response ) {
 										reduxDispatch(
 											recordTracksEvent( 'calypso_checkout_composite_step_complete', {
 												step: 1,
-												step_name: "contact-form",
+												step_name: 'contact-form',
 											} )
 										);
 									}
 									return response;
-									
-								});;
+								} );
 							} }
 							activeStepContent={
 								<WPContactForm

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -624,11 +624,11 @@ export default function CompositeCheckout( {
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_composite_step_complete', {
 					step: 2,
-					step_name: "payment-method-step",
+					step_name: 'payment-method-step',
 				} )
 			);
 		},
-		[ onPaymentComplete, onAfterPaymentComplete ]
+		[ onPaymentComplete, onAfterPaymentComplete, reduxDispatch ]
 	);
 
 	const handlePaymentError = useCallback(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -621,6 +621,12 @@ export default function CompositeCheckout( {
 		( args ) => {
 			onPaymentComplete?.( args );
 			onAfterPaymentComplete?.();
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_step_complete', {
+					step: 2,
+					step_name: "payment-method-step",
+				} )
+			);
 		},
 		[ onPaymentComplete, onAfterPaymentComplete ]
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `calypso_checkout_composite_step_complete` event with a `step_name` prop and a `step` prop that takes the step number. This event will fire when a composite-checkout step is in "completed" state.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enter checkout, verify that the `calypso_checkout_composite_step_complete` tracks event fires after completing each step.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55080
