### PR TITLE
Signup user step: migrate away from unsafe React lifecycles

### DIFF
--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -2,11 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { expect } from 'chai';
 import { createElement } from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
-import sinon from 'sinon';
 import { UserStep as User } from '../';
 
 const noop = () => {};
@@ -45,7 +43,7 @@ describe( '#signupStep User', () => {
 		} );
 		rendered = TestUtils.renderIntoDocument( testElement );
 
-		expect( rendered.state.subHeaderText ).to.equal( 'Welcome to the WordPress.com community.' );
+		expect( rendered.getSubHeaderText() ).toBe( 'Welcome to the WordPress.com community.' );
 	} );
 
 	test( 'should show provided subheader text if User step is not first in the flow', () => {
@@ -57,18 +55,15 @@ describe( '#signupStep User', () => {
 		} );
 		rendered = TestUtils.renderIntoDocument( testElement );
 
-		expect( rendered.state.subHeaderText ).to.equal( 'test subheader message' );
+		expect( rendered.getSubHeaderText() ).toBe( 'test subheader message' );
 	} );
 
-	describe( '#updateComponentProps', () => {
+	describe( '#updateSubHeaderText', () => {
 		let node;
-		let spyComponentProps;
 		let component;
 
 		beforeEach( () => {
 			node = document.createElement( 'div' );
-
-			spyComponentProps = sinon.spy( User.prototype, 'UNSAFE_componentWillReceiveProps' );
 
 			const element = createElement( User, {
 				subHeaderText: 'test subheader message',
@@ -79,10 +74,6 @@ describe( '#signupStep User', () => {
 			component = ReactDOM.render( element, node );
 		} );
 
-		afterEach( () => {
-			User.prototype.UNSAFE_componentWillReceiveProps.restore();
-		} );
-
 		test( 'should show community subheader text when new flow has user as first step', () => {
 			const testProps = {
 				subHeaderText: 'My test message',
@@ -91,12 +82,9 @@ describe( '#signupStep User', () => {
 				translate,
 			};
 
-			expect( spyComponentProps.calledOnce ).to.equal( false );
-
 			ReactDOM.render( createElement( User, testProps ), node );
 
-			expect( spyComponentProps.calledOnce ).to.equal( true );
-			expect( component.state.subHeaderText ).to.equal( 'Welcome to the WordPress.com community.' );
+			expect( component.getSubHeaderText() ).toBe( 'Welcome to the WordPress.com community.' );
 		} );
 
 		test( "should show provided subheader text when new flow doesn't have user as first step", () => {
@@ -107,12 +95,9 @@ describe( '#signupStep User', () => {
 				translate,
 			};
 
-			expect( spyComponentProps.calledOnce ).to.equal( false );
-
 			ReactDOM.render( createElement( User, testProps ), node );
 
-			expect( spyComponentProps.calledOnce ).to.equal( true );
-			expect( component.state.subHeaderText ).to.equal( 'My test message' );
+			expect( component.getSubHeaderText() ).toBe( 'My test message' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Migrates the `UserStep` component away from unsafe lifecycles.

Biggest part of that was "memoizing" the `getSubHeaderText()` result in local state, carefully recomputing it when relevant props change. I completely removed that memoizaton, simply computing the `subHeaderText` on every render, like we already do with `headerText`. Although the function is large, it's just several simple conditions and one `translate` call.

Then I moved two data fetches -- fetching OAuth client ID and ExPlat experiments -- to `componentDidMount`.

**How to test:**
As a logged-out user, start signing up for a new account. The "normal" signup should have a subheader like:
<img width="614" alt="Screenshot 2021-12-13 at 12 29 55" src="https://user-images.githubusercontent.com/664258/145805142-3519243f-5ff2-4bda-9865-cb52d29becdf.png">
And a Crowdsignal-branded signup has a different subheader:
<img width="439" alt="Screenshot 2021-12-13 at 12 31 25" src="https://user-images.githubusercontent.com/664258/145805878-bd590b9e-9dab-43c3-914d-eea375b7235e.png">

Part of #58453.
