### PR TITLE
ci: sanitize file paths in tsc reports

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -261,7 +261,7 @@ object RunAllUnitTests : BuildType({
 					set +e
 					yarn tsc --build client 2>&1 | tee tsc_out
 					mkdir -p checkstyle_results
-					yarn run typescript-checkstyle < tsc_out > ./checkstyle_results/tsc.xml
+					yarn run typescript-checkstyle < tsc_out | sed -e "s#${'$'}HOME#~#g" > ./checkstyle_results/tsc.xml
 					cat ./checkstyle_results/tsc.xml
 				)
 			"""

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -249,6 +249,7 @@ object RunAllUnitTests : BuildType({
 			name = "Run type checks"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
+				set -x
 				export NODE_ENV="test"
 
 				# These are not expected to fail
@@ -261,7 +262,7 @@ object RunAllUnitTests : BuildType({
 					set +e
 					yarn tsc --build client 2>&1 | tee tsc_out
 					mkdir -p checkstyle_results
-					yarn run typescript-checkstyle < tsc_out | sed -e "s#${'$'}HOME#~#g" > ./checkstyle_results/tsc.xml
+					yarn run typescript-checkstyle < tsc_out | sed -e "s#${'$'}PWD#~#g" > ./checkstyle_results/tsc.xml
 					cat ./checkstyle_results/tsc.xml
 				)
 			"""


### PR DESCRIPTION
### Background

We parse `tsc` output as Checkstyle to keep track of TS errors. 

Sometimes the error contains the file path (examlpe: `File '/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/client/__mocks__/lib/json-schema-draft-04.json' is not listed...`), and that path can change when run in a different agent.

This confuses TeamCity and thinks it's a brand new error because the text is not the same than previous runs, when in realitty it's the same error.

### Changes proposed in this Pull Request

Replace $CWD with `~` before parsing TypeScript errors. 

In the above example, the text should be `File '~/client/__mocks__/lib/json-schema-draft-04.json' is not listed...`

#### Testing instructions

Check the logs of Unit Tests and verify `~` are being inserted correctly.