### PR TITLE
Import onboarding: show getting started video while import is in progress

### DIFF
--- a/client/signup/steps/import-from/components/getting-started-video/index.tsx
+++ b/client/signup/steps/import-from/components/getting-started-video/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReaderFeaturedVideoBlock from 'calypso/blocks/reader-featured-video';
+
+import './style.scss';
+
+const GettingStartedVideo: React.FunctionComponent = () => {
+	const video = {
+		autoplayIframe:
+			'<iframe src="https://www.youtube.com/embed/twGLN4lug-I" width="768px" height="426px" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+		iframe:
+			'<iframe src="https://www.youtube.com/embed/twGLN4lug-I" width="768px" height="426px" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+		src: 'https://youtu.be/twGLN4lug-I',
+		aspectRatio: 1.8,
+		width: '100%',
+		height: 'auto',
+	};
+
+	return (
+		<div className="getting-started-video">
+			<p>
+				Watch <strong>Getting started on WordPress.com</strong> while you wait
+			</p>
+			<ReaderFeaturedVideoBlock { ...video } videoEmbed={ video } isExpanded={ true } />
+		</div>
+	);
+};
+
+export default GettingStartedVideo;

--- a/client/signup/steps/import-from/components/getting-started-video/index.tsx
+++ b/client/signup/steps/import-from/components/getting-started-video/index.tsx
@@ -1,9 +1,12 @@
+import { createElement, createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import ReaderFeaturedVideoBlock from 'calypso/blocks/reader-featured-video';
 
 import './style.scss';
 
 const GettingStartedVideo: React.FunctionComponent = () => {
+	const { __ } = useI18n();
 	const video = {
 		autoplayIframe:
 			'<iframe src="https://www.youtube.com/embed/twGLN4lug-I" width="768px" height="426px" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
@@ -18,7 +21,12 @@ const GettingStartedVideo: React.FunctionComponent = () => {
 	return (
 		<div className="getting-started-video">
 			<p>
-				Watch <strong>Getting started on WordPress.com</strong> while you wait
+				{ createInterpolateElement(
+					__( 'Watch <strong>Getting started on WordPress.com</strong> while you wait' ),
+					{
+						strong: createElement( 'strong' ),
+					}
+				) }
 			</p>
 			<ReaderFeaturedVideoBlock { ...video } videoEmbed={ video } isExpanded={ true } />
 		</div>

--- a/client/signup/steps/import-from/components/getting-started-video/style.scss
+++ b/client/signup/steps/import-from/components/getting-started-video/style.scss
@@ -1,5 +1,5 @@
 .getting-started-video {
-	margin: 3em 0;
+	margin: 3rem 0;
 	text-align: center;
 
 	iframe {

--- a/client/signup/steps/import-from/components/getting-started-video/style.scss
+++ b/client/signup/steps/import-from/components/getting-started-video/style.scss
@@ -5,4 +5,13 @@
 	iframe {
 		width: 100%;
 	}
+
+	p {
+		color: var( --studio-gray-50 );
+	}
+
+	strong {
+		font-weight: 500; /* stylelint-disable-line */
+		color: var( --studio-gray-100 );
+	}
 }

--- a/client/signup/steps/import-from/components/getting-started-video/style.scss
+++ b/client/signup/steps/import-from/components/getting-started-video/style.scss
@@ -1,0 +1,8 @@
+.getting-started-video {
+	margin: 3em 0;
+	text-align: center;
+
+	iframe {
+		width: 100%;
+	}
+}

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -9,6 +9,7 @@ import { calculateProgress } from 'calypso/my-sites/importer/importing-pane';
 import { startImport, resetImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
+import GettingStartedVideo from '../components/getting-started-video';
 import { Importer, ImportJob, ImportJobParams } from '../types';
 import { getImporterTypeForEngine } from '../util';
 import DoneButton from './done-button';
@@ -78,6 +79,10 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 		return job && job.importerState === appStates.IMPORT_SUCCESS;
 	}
 
+	function showVideoComponent() {
+		return checkProgress() || checkIsSuccess();
+	}
+
 	return (
 		<>
 			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
@@ -125,6 +130,8 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 						);
 					}
 				} )() }
+
+				{ showVideoComponent() && <GettingStartedVideo /> }
 			</div>
 		</>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Show getting started video while import is in progress. GettingStartedVideo component is placed in the folder components (shared folder), so the other importers could consume it.

#### Testing instructions
* Go to `/start/importer?siteSlug={YOUR_SITE}.wordpress.com`
* Enter a valid Wix website URL
* Hit the `Import your content` button
* The import process will be run with the video bellow the progress bar and hooray screens

#### Screenshots
<img width="938" alt="Screenshot 2021-12-13 at 19 09 16" src="https://user-images.githubusercontent.com/1241413/145867080-9bd40f0e-1400-4bdd-8c41-47f88e029c7d.png">

<img width="1017" alt="Screenshot 2021-12-13 at 13 59 22" src="https://user-images.githubusercontent.com/1241413/145867110-a98bb595-1d9b-4293-9e33-1352c6d6d7c2.png">


Related to #57131, #59041
