### PR TITLE
Fix/my sites cleanup pr

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -17,6 +17,7 @@ import ConfirmDisconnection from './disconnect-site/confirm';
 import ManageConnection from './manage-connection';
 import StartOver from './start-over';
 import ThemeSetup from './theme-setup';
+import { getSiteFragment } from 'calypso/lib/route';
 
 function canDeleteSite( state, siteId ) {
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
@@ -111,6 +112,16 @@ export function legacyRedirects( context, next ) {
 
 	if ( redirectMap[ section ] ) {
 		return page.redirect( redirectMap[ section ] );
+	}
+
+	next();
+}
+
+export function redirectToGeneral( context, next ) {
+	const site = getSiteFragment( context.path );
+
+	if ( site ) {
+		return page.redirect( `/settings/general/${ site }` );
 	}
 
 	next();

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
+import { getSiteFragment } from 'calypso/lib/route';
 import { billingHistory } from 'calypso/me/purchases/paths';
 import SiteSettingsMain from 'calypso/my-sites/site-settings/main';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -17,7 +18,6 @@ import ConfirmDisconnection from './disconnect-site/confirm';
 import ManageConnection from './manage-connection';
 import StartOver from './start-over';
 import ThemeSetup from './theme-setup';
-import { getSiteFragment } from 'calypso/lib/route';
 
 function canDeleteSite( state, siteId ) {
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -10,6 +10,7 @@ import {
 	legacyRedirects,
 	manageConnection,
 	redirectIfCantDeleteSite,
+	redirectToGeneral,
 	redirectToTraffic,
 	startOver,
 	themeSetup,
@@ -111,5 +112,13 @@ export default function () {
 	page( '/settings/analytics/:site_id?', redirectToTraffic );
 	page( '/settings/seo/:site_id?', redirectToTraffic );
 
-	page( '/settings/:section', legacyRedirects, siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/settings/:section',
+		legacyRedirects,
+		redirectToGeneral,
+		siteSelection,
+		sites,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -115,8 +115,8 @@ export default function () {
 	page(
 		'/settings/:section',
 		legacyRedirects,
-		redirectToGeneral,
 		siteSelection,
+		redirectToGeneral,
 		sites,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
This is a follow up PR from @mariovalney here: https://github.com/Automattic/wp-calypso/pull/26796. We created this one so we can rebase this one: pdqkMK-1k-p2#comment-19.

**Original PR:**

From #25783

#### In `my-sites/controller.js`:

- [x] Clean up `createSitesComponent`.


#### In `my-sites/site-settings/index.js`

If the site slug is in the URL, why show a site selection UI? Let's redirect to stats right away.
The issues with `/settings` site selection could be solved similarly: by improved handling of the `/settings/*` routes:

- [x] There should be a redirect from `/settings/site.slug` to `/settings/general/site.slug` if `site.slug` is a valid site slug (number or string with dots)
- [x] This redirect should take care to coexist well with the `/settings/:section` handler that does legacy redirects - `/settings/account` should redirect to `me/account`