### PR TITLE
Fix: Remove unnecessary rating check on plugins ratings.

### DIFF
--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -116,7 +116,7 @@ class PluginRatings extends Component {
 					{ inlineNumRatings && numRatings && (
 						<span className="plugin-ratings__num-ratings">
 							(
-							{ rating && Number.isInteger( numRatings )
+							{ Number.isInteger( numRatings )
 								? numRatings.toLocaleString( getLocaleSlug() )
 								: null }
 							)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove unnecessary rating check on plugins ratings, this check is already being done on L107.

#### Testing instructions
* Go to `/plugins` page
* Make sure the page still working, including the rating on plugin cards
* Click on a plugin with rating being showed
* On the Plugin Details page make sure the page still working and the ratings are being shown on the header

Related to #58866
