### PR TITLE
FSE Beta: Hide design categories in design picker

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -38,7 +38,7 @@ const Header: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const locale = useLocale();
 	const isAnchorFmSignup = useIsAnchorFm();
-	const { isEnrollingInFseBeta } = useSelect( ( select ) =>
+	const isEnrollingInFseBeta = useSelect( ( select ) =>
 		select( ONBOARD_STORE ).isEnrollingInFseBeta()
 	);
 	const isDesignPickerCategoriesEnabled =

--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -38,8 +38,11 @@ const Header: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const locale = useLocale();
 	const isAnchorFmSignup = useIsAnchorFm();
+	const { isEnrollingInFseBeta } = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).isEnrollingInFseBeta()
+	);
 	const isDesignPickerCategoriesEnabled =
-		! isAnchorFmSignup && isEnabled( 'signup/design-picker-categories' );
+		! isAnchorFmSignup && ! isEnrollingInFseBeta && isEnabled( 'signup/design-picker-categories' );
 
 	const { goBack } = useStepNavigation();
 	const title = isDesignPickerCategoriesEnabled ? __( 'Themes' ) : __( 'Choose a design' );
@@ -78,26 +81,29 @@ const Designs: React.FunctionComponent = () => {
 	const { setSelectedDesign, setFonts, resetFonts, setRandomizedDesigns } = useDispatch(
 		ONBOARD_STORE
 	);
-	const {
-		getSelectedDesign,
-		hasPaidDesign,
-		getRandomizedDesigns,
-		isEnrollingInFseBeta,
-	} = useSelect( ( select ) => select( ONBOARD_STORE ) );
-	const isAnchorFmSignup = useIsAnchorFm();
+	const { selectedDesign, hasPaidDesign, randomizedDesigns, isEnrollingInFseBeta } = useSelect(
+		( select ) => {
+			const onboardSelect = select( ONBOARD_STORE );
 
-	const selectedDesign = getSelectedDesign();
-	const isFse = isEnrollingInFseBeta();
+			return {
+				selectedDesign: onboardSelect.getSelectedDesign(),
+				hasPaidDesign: onboardSelect.hasPaidDesign(),
+				randomizedDesigns: onboardSelect.getRandomizedDesigns(),
+				isEnrollingInFseBeta: onboardSelect.isEnrollingInFseBeta(),
+			};
+		}
+	);
+	const isAnchorFmSignup = useIsAnchorFm();
 
 	// As the amount of the anchorfm related designs is little, we don't need to enable categories filter
 	const isDesignPickerCategoriesEnabled =
-		! isAnchorFmSignup && isEnabled( 'signup/design-picker-categories' );
+		! isAnchorFmSignup && ! isEnrollingInFseBeta && isEnabled( 'signup/design-picker-categories' );
 
 	const useFeaturedPicksButtons =
 		isDesignPickerCategoriesEnabled &&
 		isEnabled( 'signup/design-picker-use-featured-picks-buttons' );
 
-	const allDesigns = getRandomizedDesigns().featured.filter(
+	const allDesigns = randomizedDesigns.featured.filter(
 		( design ) =>
 			// TODO Add finalized design templates to available designs config
 			// along with `is_anchorfm` prop (config is stored in the
@@ -121,7 +127,7 @@ const Designs: React.FunctionComponent = () => {
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: selectedDesign?.slug,
-		is_selected_design_premium: hasPaidDesign(),
+		is_selected_design_premium: hasPaidDesign,
 	} ) );
 
 	const [ userHasSelectedDesign, setUserHasSelectedDesign ] = React.useState( false );
@@ -152,11 +158,11 @@ const Designs: React.FunctionComponent = () => {
 		// Make sure we're using the right designs since we can't rely on config variables
 		// any more and `getRandomizedDesigns` is auto-populated in a state-agnostic way.
 		const availableDesigns = getAvailableDesigns( {
-			useFseDesigns: isFse,
+			useFseDesigns: isEnrollingInFseBeta,
 			randomize: true,
 		} );
 		setRandomizedDesigns( availableDesigns );
-	}, [ isFse, setRandomizedDesigns ] );
+	}, [ isEnrollingInFseBeta, setRandomizedDesigns ] );
 
 	return (
 		<div className="gutenboarding-page designs">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we currently have a fairly limited selection of design choices, hide the design category filter in the FSE Beta flow, for now.

#### Testing instructions

* Go to `/new` and enroll in the FSE Beta
* See that the design categories are hidden in the design picker step
* Go back and choose _not_to enroll in the FSE Beta
* See that the design picker category filters are present and working, as normal

| **Before** | **After** |
| - | - |
| <img width="1500" alt="image" src="https://user-images.githubusercontent.com/1699996/146078993-a12bc83a-ce66-4f28-a6d2-7da12291b12e.png"> | <img width="1498" alt="image" src="https://user-images.githubusercontent.com/1699996/146079049-e34c5e8a-d212-443a-be45-a875c21a1176.png"> |

See conversation at p1639511207127100-slack-C029SB8JT8S