### PR TITLE
Add domain notices to the redesigned domains list pages

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -51,11 +51,16 @@ export function resolveDomainStatus(
 			if ( isExpiringSoon( domain, 30 ) ) {
 				const expiresMessage =
 					null !== domain.bundledPlanSubscriptionId
-						? translate( 'Domain connection expires with your plan on %(expiryDate)s', {
-								args: { expiryDate: moment.utc( domain.expiry ).format( 'LL' ) },
-						  } )
-						: translate( 'Domain connection expires in %(days)s', {
+						? translate(
+								'Domain connection expires with your plan on {{strong}}%(expiryDate)s{{/strong}}',
+								{
+									args: { expiryDate: moment.utc( domain.expiry ).format( 'LL' ) },
+									components: { strong: <strong /> },
+								}
+						  )
+						: translate( 'Domain connection expires in {{strong}}%(days)s{{/strong}}', {
 								args: { days: moment.utc( domain.expiry ).fromNow( true ) },
+								components: { strong: <strong /> },
 						  } );
 
 				if ( isExpiringSoon( domain, 5 ) ) {
@@ -148,8 +153,11 @@ export function resolveDomainStatus(
 					icon: 'verifying',
 					listStatusText: status,
 					noticeText: translate(
-						'It can take between a few minutes to 72 hours to verify the connection. You can continue to work on your site, but %(domainName)s won’t be reachable just yet.',
+						'It can take between a few minutes to 72 hours to verify the connection. You can continue to work on your site, but {{strong}}%(domainName)s{{/strong}} won’t be reachable just yet.',
 						{
+							components: {
+								strong: <strong />,
+							},
 							args: {
 								domainName: domain.name,
 							},
@@ -258,17 +266,21 @@ export function resolveDomainStatus(
 
 					renewCta = domain.currentUserIsOwner
 						? translate(
-								'You can renew the domain at the regular rate until %(renewableUntil)s. {{a}}Renew now{{/a}}',
+								'You can renew the domain at the regular rate until {{strong}}%(renewableUntil)s{{/strong}}. {{a}}Renew now{{/a}}',
 								{
 									components: {
+										strong: <strong />,
 										a: <Button plain onClick={ () => handleRenewNowClick( purchase, siteSlug ) } />,
 									},
 									args: { renewableUntil },
 								}
 						  )
 						: translate(
-								'The domain owner can renew the domain at the regular rate until %(renewableUntil)s.',
+								'The domain owner can renew the domain at the regular rate until {{strong}}%(renewableUntil)s{{/strong}}.',
 								{
+									components: {
+										strong: <strong />,
+									},
 									args: { renewableUntil },
 								}
 						  );
@@ -279,28 +291,38 @@ export function resolveDomainStatus(
 
 					renewCta = domain.currentUserIsOwner
 						? translate(
-								'You can still renew the domain until %(redeemableUntil)s by paying an additional redemption fee. {{a}}Renew now{{/a}}',
+								'You can still renew the domain until {{strong}}%(redeemableUntil)s{{/strong}} by paying an additional redemption fee. {{a}}Renew now{{/a}}',
 								{
 									components: {
+										strong: <strong />,
 										a: <Button plain onClick={ () => handleRenewNowClick( purchase, siteSlug ) } />,
 									},
 									args: { redeemableUntil },
 								}
 						  )
 						: translate(
-								'The domain owner can still renew the domain until %(redeemableUntil)s by paying an additional redemption fee.',
+								'The domain owner can still renew the domain until {{strong}}%(redeemableUntil)s{{/strong}} by paying an additional redemption fee.',
 								{
+									components: {
+										strong: <strong />,
+									},
 									args: { redeemableUntil },
 								}
 						  );
 				}
 
-				const domainExpirationMessage = translate( 'This domain expired on %(expiryDate)s. ', {
-					args: {
-						expiryDate: moment.utc( domain.expiry ).format( 'LL' ),
-						renewCta,
-					},
-				} );
+				const domainExpirationMessage = translate(
+					'This domain expired on {{strong}}%(expiryDate)s{{/strong}}. ',
+					{
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							expiryDate: moment.utc( domain.expiry ).format( 'LL' ),
+							renewCta,
+						},
+					}
+				);
 
 				const noticeText = [ domainExpirationMessage, renewCta ];
 
@@ -331,9 +353,13 @@ export function resolveDomainStatus(
 					  } )
 					: translate( 'It can be renewed by the owner.' );
 
-				const domainExpirationMessage = translate( 'This domain will expire on %(expiryDate)s. ', {
-					args: { expiryDate: moment.utc( domain.expiry ).format( 'LL' ) },
-				} );
+				const domainExpirationMessage = translate(
+					'This domain will expire on {{strong}}%(expiryDate)s{{/strong}}. ',
+					{
+						args: { expiryDate: moment.utc( domain.expiry ).format( 'LL' ) },
+						components: { strong: <strong /> },
+					}
+				);
 
 				const expiresMessage = [ domainExpirationMessage, renewCta ];
 
@@ -366,12 +392,13 @@ export function resolveDomainStatus(
 				let noticeText;
 				if ( domain.isPrimary ) {
 					noticeText = translate(
-						'We are setting up your domain. It should start working immediately, but may be unreliable during the first 30 minutes. If you are unable to access your site at %(domainName)s, try setting the primary domain to a domain you know is working. {{learnMore}}Learn more{{/learnMore}} about setting the primary domain, or try {{try}}%(domainName)s{{/try}} now.',
+						'We are setting up your domain. It should start working immediately, but may be unreliable during the first 30 minutes. If you are unable to access your site at {{strong}}%(domainName)s{{/strong}}, try setting the primary domain to a domain you know is working. {{learnMore}}Learn more{{/learnMore}} about setting the primary domain, or try {{try}}{{strong}}%(domainName)s{{/strong}}{{/try}} now.',
 						{
 							args: {
 								domainName: domain.name,
 							},
 							components: {
+								strong: <strong />,
 								learnMore: (
 									<a href={ SETTING_PRIMARY_DOMAIN } rel="noopener noreferrer" target="_blank" />
 								),
@@ -449,9 +476,10 @@ export function resolveDomainStatus(
 						}
 					),
 					noticeText: translate(
-						'Transfer successful! To make this domain work with your WordPress.com site you need {{a}}point it to WordPress.com name servers.{{/a}}',
+						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need {{a}}point it to WordPress.com name servers.{{/a}}',
 						{
 							components: {
+								strong: <strong />,
 								a: <a href={ domainManagementNameServers( siteSlug, domain.domain ) } />,
 							},
 						}
@@ -595,7 +623,7 @@ export function resolveDomainStatus(
 							transferOptions
 						),
 						noticeText: translate(
-							'The transfer should complete by %(transferFinishDate)s. We are waiting for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
+							'The transfer should complete by {{strong}}%(transferFinishDate)s{{/strong}}. We are waiting for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
 							transferOptions
 						),
 						listStatusClass: 'verifying',
@@ -631,7 +659,7 @@ export function resolveDomainStatus(
 				),
 				noticeText: domain.transferEndDate
 					? translate(
-							'The transfer should complete by %(transferFinishDate)s. {{a}}Learn more{{/a}}',
+							'The transfer should complete by {{strong}}%(transferFinishDate)s{{/strong}}. {{a}}Learn more{{/a}}',
 							transferOptions
 					  )
 					: null,

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -284,15 +284,15 @@ export function resolveDomainStatus(
 						  );
 				}
 
-				const noticeText = [
-					translate( 'This domain expired on %(expiryDate)s. ', {
-						args: {
-							expiryDate: moment.utc( domain.expiry ).format( 'LL' ),
-							renewCta,
-						},
-					} ),
-					renewCta,
-				];
+				const domainExpirationMessage = translate( 'This domain expired on %(expiryDate)s. ', {
+					args: {
+						expiryDate: moment.utc( domain.expiry ).format( 'LL' ),
+						renewCta,
+					},
+				} );
+
+				const noticeText = [ domainExpirationMessage, renewCta ];
+
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
@@ -320,20 +320,19 @@ export function resolveDomainStatus(
 					  } )
 					: translate( 'It can be renewed by the owner.' );
 
-				const expiresMessage = [
-					translate( 'This domain will expire on %(expiryDate)s. ', {
-						args: { expiryDate: moment.utc( domain.expiry ).format( 'LL' ) },
-					} ),
-					renewCta,
-				];
+				const domainExpirationMessage = translate( 'This domain will expire on %(expiryDate)s. ', {
+					args: { expiryDate: moment.utc( domain.expiry ).format( 'LL' ) },
+				} );
+
+				const expiresMessage = [ domainExpirationMessage, renewCta ];
 
 				if ( isExpiringSoon( domain, 5 ) ) {
 					return {
-						statusText: expiresMessage,
+						statusText: domainExpirationMessage,
 						statusClass: 'status-error',
 						status: translate( 'Expiring soon' ),
 						icon: 'info',
-						listStatusText: expiresMessage,
+						listStatusText: domainExpirationMessage,
 						noticeText: expiresMessage,
 						listStatusClass: 'alert',
 						listStatusWeight: 1000,

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -39,7 +39,7 @@ export function resolveDomainStatus(
 			),
 		},
 		args: {
-			transferFinishDate: moment( domain.transferEndDate ).format( 'LL' ),
+			transferFinishDate: moment.utc( domain.transferEndDate ).format( 'LL' ),
 		},
 	};
 
@@ -49,10 +49,10 @@ export function resolveDomainStatus(
 				const expiresMessage =
 					null !== domain.bundledPlanSubscriptionId
 						? translate( 'Domain connection expires with your plan on %(expiryDate)s', {
-								args: { expiryDate: moment( domain.expiry ).format( 'LL' ) },
+								args: { expiryDate: moment.utc( domain.expiry ).format( 'LL' ) },
 						  } )
 						: translate( 'Domain connection expires in %(days)s', {
-								args: { days: moment( domain.expiry ).fromNow( true ) },
+								args: { days: moment.utc( domain.expiry ).fromNow( true ) },
 						  } );
 
 				if ( isExpiringSoon( domain, 5 ) ) {
@@ -238,12 +238,12 @@ export function resolveDomainStatus(
 			}
 
 			if ( domain.expired ) {
-				const daysSinceExpiration = moment().diff( domain.expiry, 'days' );
+				const daysSinceExpiration = moment.utc().diff( moment.utc( domain.expiry ), 'days' );
 
 				let renewCta;
 
 				if ( daysSinceExpiration >= 1 && daysSinceExpiration <= 43 ) {
-					const renewableUntil = moment( domain.renewableUntil ).format( 'LL' );
+					const renewableUntil = moment.utc( domain.renewableUntil ).format( 'LL' );
 
 					renewCta = domain.currentUserIsOwner
 						? translate(
@@ -264,7 +264,7 @@ export function resolveDomainStatus(
 				}
 
 				if ( daysSinceExpiration > 43 ) {
-					const redeemableUntil = moment( domain.redeemableUntil ).format( 'LL' );
+					const redeemableUntil = moment.utc( domain.redeemableUntil ).format( 'LL' );
 
 					renewCta = domain.currentUserIsOwner
 						? translate(
@@ -300,7 +300,7 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusText: translate( 'Expired %(timeSinceExpiry)s', {
 						args: {
-							timeSinceExpiry: moment( domain.expiry ).fromNow(),
+							timeSinceExpiry: moment.utc( domain.expiry ).fromNow(),
 						},
 						comment:
 							'timeSinceExpiry is of the form "[number] [time-period] ago" e.g. "3 days ago"',
@@ -544,7 +544,7 @@ export function resolveDomainStatus(
 								),
 							},
 							args: {
-								beginTransferUntilDate: moment( domain.beginTransferUntilDate ).format( 'LL' ),
+								beginTransferUntilDate: moment.utc( domain.beginTransferUntilDate ).format( 'LL' ),
 							},
 						}
 					),

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -219,19 +219,25 @@ export function resolveDomainStatus(
 			}
 
 			if ( domain.isPendingIcannVerification && domain.currentUserCanManage ) {
+				const noticeText = domain.currentUserIsOwner
+					? translate(
+							'We sent an email at %(email)s to verify your contact information. Please complete the verification or your domain will stop working.',
+							{
+								args: {
+									domainName: domain.name,
+									email,
+								},
+							}
+					  )
+					: translate(
+							'We sent an email to the domain owner. Please complete the verification or your domain will stop working.'
+					  );
+
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: translate( 'Verify email' ),
-					noticeText: translate(
-						'We sent you an email at %(email)s to verify your contact information. Please complete the verification or your domain will stop working.',
-						{
-							args: {
-								domainName: domain.name,
-								email,
-							},
-						}
-					),
+					noticeText,
 					icon: 'info',
 					listStatusWeight: 600,
 				};

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -372,14 +372,7 @@ export function resolveDomainStatus(
 					);
 				} else {
 					noticeText = translate(
-						'We are setting up your domain. It should start working immediately, but may be unreliable during the first 30 minutes. {{learnMore}}Learn more{{/learnMore}}',
-						{
-							components: {
-								learnMore: (
-									<a href={ SETTING_PRIMARY_DOMAIN } rel="noopener noreferrer" target="_blank" />
-								),
-							},
-						}
+						'We are setting up your domain. It should start working immediately, but may be unreliable during the first 30 minutes.'
 					);
 				}
 

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -11,7 +11,11 @@ import {
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	GDPR_POLICIES,
 } from 'calypso/lib/url/support';
-import { domainManagementNameServers, domainMappingSetup } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementEditContactInfo,
+	domainManagementNameServers,
+	domainMappingSetup,
+} from 'calypso/my-sites/domains/paths';
 import { transferStatus, type as domainTypes, gdprConsentStatus } from './constants';
 
 export function resolveDomainStatus(
@@ -23,7 +27,6 @@ export function resolveDomainStatus(
 		isDomainOnlySite = false,
 		siteSlug = null,
 		getMappingErrors = false,
-		email = null,
 	} = {}
 ) {
 	const transferOptions = {
@@ -221,11 +224,13 @@ export function resolveDomainStatus(
 			if ( domain.isPendingIcannVerification && domain.currentUserCanManage ) {
 				const noticeText = domain.currentUserIsOwner
 					? translate(
-							'We sent an email at %(email)s to verify your contact information. Please complete the verification or your domain will stop working.',
+							'We sent you an email to verify your contact information. Please complete the verification or your domain will stop working. You can also {{a}}change you email address{{/a}} if you like.',
 							{
+								components: {
+									a: <a href={ domainManagementEditContactInfo( siteSlug, domain.name ) }></a>,
+								},
 								args: {
 									domainName: domain.name,
-									email,
 								},
 							}
 					  )
@@ -461,9 +466,7 @@ export function resolveDomainStatus(
 				domain.pendingRegistration
 			) {
 				const detailCta = domain.currentUserIsOwner
-					? translate( 'Please check the email sent to %(email)s for further details', {
-							args: { email },
-					  } )
+					? translate( 'Please check the email sent to you for further details' )
 					: translate( 'Please check the email sent to the domain owner for further details' );
 
 				const noticeText = translate(

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -425,7 +425,7 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( domain.transfer_status === transferStatus.COMPLETED && ! domain.pointsToWpcom ) {
+			if ( domain.transferStatus === transferStatus.COMPLETED && ! domain.pointsToWpcom ) {
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-success',

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -33,6 +33,7 @@ export const EMAIL_FORWARDING = `${ root }/email-forwarding`;
 export const EMAIL_VALIDATION_AND_VERIFICATION = `${ root }/domains/register-domain/#email-validation-and-verification`;
 export const EMPTY_SITE = `${ root }/empty-site/`;
 export const FORMS = `${ root }/forms`;
+export const GDPR_POLICIES = `${ root }/your-site-and-the-gdpr`;
 export const GSUITE_LEARNING_CENTER = 'https://workspace.google.com/learning-center/';
 export const GUIDED_TRANSFER = `${ root }/guided-transfer`;
 export const HTTPS_SSL = `${ root }/https-ssl`;

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -455,22 +455,13 @@ class DomainRow extends PureComponent {
 	}
 
 	render() {
-		const {
-			domain,
-			contactDetails,
-			isManagingAllSites,
-			site,
-			showCheckbox,
-			purchase,
-			translate,
-		} = this.props;
+		const { domain, isManagingAllSites, site, showCheckbox, purchase, translate } = this.props;
 		const { showNotice } = this.state;
 		const domainTypeText = getDomainTypeText( domain, translate, domainInfoContext.DOMAIN_ROW );
 		const expiryDate = domain?.expiry ? moment.utc( domain?.expiry ) : null;
 		const { noticeText, statusClass } = resolveDomainStatus( domain, purchase, {
 			siteSlug: site?.slug,
 			getMappingErrors: true,
-			email: contactDetails?.email,
 		} );
 
 		return (

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -467,7 +467,7 @@ class DomainRow extends PureComponent {
 		const { showNotice } = this.state;
 		const domainTypeText = getDomainTypeText( domain, translate, domainInfoContext.DOMAIN_ROW );
 		const expiryDate = domain?.expiry ? moment.utc( domain?.expiry ) : null;
-		const { noticeText } = resolveDomainStatus( domain, purchase, {
+		const { noticeText, statusClass } = resolveDomainStatus( domain, purchase, {
 			siteSlug: site?.slug,
 			getMappingErrors: true,
 			email: contactDetails?.email,
@@ -497,7 +497,10 @@ class DomainRow extends PureComponent {
 						<Icon
 							icon={ info }
 							size={ 18 }
-							className="domain-row__domain-notice-icon gridicon"
+							className={ classnames( 'domain-row__domain-notice-icon gridicon', {
+								'gridicon--error': 'status-success' !== statusClass,
+								'gridicon--success': 'status-success' === statusClass,
+							} ) }
 							viewBox="2 2 20 20"
 						/>
 						<div className="domain-row__domain-notice-message">{ noticeText }</div>

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { Icon, home, info, moreVertical, redo, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -63,10 +63,6 @@ class DomainRow extends PureComponent {
 		isLoadingDomainDetails: false,
 		isBusy: false,
 		showDomainDetails: true,
-	};
-
-	state = {
-		showNotice: true,
 	};
 
 	stopPropagation = ( event ) => {
@@ -425,10 +421,6 @@ class DomainRow extends PureComponent {
 		);
 	}
 
-	dismissNotice = () => {
-		this.setState( { showNotice: false } );
-	};
-
 	handleDomainSelection = ( event ) => {
 		const { domain } = this.props;
 		return this.props.handleDomainItemToggle( domain.name, event.target.checked );
@@ -456,7 +448,6 @@ class DomainRow extends PureComponent {
 
 	render() {
 		const { domain, isManagingAllSites, site, showCheckbox, purchase, translate } = this.props;
-		const { showNotice } = this.state;
 		const domainTypeText = getDomainTypeText( domain, translate, domainInfoContext.DOMAIN_ROW );
 		const expiryDate = domain?.expiry ? moment.utc( domain?.expiry ) : null;
 		const { noticeText, statusClass } = resolveDomainStatus( domain, purchase, {
@@ -483,7 +474,7 @@ class DomainRow extends PureComponent {
 					{ this.renderDomainStatus() }
 					{ this.renderMobileExtraInfo( expiryDate, domainTypeText ) }
 				</div>
-				{ showNotice && noticeText && (
+				{ noticeText && (
 					<div className="domain-row__domain-notice">
 						<Icon
 							icon={ info }
@@ -495,13 +486,6 @@ class DomainRow extends PureComponent {
 							viewBox="2 2 20 20"
 						/>
 						<div className="domain-row__domain-notice-message">{ noticeText }</div>
-						<Button
-							className="domain-row__domain-notice-dismiss"
-							onClick={ this.dismissNotice }
-							plain
-						>
-							<Gridicon icon="cross" size={ 16 } />
-						</Button>
 					</div>
 				) }
 				{ this.renderOverlay() }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,5 +1,5 @@
-import { Button } from '@automattic/components';
-import { Icon, home, moreVertical, redo, plus } from '@wordpress/icons';
+import { Button, Gridicon } from '@automattic/components';
+import { Icon, home, info, moreVertical, redo, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -469,6 +469,28 @@ class DomainRow extends PureComponent {
 				<div className="domain-row__mobile-container3">
 					{ this.renderDomainStatus() }
 					{ this.renderMobileExtraInfo( expiryDate, domainTypeText ) }
+				</div>
+				<div className="domain-row__domain-notice">
+					<Icon
+						icon={ info }
+						size={ 18 }
+						className="domain-row__domain-notice-icon gridicon"
+						viewBox="2 2 20 20"
+					/>
+					<div className="domain-row__domain-notice-message">
+						{ translate(
+							'Maecenas sed diam eget risus varius {{strong}}blandit sit amet{{/strong}} non magna. Donec sed odio dui. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. {{a}}Euismod Malesuada{{/a}}',
+							{
+								components: {
+									strong: <strong />,
+									a: <a href="#" target="_blank" rel="noopener noreferrer" />,
+								},
+							}
+						) }
+					</div>
+					<Button className="domain-row__domain-notice-dismiss" href="#" plain>
+						<Gridicon icon="cross" size={ 16 } />
+					</Button>
 				</div>
 				{ this.renderOverlay() }
 			</div>

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -65,6 +65,10 @@ class DomainRow extends PureComponent {
 		showDomainDetails: true,
 	};
 
+	state = {
+		showNotice: true,
+	};
+
 	stopPropagation = ( event ) => {
 		event.stopPropagation();
 	};
@@ -421,6 +425,10 @@ class DomainRow extends PureComponent {
 		);
 	}
 
+	dismissNotice = () => {
+		this.setState( { showNotice: false } );
+	};
+
 	handleDomainSelection = ( event ) => {
 		const { domain } = this.props;
 		return this.props.handleDomainItemToggle( domain.name, event.target.checked );
@@ -447,9 +455,23 @@ class DomainRow extends PureComponent {
 	}
 
 	render() {
-		const { domain, isManagingAllSites, showCheckbox, translate } = this.props;
+		const {
+			domain,
+			contactDetails,
+			isManagingAllSites,
+			site,
+			showCheckbox,
+			purchase,
+			translate,
+		} = this.props;
+		const { showNotice } = this.state;
 		const domainTypeText = getDomainTypeText( domain, translate, domainInfoContext.DOMAIN_ROW );
 		const expiryDate = domain?.expiry ? moment.utc( domain?.expiry ) : null;
+		const { noticeText } = resolveDomainStatus( domain, purchase, {
+			siteSlug: site?.slug,
+			getMappingErrors: true,
+			email: contactDetails?.email,
+		} );
 
 		return (
 			<div className="domain-row">
@@ -470,28 +492,24 @@ class DomainRow extends PureComponent {
 					{ this.renderDomainStatus() }
 					{ this.renderMobileExtraInfo( expiryDate, domainTypeText ) }
 				</div>
-				<div className="domain-row__domain-notice">
-					<Icon
-						icon={ info }
-						size={ 18 }
-						className="domain-row__domain-notice-icon gridicon"
-						viewBox="2 2 20 20"
-					/>
-					<div className="domain-row__domain-notice-message">
-						{ translate(
-							'Maecenas sed diam eget risus varius {{strong}}blandit sit amet{{/strong}} non magna. Donec sed odio dui. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. {{a}}Euismod Malesuada{{/a}}',
-							{
-								components: {
-									strong: <strong />,
-									a: <a href="#" target="_blank" rel="noopener noreferrer" />,
-								},
-							}
-						) }
+				{ showNotice && noticeText && (
+					<div className="domain-row__domain-notice">
+						<Icon
+							icon={ info }
+							size={ 18 }
+							className="domain-row__domain-notice-icon gridicon"
+							viewBox="2 2 20 20"
+						/>
+						<div className="domain-row__domain-notice-message">{ noticeText }</div>
+						<Button
+							className="domain-row__domain-notice-dismiss"
+							onClick={ this.dismissNotice }
+							plain
+						>
+							<Gridicon icon="cross" size={ 16 } />
+						</Button>
 					</div>
-					<Button className="domain-row__domain-notice-dismiss" href="#" plain>
-						<Gridicon icon="cross" size={ 16 } />
-					</Button>
-				</div>
+				) }
 				{ this.renderOverlay() }
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -7,6 +7,7 @@
 	border-bottom: 1px solid var( --studio-gray-5 );
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
+	flex-wrap: wrap;
 
 	@include break-mobile {
 		display: flex;
@@ -74,6 +75,7 @@
 	flex: 233 233 0;
 	overflow: hidden;
 	display: flex;
+	flex-basis: 100%;
 }
 
 .domain-row__mobile-container2 {
@@ -94,6 +96,39 @@
 
 	@include break-mobile {
 		display: none;
+	}
+}
+
+.domain-row__domain-notice {
+	flex-basis: 100%;
+	background-color: var( --studio-gray-0 );
+	display: flex;
+	align-items: center;
+	padding: 5px;
+	margin-top: 12px;
+	gap: 8px;
+	border-radius: 2px;
+
+	.domain-row__domain-notice-icon.gridicon {
+		align-self: flex-start;
+		min-width: 18px;
+		fill: var( --studio-orange-40 );
+		position: relative;
+		top: 2px;
+	}
+
+	.domain-row__domain-notice-message {
+		font-weight: 400;
+		font-size: $font-body-small;
+		color: var( --studio-gray-80 );
+	}
+
+	.domain-row__domain-notice-dismiss {
+		margin-left: auto;
+		.gridicon {
+			fill: var( --studio-gray-20 );
+			vertical-align: middle;
+		}
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -121,6 +121,15 @@
 		font-weight: 400;
 		font-size: $font-body-small;
 		color: var( --studio-gray-80 );
+
+		button.button-plain {
+			cursor: pointer;
+			color: var( --color-link );
+
+			&:hover, &:focus, &:active {
+				color: var( --color-link-dark );
+			}
+		}
 	}
 
 	.domain-row__domain-notice-dismiss {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -112,9 +112,17 @@
 	.domain-row__domain-notice-icon.gridicon {
 		align-self: flex-start;
 		min-width: 18px;
-		fill: var( --studio-orange-40 );
+		fill: var( --studio-gray-20 );
 		position: relative;
 		top: 2px;
+
+		&--error {
+			fill: var( --studio-orange-40 );
+		}
+
+		&--success {
+			fill: var( --studio-green-50 );
+		}
 	}
 
 	.domain-row__domain-notice-message {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -118,6 +118,7 @@
 
 		&--error {
 			fill: var( --studio-orange-40 );
+			transform: rotate( 180deg );
 		}
 
 		&--success {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -135,6 +135,7 @@
 	.domain-row__domain-notice-dismiss {
 		margin-left: auto;
 		.gridicon {
+			cursor: pointer;
 			fill: var( --studio-gray-20 );
 			vertical-align: middle;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR creates the redesigned notices with the new messages and statuses - as described in p1638882214174600-slack-C020919TDRA) for the domain list. 

This is part of the domain settings pages redesign project detailed in pcYYhz-m2-p2.

#### Preview - all possible status
![image](https://user-images.githubusercontent.com/18705930/148577243-710987ff-3ebb-4fd5-9388-0a3821251cb7.png)

#### Testing instructions
- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades > Domains"
- Make sure that the notices are correctly displayed following the same logic described in p1638882214174600-slack-C020919TDRA.
- Confirm that all the original features of the "old" management pages are still working as intended.

**P.S: Please note that it was not possible to implement some of the statuses in the notices. We will eventually move the controlling logic for them somewhere else so these remaining statuses can be handled.**