### PR TITLE
Adds billing interval switcher in plugin details and plugins browser.

### DIFF
--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -21,3 +21,4 @@ function render() {
 ## Props
 
 - `items` (`{ label: string; href?: string }[]`) - The Navigations items to be shown
+- `compact` (`boolean`) - Displays only the previous item URL reading "Back" (optional)

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
 import { Key } from 'react';
 
 const StyledUl = styled.ul`
@@ -34,14 +35,23 @@ const StyledGridicon = styled( Gridicon )`
 
 interface Props {
 	items: { label: string; href?: string }[];
+	compact?: boolean;
 }
 
-const Breadcrumb: React.FunctionComponent< Props > = ( { items } ) => {
+const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false } ) => {
+	const translate = useTranslate();
+	const back = translate( 'Back' ) as string;
+	if ( compact ) {
+		// Show only the exactly previous page
+		items = items.slice( -2, -1 );
+		items.map( ( item ) => ( item.label = back ) );
+	}
 	return (
 		<StyledUl>
 			{ items.map( ( item: { href?: string; label: string }, index: Key ) => {
 				return (
 					<StyledLi key={ index }>
+						{ compact && <StyledGridicon icon="chevron-left" size={ 18 } /> }
 						{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 18 } /> }
 						{ item.href ? <a href={ item.href }>{ item.label }</a> : <span>{ item.label }</span> }
 					</StyledLi>

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -44,7 +44,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false 
 	if ( compact ) {
 		// Show only the exactly previous page
 		items = items.slice( -2, -1 );
-		items.map( ( item ) => ( item.label = back ) );
+		items[ 0 ].label = back;
 	}
 	return (
 		<StyledUl>

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -41,7 +41,7 @@ interface Props {
 const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false } ) => {
 	const translate = useTranslate();
 	const back = translate( 'Back' ) as string;
-	if ( compact ) {
+	if ( compact && items.length > 1 ) {
 		// Show only the exactly previous page
 		items = items.slice( -2, -1 );
 		items[ 0 ].label = back;

--- a/client/components/fixed-navigation-header/README.md
+++ b/client/components/fixed-navigation-header/README.md
@@ -26,3 +26,4 @@ function render() {
 - `id` (`string`) - ID for the header (optional)
 - `className` (`string`) - A class name for the wrapped component (optional)
 - `children` (`nodes`) – Any children elements which are being rendered to the far right (optional)
+- `compactBreadcrumb` (`boolean`) - Displays only the previous item URL reading "Back" in the breadcrumb (optional)

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -57,10 +57,11 @@ interface Props {
 	children?: ReactNode;
 	navigationItems: { label: string; href?: string }[];
 	contentRef?: React.RefObject< HTMLElement >;
+	compactBreadcrumb?: boolean;
 }
 
 const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
-	const { id, className, children, navigationItems, contentRef } = props;
+	const { id, className, children, navigationItems, contentRef, compactBreadcrumb = false } = props;
 	const actionsRef = useRef< HTMLDivElement >( null );
 	const headerRef = useRef< HTMLElement >( null );
 
@@ -98,7 +99,7 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 	return (
 		<Header id={ id } className={ className } ref={ headerRef }>
 			<Container>
-				<Breadcrumb items={ navigationItems } />
+				<Breadcrumb items={ navigationItems } compact={ compactBreadcrumb } />
 				<ActionsContainer ref={ actionsRef }>{ children }</ActionsContainer>
 			</Container>
 		</Header>

--- a/client/my-sites/marketplace/components/billing-interval-switcher/constants.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/constants.tsx
@@ -1,0 +1,4 @@
+export enum IntervalLength {
+	ANNUALLY = 'ANNUALLY',
+	MONTHLY = 'MONTHLY',
+}

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.jsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.jsx
@@ -17,26 +17,24 @@ const PlansIntervalToggleLabel = styled.span`
 
 const BillingIntervalSwitcher = ( { billingPeriod, onChange, compact } ) => {
 	const translate = useTranslate();
+	const monthlyLabel = translate( 'Monthly price' );
+	const annualLabel = translate( 'Annual price' );
 
 	if ( compact ) {
 		return (
 			<Container>
-				<SelectDropdown
-					selectedText={
-						billingPeriod === 'MONTHLY' ? translate( 'Monthly price' ) : translate( 'Annual price' )
-					}
-				>
+				<SelectDropdown selectedText={ billingPeriod === 'MONTHLY' ? monthlyLabel : annualLabel }>
 					<SelectDropdown.Item
 						selected={ billingPeriod === 'MONTHLY' }
 						onClick={ () => onChange( 'MONTHLY' ) }
 					>
-						{ translate( 'Monthly price' ) }
+						{ monthlyLabel }
 					</SelectDropdown.Item>
 					<SelectDropdown.Item
 						selected={ billingPeriod === 'ANNUALLY' }
 						onClick={ () => onChange( 'ANNUALLY' ) }
 					>
-						{ translate( 'Annual price' ) }
+						{ annualLabel }
 					</SelectDropdown.Item>
 				</SelectDropdown>
 			</Container>

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.jsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.jsx
@@ -2,6 +2,7 @@ import { PlansIntervalToggle } from '@automattic/plans-grid/src';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import SelectDropdown from 'calypso/components/select-dropdown';
+import { IntervalLength } from './constants';
 
 const Container = styled.div`
 	.plans-interval-toggle {
@@ -23,16 +24,18 @@ const BillingIntervalSwitcher = ( { billingPeriod, onChange, compact } ) => {
 	if ( compact ) {
 		return (
 			<Container>
-				<SelectDropdown selectedText={ billingPeriod === 'MONTHLY' ? monthlyLabel : annualLabel }>
+				<SelectDropdown
+					selectedText={ billingPeriod === IntervalLength.MONTHLY ? monthlyLabel : annualLabel }
+				>
 					<SelectDropdown.Item
-						selected={ billingPeriod === 'MONTHLY' }
-						onClick={ () => onChange( 'MONTHLY' ) }
+						selected={ billingPeriod === IntervalLength.MONTHLY }
+						onClick={ () => onChange( IntervalLength.MONTHLY ) }
 					>
 						{ monthlyLabel }
 					</SelectDropdown.Item>
 					<SelectDropdown.Item
-						selected={ billingPeriod === 'ANNUALLY' }
-						onClick={ () => onChange( 'ANNUALLY' ) }
+						selected={ billingPeriod === IntervalLength.ANNUALY }
+						onClick={ () => onChange( IntervalLength.ANNUALY ) }
 					>
 						{ annualLabel }
 					</SelectDropdown.Item>

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.jsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.jsx
@@ -1,0 +1,51 @@
+import { PlansIntervalToggle } from '@automattic/plans-grid/src';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import SelectDropdown from 'calypso/components/select-dropdown';
+
+const Container = styled.div`
+	.plans-interval-toggle {
+		display: inline-flex;
+	}
+`;
+
+const PlansIntervalToggleLabel = styled.span`
+	font-size: 14px;
+	color: var( --studio-gray-60 );
+	margin-right: 10px;
+`;
+
+const BillingIntervalSwitcher = ( { billingPeriod, onChange, compact } ) => {
+	const translate = useTranslate();
+
+	if ( compact ) {
+		return (
+			<SelectDropdown
+				selectedText={
+					billingPeriod === 'MONTHLY' ? translate( 'Monthly price' ) : translate( 'Annual price' )
+				}
+			>
+				<SelectDropdown.Item
+					selected={ billingPeriod === 'MONTHLY' }
+					onClick={ () => onChange( 'MONTHLY' ) }
+				>
+					{ translate( 'Monthly price' ) }
+				</SelectDropdown.Item>
+				<SelectDropdown.Item
+					selected={ billingPeriod === 'ANNUALLY' }
+					onClick={ () => onChange( 'ANNUALLY' ) }
+				>
+					{ translate( 'Annual price' ) }
+				</SelectDropdown.Item>
+			</SelectDropdown>
+		);
+	}
+
+	return (
+		<Container>
+			<PlansIntervalToggleLabel>{ translate( 'Price' ) }</PlansIntervalToggleLabel>
+			<PlansIntervalToggle intervalType={ billingPeriod } onChange={ onChange } />
+		</Container>
+	);
+};
+export default BillingIntervalSwitcher;

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.jsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.jsx
@@ -20,24 +20,26 @@ const BillingIntervalSwitcher = ( { billingPeriod, onChange, compact } ) => {
 
 	if ( compact ) {
 		return (
-			<SelectDropdown
-				selectedText={
-					billingPeriod === 'MONTHLY' ? translate( 'Monthly price' ) : translate( 'Annual price' )
-				}
-			>
-				<SelectDropdown.Item
-					selected={ billingPeriod === 'MONTHLY' }
-					onClick={ () => onChange( 'MONTHLY' ) }
+			<Container>
+				<SelectDropdown
+					selectedText={
+						billingPeriod === 'MONTHLY' ? translate( 'Monthly price' ) : translate( 'Annual price' )
+					}
 				>
-					{ translate( 'Monthly price' ) }
-				</SelectDropdown.Item>
-				<SelectDropdown.Item
-					selected={ billingPeriod === 'ANNUALLY' }
-					onClick={ () => onChange( 'ANNUALLY' ) }
-				>
-					{ translate( 'Annual price' ) }
-				</SelectDropdown.Item>
-			</SelectDropdown>
+					<SelectDropdown.Item
+						selected={ billingPeriod === 'MONTHLY' }
+						onClick={ () => onChange( 'MONTHLY' ) }
+					>
+						{ translate( 'Monthly price' ) }
+					</SelectDropdown.Item>
+					<SelectDropdown.Item
+						selected={ billingPeriod === 'ANNUALLY' }
+						onClick={ () => onChange( 'ANNUALLY' ) }
+					>
+						{ translate( 'Annual price' ) }
+					</SelectDropdown.Item>
+				</SelectDropdown>
+			</Container>
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -216,7 +216,7 @@ function PluginDetails( props ) {
 				navigationItems={ getNavigationItems() }
 				compactBreadcrumb={ ! isWide }
 			>
-				{ isEnabled( 'marketplace-v1' ) && (
+				{ isEnabled( 'marketplace-v1' ) && isMarketplaceProduct && (
 					<BillingIntervalSwitcher
 						billingPeriod={ billingPeriod }
 						onChange={ setBillingPeriod }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,5 +1,6 @@
+import { PlansIntervalToggle } from '@automattic/plans-grid';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
@@ -91,6 +92,7 @@ function PluginDetails( props ) {
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isWpcom = selectedSite && ! isJetpack;
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
+	const [ billingPeriod, setBillingPeriod ] = useState( 'ANNUALLY' );
 
 	// Determine if the plugin is WPcom or WPorg hosted
 	const productsList = useSelector( ( state ) => getProductsList( state ) );
@@ -205,7 +207,13 @@ function PluginDetails( props ) {
 			<SidebarNavigation />
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QueryProductsList />
-			<FixedNavigationHeader navigationItems={ getNavigationItems() } />
+			<FixedNavigationHeader navigationItems={ getNavigationItems() }>
+				<PlansIntervalToggle
+					intervalType={ billingPeriod }
+					onChange={ setBillingPeriod }
+					className="plugin-details__pricing-toggle"
+				/>
+			</FixedNavigationHeader>
 			<PluginNotices
 				pluginId={ fullPlugin.id }
 				sites={ sitesWithPlugins }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,4 +1,5 @@
-import { PlansIntervalToggle } from '@automattic/plans-grid/src';
+import { isEnabled } from '@automattic/calypso-config';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -13,6 +14,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginDetailsCTA from 'calypso/my-sites/plugins/plugin-details-CTA';
@@ -92,7 +94,10 @@ function PluginDetails( props ) {
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isWpcom = selectedSite && ! isJetpack;
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
-	const [ billingPeriod, setBillingPeriod ] = useState( 'ANNUALLY' );
+
+	// Header Navigation and billing period switcher.
+	const isWide = useBreakpoint( '>1280px' );
+	const [ billingPeriod, setBillingPeriod ] = useState( 'MONTHLY' );
 
 	// Determine if the plugin is WPcom or WPorg hosted
 	const productsList = useSelector( ( state ) => getProductsList( state ) );
@@ -207,14 +212,17 @@ function PluginDetails( props ) {
 			<SidebarNavigation />
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QueryProductsList />
-			<FixedNavigationHeader navigationItems={ getNavigationItems() }>
-				<>
-					<div className="plugin-details__price-toggle">
-						<span className="plugin-details__price-toggle-label">{ translate( 'Price' ) }</span>
-
-						<PlansIntervalToggle intervalType={ billingPeriod } onChange={ setBillingPeriod } />
-					</div>
-				</>
+			<FixedNavigationHeader
+				navigationItems={ getNavigationItems() }
+				compactBreadcrumb={ ! isWide }
+			>
+				{ isEnabled( 'marketplace-v1' ) && (
+					<BillingIntervalSwitcher
+						billingPeriod={ billingPeriod }
+						onChange={ setBillingPeriod }
+						compact={ ! isWide }
+					/>
+				) }
 			</FixedNavigationHeader>
 			<PluginNotices
 				pluginId={ fullPlugin.id }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -15,6 +15,7 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginDetailsCTA from 'calypso/my-sites/plugins/plugin-details-CTA';
@@ -97,7 +98,7 @@ function PluginDetails( props ) {
 
 	// Header Navigation and billing period switcher.
 	const isWide = useBreakpoint( '>1280px' );
-	const [ billingPeriod, setBillingPeriod ] = useState( 'MONTHLY' );
+	const [ billingPeriod, setBillingPeriod ] = useState( IntervalLength.MONTHLY );
 
 	// Determine if the plugin is WPcom or WPorg hosted
 	const productsList = useSelector( ( state ) => getProductsList( state ) );

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -208,11 +208,13 @@ function PluginDetails( props ) {
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QueryProductsList />
 			<FixedNavigationHeader navigationItems={ getNavigationItems() }>
-				<PlansIntervalToggle
-					intervalType={ billingPeriod }
-					onChange={ setBillingPeriod }
-					className="plugin-details__pricing-toggle"
-				/>
+				<>
+					<div className="plugin-details__price-toggle">
+						<span className="plugin-details__price-toggle-label">{ translate( 'Price' ) }</span>
+
+						<PlansIntervalToggle intervalType={ billingPeriod } onChange={ setBillingPeriod } />
+					</div>
+				</>
 			</FixedNavigationHeader>
 			<PluginNotices
 				pluginId={ fullPlugin.id }
@@ -233,6 +235,7 @@ function PluginDetails( props ) {
 							selectedSite={ selectedSite }
 							isPluginInstalledOnsite={ isPluginInstalledOnsite }
 							isPlaceholder={ showPlaceholder }
+							billingPeriod={ billingPeriod }
 						/>
 					</div>
 				</div>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,4 +1,4 @@
-import { PlansIntervalToggle } from '@automattic/plans-grid';
+import { PlansIntervalToggle } from '@automattic/plans-grid/src';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@automattic/components';
 import Search from '@automattic/search';
 import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -27,6 +28,7 @@ import { PaginationVariant } from 'calypso/components/pagination/constants';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import UrlSearch from 'calypso/lib/url-search';
+import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import NoResults from 'calypso/my-sites/no-results';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -74,6 +76,10 @@ const PluginsBrowser = ( {
 } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
+
+	// Billing period switcher.
+	const isWide = useBreakpoint( '>1280px' );
+	const [ billingPeriod, setBillingPeriod ] = useState( 'MONTHLY' );
 
 	const hasBusinessPlan =
 		sitePlan && ( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
@@ -235,6 +241,15 @@ const PluginsBrowser = ( {
 					className="plugins-browser__header"
 					navigationItems={ navigationItems }
 				>
+					{ isEnabled( 'marketplace-v1' ) && ! jetpackNonAtomic && (
+						<div className="plugins-browser__billling-interval-switcher">
+							<BillingIntervalSwitcher
+								billingPeriod={ billingPeriod }
+								onChange={ setBillingPeriod }
+								compact={ ! isWide }
+							/>
+						</div>
+					) }
 					<div className="plugins-browser__main-buttons">
 						<ManageButton
 							shouldShowManageButton={ shouldShowManageButton }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -29,6 +29,7 @@ import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-quer
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import UrlSearch from 'calypso/lib/url-search';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import NoResults from 'calypso/my-sites/no-results';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -79,7 +80,7 @@ const PluginsBrowser = ( {
 
 	// Billing period switcher.
 	const isWide = useBreakpoint( '>1280px' );
-	const [ billingPeriod, setBillingPeriod ] = useState( 'MONTHLY' );
+	const [ billingPeriod, setBillingPeriod ] = useState( IntervalLength.MONTHLY );
 
 	const hasBusinessPlan =
 		sitePlan && ( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -28,6 +28,10 @@
 	}
 }
 
+.plugins-browser__billling-interval-switcher {
+	margin-right: 15px;
+}
+
 .plugins-browser__main-buttons {
 	display: flex;
 	align-items: center;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -147,17 +147,6 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 }
 
-.plugin-details__price-toggle {
-	.plugin-details__price-toggle-label {
-		font-size: $font-body-small;
-		color: var( --studio-gray-60 );
-		margin-right: 10px;
-	}
-	.plans-interval-toggle {
-		display: inline-flex;
-	}
-}
-
 .plugin-details__body {
 	border-top: 1px solid var( --studio-gray-5 );
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -147,6 +147,17 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 }
 
+.plugin-details__price-toggle {
+	.plugin-details__price-toggle-label {
+		font-size: $font-body-small;
+		color: var( --studio-gray-60 );
+		margin-right: 10px;
+	}
+	.plans-interval-toggle {
+		display: inline-flex;
+	}
+}
+
 .plugin-details__body {
 	border-top: 1px solid var( --studio-gray-5 );
 

--- a/packages/plans-grid/src/index.ts
+++ b/packages/plans-grid/src/index.ts
@@ -1,2 +1,3 @@
+export { default as PlansIntervalToggle } from './plans-interval-toggle';
 export { default } from './plans-grid';
 export type { Props } from './plans-grid';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new `compact` prop to `<Breadcrumb>`, so that we can just display "Back" in smaller breakpoints
* Creates a billing interval switcher component for the Marketplace by composition of two already existing components
* Uses the above component in plugins browser and plugin details
* Note: the placement in plugins browser is not identical to the designs but we can iterate on it on future PRs

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario WPCOM sites with paid plugin**
* go to `/plugins/[domain]`
* inspect the new switcher
* change breakpoint, make sure nothing breaks
* repeat for `/plugins/woocommerce-subscriptions/`

**Scenario WPCOM sites with free plugin**
* go to `/plugins/woocommerce/`
* switcher should not show

**Scenario Jetpack Self hosted sites**
* go to `/plugins/[domain]`
* switcher should not show 

|Before List | After List|
|-------|------|
|<img width="1091" alt="SS 2021-12-15 at 16 48 05" src="https://user-images.githubusercontent.com/12430020/146208052-79343188-6666-4cfe-bfcc-d3fc4e0d92cb.png">|<img width="1099" alt="SS 2021-12-15 at 16 48 21" src="https://user-images.githubusercontent.com/12430020/146208092-46adf1a7-de80-428c-bd86-94900d6a5ca6.png">|

|Before Details | After Details|
|-------|------|
|<img width="1103" alt="SS 2021-12-15 at 16 48 53" src="https://user-images.githubusercontent.com/12430020/146208174-e835b599-85c4-4f2f-bba5-e35986b1e52f.png">|<img width="1118" alt="SS 2021-12-15 at 16 49 07" src="https://user-images.githubusercontent.com/12430020/146208218-27798f41-e90f-4c61-9695-3604f1618933.png">|

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57102
