### PR TITLE
Update description for the domain registration subscription on the purchases page

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -586,8 +586,7 @@ class ManagePurchase extends Component {
 
 		if ( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) {
 			return translate(
-				"Replaces your site's free address, %(domain)s, with the domain, " +
-					'making it easier to remember and easier to share.',
+				'Custom domains are easier to remember and share. When you upgrade to a paid plan, you have the option to replace your free WordPress.com site address with a custom domain.',
 				{
 					args: {
 						domain: purchase.domain,


### PR DESCRIPTION
Updating the messaging to reflect the free domain address is only replaced while having a paid plan.

#### Changes proposed in this Pull Request

A customer recently suggested that the previous messaging on the domains purchases page was a bit confusing. We would like to update this copy to be more clear that the free domain is only being replaced while having a paid WordPress.com plan. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 * Navigate to /me/purchases, then select a domain.
* Check to make sure that there are no spelling errors, spacing issues, etc. 


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
