### PR TITLE
Config: Cleanup unused perfmon feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -118,7 +118,6 @@
 		"p2/p2-plus": true,
 		"p2/preapproved-domains": true,
 		"page/export": true,
-		"perfmon": false,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -75,7 +75,6 @@
 		"network-connection": true,
 		"p2/p2-plus": true,
 		"p2/preapproved-domains": false,
-		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"publicize-preview": true,

--- a/config/production.json
+++ b/config/production.json
@@ -76,7 +76,6 @@
 		"me/vat-details": true,
 		"p2/p2-plus": true,
 		"p2/preapproved-domains": false,
-		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -76,7 +76,6 @@
 		"p2/p2-plus": true,
 		"p2/preapproved-domains": true,
 		"page/export": true,
-		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,

--- a/config/test.json
+++ b/config/test.json
@@ -63,7 +63,6 @@
 		"me/vat-details": true,
 		"network-connection": true,
 		"p2/preapproved-domains": true,
-		"perfmon": false,
 		"plans/personal-plan": true,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -85,7 +85,6 @@
 		"network-connection": true,
 		"p2/p2-plus": true,
 		"p2/preapproved-domains": true,
-		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #54748, the `perfmon` feature flag is unused. This PR removes it.

#### Testing instructions

Verify the removed feature flag is not in use.