### PR TITLE
Convert viewport package to TypeScript

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -34,6 +34,8 @@
 		{ "path": "./shopping-cart" },
 		{ "path": "./state-utils" },
 		{ "path": "./tree-select" },
+		{ "path": "./viewport" },
+		{ "path": "./viewport-react" },
 		{ "path": "./wpcom-checkout" }
 	]
 }

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -4,7 +4,7 @@
 	"description": "Vanilla helpers for tracking viewport changes",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
-	"calypso:src": "src/index.js",
+	"calypso:src": "src/index.ts",
 	"types": "dist/types/index.d.ts",
 	"sideEffects": false,
 	"repository": {

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -24,7 +24,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/viewport#readme",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"publishConfig": {

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -5,12 +5,17 @@
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"calypso:src": "src/index.js",
+	"types": "dist/types/index.d.ts",
 	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
 		"directory": "packages/viewport"
 	},
+	"files": [
+		"dist",
+		"src"
+	],
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",
 	"bugs": {
@@ -18,8 +23,8 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/viewport#readme",
 	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "transpile",
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"publishConfig": {

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -130,11 +130,11 @@ export function getMediaQueryList(
  * Returns whether the current window width matches a breakpoint.
  *
  * @param {string} breakpoint The breakpoint to consider.
- * @returns {boolean} Whether the provided breakpoint is matched.
+ * @returns {boolean|undefined} Whether the provided breakpoint is matched.
  */
-export function isWithinBreakpoint( breakpoint: string ): boolean {
+export function isWithinBreakpoint( breakpoint: string ): boolean | undefined {
 	const mediaQueryList = getMediaQueryList( breakpoint );
-	return mediaQueryList ? mediaQueryList.matches : false;
+	return mediaQueryList ? mediaQueryList.matches : undefined;
 }
 
 /**
@@ -167,9 +167,9 @@ export function subscribeIsWithinBreakpoint(
 /**
  * Returns whether the current window width matches the mobile breakpoint.
  *
- * @returns {boolean} Whether the mobile breakpoint is matched.
+ * @returns {boolean|undefined} Whether the mobile breakpoint is matched.
  */
-export function isMobile(): boolean {
+export function isMobile(): boolean | undefined {
 	return isWithinBreakpoint( MOBILE_BREAKPOINT );
 }
 
@@ -186,9 +186,9 @@ export function subscribeIsMobile( listener: ListenerCallback ): UnsubcribeCallb
 /**
  * Returns whether the current window width matches the desktop breakpoint.
  *
- * @returns {boolean} Whether the desktop breakpoint is matched.
+ * @returns {boolean|undefined} Whether the desktop breakpoint is matched.
  */
-export function isDesktop(): boolean {
+export function isDesktop(): boolean | undefined {
 	return isWithinBreakpoint( DESKTOP_BREAKPOINT );
 }
 

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -47,7 +47,23 @@ const isServer = typeof window === 'undefined' || ! window.matchMedia;
 
 const noop = () => null;
 
-export type MinimalMediaQueryList = { matches: boolean };
+export type ListenerCallback = ( matches: boolean ) => void;
+export type UnsubcribeCallback = () => void;
+export type MinimalMediaQueryList = {
+	matches: boolean;
+	addListener: MediaQueryList[ 'addListener' ];
+	removeListener: MediaQueryList[ 'removeListener' ];
+};
+
+function addListenerFunctions(
+	obj: Pick< MinimalMediaQueryList, 'matches' >
+): MinimalMediaQueryList {
+	return {
+		addListener: () => undefined,
+		removeListener: () => undefined,
+		...obj,
+	};
+}
 
 function createMediaQueryList(
 	args: undefined | { min?: number; max?: number }
@@ -55,19 +71,19 @@ function createMediaQueryList(
 	const { min, max } = args ?? {};
 	if ( min !== undefined && max !== undefined ) {
 		return isServer
-			? { matches: SERVER_WIDTH > min && SERVER_WIDTH <= max }
+			? addListenerFunctions( { matches: SERVER_WIDTH > min && SERVER_WIDTH <= max } )
 			: window.matchMedia( `(min-width: ${ min + 1 }px) and (max-width: ${ max }px)` );
 	}
 
 	if ( min !== undefined ) {
 		return isServer
-			? { matches: SERVER_WIDTH > min }
+			? addListenerFunctions( { matches: SERVER_WIDTH > min } )
 			: window.matchMedia( `(min-width: ${ min + 1 }px)` );
 	}
 
 	if ( max !== undefined ) {
 		return isServer
-			? { matches: SERVER_WIDTH <= max }
+			? addListenerFunctions( { matches: SERVER_WIDTH <= max } )
 			: window.matchMedia( `(max-width: ${ max }px)` );
 	}
 
@@ -120,9 +136,6 @@ export function isWithinBreakpoint( breakpoint: string ): boolean {
 	const mediaQueryList = getMediaQueryList( breakpoint );
 	return mediaQueryList ? mediaQueryList.matches : false;
 }
-
-export type ListenerCallback = ( matches: boolean ) => void;
-export type UnsubcribeCallback = () => void;
 
 /**
  * Registers a listener to be notified of changes to breakpoint matching status.

--- a/packages/viewport/tsconfig-cjs.json
+++ b/packages/viewport/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/viewport/tsconfig.json
+++ b/packages/viewport/tsconfig.json
@@ -1,3 +1,10 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json"
+	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ]
 }

--- a/packages/viewport/tsconfig.json
+++ b/packages/viewport/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
 	"compilerOptions": {
 		"declarationDir": "dist/types",
 		"outDir": "dist/esm",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This converts the `@automattic/viewport` package to TypeScript. This will prevent TS errors when importing this package.

#### Testing instructions

None should be required. This does not change the behavior of the package; it only adds types, with one exception: 

There was a possible bug where listeners could be called that did not exist. This PR creates mock listeners so that will not throw an error (presumably this is safe because there's never been any listener callbacks before and no one has complained so mock callbacks shouldn't be any worse).

Several of the exported functions claim to return booleans, but they in fact return `boolean|undefined`, so I've typed them that way. I thought perhaps to make them actually return booleans but the unit tests exploit the unfiltered return values.

The compilation and tests should really be sufficient, but to verify that the package still works, we could test one of the exports:

- You can type the following into your browser console and reload the page to see analytics events there: `localStorage.setItem('debug', 'calypso:analytics')`.
- Add a product to your cart and visit checkout.
- Complete a purchase.
- Verify that you see the `calypso_checkout_payment_success` event recorded with the `device` property set to `'desktop'` (assuming you're on a desktop device).