### PR TITLE
Update yarn version in .yarnrc as well

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-yarn-path ".yarn/releases/yarn-3.1.0.cjs"
+yarn-path ".yarn/releases/yarn-3.1.1.cjs"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates `.yarnrc` to point to the right Yarn version.

The change was applied by Renovate to `.yarnrc.yml`, used by more modern versions, but `.yarnrc` was left unchanged. This file is used by old Yarn versions (`1.15.2` fails, may affect other versions as well).
