### PR TITLE
Videos UI: Preparing for reading data from wpcommedia.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -56,7 +56,10 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 				return;
 			}
 		}
-		const initialVideoId = 'find-theme';
+		let initialVideoId = 'find-theme';
+		if ( -1 === videoSlugs.indexOf( initialVideoId ) ) {
+			initialVideoId = 'video-1';
+		}
 		setCurrentVideoKey( initialVideoId );
 		setSelectedChapterIndex( videoSlugs.indexOf( initialVideoId ) );
 	}, [ course, initialUserCourseProgression ] );


### PR DESCRIPTION
Once D71461-code is merged video slugs are going to change. This diff works with previous and new slugs.

After merging D71461-code we can revert to hardcoding `video-1` as initial slug.