### PR TITLE
WPCOM: Migrate `wpcom.undocumented()` dns to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -31,30 +31,6 @@ Undocumented.prototype.checkAuthCode = function ( domain, authCode, fn ) {
 	);
 };
 
-Undocumented.prototype.fetchDns = function ( domainName, fn ) {
-	return this.wpcom.req.get( '/domains/' + domainName + '/dns', fn );
-};
-
-Undocumented.prototype.updateDns = function ( domain, records, fn ) {
-	const body = { dns: JSON.stringify( records ) };
-
-	return this.wpcom.req.post( '/domains/' + domain + '/dns', body, fn );
-};
-
-Undocumented.prototype.applyDnsTemplate = function (
-	domain,
-	provider,
-	service,
-	variables,
-	callback
-) {
-	return this.wpcom.req.post(
-		'/domains/' + domain + '/dns/providers/' + provider + '/services/' + service,
-		{ variables },
-		callback
-	);
-};
-
 Undocumented.prototype.applyDnsTemplateSyncFlow = function (
 	domain,
 	provider,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` DNS management methods to `wpcom.req`.

Note that the DNS management page is currently being redesigned, and both versions co-exist currently, so we should test them both thoroughly. 

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

#### Testing instructions

* Observe network requests and make sure they work the same way as before while testing.
* Go to `/domains/manage/:domain/dns/:domain?flags=-domains/dns-records-redesign` where `:domain` is the domain of a site on a custom domain hosted with WP.com
* Verify you can add and delete DNS records properly.
* Go to `/domains/manage/:domain/dns/:domain?flags=domains/dns-records-redesign` where `:domain` is the domain of a site on a custom domain hosted with WP.com
* Verify you can add, delete and edit DNS records properly.