### PR TITLE
`InvitePeople`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -75,7 +75,8 @@ function renderInvitePeople( context, next ) {
 	context.store.dispatch( setTitle( i18n.translate( 'Invite People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
 
 	context.primary = createElement( InvitePeople, {
-		site: site,
+		key: site.ID,
+		site,
 	} );
 	next();
 }

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -58,20 +58,22 @@ const debug = debugModule( 'calypso:my-sites:people:invite' );
 class InvitePeople extends Component {
 	static displayName = 'InvitePeople';
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		if (
-			this.props.siteId !== nextProps.siteId ||
-			this.props.needsVerification !== nextProps.needsVerification ||
-			this.props.showSSONotice !== nextProps.showSSONotice ||
-			this.props.isJetpack !== nextProps.isJetpack
+			prevProps.needsVerification !== this.props.needsVerification ||
+			prevProps.showSSONotice !== this.props.showSSONotice ||
+			prevProps.isJetpack !== this.props.isJetpack
 		) {
-			this.setState( this.resetState( nextProps ) );
+			this.resetState();
 		}
 	}
 
-	resetState = ( props = this.props ) => {
-		const { isWPForTeamsSite } = props;
+	resetState = () => {
+		this.setState( this.getInitialState() );
+	};
+
+	getInitialState = () => {
+		const { isWPForTeamsSite } = this.props;
 
 		const defaultRole = isWPForTeamsSite ? 'editor' : 'follower';
 
@@ -110,7 +112,7 @@ class InvitePeople extends Component {
 		const errorKeys = Object.keys( errors );
 
 		if ( success.length && ! errorKeys.length ) {
-			this.setState( this.resetState() );
+			this.resetState();
 			this.props.recordTracksEvent( 'calypso_invite_people_form_refresh_initial' );
 			debug( 'Submit successful. Resetting form.' );
 			return;
@@ -531,7 +533,7 @@ class InvitePeople extends Component {
 			( accepted ) => {
 				if ( accepted ) {
 					this.props.disableInviteLinks( this.props.siteId );
-					this.setState( this.resetState() );
+					this.resetState();
 				}
 			},
 			this.props.translate( 'Disable' )
@@ -693,7 +695,7 @@ class InvitePeople extends Component {
 		return inviteLinkForm;
 	};
 
-	state = this.resetState();
+	state = this.getInitialState();
 
 	render() {
 		const { site, translate, isWPForTeamsSite, isJetpack } = this.props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `InvitePeople`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/people/new/:site` and verify the form renders as expected
* Change your currently active site, you should get a new form (depending on which site you chose roles get updated or additional notices are shown, e.g. on P2 sites)
* Choose a Jetpack site and hit reload, there's a short span where you should see a warning about SSO (if the notice persists, hit _Enable_, it should then go away and the form should be enabled)

Related to #58453 
