### PR TITLE
E2E: Fix COBLOCKS_EDGE and GUTENBERG_EDGE vars checks

### DIFF
--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -95,7 +95,7 @@ export function getLaunchConfiguration( chromeVersion: string ): BrowserContextO
  * @returns {boolean} True if should target Gutenberg edge. False otherwise.
  */
 export function targetGutenbergEdge(): boolean {
-	return !! process.env.GUTENBERG_EDGE;
+	return process.env.GUTENBERG_EDGE === 'true';
 }
 
 /**
@@ -104,7 +104,7 @@ export function targetGutenbergEdge(): boolean {
  * @returns {boolean} True if should target CoBlocks edge. False otherwise.
  */
 export function targetCoBlocksEdge(): boolean {
-	return !! process.env.COBLOCKS_EDGE;
+	return process.env.COBLOCKS_EDGE === 'true';
 }
 
 /**


### PR DESCRIPTION
TC always sets both `GUTENBERG_EDGE` and `COBLOCKS_EDGE` env vars to either `"true"` or `"false"` value. Our [env var helpers](https://github.com/Automattic/wp-calypso/blob/26fd6d7d6e9945b4be680a86a2967083781e0815/packages/calypso-e2e/src/browser-helper.ts#L92-L108) have been incorrectly checking only for the existence of these vars instead of the actual value. This PR fixes suites where those helpers are used causing the tests to always run against edge site:

- [wp-blocks__coblocks__blocks](https://github.com/Automattic/wp-calypso/blob/152fc5463eeff5d752021987c32ceaa40eeec9cb/test/e2e/specs/specs-playwright/wp-blocks__coblocks__blocks.ts)
- [wp-blocks__coblocks__extensions__cover-styles](https://github.com/Automattic/wp-calypso/blob/152fc5463eeff5d752021987c32ceaa40eeec9cb/test/e2e/specs/specs-playwright/wp-blocks__coblocks__extensions__cover-styles.ts)
- [wp-blocks__coblocks__extensions__gutter-control](https://github.com/Automattic/wp-calypso/blob/152fc5463eeff5d752021987c32ceaa40eeec9cb/test/e2e/specs/specs-playwright/wp-blocks__coblocks__extensions__gutter-control.ts)
- [wp-blocks__coblocks__extensions__replace-image](https://github.com/Automattic/wp-calypso/blob/152fc5463eeff5d752021987c32ceaa40eeec9cb/test/e2e/specs/specs-playwright/wp-blocks__coblocks__extensions__replace-image.ts)
- [wp-editor__post-basic-flow-spec](https://github.com/Automattic/wp-calypso/blob/5179a15e140d9efe61b581fa3bab87bb984e260c/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts)
- [wp-widgets__spec](https://github.com/Automattic/wp-calypso/blob/5a297e2fe4bc7e496d4e4c6c78c407bfcae77e8a/test/e2e/specs/specs-playwright/wp-widgets__spec.ts)

### Testing instructions

Comparing the following, confirm that the current branch doesn't refer to the edge account as `trunk` does:
- trunk: https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_Playwright_desktop/7131027?buildTab=log&focusLine=360&linesState=302
- this branch: https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_Playwright_desktop/7134046?buildTab=log&focusLine=356&linesState=298