### PR TITLE
Theme Showcase: Re-add prices

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,4 +1,4 @@
-import { Card, Ribbon, Gridicon } from '@automattic/components';
+import { Card, Ribbon, Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty, isEqual, some } from 'lodash';
@@ -7,8 +7,10 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Badge from 'calypso/components/badge';
+import InfoPopover from 'calypso/components/info-popover';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -36,6 +38,8 @@ export class Theme extends Component {
 		} ),
 		// If true, highlight this theme as active
 		active: PropTypes.bool,
+		// Theme price (pre-formatted string) -- empty string indicates free theme
+		price: PropTypes.string,
 		// If true, the theme is being installed
 		installing: PropTypes.bool,
 		// If true, render a placeholder
@@ -84,6 +88,7 @@ export class Theme extends Component {
 		return (
 			nextProps.theme.id !== this.props.theme.id ||
 			nextProps.active !== this.props.active ||
+			nextProps.price !== this.props.price ||
 			nextProps.installing !== this.props.installing ||
 			! isEqual(
 				Object.keys( nextProps.buttonContents ),
@@ -128,18 +133,33 @@ export class Theme extends Component {
 		}
 	}
 
+	onUpsellClick = () => {
+		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
+			cta_name: 'theme-upsell-popup',
+			theme: this.props.theme.id,
+		} );
+	};
+
 	setBookmark = () => {
 		this.props.setThemesBookmark( this.props.theme.id );
 	};
 
 	render() {
-		const { active, blockEditorSettings, theme, translate } = this.props;
+		const { active, blockEditorSettings, price, theme, translate, upsellUrl } = this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
 			'is-active': active,
 			'is-actionable': isActionable,
 		} );
+
+		const hasPrice = /\d/g.test( price );
+		const showUpsell = hasPrice && upsellUrl;
+		const priceClass = classNames( 'theme__badge-price', {
+			'theme__badge-price-upgrade': ! hasPrice,
+			'theme__badge-price-test': showUpsell,
+		} );
+
 		const themeDescription = decodeEntities( description );
 
 		// for performance testing
@@ -148,6 +168,37 @@ export class Theme extends Component {
 		if ( this.props.isPlaceholder ) {
 			return this.renderPlaceholder();
 		}
+
+		const impressionEventName = 'calypso_upgrade_nudge_impression';
+		const upsellEventProperties = { cta_name: 'theme-upsell', theme: theme.id };
+		const upsellPopupEventProperties = { cta_name: 'theme-upsell-popup', theme: theme.id };
+		const upsell = showUpsell && (
+			<span className="theme__upsell">
+				<TrackComponentView
+					eventName={ impressionEventName }
+					eventProperties={ upsellEventProperties }
+				/>
+				<InfoPopover icon="star" className="theme__upsell-icon" position="top left">
+					<TrackComponentView
+						eventName={ impressionEventName }
+						eventProperties={ upsellPopupEventProperties }
+					/>
+					<div className="theme__upsell-popover">
+						<h2 className="theme__upsell-heading">
+							{ translate( 'Use this theme at no extra cost on our Premium or Business Plan' ) }
+						</h2>
+						<Button
+							onClick={ this.onUpsellClick }
+							className="theme__upsell-cta"
+							primary
+							href={ upsellUrl }
+						>
+							{ translate( 'Upgrade Now' ) }
+						</Button>
+					</div>
+				</InfoPopover>
+			</span>
+		);
 
 		const fit = '479,360';
 		const themeImgSrc = photon( screenshot, { fit } );
@@ -208,6 +259,8 @@ export class Theme extends Component {
 								} ) }
 							</span>
 						) }
+						<span className={ priceClass }>{ price }</span>
+						{ upsell }
 						{ ! isEmpty( this.props.buttonContents ) ? (
 							<ThemeMoreButton
 								index={ this.props.index }

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -83,6 +83,53 @@ $theme-info-height: 54px;
 	}
 }
 
+.theme__badge-price {
+	flex: 0 0 auto;
+	padding: 18px 10px 0;
+	color: var( --color-success );
+	font-size: $font-body-small;
+	font-weight: 600;
+}
+
+.theme__badge-price-test {
+	padding: 18px 5px;
+}
+
+.theme__upsell {
+	flex: 0 0 auto;
+	padding: 16px 10px 0 0;
+	color: var( --color-neutral-light );
+}
+
+.theme__upsell-icon svg {
+	transform: scale( 0.8 );
+	border: 2px solid var( --color-neutral-20 );
+	border-radius: 100%;
+	display: inline-block;
+	width: 22px;
+	height: 22px;
+	z-index: 0;
+	padding: 0 1px 1px 0;
+	box-sizing: border-box;
+
+	&:hover {
+		border-color: #000;
+	}
+}
+
+.theme__upsell-popover {
+	text-align: center;
+}
+
+.theme__upsell-cta {
+	margin-top: 10px;
+}
+
+.theme__badge-price-upgrade {
+	text-transform: uppercase;
+	font-size: 80%;
+}
+
 .theme__badge-active {
 	flex: 0 0 auto;
 	padding: 18px 10px 0;

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -33,6 +33,9 @@ exports[`Theme rendering with default display buttonContents should match snapsh
       >
         Twenty Seventeen
       </h2>
+      <span
+        className="theme__badge-price theme__badge-price-upgrade"
+      />
       <ThemeMoreButton
         active={false}
         onMoreButtonClick={[Function]}

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { parse } from 'url';
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import { createElement } from 'react';
@@ -60,16 +61,24 @@ describe( 'Theme', () => {
 			test( 'should include photon parameters', () => {
 				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
 				const src = imgNode.getAttribute( 'src' );
-				const url = new URL( src );
-				const params = new URLSearchParams( url.search );
-				const fitParam = params.get( 'fit' );
-				expect( fitParam ).toEqual( expect.stringMatching( /\d+,\d+/ ) );
+				const { query } = parse( src, true );
+
+				expect( query ).toMatchObject( {
+					fit: expect.stringMatching( /\d+,\d+/ ),
+				} );
 			} );
 
 			test( 'should call onScreenshotClick() on click on screenshot', () => {
 				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
 				TestUtils.Simulate.click( imgNode );
 				assert( props.onScreenshotClick.calledOnce, 'onClick did not trigger onScreenshotClick' );
+			} );
+
+			test( 'should not show a price when there is none', () => {
+				assert(
+					themeNode.getElementsByClassName( 'price' ).length === 0,
+					'price should not appear'
+				);
 			} );
 
 			test( 'should render a More button', () => {
@@ -115,6 +124,19 @@ describe( 'Theme', () => {
 		test( 'should render a <div> with an is-placeholder class', () => {
 			assert( themeNode.nodeName === 'DIV', 'nodeName doesn\'t equal "DIV"' );
 			assert.include( themeNode.className, 'is-placeholder', 'no is-placeholder' );
+		} );
+	} );
+
+	describe( 'when the theme has a price', () => {
+		beforeEach( () => {
+			const themeElement = TestUtils.renderIntoDocument(
+				createElement( Theme, { ...props, price: '$50' } )
+			);
+			themeNode = ReactDom.findDOMNode( themeElement );
+		} );
+
+		test( 'should show a price', () => {
+			assert( themeNode.getElementsByClassName( 'theme__badge-price' )[ 0 ].textContent === '$50' );
 		} );
 	} );
 } );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -55,6 +55,7 @@ import {
 	isPremiumThemeAvailable,
 	isWpcomTheme as isThemeWpcom,
 	getCanonicalTheme,
+	getPremiumThemePrice,
 	getThemeDetailsUrl,
 	getThemeRequestErrors,
 	getThemeForumUrl,
@@ -77,6 +78,7 @@ class ThemeSheet extends Component {
 		author: PropTypes.string,
 		screenshot: PropTypes.string,
 		screenshots: PropTypes.array,
+		price: PropTypes.string,
 		description: PropTypes.string,
 		descriptionLong: PropTypes.oneOfType( [
 			PropTypes.string,
@@ -604,9 +606,25 @@ class ThemeSheet extends Component {
 		);
 	};
 
+	renderPrice = () => {
+		let price = this.props.price;
+		if ( ! this.isLoaded() || this.props.isActive ) {
+			price = '';
+		} else if ( ! this.props.isPremium ) {
+			price = this.props.translate( 'Free' );
+		}
+
+		const className = classNames( 'theme__sheet-action-bar-cost', {
+			'theme__sheet-action-bar-cost-upgrade': ! /\d/g.test( this.props.price ),
+		} );
+
+		return price ? <span className={ className }>{ price }</span> : '';
+	};
+
 	renderButton = () => {
 		const { getUrl } = this.props.defaultOption;
 		const label = this.getDefaultOptionLabel();
+		const price = this.renderPrice();
 		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
 		const { isActive } = this.props;
 
@@ -619,6 +637,11 @@ class ThemeSheet extends Component {
 				target={ isActive ? '_blank' : null }
 			>
 				{ this.isLoaded() ? label : placeholder }
+				{ price && this.props.isWpcomTheme && (
+					<Badge type="info" className="theme__sheet-badge-beta">
+						{ price }
+					</Badge>
+				) }
 			</Button>
 		);
 	};
@@ -843,6 +866,7 @@ export default connect(
 		return {
 			...theme,
 			id,
+			price: getPremiumThemePrice( state, id, siteId ),
 			error,
 			siteId,
 			siteSlug,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-add premium themes prince refs - Revert changes from #58677 

- Re-add individual theme price on theme sheet
- Re-add individual theme price and upsell icon/tooltip on multi-theme views
- Re-add related tests/snapshots

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the API and on your sandbox, comment out the retired themes filter on line 194 of `public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-themes-v1-2-endpoint.php`
* Visit `/themes/siteurl.wordpress.com/?flags=themes/premium` to enable the feature flag
* Edit your local calypso and add `theme.retired = false;` on or around line 827 of `/client/my-sites/theme/main.jsx`
* Click on the Premium filter to show only Premium themes; you should be able to see all retired premium themes in the Showcase now
* You should be able to see individual price information when viewing all premium themes in the Showcase
* Clicking on any premium theme should show the theme sheet, which should have an individual price as well.

<img width="1154" alt="Screen Shot 2021-11-30 at 2 15 20 PM" src="https://user-images.githubusercontent.com/2124984/144112818-856735b9-56ff-4c25-9042-9e3c46c96f68.png">
<img width="1449" alt="Screen Shot 2021-11-30 at 2 15 39 PM" src="https://user-images.githubusercontent.com/2124984/144112832-a3a43fef-7b00-4760-bbae-6e755924b5b0.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59125
