### PR TITLE
New accordion component (settings page)

### DIFF
--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import './style.scss';
 import FoldableCard from 'calypso/components/foldable-card';
 import { AccordionProps } from './types';
+import './style.scss';
 
 const Accordion = ( {
 	title,

--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import './style.scss';
+import FoldableCard from 'calypso/components/foldable-card';
+import { AccordionProps } from './types';
+
+const Accordion = ( {
+	title,
+	subtitle,
+	children,
+	expanded = false,
+}: AccordionProps ): JSX.Element => {
+	const renderHeader = () => {
+		return (
+			<div>
+				<p className="accordion__title">{ title }</p>
+				{ subtitle && <p className="accordion__subtitle">{ subtitle }</p> }
+			</div>
+		);
+	};
+	return (
+		<div className="accordion">
+			<FoldableCard header={ renderHeader() } expanded={ expanded }>
+				{ children }
+			</FoldableCard>
+		</div>
+	);
+};
+
+export default Accordion;

--- a/client/components/domains/accordion/style.scss
+++ b/client/components/domains/accordion/style.scss
@@ -1,0 +1,53 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.accordion {
+	.foldable-card {
+		margin: 0;
+		&.is-expanded {
+			margin: 0;
+			.foldable-card__content {
+				border-top: none;
+				padding: 0 24px 16px 16px;
+				@include break-small {
+					padding: 0 30px 24px 24px;
+				}
+			}
+			.foldable-card__header {
+				padding-bottom: 8px;
+				@include break-small {
+					padding-bottom: 16px;
+				}
+			}
+		}
+		&__header {
+			padding: 16px 24px 16px 16px;
+			@include break-small {
+				padding: 24px 30px 24px 24px;
+			}
+		}
+		&__expand {
+			width: 56px;
+			@include break-small {
+				width: 74px;
+			}
+			.gridicon {
+				fill: var( --color-neutral-80 );
+			}
+		}
+		&__secondary {
+			display: none;
+		}
+	}
+	&__title {
+		margin-bottom: 0;
+		line-height: 1.5em;
+		font-weight: 600;
+		color: var( --studio-gray-80 );
+	}
+	&__subtitle {
+		font-size: $font-body-small;
+		margin-bottom: 0;
+		color: var( --studio-gray-50 );
+	}
+}

--- a/client/components/domains/accordion/types.ts
+++ b/client/components/domains/accordion/types.ts
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react';
+
+export type AccordionProps = {
+	children: ReactNode;
+	title: string;
+	subtitle?: string;
+	expanded?: boolean;
+};

--- a/client/components/domains/accordion/types.ts
+++ b/client/components/domains/accordion/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 export type AccordionProps = {
 	children: ReactNode;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import Accordion from 'calypso/components/domains/accordion';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
@@ -42,6 +43,15 @@ const Settings = ( props: SettingsPageProps ): JSX.Element => {
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
 			Page goes here.
+			{ /* Placeholder to test accordion */ }
+			<div style={ { marginTop: '30px' } }>
+				<Accordion title="First element title" subtitle="First element subtitle" expanded={ true }>
+					<div>Component placeholder: this one is exapanded by default</div>
+				</Accordion>
+				<Accordion title="Second element title" subtitle="Second element subtitle">
+					<div>Component placeholder: this one i'snt exapanded by default</div>
+				</Accordion>
+			</div>
 		</Main>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In this PR I've created a new accordion component to use in new domain page settings (or anywhere else).

![Markup on 2021-12-10 at 16:35:05](https://user-images.githubusercontent.com/2797601/145599940-4df2639b-d555-4043-9ad4-88d59d6b3e5d.png)

#### Testing instructions

* Build this branch locally or open the live Calypso link
* If you're in the live Calypso link, please append ?flags=domains/settings-page-redesign to your URL to enable the appropriate feature flag
* Go to "Upgrades > Domains"
* Select one of your domains
* Ensure accordions placeholders are correctly displayed (the first one should be open by default)
