### PR TITLE
Onboarding medium importer base

### DIFF
--- a/client/signup/steps/import-from/components/done-button/index.tsx
+++ b/client/signup/steps/import-from/components/done-button/index.tsx
@@ -2,7 +2,7 @@ import { NextButton } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import React from 'react';
-import { ImportJob } from './types';
+import { ImportJob } from '../../types';
 
 interface Props {
 	job: ImportJob;

--- a/client/signup/steps/import-from/done-button.tsx
+++ b/client/signup/steps/import-from/done-button.tsx
@@ -2,7 +2,7 @@ import { NextButton } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import React from 'react';
-import { ImportJob } from '../types';
+import { ImportJob } from './types';
 
 interface Props {
 	job: ImportJob;

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -121,7 +121,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 									isEnabled( 'gutenboarding/import-from-medium' )
 								) {
 									/**
-									 * Wix importer
+									 * Medium importer
 									 */
 									return (
 										<MediumImporter

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -15,6 +15,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { GoToStep } from '../import/types';
 import NotAuthorized from './components/not-authorized';
+import { MediumImporter } from './medium';
 import { Importer, QueryObject, ImportJob } from './types';
 import { getImporterTypeForEngine } from './util';
 import WixImporter from './wix';
@@ -115,6 +116,22 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 									 * Permission screen
 									 */
 									return <NotAuthorized goToStep={ goToStep } siteSlug={ siteSlug } />;
+								} else if (
+									engine === 'medium' &&
+									isEnabled( 'gutenboarding/import-from-medium' )
+								) {
+									/**
+									 * Wix importer
+									 */
+									return (
+										<MediumImporter
+											job={ getImportJob( engine ) }
+											run={ runImportInitially }
+											siteId={ siteId }
+											siteSlug={ siteSlug }
+											fromSite={ fromSite }
+										/>
+									);
 								} else if ( engine === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) ) {
 									/**
 									 * Wix importer

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -16,9 +16,9 @@ interface Props {
 	siteId: number;
 	siteSlug: string;
 	fromSite: string;
-	importSite: ( params: ImportJobParams ) => void;
-	startImport: ( siteId: number, type: string ) => void;
-	resetImport: ( siteId: number, importerId: string ) => void;
+	importSite?: ( params: ImportJobParams ) => void;
+	startImport?: ( siteId: number, type: string ) => void;
+	resetImport?: ( siteId: number, importerId: string ) => void;
 }
 export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 	const importer: Importer = 'medium';

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { resetImport, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
-import DoneButton from '../done-button';
+import DoneButton from '../components/done-button';
 import { Importer, ImportJob, ImportJobParams } from '../types';
 import { getImporterTypeForEngine } from '../util';
 import './style.scss';

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -1,0 +1,99 @@
+import { Hooray, SubTitle, Title } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { resetImport, startImport } from 'calypso/state/imports/actions';
+import { appStates } from 'calypso/state/imports/constants';
+import { importSite } from 'calypso/state/imports/site-importer/actions';
+import DoneButton from '../done-button';
+import { Importer, ImportJob, ImportJobParams } from '../types';
+import { getImporterTypeForEngine } from '../util';
+import './style.scss';
+
+interface Props {
+	job?: ImportJob;
+	run: boolean;
+	siteId: number;
+	siteSlug: string;
+	fromSite: string;
+	importSite: ( params: ImportJobParams ) => void;
+	startImport: ( siteId: number, type: string ) => void;
+	resetImport: ( siteId: number, importerId: string ) => void;
+}
+export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
+	const importer: Importer = 'medium';
+	const { __ } = useI18n();
+	const { job, run, siteId, siteSlug, fromSite, importSite, startImport, resetImport } = props;
+
+	/**
+	 ↓ Effects
+	 */
+	useEffect( runImport, [ job ] );
+
+	/**
+	 ↓ Methods
+	 */
+	function runImport() {
+		if ( ! run ) return;
+
+		// If there is no existing import job, start a new
+		if ( job === undefined ) {
+			startImport( siteId, getImporterTypeForEngine( importer ) );
+		} else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
+			importSite( prepareImportParams() );
+		}
+	}
+
+	function prepareImportParams(): ImportJobParams {
+		const targetSiteUrl = fromSite.startsWith( 'http' ) ? fromSite : 'https://' + fromSite;
+
+		return {
+			engine: importer,
+			importerStatus: job as ImportJob,
+			params: { engine: importer },
+			site: { ID: siteId },
+			targetSiteUrl,
+			supportedContent: [],
+			unsupportedContent: [],
+		};
+	}
+
+	function checkIsSuccess() {
+		return true;
+	}
+
+	return (
+		<>
+			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
+				{ ( () => {
+					if ( checkIsSuccess() ) {
+						/**
+						 * Complete screen
+						 */
+						return (
+							<Hooray>
+								<Title>{ __( 'Hooray!' ) }</Title>
+								<SubTitle>
+									{ __( 'Congratulations. Your content was successfully imported.' ) }
+								</SubTitle>
+								<DoneButton
+									siteId={ siteId }
+									siteSlug={ siteSlug }
+									job={ job as ImportJob }
+									resetImport={ resetImport }
+								/>
+							</Hooray>
+						);
+					}
+				} )() }
+			</div>
+		</>
+	);
+};
+
+export default connect( null, {
+	importSite,
+	startImport,
+	resetImport,
+} )( MediumImporter );

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -1,14 +1,13 @@
 import { Hooray, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { resetImport, startImport } from 'calypso/state/imports/actions';
-import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import DoneButton from '../components/done-button';
 import { Importer, ImportJob, ImportJobParams } from '../types';
-import { getImporterTypeForEngine } from '../util';
+
 import './style.scss';
 
 interface Props {
@@ -24,40 +23,7 @@ interface Props {
 export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 	const importer: Importer = 'medium';
 	const { __ } = useI18n();
-	const { job, run, siteId, siteSlug, fromSite, importSite, startImport, resetImport } = props;
-
-	/**
-	 ↓ Effects
-	 */
-	useEffect( runImport, [ job ] );
-
-	/**
-	 ↓ Methods
-	 */
-	function runImport() {
-		if ( ! run ) return;
-
-		// If there is no existing import job, start a new
-		if ( job === undefined ) {
-			startImport( siteId, getImporterTypeForEngine( importer ) );
-		} else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
-			importSite( prepareImportParams() );
-		}
-	}
-
-	function prepareImportParams(): ImportJobParams {
-		const targetSiteUrl = fromSite.startsWith( 'http' ) ? fromSite : 'https://' + fromSite;
-
-		return {
-			engine: importer,
-			importerStatus: job as ImportJob,
-			params: { engine: importer },
-			site: { ID: siteId },
-			targetSiteUrl,
-			supportedContent: [],
-			unsupportedContent: [],
-		};
-	}
+	const { job, siteId, siteSlug } = props;
 
 	function checkIsSuccess() {
 		return true;

--- a/client/signup/steps/import-from/medium/style.scss
+++ b/client/signup/steps/import-from/medium/style.scss
@@ -1,0 +1,4 @@
+.importer-medium {
+	// ...
+}
+

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -9,8 +9,8 @@ import { calculateProgress } from 'calypso/my-sites/importer/importing-pane';
 import { startImport, resetImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
+import DoneButton from '../components/done-button';
 import GettingStartedVideo from '../components/getting-started-video';
-import DoneButton from '../done-button';
 import { Importer, ImportJob, ImportJobParams } from '../types';
 import { getImporterTypeForEngine } from '../util';
 

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -10,9 +10,9 @@ import { startImport, resetImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import GettingStartedVideo from '../components/getting-started-video';
+import DoneButton from '../done-button';
 import { Importer, ImportJob, ImportJobParams } from '../types';
 import { getImporterTypeForEngine } from '../util';
-import DoneButton from './done-button';
 
 import './style.scss';
 

--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -69,7 +69,10 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 
 	const goToImporterPage = ( platform: ImporterPlatform ): void => {
 		let importerUrl;
-		if ( platform === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) ) {
+		if (
+			( platform === 'medium' && isEnabled( 'gutenboarding/import-from-medium' ) ) ||
+			( platform === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) )
+		) {
 			importerUrl = getWpComOnboardingUrl( signupDependencies.siteSlug, platform, urlData.url );
 		} else {
 			importerUrl = getImporterUrl( signupDependencies.siteSlug, platform, urlData.url );

--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -10,7 +10,7 @@ import { isAnalyzing, getUrlData } from 'calypso/state/imports/url-analyzer/sele
 import CaptureStep from './capture';
 import ListStep from './list';
 import { ReadyPreviewStep, ReadyNotStep, ReadyStep, ReadyAlreadyOnWPCOMStep } from './ready';
-import { GoToStep, GoToNextStep, UrlData, RecordTracksEvent } from './types';
+import { GoToStep, GoToNextStep, UrlData, RecordTracksEvent, ImporterPlatform } from './types';
 import { getImporterUrl, getWpComOnboardingUrl } from './util';
 import './style.scss';
 
@@ -67,7 +67,7 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 		page( getStepWithQueryParamUrl( stepName, stepSectionName, flowName, dependency ) );
 	};
 
-	const goToImporterPage = ( platform: string ): void => {
+	const goToImporterPage = ( platform: ImporterPlatform ): void => {
 		let importerUrl;
 		if ( platform === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) ) {
 			importerUrl = getWpComOnboardingUrl( signupDependencies.siteSlug, platform, urlData.url );

--- a/client/signup/steps/import/list/index.tsx
+++ b/client/signup/steps/import/list/index.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
 import { urlDataUpdate } from 'calypso/state/imports/url-analyzer/actions';
-import { GoToStep, UrlData } from '../types';
+import { GoToStep, ImporterPlatform, UrlData } from '../types';
 import type * as React from 'react';
 import './style.scss';
 
@@ -20,7 +20,7 @@ const ListStep: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const { goToStep, urlDataUpdate } = props;
 
-	const onButtonClick = ( platform: string ): void => {
+	const onButtonClick = ( platform: ImporterPlatform ): void => {
 		urlDataUpdate( {
 			url: '',
 			platform,

--- a/client/signup/steps/import/ready/index.tsx
+++ b/client/signup/steps/import/ready/index.tsx
@@ -3,7 +3,7 @@ import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect } from 'react';
-import { UrlData, GoToStep, RecordTracksEvent } from '../types';
+import { UrlData, GoToStep, RecordTracksEvent, ImporterPlatform } from '../types';
 import { convertPlatformName, convertToFriendlyWebsiteName } from '../util';
 import ImportPlatformDetails, { coveredPlatforms } from './platform-details';
 import ImportPreview from './preview';
@@ -20,7 +20,7 @@ const trackEventParams = {
 interface ReadyPreviewProps {
 	urlData: UrlData;
 	siteSlug: string;
-	goToImporterPage: ( platform: string ) => void;
+	goToImporterPage: ( platform: ImporterPlatform ) => void;
 	recordTracksEvent: RecordTracksEvent;
 }
 
@@ -160,8 +160,8 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( {
 };
 
 interface ReadyProps {
-	platform: string;
-	goToImporterPage: ( platform: string ) => void;
+	platform: ImporterPlatform;
+	goToImporterPage: ( platform: ImporterPlatform ) => void;
 	recordTracksEvent: RecordTracksEvent;
 }
 

--- a/client/signup/steps/import/ready/platform-details.tsx
+++ b/client/signup/steps/import/ready/platform-details.tsx
@@ -2,13 +2,13 @@ import { Modal } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { Icon, close, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { FeatureName, FeatureList } from '../types';
+import { FeatureName, FeatureList, ImporterPlatform } from '../types';
 import type * as React from 'react';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface DetailsProps {
-	platform: string;
+	platform: ImporterPlatform;
 	onClose: () => void;
 }
 
@@ -60,7 +60,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 		plugins: __( 'Plugins' ),
 	};
 
-	const getTitle = ( _platform: string ): string => {
+	const getTitle = ( _platform: ImporterPlatform ): string => {
 		switch ( _platform ) {
 			case 'wix':
 				return __( 'Importing content from Wix' );
@@ -77,7 +77,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 		}
 	};
 
-	const getInfo = ( _platform: string ): string => {
+	const getInfo = ( _platform: ImporterPlatform ): string => {
 		switch ( _platform ) {
 			case 'wix':
 				return __(

--- a/client/signup/steps/import/types.ts
+++ b/client/signup/steps/import/types.ts
@@ -3,7 +3,7 @@ export type GoToNextStep = () => void;
 export type RecordTracksEvent = ( name: string, properties: { [ key: string ]: string } ) => void;
 export type UrlData = {
 	url: string;
-	platform: string;
+	platform: ImporterPlatform;
 	platform_data?: {
 		is_wpcom: boolean;
 	};
@@ -31,3 +31,22 @@ export type FeatureName =
 	| 'plugins';
 
 export type FeatureList = { [ key in FeatureName ]: string };
+
+// List of supported importer platforms (most important)
+export type ImporterMainPlatform =
+	| 'blogger'
+	| 'medium'
+	| 'squarespace'
+	| 'wordpress'
+	| 'wix'
+	| ImporterPlatformOther;
+// List of supported importer platforms (others)
+export type ImporterPlatformOther =
+	| 'blogroll'
+	| 'ghost'
+	| 'livejournal'
+	| 'movabletype'
+	| 'tumblr'
+	| 'xanga';
+export type ImporterPlatformExtra = 'godaddy-central';
+export type ImporterPlatform = ImporterMainPlatform | ImporterPlatformOther | ImporterPlatformExtra;

--- a/client/signup/steps/import/util.ts
+++ b/client/signup/steps/import/util.ts
@@ -1,4 +1,6 @@
-const platformMap: { [ key: string ]: string } = {
+import { ImporterPlatform } from './types';
+
+const platformMap: { [ key in ImporterPlatform ]: string } = {
 	wordpress: 'WordPress',
 	wix: 'Wix',
 	blogger: 'Blogger',
@@ -20,7 +22,7 @@ export const platformImporterNameMap: { [ key: string ]: string } = {
 	movabletype: 'mt',
 };
 
-export const orgImporters: string[] = [
+export const orgImporters: ImporterPlatform[] = [
 	'xanga',
 	'tumblr',
 	'movabletype',
@@ -32,11 +34,11 @@ export const orgImporters: string[] = [
 /**
  * Platform name helpers
  */
-export function getPlatformImporterName( platform: string ): string {
+export function getPlatformImporterName( platform: ImporterPlatform ): string {
 	return platformImporterNameMap[ platform ] ? platformImporterNameMap[ platform ] : platform;
 }
 
-export function convertPlatformName( platform: string ): string {
+export function convertPlatformName( platform: ImporterPlatform ): string {
 	return platformMap[ platform ] !== undefined ? platformMap[ platform ] : 'Unknown';
 }
 
@@ -56,7 +58,7 @@ export function getWpComMigrateUrl( siteSlug: string, fromSite?: string ): strin
 
 export function getWpComOnboardingUrl(
 	siteSlug: string,
-	platform: string,
+	platform: ImporterPlatform,
 	fromSite?: string
 ): string {
 	return '/start/from/importing/{importer}?from={fromSite}&to={siteSlug}&run=true'
@@ -67,7 +69,7 @@ export function getWpComOnboardingUrl(
 
 export function getWpComImporterUrl(
 	siteSlug: string,
-	platform: string,
+	platform: ImporterPlatform,
 	fromSite?: string
 ): string {
 	const wpComBase = '/import/{siteSlug}?engine={importer}&from-site={fromSite}';
@@ -78,7 +80,7 @@ export function getWpComImporterUrl(
 		.replace( '{fromSite}', fromSite || '' );
 }
 
-export function getWpOrgImporterUrl( siteSlug: string, platform: string ): string {
+export function getWpOrgImporterUrl( siteSlug: string, platform: ImporterPlatform ): string {
 	const wpAdminBase = 'https://{siteSlug}/wp-admin/admin.php?import={importer}';
 
 	return wpAdminBase
@@ -86,7 +88,11 @@ export function getWpOrgImporterUrl( siteSlug: string, platform: string ): strin
 		.replace( '{importer}', getPlatformImporterName( platform ) );
 }
 
-export function getImporterUrl( siteSlug: string, platform: string, fromSite?: string ): string {
+export function getImporterUrl(
+	siteSlug: string,
+	platform: ImporterPlatform,
+	fromSite?: string
+): string {
 	if ( platform === 'wordpress' ) {
 		return getWpComMigrateUrl( siteSlug, fromSite );
 	} else if ( orgImporters.includes( platform ) ) {

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,7 @@
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/import": true,
-		"gutenboarding/import-from-medium": true,
+		"gutenboarding/import-from-medium": false,
 		"gutenboarding/import-from-wix": true,
 		"help": true,
 		"home/layout-dev": true,

--- a/config/development.json
+++ b/config/development.json
@@ -67,6 +67,7 @@
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/import": true,
+		"gutenboarding/import-from-medium": true,
 		"gutenboarding/import-from-wix": true,
 		"help": true,
 		"home/layout-dev": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,7 +45,7 @@
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/import": true,
-		"gutenboarding/import-from-medium": true,
+		"gutenboarding/import-from-medium": false,
 		"gutenboarding/import-from-wix": true,
 		"happychat": true,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,6 +45,7 @@
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/import": true,
+		"gutenboarding/import-from-medium": true,
 		"gutenboarding/import-from-wix": true,
 		"happychat": true,
 		"help": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new base `MediumImporter` component that provides a base for the new Medium import flow. The component redirects directly to the _Hooray!_ page in this status.

* Added a new `gutenboarding/import-from-medium`, currently disabled, feature flag.
* Added a new Medium flow that substitutes the old one when the feature flag is enabled.
* Moved the `DoneButton` in the `import-from` folder in other to be used by other future routes.
* Minor refactoring provides a [ImporterPlatform](https://github.com/Automattic/wp-calypso/commit/78fb9d482bab22900931e96eb185df4b9e1cefae#diff-eb58176c5d27ca67227fe2c0e409be6d3a8fb526de9a30a22708b6e4e47cebc3R52) type that is used instead of a generic string.

Related to #59036

#### Testing instructions

* Enable `gutenboarding/import-from-medium` feature flag either by environment variables or a query parameter.
* Visit http://calypso.localhost:3000/start/importer/capture?siteSlug=SLUG
* Insert a Medium site address. E.g., https://medium.com/@worthy_shadows_goose_107
* Click "Import your content".
* Ensure that you are redirected to the _Hooray!_ page.

#### Next steps

* Add the file upload step
* Add the actual import