### PR TITLE
`PostTypeListMaxPagesNotice`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/post-type-list/max-pages-notice.jsx
+++ b/client/my-sites/post-type-list/max-pages-notice.jsx
@@ -13,8 +13,7 @@ class PostTypeListMaxPagesNotice extends Component {
 		totalPosts: PropTypes.number,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_post_type_list_max_pages_view' );
 	}
 

--- a/client/my-sites/post-type-list/max-pages-notice.jsx
+++ b/client/my-sites/post-type-list/max-pages-notice.jsx
@@ -32,6 +32,7 @@ class PostTypeListMaxPagesNotice extends Component {
 					'Showing %(displayedPosts)d post of %(totalPosts)d.',
 					'Showing %(displayedPosts)d posts of %(totalPosts)d.',
 					{
+						count: displayedPosts,
 						args: {
 							displayedPosts,
 							totalPosts,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `PostTypeListMaxPagesNotice`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/posts` (showing all posts from all sites)
* Scroll down a bit (it takes 10 requests to get to the end)
* Make sure you see an action dispatched like shown below

<img width="420" alt="Screenshot 2021-12-13 at 14 39 11" src="https://user-images.githubusercontent.com/9202899/145822790-47e597a3-493b-476d-a563-ea5fd5840582.png">

Related to #58453 
