### PR TITLE
Notifications: remove usage of React.createFactory

### DIFF
--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -1,4 +1,4 @@
-import { Component, createFactory } from 'react';
+import { Component } from 'react';
 import { html } from '../indices-to-html';
 import { linkProps } from './functions';
 
@@ -61,27 +61,25 @@ class UserHeader extends Component {
 	}
 }
 
-const Header = createFactory(
-	class extends Component {
-		render() {
-			const subject = (
-				<div
-					className="wpnc__subject"
-					dangerouslySetInnerHTML={ {
-						__html: html( this.props.subject ),
-					} }
-				/>
-			);
+class Header extends Component {
+	render() {
+		const subject = (
+			<div
+				className="wpnc__subject"
+				dangerouslySetInnerHTML={ {
+					__html: html( this.props.subject ),
+				} }
+			/>
+		);
 
-			return (
-				<div className="wpnc__summary">
-					{ subject }
-					<Snippet note={ this.props.note } snippet={ this.props.snippet } url={ this.props.url } />
-				</div>
-			);
-		}
+		return (
+			<div className="wpnc__summary">
+				{ subject }
+				<Snippet note={ this.props.note } snippet={ this.props.snippet } url={ this.props.url } />
+			</div>
+		);
 	}
-);
+}
 
 class SummaryInSingle extends Component {
 	render() {


### PR DESCRIPTION
Removes usage of `React.createFactory`, a very outdated React API function. There's only one usage in the codebase.

The usage was incorrect, and worked mostly by accident. `createFactory` creates helpers that return elements:
```js
const createFactory = ( type ) => ( props, children ) => React.createElement( type, props, children );
```
and is useful when building React UI without JSX:
```js
const div = createFactory( 'div' );
const header = createFactory( Header );
return header(
  { className: 'header' },
  div( null, 'hello' ),
  div( null, 'world' ),
);
```
Accidentally, the function returned by `createFactory` also passes as a function component `(props) => ReactElement` so the `Header` factory could be used as `<Header />`.

This PR removes the unnecessary indirection.

**How to test:**
I have bad news that I haven't found a way to test this. The `<Header>` component is rendered in `SummaryInSingle` (the popup that opens when you click on a notification in the list) only when the notification i) has a header and ii) the header is not of type `user`. But I have no notifications like this. Vast majority of notifications comes from a user (someone posted this or liked that) and these that don't come from a user, like "Jetpack backed up your site", have no header at all. If you, the reviewer, can find a notification that hits this code path that would be awesome.