### PR TITLE
Migrate wpcom.undocumented().getSiteConnectInfo() to wpcom.req

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -59,16 +59,6 @@ Undocumented.prototype.getDnsTemplateRecords = function (
 	);
 };
 
-/**
- * Check different info about WordPress and Jetpack status on a url
- *
- * @param  {string}  inputUrl The url of the site to check. Must use http or https protocol.
- * @returns {Promise} promise  Request promise
- */
-Undocumented.prototype.getSiteConnectInfo = function ( inputUrl ) {
-	return this.wpcom.req.get( '/connect/site-info', { url: inputUrl } );
-};
-
 Undocumented.prototype.getDomainConnectSyncUxUrl = function (
 	domain,
 	providerId,

--- a/client/state/jetpack-connect/actions/check-url.js
+++ b/client/state/jetpack-connect/actions/check-url.js
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import { pick } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -23,12 +22,12 @@ export function checkUrl( url, isUrlOnSites, allowWPCOMSite ) {
 		if ( isUrlOnSites ) {
 			dispatch( {
 				type: JETPACK_CONNECT_CHECK_URL,
-				url: url,
+				url,
 			} );
 			setTimeout( () => {
 				dispatch( {
 					type: JETPACK_CONNECT_CHECK_URL_RECEIVE,
-					url: url,
+					url,
 					data: {
 						exists: true,
 						isWordPress: true,
@@ -47,7 +46,7 @@ export function checkUrl( url, isUrlOnSites, allowWPCOMSite ) {
 		setTimeout( () => {
 			dispatch( {
 				type: JETPACK_CONNECT_CHECK_URL,
-				url: url,
+				url,
 			} );
 		}, 1 );
 		wpcom.req
@@ -57,8 +56,8 @@ export function checkUrl( url, isUrlOnSites, allowWPCOMSite ) {
 				debug( 'jetpack-connect state checked for url', url, data );
 				dispatch( {
 					type: JETPACK_CONNECT_CHECK_URL_RECEIVE,
-					url: url,
-					data: data,
+					url,
+					data,
 					error: null,
 				} );
 
@@ -85,7 +84,7 @@ export function checkUrl( url, isUrlOnSites, allowWPCOMSite ) {
 				if ( errorCode ) {
 					dispatch(
 						recordTracksEvent( errorCode, {
-							url: url,
+							url,
 							type: instructionsType,
 						} )
 					);
@@ -95,15 +94,11 @@ export function checkUrl( url, isUrlOnSites, allowWPCOMSite ) {
 				_fetching[ url ] = null;
 				dispatch( {
 					type: JETPACK_CONNECT_CHECK_URL_RECEIVE,
-					url: url,
+					url,
 					data: null,
-					error: pick( error, [ 'error', 'status', 'message' ] ),
+					error,
 				} );
-				dispatch(
-					recordTracksEvent( 'calypso_jpc_error_other', {
-						url: url,
-					} )
-				);
+				dispatch( recordTracksEvent( 'calypso_jpc_error_other', { url } ) );
 			} );
 	};
 }

--- a/client/state/jetpack-connect/actions/check-url.js
+++ b/client/state/jetpack-connect/actions/check-url.js
@@ -50,9 +50,8 @@ export function checkUrl( url, isUrlOnSites, allowWPCOMSite ) {
 				url: url,
 			} );
 		}, 1 );
-		wpcom
-			.undocumented()
-			.getSiteConnectInfo( url )
+		wpcom.req
+			.get( '/connect/site-info', { url } )
 			.then( ( data ) => {
 				_fetching[ url ] = null;
 				debug( 'jetpack-connect state checked for url', url, data );


### PR DESCRIPTION
Migrates the `/connect/site-info` request. As a drive-by, I'm removing `_.pick` usage from the `checkUrl` action thunk. It was used to pick `error`, `status` and `message` fields from an error object. But why not store the entire object without picking? The state is not serialized anywhere, so an `Error` object is OK.

**How to test:**
Go to `/jetpack/connect` and enter site URL to the input box:

<img width="443" alt="Screenshot 2021-12-13 at 10 28 29" src="https://user-images.githubusercontent.com/664258/145787265-a6f36cc7-e114-45f2-a23b-aee1c739eb50.png">

Verify that the `/connect/site-info` endpoint is called and verifies the target site's WordPress-ishness and Jetpack-ishness.