### PR TITLE
Woop installer: Error handling when transferring

### DIFF
--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -32,7 +32,9 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 	const navigationItems = [ { label: 'WooCommerce', href: `/woocommerce-installation` } ];
 	const ctaRef = useRef( null );
 
-	const { hasBlockers, wpcomDomain, isDataReady } = useWooCommerceOnPlansEligibility( siteId );
+	const { isTransferringBlocked, wpcomDomain, isDataReady } = useWooCommerceOnPlansEligibility(
+		siteId
+	);
 
 	function onCTAClickHandler() {
 		if ( isEnabled( 'woop' ) ) {
@@ -43,7 +45,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 	}
 
 	function renderWarningNotice() {
-		if ( ! hasBlockers || ! isDataReady ) {
+		if ( ! isTransferringBlocked || ! isDataReady ) {
 			return null;
 		}
 
@@ -61,7 +63,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 	return (
 		<div className="woop__landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
-				<Button onClick={ onCTAClickHandler } primary disabled={ hasBlockers }>
+				<Button onClick={ onCTAClickHandler } primary disabled={ isTransferringBlocked }>
 					{ __( 'Set up my store!' ) }
 				</Button>
 			</FixedNavigationHeader>
@@ -70,7 +72,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 				headline={ __( 'Build exactly the eCommerce website you want.' ) }
 				buttonText={ __( 'Set up my store!' ) }
 				buttonAction={ onCTAClickHandler }
-				buttonDisabled={ hasBlockers }
+				buttonDisabled={ isTransferringBlocked }
 				ctaRef={ ctaRef }
 				notice={ renderWarningNotice() }
 			>

--- a/client/signup/steps/woocommerce-install/components/support-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/support-card/index.tsx
@@ -16,7 +16,7 @@ const SupportLinkContainer = styled.p`
 
 const SupportLinkStyle = styled.a`
 	/* Gray / Gray 100 - have to find the var value for this color */
-	color: #101517 !important;
+	color: var( --studio-gray-100 ) !important;
 	text-decoration: underline;
 	font-weight: bold;
 `;

--- a/client/signup/steps/woocommerce-install/components/support-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/support-card/index.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const SupportLinkContainer = styled.p`
+	@media ( max-width: 320px ) {
+		margin-top: 0px;
+		width: 100%;
+	}
+`;
+
+const SupportLinkStyle = styled.a`
+	/* Gray / Gray 100 - have to find the var value for this color */
+	color: #101517 !important;
+	text-decoration: underline;
+	font-weight: bold;
+`;
+
+export default function SupportLink(): ReactElement {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+
+	return (
+		<SupportLinkContainer>
+			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
+				a: (
+					<SupportLinkStyle
+						href={ addQueryArgs( '/help/contact', {
+							redirect_to: `/start/woocommerce-install/confirm?site=${ domain }`,
+						} ) }
+					/>
+				),
+			} ) }
+		</SupportLinkContainer>
+	);
+}

--- a/client/signup/steps/woocommerce-install/components/support-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/support-card/index.tsx
@@ -21,7 +21,7 @@ const SupportLinkStyle = styled.a`
 	font-weight: bold;
 `;
 
-export default function SupportLink(): ReactElement {
+export default function SupportCard(): ReactElement {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 

--- a/client/signup/steps/woocommerce-install/components/support-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/support-card/index.tsx
@@ -15,7 +15,6 @@ const SupportLinkContainer = styled.p`
 `;
 
 const SupportLinkStyle = styled.a`
-	/* Gray / Gray 100 - have to find the var value for this color */
 	color: var( --studio-gray-100 ) !important;
 	text-decoration: underline;
 	font-weight: bold;

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -19,7 +19,7 @@ import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '../';
 import './style.scss';
 
-const SupportLinkStyle = styled.a`
+export const SupportLinkStyle = styled.a`
 	/* Gray / Gray 100 - have to find the var value for this color */
 	color: #101517 !important;
 	text-decoration: underline;

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -14,6 +14,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WarningCard from 'calypso/components/warning-card';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '../';
@@ -61,7 +62,10 @@ const StyledNextButton = styled( NextButton )`
 	}
 `;
 
-export function SupportLink( { domain }: { domain: string } ): ReactElement {
+export function SupportLink(): ReactElement {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+
 	return (
 		<SupportLinkContainer>
 			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
@@ -157,7 +161,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					{ getCheckoutContent() }
 					{ getWarningsOrHoldsSection() }
 					<ActionSection>
-						<SupportLink domain={ wpcomDomain } />
+						<SupportLink />
 						<StyledNextButton
 							disabled={ hasBlockers || ! isDataReady }
 							onClick={ () => {

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -58,7 +58,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		stagingDomain,
 		wpcomSubdomainWarning,
 		siteUpgrading,
-		hasBlockers,
+		isTransferringBlocked,
 		isDataReady,
 		warnings,
 		isAtomicSite,
@@ -92,7 +92,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 	}
 
 	function getWarningsOrHoldsSection() {
-		if ( hasBlockers ) {
+		if ( isTransferringBlocked ) {
 			return (
 				<WarningsOrHoldsSection>
 					<WarningCard
@@ -127,7 +127,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					<ActionSection>
 						<SupportCard />
 						<StyledNextButton
-							disabled={ hasBlockers || ! isDataReady }
+							disabled={ isTransferringBlocked || ! isDataReady }
 							onClick={ () => {
 								dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
 								if ( siteUpgrading.required ) {

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -1,9 +1,6 @@
 import { NextButton } from '@automattic/onboarding';
 import styled from '@emotion/styled';
-import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { addQueryArgs } from '@wordpress/url';
 import page from 'page';
 import { ReactElement, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -14,18 +11,11 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WarningCard from 'calypso/components/warning-card';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import SupportCard from '../components/support-card';
 import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '../';
 import './style.scss';
-
-export const SupportLinkStyle = styled.a`
-	/* Gray / Gray 100 - have to find the var value for this color */
-	color: #101517 !important;
-	text-decoration: underline;
-	font-weight: bold;
-`;
 
 const ActionSection = styled.div`
 	display: flex;
@@ -48,38 +38,12 @@ const WarningsOrHoldsSection = styled.div`
 	margin-bottom: 40px;
 `;
 
-const SupportLinkContainer = styled.p`
-	@media ( max-width: 320px ) {
-		margin-top: 0px;
-		width: 100%;
-	}
-`;
-
 const StyledNextButton = styled( NextButton )`
 	@media ( max-width: 320px ) {
 		width: 100%;
 		margin-bottom: 20px;
 	}
 `;
-
-export function SupportLink(): ReactElement {
-	const siteId = useSelector( getSelectedSiteId ) as number;
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-
-	return (
-		<SupportLinkContainer>
-			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
-				a: (
-					<SupportLinkStyle
-						href={ addQueryArgs( '/help/contact', {
-							redirect_to: `/start/woocommerce-install/confirm?site=${ domain }`,
-						} ) }
-					/>
-				),
-			} ) }
-		</SupportLinkContainer>
-	);
-}
 
 export default function Confirm( props: WooCommerceInstallProps ): ReactElement | null {
 	const { goToStep, isReskinned, headerTitle, headerDescription } = props;
@@ -161,7 +125,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 					{ getCheckoutContent() }
 					{ getWarningsOrHoldsSection() }
 					<ActionSection>
-						<SupportLink />
+						<SupportCard />
 						<StyledNextButton
 							disabled={ hasBlockers || ! isDataReady }
 							onClick={ () => {

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -61,7 +61,7 @@ const StyledNextButton = styled( NextButton )`
 	}
 `;
 
-function SupportLink( { domain }: { domain: string } ): ReactElement {
+export function SupportLink( { domain }: { domain: string } ): ReactElement {
 	return (
 		<SupportLinkContainer>
 			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
@@ -37,7 +37,7 @@ The hook returns an object with the following properties:
 
 ### transferringBlockers
 
-### hasBlockers
+### isTransferringBlocked
 
 ### siteUpgrading
 

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -67,8 +67,8 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	/*
 	 * Inspect transfer status to detect blockers.
 	 * It's considered blocked when code:
-	 * has the 5xx shape.
-	 * Is `active`.
+	 * - has the 5xx shape.
+	 * - its value is one of: [ `active`,...] @todo: add more codes.
 	 */
 	const transferStatus = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) )
 		?.status;
@@ -102,7 +102,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	);
 
 	if ( isBlockByTransferStatus ) {
-		transferringBlockers?.push( 'transfer_blocked' );
+		transferringBlockers?.push( eligibilityHoldsConstants.BLOCKED_ATOMIC_TRANSFER );
 	}
 
 	const transferringDataIsAvailable =

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -25,15 +25,13 @@ const TRANSFERRING_NOT_BLOCKERS = [
 ];
 
 type EligibilityHook = {
-	eligibilityHolds?: string[];
-	eligibilityWarnings?: EligibilityWarning[];
 	warnings: EligibilityWarning[];
 	wpcomDomain: string | null;
 	stagingDomain: string | null;
 	wpcomSubdomainWarning: EligibilityWarning | undefined;
 	transferringBlockers: string[];
 	isDataReady: boolean;
-	hasBlockers: boolean;
+	isTransferringBlocked: boolean;
 	siteUpgrading: {
 		required: boolean;
 		checkoutUrl: string;
@@ -108,8 +106,11 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	const transferringDataIsAvailable =
 		typeof transferringBlockers !== 'undefined' && typeof transferStatus !== 'undefined';
 
-	// Check whether the site has transferring blockers. True as default.
-	const hasBlockers = ! transferringDataIsAvailable || transferringBlockers?.length > 0;
+	/*
+	 * Check whether the site transferring is blocked.
+	 * True as default, meaning it's True when requesting data.
+	 */
+	const isTransferringBlocked = ! transferringDataIsAvailable || transferringBlockers?.length > 0;
 
 	/*
 	 * Plan site and `woop` site feature.
@@ -168,19 +169,16 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	};
 
 	return {
-		eligibilityHolds,
-		eligibilityWarnings,
 		warnings,
 		wpcomDomain,
 		stagingDomain,
 		wpcomSubdomainWarning,
-
 		transferringBlockers: transferringBlockers || [],
-		hasBlockers,
+		isTransferringBlocked,
 		siteUpgrading,
 		isDataReady: transferringDataIsAvailable,
 		isReadyForTransfer: transferringDataIsAvailable
-			? ! hasBlockers && ! ( eligibilityWarnings && eligibilityWarnings.length )
+			? ! isTransferringBlocked && ! ( eligibilityWarnings && eligibilityWarnings.length )
 			: false,
 		isAtomicSite: !! useSelector( ( state ) => isAtomicSite( state, siteId ) ),
 	};

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -101,7 +101,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		( hold ) => ! TRANSFERRING_NOT_BLOCKERS.includes( hold )
 	);
 
-	// Add blocked transfer hold when somwthign is wrong in the transfer status.
+	// Add blocked transfer hold when something is wrong in the transfer status.
 	if (
 		! transferringBlockers?.includes( eligibilityHoldsConstants.BLOCKED_ATOMIC_TRANSFER ) &&
 		( isBlockByTransferStatus || isTransferStuck )

--- a/client/signup/steps/woocommerce-install/transfer/error.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/error.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement } from 'react';
-import { SupportLink } from '../confirm';
+import SupportCard from '../components/support-card';
 import StepContent from './step-content';
 
 const WarningsOrHoldsSection = styled.div`
@@ -19,7 +19,7 @@ export default function Error(): ReactElement {
 			) }
 		>
 			<WarningsOrHoldsSection>
-				<SupportLink />
+				<SupportCard />
 			</WarningsOrHoldsSection>
 		</StepContent>
 	);

--- a/client/signup/steps/woocommerce-install/transfer/error.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/error.tsx
@@ -1,32 +1,25 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement } from 'react';
-import WarningCard from 'calypso/components/warning-card';
+import { SupportLink } from '../confirm';
 import StepContent from './step-content';
 
 const WarningsOrHoldsSection = styled.div`
-	margin-bottom: 40px;
+	margin-top: 40px;
 `;
 
-export default function Error( { message }: { message: string } ): ReactElement {
+export default function Error(): ReactElement {
 	const { __ } = useI18n();
 	// todo: both messages sort of say the same thing, refer to figma and fix
 	return (
 		<StepContent
 			title={ __( "We've hit a snag" ) }
 			subtitle={ __(
-				'It looks like something went wrong while setting up your store. If this is unexpected, please contact support so that we can help you out.'
+				'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
 			) }
 		>
 			<WarningsOrHoldsSection>
-				<WarningCard
-					message={
-						message ||
-						__(
-							'There is an error that is stopping us from being able to install this product, please contact support.'
-						)
-					}
-				/>
+				<SupportLink />
 			</WarningsOrHoldsSection>
 		</StepContent>
 	);

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -36,7 +36,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			hideSkip={ true }
 			hideFormattedHeader={ true }
 			isWideLayout={ props.isReskinned }
-			backUrl={ hasFailed ? `/woocommerce-installation/${ domain }` : null }
+			backUrl={ `/woocommerce-installation/${ domain }` }
 			stepContent={
 				<>
 					{ isAtomic && <InstallPlugins /> }

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -1,12 +1,12 @@
-import { ReactElement } from 'react';
+import { ReactElement, useState } from 'react';
 import { useSelector } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InstallPlugins from './install-plugins';
 import TransferSite from './transfer-site';
 import type { WooCommerceInstallProps } from '../';
-
 import './style.scss';
 
 export default function Transfer( props: WooCommerceInstallProps ): ReactElement | null {
@@ -19,6 +19,9 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 		signupDependencies: { siteConfirmed },
 	} = props;
 
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const [ hasFailed, setHasFailed ] = useState( false );
+
 	if ( siteConfirmed !== siteId ) {
 		goToStep( 'confirm' );
 		return null;
@@ -28,15 +31,16 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 		<StepWrapper
 			className="transfer__step-wrapper"
 			flowName="woocommerce-install"
-			hideBack={ true }
+			hideBack={ ! hasFailed }
 			hideNext={ true }
 			hideSkip={ true }
 			hideFormattedHeader={ true }
 			isWideLayout={ props.isReskinned }
+			backUrl={ hasFailed ? `/woocommerce-installation/${ domain }` : null }
 			stepContent={
 				<>
 					{ isAtomic && <InstallPlugins /> }
-					{ ! isAtomic && <TransferSite /> }
+					{ ! isAtomic && <TransferSite onFailure={ () => setHasFailed( true ) } /> }
 				</>
 			}
 			{ ...props }

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -26,7 +26,15 @@ export default function TransferSite(): ReactElement | null {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const transfer = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
 	const transferStatus = transfer?.status;
-	const transferFailed = !! transfer?.error;
+
+	// Check transfer status code 2xx.
+	const isErrorTransferStatus =
+		Number.isInteger( Number( transferStatus ) ) &&
+		transferStatus &&
+		2 !== Math.floor( Number( transferStatus ) / 100 );
+
+	const transferFailed = !! transfer?.error || isErrorTransferStatus;
+
 	const software = useSelector( ( state ) =>
 		getAtomicSoftwareStatus( state, siteId, 'woo-on-plans' )
 	);
@@ -52,7 +60,7 @@ export default function TransferSite(): ReactElement | null {
 	// Poll for software status
 	useInterval(
 		() => {
-			// Only poll if the transfer is completed
+			// Only poll if the transfer is completed and not failed
 			if ( transferFailed || ! transferStates.COMPLETED ) {
 				return;
 			}

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -52,6 +52,10 @@ export default function TransferSite(): ReactElement | null {
 	// Poll for software status
 	useInterval(
 		() => {
+			// Only poll if the transfer is completed
+			if ( transferFailed || ! transferStates.COMPLETED ) {
+				return;
+			}
 			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
 		},
 		softwareApplied ? null : 3000

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -35,7 +35,7 @@ export default function TransferSite( {
 	const isErrorTransferStatus =
 		Number.isInteger( Number( transferStatus ) ) &&
 		transferStatus &&
-		2 !== Math.floor( Number( transferStatus ) / 100 );
+		5 === Math.floor( Number( transferStatus ) / 100 );
 
 	const transferFailed = !! transfer?.error || isErrorTransferStatus;
 

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -31,7 +31,7 @@ export default function TransferSite( {
 	const transfer = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
 	const transferStatus = transfer?.status;
 
-	// Check transfer status code 2xx.
+	// Check transfer status code (5xx).
 	const isErrorTransferStatus =
 		Number.isInteger( Number( transferStatus ) ) &&
 		transferStatus &&

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -17,7 +17,11 @@ import Progress from './progress';
 
 import './style.scss';
 
-export default function TransferSite(): ReactElement | null {
+export default function TransferSite( {
+	onFailure,
+}: {
+	onFailure: () => void;
+} ): ReactElement | null {
 	const dispatch = useDispatch();
 
 	const [ progress, setProgress ] = useState( 0.1 );
@@ -92,8 +96,9 @@ export default function TransferSite(): ReactElement | null {
 
 		if ( transferFailed || transferStatus === transferStates.ERROR ) {
 			setProgress( 1 );
+			onFailure();
 		}
-	}, [ siteId, transferStatus, transferFailed ] );
+	}, [ siteId, transferStatus, transferFailed, onFailure ] );
 
 	// Redirect to wc-admin once software installation is confirmed.
 	useEffect( () => {
@@ -113,7 +118,7 @@ export default function TransferSite(): ReactElement | null {
 	// todo: transferFailed states need testing and if required, pass the message through correctly
 	return (
 		<>
-			{ transferFailed && <Error message={ transferStatus || '' } /> }
+			{ transferFailed && <Error /> }
 			{ ! transferFailed && <Progress progress={ progress } /> }
 		</>
 	);

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -58,19 +58,16 @@ export default function TransferSite( {
 		() => {
 			dispatch( requestLatestAtomicTransfer( siteId ) );
 		},
-		transferStatus === transferStates.COMPLETED ? null : 3000
+		transferFailed || transferStatus === transferStates.COMPLETED ? null : 3000
 	);
 
 	// Poll for software status
 	useInterval(
 		() => {
-			// Only poll if the transfer is completed and not failed
-			if ( transferFailed || ! transferStates.COMPLETED ) {
-				return;
-			}
 			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
 		},
-		softwareApplied ? null : 3000
+		// Only poll if the transfer is completed and not failed
+		transferFailed || transferStates.COMPLETED !== transferStatus || softwareApplied ? null : 3000
 	);
 
 	// Watch transfer status

--- a/client/state/data-layer/wpcom/sites/atomic/software/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/software/index.js
@@ -7,6 +7,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setAtomicSoftwareStatus } from 'calypso/state/atomic/software/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
 
@@ -44,6 +45,7 @@ const requestSoftware = ( action ) =>
 			apiNamespace: 'wpcom/v2',
 			method: 'GET',
 			path: `/sites/${ action.siteId }/atomic/software/${ action.softwareSet }`,
+			retryPolicy: noRetry(),
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/latest/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/latest/index.js
@@ -2,6 +2,7 @@ import { ATOMIC_TRANSFER_REQUEST_LATEST } from 'calypso/state/action-types';
 import { setLatestAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
 const requestLatestAtomicTransfer = ( action ) =>
@@ -10,6 +11,7 @@ const requestLatestAtomicTransfer = ( action ) =>
 			apiNamespace: 'wpcom/v2',
 			method: 'GET',
 			path: `/sites/${ action.siteId }/atomic/transfers/latest`,
+			retryPolicy: noRetry(),
 		},
 		action
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is the first attempt to handle the transferring errors when something gets wrong.

* Checks the `transfer.error` prop.
* Checks the `transfer.status` in case it is a number: For instance, failed WoA sites.

It doesn't allow go/stay to the transfer step when something is wrong. If so, it should end up in the confirm step, with the chance to go back to the landing page, by clicking on the back button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~Apply D71691-code and get sandboxed in case it isn't :shipit: yet~
* Try to transfer a site, generating transferring issues. More instructions in progress 😓 
* Confirm when something gets wrong, you see the error message

<img src="https://user-images.githubusercontent.com/77539/146377884-68290d96-b4da-4719-aabc-dc368fa460cd.png" width="500px" />


* Confirm you see the `Back` button in the header

* Confirm for broken sites the button is disabled even on the Landing page.

<img src="https://user-images.githubusercontent.com/77539/146377809-3bd335bf-98a2-4eb4-b040-ebd2c01deafe.png" width="500px" />


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/58331
 