### PR TITLE
Follow-up email-only registration test

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -381,6 +381,7 @@ export default class SignupFlowController {
 			this._processingSteps.delete( step.stepName );
 			recordTracksEvent( 'calypso_signup_actions_complete_step', {
 				step: step.stepName,
+				flow: this._flowName,
 			} );
 			this._reduxStore.dispatch( completeSignupStep( step, dependenciesFound ) );
 			return;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -154,6 +154,7 @@ export default function WPCheckoutOrderReview( {
 	};
 
 	const planIsP2Plus = hasP2PlusPlan( responseCart );
+	const shouldShowDomainNote = experiment?.variationName && domainUrl?.includes( 'wordpress.com' );
 	const isPwpoUser = useSelector(
 		( state ) =>
 			getCurrentUser( state ) && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
@@ -167,7 +168,7 @@ export default function WPCheckoutOrderReview( {
 				<SiteSummary>
 					{ translate( 'Site: %s', { args: domainUrl } ) }
 
-					{ experiment?.variationName && (
+					{ shouldShowDomainNote && (
 						<GeneratedNameNote>
 							{ translate( 'You can change this name at any time in your account settings.' ) }
 						</GeneratedNameNote>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -106,10 +106,15 @@ export default function WPCheckoutOrderReview( {
 		const experimentCheck = isDesktop
 			? 'registration_email_only_desktop_random_usernames'
 			: 'registration_email_only_mobile_random_usernames';
-
+		let shouldCheck = true;
 		loadExperimentAssignment( experimentCheck ).then( ( experimentObject ) => {
-			setExperiment( experimentObject );
+			if ( shouldCheck ) {
+				setExperiment( experimentObject );
+			}
 		} );
+		return () => {
+			shouldCheck = false;
+		};
 	}, [ isDesktop ] );
 
 	const onRemoveProductCancel = useCallback( () => {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -110,7 +110,7 @@ export default function WPCheckoutOrderReview( {
 		loadExperimentAssignment( experimentCheck ).then( ( experimentObject ) => {
 			setExperiment( experimentObject );
 		} );
-	}, [] );
+	}, [ isDesktop ] );
 
 	const onRemoveProductCancel = useCallback( () => {
 		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' ) );
@@ -167,7 +167,6 @@ export default function WPCheckoutOrderReview( {
 			{ ! planIsP2Plus && domainUrl && 'no-user' !== domainUrl && (
 				<SiteSummary>
 					{ translate( 'Site: %s', { args: domainUrl } ) }
-
 					{ shouldShowDomainNote && (
 						<GeneratedNameNote>
 							{ translate( 'You can change this name at any time in your account settings.' ) }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -4,6 +4,7 @@
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { render, fireEvent, screen, within } from '@testing-library/react';
+import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -76,6 +77,20 @@ describe( 'CompositeCheckout with a variant picker', () => {
 		};
 
 		const store = createTestReduxStore();
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
+		Object.defineProperty( window, 'matchMedia', {
+			writable: true,
+			value: jest.fn().mockImplementation( ( query ) => ( {
+				matches: false,
+				media: query,
+				onchange: null,
+				addListener: jest.fn(), // deprecated
+				removeListener: jest.fn(), // deprecated
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+				dispatchEvent: jest.fn(),
+			} ) ),
+		} );
 
 		MyCheckout = ( { cartChanges, additionalProps, additionalCartProps, useUndefinedCartKey } ) => {
 			const managerClient = createShoppingCartManagerClient( {
@@ -151,6 +166,7 @@ describe( 'CompositeCheckout with a variant picker', () => {
 				data: getActivePersonalPlanDataForType( activePlan ),
 			} ) );
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
+			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 			fireEvent.click( editOrderButton );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -148,7 +148,6 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the line items with prices', async () => {
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			screen
@@ -158,7 +157,6 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the tax amount', async () => {
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			screen
@@ -168,7 +166,6 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the total amount', async () => {
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			screen
@@ -185,7 +182,6 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'does not render the full credits payment method option when no credits are available', async () => {
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
@@ -194,7 +190,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render the full credits payment method option when partial credits are available', async () => {
 		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
@@ -203,7 +198,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the paypal payment method option when partial credits are available', async () => {
 		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'PayPal' ) ).toBeInTheDocument();
@@ -217,7 +211,6 @@ describe( 'CompositeCheckout', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( /WordPress.com Credits:/ ) ).toBeInTheDocument();
@@ -231,7 +224,6 @@ describe( 'CompositeCheckout', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( 'PayPal' ) ).not.toBeInTheDocument();
@@ -239,7 +231,6 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'does not render the free payment method option when the purchase is not free', async () => {
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( 'Free Purchase' ) ).not.toBeInTheDocument();
@@ -248,7 +239,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render the paypal payment method option when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( 'PayPal' ) ).not.toBeInTheDocument();
@@ -266,7 +256,6 @@ describe( 'CompositeCheckout', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
@@ -275,7 +264,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the free payment method option when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Free Purchase' ) ).toBeInTheDocument();
@@ -284,7 +272,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render the contact step when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect(
@@ -294,7 +281,6 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the contact step when the purchase is not free', async () => {
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.getByText( /Enter your (billing|contact) information/ ) ).toBeInTheDocument();
@@ -303,7 +289,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the tax fields only when no domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -314,7 +299,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the domain fields when a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -325,7 +309,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the domain fields when a domain transfer is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainTransferProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -336,7 +319,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render country-specific domain fields when no country has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -351,7 +333,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders country-specific domain fields when a country has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'US' } } );
@@ -369,7 +350,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders domain fields with postal code when a country with postal code support has been chosen and a plan is in the cart', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'US' } } );
@@ -382,7 +362,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a plan is in the cart', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'CW' } } );
@@ -395,7 +374,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders domain fields with postal code when a country with postal code support has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'US' } } );
@@ -410,7 +388,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'CW' } } );
@@ -427,7 +404,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not complete the contact step when the contact step button has not been clicked', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -531,7 +507,6 @@ describe( 'CompositeCheckout', () => {
 						success: email === 'passes',
 					};
 				} );
-			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 
 			render(
 				<MyCheckout
@@ -589,7 +564,6 @@ describe( 'CompositeCheckout', () => {
 	);
 
 	it( 'renders the checkout summary', async () => {
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
@@ -599,7 +573,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'removes a product from the cart after clicking to remove it in edit mode', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );
@@ -619,7 +592,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'removes a product from the cart after clicking to remove it outside of edit mode', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
@@ -637,7 +609,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'redirects to the plans page if the cart is empty after removing the last product', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );
@@ -655,7 +626,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not redirect to the plans page if the cart is empty after removing a product when it is not the last', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );
@@ -673,7 +643,6 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not redirect to the plans page if the cart is empty when it loads', async () => {
 		const cartChanges = { products: [] };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( async () => {
 			expect( page.redirect ).not.toHaveBeenCalledWith( '/plans/foo.com' );
@@ -683,7 +652,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'does not redirect if the cart is empty when it loads but the url has a plan alias', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -696,7 +664,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds the aliased plan to the cart when the url has a plan alias', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -714,7 +681,6 @@ describe( 'CompositeCheckout', () => {
 
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -732,7 +698,6 @@ describe( 'CompositeCheckout', () => {
 
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan,jetpack_backup_daily' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -762,7 +727,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds the domain mapping product to the cart when the url has a concierge session', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'concierge-session' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -781,7 +745,6 @@ describe( 'CompositeCheckout', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'theme:ovation' };
 		await act( async () => {
-			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render(
 				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 				container
@@ -793,7 +756,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds the domain mapping product to the cart when the url has a theme', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'theme:ovation' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -812,7 +774,6 @@ describe( 'CompositeCheckout', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'domain-mapping:bar.com' };
 		await act( async () => {
-			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render(
 				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 				container
@@ -824,7 +785,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds the domain mapping product to the cart when the url has a domain map', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'domain-mapping:bar.com' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -843,7 +803,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds renewal product to the cart when the url has a renewal', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal-bundle', purchaseId: '12345' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -858,7 +817,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds renewal product to the cart when the url has a renewal with a domain registration', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'domain_reg:foo.cash', purchaseId: '12345' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -872,7 +830,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds renewal product to the cart when the url has a renewal with a domain mapping', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'domain_map:bar.com', purchaseId: '12345' };
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -889,7 +846,6 @@ describe( 'CompositeCheckout', () => {
 			productAliasFromUrl: 'domain_map:bar.com,domain_reg:bar.com',
 			purchaseId: '12345,54321',
 		};
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -908,7 +864,6 @@ describe( 'CompositeCheckout', () => {
 			coupon_savings_total_integer: 10,
 			coupon_savings_total_display: '$R10',
 		};
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -104,6 +104,20 @@ describe( 'CompositeCheckout', () => {
 			} );
 			const mainCartKey = 'foo.com';
 			useCartKey.mockImplementation( () => ( useUndefinedCartKey ? undefined : mainCartKey ) );
+			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
+			Object.defineProperty( window, 'matchMedia', {
+				writable: true,
+				value: jest.fn().mockImplementation( ( query ) => ( {
+					matches: false,
+					media: query,
+					onchange: null,
+					addListener: jest.fn(), // deprecated
+					removeListener: jest.fn(), // deprecated
+					addEventListener: jest.fn(),
+					removeEventListener: jest.fn(),
+					dispatchEvent: jest.fn(),
+				} ) ),
+			} );
 			return (
 				<ReduxProvider store={ store }>
 					<ShoppingCartProvider
@@ -134,6 +148,7 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the line items with prices', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			screen
@@ -143,6 +158,7 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the tax amount', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			screen
@@ -152,6 +168,7 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the total amount', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			screen
@@ -168,6 +185,7 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'does not render the full credits payment method option when no credits are available', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
@@ -176,6 +194,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render the full credits payment method option when partial credits are available', async () => {
 		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
@@ -184,6 +203,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the paypal payment method option when partial credits are available', async () => {
 		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'PayPal' ) ).toBeInTheDocument();
@@ -197,6 +217,7 @@ describe( 'CompositeCheckout', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( /WordPress.com Credits:/ ) ).toBeInTheDocument();
@@ -210,6 +231,7 @@ describe( 'CompositeCheckout', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( 'PayPal' ) ).not.toBeInTheDocument();
@@ -217,6 +239,7 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'does not render the free payment method option when the purchase is not free', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( 'Free Purchase' ) ).not.toBeInTheDocument();
@@ -225,6 +248,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render the paypal payment method option when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( 'PayPal' ) ).not.toBeInTheDocument();
@@ -242,6 +266,7 @@ describe( 'CompositeCheckout', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
@@ -250,6 +275,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the free payment method option when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Free Purchase' ) ).toBeInTheDocument();
@@ -258,6 +284,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render the contact step when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect(
@@ -267,6 +294,7 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the contact step when the purchase is not free', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.getByText( /Enter your (billing|contact) information/ ) ).toBeInTheDocument();
@@ -275,6 +303,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the tax fields only when no domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -285,6 +314,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the domain fields when a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -295,6 +325,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the domain fields when a domain transfer is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainTransferProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -305,6 +336,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render country-specific domain fields when no country has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -319,6 +351,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders country-specific domain fields when a country has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'US' } } );
@@ -336,6 +369,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders domain fields with postal code when a country with postal code support has been chosen and a plan is in the cart', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'US' } } );
@@ -348,6 +382,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a plan is in the cart', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'CW' } } );
@@ -360,6 +395,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders domain fields with postal code when a country with postal code support has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'US' } } );
@@ -374,6 +410,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			fireEvent.change( screen.getByLabelText( 'Country' ), { target: { value: 'CW' } } );
@@ -390,6 +427,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not complete the contact step when the contact step button has not been clicked', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -551,6 +589,7 @@ describe( 'CompositeCheckout', () => {
 	);
 
 	it( 'renders the checkout summary', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
@@ -560,6 +599,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'removes a product from the cart after clicking to remove it in edit mode', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );
@@ -579,6 +619,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'removes a product from the cart after clicking to remove it outside of edit mode', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
@@ -596,6 +637,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'redirects to the plans page if the cart is empty after removing the last product', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );
@@ -613,6 +655,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not redirect to the plans page if the cart is empty after removing a product when it is not the last', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );
@@ -630,6 +673,7 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not redirect to the plans page if the cart is empty when it loads', async () => {
 		const cartChanges = { products: [] };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( async () => {
 			expect( page.redirect ).not.toHaveBeenCalledWith( '/plans/foo.com' );
@@ -639,6 +683,7 @@ describe( 'CompositeCheckout', () => {
 	it( 'does not redirect if the cart is empty when it loads but the url has a plan alias', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -651,6 +696,7 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds the aliased plan to the cart when the url has a plan alias', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -668,6 +714,7 @@ describe( 'CompositeCheckout', () => {
 
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -685,6 +732,7 @@ describe( 'CompositeCheckout', () => {
 
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan,jetpack_backup_daily' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -714,6 +762,7 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds the domain mapping product to the cart when the url has a concierge session', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'concierge-session' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -732,6 +781,7 @@ describe( 'CompositeCheckout', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'theme:ovation' };
 		await act( async () => {
+			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render(
 				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 				container
@@ -743,6 +793,7 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds the domain mapping product to the cart when the url has a theme', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'theme:ovation' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -761,6 +812,7 @@ describe( 'CompositeCheckout', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'domain-mapping:bar.com' };
 		await act( async () => {
+			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render(
 				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 				container
@@ -772,6 +824,7 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds the domain mapping product to the cart when the url has a domain map', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'domain-mapping:bar.com' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -790,6 +843,7 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds renewal product to the cart when the url has a renewal', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal-bundle', purchaseId: '12345' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -804,6 +858,7 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds renewal product to the cart when the url has a renewal with a domain registration', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'domain_reg:foo.cash', purchaseId: '12345' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -817,6 +872,7 @@ describe( 'CompositeCheckout', () => {
 	it( 'adds renewal product to the cart when the url has a renewal with a domain mapping', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'domain_map:bar.com', purchaseId: '12345' };
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -833,6 +889,7 @@ describe( 'CompositeCheckout', () => {
 			productAliasFromUrl: 'domain_map:bar.com,domain_reg:bar.com',
 			purchaseId: '12345,54321',
 		};
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container
@@ -851,6 +908,7 @@ describe( 'CompositeCheckout', () => {
 			coupon_savings_total_integer: 10,
 			coupon_savings_total_display: '$R10',
 		};
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 		render(
 			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
 			container

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -125,7 +125,21 @@ export class UserStep extends Component {
 		if ( oauth2Signup && clientId ) {
 			this.props.fetchOAuth2ClientData( clientId );
 		}
-		if ( flowName === 'onboarding' ) {
+		const signupFlows = [
+			'onboarding',
+			'free',
+			'personal',
+			'premium',
+			'business',
+			'ecommerce',
+			'with-theme',
+			'personal-monthly',
+			'premium-monthly',
+			'business-monthly',
+			'ecommerce-monthly',
+			'with-design-picker',
+		];
+		if ( signupFlows.includes( flowName ) ) {
 			const experimentCheck = this.state.isDesktop
 				? 'registration_email_only_desktop_random_usernames'
 				: 'registration_email_only_mobile_random_usernames';

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -103,6 +103,39 @@ export class UserStep extends Component {
 		isDesktop: isDesktop(),
 	};
 
+	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
+	UNSAFE_componentWillReceiveProps( nextProps ) {
+		if (
+			this.props.flowName !== nextProps.flowName ||
+			this.props.locale !== nextProps.locale ||
+			this.props.subHeaderText !== nextProps.subHeaderText
+		) {
+			this.setSubHeaderText( nextProps );
+		}
+	}
+
+	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
+	UNSAFE_componentWillMount() {
+		const { oauth2Signup, initialContext, flowName } = this.props;
+
+		const clientId = get( initialContext, 'query.oauth2_client_id', null );
+
+		this.setSubHeaderText( this.props );
+
+		if ( oauth2Signup && clientId ) {
+			this.props.fetchOAuth2ClientData( clientId );
+		}
+		if ( flowName === 'onboarding' ) {
+			const experimentCheck = this.state.isDesktop
+				? 'registration_email_only_desktop_random_usernames'
+				: 'registration_email_only_mobile_random_usernames';
+
+			loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
+				this.setState( { experiment: experimentName } );
+			} );
+		}
+	}
+
 	componentDidUpdate() {
 		if ( this.userCreationCompletedAndHasHistory( this.props ) ) {
 			// It looks like the user just completed the User Registartion Step

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -103,53 +103,6 @@ export class UserStep extends Component {
 		isDesktop: isDesktop(),
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			this.props.flowName !== nextProps.flowName ||
-			this.props.locale !== nextProps.locale ||
-			this.props.subHeaderText !== nextProps.subHeaderText
-		) {
-			this.setSubHeaderText( nextProps );
-		}
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		const { oauth2Signup, initialContext, flowName } = this.props;
-
-		const clientId = get( initialContext, 'query.oauth2_client_id', null );
-
-		this.setSubHeaderText( this.props );
-
-		if ( oauth2Signup && clientId ) {
-			this.props.fetchOAuth2ClientData( clientId );
-		}
-		const signupFlows = [
-			'onboarding',
-			'free',
-			'personal',
-			'premium',
-			'business',
-			'ecommerce',
-			'with-theme',
-			'personal-monthly',
-			'premium-monthly',
-			'business-monthly',
-			'ecommerce-monthly',
-			'with-design-picker',
-		];
-		if ( signupFlows.includes( flowName ) ) {
-			const experimentCheck = this.state.isDesktop
-				? 'registration_email_only_desktop_random_usernames'
-				: 'registration_email_only_mobile_random_usernames';
-
-			loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
-				this.setState( { experiment: experimentName } );
-			} );
-		}
-	}
-
 	componentDidUpdate() {
 		if ( this.userCreationCompletedAndHasHistory( this.props ) ) {
 			// It looks like the user just completed the User Registartion Step
@@ -175,10 +128,24 @@ export class UserStep extends Component {
 			this.props.fetchOAuth2ClientData( clientId );
 		}
 
-		if ( this.props.flowName === 'onboarding' ) {
+		const signupFlows = [
+			'onboarding',
+			'free',
+			'personal',
+			'premium',
+			'business',
+			'ecommerce',
+			'with-theme',
+			'personal-monthly',
+			'premium-monthly',
+			'business-monthly',
+			'ecommerce-monthly',
+			'with-design-picker',
+		];
+		if ( signupFlows.includes( this.props.flowName ) ) {
 			const experimentCheck = this.state.isDesktop
-				? 'registration_email_only_desktop_relaunch'
-				: 'registration_email_only_mobile_relaunch';
+				? 'registration_email_only_desktop_random_usernames'
+				: 'registration_email_only_mobile_random_usernames';
 
 			loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
 				this.setState( { experiment: experimentName } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up test to the email-only test described and discussed at pbxNRc-144-p2. That flow auto-generates a site name based on the user's email address and is likely leading to a drop in purchase rate for this flow (pbxNRc-144-p2#comment-2770).

This PR changes the generated site name to one based on random words and adds a note to the checkout page. The note informs the user that they can change the site name at any point.

Here's a screenshot of the updated checkout page:

<img width="937" alt="CleanShot 2021-12-12 at 08 04 22@2x" src="https://user-images.githubusercontent.com/35781181/145714142-fff3a46f-425c-4e0b-951b-1c49c3ca1a83.png">

The new Explat test names are:
`registration_email_only_mobile_random_usernames`
`registration_email_only_desktop_random_usernames`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch your sandbox with D71395 (this updates the api that generates the username)
* Sandbox public-api.wordpress.com
* Checkout this branch and start Calypso
* Add the Abacus bookmarklets for both tests listed above.
* Navigate to `[LOCALCALYPSO]/start/new` in an incognito browser
* Repeat the following steps in both mobile and desktop viewports:
* Assign yourself to the treatment variation for the relevant viewport (it may take a minute or two after clicking the bookmarklet for your variation assignment to propagate).
* Go through the control and treatment variations for each viewport.
* Test the flow through a non-onboarding signup flow (such as `/start/personal`)
* Check non-signup checkout flows and confirm that the user isn't assigned to either test, regardless of viewport. (This check is handled in Abacus).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58404
