### PR TITLE
Compare whether legacy FSE templates are edited from the default.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -221,9 +221,9 @@ function has_legacy_FSE_template_edits( $blog_id ) {
 	$is_fse = has_blog_sticker( 'full-site-editing' );
 	$theme_slug = normalize_theme_slug( get_stylesheet() );
 
-	if ( ! $is_fse || ! in_array( $theme_slug, get_supported_themes() )) {
+	if ( ! $is_fse || ! in_array( $theme_slug, get_supported_themes() ) || ! $theme_slug || is_wp_error( $theme_slug ) ) {
 		restore_current_blog();
-		return 'not-fse';
+		return 'inconclusive';
 	}
 
 	dangerously_load_full_site_editing_files();
@@ -379,12 +379,12 @@ function count_customized_legacy_FSE_sites( $blog_ids ) {
 	$tally = array(
 		'customized' => 0,
 		'not-customized' => 0,
-		'not-fse' => 0
+		'inconclusive' => 0
 	);
 	foreach( $blog_ids as $blog_id ) {
 		$has_edits = has_legacy_FSE_template_edits($blog_id);
-		if( $has_edits && $has_edits === 'not-fse' ) {
-			$tally['not-fse'] += 1;
+		if( $has_edits && $has_edits === 'inconclusive' ) {
+			$tally['inconclusive'] += 1;
 		} else if ( $has_edits ) {
 			$tally['customized'] += 1;
 		} else {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -211,7 +211,15 @@ add_action( 'switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );
 
 function has_legacy_FSE_template_edits( $blog_id ) {
 	switch_to_blog( $blog_id );
+
+	$is_fse = has_blog_sticker( 'full-site-editing' );
 	$theme_slug = normalize_theme_slug( get_stylesheet() );
+	$fse_themes = array( 'maywood', 'morden', 'alves', 'stow', 'hever', 'shawburn', 'exford' );
+
+	if ( ! $is_fse || ! in_array( $theme_slug, $fse_themes )) {
+		restore_current_blog();
+		return 'not-fse';
+	}
 
 	dangerously_load_full_site_editing_files();
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -216,6 +216,8 @@ function has_legacy_FSE_template_edits( $blog_id ) {
 	dangerously_load_full_site_editing_files();
 
 	// Get saved template part markup
+	$template_inserter = new WP_Template_Inserter( $theme_slug );
+	$template_inserter->register_template_post_types();
 	$template_manager = new WP_Template();
 	$header_content = $template_manager->get_template_content( 'header' );
 	$footer_content = $template_manager->get_template_content( 'footer' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -214,9 +214,8 @@ function has_legacy_FSE_template_edits( $blog_id ) {
 
 	$is_fse = has_blog_sticker( 'full-site-editing' );
 	$theme_slug = normalize_theme_slug( get_stylesheet() );
-	$fse_themes = array( 'maywood', 'morden', 'alves', 'stow', 'hever', 'shawburn', 'exford' );
 
-	if ( ! $is_fse || ! in_array( $theme_slug, $fse_themes )) {
+	if ( ! $is_fse || ! in_array( $theme_slug, get_supported_themes() )) {
 		restore_current_blog();
 		return 'not-fse';
 	}
@@ -298,8 +297,27 @@ function filter_empty_paragraphs( $markup ) {
 	return str_replace( $empty_paragraph_markup, '', $markup );
 }
 
+// Some social links default urls are different bcause of '\\' additions
+function filter_escaping( $markup ) {
+	return str_replace( '\\', '', $markup );
+}
+
+
+/**
+ * Notes
+ *
+ * Saved social links markup differently (effects morden, stow, hever, shawburn, exford)
+ * Sometimes with initial urls (like in Morden):
+ * before saving: '<!-- wp:social-link-twitter {"url":"add_your_email@address.com"} /-->'
+ * after saving: '<!-- wp:social-link {"url":"add_your_email@address.com","service":"twitter"} /-->'
+ * Sometimes without initial urls (like in Stow):
+ * before saving: '<!-- wp:social-link-twitter /-->'
+ * after saving: '<!-- wp:social-link {"service":"twitter"} /-->'
+ */
+
 function filter_markup( $markup ) {
 	$filtered_markup = filter_img_src( $markup );
 	$filtered_markup = filter_empty_paragraphs( $filtered_markup );
+	$filtered_markup = filter_escaping( $filtered_markup );
 	return trim( $filtered_markup );
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -372,4 +372,24 @@ function filter_markup( $markup ) {
 	return trim( $filtered_markup );
 }
 
-
+/**
+ * Given an array of blog_ids, tallys the numbers for customized, non-customized, and non-fse sites.
+ */
+function count_customized_legacy_FSE_sites( $blog_ids ) {
+	$tally = array(
+		'customized' => 0,
+		'not-customized' => 0,
+		'not-fse' => 0
+	);
+	foreach( $blog_ids as $blog_id ) {
+		$has_edits = has_legacy_FSE_template_edits($blog_id);
+		if( $has_edits && $has_edits === 'not-fse' ) {
+			$tally['not-fse'] += 1;
+		} else if ( $has_edits ) {
+			$tally['customized'] += 1;
+		} else {
+			$tally['not-customized'] += 1;
+		}
+	}
+	return $tally;
+}


### PR DESCRIPTION
This introduces a helper function to compare the saved templates for a given legacy FSE site to the default FSE templates for that theme.

There are a handful of conflicts to handle when comparing template for legacy FSE that result from a basic save of the editor. Some sections of markup are updated even if those blocks are not customized. Here we do our best to mitigate these inconsistencies and evaluate whether or not the site has legacy FSE template customizations.

### Testing

I have been testing this pretty thoroughly for each legacy FSE theme which has also allowed me to identify the most common conflicts. Below is a rough outline of testing:

Setup:
Create a legacy FSE site and find its `blogId`.
Sync this code to your sandbox so you can test at various points by running `return \A8C\FSE\has_legacy_FSE_template_edits( $blog_id );` in wpsh.

Now run the above with the site on various legacy FSE themes and customizations:
* At first, this should return `FALSE`.
* Make some edits to the header that should not count as customizations (change the value of the site title, add an empty paragraph block, etc.) and save.
* Verify this still returns `FALSE`
* Customize something (a block color setting, adding more blocks, resizing things, etc.) that seems like it should be considered a customization and save.
* Verify the function now returns `TRUE`
* Change to other FSE themes and repeat.


