### PR TITLE
Welcome Tour: Temporary fix overlap between mobile gifs and Tour kit header controls

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -161,7 +161,6 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 .welcome-tour-card__overlay-controls {
 	left: 0;
 	padding: $grid-unit-15;
-	position: absolute;
 	right: 0;
 	z-index: 1; // z-index is needed because overlay controls are written before components-card__media, and so ends up under the image
 
@@ -196,6 +195,10 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 			}
 		}
 	}
+}
+
+.welcome-tour-card__overlay-controls__absolute {
+	position: absolute;
 }
 
 .welcome-tour-card__next-btn {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { getMediaQueryList, isMobile } from '@automattic/viewport';
+import { getMediaQueryList, isMobile, MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -65,7 +65,7 @@ function WelcomeTourCard( {
 						<source
 							srcSet={ imgSrc.mobile.src }
 							type={ imgSrc.mobile.type }
-							media={ getMediaQueryList( '<480px' )?.media }
+							media={ getMediaQueryList( MOBILE_BREAKPOINT )?.media }
 						/>
 					) }
 					<img

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { getMediaQueryList } from '@automattic/viewport';
+import { getMediaQueryList, isMobile } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -155,7 +155,9 @@ function CardNavigation( {
 }
 
 function CardOverlayControls( { onMinimize, onDismiss } ) {
-	const buttonClasses = classNames( 'welcome-tour-card__overlay-controls' );
+	const buttonClasses = classNames( 'welcome-tour-card__overlay-controls', {
+		'welcome-tour-card__overlay-controls__absolute': ! isMobile(),
+	} );
 
 	return (
 		<div className={ buttonClasses }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The gifs we are using for the mobile version of the Welcome Tour overlap with the header buttons.

![Screenshot 2021-12-10 at 09 56 14](https://user-images.githubusercontent.com/52076348/145546272-5e302269-288d-4ddb-8035-2a286d20c621.png)

We should change the gifs, and in the meantime, this is a temporary solution.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* yarn dev --sync for ETK
* Check that in the sandboxed site the gifs and the header controls do not overlap

![Screenshot 2021-12-10 at 10 19 03](https://user-images.githubusercontent.com/52076348/145549402-e73ef332-465a-44c2-939f-c5b1e0115ace.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #55826
Related to #55826
