### PR TITLE
Add pricing to PluginsBrowserItem.

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -93,6 +93,7 @@ export function getAllowedPluginData( plugin ) {
 		'tested',
 		'update',
 		'updating',
+		'variations',
 		'version',
 		'wp_admin_settings_page_url'
 	);

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -176,8 +176,19 @@ const InstalledInOrPricing = ( {
 	period = 'monthly',
 } ) => {
 	const translate = useTranslate();
-	const priceSlug = `${ plugin?.slug?.replaceAll( '-', '_' ) }_${ period }`;
+	const priceSlug = plugin?.variations?.[ period ]?.product_slug;
 	const price = useSelector( ( state ) => getProductDisplayCost( state, priceSlug ) );
+
+	const getPeriodText = ( periodValue ) => {
+		switch ( periodValue ) {
+			case 'monthly':
+				return translate( 'monthly' );
+			case 'yearly':
+				return translate( 'per year' );
+			default:
+				return '';
+		}
+	};
 
 	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
 		return (
@@ -190,7 +201,18 @@ const InstalledInOrPricing = ( {
 		);
 	}
 
-	return <div className="plugins-browser-item__pricing">{ price || translate( 'Free' ) }</div>;
+	return (
+		<div className="plugins-browser-item__pricing">
+			{ price ? (
+				<>
+					{ price + ' ' }
+					<span className="plugins-browser-item__period">{ getPeriodText( period ) }</span>
+				</>
+			) : (
+				translate( 'Free' )
+			) }
+		</div>
+	);
 };
 
 const Placeholder = ( { iconSize } ) => {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -12,6 +12,7 @@ import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
+import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserElementVariant } from './types';
@@ -139,6 +140,7 @@ const PluginsBrowserListElement = ( props ) => {
 						<InstalledInOrPricing
 							sitesWithPlugin={ sitesWithPlugin }
 							isWpcomPreinstalled={ isWpcomPreinstalled }
+							plugin={ plugin }
 						/>
 					) }
 					<div className="plugins-browser-item__additional-info">
@@ -167,8 +169,15 @@ const PluginsBrowserListElement = ( props ) => {
 	);
 };
 
-const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled } ) => {
+const InstalledInOrPricing = ( {
+	sitesWithPlugin,
+	isWpcomPreinstalled,
+	plugin,
+	period = 'monthly',
+} ) => {
 	const translate = useTranslate();
+	const priceSlug = `${ plugin?.slug?.replaceAll( '-', '_' ) }_${ period }`;
+	const price = useSelector( ( state ) => getProductDisplayCost( state, priceSlug ) );
 
 	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
 		return (
@@ -181,7 +190,7 @@ const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled } ) => {
 		);
 	}
 
-	return <div className="plugins-browser-item__pricing">{ translate( 'Free' ) }</div>;
+	return <div className="plugins-browser-item__pricing">{ price || translate( 'Free' ) }</div>;
 };
 
 const Placeholder = ( { iconSize } ) => {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -8,6 +8,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import version_compare from 'calypso/lib/version-compare';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
@@ -32,6 +33,7 @@ const PluginsBrowserListElement = ( props ) => {
 		iconSize = 40,
 		variant = PluginsBrowserElementVariant.Compact,
 		currentSites,
+		billingPeriod,
 	} = props;
 
 	const translate = useTranslate();
@@ -144,6 +146,7 @@ const PluginsBrowserListElement = ( props ) => {
 							sitesWithPlugin={ sitesWithPlugin }
 							isWpcomPreinstalled={ isWpcomPreinstalled }
 							plugin={ plugin }
+							billingPeriod={ billingPeriod }
 						/>
 					) }
 					<div className="plugins-browser-item__additional-info">
@@ -172,10 +175,15 @@ const PluginsBrowserListElement = ( props ) => {
 	);
 };
 
-const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled, plugin } ) => {
+const InstalledInOrPricing = ( {
+	sitesWithPlugin,
+	isWpcomPreinstalled,
+	plugin,
+	billingPeriod,
+} ) => {
 	const translate = useTranslate();
-	const period = 'monthly'; // TODO: get period data from state
-	const priceSlug = plugin?.variations?.[ period ]?.product_slug;
+	const variationPeriod = getPeriodVariationValue( billingPeriod );
+	const priceSlug = plugin?.variations?.[ variationPeriod ]?.product_slug;
 	const price = useSelector( ( state ) => getProductDisplayCost( state, priceSlug ) );
 	const isProductsListFetching = useSelector( getIsProductsListFetching );
 
@@ -208,7 +216,9 @@ const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled, plugin } 
 					{ price ? (
 						<>
 							{ price + ' ' }
-							<span className="plugins-browser-item__period">{ getPeriodText( period ) }</span>
+							<span className="plugins-browser-item__period">
+								{ getPeriodText( variationPeriod ) }
+							</span>
 						</>
 					) : (
 						translate( 'Free' )
@@ -233,5 +243,17 @@ const Placeholder = ( { iconSize } ) => {
 		</li>
 	);
 };
+
+function getPeriodVariationValue( billingPeriod ) {
+	switch ( billingPeriod ) {
+		case IntervalLength.MONTHLY:
+			return 'monthly';
+		case IntervalLength.ANNUALLY:
+			return 'yearly';
+
+		default:
+			return '';
+	}
+}
 
 export default PluginsBrowserListElement;

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -12,7 +12,10 @@ import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
-import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
+import {
+	getProductDisplayCost,
+	isProductsListFetching as getIsProductsListFetching,
+} from 'calypso/state/products-list/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserElementVariant } from './types';
@@ -169,15 +172,12 @@ const PluginsBrowserListElement = ( props ) => {
 	);
 };
 
-const InstalledInOrPricing = ( {
-	sitesWithPlugin,
-	isWpcomPreinstalled,
-	plugin,
-	period = 'monthly',
-} ) => {
+const InstalledInOrPricing = ( { sitesWithPlugin, isWpcomPreinstalled, plugin } ) => {
 	const translate = useTranslate();
+	const period = 'monthly'; // TODO: get period data from state
 	const priceSlug = plugin?.variations?.[ period ]?.product_slug;
 	const price = useSelector( ( state ) => getProductDisplayCost( state, priceSlug ) );
+	const isProductsListFetching = useSelector( getIsProductsListFetching );
 
 	const getPeriodText = ( periodValue ) => {
 		switch ( periodValue ) {
@@ -203,13 +203,17 @@ const InstalledInOrPricing = ( {
 
 	return (
 		<div className="plugins-browser-item__pricing">
-			{ price ? (
+			{ ! isProductsListFetching && (
 				<>
-					{ price + ' ' }
-					<span className="plugins-browser-item__period">{ getPeriodText( period ) }</span>
+					{ price ? (
+						<>
+							{ price + ' ' }
+							<span className="plugins-browser-item__period">{ getPeriodText( period ) }</span>
+						</>
+					) : (
+						translate( 'Free' )
+					) }
 				</>
-			) : (
-				translate( 'Free' )
 			) }
 		</div>
 	);

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -159,3 +159,7 @@
 	justify-content: space-between;
 }
 
+.plugins-browser-item__period {
+	color: var( --studio-gray-60 );
+	font-size: $font-body-extra-small;
+}

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -38,6 +38,7 @@ class PluginsBrowserList extends Component {
 							? PluginsBrowserElementVariant.Extended
 							: PluginsBrowserElementVariant.Compact
 					}
+					billingPeriod={ this.props.billingPeriod }
 				/>
 			);
 		} );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -299,6 +299,7 @@ const PluginsBrowser = ( {
 				searchTitle={ searchTitle }
 				siteSlug={ siteSlug }
 				jetpackNonAtomic={ jetpackNonAtomic }
+				billingPeriod={ billingPeriod }
 			/>
 			<InfiniteScroll nextPageMethod={ fetchNextPagePlugins } />
 		</MainComponent>
@@ -439,6 +440,7 @@ const PluginSingleListView = ( {
 	isFetchingPaidPlugins,
 	siteSlug,
 	sites,
+	billingPeriod,
 } ) => {
 	const translate = useTranslate();
 
@@ -472,6 +474,7 @@ const PluginSingleListView = ( {
 			showPlaceholders={ isFetching }
 			currentSites={ sites }
 			variant={ PluginsBrowserListVariant.Fixed }
+			billingPeriod={ billingPeriod }
 			extended
 		/>
 	);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -19,6 +19,7 @@ import announcementImage from 'calypso/assets/images/marketplace/plugins-revamp.
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
@@ -224,6 +225,7 @@ const PluginsBrowser = ( {
 					<QueryWporgPlugins category="featured" />
 				</>
 			) }
+			{ isEnabled( 'marketplace-v1' ) && ! jetpackNonAtomic && <QueryProductsList /> }
 			<PageViewTrackerWrapper
 				category={ category }
 				selectedSiteId={ selectedSite?.ID }
@@ -485,13 +487,11 @@ const PluginBrowserContent = ( props ) => {
 
 	return (
 		<>
-			{ /* eslint-disable no-nested-ternary */ }
 			{ isEnabled( 'marketplace-v1' ) && ! props.jetpackNonAtomic ? (
 				<PluginSingleListView { ...props } category="paid" />
 			) : (
 				<PluginSingleListView { ...props } category="featured" />
 			) }
-			{ /* eslint-enable no-nested-ternary */ }
 
 			<PluginSingleListView { ...props } category="popular" />
 			<PluginSingleListView { ...props } category="new" />

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -63,6 +63,7 @@ const initialReduxState = {
 	},
 	documentHead: {},
 	preferences: { remoteValues: {} },
+	productsList: {},
 };
 
 function mountWithRedux( ui, overrideState ) {
@@ -83,7 +84,6 @@ describe( 'Search view', () => {
 		const comp = mountWithRedux( <PluginsBrowser { ...myProps } /> );
 		expect( comp.find( 'NoResults' ).length ).toBe( 1 );
 	} );
-
 	test( 'should show plugin list when there are results', () => {
 		const comp = mountWithRedux( <PluginsBrowser { ...myProps } />, {
 			plugins: { wporg: { lists: { search: { searchterm: [ {} ] } } } },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- [x] Add pricing to PluginsBrowserItem.
- [x] Show price accordingly payment period

#### Testing instructions
* Go to `/plugins` page and select a site with installed plugins
* Check if the featured section contains paid plugins with their given prices.
* Switch the billing period selector for monthly and annually and see if the prices changes.
* Check if the non-paid plugins show the "Free" or "Installed" on the price area.
* Click on a paid plugin to see the details

|Monthly | Yearly|
|-------|------|
|<img width="1081" alt="Screen Shot 2021-12-15 at 10 25 13" src="https://user-images.githubusercontent.com/5039531/146204165-c9d3b395-b992-4bac-9a2c-f0cd0a8b8774.png">|<img width="1062" alt="Screen Shot 2021-12-15 at 12 36 41" src="https://user-images.githubusercontent.com/5039531/146227799-4d443b51-96cf-41b5-b4b8-8a37eeea595a.png">|




---
Fixes #57761
