### PR TITLE
Emails: Show discount star in the Google Workspace section in the Email Comparison page

### DIFF
--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -16,6 +16,7 @@ function EmailProviderCard( {
 	logo,
 	title,
 	badge,
+	starLabel,
 	description,
 	formattedPrice,
 	discount,
@@ -42,9 +43,12 @@ function EmailProviderCard( {
 
 	const labelForExpandButton = expandButtonLabel ? expandButtonLabel : buttonLabel;
 
+	const showStar = detailsExpanded && starLabel;
+
 	return (
 		<PromoCard
 			className={ classnames( 'email-providers-comparison__provider-card', {
+				'has-star': showStar,
 				'is-expanded': detailsExpanded,
 				'is-forwarding': providerKey === 'forwarding',
 			} ) }
@@ -52,6 +56,16 @@ function EmailProviderCard( {
 			title={ title }
 			badge={ badge }
 		>
+			{ showStar && (
+				<div className="email-providers-comparison__provider-card-star">
+					<span>
+						<span>
+							<span>{ starLabel }</span>
+						</span>
+					</span>
+				</div>
+			) }
+
 			<div className="email-providers-comparison__provider-card-main-details">
 				<p>{ description }</p>
 
@@ -105,6 +119,7 @@ EmailProviderCard.propTypes = {
 	logo: PropTypes.object.isRequired,
 	title: PropTypes.string.isRequired,
 	badge: PropTypes.object,
+	starLabel: PropTypes.string,
 	description: PropTypes.string,
 	formattedPrice: PropTypes.node,
 	discount: PropTypes.node,

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -426,6 +426,15 @@ class EmailProvidersComparison extends Component {
 			</span>
 		) : null;
 
+		const starLabel = productIsDiscounted
+			? translate( '%(discount)d%% off!', {
+					args: {
+						discount: gSuiteProduct.sale_coupon.discount,
+					},
+					comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
+			  } )
+			: null;
+
 		// If we don't have any users, initialize the list to have 1 empty user
 		const googleUsers =
 			( this.state.googleUsers ?? [] ).length === 0
@@ -485,6 +494,7 @@ class EmailProvidersComparison extends Component {
 				providerKey="google"
 				logo={ { path: googleWorkspaceIcon } }
 				title={ getGoogleMailServiceFamily() }
+				starLabel={ starLabel }
 				description={ translate(
 					'Professional email integrated with Google Meet and other productivity tools from Google.'
 				) }

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -106,6 +106,13 @@
 		display: none;
 	}
 
+	&.has-star {
+		.action-panel__title,
+		.email-providers-comparison__provider-card-main-details{
+			margin-right: 70px;
+		}
+	}
+
 	&.is-expanded .promo-card__title-badge {
 		background: none;
 		display: inline-block;
@@ -325,5 +332,31 @@
 			margin-top: 0;
 			margin-left: $child-left-margin;
 		}
+	}
+}
+
+.email-providers-comparison__provider-card-star,
+.email-providers-comparison__provider-card-star span {
+	background-color: var( --color-error-40 );
+	height: 70px;
+	width: 70px;
+}
+
+.email-providers-comparison__provider-card-star {
+	color: #FFFFFF;
+	font-size: $font-body-large;
+	font-weight: bold;
+	position: absolute;
+	right: 8px;
+	text-align: center;
+	top: 8px;
+	transform: rotate( -45deg );
+
+	span {
+		align-items: center;
+		display: flex;
+		justify-content: center;
+		text-shadow: 0 0 30px var( --color-error-10 ), 0 0 5px var( --color-error-90 );
+		transform: rotate( 22.5deg );
 	}
 }


### PR DESCRIPTION
This pull request updates the `Email Comparison` page to show a star with a discount in the Google Workspace section when Google Workspace is on sale:

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/146037695-0add172a-3a04-421a-8f4f-cbe1da7258ac.png) | ![image](https://user-images.githubusercontent.com/594356/146038233-48eb1b3f-1811-4d1a-8558-da89a7115003.png)

#### Testing instructions

1. Run `git checkout add/google-workspace-star` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/59189#issuecomment-993684919)
2. Open the [`Emails` page](http://calypso.localhost:3000/email)
3. Click the `Add Email` button to access the `Email Comparison` page
4. Assert that you see a star with a label in the Google Workspace section
5. Assert that there is no display issue on mobile devices