### PR TITLE
Domains: Create redesigned domain settings page sidebar

### DIFF
--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -16,3 +16,16 @@
 		vertical-align: middle;
 	}
 }
+
+
+.dialog__button--domains-remove {
+	> .dialog__button-label {
+		display: flex;
+		align-items: center;
+		column-gap: 7px;
+
+		> svg {
+			fill: var( --color-text-inverted );
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { type as domainType } from 'calypso/lib/domains/constants';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
 import {
 	getByPurchaseId,
@@ -10,17 +11,29 @@ import DomainInfoCard from '..';
 import { DomainDeleteInfoCardProps, DomainInfoCardProps } from '../types';
 
 const DomainDeleteInfoCard = ( {
+	domain,
 	selectedSite,
 	purchase,
 }: DomainDeleteInfoCardProps ): JSX.Element => {
 	const translate = useTranslate();
 	const removePurchaseClassName = 'is-compact button';
 
+	const getDescription = () => {
+		switch ( domain.type ) {
+			case domainType.MAPPED:
+				return translate( 'Remove this domain connection permanently' );
+			case domainType.TRANSFER:
+				return translate( 'Remove this domain transfer permanently' );
+			default:
+				return translate( 'Remove this domain permanently' );
+		}
+	};
+
 	return (
 		<DomainInfoCard
 			type="custom"
 			title={ translate( 'Delete' ) }
-			description={ translate( 'Remove this domain permanently' ) }
+			description={ getDescription() }
 			cta={
 				<RemovePurchase
 					hasLoadedSites={ true }

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -1,0 +1,46 @@
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import RemovePurchase from 'calypso/me/purchases/remove-purchase';
+import {
+	getByPurchaseId,
+	hasLoadedSitePurchasesFromServer,
+	isFetchingSitePurchases,
+} from 'calypso/state/purchases/selectors';
+import DomainInfoCard from '..';
+import { DomainDeleteInfoCardProps, DomainInfoCardProps } from '../types';
+
+const DomainDeleteInfoCard = ( {
+	selectedSite,
+	purchase,
+}: DomainDeleteInfoCardProps ): JSX.Element => {
+	const translate = useTranslate();
+	const removePurchaseClassName = 'is-compact button';
+
+	return (
+		<DomainInfoCard
+			type="custom"
+			title={ translate( 'Delete' ) }
+			description={ translate( 'Remove this domain permanently' ) }
+			cta={
+				<RemovePurchase
+					hasLoadedSites={ true }
+					hasLoadedUserPurchasesFromServer={ true }
+					site={ selectedSite }
+					purchase={ purchase }
+					className={ removePurchaseClassName }
+				>
+					{ translate( 'Delete' ) }
+				</RemovePurchase>
+			}
+		/>
+	);
+};
+
+export default connect( ( state, ownProps: DomainInfoCardProps ) => {
+	const { subscriptionId } = ownProps.domain;
+	return {
+		purchase: getByPurchaseId( state, Number( subscriptionId ) )!,
+		isLoadingPurchase:
+			isFetchingSitePurchases( state ) && ! hasLoadedSitePurchasesFromServer( state ),
+	};
+} )( DomainDeleteInfoCard );

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -18,12 +18,15 @@ const DomainDeleteInfoCard = ( {
 	const translate = useTranslate();
 	const removePurchaseClassName = 'is-compact button';
 
+	const title =
+		domain.type === domainType.TRANSFER ? translate( 'Cancel transfer' ) : translate( 'Delete' );
+
 	const getDescription = () => {
 		switch ( domain.type ) {
 			case domainType.MAPPED:
 				return translate( 'Remove this domain connection permanently' );
 			case domainType.TRANSFER:
-				return translate( 'Remove this domain transfer permanently' );
+				return translate( 'Cancel this domain transfer' );
 			default:
 				return translate( 'Remove this domain permanently' );
 		}
@@ -32,7 +35,7 @@ const DomainDeleteInfoCard = ( {
 	return (
 		<DomainInfoCard
 			type="custom"
-			title={ translate( 'Delete' ) }
+			title={ title }
 			description={ getDescription() }
 			cta={
 				<RemovePurchase

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -8,7 +8,7 @@ import {
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
 import DomainInfoCard from '..';
-import { DomainDeleteInfoCardProps, DomainInfoCardProps } from '../types';
+import type { DomainDeleteInfoCardProps, DomainInfoCardProps } from '../types';
 
 const DomainDeleteInfoCard = ( {
 	domain,

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -18,7 +18,7 @@ const DomainDeleteInfoCard = ( {
 }: DomainDeleteInfoCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
 
-	if ( ! isLoadingPurchase && ! purchase ) return null;
+	if ( isLoadingPurchase || ! purchase ) return null;
 
 	const removePurchaseClassName = 'is-compact button';
 

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -14,8 +14,12 @@ const DomainDeleteInfoCard = ( {
 	domain,
 	selectedSite,
 	purchase,
-}: DomainDeleteInfoCardProps ): JSX.Element => {
+	isLoadingPurchase,
+}: DomainDeleteInfoCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
+
+	if ( ! isLoadingPurchase && ! purchase ) return null;
+
 	const removePurchaseClassName = 'is-compact button';
 
 	const title =
@@ -32,22 +36,26 @@ const DomainDeleteInfoCard = ( {
 		}
 	};
 
+	const removePurchaseRenderedComponent = (
+		<RemovePurchase
+			hasLoadedSites={ true }
+			hasLoadedUserPurchasesFromServer={ true }
+			site={ selectedSite }
+			purchase={ purchase }
+			className={ removePurchaseClassName }
+		>
+			{ translate( 'Delete' ) }
+		</RemovePurchase>
+	);
+
+	if ( ! removePurchaseRenderedComponent ) return null;
+
 	return (
 		<DomainInfoCard
 			type="custom"
 			title={ title }
 			description={ getDescription() }
-			cta={
-				<RemovePurchase
-					hasLoadedSites={ true }
-					hasLoadedUserPurchasesFromServer={ true }
-					site={ selectedSite }
-					purchase={ purchase }
-					className={ removePurchaseClassName }
-				>
-					{ translate( 'Delete' ) }
-				</RemovePurchase>
-			}
+			cta={ removePurchaseRenderedComponent }
 		/>
 	);
 };
@@ -55,7 +63,7 @@ const DomainDeleteInfoCard = ( {
 export default connect( ( state, ownProps: DomainInfoCardProps ) => {
 	const { subscriptionId } = ownProps.domain;
 	return {
-		purchase: getByPurchaseId( state, Number( subscriptionId ) )!,
+		purchase: getByPurchaseId( state, Number( subscriptionId ) ),
 		isLoadingPurchase:
 			isFetchingSitePurchases( state ) && ! hasLoadedSitePurchasesFromServer( state ),
 	};

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
 import { getEmailAddress } from 'calypso/lib/emails';
+import { emailManagement } from 'calypso/my-sites/email/paths';
 import DomainInfoCard from '..';
 import { DomainInfoCardProps } from '../types';
 import { EmailAccount } from './types';
@@ -25,6 +26,8 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): J
 
 	return ! emailAddresses.length ? (
 		<DomainInfoCard
+			type="href"
+			href={ emailManagement( selectedSite.slug, domain.name ) }
 			title={ translate( 'Email' ) }
 			description={ translate( 'Send and receive emails from youremail@%(domainName)s', {
 				args: { domainName: domain.name },
@@ -34,6 +37,8 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): J
 		/>
 	) : (
 		<DomainInfoCard
+			type="href"
+			href={ emailManagement( selectedSite.slug, domain.name ) }
 			title={ translate( 'Email' ) }
 			description={ emailAddresses.join( '\n' ) }
 			ctaText={ translate( 'View emails' ) }

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -1,17 +1,23 @@
 import { useTranslate } from 'i18n-calypso';
 import Count from 'calypso/components/count';
 import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
+import { type as domainType } from 'calypso/lib/domains/constants';
 import { getEmailAddress } from 'calypso/lib/emails';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import DomainInfoCard from '..';
 import type { DomainInfoCardProps } from '../types';
 import type { EmailAccount } from './types';
 
-const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): JSX.Element => {
+const DomainEmailInfoCard = ( {
+	domain,
+	selectedSite,
+}: DomainInfoCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
+	const { data, error, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name );
+
 	let emailAddresses: string[] = [];
 
-	const { data, error, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name );
+	if ( domain.type === domainType.TRANSFER ) return null;
 
 	if ( ! isLoading && ! error ) {
 		const emailAccounts: EmailAccount[] = data?.accounts;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -3,7 +3,7 @@ import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
 import { getEmailAddress } from 'calypso/lib/emails';
 import DomainInfoCard from '..';
 import { DomainInfoCardProps } from '../types';
-import { Mailbox } from './types';
+import { EmailAccount } from './types';
 
 const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): JSX.Element => {
 	const translate = useTranslate();
@@ -12,10 +12,14 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): J
 	const { data, error, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name );
 
 	if ( ! isLoading && ! error ) {
-		const [ mailAccount ]: [ { emails: Mailbox[] } ] = data?.accounts;
+		const emailAccounts: EmailAccount[] = data?.accounts;
 
-		if ( mailAccount ) {
-			emailAddresses = mailAccount.emails.map( getEmailAddress ).filter( ( email ) => email );
+		if ( emailAccounts.length ) {
+			emailAddresses = emailAccounts
+				.map( ( a ) => a.emails )
+				.flat()
+				.map( getEmailAddress )
+				.filter( ( email ) => email );
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -1,0 +1,38 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
+import { getEmailAddress } from 'calypso/lib/emails';
+import DomainInfoCard from '..';
+import { DomainInfoCardProps } from '../types';
+import { Mailbox } from './types';
+
+const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): JSX.Element => {
+	const translate = useTranslate();
+	let emailAddresses: string[] = [];
+
+	const { data, error, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name );
+
+	if ( ! isLoading && ! error ) {
+		const [ mailAccount ]: [ { emails: Mailbox[] } ] = data?.accounts;
+
+		if ( mailAccount ) {
+			emailAddresses = mailAccount.emails.map( getEmailAddress ).filter( ( email ) => email );
+		}
+	}
+
+	return ! emailAddresses.length ? (
+		<DomainInfoCard
+			title={ translate( 'Email' ) }
+			description={ translate( 'Send and receive emails from youremail@travelingwithkids.com' ) }
+			ctaText={ translate( 'Add professional email' ) }
+			isPrimary={ true }
+		/>
+	) : (
+		<DomainInfoCard
+			title={ translate( 'Email' ) }
+			description={ emailAddresses.join( '\n' ) }
+			ctaText={ translate( 'View emails' ) }
+		/>
+	);
+};
+
+export default DomainEmailInfoCard;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -22,7 +22,9 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): J
 	return ! emailAddresses.length ? (
 		<DomainInfoCard
 			title={ translate( 'Email' ) }
-			description={ translate( 'Send and receive emails from youremail@travelingwithkids.com' ) }
+			description={ translate( 'Send and receive emails from youremail@%(domainName)s', {
+				args: { domainName: domain.name },
+			} ) }
 			ctaText={ translate( 'Add professional email' ) }
 			isPrimary={ true }
 		/>

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -4,8 +4,8 @@ import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
 import { getEmailAddress } from 'calypso/lib/emails';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import DomainInfoCard from '..';
-import { DomainInfoCardProps } from '../types';
-import { EmailAccount } from './types';
+import type { DomainInfoCardProps } from '../types';
+import type { EmailAccount } from './types';
 
 const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): JSX.Element => {
 	const translate = useTranslate();

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import Count from 'calypso/components/count';
 import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
 import { getEmailAddress } from 'calypso/lib/emails';
 import { emailManagement } from 'calypso/my-sites/email/paths';
@@ -39,7 +40,12 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): J
 		<DomainInfoCard
 			type="href"
 			href={ emailManagement( selectedSite.slug, domain.name ) }
-			title={ translate( 'Email' ) }
+			title={
+				<>
+					{ translate( 'Email' ) }
+					<Count count={ emailAddresses.length }></Count>
+				</>
+			}
 			description={ emailAddresses.join( '\n' ) }
 			ctaText={ translate( 'View emails' ) }
 		/>

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/types.tsx
@@ -5,5 +5,5 @@ export type Mailbox = {
 
 export type EmailAccount = {
 	account_type: string;
-	emails: Mailbox;
+	emails: Mailbox[];
 };

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/types.tsx
@@ -1,0 +1,9 @@
+export type Mailbox = {
+	domain: string;
+	mailbox: string;
+};
+
+export type EmailAccount = {
+	account_type: string;
+	emails: Mailbox;
+};

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
@@ -1,0 +1,24 @@
+import ActionCard from 'calypso/components/action-card';
+import type { CardProps, DomainInfoCardProps } from './types';
+
+const DomainInfoCard = ( {
+	title,
+	description,
+	ctaText,
+	isPrimary,
+}: DomainInfoCardProps ): JSX.Element => {
+	const cardProps: CardProps = {
+		headerText: title,
+		mainText: description,
+		classNames: 'domain-info-card',
+	};
+
+	if ( ctaText ) {
+		cardProps.buttonText = ctaText;
+		cardProps.buttonPrimary = isPrimary;
+	}
+
+	return <ActionCard { ...cardProps }></ActionCard>;
+};
+
+export default DomainInfoCard;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import ActionCard from 'calypso/components/action-card';
-import type { CardProps, DomainInfoCardProps } from './types';
+import type { CardProps, GenericDomainInfoCardProps } from './types';
 
 import './style.scss';
 
@@ -9,7 +9,7 @@ const DomainInfoCard = ( {
 	description,
 	ctaText,
 	isPrimary,
-}: DomainInfoCardProps ): JSX.Element => {
+}: GenericDomainInfoCardProps ): JSX.Element => {
 	const cardProps: CardProps = {
 		headerText: title,
 		mainText: description,

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
@@ -1,35 +1,39 @@
 import { Button } from '@automattic/components';
 import ActionCard from 'calypso/components/action-card';
-import type { CardProps, GenericDomainInfoCardProps } from './types';
+import type { CardProps, GenericActionCardProps } from './types';
 
 import './style.scss';
 
-const DomainInfoCard = ( {
-	title,
-	description,
-	ctaText,
-	isPrimary,
-}: GenericDomainInfoCardProps ): JSX.Element => {
+const DomainInfoCard = ( props: GenericActionCardProps ): JSX.Element => {
+	const { title, description, type } = props;
 	const cardProps: CardProps = {
 		headerText: title,
 		mainText: description,
 		classNames: 'domain-info-card',
 	};
 
-	if ( ctaText ) {
-		cardProps.buttonText = ctaText;
-		cardProps.buttonPrimary = isPrimary;
-	}
+	switch ( type ) {
+		case 'href':
+			return (
+				<ActionCard { ...cardProps }>
+					<Button compact primary={ props.isPrimary } href={ props.href }>
+						{ props.ctaText }
+					</Button>
+				</ActionCard>
+			);
 
-	return (
-		<ActionCard { ...cardProps }>
-			{ ctaText && (
-				<Button compact primary={ isPrimary }>
-					{ ctaText }
-				</Button>
-			) }
-		</ActionCard>
-	);
+		case 'click':
+			return (
+				<ActionCard { ...cardProps }>
+					<Button compact primary={ props.isPrimary } onClick={ props.onClick }>
+						{ props.ctaText }
+					</Button>
+				</ActionCard>
+			);
+
+		default:
+			return <ActionCard { ...cardProps } />;
+	}
 };
 
 export default DomainInfoCard;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
@@ -31,6 +31,9 @@ const DomainInfoCard = ( props: GenericActionCardProps ): JSX.Element => {
 				</ActionCard>
 			);
 
+		case 'custom':
+			return <ActionCard { ...cardProps }>{ props.cta }</ActionCard>;
+
 		default:
 			return <ActionCard { ...cardProps } />;
 	}

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/index.tsx
@@ -1,5 +1,8 @@
+import { Button } from '@automattic/components';
 import ActionCard from 'calypso/components/action-card';
 import type { CardProps, DomainInfoCardProps } from './types';
+
+import './style.scss';
 
 const DomainInfoCard = ( {
 	title,
@@ -18,7 +21,15 @@ const DomainInfoCard = ( {
 		cardProps.buttonPrimary = isPrimary;
 	}
 
-	return <ActionCard { ...cardProps }></ActionCard>;
+	return (
+		<ActionCard { ...cardProps }>
+			{ ctaText && (
+				<Button compact primary={ isPrimary }>
+					{ ctaText }
+				</Button>
+			) }
+		</ActionCard>
+	);
 };
 
 export default DomainInfoCard;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -38,6 +38,11 @@
         > .button {
             margin-left: 0;
             padding: 7px 12px;
+            box-shadow: none;
+
+            &:hover {
+                color: var( --color-text-subtle );
+            }
         }
     }
 

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -1,0 +1,42 @@
+.action-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    $parent: &;
+
+    &__main {
+        @at-root {
+            div #{$parent}__heading {
+                margin: 0;
+                font-weight: 600;
+                line-height: 24px;
+                font-size: $font-body;
+            }
+        }
+
+        p {
+            margin-bottom: 16px;
+            font-size: $font-body-small;
+            color: var( --studio-gray-50 );
+        }
+    }
+
+    div &__button-container {
+        align-self: unset;
+
+        > .button {
+            margin-left: 0;
+            padding: 7px 12px;
+        }
+    }
+
+    &.domain-info-card {
+        padding: 24px 0;
+        box-shadow: none;
+
+        & ~ & {
+            border-top: 1px solid var( --studio-gray-5 );
+        }
+    }
+}

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -16,9 +16,16 @@
         }
 
         p {
-            margin-bottom: 16px;
+            margin: 5px 0 16px;
             font-size: $font-body-small;
             color: var( --studio-gray-50 );
+            display: flex;
+            align-items: center;
+
+            svg {
+                fill: var( --studio-gray-50 );
+                margin: 0 8px 0 3px;
+            }
         }
     }
 

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -1,13 +1,17 @@
-.action-card {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
+.domain-info-card {
+    &.action-card {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 24px 0;
+        box-shadow: none;
 
-    $parent: &;
+        & ~ & {
+            border-top: 1px solid var( --studio-gray-5 );
+        }
 
-    &__main {
-        @at-root {
-            div #{$parent}__heading {
+        .action-card__main {
+            .action-card__heading {
                 margin: 0;
                 font-weight: 600;
                 line-height: 24px;
@@ -16,42 +20,33 @@
                 column-gap: 8px;
                 align-items: center;
             }
-        }
 
-        p {
-            margin: 5px 0 16px;
-            font-size: $font-body-small;
-            color: var( --studio-gray-50 );
-            display: flex;
-            align-items: center;
+            p {
+                margin: 5px 0 16px;
+                font-size: $font-body-small;
+                color: var( --studio-gray-50 );
+                display: flex;
+                align-items: center;
 
-            svg {
-                fill: var( --studio-gray-50 );
-                margin: 0 8px 0 3px;
+                svg {
+                    fill: var( --studio-gray-50 );
+                    margin: 0 8px 0 3px;
+                }
             }
         }
-    }
 
-    div &__button-container {
-        align-self: unset;
+        .action-card__button-container {
+            align-self: unset;
 
-        > .button {
-            margin-left: 0;
-            padding: 7px 12px;
-            box-shadow: none;
+            > .button {
+                margin-left: 0;
+                padding: 7px 12px;
+                box-shadow: none;
 
-            &:hover {
-                color: var( --color-text-subtle );
+                &:hover {
+                    color: var( --color-text-subtle );
+                }
             }
-        }
-    }
-
-    &.domain-info-card {
-        padding: 24px 0;
-        box-shadow: none;
-
-        & ~ & {
-            border-top: 1px solid var( --studio-gray-5 );
         }
     }
 }

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -12,6 +12,9 @@
                 font-weight: 600;
                 line-height: 24px;
                 font-size: $font-body;
+                display: flex;
+                column-gap: 8px;
+                align-items: center;
             }
         }
 

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -5,8 +5,13 @@ import { domainManagementTransfer } from 'calypso/my-sites/domains/paths';
 import DomainInfoCard from '..';
 import { DomainInfoCardProps } from '../types';
 
-const DomainTransferInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): JSX.Element => {
+const DomainTransferInfoCard = ( {
+	domain,
+	selectedSite,
+}: DomainInfoCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
+
+	if ( domain.type === domainType.TRANSFER ) return null;
 
 	const getDescription = () => {
 		switch ( domain.type ) {

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -1,0 +1,30 @@
+import { Icon, lock } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { domainManagementTransfer } from 'calypso/my-sites/domains/paths';
+import DomainInfoCard from '..';
+import { DomainInfoCardProps } from '../types';
+
+const DomainTransferInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): JSX.Element => {
+	const translate = useTranslate();
+
+	return (
+		<DomainInfoCard
+			type="href"
+			href={ domainManagementTransfer( selectedSite.slug, domain.name ) }
+			title={ translate( 'Transfer' ) }
+			description={
+				domain.isLocked ? (
+					<>
+						<Icon icon={ lock } size={ 16 } viewBox="0 0 22 22" />
+						{ translate( 'Transfer lock on' ) }
+					</>
+				) : (
+					translate( 'Transfer lock off' )
+				)
+			}
+			ctaText={ translate( 'Transfer' ) }
+		/>
+	);
+};
+
+export default DomainTransferInfoCard;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -1,11 +1,21 @@
 import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { type as domainType } from 'calypso/lib/domains/constants';
 import { domainManagementTransfer } from 'calypso/my-sites/domains/paths';
 import DomainInfoCard from '..';
 import { DomainInfoCardProps } from '../types';
 
 const DomainTransferInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ): JSX.Element => {
 	const translate = useTranslate();
+
+	const getDescription = () => {
+		switch ( domain.type ) {
+			case domainType.MAPPED:
+				return translate( 'Transfer this domain connection' );
+			default:
+				return translate( 'Transfer this domain' );
+		}
+	};
 
 	return (
 		<DomainInfoCard
@@ -19,7 +29,7 @@ const DomainTransferInfoCard = ( { domain, selectedSite }: DomainInfoCardProps )
 						{ translate( 'Transfer lock on' ) }
 					</>
 				) : (
-					translate( 'Transfer lock off' )
+					getDescription()
 				)
 			}
 			ctaText={ translate( 'Transfer' ) }

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { type as domainType } from 'calypso/lib/domains/constants';
 import { domainManagementTransfer } from 'calypso/my-sites/domains/paths';
 import DomainInfoCard from '..';
-import { DomainInfoCardProps } from '../types';
+import type { DomainInfoCardProps } from '../types';
 
 const DomainTransferInfoCard = ( {
 	domain,

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -3,7 +3,7 @@ import ActionCard from 'calypso/components/action-card';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
 
-export type GenericDomainInfoCardProps = {
+export type GenericActionCardProps = {
 	title: TranslateResult;
 	description: TranslateResult;
 	ctaText?: TranslateResult;
@@ -16,7 +16,8 @@ export type DomainInfoCardProps = {
 };
 
 export type CardProps = Partial< React.ComponentProps< typeof ActionCard > > & {
-	mainText: GenericDomainInfoCardProps[ 'description' ];
-	headerText: GenericDomainInfoCardProps[ 'title' ];
+	mainText: GenericActionCardProps[ 'description' ];
+
+	headerText: GenericActionCardProps[ 'title' ];
 	classNames: string;
 };

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -2,6 +2,7 @@ import { TranslateResult } from 'i18n-calypso';
 import ActionCard from 'calypso/components/action-card';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { Purchase } from 'calypso/lib/purchases/types';
 
 type ActionCardPropsBase = {
 	title: TranslateResult;
@@ -22,6 +23,11 @@ type ActionCardPropsWithCallback = ActionCardPropsWithCta & {
 	onClick: () => void;
 };
 
+type ActionCardPropsWithCustomCta = ActionCardPropsBase & {
+	type: 'custom';
+	cta: React.ReactNode;
+};
+
 type ActionCardPropsWithHref = ActionCardPropsWithCta & {
 	type: 'href';
 	href: string;
@@ -30,11 +36,17 @@ type ActionCardPropsWithHref = ActionCardPropsWithCta & {
 export type GenericActionCardProps =
 	| ActionCardPropsWithHref
 	| ActionCardPropsWithCallback
+	| ActionCardPropsWithCustomCta
 	| ActionCardPropsInfoOnly;
 
 export type DomainInfoCardProps = {
 	domain: ResponseDomain;
 	selectedSite: SiteData;
+};
+export type DomainDeleteInfoCardProps = DomainInfoCardProps & {
+	selectedSite: SiteData;
+	purchase: Purchase | null;
+	isLoadingPurchase: boolean;
 };
 
 export type CardProps = Partial< React.ComponentProps< typeof ActionCard > > & {

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -1,8 +1,8 @@
-import { TranslateResult } from 'i18n-calypso';
 import ActionCard from 'calypso/components/action-card';
-import { ResponseDomain } from 'calypso/lib/domains/types';
-import { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { TranslateResult } from 'i18n-calypso';
 
 type ActionCardPropsBase = {
 	title: TranslateResult;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -1,15 +1,22 @@
 import { TranslateResult } from 'i18n-calypso';
 import ActionCard from 'calypso/components/action-card';
+import { ResponseDomain } from 'calypso/lib/domains/types';
+import { SiteData } from 'calypso/state/ui/selectors/site-data';
 
-export type DomainInfoCardProps = {
+export type GenericDomainInfoCardProps = {
 	title: TranslateResult;
 	description: TranslateResult;
 	ctaText?: TranslateResult;
 	isPrimary?: boolean;
 };
 
+export type DomainInfoCardProps = {
+	domain: ResponseDomain;
+	selectedSite: SiteData;
+};
+
 export type CardProps = Partial< React.ComponentProps< typeof ActionCard > > & {
-	mainText: DomainInfoCardProps[ 'description' ];
-	headerText: DomainInfoCardProps[ 'title' ];
+	mainText: GenericDomainInfoCardProps[ 'description' ];
+	headerText: GenericDomainInfoCardProps[ 'title' ];
 	classNames: string;
 };

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -45,7 +45,7 @@ export type DomainInfoCardProps = {
 };
 export type DomainDeleteInfoCardProps = DomainInfoCardProps & {
 	selectedSite: SiteData;
-	purchase: Purchase | null;
+	purchase?: Purchase | null;
 	isLoadingPurchase: boolean;
 };
 

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -3,12 +3,34 @@ import ActionCard from 'calypso/components/action-card';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
 
-export type GenericActionCardProps = {
+type ActionCardPropsBase = {
 	title: TranslateResult;
 	description: TranslateResult;
-	ctaText?: TranslateResult;
+};
+
+type ActionCardPropsInfoOnly = ActionCardPropsBase & {
+	type: 'info';
+};
+
+type ActionCardPropsWithCta = ActionCardPropsBase & {
+	ctaText: TranslateResult;
 	isPrimary?: boolean;
 };
+
+type ActionCardPropsWithCallback = ActionCardPropsWithCta & {
+	type: 'click';
+	onClick: () => void;
+};
+
+type ActionCardPropsWithHref = ActionCardPropsWithCta & {
+	type: 'href';
+	href: string;
+};
+
+export type GenericActionCardProps =
+	| ActionCardPropsWithHref
+	| ActionCardPropsWithCallback
+	| ActionCardPropsInfoOnly;
 
 export type DomainInfoCardProps = {
 	domain: ResponseDomain;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -1,0 +1,14 @@
+import ActionCard from 'calypso/components/action-card';
+
+export type DomainInfoCardProps = {
+	title: boolean;
+	description: string;
+	ctaText?: string;
+	isPrimary?: boolean;
+};
+
+export type CardProps = Partial< React.ComponentProps< typeof ActionCard > > & {
+	mainText: DomainInfoCardProps[ 'description' ];
+	headerText: DomainInfoCardProps[ 'title' ];
+	classNames: string;
+};

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -1,9 +1,10 @@
+import { TranslateResult } from 'i18n-calypso';
 import ActionCard from 'calypso/components/action-card';
 
 export type DomainInfoCardProps = {
-	title: boolean;
-	description: string;
-	ctaText?: string;
+	title: TranslateResult;
+	description: TranslateResult;
+	ctaText?: TranslateResult;
 	isPrimary?: boolean;
 };
 

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -8,6 +8,7 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card';
 import DomainEmailInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/email';
+import DomainTransferInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/transfer';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -46,11 +47,7 @@ const Settings = ( props: SettingsPageProps ): JSX.Element => {
 	const renderSettingsCards = () => (
 		<>
 			<DomainEmailInfoCard selectedSite={ props.selectedSite } domain={ props.domain } />
-			<DomainInfoCard
-				title={ translate( 'Transfer' ) }
-				description={ translate( 'Transfer lock on' ) }
-				ctaText={ translate( 'Transfer' ) }
-			/>
+			<DomainTransferInfoCard selectedSite={ props.selectedSite } domain={ props.domain } />
 			<DomainInfoCard
 				title={ translate( 'Delete' ) }
 				description={ translate( 'Remove this domain permanently' ) }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -11,7 +11,7 @@ import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/dom
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import SettingsHeader from './settings-header';
-import { SettingsPageProps } from './types';
+import { SettingsPageConnectedProps, SettingsPagePassedProps, SettingsPageProps } from './types';
 
 const Settings = ( props: SettingsPageProps ): JSX.Element => {
 	const domain = props.domains && getSelectedDomain( props );
@@ -94,9 +94,12 @@ const Settings = ( props: SettingsPageProps ): JSX.Element => {
 	);
 };
 
-export default connect( ( state, ownProps: SettingsPageProps ) => {
-	return {
-		currentRoute: getCurrentRoute( state ),
-		hasDomainOnlySite: isDomainOnlySite( state, ownProps.selectedSite!.ID ),
-	};
-} )( Settings );
+export default connect(
+	( state, ownProps: SettingsPagePassedProps ): SettingsPageConnectedProps => {
+		return {
+			domain: getSelectedDomain( ownProps )!,
+			currentRoute: getCurrentRoute( state ),
+			hasDomainOnlySite: Boolean( isDomainOnlySite( state, ownProps.selectedSite!.ID ) ),
+		};
+	}
+)( Settings );

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -7,6 +7,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card';
+import DomainEmailInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/email';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -14,7 +15,6 @@ import SettingsHeader from './settings-header';
 import { SettingsPageConnectedProps, SettingsPagePassedProps, SettingsPageProps } from './types';
 
 const Settings = ( props: SettingsPageProps ): JSX.Element => {
-	const domain = props.domains && getSelectedDomain( props );
 	const translate = useTranslate();
 
 	const renderBreadcrumbs = () => {
@@ -45,12 +45,7 @@ const Settings = ( props: SettingsPageProps ): JSX.Element => {
 
 	const renderSettingsCards = () => (
 		<>
-			<DomainInfoCard
-				title={ translate( 'Email' ) }
-				description={ translate( 'Send and receive emails from youremail@travelingwithkids.com' ) }
-				ctaText={ translate( 'Add professional email' ) }
-				isPrimary={ true }
-			/>
+			<DomainEmailInfoCard selectedSite={ props.selectedSite } domain={ props.domain } />
 			<DomainInfoCard
 				title={ translate( 'Transfer' ) }
 				description={ translate( 'Transfer lock on' ) }
@@ -68,7 +63,7 @@ const Settings = ( props: SettingsPageProps ): JSX.Element => {
 		<Main wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
-			<SettingsHeader domain={ domain } />
+			<SettingsHeader domain={ props.domain } />
 			<TwoColumnsLayout
 				content={
 					<>

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -13,7 +13,11 @@ import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/dom
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import SettingsHeader from './settings-header';
-import { SettingsPageConnectedProps, SettingsPagePassedProps, SettingsPageProps } from './types';
+import type {
+	SettingsPageConnectedProps,
+	SettingsPagePassedProps,
+	SettingsPageProps,
+} from './types';
 
 const Settings = ( props: SettingsPageProps ): JSX.Element => {
 	const translate = useTranslate();

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -6,7 +6,7 @@ import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
-import DomainInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card';
+import DomainDeleteInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/delete';
 import DomainEmailInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/email';
 import DomainTransferInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/transfer';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
@@ -48,11 +48,7 @@ const Settings = ( props: SettingsPageProps ): JSX.Element => {
 		<>
 			<DomainEmailInfoCard selectedSite={ props.selectedSite } domain={ props.domain } />
 			<DomainTransferInfoCard selectedSite={ props.selectedSite } domain={ props.domain } />
-			<DomainInfoCard
-				title={ translate( 'Delete' ) }
-				description={ translate( 'Remove this domain permanently' ) }
-				ctaText={ translate( 'Delete' ) }
-			/>
+			<DomainDeleteInfoCard selectedSite={ props.selectedSite } domain={ props.domain } />
 		</>
 	);
 

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,10 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Accordion from 'calypso/components/domains/accordion';
+import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
+import DomainInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -41,21 +43,53 @@ const Settings = ( props: SettingsPageProps ): JSX.Element => {
 		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
 	};
 
+	const renderSettingsCards = () => (
+		<>
+			<DomainInfoCard
+				title={ translate( 'Email' ) }
+				description={ translate( 'Send and receive emails from youremail@travelingwithkids.com' ) }
+				ctaText={ translate( 'Add professional email' ) }
+				isPrimary={ true }
+			/>
+			<DomainInfoCard
+				title={ translate( 'Transfer' ) }
+				description={ translate( 'Transfer lock on' ) }
+				ctaText={ translate( 'Transfer' ) }
+			/>
+			<DomainInfoCard
+				title={ translate( 'Delete' ) }
+				description={ translate( 'Remove this domain permanently' ) }
+				ctaText={ translate( 'Delete' ) }
+			/>
+		</>
+	);
+
 	return (
 		<Main wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
 			<SettingsHeader domain={ domain } />
-			Page goes here.
-			{ /* Placeholder to test accordion */ }
-			<div style={ { marginTop: '30px' } }>
-				<Accordion title="First element title" subtitle="First element subtitle" expanded={ true }>
-					<div>Component placeholder: this one is exapanded by default</div>
-				</Accordion>
-				<Accordion title="Second element title" subtitle="Second element subtitle">
-					<div>Component placeholder: this one i'snt exapanded by default</div>
-				</Accordion>
-			</div>
+			<TwoColumnsLayout
+				content={
+					<>
+						Page goes here.
+						{ /* Placeholder to test accordion */ }
+						<div style={ { marginTop: '30px' } }>
+							<Accordion
+								title="First element title"
+								subtitle="First element subtitle"
+								expanded={ true }
+							>
+								<div>Component placeholder: this one is exapanded by default</div>
+							</Accordion>
+							<Accordion title="Second element title" subtitle="Second element subtitle">
+								<div>Component placeholder: this one i'snt exapanded by default</div>
+							</Accordion>
+						</div>
+					</>
+				}
+				sidebar={ renderSettingsCards() }
+			/>
 		</Main>
 	);
 };

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -1,15 +1,21 @@
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
 
-export type SettingsPageProps = {
+export type SettingsPagePassedProps = {
 	domains: ResponseDomain[] | null;
 
 	currentRoute: string;
-	selectedDomainName: string;
 	selectedSite: SiteData;
+	selectedDomainName: string;
+};
+
+export type SettingsPageConnectedProps = {
+	domain: ResponseDomain;
+	currentRoute: string;
 	hasDomainOnlySite: boolean;
 };
 
 export type SettingsHeaderProps = {
 	domain: ResponseDomain;
 };
+export type SettingsPageProps = SettingsPagePassedProps & SettingsPageConnectedProps;

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -1,5 +1,5 @@
-import { ResponseDomain } from 'calypso/lib/domains/types';
-import { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 export type SettingsPagePassedProps = {
 	domains: ResponseDomain[] | null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds the sidebar elements to the new domain settings page. 
This is part of the domain management redesign project described in pcYYhz-m2-p2.

#### Preview
<img width="420" src="https://user-images.githubusercontent.com/18705930/145658879-a48c7b35-d93d-4deb-8179-d12f76a5d1a1.png" />
<img width="420" src="https://user-images.githubusercontent.com/18705930/145658883-52f3efc5-e955-4ed4-8962-10b8c6bd0a58.png" />
<img width="420" src="https://user-images.githubusercontent.com/18705930/145658890-0af8b6c1-2af9-41a4-8c0b-476444b54e91.png" />
<img width="420" src="https://user-images.githubusercontent.com/18705930/145658899-d8e0a7f1-b7f8-4ef4-9ebc-c430734f9440.png" />
<img width="420" src="https://user-images.githubusercontent.com/18705930/145658955-3396e5de-845d-41c2-aa5e-c1d4debe8780.png" />


#### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select one of your registered domains or domain connections
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Please check that:
  - The sidebar is shown as in the screenshots and as described in the redesign (hlVh2q24ad6MCwlwNnE9PQ-fi-600%3A53742)
  - Email count works as expected;
  - All buttons redirect to the correct page;
  - Transfer card is not rendered if the domain is a transfer;
  - Delete/cancel button is not rendered if the purchase is not removable (_follows the same logic as in the [`RemovePurchase`](https://github.com/Automattic/wp-calypso/commit/3cb00c240c54273de0c372daa7afe3dff7ab946c) component_);
  - The cards' labels change according to the domain type: connection, transfer, etc);
  - Mobile view looks correct as shown in the screenshot above;
  - No other elements have been affected by the changes, and also make sure that the page without the feature flag looks the same as before.