### PR TITLE
Woop installer: redirect from checkout to transfer step

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -103,7 +103,7 @@ class HelpContact extends Component {
 	backToHelp = () => {
 		const searchParams = new URLSearchParams( window.location.search );
 		const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
-		if ( redirectPath.match( /^\/[^/]?/ ) ) {
+		if ( redirectPath.match( /^\/(?!\/)/ ) ) {
 			page( redirectPath );
 			return;
 		}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -700,6 +700,15 @@ export default function CompositeCheckout( {
 				clearSignupDestinationCookie();
 			}
 
+			if ( searchParams.has( 'cancel_to' ) ) {
+				const cancelPath = searchParams.get( 'cancel_to' ) ?? '';
+				// Only allow redirecting to relative paths.
+				if ( cancelPath.match( /^\/[^/]?/ ) ) {
+					page( cancelPath );
+					return;
+				}
+			}
+
 			// Some places that open checkout (eg: purchase page renewals) return the
 			// user there after checkout by putting the previous page's path in the
 			// `redirect_to` query param. When leaving checkout via the close button,
@@ -707,7 +716,7 @@ export default function CompositeCheckout( {
 			if ( searchParams.has( 'redirect_to' ) ) {
 				const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
 				// Only allow redirecting to relative paths.
-				if ( redirectPath.startsWith( '/' ) ) {
+				if ( redirectPath.match( /^\/[^/]?/ ) ) {
 					page( redirectPath );
 					return;
 				}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -703,7 +703,7 @@ export default function CompositeCheckout( {
 			if ( searchParams.has( 'cancel_to' ) ) {
 				const cancelPath = searchParams.get( 'cancel_to' ) ?? '';
 				// Only allow redirecting to relative paths.
-				if ( cancelPath.match( /^\/[^/]?/ ) ) {
+				if ( cancelPath.match( /^\/(?!\/)/ ) ) {
 					page( cancelPath );
 					return;
 				}
@@ -716,7 +716,7 @@ export default function CompositeCheckout( {
 			if ( searchParams.has( 'redirect_to' ) ) {
 				const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
 				// Only allow redirecting to relative paths.
-				if ( redirectPath.match( /^\/[^/]?/ ) ) {
+				if ( redirectPath.match( /^\/(?!\/)/ ) ) {
 					page( redirectPath );
 					return;
 				}

--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -62,6 +62,16 @@ export const leaveCheckout = ( {
 			window.location.href = closeUrl;
 			return;
 		}
+
+		if ( searchParams.has( 'cancel_to' ) ) {
+			const cancelPath = searchParams.get( 'cancel_to' ) ?? '';
+			// Only allow redirecting to relative paths.
+			if ( cancelPath.match( /^\/[^/]?/ ) ) {
+				navigate( cancelPath );
+				return;
+			}
+		}
+
 		// Some places that open checkout (eg: purchase page renewals) return the
 		// user there after checkout by putting the previous page's path in the
 		// `redirect_to` query param. When leaving checkout via the close button,
@@ -69,7 +79,7 @@ export const leaveCheckout = ( {
 		if ( searchParams.has( 'redirect_to' ) ) {
 			const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
 			// Only allow redirecting to relative paths.
-			if ( redirectPath.startsWith( '/' ) ) {
+			if ( redirectPath.match( /^\/[^/]?/ ) ) {
 				navigate( redirectPath );
 				return;
 			}

--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -66,7 +66,7 @@ export const leaveCheckout = ( {
 		if ( searchParams.has( 'cancel_to' ) ) {
 			const cancelPath = searchParams.get( 'cancel_to' ) ?? '';
 			// Only allow redirecting to relative paths.
-			if ( cancelPath.match( /^\/[^/]?/ ) ) {
+			if ( cancelPath.match( /^\/(?!\/)/ ) ) {
 				navigate( cancelPath );
 				return;
 			}
@@ -79,7 +79,7 @@ export const leaveCheckout = ( {
 		if ( searchParams.has( 'redirect_to' ) ) {
 			const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
 			// Only allow redirecting to relative paths.
-			if ( redirectPath.match( /^\/[^/]?/ ) ) {
+			if ( redirectPath.match( /^\/(?!\/)/ ) ) {
 				navigate( redirectPath );
 				return;
 			}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -441,6 +441,7 @@ export function generateFlows( {
 			description: 'Onboarding and installation flow for woocommerce on all plans.',
 			providesDependenciesInQuery: [ 'site' ],
 			lastModified: '2021-11-11',
+			disallowResume: false,
 		},
 	];
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -781,10 +781,11 @@ export function generateSteps( {
 				),
 			},
 			dependencies: [ 'site' ],
+			providesDependencies: [ 'siteConfirmed' ],
 		},
 		transfer: {
 			stepName: 'transfer',
-			dependencies: [ 'site' ],
+			dependencies: [ 'site', 'siteConfirmed' ],
 		},
 	};
 }

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -5,13 +5,14 @@ import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ReactElement, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
 import PlanWarning from 'calypso/components/eligibility-warnings/plan-warning';
 import EligibilityWarningsList from 'calypso/components/eligibility-warnings/warnings-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WarningCard from 'calypso/components/warning-card';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '../';
@@ -79,6 +80,7 @@ function SupportLink( { domain }: { domain: string } ): ReactElement {
 export default function Confirm( props: WooCommerceInstallProps ): ReactElement | null {
 	const { goToStep, isReskinned, headerTitle, headerDescription } = props;
 	const { __ } = useI18n();
+	const dispatch = useDispatch();
 
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -97,10 +99,11 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 
 	useEffect( () => {
 		// Automatically start the transfer process when it's ready.
-		if ( isDataReady && ( isAtomicSite || isReadyForTransfer ) ) {
-			return goToStep( 'transfer' );
+		if ( siteId && isDataReady && ( isAtomicSite || isReadyForTransfer ) ) {
+			dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
+			goToStep( 'transfer' );
 		}
-	}, [ goToStep, isDataReady, isAtomicSite, isReadyForTransfer ] );
+	}, [ dispatch, goToStep, siteId, isDataReady, isAtomicSite, isReadyForTransfer ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {
@@ -158,6 +161,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 						<StyledNextButton
 							disabled={ hasBlockers || ! isDataReady }
 							onClick={ () => {
+								dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
 								if ( siteUpgrading.required ) {
 									return ( window.location.href = siteUpgrading.checkoutUrl );
 								}

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -4,6 +4,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
+import page from 'page';
 import { ReactElement, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
@@ -16,7 +17,6 @@ import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '../';
-
 import './style.scss';
 
 const SupportLinkStyle = styled.a`
@@ -163,7 +163,8 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 							onClick={ () => {
 								dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
 								if ( siteUpgrading.required ) {
-									return ( window.location.href = siteUpgrading.checkoutUrl );
+									page( siteUpgrading.checkoutUrl );
+									return;
 								}
 								goToStep( 'transfer' );
 							} }

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -123,6 +123,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		checkoutUrl: addQueryArgs(
 			{
 				redirect_to: addQueryArgs( { site: wpcomDomain }, '/start/woocommerce-install/transfer' ),
+				cancel_to: addQueryArgs( { site: wpcomDomain }, '/start/woocommerce-install/confirm' ),
 			},
 			`/checkout/${ wpcomDomain }/${ upgradingPlan.product_slug }`
 		),

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -122,7 +122,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		required: requiresUpgrade,
 		checkoutUrl: addQueryArgs(
 			{
-				redirect_to: addQueryArgs( { site: wpcomDomain }, '/start/woocommerce-install/confirm' ),
+				redirect_to: addQueryArgs( { site: wpcomDomain }, '/start/woocommerce-install/transfer' ),
 			},
 			`/checkout/${ wpcomDomain }/${ upgradingPlan.product_slug }`
 		),

--- a/client/signup/steps/woocommerce-install/index.tsx
+++ b/client/signup/steps/woocommerce-install/index.tsx
@@ -10,9 +10,10 @@ export interface WooCommerceInstallProps {
 	headerTitle: string;
 	headerDescription: string;
 	queryObject: {
-		siteSlug: string;
+		site: string;
 	};
 	signupDependencies: {
-		siteSlug: string;
+		site: string;
+		siteConfirmed?: number;
 	};
 }

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -27,7 +27,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 	}
 
 	// if the user gets to this screen and needs a plan upgrade send it back to the confirm screen.
-	if ( siteUpgrading ) {
+	if ( siteUpgrading.required ) {
 		goToStep( 'confirm' );
 		return null;
 	}

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import InstallPlugins from './install-plugins';
 import TransferSite from './transfer-site';
 import type { WooCommerceInstallProps } from '../';
@@ -13,6 +14,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const { siteUpgrading } = useWooCommerceOnPlansEligibility( siteId );
 
 	const {
 		goToStep,
@@ -20,6 +22,12 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 	} = props;
 
 	if ( siteId !== siteConfirmed ) {
+		goToStep( 'confirm' );
+		return null;
+	}
+
+	// if the user gets to this screen and needs a plan upgrade send it back to the confirm screen.
+	if ( siteUpgrading ) {
 		goToStep( 'confirm' );
 		return null;
 	}

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import InstallPlugins from './install-plugins';
 import TransferSite from './transfer-site';
 import type { WooCommerceInstallProps } from '../';
@@ -14,20 +13,13 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-	const { siteUpgrading } = useWooCommerceOnPlansEligibility( siteId );
 
 	const {
 		goToStep,
 		signupDependencies: { siteConfirmed },
 	} = props;
 
-	if ( siteId !== siteConfirmed ) {
-		goToStep( 'confirm' );
-		return null;
-	}
-
-	// if the user gets to this screen and needs a plan upgrade send it back to the confirm screen.
-	if ( siteUpgrading.required ) {
+	if ( siteConfirmed !== siteId ) {
 		goToStep( 'confirm' );
 		return null;
 	}

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -14,6 +14,16 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
+	const {
+		goToStep,
+		signupDependencies: { siteConfirmed },
+	} = props;
+
+	if ( siteId !== siteConfirmed ) {
+		goToStep( 'confirm' );
+		return null;
+	}
+
 	return (
 		<StepWrapper
 			className="transfer__step-wrapper"

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -1,3 +1,4 @@
+import page from 'page';
 import { ReactElement, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useInterval } from 'calypso/lib/interval/use-interval';
@@ -53,7 +54,7 @@ export default function InstallPlugins(): ReactElement | null {
 			setProgress( 1 );
 			// Allow progress bar to complete
 			setTimeout( () => {
-				window.location.href = wcAdmin;
+				page( wcAdmin );
 			}, 500 );
 		}
 	}, [ siteId, softwareApplied, wcAdmin ] );

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -1,3 +1,4 @@
+import page from 'page';
 import { ReactElement, useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useInterval } from 'calypso/lib/interval/use-interval';
@@ -92,7 +93,7 @@ export default function TransferSite(): ReactElement | null {
 			setProgress( 1 );
 			// Allow progress bar to complete
 			setTimeout( () => {
-				window.location.href = wcAdmin;
+				page( wcAdmin );
 			}, 500 );
 		}
 	}, [ siteId, softwareApplied, wcAdmin ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the checkout `redirect_to` URL when the site doesn't have the proper plan to `transfer`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with a Simple site without a proper plan (Free, for instance)
* Confirm clicking on the checkout cancel button (cross at top left), redirects to `transfer` and then redirects to `confirm` step on the fly.
* Confirm once the checkout is done is redirects straight to transfer step, avoiding the need to click on the `Sounds Good` button

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
