### PR TITLE
Plugin Details: check how the description of paid plugins renders

### DIFF
--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -3,7 +3,9 @@ import './style.scss';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 
 const PluginDetailsSidebar = ( props ) => {
-	const { plugin } = props;
+	const {
+		plugin: { active_installs, tested },
+	} = props;
 
 	const translate = useTranslate();
 
@@ -13,20 +15,24 @@ const PluginDetailsSidebar = ( props ) => {
 				{ translate( 'Plugin details' ) }
 			</div>
 			<div className="plugin-details-sidebar__plugin-details-content">
-				<div className="plugin-details-sidebar__active-installs">
-					<div className="plugin-details-sidebar__active-installs-text title">
-						{ translate( 'Active installations' ) }
+				{ Boolean( active_installs ) && (
+					<div className="plugin-details-sidebar__active-installs">
+						<div className="plugin-details-sidebar__active-installs-text title">
+							{ translate( 'Active installations' ) }
+						</div>
+						<div className="plugin-details-sidebar__active-installs-value value">
+							{ formatNumberMetric( active_installs, 'en' ) }
+						</div>
 					</div>
-					<div className="plugin-details-sidebar__active-installs-value value">
-						{ formatNumberMetric( plugin.active_installs, 'en' ) }
+				) }
+				{ Boolean( tested ) && (
+					<div className="plugin-details-sidebar__tested">
+						<div className="plugin-details-sidebar__tested-text title">
+							{ translate( 'Tested up to' ) }
+						</div>
+						<div className="plugin-details-sidebar__tested-value value">{ tested }</div>
 					</div>
-				</div>
-				<div className="plugin-details-sidebar__tested">
-					<div className="plugin-details-sidebar__tested-text title">
-						{ translate( 'Tested up to' ) }
-					</div>
-					<div className="plugin-details-sidebar__tested-value value">{ plugin.tested }</div>
-				</div>
+				) }
 			</div>
 		</>
 	);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -94,7 +93,7 @@ function PluginDetails( props ) {
 
 	// Determine if the plugin is WPcom or WPorg hosted
 	const productsList = useSelector( ( state ) => getProductsList( state ) );
-	const isProductListFetched = ! isEmpty( productsList );
+	const isProductListFetched = Object.values( productsList ).length > 0;
 
 	const isMarketplaceProduct = useSelector( ( state ) =>
 		isMarketplaceProductSelector( state, props.pluginSlug )
@@ -136,7 +135,6 @@ function PluginDetails( props ) {
 	}, [ plugin, wporgPlugin, wpComPluginData, isWpComPluginFetched ] );
 
 	const existingPlugin = useMemo( () => {
-		// ( ! isMarketplaceProduct && ( isWporgPluginFetching || ! isWporgPluginFetched ) ) ||
 		if (
 			( ! isMarketplaceProduct && ( isWporgPluginFetching || ! isWporgPluginFetched ) ) ||
 			( isMarketplaceProduct && ( isWpComPluginFetching || ! isWpComPluginFetched ) )

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -9,6 +10,7 @@ import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import MainComponent from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -29,10 +31,14 @@ import {
 } from 'calypso/state/plugins/installed/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import {
-	isFetching as isWporgPluginFetching,
-	isFetched as isWporgPluginFetched,
-	getPlugin as getWporgPlugin,
+	isFetching as isWporgPluginFetchingSelector,
+	isFetched as isWporgPluginFetchedSelector,
+	getPlugin as getWporgPluginSelector,
 } from 'calypso/state/plugins/wporg/selectors';
+import {
+	isMarketplaceProduct as isMarketplaceProductSelector,
+	getProductsList,
+} from 'calypso/state/products-list/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
@@ -61,9 +67,13 @@ function PluginDetails( props ) {
 
 	// Plugin information.
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );
-	const wporgPlugin = useSelector( ( state ) => getWporgPlugin( state, props.pluginSlug ) );
-	const isFetching = useSelector( ( state ) => isWporgPluginFetching( state, props.pluginSlug ) );
-	const isFetched = useSelector( ( state ) => isWporgPluginFetched( state, props.pluginSlug ) );
+	const wporgPlugin = useSelector( ( state ) => getWporgPluginSelector( state, props.pluginSlug ) );
+	const isWporgPluginFetching = useSelector( ( state ) =>
+		isWporgPluginFetchingSelector( state, props.pluginSlug )
+	);
+	const isWporgPluginFetched = useSelector( ( state ) =>
+		isWporgPluginFetchedSelector( state, props.pluginSlug )
+	);
 	const sitePlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, selectedSite?.ID, props.pluginSlug )
 	);
@@ -82,22 +92,55 @@ function PluginDetails( props ) {
 	const isWpcom = selectedSite && ! isJetpack;
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 
-	const fullPlugin = useMemo(
-		() => ( {
-			...plugin,
-			...wporgPlugin,
-		} ),
-		[ plugin, wporgPlugin ]
+	// Determine if the plugin is WPcom or WPorg hosted
+	const productsList = useSelector( ( state ) => getProductsList( state ) );
+	const isProductListFetched = ! isEmpty( productsList );
+
+	const isMarketplaceProduct = useSelector( ( state ) =>
+		isMarketplaceProductSelector( state, props.pluginSlug )
 	);
 
+	// Fetch WPorg plugin data if needed
 	useEffect( () => {
-		if ( ! isFetched ) {
+		if ( isProductListFetched && ! isMarketplaceProduct && ! isWporgPluginFetched ) {
 			dispatch( wporgFetchPluginData( props.pluginSlug ) );
 		}
-	}, [ isFetched, props.pluginSlug, dispatch ] );
+	}, [
+		isProductListFetched,
+		isMarketplaceProduct,
+		isWporgPluginFetched,
+		props.pluginSlug,
+		dispatch,
+	] );
+
+	// Fetch WPcom plugin data if needed
+	const {
+		data: wpComPluginData,
+		isFetched: isWpComPluginFetched,
+		isFetching: isWpComPluginFetching,
+	} = useWPCOMPlugin( props.pluginSlug, { enabled: isProductListFetched && isMarketplaceProduct } );
+
+	// Unify plugin details
+	const fullPlugin = useMemo( () => {
+		const wpcomPlugin = {
+			...wpComPluginData,
+			fetched: isWpComPluginFetched,
+			rating: ( wpComPluginData?.rating / 5 ) * 100,
+		};
+
+		return {
+			...plugin,
+			...wpcomPlugin,
+			...wporgPlugin,
+		};
+	}, [ plugin, wporgPlugin, wpComPluginData, isWpComPluginFetched ] );
 
 	const existingPlugin = useMemo( () => {
-		if ( isFetching || ! isFetched ) {
+		// ( ! isMarketplaceProduct && ( isWporgPluginFetching || ! isWporgPluginFetched ) ) ||
+		if (
+			( ! isMarketplaceProduct && ( isWporgPluginFetching || ! isWporgPluginFetched ) ) ||
+			( isMarketplaceProduct && ( isWpComPluginFetching || ! isWpComPluginFetched ) )
+		) {
 			return 'unknown';
 		}
 		if ( fullPlugin && fullPlugin.fetched ) {
@@ -105,7 +148,7 @@ function PluginDetails( props ) {
 		}
 
 		// If the plugin has at least one site then we know it exists
-		const pluginSites = Object.values( fullPlugin.sites );
+		const pluginSites = fullPlugin?.sites ? Object.values( fullPlugin.sites ) : [];
 		if ( pluginSites && pluginSites[ 0 ] ) {
 			return true;
 		}
@@ -115,7 +158,15 @@ function PluginDetails( props ) {
 		}
 
 		return false;
-	}, [ isFetching, isFetched, fullPlugin, requestingPluginsForSites ] );
+	}, [
+		isMarketplaceProduct,
+		isWpComPluginFetching,
+		isWpComPluginFetched,
+		isWporgPluginFetching,
+		isWporgPluginFetched,
+		fullPlugin,
+		requestingPluginsForSites,
+	] );
 
 	const getNavigationItems = () => {
 		// ToDo:
@@ -233,7 +284,9 @@ function SitesListArea( { fullPlugin: plugin, isPluginInstalledOnsite, ...props 
 	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sitesWithPlugins ) ) ];
 
-	const isFetching = useSelector( ( state ) => isWporgPluginFetching( state, props.pluginSlug ) );
+	const isFetching = useSelector( ( state ) =>
+		isWporgPluginFetchingSelector( state, props.pluginSlug )
+	);
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, props.pluginSlug )
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added the `useWPCOMPlugin` hook to fetch paid plugin data
* Plugin data is now fetched either from the WPorg or WPcom API, based on the `isMarketplaceProduct` selector

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### WPorg plugins
* Go to a WPorg plugin page (eg. `/plugins/woocommerce`)
* Check for regressions

##### WPCom plugins
* Go to a WPcom plugin page (eg. `/plugins/woocommerce-subscriptions`)
* Verify that the description is formatted correctly
* Verify that fields are displayed as below:
  
  | Site/host | WPcom | WPorg |  
  | --- | --- | --- |
  | Single site | ![wpcom-singlesite](https://user-images.githubusercontent.com/11555574/146053959-2c55e62c-7d5e-4494-82df-394ee566c691.png) | ![wporg-singlesite](https://user-images.githubusercontent.com/11555574/146053898-5212adab-30ea-4e15-844b-d30bb9cb450a.png) |
  | Multisite | ![wpcom-multisite](https://user-images.githubusercontent.com/11555574/146053992-fbc29a0b-7fcf-4310-bd41-b591df5d8bd6.png) | ![wporg-multisite](https://user-images.githubusercontent.com/11555574/146053865-d566097c-0823-4f9d-bae6-56b76752754f.png) |
  
  With WPcom plugins, the `Active installs` and `Tested version` fields should not be visible, and the `Author` field should not have a URL, as these fields aren't yet in the API response. (The author field will be addressed in #57749) The `Rating`, `Last updated`, and `Version` fields should work the same as with WPorg plugins.

#### Known issues

In the WPcom API reponse, there are some fields missing compared to the WPorg API. This cause UI elements to not render on the page:

```json
"banners": {
        "high": "",
        "low": ""
},
"num_ratings": 3812,
"ratings": {
        "1": 323,
        "2": 83,
        "3": 83,
        "4": 157,
        "5": 3166
},
"requires": "5.6",
"requires_php": "7.0",
"tags": {
        "e-commerce": "e-commerce",
        "sales": "sales",
        "sell": "sell",
        "store": "store",
        "woo": "woo"
},
"tested": "5.8.2",
```

<s>I'll add create an issue to track these differences and add a minimal set of fields, so the UI elements render similarly to WPorg plugins. </s> Added #59195 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #57756
