### PR TITLE
Videos UI - add notification that videos are only in English

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -27,7 +27,8 @@ const VideosUi = ( { HeaderBar, FooterBar, areVideosTranslated = true } ) => {
 	}, [ initialUserCourseProgression ] );
 
 	const [ shouldShowVideoTranslationNotice, setShouldShowVideoTranslationNotice ] = useState(
-		! isEnglish && ! areVideosTranslated
+		// @TODO remove the '&& false' as soon as notification text is translated
+		! isEnglish && ! areVideosTranslated && false
 	);
 
 	const completedVideoCount = Object.keys( userCourseProgression ).length;

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -1,16 +1,19 @@
+import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
+import Notice from 'calypso/components/notice';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import useUpdateUserCourseProgressionMutation from 'calypso/data/courses/use-update-user-course-progression-mutation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import VideoPlayer from './video-player';
 import './style.scss';
 
-const VideosUi = ( { HeaderBar, FooterBar } ) => {
+const VideosUi = ( { HeaderBar, FooterBar, areVideosTranslated = true } ) => {
 	const translate = useTranslate();
+	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
 
 	const courseSlug = 'blogging-quick-start';
 	const { data: course } = useCourseQuery( courseSlug, { retry: false } );
@@ -22,6 +25,10 @@ const VideosUi = ( { HeaderBar, FooterBar } ) => {
 	useEffect( () => {
 		setUserCourseProgression( initialUserCourseProgression );
 	}, [ initialUserCourseProgression ] );
+
+	const [ shouldShowVideoTranslationNotice, setShouldShowVideoTranslationNotice ] = useState(
+		! isEnglish && ! areVideosTranslated
+	);
 
 	const completedVideoCount = Object.keys( userCourseProgression ).length;
 	const courseChapterCount = course ? Object.keys( course.videos ).length : 0;
@@ -120,6 +127,18 @@ const VideosUi = ( { HeaderBar, FooterBar } ) => {
 			<div className="videos-ui__body">
 				<div className="videos-ui__body-title">
 					<h3>{ course && course.title }</h3>
+					{ currentVideo && shouldShowVideoTranslationNotice && (
+						<Notice onDismissClick={ () => setShouldShowVideoTranslationNotice( false ) }>
+							{ translate(
+								'These videos are currently only available in English. Please {{supportLink}}let us know{{/supportLink}} if you would like them translated.',
+								{
+									components: {
+										supportLink: <a href="mailto:support@wordpress.com" />,
+									},
+								}
+							) }
+						</Notice>
+					) }
 				</div>
 				<div className="videos-ui__video-content">
 					{ currentVideo && (

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -76,6 +76,10 @@
 			margin-bottom: 24px;
 		}
 
+		.notice {
+			background-color: #1d262a;
+		}
+
 		.videos-ui__video-content {
 			display: flex;
 			flex-direction: column;

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
@@ -19,6 +19,7 @@ const BloggingQuickStartModal = ( props ) => {
 						FooterBar={ ( footerProps ) => (
 							<ModalFooterBar onBackClick={ onClose } { ...footerProps } />
 						) }
+						areVideosTranslated={ false }
 					/>
 				</BlankCanvas.Content>
 			</BlankCanvas>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR addresses https://github.com/Automattic/wp-calypso/issues/58206 by adding a notice bar to the Videos UI when the user is using any account language other than English, indicating that the videos are not currently translated and providing a support email where the user can reach out to request translations.

(Note - do not merge this until we have feedback from Ollie in #58206 regarding the style of the notice.

![image](https://user-images.githubusercontent.com/13437011/145898809-7cbba337-e0e1-4f34-b632-2c420bdc5963.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to local.
* Sandbox the API, and comment out lines 98-100 of `wp-content/lib/home/cards.php` (which hides the card for non-English speakers).
    * Also comment out the `&& false` on `client/components/videos-ui/index.jsx:31`, which is added to [hide the notification until we have gotten it translated](https://github.com/Automattic/wp-calypso/pull/59155#discussion_r769764729).
* Verify that when you have English language set for your account, the notification does not display in the Videos UI modal, but that it does when other languages are enabled.
    * Note that while the notice will display, it will not actually be translated into the account language until after this PR has been merged.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58206
