### PR TITLE
Launch reskinned design to all plan-based flows

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -444,15 +444,32 @@ class DomainsStep extends Component {
 		return typeof lastQuery === 'string' && lastQuery.includes( '.blog' );
 	}
 
+	shouldHideDomainExplainer = () => {
+		const { flowName } = this.props;
+		return [
+			'free',
+			'personal',
+			'personal-monthly',
+			'premium',
+			'premium-monthly',
+			'business',
+			'business-monthly',
+			'ecommerce',
+			'ecommerce-monthly',
+		].includes( flowName );
+	};
+
 	getSideContent = () => {
 		return (
 			<div className="domains__domain-side-content-container">
-				<div className="domains__domain-side-content">
-					<ReskinSideExplainer
-						onClick={ this.handleDomainExplainerClick }
-						type={ 'free-domain-explainer' }
-					/>
-				</div>
+				{ ! this.shouldHideDomainExplainer() && (
+					<div className="domains__domain-side-content">
+						<ReskinSideExplainer
+							onClick={ this.handleDomainExplainerClick }
+							type={ 'free-domain-explainer' }
+						/>
+					</div>
+				) }
 				<div className="domains__domain-side-content">
 					<ReskinSideExplainer
 						onClick={ this.handleUseYourDomainClick }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -182,7 +182,16 @@
 		"do-it-for-me",
 		"importer",
 		"from",
-		"woocommerce-install"
+		"woocommerce-install",
+		"free",
+		"personal",
+		"personal-monthly",
+		"premium",
+		"premium-monthly",
+		"business",
+		"business-monthly",
+		"ecommerce",
+		"ecommerce-monthly"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"difm_typeform_id": "YMiXMYId",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context - p58i-bxw-p2#comment-52688

* This launches the reskinned signup flow, current live on wordpress.com/start to the following plan-based flows:
  * `/start/free`
  * `/start/personal`
  * `/start/personal-monthly`
  * `/start/premium`
  * `/start/premium-monthly`
  * `/start/business`
  * `/start/business-monthly`
  * `/start/ecommerce`
  * `/start/ecommerce-monthly`
* This also hides the "Get a free on-year domain ..." section for these plan-base flows.


#### Testing instructions

* Go through each of the flows from above
* Make sure the reskinned signup flow  is used
* The  "Get a free on-year domain ..." section **should not** be visible
<img width="480" alt="Screenshot on 2021-12-16 at 10-02-58" src="https://user-images.githubusercontent.com/2749938/146331701-d2a3f4c3-9378-4538-8a0f-6d79d46dc364.png">

* Go to a non-plan-based flow (ex. /start/onboarding)
* The  "Get a free on-year domain ..." section **should** be visible
<img width="480" alt="Screenshot on 2021-12-15 at 18-11-50" src="https://user-images.githubusercontent.com/2749938/146222714-0b08f553-4a5a-423f-85b9-7aa227e7f7ac.png">
