### PR TITLE
Migrate Photon to Typescript

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -60,6 +60,7 @@
 		"@automattic/plans-grid": "workspace:^",
 		"@automattic/tour-kit": "workspace:^",
 		"@automattic/typography": "workspace:^",
+		"@automattic/viewport": "workspace:^",
 		"@automattic/whats-new": "workspace:^",
 		"@babel/core": "^7.16.5",
 		"@emotion/react": "^11.4.1",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -43,7 +43,8 @@
 		"seed-random": "^2.2.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-typescript-config": "workspace:^"
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^4.5.3"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -37,17 +37,17 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"dependencies": {
+		"@types/seed-random": "^2.2.1",
 		"crc32": "^0.2.2",
 		"debug": "^4.0.0",
 		"seed-random": "^2.2.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-typescript-config": "workspace:^",
-		"@types/seed-random": "^2.2.1"
+		"@automattic/calypso-typescript-config": "workspace:^"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -4,7 +4,7 @@
 	"description": "JavaScript library for the WordPress.com Photon image manipulation service",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
-	"calypso:src": "src/index.js",
+	"calypso:src": "src/index.ts",
 	"types": "dist/types/index.d.ts",
 	"sideEffects": false,
 	"repository": {

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -5,6 +5,7 @@
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"calypso:src": "src/index.js",
+	"types": "dist/types/index.d.ts",
 	"sideEffects": false,
 	"repository": {
 		"type": "git",
@@ -22,6 +23,10 @@
 		"api",
 		"library"
 	],
+	"files": [
+		"dist",
+		"src"
+	],
 	"author": "Automattic Inc.",
 	"contributors": [
 		"Nathan Rajlich <nathan@automattic.com>"
@@ -37,11 +42,12 @@
 		"seed-random": "^2.2.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-typescript-config": "workspace:^"
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"@types/seed-random": "^2.2.1"
 	},
 	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "transpile",
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/photon/src/decs.d.ts
+++ b/packages/photon/src/decs.d.ts
@@ -1,0 +1,3 @@
+declare module 'crc32' {
+	export default function crc32( s: string ): string;
+}

--- a/packages/photon/src/index.ts
+++ b/packages/photon/src/index.ts
@@ -7,16 +7,35 @@ const debug = debugFactory( 'photon' );
 /**
  * Options argument to query string parameter mappings.
  */
-const mappings = {
-	width: 'w',
-	height: 'h',
-	letterboxing: 'lb',
-	removeLetterboxing: 'ulb',
-};
+function optionToQueryParam( key: string ) {
+	switch ( key ) {
+		case 'width':
+			return 'w';
+		case 'height':
+			return 'h';
+		case 'letterboxing':
+			return 'lb';
+		case 'removeLetterboxing':
+			return 'ulb';
+		default:
+			return key;
+	}
+}
 
 const PARSE_BASE_HOST = '__domain__.invalid';
 const PARSE_BASE_URL = `https://${ PARSE_BASE_HOST }`;
 const PHOTON_BASE_URL = 'https://i0.wp.com';
+
+type PhotonOpts = {
+	width?: number;
+	height?: number;
+	hostname?: string;
+	host?: string;
+	secure?: boolean;
+	zoom?: number;
+	resize?: string;
+	fit?: string;
+};
 
 /**
  * Returns a "photon" URL from the given image URL.
@@ -26,11 +45,11 @@ const PHOTON_BASE_URL = 'https://i0.wp.com';
  *
  * Photon documentation: http://developer.wordpress.com/docs/photon/
  *
- * @param {string} imageUrl - the URL of the image to run through Photon
- * @param {object} [opts] - optional options object with Photon options
- * @returns {string} The generated Photon URL string
+ * @param imageUrl - the URL of the image to run through Photon
+ * @param [opts] - optional options object with Photon options
+ * @returns The generated Photon URL string
  */
-export default function photon( imageUrl, opts ) {
+export default function photon( imageUrl: string, opts?: PhotonOpts ): string | null {
 	let parsedUrl;
 	try {
 		parsedUrl = new URL( imageUrl, PARSE_BASE_URL );
@@ -64,25 +83,21 @@ export default function photon( imageUrl, opts ) {
 		photonUrl.pathname = formattedUrl;
 		photonUrl.hostname = serverFromUrlParts( formattedUrl, photonUrl.protocol === 'https:' );
 		if ( wasSecure ) {
-			photonUrl.searchParams.set( 'ssl', 1 );
+			photonUrl.searchParams.set( 'ssl', '1' );
 		}
 	}
 
 	if ( opts ) {
-		for ( const i in opts ) {
-			// allow configurable "hostname"
-			if ( i === 'host' || i === 'hostname' ) {
-				photonUrl.hostname = opts[ i ];
+		for ( const [ opt, value ] of Object.entries( opts ) ) {
+			if ( opt === 'host' || opt === 'hostname' ) {
+				photonUrl.hostname = value as string;
 				continue;
 			}
-
-			// allow non-secure access
-			if ( i === 'secure' && ! opts[ i ] ) {
+			if ( opt === 'secure' && ! value ) {
 				photonUrl.protocol = 'http:';
 				continue;
 			}
-
-			photonUrl.searchParams.set( mappings[ i ] || i, opts[ i ] );
+			photonUrl.searchParams.set( optionToQueryParam( opt ), value.toString() );
 		}
 	}
 
@@ -92,7 +107,7 @@ export default function photon( imageUrl, opts ) {
 	return photonUrl.href;
 }
 
-function isAlreadyPhotoned( host ) {
+function isAlreadyPhotoned( host: string ) {
 	return /^i[0-2]\.wp\.com$/.test( host );
 }
 
@@ -107,7 +122,7 @@ function isAlreadyPhotoned( host ) {
  * @param  {boolean} isSecure Whether we're constructing a HTTPS URL or a HTTP one
  * @returns {string}          The hostname for the pathname
  */
-function serverFromUrlParts( pathname, isSecure ) {
+function serverFromUrlParts( pathname: string, isSecure: boolean ) {
 	if ( isSecure ) {
 		return 'i0.wp.com';
 	}

--- a/packages/photon/src/index.ts
+++ b/packages/photon/src/index.ts
@@ -7,20 +7,12 @@ const debug = debugFactory( 'photon' );
 /**
  * Options argument to query string parameter mappings.
  */
-function optionToQueryParam( key: string ) {
-	switch ( key ) {
-		case 'width':
-			return 'w';
-		case 'height':
-			return 'h';
-		case 'letterboxing':
-			return 'lb';
-		case 'removeLetterboxing':
-			return 'ulb';
-		default:
-			return key;
-	}
-}
+const mappings: Record< string, string > = {
+	width: 'w',
+	height: 'h',
+	letterboxing: 'lb',
+	removeLetterboxing: 'ulb',
+};
 
 const PARSE_BASE_HOST = '__domain__.invalid';
 const PARSE_BASE_URL = `https://${ PARSE_BASE_HOST }`;
@@ -35,6 +27,8 @@ type PhotonOpts = {
 	zoom?: number;
 	resize?: string;
 	fit?: string;
+	letterboxing?: string;
+	removeLetterBoxing?: boolean;
 };
 
 /**
@@ -46,7 +40,7 @@ type PhotonOpts = {
  * Photon documentation: http://developer.wordpress.com/docs/photon/
  *
  * @param imageUrl - the URL of the image to run through Photon
- * @param [opts] - optional options object with Photon options
+ * @param [opts]   - optional options object with Photon options
  * @returns The generated Photon URL string
  */
 export default function photon( imageUrl: string, opts?: PhotonOpts ): string | null {
@@ -97,7 +91,7 @@ export default function photon( imageUrl: string, opts?: PhotonOpts ): string | 
 				photonUrl.protocol = 'http:';
 				continue;
 			}
-			photonUrl.searchParams.set( optionToQueryParam( opt ), value.toString() );
+			photonUrl.searchParams.set( mappings[ opt ] ?? opt, value.toString() );
 		}
 	}
 

--- a/packages/photon/tsconfig-cjs.json
+++ b/packages/photon/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/photon/tsconfig.json
+++ b/packages/photon/tsconfig.json
@@ -1,3 +1,10 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json"
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -29,6 +29,7 @@
 		{ "path": "./launch" },
 		{ "path": "./onboarding" },
 		{ "path": "./page-pattern-modal" },
+		{ "path": "./photon" },
 		{ "path": "./plans-grid" },
 		{ "path": "./search" },
 		{ "path": "./shopping-cart" },

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -31,6 +31,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@automattic/calypso-typescript-config": "workspace:^"
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^4.5.3"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,6 +1375,7 @@ __metadata:
     "@automattic/plans-grid": "workspace:^"
     "@automattic/tour-kit": "workspace:^"
     "@automattic/typography": "workspace:^"
+    "@automattic/viewport": "workspace:^"
     "@automattic/whats-new": "workspace:^"
     "@babel/core": ^7.16.5
     "@emotion/react": ^11.4.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -27857,6 +27857,7 @@ fsevents@~2.1.2:
     crc32: ^0.2.2
     debug: ^4.0.0
     seed-random: ^2.2.0
+    typescript: ^4.5.3
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,6 +1182,7 @@ __metadata:
   resolution: "@automattic/viewport@workspace:packages/viewport"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    typescript: ^4.5.3
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6910,6 +6910,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/seed-random@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@types/seed-random@npm:2.2.1"
+  checksum: 4efc78a6c2786b3c7d84c85ebef9b6d14a9e861d1852893b835eea8fb838fd602244b2a79cef6da6feedaefc89ecac7a3728746471e3f33265e5ccef533a21ab
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^7.3.4":
   version: 7.3.9
   resolution: "@types/semver@npm:7.3.9"
@@ -27846,6 +27853,7 @@ fsevents@~2.1.2:
   resolution: "photon@workspace:packages/photon"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@types/seed-random": ^2.2.1
     crc32: ^0.2.2
     debug: ^4.0.0
     seed-random: ^2.2.0


### PR DESCRIPTION
### Changes proposed in this Pull Request

Inspired by #59031, where @sirbrillig ports a JS package to Typescript. We're doing this because these packages do not have any type definitions, which means they cause errors when imported into TS files in the Calypso client. Now, we could just add typedefs -- but where's the fun in that!? :)

### Testing instructions
1. Load calypso.live
2. Visit `/themes/$site` for a simple site
3. Verify that the screenshots of themes in the list still load.

Each image in the list goes through photon:
![image](https://user-images.githubusercontent.com/6265975/146079854-fae3c299-bed2-4c16-b8c9-02a8a4a1fada.png)
