### PR TITLE
Abstract and refactor Checkout exit points

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -2,19 +2,16 @@ import { checkoutTheme, CheckoutModal } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useCallback, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
-import { navigate } from 'calypso/lib/navigate';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
+import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Item from './item';
 import Masterbar from './masterbar';
-
 interface Props {
 	title: string;
 	isJetpackNotAtomic?: boolean;
@@ -30,65 +27,21 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const checkoutBackUrl = useValidCheckoutBackUrl( siteSlug );
+	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( siteSlug );
 	const isJetpackCheckout = window.location.pathname.startsWith( '/checkout/jetpack' );
 	const isJetpack = isJetpackCheckout || isJetpackNotAtomic;
-
-	const leaveCheckout = useCallback( () => {
-		let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
-
-		dispatch( recordTracksEvent( 'calypso_masterbar_close_clicked' ) );
-
-		if ( checkoutBackUrl ) {
-			closeUrl = checkoutBackUrl;
-		}
-
-		if (
-			! checkoutBackUrl &&
-			previousPath &&
-			'' !== previousPath &&
-			previousPath !== window.location.href &&
-			! previousPath.includes( '/checkout/' )
-		) {
-			closeUrl = previousPath;
-		}
-
-		try {
-			const searchParams = new URLSearchParams( window.location.search );
-
-			if ( searchParams.has( 'signup' ) ) {
-				clearSignupDestinationCookie();
-			}
-
-			// Some places that open checkout (eg: purchase page renewals) return the
-			// user there after checkout by putting the previous page's path in the
-			// `redirect_to` query param. When leaving checkout via the close button,
-			// we probably want to return to that location also.
-			if ( ! checkoutBackUrl && searchParams.has( 'redirect_to' ) ) {
-				const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
-				// Only allow redirecting to relative paths.
-				if ( redirectPath.startsWith( '/' ) ) {
-					closeUrl = redirectPath;
-				}
-			}
-		} catch ( error ) {
-			// Silently ignore query string errors (eg: which may occur in IE since it doesn't support URLSearchParams).
-			// eslint-disable-next-line no-console
-			console.error( 'Error getting query string in close button' );
-		}
-
-		navigate( closeUrl );
-	}, [ siteSlug, checkoutBackUrl, previousPath, dispatch ] );
-
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const closeAndLeave = () =>
+		leaveCheckout( { siteSlug, jetpackCheckoutBackUrl, previousPath, dispatch } );
+
 	const clickClose = () => {
 		if ( responseCart.products.length > 0 ) {
 			setIsModalVisible( true );
 			return;
 		}
-		leaveCheckout();
+		closeAndLeave();
 	};
 
 	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );
@@ -99,8 +52,9 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	const modalSecondaryText = translate( 'Empty cart' );
 	const clearCartAndLeave = () => {
 		replaceProductsInCart( [] );
-		leaveCheckout();
+		closeAndLeave();
 	};
+
 	return (
 		<Masterbar>
 			<div className="masterbar__secure-checkout">
@@ -123,7 +77,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 				closeModal={ () => setIsModalVisible( false ) }
 				isVisible={ isModalVisible }
 				primaryButtonCTA={ modalPrimaryText }
-				primaryAction={ leaveCheckout }
+				primaryAction={ closeAndLeave }
 				secondaryButtonCTA={ modalSecondaryText }
 				secondaryAction={ clearCartAndLeave }
 			/>

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -59,7 +59,6 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 		<Masterbar>
 			<div className="masterbar__secure-checkout">
 				<Item
-					url={ '#' }
 					icon="cross"
 					className="masterbar__close-button"
 					onClick={ clickClose }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -203,6 +203,7 @@ $autobar-height: 20px;
 	&.masterbar__close-button {
 		border-right: 1px solid var( --color-masterbar-border );
 		margin-right: 15px;
+		cursor: pointer;
 
 		.is-section-checkout.is-jetpack-site & {
 			border-right: 1px solid var( --color-jetpack-masterbar-border );

--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -1,10 +1,10 @@
+import debugFactory from 'debug';
 import { useDispatch } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-/*
- */
+const debug = debugFactory( 'calypso:leave-checkout' );
 
 export const leaveCheckout = ( {
 	siteSlug,
@@ -20,6 +20,12 @@ export const leaveCheckout = ( {
 	createUserAndSiteBeforeTransaction?: boolean;
 } ): void => {
 	dispatch( recordTracksEvent( 'calypso_masterbar_close_clicked' ) );
+	debug( 'leaving checkout with args', {
+		siteSlug,
+		jetpackCheckoutBackUrl,
+		previousPath,
+		createUserAndSiteBeforeTransaction,
+	} );
 
 	if ( jetpackCheckoutBackUrl ) {
 		window.location.href = jetpackCheckoutBackUrl;

--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -1,0 +1,78 @@
+import { useDispatch } from 'react-redux';
+import { navigate } from 'calypso/lib/navigate';
+import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+/*
+ */
+
+export const leaveCheckout = ( {
+	siteSlug,
+	jetpackCheckoutBackUrl,
+	previousPath,
+	dispatch,
+	createUserAndSiteBeforeTransaction,
+}: {
+	siteSlug?: string;
+	jetpackCheckoutBackUrl?: string;
+	previousPath?: string;
+	dispatch: ReturnType< typeof useDispatch >;
+	createUserAndSiteBeforeTransaction?: boolean;
+} ): void => {
+	dispatch( recordTracksEvent( 'calypso_masterbar_close_clicked' ) );
+
+	if ( jetpackCheckoutBackUrl ) {
+		window.location.href = jetpackCheckoutBackUrl;
+		return;
+	}
+
+	let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
+
+	if (
+		previousPath &&
+		'' !== previousPath &&
+		previousPath !== window.location.href &&
+		! previousPath.includes( '/checkout/' )
+	) {
+		closeUrl = previousPath;
+	}
+
+	try {
+		const searchParams = new URLSearchParams( window.location.search );
+
+		if ( searchParams.has( 'signup' ) ) {
+			clearSignupDestinationCookie();
+		}
+
+		if ( createUserAndSiteBeforeTransaction ) {
+			try {
+				window.localStorage.removeItem( 'shoppingCart' );
+				window.localStorage.removeItem( 'siteParams' );
+			} catch ( err ) {}
+
+			// We use window.location instead of page.redirect() so that if the user already has an account and site at
+			// this point, then window.location will reload with the cookies applied and takes to the /plans page.
+			// (page.redirect() will take to the log in page instead).
+			window.location.href = closeUrl;
+			return;
+		}
+		// Some places that open checkout (eg: purchase page renewals) return the
+		// user there after checkout by putting the previous page's path in the
+		// `redirect_to` query param. When leaving checkout via the close button,
+		// we probably want to return to that location also.
+		if ( searchParams.has( 'redirect_to' ) ) {
+			const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
+			// Only allow redirecting to relative paths.
+			if ( redirectPath.startsWith( '/' ) ) {
+				navigate( redirectPath );
+				return;
+			}
+		}
+	} catch ( error ) {
+		// Silently ignore query string errors (eg: which may occur in IE since it doesn't support URLSearchParams).
+		// eslint-disable-next-line no-console
+		console.error( 'Error getting query string in close button' );
+	}
+
+	navigate( closeUrl );
+};

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -13,8 +13,8 @@ import {
 	waitForElementToBeRemoved,
 } from '@testing-library/react';
 import nock from 'nock';
-import page from 'page';
 import { Provider as ReduxProvider } from 'react-redux';
+import { navigate } from 'calypso/lib/navigate';
 import '@testing-library/jest-dom/extend-expect';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
@@ -48,10 +48,7 @@ jest.mock( 'calypso/state/sites/plans/selectors/get-plans-by-site' );
 jest.mock( 'calypso/my-sites/checkout/use-cart-key' );
 jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
-
-jest.mock( 'page', () => ( {
-	redirect: jest.fn(),
-} ) );
+jest.mock( 'calypso/lib/navigate' );
 
 describe( 'CompositeCheckout', () => {
 	let container;
@@ -554,7 +551,7 @@ describe( 'CompositeCheckout', () => {
 		render( <MyCheckout />, container );
 		await waitFor( () => {
 			expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
-			expect( page.redirect ).not.toHaveBeenCalled();
+			expect( navigate ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -607,7 +604,7 @@ describe( 'CompositeCheckout', () => {
 		const confirmButton = await screen.findByText( 'Continue' );
 		fireEvent.click( confirmButton );
 		await waitFor( () => {
-			expect( page.redirect ).toHaveBeenCalledWith( '/plans/foo.com' );
+			expect( navigate ).toHaveBeenCalledWith( '/plans/foo.com' );
 		} );
 	} );
 
@@ -624,7 +621,7 @@ describe( 'CompositeCheckout', () => {
 		const confirmButton = await screen.findByText( 'Continue' );
 		fireEvent.click( confirmButton );
 		await waitFor( async () => {
-			expect( page.redirect ).not.toHaveBeenCalledWith( '/plans/foo.com' );
+			expect( navigate ).not.toHaveBeenCalledWith( '/plans/foo.com' );
 		} );
 	} );
 
@@ -632,7 +629,7 @@ describe( 'CompositeCheckout', () => {
 		const cartChanges = { products: [] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		await waitFor( async () => {
-			expect( page.redirect ).not.toHaveBeenCalledWith( '/plans/foo.com' );
+			expect( navigate ).not.toHaveBeenCalledWith( '/plans/foo.com' );
 		} );
 	} );
 
@@ -644,7 +641,7 @@ describe( 'CompositeCheckout', () => {
 			container
 		);
 		await waitFor( async () => {
-			expect( page.redirect ).not.toHaveBeenCalled();
+			expect( navigate ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -708,7 +705,7 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		expect( page.redirect ).not.toHaveBeenCalled();
+		expect( navigate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'adds the domain mapping product to the cart when the url has a concierge session', async () => {
@@ -737,7 +734,7 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		expect( page.redirect ).not.toHaveBeenCalled();
+		expect( navigate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'adds the domain mapping product to the cart when the url has a theme', async () => {
@@ -766,7 +763,7 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		expect( page.redirect ).not.toHaveBeenCalled();
+		expect( navigate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'adds the domain mapping product to the cart when the url has a domain map', async () => {

--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -14,7 +14,7 @@ const selectors = {
 	renewNowCardButton: 'button.card:has-text("Renew Now")',
 	cancelAndRefundButton: 'a:text("Cancel Subscription and Refund")',
 	cancelSubscriptionButton: 'button:text("Cancel Subscription")',
-	upgradeButton: 'a:text("Upgrade")',
+	upgradeButton: 'a.card:text("Upgrade")',
 
 	// Purchased item actions: domains
 	deleteDomainCard: 'a:has-text("Delete your domain permanently")',

--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -77,11 +77,7 @@ export class IndividualPurchasePage {
 	 * Click the "Upgrade" button to navigate to the plans page.
 	 */
 	async clickUpgradeButton(): Promise< void > {
-		// This triggers a real navigation to the `/checkout/<site_name>` endpoint.
-		await Promise.all( [
-			this.page.waitForNavigation( { timeout: 45 * 1000, waitUntil: 'networkidle' } ),
-			this.page.click( selectors.upgradeButton ),
-		] );
+		await this.page.click( selectors.upgradeButton );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -14,6 +14,7 @@ const selectors = {
 	renewNowCardButton: 'button.card:has-text("Renew Now")',
 	cancelAndRefundButton: 'a:text("Cancel Subscription and Refund")',
 	cancelSubscriptionButton: 'button:text("Cancel Subscription")',
+	upgradeButton: 'button:text("Upgrade")',
 
 	// Purchased item actions: domains
 	deleteDomainCard: 'a:has-text("Delete your domain permanently")',
@@ -69,6 +70,17 @@ export class IndividualPurchasePage {
 		await Promise.all( [
 			this.page.waitForNavigation( { timeout: 45 * 1000, waitUntil: 'networkidle' } ),
 			this.page.click( selectors.renewNowCardButton ),
+		] );
+	}
+
+	/**
+	 * Click the "Upgrade" button to navigate to the plans page.
+	 */
+	async clickUpgradeButton(): Promise< void > {
+		// This triggers a real navigation to the `/checkout/<site_name>` endpoint.
+		await Promise.all( [
+			this.page.waitForNavigation( { timeout: 45 * 1000, waitUntil: 'networkidle' } ),
+			this.page.click( selectors.upgradeButton ),
 		] );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -14,7 +14,7 @@ const selectors = {
 	renewNowCardButton: 'button.card:has-text("Renew Now")',
 	cancelAndRefundButton: 'a:text("Cancel Subscription and Refund")',
 	cancelSubscriptionButton: 'button:text("Cancel Subscription")',
-	upgradeButton: 'button:text("Upgrade")',
+	upgradeButton: 'a:text("Upgrade")',
 
 	// Purchased item actions: domains
 	deleteDomainCard: 'a:has-text("Delete your domain permanently")',

--- a/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
@@ -75,9 +75,9 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 			await cartCheckoutPage.removeCartItem( cartItemForPremiumPlan );
 		} );
 
-		it( 'Automatically return to Plans page', async function () {
-			plansPage = new PlansPage( page );
-			await plansPage.validateActiveNavigationTab( 'Plans' );
+		it( 'Automatically return to purchase page', async function () {
+			purchasesPage = new IndividualPurchasePage( page );
+			await purchasesPage.validatePurchaseTitle( cartItemForPremiumPlan );
 		} );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
@@ -85,6 +85,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 		const cartItemForBusinessPlan = 'WordPress.com Business';
 
 		it( 'Click on "Upgrade" button for WordPress.com Business plan', async function () {
+			await purchasesPage.clickUpgradeButton();
 			await plansPage.clickPlanActionButton( { plan: 'Business', buttonText: 'Upgrade' } );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, [there was a](https://github.com/Automattic/wp-calypso/blob/8ae68997056a416ac858291166ca1bc6afcd63cf/client/layout/masterbar/checkout.tsx#L32-L77) `clickClose` function we used to exit the Checkout from the masterbar 'X' icon. This code was being duplicated for [other points](https://github.com/Automattic/wp-calypso/blob/c42834476a9ef02a215c0e235c15bc6f1f2246e7/client/my-sites/checkout/composite-checkout/composite-checkout.tsx#L591-L638) in the checkout to redirect customers back to their previous page. This PR abstracts the `clickClose` function into a helper function called `leaveCheckout` which can be reused.

Additionally, this PR adds the `leaveCheckout` function in two places throughout Checkout:
- The 'X' icon found in the Checkout masterbar
- When the cart is emptied, the function is triggered as a callback

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a domain to your cart
* Go to cart and click the 'X' icon in the masterbar, this should bring you back to the previous page
* For instance, if you bought a domain then you should land on the domain checkout flow you were originally on
* Go back to the cart, remove the domain and ensure the cart is empty
* The empty cart redirect should bring you back to the domain checkout flow

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- [x] Once this is tested I'll also need to add this functionality to [here](https://github.com/Automattic/wp-calypso/blob/c42834476a9ef02a215c0e235c15bc6f1f2246e7/client/my-sites/checkout/composite-checkout/composite-checkout.tsx#L591-L638) in a separate PR - PR here - https://github.com/Automattic/wp-calypso/pull/59368

Related to 374-gh-Automattic/payments-shilling 