### PR TITLE
Introduce NotAuthorized component

### DIFF
--- a/client/signup/steps/import-from/components/not-authorized/index.tsx
+++ b/client/signup/steps/import-from/components/not-authorized/index.tsx
@@ -1,0 +1,41 @@
+import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
+import { GoToStep } from '../../../import/types';
+
+import './style.scss';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+interface Props {
+	goToStep: GoToStep;
+}
+
+const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
+	const { __ } = useI18n();
+	const { goToStep } = props;
+
+	return (
+		<div className="import-layout__center">
+			<div className="import__header">
+				<div className="import__heading  import__heading-center">
+					<Title>{ __( 'Your are not authorized to import content' ) }</Title>
+					<SubTitle>{ __( 'Please check with your site admin.' ) }</SubTitle>
+
+					<div className="import__buttons-group">
+						<NextButton onClick={ () => goToStep( 'intent', '', 'setup-site' ) }>
+							{ __( 'Start building' ) }
+						</NextButton>
+						<div>
+							<BackButton onClick={ () => goToStep( 'capture' ) }>
+								{ __( 'Back to start' ) }
+							</BackButton>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default NotAuthorized;

--- a/client/signup/steps/import-from/components/not-authorized/index.tsx
+++ b/client/signup/steps/import-from/components/not-authorized/index.tsx
@@ -1,6 +1,8 @@
 import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
+import page from 'page';
 import React from 'react';
+import { getStepUrl } from 'calypso/signup/utils';
 import { GoToStep } from '../../../import/types';
 
 import './style.scss';
@@ -9,11 +11,19 @@ import './style.scss';
 
 interface Props {
 	goToStep: GoToStep;
+	siteSlug: string;
 }
 
 const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { goToStep } = props;
+	const { goToStep, siteSlug } = props;
+
+	/**
+	 ↓ Methods
+	 */
+	const backToStart = (): void => {
+		page( getStepUrl( 'importer', 'capture', '', '', { siteSlug } ) );
+	};
 
 	return (
 		<div className="import-layout__center">
@@ -27,9 +37,7 @@ const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 							{ __( 'Start building' ) }
 						</NextButton>
 						<div>
-							<BackButton onClick={ () => goToStep( 'capture' ) }>
-								{ __( 'Back to start' ) }
-							</BackButton>
+							<BackButton onClick={ backToStart }>{ __( 'Back to start' ) }</BackButton>
 						</div>
 					</div>
 				</div>

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Title } from '@automattic/onboarding';
 import page from 'page';
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
@@ -14,6 +13,8 @@ import {
 } from 'calypso/state/imports/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteId } from 'calypso/state/sites/selectors';
+import { GoToStep } from '../import/types';
+import NotAuthorized from './components/not-authorized';
 import { Importer, QueryObject, ImportJob } from './types';
 import { getImporterTypeForEngine } from './util';
 import WixImporter from './wix';
@@ -34,6 +35,7 @@ interface Props {
 	isImporterStatusHydrated: boolean;
 	siteImports: ImportJob[];
 	fetchImporterState: ( siteId: number ) => void;
+	goToStep: GoToStep;
 }
 const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const {
@@ -44,6 +46,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 		siteImports,
 		isImporterStatusHydrated,
 		fromSite,
+		goToStep,
 	} = props;
 
 	/**
@@ -73,7 +76,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function hasPermission(): boolean {
-		return canImport;
+		return canImport && false;
 	}
 
 	function checkInitialRunState() {
@@ -111,7 +114,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 									/**
 									 * Permission screen
 									 */
-									return <Title>You are not authorized to view this page</Title>;
+									return <NotAuthorized goToStep={ goToStep } />;
 								} else if ( engine === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) ) {
 									/**
 									 * Wix importer

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -76,7 +76,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function hasPermission(): boolean {
-		return canImport && false;
+		return canImport;
 	}
 
 	function checkInitialRunState() {

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -114,7 +114,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 									/**
 									 * Permission screen
 									 */
-									return <NotAuthorized goToStep={ goToStep } />;
+									return <NotAuthorized goToStep={ goToStep } siteSlug={ siteSlug } />;
 								} else if ( engine === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) ) {
 									/**
 									 * Wix importer

--- a/client/signup/steps/import/style.scss
+++ b/client/signup/steps/import/style.scss
@@ -34,7 +34,7 @@
 
 		@include break-medium {
 			h1 {
-				width: 492px;
+				width: 500px;
 				margin: auto;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Changes contain a new screen for non-authorized users.

#### Testing instructions
- Log in with user without `manage_options` permission
- Go to `/start/importer?siteSlug={YOUR_SITE}.wordpress.com`
- Enter a valid Wix website URL
- Hit the Import your content button
- The redesigned screen for the non-authorized users will be shown

#### Screenshots
Before:
<img width="945" alt="Screenshot 2021-12-14 at 15 33 46" src="https://user-images.githubusercontent.com/1241413/146018305-19df4e9e-5691-451a-be85-65a7e111bad9.png">

After:
<img width="634" alt="Screenshot 2021-12-14 at 15 27 25" src="https://user-images.githubusercontent.com/1241413/146018337-dcdc8b0f-39de-4ec6-8bc1-5147121f5542.png">


Related to #59041
