### PR TITLE
Wix onboarding: UX & functional improvements

### DIFF
--- a/client/signup/steps/import-from/components/error-message/index.tsx
+++ b/client/signup/steps/import-from/components/error-message/index.tsx
@@ -1,0 +1,54 @@
+import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
+import { createElement, createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import page from 'page';
+import React from 'react';
+import { getStepUrl } from 'calypso/signup/utils';
+
+import './style.scss';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+interface Props {
+	siteSlug: string;
+}
+
+const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
+	const { __ } = useI18n();
+	const { siteSlug } = props;
+
+	/**
+	 ↓ Methods
+	 */
+	const backToStart = (): void => {
+		page( getStepUrl( 'importer', 'capture', '', '', { siteSlug } ) );
+	};
+
+	const backToIntent = (): void => {
+		page( getStepUrl( 'setup-site', 'intent', '', '', { siteSlug } ) );
+	};
+
+	return (
+		<div className="import-layout__center">
+			<div className="import__header">
+				<div className="import__heading import__heading-center">
+					<Title>
+						{ createInterpolateElement( __( 'Oops, <br />something went wrong.' ), {
+							br: createElement( 'br' ),
+						} ) }
+					</Title>
+					<SubTitle>{ __( 'Please try again soon or contact support for help.' ) }</SubTitle>
+
+					<div className="import__buttons-group">
+						<NextButton onClick={ backToIntent }>{ __( 'Start building' ) }</NextButton>
+						<div>
+							<BackButton onClick={ backToStart }>{ __( 'Back to start' ) }</BackButton>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default ErrorMessage;

--- a/client/signup/steps/import-from/components/not-authorized/index.tsx
+++ b/client/signup/steps/import-from/components/not-authorized/index.tsx
@@ -3,26 +3,27 @@ import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import React from 'react';
 import { getStepUrl } from 'calypso/signup/utils';
-import { GoToStep } from '../../../import/types';
 
 import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface Props {
-	goToStep: GoToStep;
 	siteSlug: string;
 }
 
 const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { goToStep, siteSlug } = props;
+	const { siteSlug } = props;
 
 	/**
 	 ↓ Methods
 	 */
 	const backToStart = (): void => {
 		page( getStepUrl( 'importer', 'capture', '', '', { siteSlug } ) );
+	};
+	const backToIntent = (): void => {
+		page( getStepUrl( 'setup-site', 'intent', '', '', { siteSlug } ) );
 	};
 
 	return (
@@ -33,9 +34,7 @@ const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 					<SubTitle>{ __( 'Please check with your site admin.' ) }</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ () => goToStep( 'intent', '', 'setup-site' ) }>
-							{ __( 'Start building' ) }
-						</NextButton>
+						<NextButton onClick={ backToIntent }>{ __( 'Start building' ) }</NextButton>
 						<div>
 							<BackButton onClick={ backToStart }>{ __( 'Back to start' ) }</BackButton>
 						</div>

--- a/client/signup/steps/import-from/components/not-authorized/index.tsx
+++ b/client/signup/steps/import-from/components/not-authorized/index.tsx
@@ -30,7 +30,7 @@ const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 		<div className="import-layout__center">
 			<div className="import__header">
 				<div className="import__heading  import__heading-center">
-					<Title>{ __( 'Your are not authorized to import content' ) }</Title>
+					<Title>{ __( 'You are not authorized to import content' ) }</Title>
 					<SubTitle>{ __( 'Please check with your site admin.' ) }</SubTitle>
 
 					<div className="import__buttons-group">

--- a/client/signup/steps/import-from/components/not-found/index.tsx
+++ b/client/signup/steps/import-from/components/not-found/index.tsx
@@ -1,0 +1,18 @@
+import { Title, SubTitle } from '@automattic/onboarding';
+import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
+import React from 'react';
+
+const NotFound: React.FunctionComponent = () => {
+	return (
+		<div className={ classnames( 'import-layout__text-center' ) }>
+			<Title>{ translate( 'Uh oh. Page not found.' ) }</Title>
+			<SubTitle>
+				{ translate( "Sorry, the page you were looking for doesn't exist or has been moved." ) }
+			</SubTitle>
+			<img alt="Not Found" src="/calypso/images/illustrations/illustration-404.svg" />
+		</div>
+	);
+};
+
+export default NotFound;

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -13,7 +13,6 @@ import {
 } from 'calypso/state/imports/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteId } from 'calypso/state/sites/selectors';
-import { GoToStep } from '../import/types';
 import NotAuthorized from './components/not-authorized';
 import NotFound from './components/not-found';
 import { MediumImporter } from './medium';
@@ -37,7 +36,6 @@ interface Props {
 	isImporterStatusHydrated: boolean;
 	siteImports: ImportJob[];
 	fetchImporterState: ( siteId: number ) => void;
-	goToStep: GoToStep;
 }
 const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const {
@@ -48,7 +46,6 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 		siteImports,
 		isImporterStatusHydrated,
 		fromSite,
-		goToStep,
 	} = props;
 
 	/**
@@ -121,7 +118,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 									/**
 									 * Permission screen
 									 */
-									return <NotAuthorized goToStep={ goToStep } siteSlug={ siteSlug } />;
+									return <NotAuthorized siteSlug={ siteSlug } />;
 								} else if (
 									engine === 'medium' &&
 									isEnabled( 'gutenboarding/import-from-medium' )

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -15,6 +15,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { GoToStep } from '../import/types';
 import NotAuthorized from './components/not-authorized';
+import NotFound from './components/not-found';
 import { MediumImporter } from './medium';
 import { Importer, QueryObject, ImportJob } from './types';
 import { getImporterTypeForEngine } from './util';
@@ -106,10 +107,15 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 					<div className="import__onboarding-page import-layout__center">
 						<div className="import-layout__center">
 							{ ( () => {
-								/**
-								 * Loading screen
-								 */
-								if ( isLoading() ) {
+								if ( ! siteSlug ) {
+									/**
+									 * Not found
+									 */
+									return <NotFound />;
+								} else if ( isLoading() ) {
+									/**
+									 * Loading screen
+									 */
 									return <LoadingEllipsis />;
 								} else if ( ! hasPermission() ) {
 									/**

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -12,6 +12,7 @@ import { startImport, resetImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import DoneButton from '../components/done-button';
+import ErrorMessage from '../components/error-message';
 import GettingStartedVideo from '../components/getting-started-video';
 import { Importer, ImportJob, ImportJobParams } from '../types';
 import { getImporterTypeForEngine } from '../util';
@@ -106,6 +107,10 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 		return job && job.importerState === appStates.IMPORT_SUCCESS;
 	}
 
+	function checkIsFailed() {
+		return job && job.importerState === appStates.IMPORT_FAILURE;
+	}
+
 	function showVideoComponent() {
 		return checkProgress() || checkIsSuccess();
 	}
@@ -150,6 +155,8 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 								/>
 							</Hooray>
 						);
+					} else if ( checkIsFailed() ) {
+						return <ErrorMessage siteSlug={ siteSlug } />;
 					}
 
 					/**

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -34,19 +34,29 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 	/**
 	 ↓ Effects
 	 */
-	useEffect( runImport, [ job ] );
+	useEffect( handleRunFlagChange, [ run ] );
+	useEffect( handleJobStateTransition, [ job ] );
 
 	/**
 	 ↓ Methods
 	 */
-	function runImport() {
-		if ( ! run ) return;
-
-		// If there is no existing import job, start a new
+	function handleJobStateTransition() {
+		// If there is no existing import job, create a new job
 		if ( job === undefined ) {
 			startImport( siteId, getImporterTypeForEngine( importer ) );
-		} else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
+		}
+		// If the job is in a ready state, start the import process
+		else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
 			importSite( prepareImportParams() );
+		}
+	}
+
+	function handleRunFlagChange() {
+		if ( ! run || ! job ) return;
+
+		// the run flag means to start a new job, but previously reset existing finished jobs
+		if ( job.importerState === appStates.IMPORT_SUCCESS ) {
+			resetImport( siteId, job?.importerId );
 		}
 	}
 

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -90,19 +90,16 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 		page( getStepUrl( 'importer', 'capture', '', '', { siteSlug } ) );
 	}
 
-	function checkLoading() {
-		return (
-			job?.importerState === appStates.READY_FOR_UPLOAD ||
-			job?.importerState === appStates.UPLOAD_SUCCESS
-		);
-	}
-
 	function checkIsImporterReady() {
 		return job || run;
 	}
 
 	function checkProgress() {
-		return job && job.importerState === appStates.IMPORTING;
+		return (
+			job?.importerState === appStates.IMPORTING ||
+			job?.importerState === appStates.READY_FOR_UPLOAD ||
+			job?.importerState === appStates.UPLOAD_SUCCESS
+		);
 	}
 
 	function checkIsSuccess() {
@@ -117,16 +114,11 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 		<>
 			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
 				{ ( () => {
-					if ( checkLoading() ) {
-						/**
-						 * Loading screen
-						 */
-						return <LoadingEllipsis />;
-					} else if ( checkProgress() ) {
+					if ( checkProgress() ) {
 						/**
 						 * Progress screen
 						 */
-						const progress = calculateProgress( job?.progress );
+						const progress = job?.progress ? calculateProgress( job?.progress ) : 0;
 						return (
 							<Progress>
 								<Title>{ __( 'Importing' ) }...</Title>
@@ -159,6 +151,11 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 							</Hooray>
 						);
 					}
+
+					/**
+					 * Loading screen
+					 */
+					return <LoadingEllipsis />;
 				} )() }
 
 				{ showVideoComponent() && <GettingStartedVideo /> }

--- a/client/signup/steps/import/style.scss
+++ b/client/signup/steps/import/style.scss
@@ -116,6 +116,10 @@
 		flex-direction: column;
 		justify-content: center;
 	}
+
+	.import-layout__text-center {
+		text-align: center;
+	}
 }
 
 // Navigation


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fixed issue with running a new import job (clear the success list of imports and run a new import job)
* Show progress bar as soon as possible (switch from loading spinner)
* Introduced and integrated NotFound component
* Introduced and integrated ErrorMessage component
* Improved job status handling

---

#### Testing instructions
**Fix: Run import job twice**
1. Go to `/start/importer?siteSlug={YOUR_SITE}.wordpress.com`
2. Enter a valid Wix website URL
3. Hit the `Import your content` button
4. The import process will be run and once it is finished, there will be a Hooray screen
5. **Repeat** everything from **step 1** | _The Importing process will be regularly started (before the changes, the user saw the Hooray screen from the previous job)_

---

**UX: Progress bar improvement**
- Run Wix import explained in the steps above
- The progress bar will be shown ASAP, instead of a LoadingEllipsis component indicating the broken screen

---

**UX: Not Found component**
- Go to `/start/from/importing/wix` | 👈 there are missing required query params
- Instead of a blank white screen, there is Not Found component
<img width="694" alt="Screenshot 2021-12-16 at 12 36 22" src="https://user-images.githubusercontent.com/1241413/146691435-c4d77a19-8181-49aa-8363-da26eedf37a3.png">

---

**UX: Error message handling**
- Before this PR, we didn't cover error messages. It was a blank white screen.
- Now, there is a Error Message component
<img width="757" alt="Screenshot 2021-12-19 at 15 31 39" src="https://user-images.githubusercontent.com/1241413/146691504-7c45262b-34e1-41ed-a6ea-a160e0583402.png">

Related to #59041
