### PR TITLE
Remove domains/transfers-redesign feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -302,15 +302,11 @@ export default {
 	},
 
 	domainManagementTransfer( pageContext, next ) {
-		let component = DomainManagement.Transfer;
-		if ( config.isEnabled( 'domains/transfers-redesign' ) ) {
-			component = DomainManagement.TransferPage;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransfer( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Transfer"
-				component={ component }
+				component={ DomainManagement.TransferPage }
 				context={ pageContext }
 				needsDomains
 				selectedDomainName={ pageContext.params.domain }
@@ -320,15 +316,11 @@ export default {
 	},
 
 	domainManagementTransferToOtherSite( pageContext, next ) {
-		let transferComponent = DomainManagement.TransferToOtherSite;
-		if ( config.isEnabled( 'domains/transfers-redesign' ) ) {
-			transferComponent = DomainManagement.TransferDomainToOtherSite;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransferToOtherSite( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Transfer To Other Site"
-				component={ transferComponent }
+				component={ DomainManagement.TransferDomainToOtherSite }
 				context={ pageContext }
 				needsDomains
 				selectedDomainName={ pageContext.params.domain }
@@ -338,15 +330,11 @@ export default {
 	},
 
 	domainManagementTransferToOtherUser( pageContext, next ) {
-		let transferComponent = DomainManagement.TransferToOtherUser;
-		if ( config.isEnabled( 'domains/transfers-redesign' ) ) {
-			transferComponent = DomainManagement.TransferDomainToOtherUser;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransferToAnotherUser( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Transfer To Other User"
-				component={ transferComponent }
+				component={ DomainManagement.TransferDomainToOtherUser }
 				context={ pageContext }
 				needsDomains
 				selectedDomainName={ pageContext.params.domain }

--- a/config/development.json
+++ b/config/development.json
@@ -57,7 +57,6 @@
 		"domains/settings-page-redesign": true,
 		"domains/dns-records-redesign": true,
 		"domains/contact-info-redesign": true,
-		"domains/transfers-redesign": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the feature flag to make the new domain transfer pages live for all users.

#### Testing instructions

Make sure to use: `flags=-domains/transfers-redesign,-domains/settings-page-redesign` when testing. Go to the domain transfer pages (`/domains/manage/<domain name>/transfer/<site name>`) and make sure that the redesigned transfer pages are shown:

<img width="1408" alt="Screen Shot 2021-12-13 at 4 15 10 PM" src="https://user-images.githubusercontent.com/1379730/145889971-ed18fb30-1eb5-4527-a17e-8eab7eafb377.png">

<img width="1408" alt="Screen Shot 2021-12-13 at 3 17 44 PM" src="https://user-images.githubusercontent.com/1379730/145889800-134dd0ae-0b98-4b01-a4af-b6920f0f978c.png">

<img width="1408" alt="Screen Shot 2021-12-13 at 4 15 45 PM" src="https://user-images.githubusercontent.com/1379730/145890027-c6f4156e-986c-4d15-b0f3-ac7863d4577c.png">

