### PR TITLE
Emails: Show Google Workspace section in first position in the Email Comparison page when on sale

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -756,6 +756,7 @@ class EmailProvidersComparison extends Component {
 			isSubmittingEmailForward,
 			selectedDomainName,
 			selectedSite,
+			shouldPromoteGoogleWorkspace,
 			source,
 		} = this.props;
 
@@ -785,9 +786,11 @@ class EmailProvidersComparison extends Component {
 					/>
 				) }
 
+				{ shouldPromoteGoogleWorkspace && this.renderGoogleCard() }
+
 				{ this.renderTitanCard() }
 
-				{ this.renderGoogleCard() }
+				{ ! shouldPromoteGoogleWorkspace && this.renderGoogleCard() }
 
 				{ ! hideEmailForwardingCard && this.renderEmailForwardingCard() }
 


### PR DESCRIPTION
This pull request is a follow-up of #59054 which updates the `Email Comparison` page to show the Google Workspace section before the Professional Email one when Google Workspace is on sale:

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/145858467-cb9e537b-c199-4168-bb10-99cea3ddd865.png) | ![image](https://user-images.githubusercontent.com/594356/145858608-13730881-8de3-4059-b210-f7ee25a33e6b.png)

#### Testing instructions

1. Run `git checkout update/google-workspace-form-location` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/59127#issuecomment-992699363)
2. Open the [`Emails` page](http://calypso.localhost:3000/email)
3. Click the `Add Email` button to access the `Email Comparison` page
4. Assert that Google Workspace appears in first position