### PR TITLE
Pricing page: make product card features collapsable on mobile

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features.tsx
@@ -1,52 +1,57 @@
 import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import FeaturesItem from './features-item';
 import type { ProductCardFeatures, ProductCardFeaturesItem } from './types';
 
 export interface Props {
 	className?: string;
+	productSlug?: string;
 	features: ProductCardFeatures;
 	collapseFeaturesOnMobile?: boolean;
 }
 
 const JetpackProductCardFeatures: React.FC< Props > = ( {
 	className,
+	productSlug,
 	features: { items },
 	collapseFeaturesOnMobile,
 } ) => {
 	const translate = useTranslate();
+	const listRef = useRef< HTMLUListElement >();
 	const [ isExpanded, expand ] = useState( ! collapseFeaturesOnMobile );
+	const listId = `${ productSlug }-features-list`;
 
+	const focusOnList = useCallback( () => listRef.current?.focus?.(), [ listRef ] );
 	const onClick = useCallback( () => expand( ! isExpanded ), [ expand, isExpanded ] );
-	const onKeyPress = useCallback(
-		( { code } ) => {
-			if ( code === 'Enter' ) {
-				expand( ! isExpanded );
-			}
-		},
-		[ expand, isExpanded ]
-	);
+
+	useEffect( () => {
+		if ( collapseFeaturesOnMobile && isExpanded ) {
+			focusOnList();
+		}
+	}, [ collapseFeaturesOnMobile, isExpanded, focusOnList ] );
 
 	return (
 		<section className={ classnames( className, 'jetpack-product-card__features' ) }>
 			{ collapseFeaturesOnMobile && (
-				<header
-					className="jetpack-product-card__features-header"
-					role="button"
-					tabIndex={ 0 }
+				<button
+					className="jetpack-product-card__features-button"
 					onClick={ onClick }
-					onKeyPress={ onKeyPress }
+					aria-controls={ listId }
+					aria-expanded={ isExpanded }
 				>
 					<span>{ translate( 'Features include' ) }</span>
 					<Gridicon icon={ `chevron-${ isExpanded ? 'up' : 'down' }` } size={ 18 } />
-				</header>
+				</button>
 			) }
 			<ul
+				id={ listId }
 				className={ classnames( className, 'jetpack-product-card__features-list', {
 					'is-collapsed': ! isExpanded,
 				} ) }
+				tabIndex={ -1 }
+				ref={ listRef }
 			>
 				{ ( items as ProductCardFeaturesItem[] ).map( ( item, i ) => (
 					<FeaturesItem key={ i } item={ item } />

--- a/client/components/jetpack/card/jetpack-product-card/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features.tsx
@@ -1,17 +1,53 @@
+import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
-import * as React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useCallback } from 'react';
 import FeaturesItem from './features-item';
 import type { ProductCardFeatures, ProductCardFeaturesItem } from './types';
 
 export interface Props {
 	className?: string;
 	features: ProductCardFeatures;
+	collapseFeaturesOnMobile?: boolean;
 }
 
-const JetpackProductCardFeatures: React.FC< Props > = ( { className, features: { items } } ) => {
+const JetpackProductCardFeatures: React.FC< Props > = ( {
+	className,
+	features: { items },
+	collapseFeaturesOnMobile,
+} ) => {
+	const translate = useTranslate();
+	const [ isExpanded, expand ] = useState( ! collapseFeaturesOnMobile );
+
+	const onClick = useCallback( () => expand( ! isExpanded ), [ expand, isExpanded ] );
+	const onKeyPress = useCallback(
+		( { code } ) => {
+			if ( code === 'Enter' ) {
+				expand( ! isExpanded );
+			}
+		},
+		[ expand, isExpanded ]
+	);
+
 	return (
 		<section className={ classnames( className, 'jetpack-product-card__features' ) }>
-			<ul className="jetpack-product-card__features-list">
+			{ collapseFeaturesOnMobile && (
+				<header
+					className="jetpack-product-card__features-header"
+					role="button"
+					tabIndex={ 0 }
+					onClick={ onClick }
+					onKeyPress={ onKeyPress }
+				>
+					<span>{ translate( 'Features include' ) }</span>
+					<Gridicon icon={ `chevron-${ isExpanded ? 'up' : 'down' }` } size={ 18 } />
+				</header>
+			) }
+			<ul
+				className={ classnames( className, 'jetpack-product-card__features-list', {
+					'is-collapsed': ! isExpanded,
+				} ) }
+			>
 				{ ( items as ProductCardFeaturesItem[] ).map( ( item, i ) => (
 					<FeaturesItem key={ i } item={ item } />
 				) ) }

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -173,6 +173,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 				{ description && <p className="jetpack-product-card__description">{ description }</p> }
 				{ item.features && item.features.items.length > 0 && (
 					<JetpackProductCardFeatures
+						productSlug={ item.productSlug }
 						features={ item.features }
 						collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
 					/>

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -41,6 +41,7 @@ type OwnProps = {
 	hideSavingLabel?: boolean;
 	showAbovePriceText?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
+	collapseFeaturesOnMobile?: boolean;
 };
 
 type HeaderLevel = 1 | 2 | 3 | 4 | 5 | 6;
@@ -77,6 +78,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	showAbovePriceText,
 	aboveButtonText = null,
 	scrollCardIntoView,
+	collapseFeaturesOnMobile,
 } ) => {
 	const translate = useTranslate();
 
@@ -170,7 +172,10 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 
 				{ description && <p className="jetpack-product-card__description">{ description }</p> }
 				{ item.features && item.features.items.length > 0 && (
-					<JetpackProductCardFeatures features={ item.features } />
+					<JetpackProductCardFeatures
+						features={ item.features }
+						collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
+					/>
 				) }
 			</div>
 		</div>

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -1,4 +1,5 @@
-@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .jetpack-product-card {
 	position: relative;
@@ -171,6 +172,25 @@
 	}
 }
 
+.jetpack-product-card__features-header {
+	display: flex;
+	align-content: center;
+
+	color: var( --color-text-subtle );
+
+	font-weight: 700;
+
+	cursor: pointer;
+
+	.gridicon {
+		margin: 3px 0 0 0.5rem;
+	}
+
+	@include break-small {
+		display: none;
+	}
+}
+
 .jetpack-product-card__features-list {
 	margin: 0 16px 12px;
 
@@ -180,6 +200,14 @@
 
 	@include break-medium {
 		margin-block-end: 2rem;
+	}
+
+	&.is-collapsed {
+		display: none;
+
+		@include break-small {
+			display: block;
+		}
 	}
 }
 

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -172,18 +172,27 @@
 	}
 }
 
-.jetpack-product-card__features-header {
+.jetpack-product-card__features-button {
 	display: flex;
 	align-content: center;
 
+	margin-bottom: 1rem;
+
 	color: var( --color-text-subtle );
 
+	font-family: inherit;
+	font-size: 1rem;
 	font-weight: 700;
 
 	cursor: pointer;
 
+	&:focus-visible {
+		outline: 1px dotted;
+		outline-offset: 2px;
+	}
+
 	.gridicon {
-		margin: 3px 0 0 0.5rem;
+		margin: 1px 0 0 0.5rem;
 	}
 
 	@include break-small {

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/index.tsx
@@ -81,6 +81,7 @@ const CardWithPrice: React.FC< CardWithPriceProps > = ( { duration, siteId } ) =
 			buttonLabel={ translate( 'Get CRM' ) }
 			buttonURL={ CRM_FREE_URL }
 			onButtonClick={ onButtonClick }
+			collapseFeaturesOnMobile
 		/>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
@@ -51,6 +51,7 @@ const JetpackFreeCard: FC< OwnProps > = ( { siteId, urlQueryArgs } ) => {
 			buttonLabel={ translate( 'Start for free' ) }
 			buttonURL={ buttonHref }
 			onButtonClick={ onButtonClick }
+			collapseFeaturesOnMobile
 		/>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -48,6 +48,7 @@ interface ProductCardProps {
 	featuredLabel?: TranslateResult;
 	hideSavingLabel?: boolean;
 	scrollCardIntoView: ScrollCardIntoViewCallback;
+	collapseFeaturesOnMobile?: boolean;
 }
 
 const ProductCard: React.FC< ProductCardProps > = ( {
@@ -62,6 +63,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	featuredLabel,
 	hideSavingLabel,
 	scrollCardIntoView,
+	collapseFeaturesOnMobile,
 } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -190,6 +192,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			featuredLabel={ featuredLabel }
 			hideSavingLabel={ hideSavingLabel }
 			scrollCardIntoView={ scrollCardIntoView }
+			collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
 		/>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -177,6 +177,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 				selectedTerm={ duration }
 				scrollCardIntoView={ scrollCardIntoView }
 				createButtonURL={ createButtonURL }
+				collapseFeaturesOnMobile
 			/>
 		</li>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes product cards in the pricing page collapsable on mobile. Note that the change is limited to actual product cards in the _More Products_ section.

### Testing instructions

- Download the PR and run cloud or Calypso
- Visit the pricing/plans page
- Check that the page looks and behaves the same as in production on desktop
- On mobile, check that cards in the _More Products_ section are collapsed by default and can be expanded

### Screenshots

| Before | After |
|--------|------|
|<img width="429" alt="Screen Shot 2021-12-10 at 2 28 27 PM" src="https://user-images.githubusercontent.com/1620183/145630721-a723cd7b-4c1b-4f83-8a1b-e75ea1b76ebf.png">|<img width="424" alt="Screen Shot 2021-12-10 at 2 28 12 PM" src="https://user-images.githubusercontent.com/1620183/145630726-64455e53-b11e-487b-b236-0bb3fe6f7cd8.png">|

