### PR TITLE
Pricing page: round Complete price down

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -40,9 +40,7 @@ const Paid: React.FC< OwnProps > = ( {
 			: 1 - INTRO_PRICING_DISCOUNT_PERCENTAGE / 100;
 
 	const couponOriginalPrice = parseFloat( ( discountedPrice ?? originalPrice ).toFixed( 2 ) );
-	const couponDiscountedPrice = parseFloat(
-		( ( discountedPrice ?? originalPrice ) * DISCOUNT_PERCENTAGE ).toFixed( 2 )
-	);
+	const couponDiscountedPrice = Math.floor( couponOriginalPrice * DISCOUNT_PERCENTAGE * 100 ) / 100;
 
 	const discountElt =
 		billingTerm === TERM_ANNUALLY


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR rounds the price of _Complete_ in the pricing page down, to match the rounding mode of other products.

### Testing instructions

- Download the PR and run Calypso or cloud
- Visit the plans/pricing page
- Check that Complete is at 49.97 USD for the yearly term

### Screenshots

#### Before
<img width="357" alt="Screen Shot 2021-12-10 at 12 56 22 PM" src="https://user-images.githubusercontent.com/1620183/145619762-99ba3ef6-1fff-4896-b129-9f2beccfad65.png">


#### After
<img width="356" alt="Screen Shot 2021-12-10 at 12 56 17 PM" src="https://user-images.githubusercontent.com/1620183/145619770-db3ada2b-d68d-44c0-920a-f66dbe75a544.png">

