### PR TITLE
Add Flag to Hide Jetpack Pricing Toggle

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	PLAN_JETPACK_SECURITY_T1_YEARLY,
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
@@ -94,6 +95,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const showAnnualPlansOnly = config.isEnabled( 'jetpack/pricing-page-annual-only' );
 	const siteId = useSelector( getSelectedSiteId );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
@@ -148,16 +150,17 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	};
 
 	const filterBar = useMemo(
-		() => (
-			<div className="product-grid__filter-bar">
-				<PlansFilterBar
-					showDiscountMessage
-					onDurationChange={ onDurationChange }
-					duration={ duration }
-				/>
-			</div>
-		),
-		[ onDurationChange, duration ]
+		() =>
+			showAnnualPlansOnly ? null : (
+				<div className="product-grid__filter-bar">
+					<PlansFilterBar
+						showDiscountMessage
+						onDurationChange={ onDurationChange }
+						duration={ duration }
+					/>
+				</div>
+			),
+		[ onDurationChange, duration, showAnnualPlansOnly ]
 	);
 
 	const featuredPlans = [
@@ -196,6 +199,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 				<ul
 					className={ classNames( 'product-grid__plan-grid', {
 						'is-wrapping': shouldWrapGrid,
+						'has-top-padding': showAnnualPlansOnly,
 					} ) }
 					ref={ gridRef }
 				>

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -60,6 +60,10 @@
 	}
 }
 
+.product-grid__plan-grid.has-top-padding {
+	padding-top: 32px;
+}
+
 .product-grid__plan-grid:not( .is-wrapping ) {
 	margin-top: 72px;
 	gap: 16px 0;

--- a/config/development.json
+++ b/config/development.json
@@ -87,6 +87,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": true,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -52,6 +52,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/magic-link-signup": true,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/user-licensing": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -41,6 +41,7 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -35,6 +35,7 @@
 		"jetpack/more-informative-scan": false,
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -37,6 +37,7 @@
 		"jetpack/backups-date-picker": true,
 		"jetpack/more-informative-scan": false,
 		"jetpack/pricing-page": true,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -38,6 +38,7 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -54,6 +54,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": false,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -53,6 +53,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": true,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,

--- a/config/test.json
+++ b/config/test.json
@@ -48,6 +48,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/more-informative-scan": true,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,6 +60,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/more-informative-scan": false,
+		"jetpack/pricing-page-annual-only": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/user-licensing": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add flag to hide Jetpack Pricing Page Toggle

| without flag | with flag |
| ------------ | --------  |
| <img width="1325" alt="Screen Shot 2021-12-10 at 13 48 19" src="https://user-images.githubusercontent.com/2810519/145645687-2bc2fb04-bcc1-43ac-b8b8-052679ab76cf.png"> | <img width="1325" alt="Screen Shot 2021-12-10 at 13 48 28" src="https://user-images.githubusercontent.com/2810519/145645682-54210dbb-42b6-4b69-8800-9574792c1590.png">  |
| <img width="1053" alt="Screen Shot 2021-12-10 at 13 46 55" src="https://user-images.githubusercontent.com/2810519/145645695-c9604fa6-89b3-4bda-923a-ab615e9fa036.png"> | <img width="1053" alt="Screen Shot 2021-12-10 at 13 44 21" src="https://user-images.githubusercontent.com/2810519/145645697-ef3fd571-ae9d-4f05-8084-cbacdf85a422.png"> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot branch with Calypso Green
* Navigate to `/pricing`
* Verify it matched the "without flag" screenshot above
* Add `?flags=jetpack/pricing-page-annual-only` to the url and reload the page
* Verify it matched the "with flag" screenshot above
* Boot branch with Calypso Blue
* Navigate to `/plans/:siteSlug` for a Jetpack site
* Verify it matched the "without flag" screenshot above
* Add `?flags=jetpack/pricing-page-annual-only` to the url and reload the page
* Verify it matched the "with flag" screenshot above

#### See Also

1201295898168937-as-1201295899380968