### PR TITLE
Signup: use correct apostrophe character

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -133,7 +133,7 @@ class StepWrapper extends Component {
 				return this.props.headerText;
 			}
 
-			return this.props.translate( "Let's get started" );
+			return this.props.translate( 'Let’s get started' );
 		}
 
 		if ( this.props.fallbackHeaderText !== undefined ) {


### PR DESCRIPTION
As logged-out user, if you start signing up for a new account, you'll eventually get to the `/start/user` page with a "Let's get started" header in large type:

<img width="614" alt="Screenshot 2021-12-13 at 12 29 55" src="https://user-images.githubusercontent.com/664258/145806910-2d9824b6-7f53-4012-a8a4-b65dd6012247.png">

But this ASCII apostrophe character (U+0027) is not good and we can do much better with U+2019:

<img width="594" alt="Screenshot 2021-12-13 at 12 42 11" src="https://user-images.githubusercontent.com/664258/145807110-94bb13b4-2be2-46a0-836d-af100c54a9f4.png">

We already use U+2019 at many places in the codebase. Here the distinction is particularly well visible.

