### PR TITLE
Tour Kit: Added is-mobile and is-desktop modifiers 

### DIFF
--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -145,8 +145,11 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 		setTimeout( () => initialFocusedElement?.focus() );
 	}, [ initialFocusedElement ] );
 
-	const classNames = classnames( 'tour-kit-frame', config.options?.className );
-
+	const classNames = classnames(
+		'tour-kit-frame',
+		config.options?.className,
+		isMobile ? 'is-mobile' : 'is-desktop'
+	);
 	return (
 		<>
 			<KeyboardNavigation


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added two css modifiers, `is-mobile` and `is-desktop`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* Check that the modifier `is-desktop ` is added to `tour-kit-frame`???  when on desktop and `is-mobile` when on mobile

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59182
Fixes #59182
