### PR TITLE
Remove premium themes filter from external jetpack sites

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -377,6 +377,8 @@ class ThemeShowcase extends Component {
 				),
 		};
 
+		const isNonAtomicJetpackSite = this.props.isJetpackSite && ! this.props.isAtomic;
+
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
@@ -398,7 +400,7 @@ class ThemeShowcase extends Component {
 						onSearch={ this.doSearch }
 						search={ filterString + search }
 						tier={ tier }
-						showTierThemesControl={ ! isMultisite }
+						showTierThemesControl={ ! isMultisite && ! isNonAtomicJetpackSite }
 						select={ this.onTierSelect }
 					/>
 					{ isLoggedIn && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove premium themes filter from external jetpack sites.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the themes page using the `themes/premium` feature flag on a Jetpack-connected (but non-Atomic) site. Filter should be gone.

![image](https://user-images.githubusercontent.com/3801502/145578093-e92a49c7-77b4-4790-ab60-7bb63e0ea017.png)

* Filter should still be showing on Atomic sites:

![image](https://user-images.githubusercontent.com/3801502/145578199-295dd9d5-29a3-4db2-b229-9721444e7b7a.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58665
