### PR TITLE
WPCOM: migrate `undocumented.applyDnsTemplateSyncFlow` to `wpcom.req`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -11,20 +11,6 @@ function Undocumented( wpcom ) {
 	this.wpcom = wpcom;
 }
 
-Undocumented.prototype.getDnsTemplateRecords = function (
-	domain,
-	provider,
-	service,
-	variables,
-	callback
-) {
-	return this.wpcom.req.post(
-		'/domains/' + domain + '/dns/providers/' + provider + '/services/' + service + '/preview',
-		{ variables },
-		callback
-	);
-};
-
 Undocumented.prototype.getDomainConnectSyncUxUrl = function (
 	domain,
 	providerId,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -11,24 +11,6 @@ function Undocumented( wpcom ) {
 	this.wpcom = wpcom;
 }
 
-Undocumented.prototype.applyDnsTemplateSyncFlow = function (
-	domain,
-	provider,
-	service,
-	variables,
-	callback
-) {
-	return this.wpcom.req.get(
-		'/domain-connect/authorize/v2/domainTemplates/providers/' +
-			provider +
-			'/services/' +
-			service +
-			'/apply/authorized',
-		Object.assign( {}, { apiVersion: '1.3' }, variables ),
-		callback
-	);
-};
-
 Undocumented.prototype.getDnsTemplateRecords = function (
 	domain,
 	provider,

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -33,14 +33,8 @@ class DomainConnectAuthorize extends Component {
 
 		wpcom.req
 			.post(
-				'/domains/' +
-					domain +
-					'/dns/providers/' +
-					providerId +
-					'/services/' +
-					serviceId +
-					'/preview',
-				{ params }
+				`/domains/'${ domain }/dns/providers/${ providerId }/services/${ serviceId }/preview`,
+				{ variables: params }
 			)
 			.then(
 				( data ) => {
@@ -83,12 +77,8 @@ class DomainConnectAuthorize extends Component {
 
 		wpcom.req
 			.get(
-				'/domain-connect/authorize/v2/domainTemplates/providers/' +
-					providerId +
-					'/services/' +
-					serviceId +
-					'/apply/authorized',
-				Object.assign( {}, { apiVersion: '1.3' }, params )
+				`/domain-connect/authorize/v2/domainTemplates/providers/${ providerId }/services/${ serviceId }/apply/authorized`,
+				{ apiVersion: '1.3', ...params }
 			)
 			.then(
 				( result ) => {

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -4,15 +4,13 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import { actionType, noticeType } from './constants';
 import DomainConnectAuthorizeDescription from './domain-connect-authorize-description';
 import DomainConnectAuthorizeFooter from './domain-connect-authorize-footer';
 import DomainConnectAuthorizeRecords from './domain-connect-authorize-records';
 
 import './domain-connect-authorize.scss';
-
-const wpcom = wp.undocumented();
 
 class DomainConnectAuthorize extends Component {
 	static propTypes = {

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -33,7 +33,7 @@ class DomainConnectAuthorize extends Component {
 
 		wpcom.req
 			.post(
-				`/domains/'${ domain }/dns/providers/${ providerId }/services/${ serviceId }/preview`,
+				`/domains/${ domain }/dns/providers/${ providerId }/services/${ serviceId }/preview`,
 				{ variables: params }
 			)
 			.then(

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -31,8 +31,17 @@ class DomainConnectAuthorize extends Component {
 		const { providerId, serviceId, params, translate } = this.props;
 		const { domain } = params;
 
-		wpcom
-			.getDnsTemplateRecords( domain, providerId, serviceId, params )
+		wpcom.req
+			.post(
+				'/domains/' +
+					domain +
+					'/dns/providers/' +
+					providerId +
+					'/services/' +
+					serviceId +
+					'/preview',
+				{ params }
+			)
 			.then(
 				( data ) => {
 					this.setState( {

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -32,10 +32,9 @@ class DomainConnectAuthorize extends Component {
 		const { domain } = params;
 
 		wpcom.req
-			.post(
-				`/domains/${ domain }/dns/providers/${ providerId }/services/${ serviceId }/preview`,
-				{ variables: params }
-			)
+			.post( `/domains/${ domain }/dns/providers/${ providerId }/services/${ serviceId }/preview`, {
+				variables: params,
+			} )
 			.then(
 				( data ) => {
 					this.setState( {

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -66,44 +66,52 @@ class DomainConnectAuthorize extends Component {
 
 	handleClickConfirm = () => {
 		const { providerId, serviceId, params, translate } = this.props;
-		const { domain } = params;
 
 		this.setState( {
 			action: actionType.SUBMITTING,
 			noticeType: null,
 		} );
 
-		wpcom.applyDnsTemplateSyncFlow( domain, providerId, serviceId, params ).then(
-			( result ) => {
-				let action = actionType.CLOSE;
-				let noticeMessage = translate( 'Hurray! Your new service is now all set up.' );
-				if ( result.redirect_uri ) {
-					action = actionType.REDIRECTING;
-					noticeMessage = translate(
-						"Please wait while we redirect you back to the service provider's site to finalize this update."
-					);
-					window.location.assign( result.redirect_uri );
-				}
-				this.setState( {
-					action,
-					noticeMessage,
-					noticeType: noticeType.SUCCESS,
-				} );
-			},
-			( error ) => {
-				const errorMessage =
-					error.message ||
-					translate(
-						"We weren't able to add the DNS records needed for this service. Please try again."
-					);
+		wpcom.req
+			.get(
+				'/domain-connect/authorize/v2/domainTemplates/providers/' +
+					providerId +
+					'/services/' +
+					serviceId +
+					'/apply/authorized',
+				Object.assign( {}, { apiVersion: '1.3' }, params )
+			)
+			.then(
+				( result ) => {
+					let action = actionType.CLOSE;
+					let noticeMessage = translate( 'Hurray! Your new service is now all set up.' );
+					if ( result.redirect_uri ) {
+						action = actionType.REDIRECTING;
+						noticeMessage = translate(
+							"Please wait while we redirect you back to the service provider's site to finalize this update."
+						);
+						window.location.assign( result.redirect_uri );
+					}
+					this.setState( {
+						action,
+						noticeMessage,
+						noticeType: noticeType.SUCCESS,
+					} );
+				},
+				( error ) => {
+					const errorMessage =
+						error.message ||
+						translate(
+							"We weren't able to add the DNS records needed for this service. Please try again."
+						);
 
-				this.setState( {
-					action: actionType.READY_TO_SUBMIT,
-					noticeMessage: errorMessage,
-					noticeType: noticeType.ERROR,
-				} );
-			}
-		);
+					this.setState( {
+						action: actionType.READY_TO_SUBMIT,
+						noticeMessage: errorMessage,
+						noticeType: noticeType.ERROR,
+					} );
+				}
+			);
 	};
 
 	handleClickClose = () => {


### PR DESCRIPTION
Refactors both `undocumented.applyDnsTemplateSyncFlow` and `undocumented.getDnsTemplateRecords`. Combining into a single PR because they look like small and closely related changes.

The refactor on these two look fairly straightforward, but I could use some advice on testing. Reading over the code, it looks like these are methods used when a domain connection to WPCOM is initiated by an external provider, but I wasn't able to identify a flow to test the method in real time.

The methoda are called as [part of the `DomainConnectAuthorize` component](https://github.com/Automattic/wp-calypso/blob/e64ec136821355ae29226b39f0ab409f55ef64b3/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx#L76), which is controlled via [this router](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/domains/domain-management/domain-connect/index.jsx). Any tips on the next step of that trail would be appreciated 😄 

Related to #58458
