### PR TITLE
Promote Google Workspace when it is on sale

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -156,10 +156,6 @@ class EmailProvidersComparison extends Component {
 		};
 	}
 
-	shouldPromoteGoogleWorkspace( { gSuiteProduct, isGSuiteSupported, source } ) {
-		return isGSuiteSupported && ( source === 'google-sale' || hasDiscount( gSuiteProduct ) );
-	}
-
 	onExpandedStateChange = ( providerKey, isExpanded ) => {
 		const expandedEntries = Object.entries( this.state.expanded ).map( ( entry ) => {
 			const [ key, currentExpanded ] = entry;
@@ -760,7 +756,6 @@ class EmailProvidersComparison extends Component {
 			isSubmittingEmailForward,
 			selectedDomainName,
 			selectedSite,
-			shouldPromoteGoogleWorkspace,
 			source,
 		} = this.props;
 
@@ -770,21 +765,6 @@ class EmailProvidersComparison extends Component {
 		// - We have added an email forward from this component
 		const shouldShowEmailForwardWarning =
 			! hideEmailForwardingCard && ! isSubmittingEmailForward && ! this.state.emailForwardAdded;
-
-		const googleCard = this.renderGoogleCard();
-		const titanCard = this.renderTitanCard();
-
-		const paidCards = shouldPromoteGoogleWorkspace ? (
-			<>
-				{ googleCard }
-				{ titanCard }
-			</>
-		) : (
-			<>
-				{ titanCard }
-				{ googleCard }
-			</>
-		);
 
 		return (
 			<Main wideLayout>
@@ -805,7 +785,9 @@ class EmailProvidersComparison extends Component {
 					/>
 				) }
 
-				{ paidCards }
+				{ this.renderTitanCard() }
+
+				{ this.renderGoogleCard() }
 
 				{ ! hideEmailForwardingCard && this.renderEmailForwardingCard() }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the email comparison component to try and promote Google Workspace when it is on sale. The promotion here is to automatically expand the card when there is a sale.
* For now, this PR doesn't place the Google Workspace card first, as it takes up too much vertical space, and I am concerned that will result in too many people not seeing that we have a free option.

Note that the current implementation works when the product data is already loaded in the client, which should be the case for most situations where users get to these screens. We looked into handing that better, but it's not really feasible.

#### Testing instructions

* Open up this branch locally or via the live branch
* Navigate to Upgrades -> Domains and start the process of registering a new domain
* On the email upsell page, verify that the Professional Email card is expanded and in first position
* Enable Store Sandbox mode and ensure that there is an active sale coupon for new Google Workspace purchases
* Follow the steps above, and verify that the Google Workspace card is expanded and still in second position

#### Screenshot

<img width="1057" alt="Screenshot 2021-12-10 at 15 37 12" src="https://user-images.githubusercontent.com/3376401/145582956-0cd73bfd-e110-4a22-9984-75cef311fcff.png">