### PR TITLE
Social login: Add loading state to the google social login

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -3,7 +3,7 @@ import { loadScript } from '@automattic/load-script';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { cloneElement, Component, Fragment } from 'react';
+import { cloneElement, Component } from 'react';
 import { connect } from 'react-redux';
 import GoogleIcon from 'calypso/components/social-icons/google';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -42,6 +42,7 @@ class GoogleLoginButton extends Component {
 		showError: false,
 		errorRef: null,
 		isDisabled: true,
+		isLoading: true,
 	};
 
 	constructor( props ) {
@@ -96,7 +97,10 @@ class GoogleLoginButton extends Component {
 			)
 			.then( ( gapi ) =>
 				this.initializeAuth2( gapi ).then( () => {
-					this.setState( { isDisabled: false } );
+					this.setState( {
+						isLoading: false,
+						isDisabled: false,
+					} );
 
 					const googleAuth = gapi.auth2.getAuthInstance();
 					const currentUser = googleAuth.currentUser.get();
@@ -111,6 +115,10 @@ class GoogleLoginButton extends Component {
 			)
 			.catch( ( error ) => {
 				this.initialized = null;
+
+				this.setState( {
+					isLoading: false,
+				} );
 
 				if ( 'idpiframe_initialization_failed' === error.error ) {
 					// This error is caused by 3rd party cookies being blocked.
@@ -190,6 +198,7 @@ class GoogleLoginButton extends Component {
 		const isDisabled = Boolean(
 			this.state.isDisabled || this.props.isFormDisabled || this.state.error
 		);
+		const { isLoading } = this.state;
 
 		const { children } = this.props;
 		let customButton = null;
@@ -208,12 +217,15 @@ class GoogleLoginButton extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ customButton ? (
 					customButton
 				) : (
 					<button
-						className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+						className={ classNames( 'social-buttons__button button', {
+							disabled: isDisabled && ! isLoading,
+							loading: isLoading,
+						} ) }
 						onMouseOver={ this.showError }
 						onFocus={ this.showError }
 						onBlur={ this.hideError }
@@ -221,6 +233,7 @@ class GoogleLoginButton extends Component {
 					>
 						<GoogleIcon
 							isDisabled={ isDisabled }
+							isLoading={ isLoading }
 							width={ this.props.isReskinned ? 19 : 20 }
 							height={ this.props.isReskinned ? 19 : 20 }
 						/>
@@ -244,7 +257,7 @@ class GoogleLoginButton extends Component {
 				>
 					{ preventWidows( this.state.error ) }
 				</Popover>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -43,6 +43,7 @@ class GoogleLoginButton extends Component {
 		errorRef: null,
 		isDisabled: true,
 		isLoading: true,
+		isTemporarilyNotLoading: true,
 	};
 
 	constructor( props ) {
@@ -53,10 +54,13 @@ class GoogleLoginButton extends Component {
 		this.handleClick = this.handleClick.bind( this );
 		this.showError = this.showError.bind( this );
 		this.hideError = this.hideError.bind( this );
+		this.updateTemporarilyNotLoading = this.updateTemporarilyNotLoading.bind( this );
 	}
 
 	componentDidMount() {
 		this.initialize();
+		// Removes the loaded state after 2 seconds.
+		window.setTimeout( this.updateTemporarilyNotLoading, 2000 );
 	}
 
 	async loadDependency() {
@@ -80,6 +84,12 @@ class GoogleLoginButton extends Component {
 			redirect_uri: this.props.redirectUri,
 		} );
 		auth2InitDone = true;
+	}
+
+	updateTemporarilyNotLoading() {
+		this.setState( {
+			isTemporarilyNotLoading: false,
+		} );
 	}
 
 	initialize() {
@@ -198,7 +208,7 @@ class GoogleLoginButton extends Component {
 		const isDisabled = Boolean(
 			this.state.isDisabled || this.props.isFormDisabled || this.state.error
 		);
-		const { isLoading } = this.state;
+		const { isLoading, isTemporarilyNotLoading } = this.state;
 
 		const { children } = this.props;
 		let customButton = null;
@@ -215,7 +225,8 @@ class GoogleLoginButton extends Component {
 
 			customButton = cloneElement( children, childProps );
 		}
-
+		const isDisabledComponent = isTemporarilyNotLoading ? false : isDisabled;
+		const isLoadingComponent = isTemporarilyNotLoading ? false : isLoading;
 		return (
 			<>
 				{ customButton ? (
@@ -223,8 +234,8 @@ class GoogleLoginButton extends Component {
 				) : (
 					<button
 						className={ classNames( 'social-buttons__button button', {
-							disabled: isDisabled && ! isLoading,
-							loading: isLoading,
+							disabled: isDisabledComponent && ! isLoadingComponent,
+							loading: isLoadingComponent,
 						} ) }
 						onMouseOver={ this.showError }
 						onFocus={ this.showError }
@@ -232,8 +243,8 @@ class GoogleLoginButton extends Component {
 						onClick={ this.handleClick }
 					>
 						<GoogleIcon
-							isDisabled={ isDisabled }
-							isLoading={ isLoading }
+							isDisabled={ isDisabledComponent }
+							isLoading={ isLoadingComponent }
 							width={ this.props.isReskinned ? 19 : 20 }
 							height={ this.props.isReskinned ? 19 : 20 }
 						/>

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -117,7 +117,7 @@ class GoogleLoginButton extends Component {
 						// Make sure that handleClick Call happens on the next tick so that the popup always launches.
 						setTimeout( () => {
 							this.handleClick( this.state.isClicked );
-						}, 1 );
+						}, 10 );
 					}
 
 					return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
@@ -180,7 +180,7 @@ class GoogleLoginButton extends Component {
 
 		// Options are documented here:
 		// https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2signinoptions
-		window.gapi.auth2
+		window?.gapi.auth2
 			.getAuthInstance()
 			.signIn( { prompt: 'select_account' } )
 			.then( responseHandler, ( error ) => {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -42,7 +42,6 @@ class GoogleLoginButton extends Component {
 		showError: false,
 		errorRef: null,
 		isDisabled: false,
-		isLoading: false,
 		isInitialized: false,
 		clickEvent: undefined,
 	};
@@ -51,6 +50,8 @@ class GoogleLoginButton extends Component {
 		super( props );
 
 		this.initialized = null;
+
+		this.initialize = this.initialize.bind( this );
 
 		this.handleClick = this.handleClick.bind( this );
 		this.showError = this.showError.bind( this );
@@ -113,10 +114,7 @@ class GoogleLoginButton extends Component {
 					}
 
 					if ( this.state.clickEvent ) {
-						// Make sure that handleClick Call happens on the next tick so that the popup always launches.
-						setTimeout( () => {
-							this.handleClick( this.state.clickEvent );
-						} );
+						this.handleClick( this.state.clickEvent );
 					}
 
 					return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
@@ -152,7 +150,6 @@ class GoogleLoginButton extends Component {
 
 	handleClick( event ) {
 		event.preventDefault();
-
 		if ( ! this.state.isInitialized && ! this.state.clickEvent ) {
 			this.setState( { clickEvent: event } );
 			return;
@@ -206,7 +203,7 @@ class GoogleLoginButton extends Component {
 			this.state.isDisabled || this.props.isFormDisabled || this.state.error
 		);
 
-		const isLoading = this.state.isClicked && ! this.state.initialized && ! this.state.error;
+		const isLoading = !! this.state.clickEvent && ! this.state.initialized && ! this.state.error;
 
 		const { children } = this.props;
 		let customButton = null;

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -10,6 +10,10 @@
 			display: none;
 		}
 	}
+
+	&.loading .social-buttons__service-name {
+		@include placeholder();
+	}
 }
 
 .social-buttons__service-name {

--- a/client/components/social-icons/google.jsx
+++ b/client/components/social-icons/google.jsx
@@ -20,7 +20,7 @@ export default class GoogleIcon extends PureComponent {
 	};
 
 	render() {
-		const props = omit( this.props, [ 'isDisabled' ] );
+		const props = omit( this.props, [ 'isDisabled', 'isLoading' ] );
 
 		return (
 			<svg

--- a/client/components/social-icons/google.jsx
+++ b/client/components/social-icons/google.jsx
@@ -8,6 +8,7 @@ import './style.scss';
 export default class GoogleIcon extends PureComponent {
 	static propTypes = {
 		isDisabled: PropTypes.bool,
+		isLoading: PropTypes.bool,
 		width: PropTypes.number,
 		height: PropTypes.number,
 	};
@@ -26,6 +27,7 @@ export default class GoogleIcon extends PureComponent {
 				className={ classNames( 'social-icons social-icons__google', {
 					'social-icons--enabled': ! this.props.isDisabled,
 					'social-icons--disabled': !! this.props.isDisabled,
+					placeholder: this.props.isLoading,
 				} ) }
 				width={ this.props.width }
 				height={ this.props.height }

--- a/client/components/social-icons/google.jsx
+++ b/client/components/social-icons/google.jsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
@@ -20,14 +19,14 @@ export default class GoogleIcon extends PureComponent {
 	};
 
 	render() {
-		const props = omit( this.props, [ 'isDisabled', 'isLoading' ] );
+		const { isDisabled, isLoading, ...props } = this.props;
 
 		return (
 			<svg
 				className={ classNames( 'social-icons social-icons__google', {
 					'social-icons--enabled': ! this.props.isDisabled,
 					'social-icons--disabled': !! this.props.isDisabled,
-					placeholder: this.props.isLoading,
+					'social-icons--placeholder': this.props.isLoading,
 				} ) }
 				width={ this.props.width }
 				height={ this.props.height }

--- a/client/components/social-icons/style.scss
+++ b/client/components/social-icons/style.scss
@@ -8,3 +8,10 @@
 		fill: var( --color-neutral-0 );
 	}
 }
+
+.social-buttons__button .placeholder {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	path {
+		fill: var( --color-neutral-10 );
+	}
+}

--- a/client/components/social-icons/style.scss
+++ b/client/components/social-icons/style.scss
@@ -9,7 +9,7 @@
 	}
 }
 
-.social-buttons__button .placeholder {
+.social-buttons__button .social-icons--placeholder {
 	animation: loading-fade 1.6s ease-in-out infinite;
 	path {
 		fill: var( --color-neutral-10 );


### PR DESCRIPTION
Currently, there is no difference between a loading state and an error state on mobile.
This PR tries to add a loading state so that it is more clear that the social login is still loading.  Fixes #59023

#### Changes proposed in this Pull Request

Before:

https://user-images.githubusercontent.com/115071/145640629-6dc11f55-7e0f-4ea2-ac96-c6177e13b798.mp4

After:

https://user-images.githubusercontent.com/115071/145640635-6b388029-dd92-493e-9d5a-c2106237ffa2.mp4


#### Testing instructions
1. Load up this PR. 
2. Logout of WordPress.com
3. visit /log-in 
4. Notice that you can now see a loading state for the Google social login
5. visit /log-in/new 
6.  Notice that you can now see a loading state for the Google social login
7. visit /start/user
8.  Notice that you can now see a loading state for the Google social login
