### PR TITLE
Welcome Tour: Prevent from loading undefined asset

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -27,8 +27,9 @@ function LaunchWpcomWelcomeTour() {
 	} ) );
 
 	const localeSlug = useLocale();
+
 	// Preload first card image (others preloaded after open state confirmed)
-	new window.Image().src = usePrefetchTourAssets( [ getTourSteps( localeSlug )[ 0 ] ] );
+	usePrefetchTourAssets( [ getTourSteps( localeSlug )[ 0 ] ] );
 
 	useEffect( () => {
 		if ( ! show && ! isNewPageLayoutModalOpen ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As mentioned [here](https://github.com/Automattic/wp-calypso/pull/56347#discussion_r766441101), we should not load the `undefined` asset.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the editor
* Open the Welcome Tour
* Check is there any `undefined` resource being loaded from Network Tab of the Chrome DevTool

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/56347#discussion_r766441101
