### PR TITLE
Promisify checkInboundTransferStatus()

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -629,9 +629,8 @@ class TransferDomainStep extends Component {
 	getInboundTransferStatus = () => {
 		this.setState( { submittingWhois: true } );
 
-		checkInboundTransferStatus( getFixedDomainSearch( this.state.searchQuery ) )
+		return checkInboundTransferStatus( getFixedDomainSearch( this.state.searchQuery ) )
 			.then( ( result ) => {
-				this.setState( { submittingWhois: false } );
 				const inboundTransferStatus = {
 					creationDate: result.creation_date,
 					email: result.admin_email,
@@ -644,12 +643,11 @@ class TransferDomainStep extends Component {
 					transferRestrictionStatus: result.transfer_restriction_status,
 					unlocked: result.unlocked,
 				};
-				this.setState( { inboundTransferStatus } );
+				this.setState( { submittingWhois: false, inboundTransferStatus } );
 				return { inboundTransferStatus };
 			} )
 			.catch( () => {
 				this.setState( { submittingWhois: false } );
-				return;
 			} );
 	};
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -630,29 +630,27 @@ class TransferDomainStep extends Component {
 		this.setState( { submittingWhois: true } );
 
 		return new Promise( ( resolve ) => {
-			checkInboundTransferStatus(
-				getFixedDomainSearch( this.state.searchQuery ),
-				( error, result ) => {
+			checkInboundTransferStatus( getFixedDomainSearch( this.state.searchQuery ) ).then(
+				( result ) => {
 					this.setState( { submittingWhois: false } );
 
-					if ( ! isEmpty( error ) ) {
+					if ( ! isEmpty( result.error ) ) {
 						resolve();
 						return;
 					}
 
 					const inboundTransferStatus = {
-						creationDate: result.creation_date,
-						email: result.admin_email,
+						creationDate: result.data.creation_date,
+						email: result.data.admin_email,
 						loading: false,
-						losingRegistrar: result.registrar,
-						losingRegistrarIanaId: result.registrar_iana_id,
-						privacy: result.privacy,
-						termMaximumInYears: result.term_maximum_in_years,
-						transferEligibleDate: result.transfer_eligible_date,
-						transferRestrictionStatus: result.transfer_restriction_status,
-						unlocked: result.unlocked,
+						losingRegistrar: result.data.registrar,
+						losingRegistrarIanaId: result.data.registrar_iana_id,
+						privacy: result.data.privacy,
+						termMaximumInYears: result.data.term_maximum_in_years,
+						transferEligibleDate: result.data.transfer_eligible_date,
+						transferRestrictionStatus: result.data.transfer_restriction_status,
+						unlocked: result.data.unlocked,
 					};
-
 					this.setState( { inboundTransferStatus } );
 					resolve( { inboundTransferStatus } );
 				}

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -629,33 +629,28 @@ class TransferDomainStep extends Component {
 	getInboundTransferStatus = () => {
 		this.setState( { submittingWhois: true } );
 
-		return new Promise( ( resolve ) => {
-			checkInboundTransferStatus( getFixedDomainSearch( this.state.searchQuery ) ).then(
-				( result ) => {
-					this.setState( { submittingWhois: false } );
-
-					if ( ! isEmpty( result.error ) ) {
-						resolve();
-						return;
-					}
-
-					const inboundTransferStatus = {
-						creationDate: result.data.creation_date,
-						email: result.data.admin_email,
-						loading: false,
-						losingRegistrar: result.data.registrar,
-						losingRegistrarIanaId: result.data.registrar_iana_id,
-						privacy: result.data.privacy,
-						termMaximumInYears: result.data.term_maximum_in_years,
-						transferEligibleDate: result.data.transfer_eligible_date,
-						transferRestrictionStatus: result.data.transfer_restriction_status,
-						unlocked: result.data.unlocked,
-					};
-					this.setState( { inboundTransferStatus } );
-					resolve( { inboundTransferStatus } );
-				}
-			);
-		} );
+		checkInboundTransferStatus( getFixedDomainSearch( this.state.searchQuery ) )
+			.then( ( result ) => {
+				this.setState( { submittingWhois: false } );
+				const inboundTransferStatus = {
+					creationDate: result.creation_date,
+					email: result.admin_email,
+					loading: false,
+					losingRegistrar: result.registrar,
+					losingRegistrarIanaId: result.registrar_iana_id,
+					privacy: result.privacy,
+					termMaximumInYears: result.term_maximum_in_years,
+					transferEligibleDate: result.transfer_eligible_date,
+					transferRestrictionStatus: result.transfer_restriction_status,
+					unlocked: result.unlocked,
+				};
+				this.setState( { inboundTransferStatus } );
+				return { inboundTransferStatus };
+			} )
+			.catch( () => {
+				this.setState( { submittingWhois: false } );
+				return;
+			} );
 	};
 
 	getAuthCodeStatus = ( domain, authCode ) => {

--- a/client/lib/domains/check-inbound-transfer-status.js
+++ b/client/lib/domains/check-inbound-transfer-status.js
@@ -1,17 +1,18 @@
 import wpcom from 'calypso/lib/wp';
 
-export function checkInboundTransferStatus( domainName, onComplete ) {
-	if ( ! domainName ) {
-		onComplete( null );
-		return;
-	}
+export function checkInboundTransferStatus( domainName ) {
+	return new Promise( ( resolve ) => {
+		if ( ! domainName ) {
+			resolve( { error: null } );
+		}
 
-	wpcom.req
-		.get( `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status` )
-		.then( ( data ) => {
-			onComplete( null, data );
-		} )
-		.catch( ( error ) => {
-			onComplete( error.error );
-		} );
+		wpcom.req
+			.get( `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status` )
+			.then( ( data ) => {
+				resolve( { error: null, data: data } );
+			} )
+			.catch( ( error ) => {
+				resolve( { error: error.error } );
+			} );
+	} );
 }

--- a/client/lib/domains/check-inbound-transfer-status.js
+++ b/client/lib/domains/check-inbound-transfer-status.js
@@ -1,18 +1,9 @@
 import wpcom from 'calypso/lib/wp';
 
 export function checkInboundTransferStatus( domainName ) {
-	return new Promise( ( resolve ) => {
-		if ( ! domainName ) {
-			resolve( { error: null } );
-		}
+	if ( ! domainName ) {
+		return Promise.reject( new Error( 'missing domain parameter' ) );
+	}
 
-		wpcom.req
-			.get( `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status` )
-			.then( ( data ) => {
-				resolve( { error: null, data: data } );
-			} )
-			.catch( ( error ) => {
-				resolve( { error: error.error } );
-			} );
-	} );
+	return wpcom.req.get( `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status` );
 }


### PR DESCRIPTION
Followup to #58315.

This PR aims to Promisify `checkIndboundTransferStatus()` as suggested by @jsnajdr in the above PR.

Note: this is part of an outdated flow that's due to be removed, but was impacted by the above refactoring away from `wpcom.undocumented`

**Testing Instructions**
Using a domain name that is currently locked to prevent transfers:
- Start at `domains/manage/[DOMAIN]/transfer/precheck/[SITE]`.
- Confirm that the locked state is accurately detected, and you have an option to unlock your domain.
- Click the button indicating you've unlocked the domain name. Confirm that it recognizes the domain is still locked.
- At your domain registrar, unlock the domain, and wait a minute or two for the change to propagate.
- Come back to WPcom and click the button again to indicate that your domain is now unlocked.
- Confirm that the updated lock status is reflected and that an Auth Code is the next step.

Don't forget to lock your domain when you're done testing 😄 