### PR TITLE
When importing, the "Choose from full list" link opens in a new tab 

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -177,11 +177,7 @@ class SectionImport extends Component {
 		return (
 			<>
 				{ importerElements }
-				<CompactCard
-					href={ site.options.admin_url + 'import.php' }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
+				<CompactCard href={ site.options.admin_url + 'import.php' }>
 					{ this.props.translate( 'Choose from full list' ) }
 				</CompactCard>
 			</>


### PR DESCRIPTION
I've removed the target and rel properties from the CompactCard so that the 'Choose from full list' link will open on the same window and not display the open in new window SVG icon

Related to #51341

#### Changes proposed in this Pull Request

* Removed the target and rel properties form the "Choose from full list" CompactCard.

#### Testing instructions
1. Go to tools => import
2. "Choose from full list" Should not display the open in new page icon. 
3. Press on "Choose from full list".
4. The page should open on the current tab.

#### Test Evidence
https://user-images.githubusercontent.com/1989914/146207489-8cdf9f70-1121-42a6-bf2d-fe33eedeaeef.mp4

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
