### PR TITLE
Remove purchase option from themes page

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -19,7 +19,6 @@ import {
 	getTheme,
 	getThemeDetailsUrl,
 	getThemeHelpUrl,
-	getThemePurchaseUrl,
 	getThemeSignupUrl,
 	isPremiumThemeAvailable,
 	isThemeActive,
@@ -31,24 +30,6 @@ const identity = ( theme ) => theme;
 
 function getAllThemeOptions( { translate, blockEditorSettings } ) {
 	const isFSEActive = blockEditorSettings?.is_fse_active ?? false;
-
-	const purchase = {
-		label: translate( 'Purchase', {
-			context: 'verb',
-		} ),
-		extendedLabel: translate( 'Purchase this design' ),
-		header: translate( 'Purchase on:', {
-			context: 'verb',
-			comment: 'label for selecting a site for which to purchase a theme',
-		} ),
-		getUrl: getThemePurchaseUrl,
-		hideForTheme: ( state, themeId, siteId ) =>
-			isJetpackSite( state, siteId ) || // No individual theme purchase on a JP site
-			! isUserLoggedIn( state ) || // Not logged in
-			! isThemePremium( state, themeId ) || // Not a premium theme
-			isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
-			isThemeActive( state, themeId, siteId ), // Already active
-	};
 
 	const upgradePlan = {
 		label: translate( 'Upgrade to activate', {
@@ -174,7 +155,6 @@ function getAllThemeOptions( { translate, blockEditorSettings } ) {
 	return {
 		customize,
 		preview,
-		purchase,
 		upgradePlan,
 		activate,
 		tryandcustomize,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Purchase option from themes page for premium themes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the themes page of a free site using the `themes/premium` feature flag
* List Premium themes
* Click on a theme's options
* "Purchase" item should be gone

![image](https://user-images.githubusercontent.com/3801502/145805958-cc3773bd-1ba3-47e0-a9ba-9b5909113be8.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59113
