### PR TITLE
Revert "Migrate Photon to Typescript"

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -60,7 +60,6 @@
 		"@automattic/plans-grid": "workspace:^",
 		"@automattic/tour-kit": "workspace:^",
 		"@automattic/typography": "workspace:^",
-		"@automattic/viewport": "workspace:^",
 		"@automattic/whats-new": "workspace:^",
 		"@babel/core": "^7.16.5",
 		"@emotion/react": "^11.4.1",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -4,8 +4,7 @@
 	"description": "JavaScript library for the WordPress.com Photon image manipulation service",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
-	"calypso:src": "src/index.ts",
-	"types": "dist/types/index.d.ts",
+	"calypso:src": "src/index.js",
 	"sideEffects": false,
 	"repository": {
 		"type": "git",
@@ -23,10 +22,6 @@
 		"api",
 		"library"
 	],
-	"files": [
-		"dist",
-		"src"
-	],
 	"author": "Automattic Inc.",
 	"contributors": [
 		"Nathan Rajlich <nathan@automattic.com>"
@@ -37,18 +32,16 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"dependencies": {
-		"@types/seed-random": "^2.2.1",
 		"crc32": "^0.2.2",
 		"debug": "^4.0.0",
 		"seed-random": "^2.2.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.3"
+		"@automattic/calypso-typescript-config": "workspace:^"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"clean": "rm -rf dist",
+		"build": "transpile",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/photon/src/decs.d.ts
+++ b/packages/photon/src/decs.d.ts
@@ -1,3 +1,0 @@
-declare module 'crc32' {
-	export default function crc32( s: string ): string;
-}

--- a/packages/photon/tsconfig-cjs.json
+++ b/packages/photon/tsconfig-cjs.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig",
-	"compilerOptions": {
-		"module": "commonjs",
-		"outDir": "dist/cjs"
-	}
-}

--- a/packages/photon/tsconfig.json
+++ b/packages/photon/tsconfig.json
@@ -1,10 +1,3 @@
 {
-	"extends": "@automattic/calypso-typescript-config/ts-package.json",
-	"compilerOptions": {
-		"declarationDir": "dist/types",
-		"outDir": "dist/esm",
-		"rootDir": "src"
-	},
-	"include": [ "src" ],
-	"exclude": [ "**/test/*" ]
+	"extends": "@automattic/calypso-typescript-config/js-package.json"
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -29,7 +29,6 @@
 		{ "path": "./launch" },
 		{ "path": "./onboarding" },
 		{ "path": "./page-pattern-modal" },
-		{ "path": "./photon" },
 		{ "path": "./plans-grid" },
 		{ "path": "./search" },
 		{ "path": "./shopping-cart" },

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -31,7 +31,6 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.3"
+		"@automattic/calypso-typescript-config": "workspace:^"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,7 +1182,6 @@ __metadata:
   resolution: "@automattic/viewport@workspace:packages/viewport"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: ^4.5.3
   languageName: unknown
   linkType: soft
 
@@ -1376,7 +1375,6 @@ __metadata:
     "@automattic/plans-grid": "workspace:^"
     "@automattic/tour-kit": "workspace:^"
     "@automattic/typography": "workspace:^"
-    "@automattic/viewport": "workspace:^"
     "@automattic/whats-new": "workspace:^"
     "@babel/core": ^7.16.5
     "@emotion/react": ^11.4.1
@@ -6919,13 +6917,6 @@ __metadata:
   version: 0.16.1
   resolution: "@types/scheduler@npm:0.16.1"
   checksum: 78aa5a8b19b42b7b6dc1dc3fb64c1ef2cb87b685292a0951d06d15ac4de8926c9a219bd027f438c3cb701cf525cf1f233bc09a90af5488ae8b98af2ec84b656a
-  languageName: node
-  linkType: hard
-
-"@types/seed-random@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "@types/seed-random@npm:2.2.1"
-  checksum: 4efc78a6c2786b3c7d84c85ebef9b6d14a9e861d1852893b835eea8fb838fd602244b2a79cef6da6feedaefc89ecac7a3728746471e3f33265e5ccef533a21ab
   languageName: node
   linkType: hard
 
@@ -28035,11 +28026,9 @@ fsevents@~2.1.2:
   resolution: "photon@workspace:packages/photon"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@types/seed-random": ^2.2.1
     crc32: ^0.2.2
     debug: ^4.0.0
     seed-random: ^2.2.0
-    typescript: ^4.5.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Tests are failing on trunk; reverting.

Reverts Automattic/wp-calypso#59033