### PR TITLE
Videos UI - fix modal header/footer display when course not loaded

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -2,14 +2,14 @@ import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { cloneElement, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import useUpdateUserCourseProgressionMutation from 'calypso/data/courses/use-update-user-course-progression-mutation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import VideoPlayer from './video-player';
 import './style.scss';
 
-const VideosUi = ( { headerBar, footerBar } ) => {
+const VideosUi = ( { HeaderBar, FooterBar } ) => {
 	const translate = useTranslate();
 
 	const courseSlug = 'blogging-quick-start';
@@ -90,7 +90,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 	return (
 		<div className="videos-ui">
 			<div className="videos-ui__header">
-				{ course && cloneElement( headerBar, { course: course } ) }
+				<HeaderBar course={ course } />
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
 						<h2>{ translate( 'Watch five videos.' ) }</h2>
@@ -205,8 +205,7 @@ const VideosUi = ( { headerBar, footerBar } ) => {
 					</div>
 				</div>
 			</div>
-			{ course &&
-				cloneElement( footerBar, { course: course, isCourseComplete: isCourseComplete } ) }
+			<FooterBar course={ course } isCourseComplete={ isCourseComplete } />
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
@@ -13,8 +13,12 @@ const BloggingQuickStartModal = ( props ) => {
 			<BlankCanvas className={ 'blogging-quick-start-modal' }>
 				<BlankCanvas.Content>
 					<VideosUi
-						headerBar={ <ModalHeaderBar onClose={ onClose } /> }
-						footerBar={ <ModalFooterBar onBackClick={ onClose } /> }
+						HeaderBar={ ( headerProps ) => (
+							<ModalHeaderBar onClose={ onClose } { ...headerProps } />
+						) }
+						FooterBar={ ( footerProps ) => (
+							<ModalFooterBar onBackClick={ onClose } { ...footerProps } />
+						) }
 					/>
 				</BlankCanvas.Content>
 			</BlankCanvas>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes a bug with the videos UI which was causing the modal header/footer not to display when the course was not yet loaded. For the footer this wasn't a problem, but for the header, it meant that if the user had a long loading time on the course, they could not close the modal until it finished loading. This PR rectifies this by removing the dependency on the course being loaded to display the modal header/footer.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch to local calypso.
* Test the videos UI with a throttled connection (or change `client/components/videos-ui/index.jsx:16` to `const course = null;` to prevent the course from loading).
* Verify that even before the course has loaded in, the user can see the modal header and close the modal.
* Verify that the header and footer display correctly once the course has loaded in.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->