### PR TITLE
Domains: Fix "All domains" page load

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -183,8 +183,17 @@ class AllDomains extends Component {
 	};
 
 	isLoading() {
-		const { domainsList, requestingFlatDomains, hasAllSitesLoaded } = this.props;
-		return ! hasAllSitesLoaded || ( requestingFlatDomains && domainsList.length === 0 );
+		const {
+			domainsList,
+			requestingFlatDomains,
+			allSitesDomainsQueried,
+			hasAllSitesLoaded,
+		} = this.props;
+		return (
+			! allSitesDomainsQueried ||
+			! hasAllSitesLoaded ||
+			( requestingFlatDomains && domainsList.length === 0 )
+		);
 	}
 
 	isRequestingSiteDomains() {
@@ -260,13 +269,13 @@ class AllDomains extends Component {
 		} ) );
 	}
 
-	renderQuerySiteDomainsOnce( blogId ) {
+	renderQuerySiteDomainsOnce = ( blogId ) => {
 		if ( this.renderedQuerySiteDomains[ blogId ] ) {
 			return null;
 		}
 		this.renderedQuerySiteDomains[ blogId ] = true;
 		return <QuerySiteDomains siteId={ blogId } />;
-	}
+	};
 
 	getActionResult( domain ) {
 		if ( this.props.isContactEmailEditContext ) {
@@ -668,6 +677,10 @@ class AllDomains extends Component {
 		);
 	}
 
+	queryAllSitesDomains() {
+		return Object.keys( this.props.sites ).map( this.renderQuerySiteDomainsOnce );
+	}
+
 	renderDomainTableFilterButton() {
 		const { context } = this.props;
 
@@ -766,6 +779,7 @@ class AllDomains extends Component {
 				<div className="all-domains__form">{ this.renderActionForm() }</div>
 				<div className="all-domains__container">
 					<QueryAllDomains />
+					{ this.queryAllSitesDomains() }
 					<QueryUserPurchases />
 					<Main wideLayout>
 						<SidebarNavigation />
@@ -846,6 +860,10 @@ const getFilteredDomainsList = ( state, context ) => {
 	}
 };
 
+const hasQueriedAllSitesDomains = ( state, sites ) => {
+	return Object.keys( sites ).length === Object.keys( state.sites.domains.items ).length;
+};
+
 export default connect(
 	( state, { context } ) => {
 		const sites = getSitesById( state );
@@ -863,6 +881,7 @@ export default connect(
 			purchases: getUserPurchases( state ) || [],
 			hasLoadedUserPurchases: hasLoadedUserPurchasesFromServer( state ),
 			requestingFlatDomains: isRequestingAllDomains( state ),
+			allSitesDomainsQueried: hasQueriedAllSitesDomains( state, sites ),
 			requestingSiteDomains: getAllRequestingSiteDomains( state ),
 			sites,
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request
As https://github.com/Automattic/wp-calypso/pull/58980#issuecomment-992244728 noticed, the "All domains" page wouldn't load sometimes. This was happening because not all sites had their domains' data queried when the main component was rendered. This PR fixes it by querying all of the sites' domains data.

#### Testing instructions

- Clear the site data (Dev console -> Application -> Clear site data);
- Go to the domain management page of any site you own;
- Check that the domains are correctly loaded;
- Select the "Owned by me" filter on the header;
- Check that all the domains are correctly loaded.