### PR TITLE
Jetpack Connect: Migrate `JetpackConnectMain` away from `UNSAFE_` methods

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -39,14 +39,11 @@ export class JetpackConnectMain extends Component {
 				waitingForSites: false,
 		  };
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( this.props.url ) {
 			this.checkUrl( cleanUrl( this.props.url ) );
 		}
-	}
 
-	componentDidMount() {
 		let from = 'direct';
 		if ( this.props.type === 'install' ) {
 			from = 'jpdotcom';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `JetpackConnectMain` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions

* Go to `/jetpack/connect?url=SOME_URL` where `SOME_URL` is the URL of a Jetpack site (connected or not)
* Verify that the form still starts submitting automatically.