### PR TITLE
Fix: Continue as user on large screens

### DIFF
--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -60,7 +60,7 @@
 	.continue-as-user__not-you {
 		display: block;
 		bottom: 0;
-		margin-bottom: -40px;
+		margin-bottom: -33px;
 		position: absolute;
 		text-align: center;
 		width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix cut off text on the large screen. More then 1400px. 

Before:
<img width="590" alt="Screen Shot 2021-12-10 at 11 12 18 AM" src="https://user-images.githubusercontent.com/115071/145629054-5cf9d31b-ecb8-4828-9aca-d69d79f02cce.png">


After:
<img width="680" alt="Screen Shot 2021-12-10 at 11 12 37 AM" src="https://user-images.githubusercontent.com/115071/145629032-d1b6111e-b106-423a-b00b-de2681fda03c.png">



#### Testing instructions
1. Load this PR. 
2. Login to wordpress.com 
3. visit /login and resize the window past 1400px 
4. Notice that the paragraph is not cut off. 
5. and /login/new and resize the window past 1400px 
6. Notice that the paragraph is not cut off. 


