### PR TITLE
Contact Us: Add support to redirect_to param. Use it in confirm step

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -102,7 +102,13 @@ class HelpContact extends Component {
 
 	backToHelp = () => {
 		const searchParams = new URLSearchParams( window.location.search );
-		page( searchParams.get( 'redirect_to' ) ?? '/help' );
+		const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
+		if ( redirectPath.match( /^\/[^/]?/ ) ) {
+			page( redirectPath );
+			return;
+		}
+		page( '/help' );
+		return;
 	};
 
 	clearSavedContactForm = () => {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -101,7 +101,8 @@ class HelpContact extends Component {
 	}
 
 	backToHelp = () => {
-		page( '/help' );
+		const searchParams = new URLSearchParams( window.location.search );
+		page( searchParams.get( 'redirect_to' ) ?? '/help' );
 	};
 
 	clearSavedContactForm = () => {

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -60,13 +60,15 @@ const StyledNextButton = styled( NextButton )`
 	}
 `;
 
-function SupportLink() {
+function SupportLink( { domain }: { domain: string } ): ReactElement {
 	return (
 		<SupportLinkContainer>
 			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
 				a: (
 					<SupportLinkStyle
-						href={ addQueryArgs( '/help/contact', { redirect_to: window.location.href } ) }
+						href={ addQueryArgs( '/help/contact', {
+							redirect_to: `/start/woocommerce-install/confirm?site=${ domain }`,
+						} ) }
 					/>
 				),
 			} ) }
@@ -152,7 +154,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					{ getCheckoutContent() }
 					{ getWarningsOrHoldsSection() }
 					<ActionSection>
-						<SupportLink />
+						<SupportLink domain={ wpcomDomain } />
 						<StyledNextButton
 							disabled={ hasBlockers || ! isDataReady }
 							onClick={ () => {

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { ReactElement, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
@@ -63,7 +64,11 @@ function SupportLink() {
 	return (
 		<SupportLinkContainer>
 			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
-				a: <SupportLinkStyle href="/help/contact" />,
+				a: (
+					<SupportLinkStyle
+						href={ addQueryArgs( '/help/contact', { redirect_to: window.location.href } ) }
+					/>
+				),
 			} ) }
 		</SupportLinkContainer>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR is an improvement to define the `Back` button link through the `redirect_to` parameter into the query string. It's used in the support link of the confirm button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm you can go to the support page by clicking on the support link, and go back to the confirm page by clicking on the back button.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
