### PR TITLE
Config: Remove unused `manage/plugins/compatibility-warning` flag

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	findFirstSimilarPlanKey,
 	FEATURE_UPLOAD_PLUGINS,
@@ -10,7 +9,7 @@ import {
 import { Button, Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, includes, some } from 'lodash';
+import { get, includes } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -341,20 +340,6 @@ export class PluginMeta extends Component {
 					showDismiss={ false }
 				/>
 			);
-		} else if (
-			config.isEnabled( 'manage/plugins/compatibility-warning' ) &&
-			! this.isVersionCompatible()
-		) {
-			return (
-				<Notice
-					className="plugin-meta__version-notice"
-					text={ this.props.translate(
-						'The new version of this plugin may not be compatible with your version of WordPress'
-					) }
-					status="is-warning"
-					showDismiss={ false }
-				/>
-			);
 		}
 	}
 
@@ -410,26 +395,6 @@ export class PluginMeta extends Component {
 				</Notice>
 			);
 		}
-	}
-
-	isVersionCompatible() {
-		if ( ! this.props.selectedSite ) {
-			return true;
-		}
-
-		// still not fetched
-		if ( ! this.props.plugin.compatibility ) {
-			return true;
-		}
-
-		if ( ! this.props.plugin.compatibility || this.props.plugin.compatibility.length === 0 ) {
-			return false;
-		}
-
-		const siteVersion = this.props.selectedSite.options.software_version.split( '-' )[ 0 ];
-		return some( this.props.plugin.compatibility, ( compatibleVersion ) => {
-			return compatibleVersion.indexOf( siteVersion ) === 0;
-		} );
 	}
 
 	hasOrgInstallButton() {

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -124,13 +124,6 @@ export class PluginMeta extends Component {
 		);
 	}
 
-	getPlan() {
-		if ( ! this.props.selectedSite ) {
-			return false;
-		}
-		return this.props.selectedSite.plan();
-	}
-
 	isWpcomPreinstalled = () => {
 		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPress' ];
 

--- a/config/README.md
+++ b/config/README.md
@@ -28,7 +28,7 @@ The config files contain a features object that can be used to determine whether
 If you want to temporarily enable/disable some feature flags for a given build, you can do so by setting the `ENABLE_FEATURES` and/or `DISABLE_FEATURES` environment variables. Set them to a comma separated list of features you want to enable/disable, respectively:
 
 ```bash
-ENABLE_FEATURES=manage/plugins/compatibility-warning DISABLE_FEATURES=reader yarn start
+ENABLE_FEATURES=some/flag-name DISABLE_FEATURES=reader yarn start
 ```
 
 ### Testing Feature Flags via URLs
@@ -41,4 +41,4 @@ If you want to temporarily enable/disable some feature flags you can add a `?fla
 - `?flags=-bar` disables feature _bar_.
 - `?flags=foo,-bar` enables feature _foo_ and disables feature _bar_.
 
-E.g. <http://calypso.localhost:3000/?flags=manage/plugins/compatibility-warning>
+E.g. <http://calypso.localhost:3000/?flags=some/flag-name>

--- a/config/development.json
+++ b/config/development.json
@@ -106,7 +106,6 @@
 		"mailchimp": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/site-importer-endpoints": true,
-		"manage/plugins/compatibility-warning": false,
 		"marketplace-test": true,
 		"marketplace-v0.5": true,
 		"marketplace": true,

--- a/config/test.json
+++ b/config/test.json
@@ -58,7 +58,6 @@
 		"legal-updates-banner": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
-		"manage/plugins/compatibility-warning": false,
 		"me/account-close": true,
 		"me/vat-details": true,
 		"network-connection": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up the `manage/plugins/compatibility-warning` feature flag that is disabled everywhere.

#### Testing instructions

* Go to `/plugins/contact-form-7?flags=-marketplace-v0.5`
* Verify plugin page still loads well.