### PR TITLE
Better text wrapping in <SelectItems> when descriptions are long

### DIFF
--- a/client/signup/select-items/index.tsx
+++ b/client/signup/select-items/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { TranslateResult } from 'i18n-calypso';
-import React from 'react';
+import { preventWidows } from 'calypso/lib/formatting';
 import './style.scss';
 
 export interface SelectItem< T > {
@@ -28,8 +28,8 @@ function SelectItems< T >( { className, items, onSelect }: Props< T > ): React.R
 					<Icon className="select-items__item-icon" icon={ icon } size={ 24 } />
 					<div className="select-items__item-info-wrapper">
 						<div className="select-items__item-info">
-							<h2 className="select-items__item-title">{ title }</h2>
-							<p className="select-items__item-description">{ description }</p>
+							<h2 className="select-items__item-title">{ preventWidows( title ) }</h2>
+							<p className="select-items__item-description">{ preventWidows( description ) }</p>
 						</div>
 						<Button className="select-items__item-button" onClick={ () => onSelect( value ) }>
 							{ actionText }

--- a/client/signup/select-items/style.scss
+++ b/client/signup/select-items/style.scss
@@ -47,7 +47,10 @@
 
 	&-info {
 		flex: 1;
-		padding-right: 6px;
+
+		@include break-mobile {
+			padding-right: 20px;
+		}
 	}
 
 	&-title {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

@autumnfjeld discovered the action description text in the starting point screen doesn't wrap well in `nl`. https://github.com/Automattic/wp-calypso/pull/58979#issuecomment-990026588
![145439071-bde93008-bf34-4c4c-88d3-e18258d36d64](https://user-images.githubusercontent.com/1500769/145896852-64db6843-dbff-409d-ab5a-cd3e3192a22d.png)

* Improve `<SelectItems>`' text wrapping
  * Add extra padding to the right of the text so it matches the amount of padding we use elsewhere in Hero Flow
  * Use `preventWidows()` so we don't have single words on their own line.

After fix on desktop:
<img width="575" alt="Screenshot 2021-12-14 at 10 58 34 AM" src="https://user-images.githubusercontent.com/1500769/145898155-32733c77-e545-4fcc-b1a7-7cbdbb24a353.png">

After fix on mobile:
<img width="394" alt="Screenshot 2021-12-14 at 11 20 01 AM" src="https://user-images.githubusercontent.com/1500769/145898190-0f35da16-af60-490d-acd3-4481852ad116.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to `nl` (or any other language you want to test)
* Navigate to the `starting-point` step in the Hero Flow
* Try various screen widths to confirm the long descriptions wrap nicely

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58859
