### PR TITLE
E2E: Revamp `Reader` and `Notifications` spec to reduce overlap.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-notifications__trash.ts
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash.ts
@@ -18,34 +18,34 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	const notificationsUser = 'notificationsUser';
 	const comment = DataHelper.getRandomPhrase() + ' notifications-trash-spec';
 
-	let page: Page;
 	let notificationsComponent: NotificationsComponent;
 	let readerPage: ReaderPage;
 
-	beforeAll( async () => {
-		page = await browser.newPage();
-	} );
-
 	describe( `Leave a comment as ${ commentingUser }`, function () {
+		let page: Page;
 		let testAccount: TestAccount;
 
 		beforeAll( async function () {
+			page = await browser.newPage();
 			testAccount = new TestAccount( commentingUser );
 			await testAccount.authenticate( page );
 		} );
 
-		it( 'Visit latest post', async function () {
+		it( 'Visit latest post in reader stream', async function () {
 			readerPage = new ReaderPage( page );
 			await readerPage.visitPost( { index: 1 } );
 		} );
 
-		it( 'Comment and confirm it is shown', async function () {
+		it( 'Leave a comment on the post', async function () {
 			await readerPage.comment( comment );
 		} );
 	} );
 
 	describe( `Trash comment as ${ notificationsUser }`, function () {
+		let page: Page;
+
 		beforeAll( async function () {
+			page = await browser.newPage();
 			const testAccount = new TestAccount( notificationsUser );
 			await testAccount.authenticate( page );
 		} );

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -2,74 +2,30 @@
  * @group calypso-pr
  */
 
-import {
-	DataHelper,
-	TestAccount,
-	ReaderPage,
-	NotificationsComponent,
-	NavbarComponent,
-} from '@automattic/calypso-e2e';
+import { DataHelper, TestAccount, ReaderPage } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function () {
+describe( DataHelper.createSuiteTitle( 'Reader: View' ), function () {
 	let page: Page;
 	let readerPage: ReaderPage;
-	let notificationsComponent: NotificationsComponent;
-	const comment = DataHelper.getRandomPhrase() + ' wp-reader__view-spec';
+	let testAccount: TestAccount;
 
-	beforeAll( async () => {
+	beforeAll( async function {
 		page = await browser.newPage();
+		testAccount = new TestAccount( 'commentingUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'View the Reader stream', async function () {
 		readerPage = new ReaderPage( page );
+		const testSiteForNotifications = DataHelper.config.get( 'testSiteForNotifications' );
+		const siteOfLatestPost = await readerPage.siteOfLatestPost();
+		expect( siteOfLatestPost ).toEqual( testSiteForNotifications );
 	} );
 
-	describe( 'As the commenting user', () => {
-		let testAccount: TestAccount;
-		beforeAll( async () => {
-			testAccount = new TestAccount( 'commentingUser' );
-			await testAccount.authenticate( page );
-		} );
-
-		it( 'Go to Reader page', async function () {
-			await readerPage.visit();
-		} );
-
-		it( 'View the Reader stream', async function () {
-			const testSiteForNotifications = DataHelper.config.get( 'testSiteForNotifications' );
-			const siteOfLatestPost = await readerPage.siteOfLatestPost();
-			expect( siteOfLatestPost ).toEqual( testSiteForNotifications );
-		} );
-
-		it( 'Visit latest post', async function () {
-			await readerPage.visitPost( { index: 1 } );
-		} );
-
-		it( 'Comment and confirm it is shown', async function () {
-			await readerPage.comment( comment );
-		} );
-	} );
-
-	describe( 'As the site owner', () => {
-		beforeAll( async () => {
-			const testAccount = new TestAccount( 'notificationsUser' );
-			await testAccount.authenticate( page );
-		} );
-
-		it( 'Open Notifications panel', async function () {
-			const navBarComponent = new NavbarComponent( page );
-			await navBarComponent.openNotificationsPanel();
-		} );
-
-		it( 'Delete the new comment', async function () {
-			notificationsComponent = new NotificationsComponent( page );
-			await notificationsComponent.clickNotification( comment );
-			await notificationsComponent.clickNotificationAction( 'Trash' );
-		} );
-
-		it( 'Wait for Undo Message to display and then disappear', async function () {
-			await notificationsComponent.waitForUndoMessage();
-			await notificationsComponent.waitForUndoMessageToDisappear();
-		} );
+	it( 'Visit latest post', async function () {
+		await readerPage.visitPost( { index: 1 } );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-reader__view.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view.ts
@@ -12,7 +12,7 @@ describe( DataHelper.createSuiteTitle( 'Reader: View' ), function () {
 	let readerPage: ReaderPage;
 	let testAccount: TestAccount;
 
-	beforeAll( async function {
+	beforeAll( async function () {
 		page = await browser.newPage();
 		testAccount = new TestAccount( 'commentingUser' );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/specs-playwright/wp-user__notifications.ts
+++ b/test/e2e/specs/specs-playwright/wp-user__notifications.ts
@@ -29,7 +29,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	describe( `Leave a comment as ${ commentingUser }`, function () {
 		let testAccount: TestAccount;
 
-		beforeAll( async function() {
+		beforeAll( async function () {
 			testAccount = new TestAccount( commentingUser );
 			await testAccount.authenticate( page );
 		} );
@@ -45,7 +45,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	} );
 
 	describe( `Trash comment as ${ notificationsUser }`, function () {
-		beforeAll( async function() {
+		beforeAll( async function () {
 			const testAccount = new TestAccount( notificationsUser );
 			await testAccount.authenticate( page );
 		} );

--- a/test/e2e/specs/specs-playwright/wp-user__notifications.ts
+++ b/test/e2e/specs/specs-playwright/wp-user__notifications.ts
@@ -4,8 +4,7 @@
 
 import {
 	DataHelper,
-	PublishedPostsListPage,
-	CommentsComponent,
+	ReaderPage,
 	NavbarComponent,
 	NotificationsComponent,
 	TestAccount,
@@ -20,8 +19,8 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	const comment = DataHelper.getRandomPhrase() + ' notifications-trash-spec';
 
 	let page: Page;
-	let publishedPostsListPage: PublishedPostsListPage;
 	let notificationsComponent: NotificationsComponent;
+	let readerPage: ReaderPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -30,30 +29,23 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	describe( `Leave a comment as ${ commentingUser }`, function () {
 		let testAccount: TestAccount;
 
-		beforeAll( async () => {
+		beforeAll( async function() {
 			testAccount = new TestAccount( commentingUser );
 			await testAccount.authenticate( page );
 		} );
 
-		it( 'Visit published site', async function () {
-			// TODO make a utility to obtain a blog URL without string substitution.
-			const siteURL = `https://${ DataHelper.config.get( 'testSiteForNotifications' ) }`;
-			await page.goto( siteURL );
+		it( 'Visit latest post', async function () {
+			readerPage = new ReaderPage( page );
+			await readerPage.visitPost( { index: 1 } );
 		} );
 
-		it( 'View first post', async function () {
-			publishedPostsListPage = new PublishedPostsListPage( page );
-			publishedPostsListPage.visitPost( 1 );
-		} );
-
-		it( 'Comment on the post', async function () {
-			const commentsComponent = new CommentsComponent( page );
-			await commentsComponent.postComment( comment );
+		it( 'Comment and confirm it is shown', async function () {
+			await readerPage.comment( comment );
 		} );
 	} );
 
 	describe( `Trash comment as ${ notificationsUser }`, function () {
-		beforeAll( async () => {
+		beforeAll( async function() {
 			const testAccount = new TestAccount( notificationsUser );
 			await testAccount.authenticate( page );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to re-align some of the spec and steps to reduce duplication and to increase reliability.

Key changes:
- eliminate commenting steps in the `Reader` spec, instead movving it inside the `Notifications` spec. This is in order for the user in `Notifications` spec to leave a comment (which will be trashed in subsequent steps).
- clear the authentication state instead of launching a new context to trash the comment.

Details:

The `Notifications` spec has encountered issues in the past and has been quite flakey (16 changes out of 144 invocations). This is a fairly high flakey rate.

The changes proposed are for the following reasons:

Reader: leaving a comment on the Reader post is beyond the requirement of the test spec as suggested by the file name, which is `wp-reader__view-spec.ts`. 

Notifications: the reader stream is much quicker to load for the purpose of leaving a comment. Additionally, using the same browsercontext will permit screen recording to be saved for this portion of the test.

#### Testing instructions

Calypso
- [x] Quarantined E2E
- [x] Mobile E2E
- [x] Desktop E2E


Related to #
