### PR TITLE
Checkout: Make logged-out email field controlled

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -113,6 +113,7 @@ export default function ContactDetailsContainer( {
 							type="email"
 							label={ String( translate( 'Email' ) ) }
 							disabled={ isDisabled }
+							value={ contactDetails.email ?? '' }
 							onChange={ ( value ) => {
 								updateEmail( value );
 							} }

--- a/client/my-sites/checkout/composite-checkout/components/country-specific-payment-fields.ts
+++ b/client/my-sites/checkout/composite-checkout/components/country-specific-payment-fields.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { FunctionComponent } from 'react';
 import CountrySpecificPaymentFieldsUnstyled from 'calypso/my-sites/checkout/checkout/country-specific-payment-fields';
 
 export type CountrySpecificPaymentFieldsProps = {
@@ -11,9 +10,7 @@ export type CountrySpecificPaymentFieldsProps = {
 	disableFields: boolean;
 };
 
-const CountrySpecificPaymentFields: FunctionComponent< CountrySpecificPaymentFieldsProps > = styled(
-	CountrySpecificPaymentFieldsUnstyled
-)`
+const CountrySpecificPaymentFields = styled( CountrySpecificPaymentFieldsUnstyled )`
 	margin-top: 0;
 
 	& .checkout__form-info-text {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes the logged-out Email field a controlled React component, meaning that its value is not actually what is typed by the user directly, but rather when the user makes a change, it is stored in our data, then that data is read to display the value into the field.

Since the logged-out email field will never (?) have a pre-set value in actual usage, this is probably not that important but it does resolve a TypeScript error in the code, which requires that uses of the `Field` component be controlled.

<img width="567" alt="Screen Shot 2021-12-10 at 2 08 36 PM" src="https://user-images.githubusercontent.com/2036909/145628771-30c4854b-8d7c-4ce4-bc7e-408e71c783f4.png">


#### Testing instructions

The easiest way to test this is probably to hack the code so that the email field is displayed even when logged-in. To do that, apply the following patch:

```diff
index 8533fa2b40..48e53b317e 100644
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -45,6 +45,7 @@ export default function ContactDetailsContainer( {
        isDisabled: boolean;
        isLoggedOutCart: boolean;
 } ): JSX.Element {
+       isLoggedOutCart = true; // FIXME: for testing only
        const translate = useTranslate();
        const cartKey = useCartKey();
        const { responseCart } = useShoppingCart( cartKey );
```

- Next, add a product to your cart and visit checkout. 
- Edit the contact details step and verify that typing in the email field feels instantaneous and shows what is typed.