### PR TITLE
Fix a peer dependency issue with mocha-junit-reporter

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -178,10 +178,11 @@ object RunAllUnitTests : BuildType({
 				# The "name" property refers to the code of the message (like YN0002).
 
 				# Generate a JSON array of the errors we care about:
-				# 1. Select warning YN0002 (Unmet peer dependencies.)
-				# 2. Select warning YN0068 (A yarnrc.yml entry needs to be removed.)
-				# 3. Select any errors which aren't code 0. (Which shows the error summary, not individual problems.)
-				yarn_errors=${'$'}(cat "${'$'}yarn_out" | jq '[ .[] | select(.name == 2 or .name == 68 or (.type == "error" and .name != 0)) ]')
+				# 1. Select warning YN0002 (Missing peer dependencies.)
+				# 2. Select warning ZN0060 (Invalid peer dependency.)
+				# 3. Select warning YN0068 (A yarnrc.yml entry needs to be removed.)
+				# 4. Select any errors which aren't code 0. (Which shows the error summary, not individual problems.)
+				yarn_errors=${'$'}(cat "${'$'}yarn_out" | jq '[ .[] | select(.name == 2 or .name == 60 or .name == 68 or (.type == "error" and .name != 0)) ]')
 
 				num_errors=${'$'}(jq length <<< "${'$'}yarn_errors")
 				if [ "${'$'}num_errors" -gt 0 ] ; then

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -58,7 +58,7 @@
 		"lodash": "^4.17.20",
 		"mailosaur": "^4.0.0",
 		"mocha": "^8.1.3",
-		"mocha-junit-reporter": "^2.0.0",
+		"mocha-junit-reporter": "^2.0.2",
 		"mocha-multi-reporters": "^1.5.1",
 		"mocha-teamcity-reporter": "^3.0.0",
 		"playwright": "1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25663,18 +25663,18 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"mocha-junit-reporter@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "mocha-junit-reporter@npm:2.0.0"
+"mocha-junit-reporter@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "mocha-junit-reporter@npm:2.0.2"
   dependencies:
     debug: ^2.2.0
     md5: ^2.1.0
     mkdirp: ~0.5.1
-    strip-ansi: ^4.0.0
+    strip-ansi: ^6.0.1
     xml: ^1.0.0
   peerDependencies:
     mocha: ">=2.2.5"
-  checksum: eb82e71b70410fd8ef0c038b5aee83fd086550350963b767e4948915cd88a990ef33b6823aad4708221be7def45d6e8d2b6594015bd1aeddaf5a496f79052476
+  checksum: 6221f43ff0061e73c1a98f6feec6f07caa9b6fb634f527b0bcba6602911d8c98bb0f8dabaebcc1095d9f5d835ea2fdb59c21c6631ae4e4764c01b479d4973f33
   languageName: node
   linkType: hard
 
@@ -37723,7 +37723,7 @@ testarmada-magellan@11.0.10:
     lodash: ^4.17.20
     mailosaur: ^4.0.0
     mocha: ^8.1.3
-    mocha-junit-reporter: ^2.0.0
+    mocha-junit-reporter: ^2.0.2
     mocha-multi-reporters: ^1.5.1
     mocha-teamcity-reporter: ^3.0.0
     playwright: 1.14.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request
https://github.com/Automattic/wp-calypso/pull/59045 caused an issue with peer dependencies. I'm not sure why only the peer dep was updated, but not the dependency,

I also added the warning in question to the list of yarn warnings which should fail CI.

#### Testing instructions
CI
