### PR TITLE
G Suite: Make getFields and mapFieldValues more explicit

### DIFF
--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -38,10 +38,13 @@ export interface GSuiteProductUser {
  *
  * @param {object} user - user with a list of fields
  */
-const getFields = ( user: GSuiteNewUser ): GSuiteNewUserField[] =>
-	Object.keys( user )
-		.filter( ( key ) => 'uuid' !== key )
-		.map( ( key ) => user[ key ] );
+const getFields = ( user: GSuiteNewUser ): GSuiteNewUserField[] => [
+	user.domain,
+	user.mailBox,
+	user.firstName,
+	user.lastName,
+	user.password,
+];
 
 /**
  * Retrieves the specified user after applying a callback to all of its fields.
@@ -49,14 +52,21 @@ const getFields = ( user: GSuiteNewUser ): GSuiteNewUserField[] =>
  * @param {object} user - user with a list of fields
  * @param {Function} callback - function to call for each field
  */
-const mapFieldValues = ( user: GSuiteNewUser, callback ): GSuiteNewUser =>
-	mapValues( user, ( fieldValue, fieldName ) => {
-		if ( 'uuid' === fieldName ) {
-			return fieldValue;
-		}
-
-		return callback( fieldValue, fieldName, user );
-	} );
+const mapFieldValues = (
+	user: GSuiteNewUser,
+	callback: (
+		fieldValue: GSuiteNewUserField,
+		fieldName: string,
+		user: GSuiteNewUser
+	) => GSuiteNewUserField
+): GSuiteNewUser => ( {
+	uuid: user.uuid,
+	domain: callback( user.domain, 'domain', user ),
+	mailBox: callback( user.mailBox, 'mailBox', user ),
+	firstName: callback( user.firstName, 'firstName', user ),
+	lastName: callback( user.lastName, 'lastName', user ),
+	password: callback( user.password, 'password', user ),
+} );
 
 /*
  * Clears all previous errors from the specified field.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes some TypeScript errors in the file `client/lib/gsuite/new-users.ts` by making the private functions `getFields` and `mapFieldValues` explicit rather than relying on iterating over object keys. It should have no effect on the actual execution of the functions (unless for some reason the types of `GSuiteNewUser ` and `GSuiteNewUserField` are wrong).

#### Testing instructions

See testing instructions for https://github.com/Automattic/wp-calypso/pull/43202