### PR TITLE
Onboarding intent: disable options without permission

### DIFF
--- a/client/signup/select-items-alt/index.tsx
+++ b/client/signup/select-items-alt/index.tsx
@@ -1,4 +1,6 @@
 import { Button } from '@automattic/components';
+import { Tooltip } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { TranslateResult } from 'i18n-calypso';
 import React from 'react';
@@ -10,6 +12,8 @@ export interface SelectAltItem< T > {
 	description: TranslateResult;
 	value: T;
 	actionText: TranslateResult;
+	disable: boolean;
+	disableText: TranslateResult;
 }
 
 interface Props< T > {
@@ -22,7 +26,7 @@ function SelectItems< T >( { className, items, onSelect }: Props< T > ): React.R
 	return (
 		<div className={ classnames( 'select-items-alt', className ) }>
 			{ items.map(
-				( { show, key, description, actionText, value } ) =>
+				( { disable, disableText, show, key, description, actionText, value } ) =>
 					show && (
 						<div key={ key } className="select-items-alt__item">
 							<div className="select-items-alt__item-info-wrapper">
@@ -30,11 +34,23 @@ function SelectItems< T >( { className, items, onSelect }: Props< T > ): React.R
 									<p className="select-items-alt__item-description">{ description }</p>
 								</div>
 								<Button
+									disabled={ disable }
 									className="select-items-alt__item-button"
 									onClick={ () => onSelect( value ) }
 								>
 									{ actionText }
 								</Button>
+
+								{ disable && (
+									<>
+										&nbsp;
+										<Tooltip text={ disableText } position="bottom center">
+											<div className="select-items-alt__item-disabled-info">
+												<Icon icon={ info } size={ 20 } />
+											</div>
+										</Tooltip>
+									</>
+								) }
 							</div>
 						</div>
 					)

--- a/client/signup/select-items-alt/style.scss
+++ b/client/signup/select-items-alt/style.scss
@@ -59,8 +59,12 @@
 			margin-top: 0;
 		}
 
-		&:hover {
+		&:not( [disabled] ):hover {
 			color: var( --color-neutral-70 );
 		}
+	}
+
+	&-disabled-info svg {
+		fill: var( --color-neutral-20 );
 	}
 }

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -1,13 +1,15 @@
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import IntentScreen from './intent-screen';
 import type { IntentFlag } from './types';
 
@@ -39,6 +41,11 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	const subHeaderText = translate( 'You can change your mind at any time.' );
 	const branchSteps = useBranchSteps( stepName );
 
+	const siteId = useSelector( ( state ) => getSiteId( state, queryObject.siteSlug as string ) );
+	const canImport = useSelector( ( state ) =>
+		canCurrentUser( state, siteId as number, 'manage_options' )
+	);
+
 	const submitIntent = ( intent: IntentFlag ) => {
 		recordTracksEvent( 'calypso_signup_intent_select', { intent } );
 
@@ -63,7 +70,7 @@ export default function IntentStep( props: Props ): React.ReactNode {
 			headerImageUrl={ intentImageUrl }
 			subHeaderText={ subHeaderText }
 			fallbackSubHeaderText={ subHeaderText }
-			stepContent={ <IntentScreen onSelect={ submitIntent } /> }
+			stepContent={ <IntentScreen canImport={ canImport } onSelect={ submitIntent } /> }
 			align={ 'left' }
 			hideSkip
 			isHorizontalLayout={ true }

--- a/client/signup/steps/intent/intent-screen.tsx
+++ b/client/signup/steps/intent/intent-screen.tsx
@@ -10,6 +10,7 @@ type Intent = SelectItem< IntentFlag >;
 type IntentAlt = SelectAltItem< IntentFlag >;
 
 interface Props {
+	canImport: boolean;
 	onSelect: ( value: IntentFlag ) => void;
 	translate: LocalizeProps[ 'translate' ];
 }
@@ -35,7 +36,10 @@ const useIntents = ( { translate }: Pick< Props, 'translate' > ): Intent[] => {
 	];
 };
 
-const useIntentsAlt = ( { translate }: Pick< Props, 'translate' > ): IntentAlt[] => {
+const useIntentsAlt = ( {
+	canImport,
+	translate,
+}: Pick< Props, 'canImport' | 'translate' > ): IntentAlt[] => {
 	return [
 		{
 			show: isEnabled( 'gutenboarding/import' ),
@@ -43,13 +47,22 @@ const useIntentsAlt = ( { translate }: Pick< Props, 'translate' > ): IntentAlt[]
 			description: translate( 'Already have an existing website?' ),
 			value: 'import',
 			actionText: translate( 'Import your site content' ),
+			disable: ! canImport,
+			disableText: translate(
+				"You're not authorized to import content.{{br/}}Please check with your site admin.",
+				{
+					components: {
+						br: <br />,
+					},
+				}
+			),
 		},
 	];
 };
 
-const IntentScreen: React.FC< Props > = ( { onSelect, translate } ) => {
+const IntentScreen: React.FC< Props > = ( { canImport, onSelect, translate } ) => {
 	const intents = useIntents( { translate } );
-	const intentsAlt = useIntentsAlt( { translate } );
+	const intentsAlt = useIntentsAlt( { translate, canImport } );
 
 	return (
 		<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Changes provide logic for preventing users from going into the import flow if they don't have the proper permission for it.

#### Testing instructions
* Log in with a user who doesn't have `manage_options` permission
* Go to `/start/setup-site/intent?siteSlug={YOUR_SITE}.wordpress.com`
* Check if there is disabled `Import your site content` button with additional info in the tooltip

#### Screenshots
**With permission:**
<img width="526" alt="Screenshot 2021-12-10 at 13 47 51" src="https://user-images.githubusercontent.com/1241413/145576646-1ff1aeaa-3574-4523-8bb3-c00a32860193.png">

**Without permission:**
<img width="641" alt="Screenshot 2021-12-10 at 13 48 26" src="https://user-images.githubusercontent.com/1241413/145576674-5415bab8-a15b-4bc1-b845-0f58f13fa002.png">


Related to #57131
