### PR TITLE
Videos UI - fix useEffect dependency

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import useCourseQuery from 'calypso/data/courses/use-course-query';
 import useUpdateUserCourseProgressionMutation from 'calypso/data/courses/use-update-user-course-progression-mutation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -16,7 +16,7 @@ const VideosUi = ( { HeaderBar, FooterBar } ) => {
 	const { data: course } = useCourseQuery( courseSlug, { retry: false } );
 	const { updateUserCourseProgression } = useUpdateUserCourseProgressionMutation();
 
-	const initialUserCourseProgression = course?.completions ?? [];
+	const initialUserCourseProgression = useMemo( () => course?.completions ?? [], [ course ] );
 
 	const [ userCourseProgression, setUserCourseProgression ] = useState( [] );
 	useEffect( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes a dependency issue in one of the useEffect calls in the Videos UI component which was causing unnecessary re-renders. (It also resolves an ESLint warning that indicated this was happening. 😄 )

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR should not change any user-facing behavior.
* Check this PR out to local Calypso.
* Verify that the videos UI still loads as expected and that user progression/course completion works normally.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

