### PR TITLE
Remove the domains/contact-info-redesign feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -167,15 +167,11 @@ export default {
 	},
 
 	domainManagementEditContactInfo( pageContext, next ) {
-		let component = DomainManagement.EditContactInfo;
-		if ( config.isEnabled( 'domains/contact-info-redesign' ) ) {
-			component = DomainManagement.EditContactInfoPage;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementEditContactInfo( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Contacts and Privacy > Edit Contact Info"
-				component={ component }
+				component={ DomainManagement.EditContactInfoPage }
 				context={ pageContext }
 				needsDomains
 				selectedDomainName={ pageContext.params.domain }

--- a/config/development.json
+++ b/config/development.json
@@ -55,7 +55,6 @@
 		"domains/premium-domain-purchases": true,
 		"domains/management-list-redesign": true,
 		"domains/settings-page-redesign": true,
-		"domains/contact-info-redesign": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're ready to make the updated domain contact page live, so we just need to remove the feature flag and make the new component the default option.

#### Testing instructions

Visit the contact edit page with all of the feature flags disabled and make sure the new layout is shown.

(Ex.: http://calypso.localhost:3000/domains/manage/a8ctest.com?flags=-domains/management-list-redesign,-domains/transfers-redesign,-domains/dns-records-redesign,-domains/contact-info-redesign)

![screencapture-calypso-localhost-3000-domains-manage-a8ctest-com-edit-contact-info-a8ctest-com-2021-12-14-14_06_31](https://user-images.githubusercontent.com/1379730/146068407-7a626957-f9b1-4313-b856-e1f58105dacb.png)

