### PR TITLE
Domains: Migrate last remaining `undocumented` methods

### DIFF
--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -22,8 +22,7 @@ class TransferAwayConfirmationPage extends Component {
 
 	state = this.getLoadingState();
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		const { domain, recipientId, token } = this.props;
 		const { verifyEmail } = VerifyConfirmationCommand;
 

--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -7,12 +7,6 @@ import DomainsLandingContentCard from '../content-card';
 import DomainsLandingHeader from '../header';
 import { getMaintenanceMessageFromError } from '../utils';
 
-const VerifyConfirmationCommand = {
-	acceptTransfer: 'accept-transfer',
-	denyTransfer: 'deny-transfer',
-	verifyEmail: 'verify-email',
-};
-
 class TransferAwayConfirmationPage extends Component {
 	static propTypes = {
 		domain: PropTypes.string.isRequired,
@@ -24,9 +18,8 @@ class TransferAwayConfirmationPage extends Component {
 
 	componentDidMount() {
 		const { domain, recipientId, token } = this.props;
-		const { verifyEmail } = VerifyConfirmationCommand;
 
-		this.verifyOutboundTransferConfirmation( domain, recipientId, token, verifyEmail ).then(
+		this.verifyOutboundTransferConfirmation( domain, recipientId, token, 'verify-email' ).then(
 			() => {
 				this.setState( this.getConfirmationSelectState() );
 			},
@@ -58,11 +51,10 @@ class TransferAwayConfirmationPage extends Component {
 
 	acceptTransfer = () => {
 		const { domain, recipientId, token } = this.props;
-		const { acceptTransfer } = VerifyConfirmationCommand;
 
 		this.setState( { isProcessingRequest: true } );
 
-		this.verifyOutboundTransferConfirmation( domain, recipientId, token, acceptTransfer ).then(
+		this.verifyOutboundTransferConfirmation( domain, recipientId, token, 'accept-transfer' ).then(
 			() => {
 				this.setSuccessState( 'accept_transfer_success' );
 			},
@@ -74,11 +66,10 @@ class TransferAwayConfirmationPage extends Component {
 
 	cancelTransfer = () => {
 		const { domain, recipientId, token } = this.props;
-		const { denyTransfer } = VerifyConfirmationCommand;
 
 		this.setState( { isProcessingRequest: true } );
 
-		this.verifyOutboundTransferConfirmation( domain, recipientId, token, denyTransfer ).then(
+		this.verifyOutboundTransferConfirmation( domain, recipientId, token, 'deny-transfer' ).then(
 			() => {
 				this.setSuccessState( 'cancel_transfer_success' );
 			},

--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -7,8 +7,6 @@ import DomainsLandingContentCard from '../content-card';
 import DomainsLandingHeader from '../header';
 import { getMaintenanceMessageFromError } from '../utils';
 
-const wpcom = wp.undocumented();
-
 const VerifyConfirmationCommand = {
 	acceptTransfer: 'accept-transfer',
 	denyTransfer: 'deny-transfer',
@@ -29,7 +27,7 @@ class TransferAwayConfirmationPage extends Component {
 		const { domain, recipientId, token } = this.props;
 		const { verifyEmail } = VerifyConfirmationCommand;
 
-		wpcom.domainsVerifyOutboundTransferConfirmation( domain, recipientId, token, verifyEmail ).then(
+		this.verifyOutboundTransferConfirmation( domain, recipientId, token, verifyEmail ).then(
 			() => {
 				this.setState( this.getConfirmationSelectState() );
 			},
@@ -37,6 +35,14 @@ class TransferAwayConfirmationPage extends Component {
 				this.setErrorState( error );
 			}
 		);
+	}
+
+	verifyOutboundTransferConfirmation( domain, recipientId, token, command ) {
+		return wp.req.get( `/domains/${ domain }/outbound-transfer-confirmation-check`, {
+			recipient_id: recipientId,
+			token,
+			command,
+		} );
 	}
 
 	getLoadingState() {
@@ -57,16 +63,14 @@ class TransferAwayConfirmationPage extends Component {
 
 		this.setState( { isProcessingRequest: true } );
 
-		wpcom
-			.domainsVerifyOutboundTransferConfirmation( domain, recipientId, token, acceptTransfer )
-			.then(
-				() => {
-					this.setSuccessState( 'accept_transfer_success' );
-				},
-				() => {
-					this.setErrorState( { error: 'accept_transfer_failed' } );
-				}
-			);
+		this.verifyOutboundTransferConfirmation( domain, recipientId, token, acceptTransfer ).then(
+			() => {
+				this.setSuccessState( 'accept_transfer_success' );
+			},
+			() => {
+				this.setErrorState( { error: 'accept_transfer_failed' } );
+			}
+		);
 	};
 
 	cancelTransfer = () => {
@@ -75,16 +79,14 @@ class TransferAwayConfirmationPage extends Component {
 
 		this.setState( { isProcessingRequest: true } );
 
-		wpcom
-			.domainsVerifyOutboundTransferConfirmation( domain, recipientId, token, denyTransfer )
-			.then(
-				() => {
-					this.setSuccessState( 'cancel_transfer_success' );
-				},
-				() => {
-					this.setErrorState( { error: 'cancel_transfer_failed' } );
-				}
-			);
+		this.verifyOutboundTransferConfirmation( domain, recipientId, token, denyTransfer ).then(
+			() => {
+				this.setSuccessState( 'cancel_transfer_success' );
+			},
+			() => {
+				this.setErrorState( { error: 'cancel_transfer_failed' } );
+			}
+		);
 	};
 
 	getConfirmationSelectState = () => {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -11,31 +11,4 @@ function Undocumented( wpcom ) {
 	this.wpcom = wpcom;
 }
 
-Undocumented.prototype.getDomainConnectSyncUxUrl = function (
-	domain,
-	providerId,
-	serviceId,
-	redirectUri,
-	callback
-) {
-	return this.wpcom.req.get(
-		`/domains/${ domain }/dns/providers/${ providerId }/services/${ serviceId }/syncurl`,
-		{ redirect_uri: redirectUri },
-		callback
-	);
-};
-
-Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function (
-	domain,
-	recipientId,
-	token,
-	command
-) {
-	return this.wpcom.req.get( `/domains/${ domain }/outbound-transfer-confirmation-check`, {
-		recipient_id: recipientId,
-		token,
-		command,
-	} );
-};
-
 export default Undocumented;

--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -171,16 +171,14 @@ class DomainConnectMapping extends Component {
 	};
 
 	applyDomainConnectMappingTemplate = () => {
+		const { selectedDomainName } = this.props;
 		this.setState( { submitting: true } );
 
-		this.props.recordConfigureYourDomainClick( this.props.selectedDomainName );
+		this.props.recordConfigureYourDomainClick( selectedDomainName );
 
 		const redirectUri =
 			'https://wordpress.com' +
-			domainManagementDomainConnectMapping(
-				this.props.selectedSite.slug,
-				this.props.selectedDomainName
-			) +
+			domainManagementDomainConnectMapping( this.props.selectedSite.slug, selectedDomainName ) +
 			'?' +
 			this.getRedirectUriStatusString();
 
@@ -189,7 +187,7 @@ class DomainConnectMapping extends Component {
 
 		wp.req
 			.get(
-				`/domains/${ this.props.selectedDomainName }/dns/providers/${ providerId }/services/${ serviceId }/syncurl`,
+				`/domains/${ selectedDomainName }/dns/providers/${ providerId }/services/${ serviceId }/syncurl`,
 				{ redirect_uri: redirectUri }
 			)
 			.then(
@@ -198,10 +196,7 @@ class DomainConnectMapping extends Component {
 					const syncUxUrl = data?.sync_ux_apply_url;
 
 					if ( success && syncUxUrl ) {
-						this.props.recordConfigureYourDomainRedirect(
-							this.props.selectedDomainName,
-							syncUxUrl
-						);
+						this.props.recordConfigureYourDomainRedirect( selectedDomainName, syncUxUrl );
 						navigate( syncUxUrl );
 					} else {
 						this.setState( {

--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -182,12 +182,9 @@ class DomainConnectMapping extends Component {
 			'?' +
 			this.getRedirectUriStatusString();
 
-		const providerId = 'WordPress.com';
-		const serviceId = 'hosting';
-
 		wp.req
 			.get(
-				`/domains/${ selectedDomainName }/dns/providers/${ providerId }/services/${ serviceId }/syncurl`,
+				`/domains/${ selectedDomainName }/dns/providers/WordPress.com/services/hosting/syncurl`,
 				{ redirect_uri: redirectUri }
 			)
 			.then(

--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -20,8 +20,6 @@ import {
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
-const wpcom = wp.undocumented();
-
 class DomainConnectMapping extends Component {
 	static propTypes = {
 		domains: PropTypes.array.isRequired,
@@ -186,12 +184,13 @@ class DomainConnectMapping extends Component {
 			'?' +
 			this.getRedirectUriStatusString();
 
-		wpcom
-			.getDomainConnectSyncUxUrl(
-				this.props.selectedDomainName,
-				'WordPress.com',
-				'hosting',
-				redirectUri
+		const providerId = 'WordPress.com';
+		const serviceId = 'hosting';
+
+		wp.req
+			.get(
+				`/domains/${ this.props.selectedDomainName }/dns/providers/${ providerId }/services/${ serviceId }/syncurl`,
+				{ redirect_uri: redirectUri }
 			)
 			.then(
 				( data ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wpcom.undocumented()` last remaining domains methods to `wpcom.req`:

* `getDomainConnectSyncUxUrl`
* `verifyOutboundTransferConfirmation`

Part of the ongoing effort to get rid of `wpcom.undocumented()`, see #58458.

Also, part of #58453 where we refactor away from deprecated React lifecycle methods.

#### Testing instructions

* Verify outbound transfer confirmation (or the testing instructions of #34599) still works.
* Verify domain connect mapping (or the testing instructions of #54732) still works.

cc @Automattic/nomado, specifically @hambai, @leonardost, and @delputnam for testing and reviewing this one - thanks! 