### PR TITLE
Fix: plugin details page does not fetch products

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -4,6 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import MainComponent from 'calypso/components/main';
@@ -203,6 +204,7 @@ function PluginDetails( props ) {
 			<QueryJetpackPlugins siteIds={ siteIds } />
 			<SidebarNavigation />
 			<QueryEligibility siteId={ selectedSite?.ID } />
+			<QueryProductsList />
 			<FixedNavigationHeader navigationItems={ getNavigationItems() } />
 			<PluginNotices
 				pluginId={ fullPlugin.id }


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* query products on plugin details page

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* empty site data
* visit a plugin page (eg. `/plugins/woocommerce`)
* verify that the plugin details load correctly
  | Before | After |
  | --- | --- |
  | ![image](https://user-images.githubusercontent.com/11555574/146179216-8a089c23-2548-486b-b79c-c906028e6fc0.png) | ![image](https://user-images.githubusercontent.com/11555574/146179258-7f60fd3d-9bd4-45aa-a05a-7017920a8966.png) |


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
