### PR TITLE
Emails: Show logos from Google services in the Google Workspace form in the Email Comparison page

### DIFF
--- a/client/my-sites/email/email-provider-features/index.js
+++ b/client/my-sites/email/email-provider-features/index.js
@@ -18,7 +18,7 @@ EmailProviderFeature.propTypes = {
 	title: PropTypes.string.isRequired,
 };
 
-function EmailProviderFeatures( { features } ) {
+function EmailProviderFeatures( { features, logos } ) {
 	if ( ! features ) {
 		return null;
 	}
@@ -28,12 +28,21 @@ function EmailProviderFeatures( { features } ) {
 			{ features.map( ( feature, index ) => (
 				<EmailProviderFeature key={ index } title={ feature } />
 			) ) }
+
+			{ logos && (
+				<div className="email-provider-features__logos">
+					{ logos.map( ( { image, imageAltText, title }, index ) => (
+						<img alt={ imageAltText } key={ index } src={ image } title={ title } />
+					) ) }
+				</div>
+			) }
 		</div>
 	);
 }
 
 EmailProviderFeatures.propTypes = {
 	features: PropTypes.arrayOf( PropTypes.string ),
+	logos: PropTypes.arrayOf( PropTypes.object ),
 };
 
 export default EmailProviderFeatures;

--- a/client/my-sites/email/email-provider-features/list.js
+++ b/client/my-sites/email/email-provider-features/list.js
@@ -1,4 +1,10 @@
 import { translate } from 'i18n-calypso';
+import googleCalendarIcon from 'calypso/assets/images/email-providers/google-workspace/services/calendar.svg';
+import googleDocsIcon from 'calypso/assets/images/email-providers/google-workspace/services/docs.svg';
+import googleDriveIcon from 'calypso/assets/images/email-providers/google-workspace/services/drive.svg';
+import gmailIcon from 'calypso/assets/images/email-providers/google-workspace/services/gmail.svg';
+import googleSheetsIcon from 'calypso/assets/images/email-providers/google-workspace/services/sheets.svg';
+import googleSlidesIcon from 'calypso/assets/images/email-providers/google-workspace/services/slides.svg';
 
 const getEmailForwardingFeatures = () => {
 	return [ translate( 'No billing' ), translate( 'Receive emails sent to your custom domain' ) ];
@@ -15,6 +21,41 @@ const getGoogleFeatures = () => {
 	];
 };
 
+const getGoogleLogos = () => {
+	return [
+		{
+			image: gmailIcon,
+			imageAltText: translate( 'Gmail icon' ),
+			title: 'Gmail',
+		},
+		{
+			image: googleCalendarIcon,
+			imageAltText: translate( 'Google Calendar icon' ),
+			title: 'Google Calendar',
+		},
+		{
+			image: googleDocsIcon,
+			imageAltText: translate( 'Google Docs icon' ),
+			title: 'Google Docs',
+		},
+		{
+			image: googleDriveIcon,
+			imageAltText: translate( 'Google Drive icon' ),
+			title: 'Google Drive',
+		},
+		{
+			image: googleSheetsIcon,
+			imageAltText: translate( 'Google Sheets icon' ),
+			title: 'Google Sheets',
+		},
+		{
+			image: googleSlidesIcon,
+			imageAltText: translate( 'Google Slides icon' ),
+			title: 'Google Slides',
+		},
+	];
+};
+
 const getTitanFeatures = () => {
 	return [
 		translate( 'Monthly billing' ),
@@ -25,4 +66,4 @@ const getTitanFeatures = () => {
 	];
 };
 
-export { getEmailForwardingFeatures, getGoogleFeatures, getTitanFeatures };
+export { getEmailForwardingFeatures, getGoogleFeatures, getGoogleLogos, getTitanFeatures };

--- a/client/my-sites/email/email-provider-features/list.js
+++ b/client/my-sites/email/email-provider-features/list.js
@@ -15,32 +15,32 @@ const getGoogleAppLogos = () => {
 		{
 			image: gmailIcon,
 			imageAltText: translate( 'Gmail icon' ),
-			title: 'Gmail',
+			title: translate( 'Gmail' ),
 		},
 		{
 			image: googleCalendarIcon,
 			imageAltText: translate( 'Google Calendar icon' ),
-			title: 'Google Calendar',
+			title: translate( 'Google Calendar' ),
 		},
 		{
 			image: googleDriveIcon,
 			imageAltText: translate( 'Google Drive icon' ),
-			title: 'Google Drive',
+			title: translate( 'Google Drive' ),
 		},
 		{
 			image: googleDocsIcon,
 			imageAltText: translate( 'Google Docs icon' ),
-			title: 'Google Docs',
+			title: translate( 'Google Docs' ),
 		},
 		{
 			image: googleSheetsIcon,
 			imageAltText: translate( 'Google Sheets icon' ),
-			title: 'Google Sheets',
+			title: translate( 'Google Sheets' ),
 		},
 		{
 			image: googleSlidesIcon,
 			imageAltText: translate( 'Google Slides icon' ),
-			title: 'Google Slides',
+			title: translate( 'Google Slides' ),
 		},
 	];
 };

--- a/client/my-sites/email/email-provider-features/list.js
+++ b/client/my-sites/email/email-provider-features/list.js
@@ -10,18 +10,7 @@ const getEmailForwardingFeatures = () => {
 	return [ translate( 'No billing' ), translate( 'Receive emails sent to your custom domain' ) ];
 };
 
-const getGoogleFeatures = () => {
-	return [
-		translate( 'Annual billing' ),
-		translate( 'Send and receive from your custom domain' ),
-		translate( '30GB storage' ),
-		translate( 'Email, calendars, and contacts' ),
-		translate( 'Video calls, docs, spreadsheets, and more' ),
-		translate( 'Work from anywhere on any device – even offline' ),
-	];
-};
-
-const getGoogleLogos = () => {
+const getGoogleAppLogos = () => {
 	return [
 		{
 			image: gmailIcon,
@@ -34,14 +23,14 @@ const getGoogleLogos = () => {
 			title: 'Google Calendar',
 		},
 		{
-			image: googleDocsIcon,
-			imageAltText: translate( 'Google Docs icon' ),
-			title: 'Google Docs',
-		},
-		{
 			image: googleDriveIcon,
 			imageAltText: translate( 'Google Drive icon' ),
 			title: 'Google Drive',
+		},
+		{
+			image: googleDocsIcon,
+			imageAltText: translate( 'Google Docs icon' ),
+			title: 'Google Docs',
 		},
 		{
 			image: googleSheetsIcon,
@@ -56,6 +45,17 @@ const getGoogleLogos = () => {
 	];
 };
 
+const getGoogleFeatures = () => {
+	return [
+		translate( 'Annual billing' ),
+		translate( 'Send and receive from your custom domain' ),
+		translate( '30GB storage' ),
+		translate( 'Email, calendars, and contacts' ),
+		translate( 'Video calls, docs, spreadsheets, and more' ),
+		translate( 'Work from anywhere on any device – even offline' ),
+	];
+};
+
 const getTitanFeatures = () => {
 	return [
 		translate( 'Monthly billing' ),
@@ -66,4 +66,4 @@ const getTitanFeatures = () => {
 	];
 };
 
-export { getEmailForwardingFeatures, getGoogleFeatures, getGoogleLogos, getTitanFeatures };
+export { getEmailForwardingFeatures, getGoogleAppLogos, getGoogleFeatures, getTitanFeatures };

--- a/client/my-sites/email/email-provider-features/style.scss
+++ b/client/my-sites/email/email-provider-features/style.scss
@@ -27,14 +27,15 @@
 }
 
 .email-provider-features__logos {
+	column-gap: 5px;
 	display: flex;
 	flex-wrap: wrap;
-	margin-left: 21px;
-	margin-top: 20px;
+	margin-left: 25px;
+	margin-top: 15px;
+	row-gap: 5px;
 
 	img {
-		margin-left: 5px;
-		width: 40px;
+		width: 34px;
 	}
 }
 

--- a/client/my-sites/email/email-provider-features/style.scss
+++ b/client/my-sites/email/email-provider-features/style.scss
@@ -26,6 +26,18 @@
 	}
 }
 
+.email-provider-features__logos {
+	display: flex;
+	flex-wrap: wrap;
+	margin-left: 21px;
+	margin-top: 20px;
+
+	img {
+		margin-left: 5px;
+		width: 40px;
+	}
+}
+
 .email-provider-features__toggle-button {
 	overflow: visible;
 	white-space: nowrap;

--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -14,7 +14,6 @@ function EmailProviderCard( {
 	children,
 	providerKey,
 	logo,
-	appLogos,
 	title,
 	badge,
 	description,
@@ -28,6 +27,7 @@ function EmailProviderCard( {
 	showExpandButton = true,
 	expandButtonLabel,
 	features,
+	appLogos,
 } ) {
 	const [ areFeaturesExpanded, setFeaturesExpanded ] = useState( false );
 
@@ -104,7 +104,6 @@ function EmailProviderCard( {
 EmailProviderCard.propTypes = {
 	providerKey: PropTypes.string.isRequired,
 	logo: PropTypes.object.isRequired,
-	appLogos: PropTypes.arrayOf( PropTypes.object ),
 	title: PropTypes.string.isRequired,
 	badge: PropTypes.object,
 	description: PropTypes.string,
@@ -116,6 +115,7 @@ EmailProviderCard.propTypes = {
 	showExpandButton: PropTypes.bool,
 	expandButtonLabel: PropTypes.string,
 	features: PropTypes.arrayOf( PropTypes.string ),
+	appLogos: PropTypes.arrayOf( PropTypes.object ),
 	onExpandedChange: PropTypes.func,
 };
 

--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -14,6 +14,7 @@ function EmailProviderCard( {
 	children,
 	providerKey,
 	logo,
+	logos,
 	title,
 	badge,
 	description,
@@ -91,7 +92,7 @@ function EmailProviderCard( {
 				</div>
 
 				{ ( ! showFeaturesToggleButton || areFeaturesExpanded ) && (
-					<EmailProviderFeatures features={ features } />
+					<EmailProviderFeatures features={ features } logos={ logos } />
 				) }
 			</div>
 
@@ -103,6 +104,7 @@ function EmailProviderCard( {
 EmailProviderCard.propTypes = {
 	providerKey: PropTypes.string.isRequired,
 	logo: PropTypes.object.isRequired,
+	logos: PropTypes.arrayOf( PropTypes.object ),
 	title: PropTypes.string.isRequired,
 	badge: PropTypes.object,
 	description: PropTypes.string,

--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -14,7 +14,7 @@ function EmailProviderCard( {
 	children,
 	providerKey,
 	logo,
-	logos,
+	appLogos,
 	title,
 	badge,
 	description,
@@ -92,7 +92,7 @@ function EmailProviderCard( {
 				</div>
 
 				{ ( ! showFeaturesToggleButton || areFeaturesExpanded ) && (
-					<EmailProviderFeatures features={ features } logos={ logos } />
+					<EmailProviderFeatures features={ features } logos={ appLogos } />
 				) }
 			</div>
 
@@ -104,7 +104,7 @@ function EmailProviderCard( {
 EmailProviderCard.propTypes = {
 	providerKey: PropTypes.string.isRequired,
 	logo: PropTypes.object.isRequired,
-	logos: PropTypes.arrayOf( PropTypes.object ),
+	appLogos: PropTypes.arrayOf( PropTypes.object ),
 	title: PropTypes.string.isRequired,
 	badge: PropTypes.object,
 	description: PropTypes.string,

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -60,6 +60,7 @@ import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
 	getEmailForwardingFeatures,
 	getGoogleFeatures,
+	getGoogleLogos,
 	getTitanFeatures,
 } from 'calypso/my-sites/email/email-provider-features/list';
 import { emailManagement } from 'calypso/my-sites/email/paths';
@@ -497,6 +498,7 @@ class EmailProvidersComparison extends Component {
 				showExpandButton={ this.isDomainEligibleForEmail( domain ) }
 				expandButtonLabel={ expandButtonLabel }
 				features={ getGoogleFeatures() }
+				logos={ getGoogleLogos() }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -59,8 +59,8 @@ import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwa
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
 	getEmailForwardingFeatures,
+	getGoogleAppLogos,
 	getGoogleFeatures,
-	getGoogleLogos,
 	getTitanFeatures,
 } from 'calypso/my-sites/email/email-provider-features/list';
 import { emailManagement } from 'calypso/my-sites/email/paths';
@@ -498,7 +498,7 @@ class EmailProvidersComparison extends Component {
 				showExpandButton={ this.isDomainEligibleForEmail( domain ) }
 				expandButtonLabel={ expandButtonLabel }
 				features={ getGoogleFeatures() }
-				logos={ getGoogleLogos() }
+				appLogos={ getGoogleAppLogos() }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -2,9 +2,9 @@
 @import '@wordpress/base-styles/mixins';
 
 .email-providers-comparison__action-panel {
-
 	&.is-primary {
 		flex-direction: column;
+
 		@include break-mobile {
 			flex-direction: row;
 		}
@@ -59,17 +59,12 @@
 
 .email-providers-comparison__providers-wordpress-com-email {
 	color: var( --color-wordpress-com );
-	height: 48px;
-	width: 48px;
+	margin-left: -2px;
+	height: 42px;
+	width: 42px;
 }
 
 .email-providers-comparison__action-panel {
-	@include breakpoint-deprecated( '>1040px' ) {
-		&.is-primary {
-			padding-left: 73px;
-		}
-	}
-
 	&.is-primary .action-panel__figure {
 		max-width: 170px;
 	}
@@ -93,7 +88,7 @@
 		&.align-left {
 			float: left;
 			margin-left: 0;
-			margin-right: 24px;
+			margin-right: 0;
 			width: unset;
 		}
 


### PR DESCRIPTION
This pull request updates the `Email Comparison` page to show logos from the main Google online services in the Google Workspace section, just below the list of features:

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/145870100-e329b3b8-fa17-4fff-8cde-c24742d45c67.png) | ![image](https://user-images.githubusercontent.com/594356/145870194-38245c4c-1fcd-445e-b27d-4a5980ef472d.png)

It also fixes the size of the Professional Email logo, and makes sure the content of each section is vertically aligned.

#### Testing instructions

1. Run `git checkout add/google-workspace-logos` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/59139#issuecomment-992763204)
2. Open the [`Emails` page](http://calypso.localhost:3000/email)
3. Click the `Add Email` button to access the `Email Comparison` page
4. Assert that you see the logos in the Google Workspace section
5. Assert that the Professional Email logo has the same size than the other main logos
6. Assert that the content of each section is aligned