### PR TITLE
Remove the tools/migrate feature flag

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -7,12 +7,11 @@ import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { getStatsPathForTab } from 'calypso/lib/route';
+import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount, getCurrentUser } from 'calypso/state/current-user/selectors';
-import { requestHttpData } from 'calypso/state/data-layer/http-data';
-import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path.js';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
@@ -94,31 +93,23 @@ class MasterbarLoggedIn extends Component {
 		 *
 		 * This code makes it possible to reset the failed migration state when clicking My Sites too.
 		 */
-		if ( config.isEnabled( 'tools/migrate' ) ) {
-			const { migrationStatus, currentSelectedSiteId } = this.props;
+		const { migrationStatus, currentSelectedSiteId } = this.props;
 
-			if ( currentSelectedSiteId && migrationStatus === 'error' ) {
-				/**
-				 * Reset the in-memory site lock for the currently selected site
-				 */
-				this.props.updateSiteMigrationMeta( currentSelectedSiteId, 'inactive', null );
+		if ( currentSelectedSiteId && migrationStatus === 'error' ) {
+			/**
+			 * Reset the in-memory site lock for the currently selected site
+			 */
+			this.props.updateSiteMigrationMeta( currentSelectedSiteId, 'inactive', null );
 
-				/**
-				 * Reset the migration on the backend
-				 */
-				requestHttpData(
-					'site-migration',
-					http( {
-						apiNamespace: 'wpcom/v2',
-						method: 'POST',
-						path: `/sites/${ currentSelectedSiteId }/reset-migration`,
-						body: {},
-					} ),
-					{
-						freshness: 0,
-					}
-				);
-			}
+			/**
+			 * Reset the migration on the backend
+			 */
+			wpcom.req
+				.post( {
+					path: `/sites/${ currentSelectedSiteId }/reset-migration`,
+					apiNamespace: 'wpcom/v2',
+				} )
+				.catch( () => {} );
 		}
 	};
 

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -1,4 +1,3 @@
-import { isEnabled as isConfigEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import classNames from 'classnames';
 import { includes } from 'lodash';
@@ -94,7 +93,7 @@ class FileImporter extends PureComponent {
 			tagName: 'button',
 		};
 
-		if ( isConfigEnabled( 'tools/migrate' ) && overrideDestination ) {
+		if ( overrideDestination ) {
 			/**
 			 * Override where the user lands when they click the importer.
 			 *

--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -1,39 +1,18 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
-import page from 'page';
-import { decodeURIComponentIfValid } from 'calypso/lib/url';
-import SectionMigrate from 'calypso/my-sites/migrate/section-migrate';
 import { getSiteId } from 'calypso/state/sites/selectors';
-
-export function ensureFeatureFlag( context, next ) {
-	if ( isEnabled( 'tools/migrate' ) ) {
-		return next();
-	}
-	page.redirect( '/' );
-}
+import SectionMigrate from './section-migrate';
 
 export function migrateSite( context, next ) {
-	if ( isEnabled( 'tools/migrate' ) ) {
-		const sourceSiteId =
-			context.params.sourceSiteId &&
-			getSiteId( context.store.getState(), context.params.sourceSiteId );
-		const fromSite =
-			( context.query &&
-				context.query[ 'from-site' ] &&
-				decodeURIComponentIfValid( context.query[ 'from-site' ] ) ) ||
-			'';
+	const sourceSiteId =
+		context.params.sourceSiteId &&
+		getSiteId( context.store.getState(), context.params.sourceSiteId );
+	const fromSite = context.query[ 'from-site' ];
 
-		context.primary = (
-			<SectionMigrate
-				sourceSiteId={ sourceSiteId }
-				step={ context.migrationStep }
-				url={ fromSite }
-			/>
-		);
-		return next();
-	}
+	context.primary = (
+		<SectionMigrate sourceSiteId={ sourceSiteId } step={ context.migrationStep } url={ fromSite } />
+	);
 
-	page.redirect( '/' );
+	next();
 }
 
 export function setStep( migrationStep ) {

--- a/client/my-sites/migrate/index.js
+++ b/client/my-sites/migrate/index.js
@@ -1,17 +1,11 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'calypso/my-sites/controller';
-import {
-	ensureFeatureFlag,
-	migrateSite,
-	setSiteSelectionHeader,
-	setStep,
-} from 'calypso/my-sites/migrate/controller';
+import { migrateSite, setSiteSelectionHeader, setStep } from 'calypso/my-sites/migrate/controller';
 
 export default function () {
 	page(
 		'/migrate',
-		ensureFeatureFlag,
 		setSiteSelectionHeader,
 		siteSelection,
 		navigation,
@@ -22,7 +16,6 @@ export default function () {
 
 	page(
 		'/migrate/:site_id',
-		ensureFeatureFlag,
 		setStep( 'input' ),
 		siteSelection,
 		navigation,
@@ -34,7 +27,6 @@ export default function () {
 
 	page(
 		'/migrate/from/:sourceSiteId/to/:site_id',
-		ensureFeatureFlag,
 		setStep( 'confirm' ),
 		siteSelection,
 		navigation,
@@ -46,7 +38,6 @@ export default function () {
 
 	page(
 		'/migrate/choose/:site_id',
-		ensureFeatureFlag,
 		setStep( 'migrateOrImport' ),
 		siteSelection,
 		navigation,
@@ -58,7 +49,6 @@ export default function () {
 
 	page(
 		'/migrate/upgrade/from/:sourceSiteId/to/:site_id',
-		ensureFeatureFlag,
 		setStep( 'upgrade' ),
 		siteSelection,
 		navigation,

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -51,13 +51,11 @@ class ToolsMenu extends PureComponent {
 	getImportItem() {
 		const { isJetpack, isAtomicSite, translate } = this.props;
 
-		const migrateEnabled = config.isEnabled( 'tools/migrate' );
-
 		return {
 			name: 'import',
 			label: translate( 'Import' ),
 			capability: 'manage_options',
-			queryable: ! isJetpack || ( isAtomicSite && migrateEnabled ),
+			queryable: ! isJetpack || isAtomicSite,
 			link: '/import',
 			paths: [ '/import', '/migrate' ],
 			wpAdminLink: 'import.php',

--- a/config/development.json
+++ b/config/development.json
@@ -150,7 +150,6 @@
 		"support-user": true,
 		"themes/premium": false,
 		"titan/iframe-control-panel": false,
-		"tools/migrate": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -101,7 +101,6 @@
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,
 		"themes/premium": false,
-		"tools/migrate": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -102,7 +102,6 @@
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,
-		"tools/migrate": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,7 +112,6 @@
 		"site-indicator": true,
 		"support-user": true,
 		"themes/premium": false,
-		"tools/migrate": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
Removes the always-true `tools/migrate` feature flag.

Also updates a call to the `/reset-migration` REST endpoint (when clicking "My Sites") from a legacy http-data call to a raw `wpcom.req.post` one. Related to #58944 as this is one extra use of the endpoint.