### PR TITLE
Videos UI: refactor accordion UI to its own component

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -1,8 +1,7 @@
 import config from '@automattic/calypso-config';
-import { Button, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import { useEffect, useState } from 'react';
 import Notice from 'calypso/components/notice';
 import {
@@ -11,6 +10,7 @@ import {
 	useUpdateUserCourseProgressionMutation,
 } from 'calypso/data/courses';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import VideoChapters from './video-chapters';
 import VideoPlayer from './video-player';
 import './style.scss';
 
@@ -159,79 +159,16 @@ const VideosUi = ( {
 						/>
 					) }
 					<div className="videos-ui__chapters">
-						{ course &&
-							Object.entries( course?.videos ).map( ( data, i ) => {
-								const isVideoCompleted =
-									data[ 0 ] in course.completions && course.completions[ data[ 0 ] ];
-								const videoInfo = data[ 1 ];
-
-								return (
-									<div
-										key={ i }
-										className={ classNames( 'videos-ui__chapter', {
-											selected: isChapterSelected( i ),
-											preload: isPreloadAnimationState,
-										} ) }
-									>
-										<button
-											type="button"
-											className="videos-ui__chapter-accordion-toggle"
-											onClick={ () => onChapterSelected( i ) }
-										>
-											<span className="videos-ui__video-title">
-												{ i + 1 }. { videoInfo.title }{ ' ' }
-											</span>
-											<span className="videos-ui__duration">
-												{ moment.unix( videoInfo.duration_seconds ).format( 'm:ss' ) }
-											</span>
-											{ isVideoCompleted && (
-												<span className="videos-ui__completed-checkmark">
-													<Gridicon icon="checkmark" size={ 12 } />
-												</span>
-											) }
-											{ isChapterSelected( i ) && ! isVideoCompleted && (
-												<span className="videos-ui__status-icon">
-													<Gridicon icon="chevron-up" size={ 18 } />
-												</span>
-											) }
-											{ ! isChapterSelected( i ) && ! isVideoCompleted && (
-												<span className="videos-ui__status-icon">
-													<Gridicon icon="chevron-down" size={ 18 } />
-												</span>
-											) }
-										</button>
-										<div className="videos-ui__active-video-content">
-											<div>
-												<p>{ videoInfo.description } </p>
-												<Button
-													className={ classNames( 'videos-ui__button', {
-														'videos-ui__video-completed': isVideoCompleted,
-													} ) }
-													onClick={ () => onVideoPlayClick( data[ 0 ], videoInfo ) }
-												>
-													<svg
-														width="12"
-														height="14"
-														viewBox="0 0 12 14"
-														fill="none"
-														xmlns="http://www.w3.org/2000/svg"
-													>
-														<path
-															d="M1.9165 1.75L10.0832 7L1.9165 12.25V1.75Z"
-															fill="#101517"
-															stroke="#101517"
-															strokeWidth="2"
-															strokeLinecap="round"
-															strokeLinejoin="round"
-														/>
-													</svg>
-													<span>{ translate( 'Play video' ) }</span>
-												</Button>
-											</div>
-										</div>
-									</div>
-								);
-							} ) }
+						{ course && (
+							<VideoChapters
+								course={ course }
+								isChapterSelected={ isChapterSelected }
+								onChapterSelected={ onChapterSelected }
+								onVideoPlayClick={ onVideoPlayClick }
+								translate={ translate }
+								isPreloadAnimationState={ isPreloadAnimationState }
+							/>
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/components/videos-ui/video-chapters.jsx
+++ b/client/components/videos-ui/video-chapters.jsx
@@ -1,0 +1,86 @@
+import { Button, Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+import moment from 'moment';
+
+const VideoChapters = ( {
+	course,
+	isChapterSelected,
+	onChapterSelected,
+	translate,
+	onVideoPlayClick,
+	isPreloadAnimationState,
+} ) => {
+	return Object.entries( course?.videos ).map( ( data, i ) => {
+		const isVideoCompleted = data[ 0 ] in course.completions && course.completions[ data[ 0 ] ];
+		const videoInfo = data[ 1 ];
+
+		return (
+			<div
+				key={ i }
+				className={ classNames( 'videos-ui__chapter', {
+					selected: isChapterSelected( i ),
+					preload: isPreloadAnimationState,
+				} ) }
+			>
+				<button
+					type="button"
+					className="videos-ui__chapter-accordion-toggle"
+					onClick={ () => onChapterSelected( i ) }
+				>
+					<span className="videos-ui__video-title">
+						{ i + 1 }. { videoInfo.title }{ ' ' }
+					</span>
+					<span className="videos-ui__duration">
+						{ moment.unix( videoInfo.duration_seconds ).format( 'm:ss' ) }
+					</span>
+					{ isVideoCompleted && (
+						<span className="videos-ui__completed-checkmark">
+							<Gridicon icon="checkmark" size={ 12 } />
+						</span>
+					) }
+					{ isChapterSelected( i ) && ! isVideoCompleted && (
+						<span className="videos-ui__status-icon">
+							<Gridicon icon="chevron-up" size={ 18 } />
+						</span>
+					) }
+					{ ! isChapterSelected( i ) && ! isVideoCompleted && (
+						<span className="videos-ui__status-icon">
+							<Gridicon icon="chevron-down" size={ 18 } />
+						</span>
+					) }
+				</button>
+				<div className="videos-ui__active-video-content">
+					<div>
+						<p>{ videoInfo.description } </p>
+						<Button
+							className={ classNames( 'videos-ui__button', {
+								'videos-ui__video-completed': isVideoCompleted,
+							} ) }
+							onClick={ () => onVideoPlayClick( data[ 0 ], videoInfo ) }
+						>
+							<svg
+								width="12"
+								height="14"
+								viewBox="0 0 12 14"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									d="M1.9165 1.75L10.0832 7L1.9165 12.25V1.75Z"
+									fill="#101517"
+									stroke="#101517"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								/>
+							</svg>
+							<span>{ translate( 'Play video' ) }</span>
+						</Button>
+					</div>
+				</div>
+			</div>
+		);
+	} );
+};
+
+export default VideoChapters;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes #58509. Refactored the videos accordion UI to its own component called `VideoChapters`

The look and feel + functionality of the video modal page from the pr branch should be identical to `trunk`

#### Testing instructions
1. Navigate to http://calypso.localhost:3000/home
2. Make sure you're at the HomePage called My Home and it looks like this  
![image](https://user-images.githubusercontent.com/18711727/145702938-86f66ee0-f3f7-4bce-9a87-eae84d6abc40.png)
3. Click on the `Start Learning` in the second square: 
![image](https://user-images.githubusercontent.com/18711727/145703011-b2cdf756-924e-4ff5-a39c-0e9b260b6b8c.png)
4. The accordion should appear in the modal and selecting any of the videos in the accordion should also update the video player to play the matching video.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

