### PR TITLE
Products: Allow camelCase product slug in getJetpackProductDisplayName

### DIFF
--- a/packages/calypso-products/src/get-jetpack-product-display-name.ts
+++ b/packages/calypso-products/src/get-jetpack-product-display-name.ts
@@ -1,11 +1,14 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { getJetpackProductsDisplayNames } from './translations';
-import type { Product } from './types';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 import type { TranslateResult } from 'i18n-calypso';
 
 /**
  * Get Jetpack product display name based on the product purchase object.
  */
-export function getJetpackProductDisplayName( product: Product ): TranslateResult | undefined {
+export function getJetpackProductDisplayName(
+	product: WithSnakeCaseSlug | WithCamelCaseSlug
+): TranslateResult | undefined {
 	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
-	return jetpackProductsDisplayNames[ product.product_slug ];
+	return jetpackProductsDisplayNames[ camelOrSnakeSlug( product ) ];
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a bug where `CartPlanOverlapsOwnedProductNotice` passes a product with `productSlug` to `getJetpackProductDisplayName` by allowing camelCase slugs in that function (unless the types are wrong in `CartPlanOverlapsOwnedProductNotice` but either way this should be safe and fixes a TypeScript error).

The display behavior was added in https://github.com/Automattic/wp-calypso/pull/44943 and the regression was added in https://github.com/Automattic/wp-calypso/pull/58080

#### Testing instructions

None should be needed. TypeScript should protect against regressions, and this just gives the function more flexibility.