### PR TITLE
Remove the domains/management-list-redesign feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -31,15 +31,11 @@ import DomainManagement from '.';
 
 export default {
 	domainManagementList( pageContext, next ) {
-		let listComponent = DomainManagement.List;
-		if ( config.isEnabled( 'domains/management-list-redesign' ) ) {
-			listComponent = DomainManagement.SiteDomains;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementList( ':site' ) }
 				analyticsTitle="Domain Management"
-				component={ listComponent }
+				component={ DomainManagement.SiteDomains }
 				context={ pageContext }
 				needsContactDetails
 				needsDomains
@@ -51,15 +47,11 @@ export default {
 	},
 
 	domainManagementListAllSites( pageContext, next ) {
-		let listAllComponent = DomainManagement.ListAll;
-		if ( config.isEnabled( 'domains/management-list-redesign' ) ) {
-			listAllComponent = DomainManagement.AllDomains;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementRoot() }
 				analyticsTitle="Domain Management > All Domains"
-				component={ listAllComponent }
+				component={ DomainManagement.AllDomains }
 				context={ pageContext }
 			/>
 		);

--- a/client/my-sites/domains/domain-management/list/domains-table-filter-button.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-filter-button.jsx
@@ -14,9 +14,13 @@ class DomainsTableFilterButton extends Component {
 				count: PropTypes.number,
 			} )
 		),
-		compact: PropTypes.bool.isRequired,
+		compact: PropTypes.bool,
 		isLoading: PropTypes.bool,
 		disabled: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		compact: false,
 	};
 
 	getFilterOptions() {

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -1,6 +1,6 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
+import { Fragment, PureComponent } from 'react';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import DomainRow from './domain-row';
@@ -143,7 +143,7 @@ class DomainsTable extends PureComponent {
 
 			// TODO: how can we optimize the data loading? Can we load the daomin data using `InView` component as in list-all.jsx?
 			return (
-				<>
+				<Fragment key={ `${ domain.name }-${ index }` }>
 					{ ! isManagingAllSites &&
 						domain.blogId &&
 						this.renderQuerySitePurchasesOnce( domain.blogId ) }
@@ -151,7 +151,6 @@ class DomainsTable extends PureComponent {
 						domain.blogId &&
 						this.renderQuerySiteDomainsOnce( domain.blogId ) }
 					<DomainRow
-						key={ `${ domain.name }-${ index }` }
 						currentRoute={ currentRoute }
 						showCheckbox={ isContactEmailEditContext }
 						isSavingContactInfo={ isSavingContactInfo }
@@ -175,7 +174,7 @@ class DomainsTable extends PureComponent {
 						hasLoadedPurchases={ hasLoadedPurchases }
 						purchase={ purchase }
 					/>
-				</>
+				</Fragment>
 			);
 		} );
 

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -59,7 +59,7 @@ class AddDomainButton extends Component {
 	};
 
 	renderOptions = () => {
-		const { specificSiteActions, translate } = this.props;
+		const { selectedSiteSlug, specificSiteActions, translate } = this.props;
 
 		if ( specificSiteActions ) {
 			const useYourDomainUrl = domainUseMyDomain( this.props.selectedSiteSlug );
@@ -82,7 +82,9 @@ class AddDomainButton extends Component {
 					{ translate( 'Add a domain to a new site' ) }
 				</PopoverMenuItem>
 				<PopoverMenuItem icon="create" href="/domains/add" onClick={ this.trackMenuClick }>
-					{ translate( 'Add a domain to a different site' ) }
+					{ selectedSiteSlug
+						? translate( 'Add a domain to a different site' )
+						: translate( 'Add a domain to an existing site' ) }
 				</PopoverMenuItem>
 				<PopoverMenuItem icon="domains" href="/start/domain" onClick={ this.trackMenuClick }>
 					{ translate( 'Add a domain without a site' ) }

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -1,8 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { Icon, moreVertical, plus, search } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -12,11 +11,7 @@ import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import {
-	domainAddNew,
-	domainManagementAllRoot,
-	domainUseMyDomain,
-} from 'calypso/my-sites/domains/paths';
+import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
 import { composeAnalytics, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -83,11 +78,6 @@ class AddDomainButton extends Component {
 
 		return (
 			<Fragment>
-				{ ! config.isEnabled( 'domains/management-list-redesign' ) && (
-					<PopoverMenuItem href={ domainManagementAllRoot() } onClick={ this.trackMenuClick }>
-						{ translate( 'Manage all domains' ) }
-					</PopoverMenuItem>
-				) }
 				<PopoverMenuItem icon="plus" href="/new" onClick={ this.trackMenuClick }>
 					{ translate( 'Add a domain to a new site' ) }
 				</PopoverMenuItem>
@@ -103,7 +93,6 @@ class AddDomainButton extends Component {
 
 	renderLabel() {
 		const { ellipsisButton, specificSiteActions, translate } = this.props;
-		const isRedesign = config.isEnabled( 'domains/management-list-redesign' );
 
 		if ( ellipsisButton ) {
 			return <Icon icon={ moreVertical } className="options-domain-button__ellipsis gridicon" />;
@@ -111,22 +100,13 @@ class AddDomainButton extends Component {
 
 		let label = translate( 'Other domain options' );
 		if ( specificSiteActions ) {
-			label = isRedesign ? translate( 'Add a domain' ) : translate( 'Add a domain to this site' );
-		}
-
-		if ( isRedesign ) {
-			return (
-				<>
-					<Icon icon={ plus } className="options-domain-button__add gridicon" viewBox="2 2 20 20" />
-					<span className="options-domain-button__desktop">{ label }</span>
-				</>
-			);
+			label = translate( 'Add a domain' );
 		}
 
 		return (
 			<>
-				{ label }
-				{ <Gridicon icon="chevron-down" /> }
+				<Icon icon={ plus } className="options-domain-button__add gridicon" viewBox="2 2 20 20" />
+				<span className="options-domain-button__desktop">{ label }</span>
 			</>
 		);
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -53,7 +53,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"domains/management-list-redesign": true,
 		"domains/settings-page-redesign": true,
 		"domains/dns-records-redesign": true,
 		"domains/contact-info-redesign": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're ready to deploy the new domain list redesign features to everyone, so we can remove the `domains/management-list-redesign` feature flag.

This PR also addresses a couple of minor bugs that were causing warnings to be emitted by some of the new components.

#### Testing instructions

Visit the domain list pages for a site and for all domains and make sure there are no warnings and that the new designs load when the feature flags are not set.

Example paths:
http://calypso.localhost:3000/domains/manage/a8ctest.com?flags=-domains/management-list-redesign
http://calypso.localhost:3000/domains/manage?flags=-domains/management-list-redesign



