### PR TITLE
Disable electron builder updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,7 @@
 	],
 	"statusCheckVerify": true,
 	"rangeStrategy": "bump",
-	"ignoreDeps": [ "jquery" ],
+	"ignoreDeps": [ "jquery", "electron-builder" ],
 	"labels": [ "Framework", "[Type] Task" ],
 	"lockFileMaintenance": {
 		"enabled": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request
@nsakaimbo mentioned that electron builder should only ever be updated manually because it is so brittle. If that's the case, we don't need to have renovate remind us to update it every day :) We can do that with https://docs.renovatebot.com/configuration-options/#ignoredeps.

### Testing instructions
none, renovate will only run after merging to trunk.
