### PR TITLE
Domains: Cleanup unused local state in RegistrantExtraInfoCaForm

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -80,9 +80,6 @@ export class RegistrantExtraInfoCaForm extends PureComponent {
 		) );
 
 		this.legalTypeOptions = legalTypeOptions;
-		this.state = {
-			errorMessages: {},
-		};
 	}
 
 	componentDidMount() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up on #58396 where after cleaning up the unused TLD validation schemas, we left out some unused local state.

#### Testing instructions

Not needed, just verify that the removed local state is not in use.