### PR TITLE
Videos UI - adding loading placeholder for better UX

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -117,7 +117,11 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 					</div>
 				</div>
 			</div>
-			<div className={ `videos-ui__body ${ course ? '' : 'is-loading' }` }>
+			<div
+				className={ classNames( 'videos-ui__body', {
+					'is-loading': ! course,
+				} ) }
+			>
 				<div className="videos-ui__body-title">
 					<h3>{ course && course.title }</h3>
 				</div>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -117,11 +117,12 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 					</div>
 				</div>
 			</div>
-			<div className="videos-ui__body">
+			<div className={ `videos-ui__body ${ course ? '' : 'is-loading' }` }>
 				<div className="videos-ui__body-title">
 					<h3>{ course && course.title }</h3>
 				</div>
 				<div className="videos-ui__video-content">
+					{ ! currentVideo && <div className="videos-ui__video-placeholder" /> }
 					{ currentVideo && (
 						<VideoPlayer
 							videoData={ { ...currentVideo, ...{ slug: currentVideoKey } } }

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -369,6 +369,7 @@
 
 				.videos-ui__video-placeholder, .videos-ui__chapters {
 					margin: 0 0 20px;
+					flex: 0 0 360px;
 				}
 
 				.videos-ui__video-placeholder {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -361,6 +361,21 @@
 				.videos-ui__video-placeholder {
 					width: 100%;
 				}
+
+				.videos-ui__body-title {
+					margin-right: 0;
+					margin-left: 0;
+				}
+
+				.videos-ui__video-placeholder, .videos-ui__chapters {
+					margin: 0 0 20px;
+				}
+
+				.videos-ui__video-placeholder {
+					margin-right: 20px;
+					flex-grow: 1;
+				}
+
 			}
 		}
 

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -67,6 +67,30 @@
 	}
 
 	.videos-ui__body {
+
+		&.is-loading {
+			width: 100%;
+			padding-left: 0;
+			padding-right: 0;
+			.videos-ui__body-title, .videos-ui__video-placeholder, .videos-ui__chapters {
+				@include placeholder( --color-neutral-60 );
+				* {
+					visibility: hidden;
+				}
+			}
+			.videos-ui__body-title {
+				height: 1.5rem;
+				margin-bottom: 24px;
+				margin-right: 20px;
+				margin-left: 20px;
+			}
+
+			.videos-ui__video-placeholder, .videos-ui__chapters {
+				height: 500px;
+				margin: 0 20px 20px;
+			}
+		}
+
 		max-width: 1280px;
 		margin: 0 auto;
 		padding: 64px 20px 97px;
@@ -330,6 +354,12 @@
 				.videos-ui__chapters {
 					flex-basis: auto;
 					width: 31%;
+				}
+			}
+
+			&.is-loading {
+				.videos-ui__video-placeholder {
+					width: 100%;
 				}
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a loading state to the videos UI, displaying a pulser approximation of the layout while the video content is being loaded in.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to local.
* Test the videos UI with a throttled connection (or change `client/components/videos-ui/index.jsx:16` to `const course = null;` to prevent the course from loading).
* Verify that at both mobile and desktop screen sizes, a pulser placeholder displays until the course is loaded.

![image](https://user-images.githubusercontent.com/13437011/146244244-52622906-a7ed-4bb1-9df8-7564fe63e29f.png)
![image](https://user-images.githubusercontent.com/13437011/146244297-75c84328-57a5-4ccc-bf58-35da995e5f10.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57567
