### PR TITLE
`PeopleInviteDetails`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -32,9 +32,8 @@ export class PeopleInviteDetails extends PureComponent {
 		inviteKey: PropTypes.string.isRequired,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.deleteSuccess && ! this.props.deleteSuccess ) {
+	componentDidUpdate( prevProps ) {
+		if ( this.props.deleteSuccess && ! prevProps.deleteSuccess ) {
 			this.goBack();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `PeopleInviteDetails`: refactor away from `UNSAFE_*`

#### Testing instructions

* On a site with pending invites go to `/people/invites/<siteSlug>` and select one of the invites
* Hit _Revoke Invite_
* You should be redirected back to `/people/invites/<siteSlug>`

Related to #58453 