### PR TITLE
E2E: complete migration of Basic Post Flow spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -273,13 +273,8 @@ export class GutenbergEditorPage {
 	 */
 	async addBlock( blockName: string, blockEditorSelector: string ): Promise< ElementHandle > {
 		const frame = await this.getEditorFrame();
-
-		// Click on the editor title. This has the effect of dismissing the block inserter
-		// if open, and restores focus back to the editor root container, allowing insertion
-		// of blocks.
-		await frame.click( selectors.editorTitle );
 		await this.openBlockInserter();
-		await frame.fill( selectors.blockSearch, blockName );
+		await this.searchBlockInserter( blockName );
 		await frame.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );
 		// Confirm the block has been added to the editor body.
 		return await frame.waitForSelector( `${ blockEditorSelector }.is-selected` );
@@ -298,15 +293,47 @@ export class GutenbergEditorPage {
 	}
 
 	/**
+	 * Adds a pattern from the block inserter panel.
+	 *
+	 * The name is expected to be formatted in the same manner as it
+	 * appears on the label when visible in the block inserter panel.
+	 *
+	 * Example:
+	 * 		- Two images side by side
+	 *
+	 * @param {string} patternName Name of the pattern to insert.
+	 */
+	async addPattern( patternName: string ): Promise< ElementHandle > {
+		const frame = await this.getEditorFrame();
+		await this.openBlockInserter();
+		await this.searchBlockInserter( patternName );
+		await frame.click( `div[aria-label="${ patternName }"]` );
+		return await frame.waitForSelector( `:text('Block pattern "${ patternName }" inserted.')` );
+	}
+
+	/**
 	 * Open the block inserter panel.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
 	async openBlockInserter(): Promise< void > {
 		const frame = await this.getEditorFrame();
-
+		// Click on the editor title. This has the effect of dismissing the block inserter
+		// if open, and restores focus back to the editor root container, allowing insertion
+		// of blocks.
+		await frame.click( selectors.editorTitle );
 		await frame.click( selectors.blockInserterToggle );
 		await frame.waitForSelector( selectors.blockInserterPanel );
+	}
+
+	/**
+	 * Given a string, enters the said string to the block inserter search bar.
+	 *
+	 * @param {string} text Text to search.
+	 */
+	async searchBlockInserter( text: string ): Promise< void > {
+		const frame = await this.getEditorFrame();
+		await frame.fill( selectors.blockSearch, text );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -37,18 +37,18 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		page = args.page;
 	} );
 
-	describe( 'Block editor', function () {
+	it( 'Log in', async function () {
+		const loginPage = new LoginPage( page );
+		await loginPage.login( { account: user } );
+	} );
+
+	it( 'Start new post', async function () {
+		const newPostFlow = new NewPostFlow( page );
+		await newPostFlow.newPostFromNavbar();
+	} );
+
+	describe( 'Blocks', function () {
 		let blockHandle: ElementHandle;
-
-		it( 'Log in', async function () {
-			const loginPage = new LoginPage( page );
-			await loginPage.login( { account: user } );
-		} );
-
-		it( 'Start new post', async function () {
-			const newPostFlow = new NewPostFlow( page );
-			await newPostFlow.newPostFromNavbar();
-		} );
 
 		it( 'Enter post title', async function () {
 			gutenbergEditorPage = new GutenbergEditorPage( page );
@@ -69,7 +69,18 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		it( 'Remove image block', async function () {
 			await gutenbergEditorPage.removeBlock( blockHandle );
 		} );
+	} );
 
+	describe( 'Patterns', function () {
+		const patternName = 'Two images side by side';
+
+		it( 'Add pattern', async function () {
+			await page.pause();
+			await gutenbergEditorPage.addPattern( patternName );
+		} );
+	} );
+
+	describe( 'Categories and Tags', function () {
 		it( 'Open editor settings sidebar for post', async function () {
 			await gutenbergEditorPage.openSettings();
 			const frame = await gutenbergEditorPage.getEditorFrame();
@@ -88,7 +99,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 	} );
 
-	describe( 'Preview post', function () {
+	describe( 'Preview', function () {
 		const targetDevice = BrowserHelper.getTargetDeviceName();
 		let previewPage: Page;
 
@@ -125,7 +136,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 	} );
 
-	describe( 'Publish post', function () {
+	describe( 'Publish', function () {
 		it( 'Publish and visit post', async function () {
 			const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
 			expect( publishedURL ).toBe( page.url() );

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -72,10 +72,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Patterns', function () {
-		const patternName = 'Two images side by side';
+		const patternName = 'Event details';
 
-		it( 'Add pattern', async function () {
-			await page.pause();
+		it( `Add ${ patternName }`, async function () {
 			await gutenbergEditorPage.addPattern( patternName );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR completes the last outstanding item in https://github.com/Automattic/wp-calypso/issues/55948.

Key changes:
- add step to apply a pattern while in editor.
- extract out to a method the steps involved in opening the block inserter then entering the search term.
- better organize into nested `describe` blocks the various aspects of testing the editor.

#### Testing instructions

Calypso E2E
- [x] mobile
- [x] desktop

WPCOM E2E
- [x] mobile
- [x] desktop

Note that currently WPCOM E2E tests are permafailing and thus it is expected that there will be failures.

Closes https://github.com/Automattic/wp-calypso/issues/55948.