### PR TITLE
Merge trunk before running Unit tests

### DIFF
--- a/.teamcity/_self/lib/utils/MergeTrunk.kt
+++ b/.teamcity/_self/lib/utils/MergeTrunk.kt
@@ -1,0 +1,35 @@
+package _self.lib.utils
+
+import _self.bashNodeScript
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
+
+fun BuildSteps.mergeTrunk(): ScriptBuildStep {
+	return bashNodeScript {
+		name = "Merge trunk"
+		scriptContent = """
+			set -x
+
+			# Merge the trunk branch first.
+			# - For WPCOM plugins: our builds and tests include the latest merged version of the plugin being built.
+			#   Otherwise, we can get into a situation where the current plugin build appears "different", but that's
+			#   just because it's older.
+			# - For metric tracking: (for example, tracking TypeScript errors). Merging trunk ensures any potential fix
+			#   in trunk is included. Otherwise, we can get into a situation where trunk includes a fix for TypeScript
+			#   and this branch adds a new error, resulting in a net total increase when it is merged.
+			if [[ "%teamcity.build.branch.is_default%" != "true" ]] ; then
+				# git operations will fail if no user is set.
+				git config --local user.email "tcbuildagent@example.com"
+				git config --local user.name "TeamCity Build Agent"
+				# Note that `trunk` is already up-to-date from the `teamcity.git.fetchAllHeads`
+				# parameter in the project settings.
+				if ! git merge trunk ; then
+					echo "##teamcity[buildProblem description='There is a merge conflict with trunk. Rebase on trunk to resolve this problem.' identity='merge_conflict']]"
+					exit
+				fi
+				# See if the trunk commit shows up:
+				git --no-pager log --oneline -n 5
+			fi
+		"""
+	}
+}

--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -2,7 +2,7 @@ package _self.lib.wpcom
 
 import Settings
 import _self.bashNodeScript
-import _self.yarn_install_cmd
+import _self.lib.utils.mergeTrunk
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParametrizedWithType
@@ -83,28 +83,11 @@ open class WPComPluginBuild(
 		}
 
 		steps {
+			mergeTrunk()
 			bashNodeScript {
 				name = "Prepare environment"
 				scriptContent = """
 					set -x
-
-					# Merge the trunk branch first. This way, our builds and tests
-					# include the latest merged version of the plugin being built.
-					# Otherwise, we can get into a situation where the current plugin
-					# build appears "different", but that's just because it's older.
-					if [[ "%teamcity.build.branch.is_default%" != "true" ]] ; then
-						# git operations will fail if no user is set.
-						git config --local user.email "tcbuildagent@example.com"
-						git config --local user.name "TeamCity Build Agent"
-						# Note that `trunk` is already up-to-date from the `teamcity.git.fetchAllHeads`
-						# parameter in the project settings.
-						if ! git merge trunk ; then
-							echo "##teamcity[buildProblem description='There is a merge conflict with trunk. Rebase on trunk to resolve this problem.' identity='merge_conflict']]"
-							exit
-						fi
-						# See if the trunk commit shows up:
-						git --no-pager log --oneline -n 5
-					fi
 
 					# Update composer
 					composer install

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -13,7 +13,6 @@ object WPComPlugins : Project({
 	params {
 		param("docker_image", "registry.a8c.com/calypso/ci-wpcom:latest")
 		param("build.prefix", "1")
-		param("teamcity.git.fetchAllHeads", "true")
 	}
 
 	buildType(EditingToolkit)

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -3,6 +3,7 @@ package _self.projects
 import Settings
 import _self.bashNodeScript
 import _self.lib.playwright.prepareEnvironment
+import _self.lib.utils.mergeTrunk
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
@@ -167,6 +168,7 @@ object RunAllUnitTests : BuildType({
 	}
 
 	steps {
+		mergeTrunk()
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,18 +1,23 @@
+
 import _self.bashNodeScript
 import _self.yarn_install_cmd
-import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
-import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.dockerRegistry
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.project
+import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.dockerRegistry
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubConnection
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.version
 
 /*
 The settings script is an entry point for defining a TeamCity
@@ -54,7 +59,6 @@ project {
 		text("E2E_WORKERS", "16", label = "Magellan parallel workers", description = "Number of parallel workers in Magellan (e2e tests)", allowEmpty = true)
 		text("env.JEST_MAX_WORKERS", "16", label = "Jest max workers", description = "How many tests run in parallel", allowEmpty = true)
 		password("matticbot_oauth_token", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN)
-		param("teamcity.git.fetchAllHeads", "true")
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)
 		text("docker_image", "registry.a8c.com/calypso/base:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)
 		text("docker_image_e2e", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker e2e image", description = "Docker image used to run e2e tests", allowEmpty = true)
@@ -62,6 +66,9 @@ project {
 		password("CONFIG_E2E_ENCRYPTION_KEY", "credentialsJSON:819c139c-90a1-4803-8367-00e5aa5fdb07", display = ParameterDisplay.HIDDEN)
 		password("mc_post_root", "credentialsJSON:2f764583-d399-4d5f-8ee1-06f68ef2e2a6", display = ParameterDisplay.HIDDEN )
 		password("mc_auth_secret", "credentialsJSON:5b1903f9-4b03-43ff-bba8-4a7509d07088", display = ParameterDisplay.HIDDEN)
+
+		// Fetch all heads. This is used for builds that merge trunk before running tests
+		param("teamcity.git.fetchAllHeads", "true")
 	}
 
 	features {


### PR DESCRIPTION
### Background

A few days ago we introduced a change where Unit Tests fail if the PR increases the number of TypeScript errors compared with the latest suscessful build for that branch. If there is no suitable build to compare against, TeamCity will compare against the latest successful build from `trunk`. This has two problems:

1. Imagine there are 100 errors in `trunk`. Your create your branch and before your first PR run, someone fixes some errors in `trunk` so now it's down to 90. When you run your first build, it will see that 100>90, therefore it will fail until you rebase `trunk`.

2. Same scenario as above, imagine your branch has 100 errors and you get a successful build. You add 20 new errors but fix 25 othe errors resulting in a net reduction of 5 errors, so your build is green and allowed to merge. However, meanwhile somoeone has also fixed those 25 errors in `trunk`. When you merge your PR it will result in a net increase of 20 errors in `trunk`.

3. Continuation of the previous scenario: now `trunk` has more errors than before. So anybody that merges/rebases `trunk` into their PR will see their errors increase, and the Unit tests will fail for them.

#### Changes proposed in this Pull Request

This PR changes our build config so it merges `trunk` into your branch before running Unit Tests (but doesn't commit/push it). It should fix all the scenarios described above.

The downside is the built won't run if there are merge conflicts, but you'd have to fix those eventually anyway.


#### Testing instructions

* Check Unit Test is green
* Check the Unit Tests logs to verify `trunk` was merged.