### PR TITLE
Inline Help: Move QuerySupportTypes inside contact view

### DIFF
--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import InlineHelpForumView from 'calypso/blocks/inline-help/inline-help-forum-view';
+import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import PlaceholderLines from 'calypso/blocks/inline-help/placeholder-lines';
 import HelpContact from 'calypso/me/help/help-contact';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -27,9 +28,10 @@ function InlineHelpContactViewLoaded() {
 export default function InlineHelpContactView() {
 	const supportVariationDetermined = useSelector( isSupportVariationDetermined );
 
-	if ( ! supportVariationDetermined ) {
-		return <PlaceholderLines />;
-	}
-
-	return <InlineHelpContactViewLoaded />;
+	return (
+		<>
+			<QuerySupportTypes />
+			{ supportVariationDetermined ? <InlineHelpContactViewLoaded /> : <PlaceholderLines /> }
+		</>
+	);
 }

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import InlineHelpContactView from 'calypso/blocks/inline-help/inline-help-contact-view';
-import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
 import InlineHelpRichResult from './inline-help-rich-result';
@@ -122,7 +121,6 @@ class InlineHelpPopover extends Component {
 	renderPopoverContent = () => {
 		return (
 			<Fragment>
-				<QuerySupportTypes />
 				<div className="inline-help__search">
 					<InlineHelpSearchCard
 						searchQuery={ this.state.searchQuery }

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -70,7 +70,7 @@ export class SupportComponent {
 			this.waitForQueryComplete(),
 			// Waits for one of the network request (triggered by the opening of the popover) to complete.
 			this.page.waitForResponse(
-				( response ) => response.status() === 200 && response.url().includes( 'kayako/mine?' )
+				( response ) => response.status() === 200 && response.url().includes( 'me/purchases' )
 			),
 			this.page.click( selectors.supportPopoverButton ),
 		] );

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -68,10 +68,7 @@ export class SupportComponent {
 		await Promise.all( [
 			// Waits for all placeholder CSS elements to be removed from the DOM.
 			this.waitForQueryComplete(),
-			// Waits for one of the network request (triggered by the opening of the popover) to complete.
-			this.page.waitForResponse(
-				( response ) => response.status() === 200 && response.url().includes( 'me/purchases' )
-			),
+			this.page.waitForSelector( selectors.supportPopoverButton ),
 			this.page.click( selectors.supportPopoverButton ),
 		] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the `<QuerySupportTypes />` query component inside `<InlineHelpContactView />` as suggested by @jsnajdr in https://github.com/Automattic/wp-calypso/pull/59062#discussion_r767248773 . This is an improvement because the contact view is rendered later, and that way we query the support variations only if they are going to be used.

#### Testing instructions

* Open a page that has the inline help button and click the question mark button.
* Click on "Contact us" and verify it continues to perform a request to `/help/tickets/kayako/mine` and still works as before.