### PR TITLE
types: Uses `textOnly` for translations

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
@@ -1,5 +1,5 @@
 import { translate, TranslateResult } from 'i18n-calypso';
-import { ReactNode } from 'react';
+import { ReactChild } from 'react';
 
 export interface LinkAndInfo {
 	info?: TranslateResult;
@@ -16,23 +16,23 @@ enum InfoTypes {
 
 export interface Text {
 	type: InfoTypes.Text;
-	text: ReactNode;
+	text: ReactChild;
 }
 
 export interface Link {
 	type: InfoTypes.Link;
-	text: ReactNode;
+	text: ReactChild;
 	link: string;
 }
 
 export interface UnorderedList {
 	type: InfoTypes.UnorderedList;
-	items: ReactNode[];
+	items: ReactChild[];
 }
 
 export interface OrderedList {
 	type: InfoTypes.OrderedList;
-	items: ReactNode[];
+	items: ReactChild[];
 }
 
 export interface Line {
@@ -184,9 +184,7 @@ export const topHosts: Host[] = [
 						type: InfoTypes.OrderedList,
 						items: [
 							translate( 'Login to your Bluehost cPanel' ),
-							translate( 'Click the "Advanced" tab towards the left side of the account.', {
-								textOnly: true,
-							} ),
+							translate( 'Click the "Advanced" tab towards the left side of the account.' ),
 							translate(
 								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.'
 							),
@@ -211,9 +209,7 @@ export const topHosts: Host[] = [
 				sftp: [
 					{
 						type: InfoTypes.Text,
-						text: translate( 'For Bluehost VPS and dedicated servers, the login will be `root`.', {
-							textOnly: true,
-						} ),
+						text: translate( 'For Bluehost VPS and dedicated servers, the login will be `root`.' ),
 					},
 					{
 						type: InfoTypes.Text,
@@ -229,9 +225,7 @@ export const topHosts: Host[] = [
 						type: InfoTypes.OrderedList,
 						items: [
 							translate( 'Login to your Bluehost cPanel' ),
-							translate( 'Click the "Advanced" tab towards the left side of the account.', {
-								textOnly: true,
-							} ),
+							translate( 'Click the "Advanced" tab towards the left side of the account.' ),
 							translate(
 								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.'
 							),
@@ -240,9 +234,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Text,
-						text: translate( 'Your Bluehost FTP password is chosen by you using the tools above.', {
-							textOnly: true,
-						} ),
+						text: translate( 'Your Bluehost FTP password is chosen by you using the tools above.' ),
 					},
 					{
 						type: InfoTypes.Line,
@@ -291,12 +283,8 @@ export const topHosts: Host[] = [
 					type: InfoTypes.OrderedList,
 					items: [
 						translate( 'Login to your Bluehost cPanel' ),
-						translate( 'Click the "Advanced" tab towards the left side of the account.', {
-							textOnly: true,
-						} ),
-						translate( 'Click the Shell Access icon under the Security section.', {
-							textOnly: true,
-						} ),
+						translate( 'Click the "Advanced" tab towards the left side of the account.' ),
+						translate( 'Click the Shell Access icon under the Security section.' ),
 						translate( 'Click the Manage SSH Keys button' ),
 						translate( 'Choose generate a new key and complete the form' ),
 					],

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
@@ -99,14 +99,17 @@ export const topHosts: Host[] = [
 						type: InfoTypes.UnorderedList,
 						items: [
 							translate(
-								'FTP (File Transfer Protocol): the original standard for transferring files between servers.'
-							).toString(),
+								'FTP (File Transfer Protocol): the original standard for transferring files between servers.',
+								{ textOnly: true }
+							),
 							translate(
-								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).'
-							).toString(),
+								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).',
+								{ textOnly: true }
+							),
 							translate(
-								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.'
-							).toString(),
+								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.',
+								{ textOnly: true }
+							),
 						],
 					},
 
@@ -115,7 +118,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Read more' ).toString(),
+						text: translate( 'Read more', { textOnly: true } ),
 						link: 'https://my.bluehost.com/cgi/help/ftpaccounts',
 					},
 				],
@@ -124,14 +127,17 @@ export const topHosts: Host[] = [
 						type: InfoTypes.UnorderedList,
 						items: [
 							translate(
-								'FTP (File Transfer Protocol): the original standard for transferring files between servers.'
-							).toString(),
+								'FTP (File Transfer Protocol): the original standard for transferring files between servers.',
+								{ textOnly: true }
+							),
 							translate(
-								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).'
-							).toString(),
+								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).',
+								{ textOnly: true }
+							),
 							translate(
-								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.'
-							).toString(),
+								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.',
+								{ textOnly: true }
+							),
 						],
 					},
 
@@ -140,7 +146,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Read more' ).toString(),
+						text: translate( 'Read more', { textOnly: true } ),
 						link: 'https://www.bluehost.com/help/article/ssh-access',
 					},
 				],
@@ -149,15 +155,16 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.Text,
 					text: translate(
-						'Your Domain Name or server IP address. Both are available from the Bluehost cPanel.'
-					).toString(),
+						'Your Domain Name or server IP address. Both are available from the Bluehost cPanel.',
+						{ textOnly: true }
+					),
 				},
 				{
 					type: InfoTypes.Line,
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Visit my Bluehost cPanel' ).toString(),
+					text: translate( 'Visit my Bluehost cPanel', { textOnly: true } ),
 					link: 'https://my.bluehost.com/cgi-bin/cplogin',
 				},
 			],
@@ -165,15 +172,16 @@ export const topHosts: Host[] = [
 				ftp: [
 					{
 						type: InfoTypes.Text,
-						text: translate( 'Enter port 21 for Bluehost’s FTP service.' ).toString(),
+						text: translate( 'Enter port 21 for Bluehost’s FTP service.', { textOnly: true } ),
 					},
 				],
 				sftp: [
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'Port 2222 would be used for Bluehost shared and reseller accounts. 22 is the default for Bluehost dedicated & VPS accounts.'
-						).toString(),
+							'Port 2222 would be used for Bluehost shared and reseller accounts. 22 is the default for Bluehost dedicated & VPS accounts.',
+							{ textOnly: true }
+						),
 					},
 				],
 			},
@@ -182,43 +190,46 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.OrderedList,
 						items: [
-							translate( 'Login to your Bluehost cPanel' ).toString(),
+							translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+							translate( 'Click the "Advanced" tab towards the left side of the account.', {
+								textOnly: true,
+							} ),
 							translate(
-								'Click the "Advanced" tab towards the left side of the account.'
-							).toString(),
-							translate(
-								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.'
-							).toString(),
-							translate( 'Create a new FTP account' ).toString(),
+								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.',
+								{ textOnly: true }
+							),
+							translate( 'Create a new FTP account', { textOnly: true } ),
 						],
 					},
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'Your Bluehost username will end with your domain (e.g. test@example.com).'
-						).toString(),
+							'Your Bluehost username will end with your domain (e.g. test@example.com).',
+							{ textOnly: true }
+						),
 					},
 					{
 						type: InfoTypes.Line,
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel' ).toString(),
+						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
 				sftp: [
 					{
 						type: InfoTypes.Text,
-						text: translate(
-							'For Bluehost VPS and dedicated servers, the login will be `root`.'
-						).toString(),
+						text: translate( 'For Bluehost VPS and dedicated servers, the login will be `root`.', {
+							textOnly: true,
+						} ),
 					},
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.'
-						).toString(),
+							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.',
+							{ textOnly: true }
+						),
 					},
 				],
 			},
@@ -227,28 +238,29 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.OrderedList,
 						items: [
-							translate( 'Login to your Bluehost cPanel' ).toString(),
+							translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+							translate( 'Click the "Advanced" tab towards the left side of the account.', {
+								textOnly: true,
+							} ),
 							translate(
-								'Click the "Advanced" tab towards the left side of the account.'
-							).toString(),
-							translate(
-								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.'
-							).toString(),
-							translate( 'Create a new FTP account' ).toString(),
+								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.',
+								{ textOnly: true }
+							),
+							translate( 'Create a new FTP account', { textOnly: true } ),
 						],
 					},
 					{
 						type: InfoTypes.Text,
-						text: translate(
-							'Your Bluehost FTP password is chosen by you using the tools above.'
-						).toString(),
+						text: translate( 'Your Bluehost FTP password is chosen by you using the tools above.', {
+							textOnly: true,
+						} ),
 					},
 					{
 						type: InfoTypes.Line,
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel' ).toString(),
+						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
@@ -256,15 +268,16 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.'
-						).toString(),
+							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.',
+							{ textOnly: true }
+						),
 					},
 					{
 						type: InfoTypes.Line,
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel' ).toString(),
+						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
@@ -273,15 +286,16 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.Text,
 					text: translate(
-						'The majority of Bluehost accounts require private key authentication. Bluehost VPS and Dedicated Servers also allow for username and password authentication as secondary option.'
-					).toString(),
+						'The majority of Bluehost accounts require private key authentication. Bluehost VPS and Dedicated Servers also allow for username and password authentication as secondary option.',
+						{ textOnly: true }
+					),
 				},
 				{
 					type: InfoTypes.Line,
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Read more' ).toString(),
+					text: translate( 'Read more', { textOnly: true } ),
 					link: 'https://www.bluehost.com/help/article/ssh-access',
 				},
 			],
@@ -289,13 +303,15 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.OrderedList,
 					items: [
-						translate( 'Login to your Bluehost cPanel' ).toString(),
-						translate(
-							'Click the "Advanced" tab towards the left side of the account.'
-						).toString(),
-						translate( 'Click the Shell Access icon under the Security section.' ).toString(),
-						translate( 'Click the Manage SSH Keys button' ).toString(),
-						translate( 'Choose generate a new key and complete the form' ).toString(),
+						translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+						translate( 'Click the "Advanced" tab towards the left side of the account.', {
+							textOnly: true,
+						} ),
+						translate( 'Click the Shell Access icon under the Security section.', {
+							textOnly: true,
+						} ),
+						translate( 'Click the Manage SSH Keys button', { textOnly: true } ),
+						translate( 'Choose generate a new key and complete the form', { textOnly: true } ),
 					],
 				},
 				{
@@ -303,7 +319,7 @@ export const topHosts: Host[] = [
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Vist my Bluehost cPanel' ).toString(),
+					text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
 					link: 'https://my.bluehost.com/cgi-bin/cplogin',
 				},
 			],

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
@@ -1,4 +1,5 @@
 import { translate, TranslateResult } from 'i18n-calypso';
+import { ReactNode } from 'react';
 
 export interface LinkAndInfo {
 	info?: TranslateResult;
@@ -15,23 +16,23 @@ enum InfoTypes {
 
 export interface Text {
 	type: InfoTypes.Text;
-	text: string;
+	text: ReactNode;
 }
 
 export interface Link {
 	type: InfoTypes.Link;
-	text: string;
+	text: ReactNode;
 	link: string;
 }
 
 export interface UnorderedList {
 	type: InfoTypes.UnorderedList;
-	items: string[];
+	items: ReactNode[];
 }
 
 export interface OrderedList {
 	type: InfoTypes.OrderedList;
-	items: string[];
+	items: ReactNode[];
 }
 
 export interface Line {
@@ -99,16 +100,13 @@ export const topHosts: Host[] = [
 						type: InfoTypes.UnorderedList,
 						items: [
 							translate(
-								'FTP (File Transfer Protocol): the original standard for transferring files between servers.',
-								{ textOnly: true }
+								'FTP (File Transfer Protocol): the original standard for transferring files between servers.'
 							),
 							translate(
-								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).',
-								{ textOnly: true }
+								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).'
 							),
 							translate(
-								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.',
-								{ textOnly: true }
+								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.'
 							),
 						],
 					},
@@ -118,7 +116,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Read more', { textOnly: true } ),
+						text: translate( 'Read more' ),
 						link: 'https://my.bluehost.com/cgi/help/ftpaccounts',
 					},
 				],
@@ -127,16 +125,13 @@ export const topHosts: Host[] = [
 						type: InfoTypes.UnorderedList,
 						items: [
 							translate(
-								'FTP (File Transfer Protocol): the original standard for transferring files between servers.',
-								{ textOnly: true }
+								'FTP (File Transfer Protocol): the original standard for transferring files between servers.'
 							),
 							translate(
-								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).',
-								{ textOnly: true }
+								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).'
 							),
 							translate(
-								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.',
-								{ textOnly: true }
+								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.'
 							),
 						],
 					},
@@ -146,7 +141,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Read more', { textOnly: true } ),
+						text: translate( 'Read more' ),
 						link: 'https://www.bluehost.com/help/article/ssh-access',
 					},
 				],
@@ -155,8 +150,7 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.Text,
 					text: translate(
-						'Your Domain Name or server IP address. Both are available from the Bluehost cPanel.',
-						{ textOnly: true }
+						'Your Domain Name or server IP address. Both are available from the Bluehost cPanel.'
 					),
 				},
 				{
@@ -164,7 +158,7 @@ export const topHosts: Host[] = [
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Visit my Bluehost cPanel', { textOnly: true } ),
+					text: translate( 'Visit my Bluehost cPanel' ),
 					link: 'https://my.bluehost.com/cgi-bin/cplogin',
 				},
 			],
@@ -172,15 +166,14 @@ export const topHosts: Host[] = [
 				ftp: [
 					{
 						type: InfoTypes.Text,
-						text: translate( 'Enter port 21 for Bluehost’s FTP service.', { textOnly: true } ),
+						text: translate( 'Enter port 21 for Bluehost’s FTP service.' ),
 					},
 				],
 				sftp: [
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'Port 2222 would be used for Bluehost shared and reseller accounts. 22 is the default for Bluehost dedicated & VPS accounts.',
-							{ textOnly: true }
+							'Port 2222 would be used for Bluehost shared and reseller accounts. 22 is the default for Bluehost dedicated & VPS accounts.'
 						),
 					},
 				],
@@ -190,22 +183,20 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.OrderedList,
 						items: [
-							translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+							translate( 'Login to your Bluehost cPanel' ),
 							translate( 'Click the "Advanced" tab towards the left side of the account.', {
 								textOnly: true,
 							} ),
 							translate(
-								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.',
-								{ textOnly: true }
+								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.'
 							),
-							translate( 'Create a new FTP account', { textOnly: true } ),
+							translate( 'Create a new FTP account' ),
 						],
 					},
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'Your Bluehost username will end with your domain (e.g. test@example.com).',
-							{ textOnly: true }
+							'Your Bluehost username will end with your domain (e.g. test@example.com).'
 						),
 					},
 					{
@@ -213,7 +204,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
+						text: translate( 'Vist my Bluehost cPanel' ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
@@ -227,8 +218,7 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.',
-							{ textOnly: true }
+							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.'
 						),
 					},
 				],
@@ -238,15 +228,14 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.OrderedList,
 						items: [
-							translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+							translate( 'Login to your Bluehost cPanel' ),
 							translate( 'Click the "Advanced" tab towards the left side of the account.', {
 								textOnly: true,
 							} ),
 							translate(
-								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.',
-								{ textOnly: true }
+								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.'
 							),
-							translate( 'Create a new FTP account', { textOnly: true } ),
+							translate( 'Create a new FTP account' ),
 						],
 					},
 					{
@@ -260,7 +249,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
+						text: translate( 'Vist my Bluehost cPanel' ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
@@ -268,8 +257,7 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.',
-							{ textOnly: true }
+							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.'
 						),
 					},
 					{
@@ -277,7 +265,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
+						text: translate( 'Vist my Bluehost cPanel' ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
@@ -286,8 +274,7 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.Text,
 					text: translate(
-						'The majority of Bluehost accounts require private key authentication. Bluehost VPS and Dedicated Servers also allow for username and password authentication as secondary option.',
-						{ textOnly: true }
+						'The majority of Bluehost accounts require private key authentication. Bluehost VPS and Dedicated Servers also allow for username and password authentication as secondary option.'
 					),
 				},
 				{
@@ -295,7 +282,7 @@ export const topHosts: Host[] = [
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Read more', { textOnly: true } ),
+					text: translate( 'Read more' ),
 					link: 'https://www.bluehost.com/help/article/ssh-access',
 				},
 			],
@@ -303,15 +290,15 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.OrderedList,
 					items: [
-						translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+						translate( 'Login to your Bluehost cPanel' ),
 						translate( 'Click the "Advanced" tab towards the left side of the account.', {
 							textOnly: true,
 						} ),
 						translate( 'Click the Shell Access icon under the Security section.', {
 							textOnly: true,
 						} ),
-						translate( 'Click the Manage SSH Keys button', { textOnly: true } ),
-						translate( 'Choose generate a new key and complete the form', { textOnly: true } ),
+						translate( 'Click the Manage SSH Keys button' ),
+						translate( 'Choose generate a new key and complete the form' ),
 					],
 				},
 				{
@@ -319,7 +306,7 @@ export const topHosts: Host[] = [
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
+					text: translate( 'Vist my Bluehost cPanel' ),
 					link: 'https://my.bluehost.com/cgi-bin/cplogin',
 				},
 			],

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -13,18 +13,18 @@ const validateFilePath: validator< string > = (
 	}
 	if ( filePathBackSlashRegExp.test( pathToValidate ) ) {
 		return {
-			message: translate( 'Use forward slashes, "/", in path.', { textOnly: true } ),
+			message: translate( 'Use forward slashes, "/", in path.' ),
 		};
 	}
 
 	if ( filePathMultiSlashRegExp.test( pathToValidate ) ) {
 		return {
-			message: translate( 'Use only single slashes, "/", in path.', { textOnly: true } ),
+			message: translate( 'Use only single slashes, "/", in path.' ),
 		};
 	}
 
 	return {
-		message: translate( 'Not a valid file path.', { textOnly: true } ),
+		message: translate( 'Not a valid file path.' ),
 	};
 };
 

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -13,18 +13,18 @@ const validateFilePath: validator< string > = (
 	}
 	if ( filePathBackSlashRegExp.test( pathToValidate ) ) {
 		return {
-			message: translate( 'Use forward slashes, "/", in path.' ).toString(),
+			message: translate( 'Use forward slashes, "/", in path.', { textOnly: true } ),
 		};
 	}
 
 	if ( filePathMultiSlashRegExp.test( pathToValidate ) ) {
 		return {
-			message: translate( 'Use only single slashes, "/", in path.' ).toString(),
+			message: translate( 'Use only single slashes, "/", in path.', { textOnly: true } ),
 		};
 	}
 
 	return {
-		message: translate( 'Not a valid file path.' ).toString(),
+		message: translate( 'Not a valid file path.', { textOnly: true } ),
 	};
 };
 

--- a/client/lib/validation/types.ts
+++ b/client/lib/validation/types.ts
@@ -1,5 +1,7 @@
+import type { ReactNode } from 'react';
+
 export interface ValidationError {
-	message: string;
+	message: ReactNode;
 }
 
 export type validator< T > = ( data: T ) => null | ValidationError;

--- a/client/lib/validation/types.ts
+++ b/client/lib/validation/types.ts
@@ -1,7 +1,7 @@
-import type { ReactNode } from 'react';
+import type { ReactChild } from 'react';
 
 export interface ValidationError {
-	message: ReactNode;
+	message: ReactChild;
 }
 
 export type validator< T > = ( data: T ) => null | ValidationError;


### PR DESCRIPTION
### Background

We have a few TS files that do `translate(...).toString()`. The result of `translate()` was declared as `React.ReactNode` in #58938. This type includes `undefined | null`, therefore calling `.toString()` in a value that is potentially `undefined` or `null` is not safe.

### Changes proposed in this Pull Request

#58938 added the option `{textOnly:true}` to force the return type to be `string`, making calls to `.toString()` valid. But of course, in that case, there is no point in calling `.toString()` anymore, as the result of `translate()` is already a `string`.

This should fix all these type errors:

![image](https://user-images.githubusercontent.com/975703/145523591-4ab9364d-92c0-4a01-8a25-16daf35fd75c.png)
