### PR TITLE
Fix: broken atomic upgrade nudge

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -413,7 +413,7 @@ class CancelPurchaseForm extends Component {
 						actionText={ translate( 'Upgrade my site' ) }
 						image={ pluginsThemesImage }
 					>
-						<UpgradeATStep />
+						<UpgradeATStep selectedSite={ site } />
 					</Upsell>
 				);
 			case 'downgrade-personal':

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
@@ -14,10 +14,6 @@ export class UpgradeATStep extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	static defaultProps = {
-		translate: noop,
-	};
-
 	onClick = () => {
 		this.props.recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
 	};

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
@@ -6,9 +6,6 @@ import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-
-const noop = () => {};
 
 export class UpgradeATStep extends Component {
 	static propTypes = {
@@ -55,9 +52,6 @@ export class UpgradeATStep extends Component {
 	}
 }
 
-const mapStateToProps = ( state ) => ( {
-	selectedSite: getSelectedSite( state ),
-} );
 const mapDispatchToProps = { recordTracksEvent };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( UpgradeATStep ) );
+export default connect( null, mapDispatchToProps )( localize( UpgradeATStep ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The upgrade to Business upsell nudge is broken because `selectedSite` prop can be null:
![demo-broken-cancellation](https://user-images.githubusercontent.com/1842898/145526755-d58a9527-23dd-4835-863e-c1267e93a75b.gif)

This PR fixes it by:

* Passing the site object associated with the purchase from the parent flow instead of using `getSelectedSite()` selector. Since users can manage all of their purchases in the purchase management page, it's expected that there won't always be a "selected site".

Additional janitorial thing is to remove the default to `translate()`. `noop` is not an appropriate default, since it will return nothing even if we pass in a string. If we really want, we can pass an identity function. However, in this case, marking it as a required prop is already the best.

#### Testing instructions

1. Log in using an account with a paid plan other than the Business plan.
2. Go to /me/purchases. Find the purchase and hit the "cancel subscription" button.
3. Choose "I couldn't install a plugin/theme I wanted".
4. The upgrading to Business upsell nudge should be presented properly.

cc @mmtr here since you have done many improvements to this flow in the past few months if I'm not mistaken :)