### PR TITLE
Remove domains/dns-records-redesign feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -195,17 +195,11 @@ export default {
 	},
 
 	domainManagementDns( pageContext, next ) {
-		let component = DomainManagement.Dns;
-
-		if ( config.isEnabled( 'domains/dns-records-redesign' ) ) {
-			component = DomainManagement.DnsRecords;
-		}
-
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementDns( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Name Servers and DNS > DNS Records"
-				component={ component }
+				component={ DomainManagement.DnsRecords }
 				context={ pageContext }
 				selectedDomainName={ pageContext.params.domain }
 			/>

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { includes, find, flatMap } from 'lodash';
 import page from 'page';
@@ -184,9 +183,6 @@ class DnsAddNew extends React.Component {
 				formState.getAllFieldValues( this.state.fields ),
 				selectedDomainName
 			);
-			if ( ! config.isEnabled( 'domains/dns-records-redesign' ) ) {
-				this.formStateController.resetFields( this.getFieldsForType( this.state.type ) );
-			}
 
 			if ( recordToEdit ) {
 				this.props.updateDns( selectedDomainName, [ normalizedData ], [ recordToEdit ] ).then(
@@ -287,11 +283,9 @@ class DnsAddNew extends React.Component {
 						{ buttonLabel }
 					</FormButton>
 
-					{ config.isEnabled( 'domains/dns-records-redesign' ) && (
-						<FormButton isPrimary={ false } type="button" onClick={ this.props.goBack }>
-							{ translate( 'Cancel' ) }
-						</FormButton>
-					) }
+					<FormButton isPrimary={ false } type="button" onClick={ this.props.goBack }>
+						{ translate( 'Cancel' ) }
+					</FormButton>
 				</div>
 			</form>
 		);

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -82,6 +82,7 @@ class DnsRecords extends Component {
 
 		const mobileButtons = [
 			<DnsAddNewRecordButton
+				key="mobile-add-new-record-button"
 				site={ selectedSite.slug }
 				domain={ selectedDomainName }
 				isMobile={ true }

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { CompactCard as Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { some } from 'lodash';
@@ -101,8 +100,13 @@ class Dns extends Component {
 		};
 
 		const buttons = [
-			<DnsAddNewRecordButton site={ selectedSite.slug } domain={ selectedDomainName } />,
+			<DnsAddNewRecordButton
+				key="add-new-record-button"
+				site={ selectedSite.slug }
+				domain={ selectedDomainName }
+			/>,
 			<DnsMenuOptionsButton
+				key="menu-options-button"
 				domain={ selectedDomainName }
 				onSuccess={ this.onRestoreSuccess }
 				onError={ this.onRestoreError }
@@ -120,11 +124,7 @@ class Dns extends Component {
 	}
 
 	renderPlaceholder() {
-		return config.isEnabled( 'domains/dns-records-redesign' ) ? (
-			<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
-		) : (
-			<DomainMainPlaceholder goBack={ this.goBack } />
-		);
+		<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />;
 	}
 
 	renderMain() {

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
@@ -35,7 +34,6 @@ import {
 	CLOUDFLARE_NAMESERVERS_REGEX,
 } from './constants';
 import CustomNameserversForm from './custom-nameservers-form';
-import DnsTemplates from './dns-templates';
 import FetchError from './fetch-error';
 import withDomainNameservers from './with-domain-nameservers';
 import WpcomNameserversToggle from './wpcom-nameservers-toggle';
@@ -163,13 +161,9 @@ class NameServers extends Component {
 				</VerticalNav>
 
 				<VerticalNav>
-					{ this.hasWpcomNameservers() &&
-						! this.isPendingTransfer() &&
-						( config.isEnabled( 'domains/dns-records-redesign' ) ? (
-							<EmailSetup selectedDomainName={ this.props.selectedDomainName } />
-						) : (
-							<DnsTemplates selectedDomainName={ this.props.selectedDomainName } />
-						) ) }
+					{ this.hasWpcomNameservers() && ! this.isPendingTransfer() && (
+						<EmailSetup selectedDomainName={ this.props.selectedDomainName } />
+					) }
 				</VerticalNav>
 			</Fragment>
 		);
@@ -182,9 +176,7 @@ class NameServers extends Component {
 
 		return (
 			<Main wideLayout className={ classes }>
-				{ config.isEnabled( 'domains/dns-records-redesign' )
-					? this.renderBreadcrumbs()
-					: this.header() }
+				{ this.renderBreadcrumbs() }
 				{ this.getContent() }
 			</Main>
 		);

--- a/config/development.json
+++ b/config/development.json
@@ -55,7 +55,6 @@
 		"domains/premium-domain-purchases": true,
 		"domains/management-list-redesign": true,
 		"domains/settings-page-redesign": true,
-		"domains/dns-records-redesign": true,
 		"domains/contact-info-redesign": true,
 		"domains/transfers-redesign": true,
 		"email-accounts/enabled": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the domains/dns-records-redesign feature flag to make the new DNS pages live for all users.
* Also added missing keys to three of the breadcrumb buttons since they were emitting warnings.

#### Testing instructions

Go to the DNS page and use flags to disable the flags like this: http://calypso.localhost:3000/domains/manage/a8ctest.com?flags=-domains/management-list-redesign,-domains/transfers-redesign,-domains/dns-records-redesign,-domains/settings-page-redesign

Make sure that the redesigned pages are shown:

![screencapture-calypso-localhost-3000-domains-manage-a8ctest-com-dns-a8ctest-com-2021-12-13-19_39_36](https://user-images.githubusercontent.com/1379730/145917806-7b887a81-e5d1-4a16-b7b1-746491df3ba9.png)

![screencapture-calypso-localhost-3000-domains-manage-a8ctest-com-add-dns-record-a8ctest-com-2021-12-13-19_43_36](https://user-images.githubusercontent.com/1379730/145917838-c5a512b2-6c32-4455-996c-f33db3537a1e.png)

Check the console and make sure there are no errors or warnings related to the components on these pages.