### PR TITLE
Plugins Browser: Replace featured plugins with paid plugins 

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -105,7 +105,8 @@ const PluginsBrowser = ( {
 	);
 	const pluginsByCategoryPopular = filterPopularPlugins(
 		popularPlugins,
-		pluginsByCategoryFeatured
+		pluginsByCategoryFeatured,
+		jetpackNonAtomic
 	);
 	const pluginsBySearchTerm = useSelector( ( state ) =>
 		getPluginsListBySearchTerm( state, search )
@@ -279,6 +280,7 @@ const PluginsBrowser = ( {
 				sites={ sites }
 				searchTitle={ searchTitle }
 				siteSlug={ siteSlug }
+				jetpackNonAtomic={ jetpackNonAtomic }
 			/>
 			<InfiniteScroll nextPageMethod={ fetchNextPagePlugins } />
 		</MainComponent>
@@ -468,7 +470,7 @@ const PluginBrowserContent = ( props ) => {
 	return (
 		<>
 			{ /* eslint-disable no-nested-ternary */ }
-			{ isEnabled( 'marketplace-v1' ) ? (
+			{ isEnabled( 'marketplace-v1' ) && ! props.jetpackNonAtomic ? (
 				<PluginSingleListView { ...props } category="paid" />
 			) : (
 				<PluginSingleListView { ...props } category="featured" />
@@ -620,9 +622,11 @@ function updateWpComRating( plugin ) {
  * @param {Array} popularPlugins
  * @param {Array} featuredPlugins
  */
-function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
+function filterPopularPlugins( popularPlugins = [], featuredPlugins = [], jetpackNonAtomic ) {
 	// when marketplace-v1 is enabled no featured plugins will be showed
-	if ( isEnabled( 'marketplace-v1' ) ) {
+	// since paid plugins will not be available for Jetpack self hosted sites,
+	// continue with filtering the popular plugins.
+	if ( isEnabled( 'marketplace-v1' ) && ! jetpackNonAtomic ) {
 		featuredPlugins = [];
 	}
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -78,7 +78,7 @@ const PluginsBrowser = ( {
 	const hasBusinessPlan =
 		sitePlan && ( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
 
-	const { data: paidPluginsRawList = [], isFetchingPaidPlugins } = useWPCOMPlugins( 'all' );
+	const { data: paidPluginsRawList = [], isFetchingPaidPlugins } = useWPCOMPlugins( 'featured' );
 	const paidPlugins = useMemo( () => paidPluginsRawList.map( updateWpComRating ), [
 		paidPluginsRawList,
 	] );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -80,7 +80,10 @@ const PluginsBrowser = ( {
 	const hasBusinessPlan =
 		sitePlan && ( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
 
-	const { data: paidPlugins = [], isFetchingPaidPlugins } = useWPCOMPlugins( 'all' );
+	const { data: paidPluginsRawList = [], isFetchingPaidPlugins } = useWPCOMPlugins( 'all' );
+	const paidPlugins = useMemo( () => paidPluginsRawList.map( updateWpComRating ), [
+		paidPluginsRawList,
+	] );
 	const recommendedPlugins =
 		useSelector( ( state ) => getRecommendedPlugins( state, selectedSite?.ID ) ) || [];
 	const popularPlugins = useSelector( ( state ) => getPluginsListByCategory( state, 'popular' ) );
@@ -643,6 +646,21 @@ const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) 
 
 	return null;
 };
+
+/**
+ * Multiply the wpcom rating to match the wporg value.
+ * wpcom rating is from 1 to 5 while wporg is from 1 to 100.
+ *
+ * @param plugin
+ * @returns
+ */
+function updateWpComRating( plugin ) {
+	if ( ! plugin || ! plugin.rating ) return plugin;
+
+	plugin.rating *= 20;
+
+	return plugin;
+}
 
 /**
  * Filter the popular plugins list.

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -133,8 +133,6 @@ const PluginsBrowser = ( {
 
 	const [ isMobile, setIsMobile ] = useState();
 
-	const isPaidPluginsEnabled = isEnabled( 'marketplace-v1' );
-
 	const shouldShowManageButton = useMemo( () => {
 		if ( isJetpack ) {
 			return true;
@@ -281,7 +279,6 @@ const PluginsBrowser = ( {
 				sites={ sites }
 				searchTitle={ searchTitle }
 				siteSlug={ siteSlug }
-				isPaidPluginsEnabled={ isPaidPluginsEnabled }
 			/>
 			<InfiniteScroll nextPageMethod={ fetchNextPagePlugins } />
 		</MainComponent>
@@ -471,7 +468,7 @@ const PluginBrowserContent = ( props ) => {
 	return (
 		<>
 			{ /* eslint-disable no-nested-ternary */ }
-			{ props.isPaidPluginsEnabled ? (
+			{ isEnabled( 'marketplace-v1' ) ? (
 				<PluginSingleListView { ...props } category="paid" />
 			) : (
 				<PluginSingleListView { ...props } category="featured" />

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -654,6 +654,11 @@ const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) 
  * @param {Array} featuredPlugins
  */
 function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
+	// when marketplace-v1 is enabled no featured plugins will be showed
+	if ( isEnabled( 'marketplace-v1' ) ) {
+		featuredPlugins = [];
+	}
+
 	const displayedFeaturedSlugsMap = new Map(
 		featuredPlugins
 			.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -1,5 +1,8 @@
 /** @jest-environment jsdom */
 
+jest.mock( 'react-query', () => ( {
+	useQuery: () => [],
+} ) );
 jest.mock( 'calypso/lib/wporg', () => ( {
 	getWporgLocaleCode: () => 'it_US',
 	fetchPluginsList: () => Promise.resolve( [] ),

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -77,7 +77,7 @@
 		"mailchimp": true,
 		"manage/export/guided-transfer": true,
 		"marketplace-test": true,
-		"marketplace-v1": false,
+		"marketplace-v1": true,
 		"marketplace": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Show paid plugins on plugins browser screen when `markplace-v1` flag is active.
* Stop filtering popular list by featured plugins when featured plugins are not being shown.
* Handle the rating value from wpcom to match wporg values.

#### Testing instructions

Scenario 1 - WPCOM sites
* Go to `/plugins` page
* Check if the first section is featured but with paid plugins being shown. Eg: WooComerce Subscriptions, Xero, etc.
* Check if the cards have fhe following info: icon, name, author, last updated, description, and rating.

Scenario 2 - Jetpack self hosted sites
* Go to `/plugins` page
* You shoudn't get any paid plugins
* Popular plugins should not include featured plugins

#### Demo
<img width="1101" alt="Screen Shot 2021-12-14 at 15 03 21" src="https://user-images.githubusercontent.com/5039531/146063035-65f11a2b-b249-4acd-9ec9-0ef3b8f305de.png">


---

Closes #58656
