### PR TITLE
Convert .toString to textOnly for some translate calls

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
@@ -99,14 +99,17 @@ export const topHosts: Host[] = [
 						type: InfoTypes.UnorderedList,
 						items: [
 							translate(
-								'FTP (File Transfer Protocol): the original standard for transferring files between servers.'
-							).toString(),
+								'FTP (File Transfer Protocol): the original standard for transferring files between servers.',
+								{ textOnly: true }
+							),
 							translate(
-								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).'
-							).toString(),
+								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).',
+								{ textOnly: true }
+							),
 							translate(
-								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.'
-							).toString(),
+								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.',
+								{ textOnly: true }
+							),
 						],
 					},
 
@@ -115,7 +118,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Read more' ).toString(),
+						text: translate( 'Read more', { textOnly: true } ),
 						link: 'https://my.bluehost.com/cgi/help/ftpaccounts',
 					},
 				],
@@ -124,14 +127,17 @@ export const topHosts: Host[] = [
 						type: InfoTypes.UnorderedList,
 						items: [
 							translate(
-								'FTP (File Transfer Protocol): the original standard for transferring files between servers.'
-							).toString(),
+								'FTP (File Transfer Protocol): the original standard for transferring files between servers.',
+								{ textOnly: true }
+							),
 							translate(
-								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).'
-							).toString(),
+								'SFTP (Secure File Transfer Protocol): is like FTP, but adds a layer of security (SSH encryption).',
+								{ textOnly: true }
+							),
 							translate(
-								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.'
-							).toString(),
+								'SFTP/SSH is the preferred method to choose. Both methods are supported by Bluehost.',
+								{ textOnly: true }
+							),
 						],
 					},
 
@@ -140,7 +146,7 @@ export const topHosts: Host[] = [
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Read more' ).toString(),
+						text: translate( 'Read more', { textOnly: true } ),
 						link: 'https://www.bluehost.com/help/article/ssh-access',
 					},
 				],
@@ -149,15 +155,16 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.Text,
 					text: translate(
-						'Your Domain Name or server IP address. Both are available from the Bluehost cPanel.'
-					).toString(),
+						'Your Domain Name or server IP address. Both are available from the Bluehost cPanel.',
+						{ textOnly: true }
+					),
 				},
 				{
 					type: InfoTypes.Line,
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Visit my Bluehost cPanel' ).toString(),
+					text: translate( 'Visit my Bluehost cPanel', { textOnly: true } ),
 					link: 'https://my.bluehost.com/cgi-bin/cplogin',
 				},
 			],
@@ -165,15 +172,16 @@ export const topHosts: Host[] = [
 				ftp: [
 					{
 						type: InfoTypes.Text,
-						text: translate( 'Enter port 21 for Bluehost’s FTP service.' ).toString(),
+						text: translate( 'Enter port 21 for Bluehost’s FTP service.', { textOnly: true } ),
 					},
 				],
 				sftp: [
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'Port 2222 would be used for Bluehost shared and reseller accounts. 22 is the default for Bluehost dedicated & VPS accounts.'
-						).toString(),
+							'Port 2222 would be used for Bluehost shared and reseller accounts. 22 is the default for Bluehost dedicated & VPS accounts.',
+							{ textOnly: true }
+						),
 					},
 				],
 			},
@@ -182,43 +190,46 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.OrderedList,
 						items: [
-							translate( 'Login to your Bluehost cPanel' ).toString(),
+							translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+							translate( 'Click the "Advanced" tab towards the left side of the account.', {
+								textOnly: true,
+							} ),
 							translate(
-								'Click the "Advanced" tab towards the left side of the account.'
-							).toString(),
-							translate(
-								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.'
-							).toString(),
-							translate( 'Create a new FTP account' ).toString(),
+								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.',
+								{ textOnly: true }
+							),
+							translate( 'Create a new FTP account', { textOnly: true } ),
 						],
 					},
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'Your Bluehost username will end with your domain (e.g. test@example.com).'
-						).toString(),
+							'Your Bluehost username will end with your domain (e.g. test@example.com).',
+							{ textOnly: true }
+						),
 					},
 					{
 						type: InfoTypes.Line,
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel' ).toString(),
+						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
 				sftp: [
 					{
 						type: InfoTypes.Text,
-						text: translate(
-							'For Bluehost VPS and dedicated servers, the login will be `root`.'
-						).toString(),
+						text: translate( 'For Bluehost VPS and dedicated servers, the login will be `root`.', {
+							textOnly: true,
+						} ),
 					},
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.'
-						).toString(),
+							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.',
+							{ textOnly: true }
+						),
 					},
 				],
 			},
@@ -227,28 +238,29 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.OrderedList,
 						items: [
-							translate( 'Login to your Bluehost cPanel' ).toString(),
+							translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+							translate( 'Click the "Advanced" tab towards the left side of the account.', {
+								textOnly: true,
+							} ),
 							translate(
-								'Click the "Advanced" tab towards the left side of the account.'
-							).toString(),
-							translate(
-								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.'
-							).toString(),
-							translate( 'Create a new FTP account' ).toString(),
+								'Choose FTP from the sub-menu, or click the FTP Accounts icon from the Files section.',
+								{ textOnly: true }
+							),
+							translate( 'Create a new FTP account', { textOnly: true } ),
 						],
 					},
 					{
 						type: InfoTypes.Text,
-						text: translate(
-							'Your Bluehost FTP password is chosen by you using the tools above.'
-						).toString(),
+						text: translate( 'Your Bluehost FTP password is chosen by you using the tools above.', {
+							textOnly: true,
+						} ),
 					},
 					{
 						type: InfoTypes.Line,
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel' ).toString(),
+						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
@@ -256,15 +268,16 @@ export const topHosts: Host[] = [
 					{
 						type: InfoTypes.Text,
 						text: translate(
-							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.'
-						).toString(),
+							'If you enable shell access for individual cPanels, the SSH username and password would be the same as the cPanel username and password for those accounts.',
+							{ textOnly: true }
+						),
 					},
 					{
 						type: InfoTypes.Line,
 					},
 					{
 						type: InfoTypes.Link,
-						text: translate( 'Vist my Bluehost cPanel' ).toString(),
+						text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
 						link: 'https://my.bluehost.com/cgi-bin/cplogin',
 					},
 				],
@@ -273,15 +286,16 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.Text,
 					text: translate(
-						'The majority of Bluehost accounts require private key authentication. Bluehost VPS and Dedicated Servers also allow for username and password authentication as secondary option.'
-					).toString(),
+						'The majority of Bluehost accounts require private key authentication. Bluehost VPS and Dedicated Servers also allow for username and password authentication as secondary option.',
+						{ textOnly: true }
+					),
 				},
 				{
 					type: InfoTypes.Line,
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Read more' ).toString(),
+					text: translate( 'Read more', { textOnly: true } ),
 					link: 'https://www.bluehost.com/help/article/ssh-access',
 				},
 			],
@@ -289,13 +303,15 @@ export const topHosts: Host[] = [
 				{
 					type: InfoTypes.OrderedList,
 					items: [
-						translate( 'Login to your Bluehost cPanel' ).toString(),
-						translate(
-							'Click the "Advanced" tab towards the left side of the account.'
-						).toString(),
-						translate( 'Click the Shell Access icon under the Security section.' ).toString(),
-						translate( 'Click the Manage SSH Keys button' ).toString(),
-						translate( 'Choose generate a new key and complete the form' ).toString(),
+						translate( 'Login to your Bluehost cPanel', { textOnly: true } ),
+						translate( 'Click the "Advanced" tab towards the left side of the account.', {
+							textOnly: true,
+						} ),
+						translate( 'Click the Shell Access icon under the Security section.', {
+							textOnly: true,
+						} ),
+						translate( 'Click the Manage SSH Keys button', { textOnly: true } ),
+						translate( 'Choose generate a new key and complete the form', { textOnly: true } ),
 					],
 				},
 				{
@@ -303,7 +319,7 @@ export const topHosts: Host[] = [
 				},
 				{
 					type: InfoTypes.Link,
-					text: translate( 'Vist my Bluehost cPanel' ).toString(),
+					text: translate( 'Vist my Bluehost cPanel', { textOnly: true } ),
 					link: 'https://my.bluehost.com/cgi-bin/cplogin',
 				},
 			],

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -13,18 +13,18 @@ const validateFilePath: validator< string > = (
 	}
 	if ( filePathBackSlashRegExp.test( pathToValidate ) ) {
 		return {
-			message: translate( 'Use forward slashes, "/", in path.' ).toString(),
+			message: translate( 'Use forward slashes, "/", in path.', { textOnly: true } ),
 		};
 	}
 
 	if ( filePathMultiSlashRegExp.test( pathToValidate ) ) {
 		return {
-			message: translate( 'Use only single slashes, "/", in path.' ).toString(),
+			message: translate( 'Use only single slashes, "/", in path.', { textOnly: true } ),
 		};
 	}
 
 	return {
-		message: translate( 'Not a valid file path.' ).toString(),
+		message: translate( 'Not a valid file path.', { textOnly: true } ),
 	};
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
While investigating a separate issue, I noticed some low-hanging TS fixes. There were quite a few uses of `translate( 'foo' ).toString()`. These failed tsc, because the translate call might return undefined. I changed these to use `translate( 'foo', { textOnly: true } )`, which already has a return type of string.

### Testing instructions
- CI
- Smoke test translation on jetpack cloud's advanced credentials page. (Unsure how to do this immediately.)
