### PR TITLE
Playwright: close Welcome Tour when loading GutenbergEditorPage, attempt 2.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -355,23 +355,13 @@ export class GutenbergEditorPage {
 
 		await frame.click( selectors.publishButton( selectors.postToolbar ) );
 		await frame.click( selectors.publishButton( selectors.publishPanel ) );
-		const publishedURL = await this.getPublishedURL();
+		const viewPublishedArticleButton = await frame.waitForSelector( selectors.viewButton );
+		const publishedURL = ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
 
 		if ( visit ) {
 			await this.visitPublishedPost( publishedURL );
 		}
 		return publishedURL;
-	}
-
-	/**
-	 *
-	 * @returns
-	 */
-	async getPublishedURL(): Promise< string > {
-		const frame = await this.getEditorFrame();
-
-		const viewPublishedArticleButton = await frame.waitForSelector( selectors.viewButton );
-		return ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -99,7 +99,16 @@ export class GutenbergEditorPage {
 	 * close button is fired.
 	 */
 	async dismissWelcomeTour(): Promise< void > {
-		const response = await this.page.waitForResponse( /.*nux\?_envelope.*/ );
+		let response;
+
+		try {
+			response = await this.page.waitForResponse( /.*nux\?_envelope.*/, {
+				timeout: 105 * 1000,
+			} );
+		} catch {
+			return;
+		}
+
 		interface NuxPayload {
 			body: {
 				show_welcome_guide: boolean;

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -42,10 +42,9 @@ const selectors = {
 	// corner. This addresses the bug where the post-publish panel is immediately
 	// closed when publishing with certain blocks on the editor canvas.
 	// See https://github.com/Automattic/wp-calypso/issues/54421.
-	viewButton: 'a.components-button:has-text("View"):visible',
+	viewButton: 'text=/View (Post|Page)/',
 	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
 	closePublishPanel: 'button[aria-label="Close panel"]',
-	snackbarViewButton: 'a.components-snackbar__action:has-text("View Post"):visible',
 
 	// Welcome tour
 	welcomeTourCloseButton: 'button[aria-label="Close Tour"]',
@@ -371,9 +370,7 @@ export class GutenbergEditorPage {
 	async getPublishedURL(): Promise< string > {
 		const frame = await this.getEditorFrame();
 
-		const viewPublishedArticleButton = await frame.waitForSelector(
-			`${ selectors.viewButton }, ${ selectors.snackbarViewButton }`
-		);
+		const viewPublishedArticleButton = await frame.waitForSelector( selectors.viewButton );
 		return ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to change how the GutenbergEditorPage handles the Welcome Tour. 

Key changes:
- discontinue use of `this.page.on` in favor of `waitForResponse`.

Details:

The Welcome Tour has been quite problematic for E2E testing, with multiple attempts having been made to ensure it is dismissed reliably (#57477, #58718 with the original issue at #57660).

In #58718 the use of `page.on` to inspect network responses was attempted and this functions well for most cases. However during the development of the Post Privacy spec (upcoming) it was found that `page.on` was inspecting _every_ network request made after it had been initialized, which led to a large number of actions being logged in the Playwright debugger. This (inspection of every request) causes issues for the Post Privacy test when the user account is changed to verify post visibility.

#### Testing instructions

Calypso
- [x] Mobile E2E
- [x] Desktop E2E

WPCOM
- [x] Mobile E2E (permafailing)
- [x] Desktop E2E (permafailing)

Related to #59148
