### PR TITLE
Migrate wpcom.undocumented() methods for transferring domains

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -87,29 +87,6 @@ Undocumented.prototype.getDnsTemplateRecords = function (
 	);
 };
 
-Undocumented.prototype.transferToUser = function ( siteId, domainName, targetUserId, fn ) {
-	return this.wpcom.req.post(
-		'/sites/' + siteId + '/domains/' + domainName + '/transfer-to-user/' + targetUserId,
-		fn
-	);
-};
-
-/**
- * Transfers a domain to the specified site
- *
- * @param {number} siteId The site ID
- * @param {string} [domainName] Name of the domain
- * @param {number} [targetSiteId] The target site ID
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.transferToSite = function ( siteId, domainName, targetSiteId, fn ) {
-	return this.wpcom.req.post(
-		`/sites/${ siteId }/domains/${ domainName }/transfer-to-site/${ targetSiteId }`,
-		fn
-	);
-};
-
 Undocumented.prototype.isSiteImportable = function ( site_url ) {
 	debug( `/wpcom/v2/imports/is-site-importable?${ site_url }` );
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import SiteSelector from 'calypso/components/site-selector';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
@@ -21,8 +21,6 @@ import { requestSites } from 'calypso/state/sites/actions';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import TransferConfirmationDialog from './confirmation-dialog';
-
-const wpcom = wp.undocumented();
 
 export class TransferToOtherSite extends Component {
 	static propTypes = {
@@ -65,7 +63,7 @@ export class TransferToOtherSite extends Component {
 	};
 
 	handleConfirmTransfer = ( targetSite, closeDialog ) => {
-		const { selectedDomainName } = this.props;
+		const { selectedDomainName, selectedSite } = this.props;
 		const targetSiteTitle = targetSite.title;
 		const successMessage = this.props.translate(
 			'%(selectedDomainName)s has been transferred to site: %(targetSiteTitle)s',
@@ -79,8 +77,10 @@ export class TransferToOtherSite extends Component {
 		);
 
 		this.setState( { disableDialogButtons: true } );
-		wpcom
-			.transferToSite( this.props.selectedSite.ID, this.props.selectedDomainName, targetSite.ID )
+		wpcom.req
+			.post(
+				`/sites/${ selectedSite.ID }/domains/${ selectedDomainName }/transfer-to-site/${ targetSite.ID }`
+			)
 			.then(
 				() => {
 					this.props.successNotice( successMessage, { duration: 10000, isPersistent: true } );

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -8,7 +8,7 @@ import Main from 'calypso/components/main';
 import SiteSelector from 'calypso/components/site-selector';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
@@ -32,8 +32,6 @@ import type {
 } from './types';
 
 import './style.scss';
-
-const wpcom = wp.undocumented();
 
 export class TransferDomainToOtherSite extends Component< TransferDomainToOtherSiteProps > {
 	state = {
@@ -69,7 +67,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		targetSite: TransferDomainToOtherSiteProps[ 'selectedSite' ],
 		closeDialog: () => void
 	): void => {
-		const { selectedDomainName } = this.props;
+		const { selectedDomainName, selectedSite } = this.props;
 		const targetSiteTitle = targetSite.title;
 		const successMessage = this.props.translate(
 			'%(selectedDomainName)s has been transferred to site: %(targetSiteTitle)s',
@@ -83,8 +81,10 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		);
 
 		this.setState( { disableDialogButtons: true } );
-		wpcom
-			.transferToSite( this.props.selectedSite.ID, this.props.selectedDomainName, targetSite.ID )
+		wpcom.req
+			.post(
+				`/sites/${ selectedSite.ID }/domains/${ selectedDomainName }/transfer-to-site/${ targetSite.ID }`
+			)
 			.then(
 				() => {
 					this.props.successNotice( successMessage, { duration: 10000, isPersistent: true } );

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -11,7 +11,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import Main from 'calypso/components/main';
 import useUsersQuery from 'calypso/data/users/use-users-query';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
@@ -24,8 +24,6 @@ import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
-
-const wpcom = wp.undocumented();
 
 const getWpcomUserId = ( user ) => user.linked_user_ID ?? user.ID;
 
@@ -66,7 +64,8 @@ class TransferOtherUser extends Component {
 	}
 
 	handleConfirmTransferDomain( closeDialog ) {
-		const { selectedDomainName } = this.props;
+		const { selectedDomainName, selectedSite } = this.props;
+		const { selectedUserId } = this.state;
 		const selectedUserDisplay = this.getSelectedUserDisplayName();
 		const successMessage = this.props.translate(
 			'%(selectedDomainName)s has been transferred to %(selectedUserDisplay)s',
@@ -74,17 +73,13 @@ class TransferOtherUser extends Component {
 		);
 		const defaultErrorMessage = this.props.translate(
 			'Failed to transfer %(selectedDomainName)s, please try again or contact support.',
-			{
-				args: { selectedDomainName },
-			}
+			{ args: { selectedDomainName } }
 		);
 
 		this.setState( { disableDialogButtons: true } );
-		wpcom
-			.transferToUser(
-				this.props.selectedSite.ID,
-				this.props.selectedDomainName,
-				this.state.selectedUserId
+		wpcom.req
+			.post(
+				`/sites/${ selectedSite.ID }/domains/${ selectedDomainName }/transfer-to-user/${ selectedUserId }`
 			)
 			.then(
 				() => {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -13,7 +13,7 @@ import Main from 'calypso/components/main';
 import useUsersQuery from 'calypso/data/users/use-users-query';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
@@ -30,8 +30,6 @@ import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
-
-const wpcom = wp.undocumented();
 
 const getWpcomUserId = ( user ) => user.linked_user_ID ?? user.ID;
 
@@ -77,7 +75,8 @@ class TransferDomainToOtherUser extends Component {
 	};
 
 	handleConfirmTransferDomain( closeDialog ) {
-		const { selectedDomainName } = this.props;
+		const { selectedDomainName, selectedSite } = this.props;
+		const { selectedUserId } = this.state;
 		const selectedUserDisplay = this.getSelectedUserDisplayName();
 		const successMessage = this.props.translate(
 			'%(selectedDomainName)s has been transferred to %(selectedUserDisplay)s',
@@ -85,17 +84,13 @@ class TransferDomainToOtherUser extends Component {
 		);
 		const defaultErrorMessage = this.props.translate(
 			'Failed to transfer %(selectedDomainName)s, please try again or contact support.',
-			{
-				args: { selectedDomainName },
-			}
+			{ args: { selectedDomainName } }
 		);
 
 		this.setState( { disableDialogButtons: true } );
-		wpcom
-			.transferToUser(
-				this.props.selectedSite.ID,
-				this.props.selectedDomainName,
-				this.state.selectedUserId
+		wpcom.req
+			.post(
+				`/sites/${ selectedSite.ID }/domains/${ selectedDomainName }/transfer-to-user/${ selectedUserId }`
 			)
 			.then(
 				() => {


### PR DESCRIPTION
Migrates REST requests to transfer a domain to another user or site.

**How to test:**
- in dev mode, you'll first need to disable some feature flags because the affected Domain mgmt screens are undergoing a redesign. Loading Calypso with a `?flags=-domains/transfers-redesign,-domains/settings-page-redesign` query string will achieve that. Without this step, you would see empty stubs in place of some pages.
- then select some domain your own and transfer it to another site or user. Verify that the `transfer-to-*` REST request was sent and that the transfer is performed.