### PR TITLE
Add set as primary block on domain settings

### DIFF
--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -1,5 +1,5 @@
 import FoldableCard from 'calypso/components/foldable-card';
-import { AccordionProps } from './types';
+import type { AccordionProps } from './types';
 import './style.scss';
 
 const Accordion = ( {

--- a/client/components/domains/accordion/types.ts
+++ b/client/components/domains/accordion/types.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 export type AccordionProps = {
 	children: ReactNode;
-	title: string;
-	subtitle?: string;
+	title: ReactNode;
+	subtitle?: ReactNode;
 	expanded?: boolean;
 };

--- a/client/components/domains/accordion/types.ts
+++ b/client/components/domains/accordion/types.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 export type AccordionProps = {
 	children: ReactNode;
-	title: ReactNode;
-	subtitle?: ReactNode;
+	title: string;
+	subtitle?: string;
 	expanded?: boolean;
 };

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -22,6 +22,7 @@ import {
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import RegisteredDomainDetails from './cards/registered-domain-details';
+import SetAsPrimary from './set-as-primary';
 import SettingsHeader from './settings-header';
 import type { SettingsPageConnectedProps, SettingsPageProps } from './types';
 
@@ -95,9 +96,18 @@ const Settings = ( {
 		return null;
 	};
 
+	const renderSetAsPrimaryDomainSection = () => {
+		return <SetAsPrimary domain={ domain } selectedSite={ selectedSite } />;
+	};
+
 	const renderMainContent = () => {
 		// TODO: If it's a registered domain or transfer and the domain's registrar is in maintenance, show maintenance card
-		return <>{ renderDetailsSection() }</>;
+		return (
+			<>
+				{ renderDetailsSection() }
+				{ renderSetAsPrimaryDomainSection() }
+			</>
+		);
 	};
 
 	const renderSettingsCards = () => (

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -98,7 +98,7 @@ const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
 				<p className="set-as-primary__content">
 					{ translate( 'Your current primary site address is %(domainName)s', {
 						args: {
-							domainName: domain.name,
+							domainName: selectedSite.domain,
 						},
 					} ) }
 				</p>

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -1,0 +1,151 @@
+import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { connect } from 'react-redux';
+import Accordion from 'calypso/components/domains/accordion';
+import { type } from 'calypso/lib/domains/constants';
+import { isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
+import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
+import {
+	showUpdatePrimaryDomainSuccessNotice,
+	showUpdatePrimaryDomainErrorNotice,
+} from 'calypso/state/domains/management/actions';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
+import type {
+	SetAsPrimaryProps,
+	SetAsPrimaryPassedProps,
+	SetAsPrimaryStateProps,
+	ChangePrimaryFunctionSignature,
+} from './types';
+
+const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
+	const translate = useTranslate();
+	const [ isSettingPrimaryDomain, setIsSettingPrimaryDomain ] = useState( false );
+	const {
+		domain,
+		hasDomainOnlySite,
+		isOnFreePlan,
+		hasNonPrimaryDomainsFlag,
+		canSetPrimaryDomain,
+		isManagingAllSites,
+		selectedSite,
+	} = props;
+
+	const shouldUpgradeToMakeDomainPrimary = () => {
+		return (
+			hasNonPrimaryDomainsFlag &&
+			isOnFreePlan &&
+			( domain.type === type.REGISTERED || domain.type === type.MAPPED ) &&
+			! hasDomainOnlySite &&
+			! domain.isPrimary &&
+			! domain.isWPCOMDomain &&
+			! domain.isWpcomStagingDomain &&
+			! canSetPrimaryDomain
+		);
+	};
+
+	const canSetAsPrimary = () => {
+		return (
+			! isManagingAllSites &&
+			domain &&
+			domain.canSetAsPrimary &&
+			! domain.isPrimary &&
+			! shouldUpgradeToMakeDomainPrimary()
+		);
+	};
+
+	const setPrimaryDomain = ( domainName: string ) => {
+		return new Promise( ( resolve, reject ) => {
+			props.setPrimaryDomain( selectedSite.ID, domainName, ( error, data ) => {
+				if ( ! error && data && data.success ) {
+					resolve( null );
+				} else {
+					reject( error );
+				}
+			} );
+		} );
+	};
+
+	const handleSetPrimaryDomainClick = async () => {
+		setIsSettingPrimaryDomain( true );
+		props.changePrimary( domain, 'button_click' );
+		try {
+			await setPrimaryDomain( domain.name );
+			props.showUpdatePrimaryDomainSuccessNotice( domain.name );
+		} catch ( error ) {
+			props.showUpdatePrimaryDomainSuccessNotice( domain.name );
+		} finally {
+			setIsSettingPrimaryDomain( false );
+		}
+	};
+	if ( ! canSetAsPrimary() ) return null;
+	return (
+		<div className="set-as-primary">
+			<Accordion
+				title={ translate( 'Set as primary' ) }
+				subtitle={ translate( 'Make this domain your primary site address' ) }
+			>
+				<p className="set-as-primary__content">
+					{ translate( 'Your current primary site address is %(domainName)s', {
+						args: {
+							domainName: domain.name,
+						},
+					} ) }
+				</p>
+				<Button onClick={ handleSetPrimaryDomainClick } busy={ isSettingPrimaryDomain }>
+					{ translate( 'Set this domain as primary' ) }
+				</Button>
+			</Accordion>
+		</div>
+	);
+};
+
+const changePrimary: ChangePrimaryFunctionSignature = ( domain, mode ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Changed Primary Domain to in Settings',
+			'Domain Name',
+			domain.name
+		),
+		recordTracksEvent( 'calypso_domain_management_settings_change_primary_domain_click', {
+			section: domain.type,
+			mode,
+		} )
+	);
+
+export default connect(
+	( state, ownProps: SetAsPrimaryPassedProps ): SetAsPrimaryStateProps => {
+		const { selectedSite } = ownProps;
+		const isOnFreePlan = selectedSite?.plan?.is_free || false;
+		return {
+			hasDomainOnlySite: !! isDomainOnlySite( state, selectedSite.ID ),
+			hasNonPrimaryDomainsFlag: getCurrentUser( state )
+				? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+				: false,
+			isOnFreePlan,
+			isManagingAllSites: isUnderDomainManagementAll( getCurrentRoute( state ) ),
+			canSetPrimaryDomain: hasActiveSiteFeature(
+				state,
+				selectedSite.ID,
+				FEATURE_SET_PRIMARY_CUSTOM_DOMAIN
+			),
+		};
+	},
+	{
+		changePrimary,
+		setPrimaryDomain,
+		showUpdatePrimaryDomainErrorNotice,
+		showUpdatePrimaryDomainSuccessNotice,
+	}
+)( SetAsPrimary );

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -94,8 +94,8 @@ const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
 	return (
 		<div className="set-as-primary">
 			<Accordion
-				title={ translate( 'Set as primary' ) }
-				subtitle={ translate( 'Make this domain your primary site address' ) }
+				title={ translate( 'Set as primary', { textOnly: true } ) }
+				subtitle={ translate( 'Make this domain your primary site address', { textOnly: true } ) }
 			>
 				<p className="set-as-primary__content">
 					{ translate( 'Your current primary site address is {{strong}}%(domainName)s{{/strong}}', {

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -25,7 +25,7 @@ import type {
 	SetAsPrimaryProps,
 	SetAsPrimaryPassedProps,
 	SetAsPrimaryStateProps,
-	ChangePrimaryFunctionSignature,
+	ChangePrimaryFunction,
 } from './types';
 
 const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
@@ -88,7 +88,9 @@ const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
 			setIsSettingPrimaryDomain( false );
 		}
 	};
+
 	if ( ! canSetAsPrimary() ) return null;
+
 	return (
 		<div className="set-as-primary">
 			<Accordion
@@ -96,9 +98,12 @@ const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
 				subtitle={ translate( 'Make this domain your primary site address' ) }
 			>
 				<p className="set-as-primary__content">
-					{ translate( 'Your current primary site address is %(domainName)s', {
+					{ translate( 'Your current primary site address is {{strong}}%(domainName)s{{/strong}}', {
 						args: {
 							domainName: selectedSite.domain,
+						},
+						components: {
+							strong: <strong />,
 						},
 					} ) }
 				</p>
@@ -110,11 +115,11 @@ const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
 	);
 };
 
-const changePrimary: ChangePrimaryFunctionSignature = ( domain, mode ) =>
+const changePrimary: ChangePrimaryFunction = ( domain, mode ) =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Management',
-			'Changed Primary Domain to in Settings',
+			'Changed Primary Domain in Settings',
 			'Domain Name',
 			domain.name
 		),

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/types.ts
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/types.ts
@@ -1,0 +1,33 @@
+import {
+	showUpdatePrimaryDomainSuccessNotice,
+	showUpdatePrimaryDomainErrorNotice,
+} from 'calypso/state/domains/management/actions';
+import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+
+export type SetAsPrimaryPassedProps = {
+	domain: ResponseDomain;
+	selectedSite: SiteData;
+};
+
+export type SetAsPrimaryStateProps = {
+	canSetPrimaryDomain: boolean;
+	hasNonPrimaryDomainsFlag: boolean;
+	hasDomainOnlySite: boolean;
+	isOnFreePlan: boolean;
+	isManagingAllSites: boolean;
+};
+
+export type ChangePrimaryFunctionSignature = ( domain: ResponseDomain, mode: string ) => void;
+
+export type SetAsPrimaryDispatchProps = {
+	setPrimaryDomain: typeof setPrimaryDomain;
+	showUpdatePrimaryDomainErrorNotice: ReturnType< typeof showUpdatePrimaryDomainErrorNotice >;
+	showUpdatePrimaryDomainSuccessNotice: ReturnType< typeof showUpdatePrimaryDomainSuccessNotice >;
+	changePrimary: ChangePrimaryFunctionSignature;
+};
+
+export type SetAsPrimaryProps = SetAsPrimaryPassedProps &
+	SetAsPrimaryStateProps &
+	SetAsPrimaryDispatchProps;

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/types.ts
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/types.ts
@@ -19,13 +19,13 @@ export type SetAsPrimaryStateProps = {
 	isManagingAllSites: boolean;
 };
 
-export type ChangePrimaryFunctionSignature = ( domain: ResponseDomain, mode: string ) => void;
+export type ChangePrimaryFunction = ( domain: ResponseDomain, mode: string ) => void;
 
 export type SetAsPrimaryDispatchProps = {
 	setPrimaryDomain: typeof setPrimaryDomain;
 	showUpdatePrimaryDomainErrorNotice: ReturnType< typeof showUpdatePrimaryDomainErrorNotice >;
 	showUpdatePrimaryDomainSuccessNotice: ReturnType< typeof showUpdatePrimaryDomainSuccessNotice >;
-	changePrimary: ChangePrimaryFunctionSignature;
+	changePrimary: ChangePrimaryFunction;
 };
 
 export type SetAsPrimaryProps = SetAsPrimaryPassedProps &


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR creates the new section Set As Primary domain, which is shown in the domain settings page for registered and connected domains. This is part of the domain management pages redesign project detailed in pcYYhz-m2-p2.

![Markup on 2021-12-16 at 09:51:25](https://user-images.githubusercontent.com/2797601/146341551-909a7435-0e7a-43a4-96c8-40a6c908857e.png)

![Markup on 2021-12-16 at 09:52:49](https://user-images.githubusercontent.com/2797601/146341570-797afddc-b12f-45ac-b489-5f8e88224a17.png)

![Markup on 2021-12-16 at 10:15:48](https://user-images.githubusercontent.com/2797601/146342871-fbab38d6-89a6-47d4-bdd1-13f5320ae177.png)

![mobile](https://user-images.githubusercontent.com/2797601/146342890-901e8934-8361-42bf-bd0e-ab14319a14e9.png)

#### Testing instructions
- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to **Upgrades > Domains**
- Select one of your registered or mapped domains, that are not set as Primary domain.
- Ensure that:
  - The **Set as primary** section it's displayed and it looks like the screenshot above
  - Expand the accordion and verify that the copy shows the actual primary domain correctly
  - Click on "Set this domain as primary" button.
  - Verify that the domain is now correctly set as primary (success message is displayed, Set as primary section is removed and the badge "primary site address" is showed on the header).



