### PR TITLE
Move FSE management page to the settings menu

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -135,14 +135,14 @@ function unload_helpers() {
  * @return void
  */
 function add_submenu() {
-	add_theme_page(
+	add_options_page(
 		__( 'Full Site Editing (beta)', 'full-site-editing' ),
 		sprintf(
 		/* translators: %s: "beta" label. */
 			__( 'Full Site Editing %s', 'full-site-editing' ),
 			'<span class="awaiting-mod">' . esc_html__( 'beta', 'full-site-editing' ) . '</span>'
 		),
-		'edit_theme_options',
+		'manage_options',
 		'site-editor-toggle',
 		__NAMESPACE__ . '\menu_page'
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -136,10 +136,10 @@ function unload_helpers() {
  */
 function add_submenu() {
 	add_theme_page(
-		__( 'Site Editor (beta)', 'full-site-editing' ),
+		__( 'Full Site Editing (beta)', 'full-site-editing' ),
 		sprintf(
 		/* translators: %s: "beta" label. */
-			__( 'Site Editor %s', 'full-site-editing' ),
+			__( 'Full Site Editing %s', 'full-site-editing' ),
 			'<span class="awaiting-mod">' . esc_html__( 'beta', 'full-site-editing' ) . '</span>'
 		),
 		'edit_theme_options',
@@ -243,7 +243,7 @@ function menu_page() {
 		id="site-editor-toggle"
 		class="wrap"
 	>
-	<h1><?php esc_html_e( 'Site Editor (beta)', 'full-site-editing' ); ?></h1>
+	<h1><?php esc_html_e( 'Full Site Editing (beta)', 'full-site-editing' ); ?></h1>
 	<?php settings_errors(); ?>
 	<form method="post" action="options.php">
 		<?php settings_fields( 'site-editor-toggle' ); ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Rename the page from `Site Editor (Beta)` to `Full Site Editing (Beta)` and move it from `Appearance` to `Settings` menu.

#### Testing instructions

- Check out this branch;
- Start local Calypso;
- Sync ETK to your sandbox with `yarn dev --sync`;
- Sandbox your site so you get the development version of ETK.

Verify that the `Full Site Editing (Beta)` page appears under the `Settings` menu.

#### Calypso Screenshots

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/26530524/146271894-984e87d8-247c-475e-95f7-c325f1b31d70.png) | ![image](https://user-images.githubusercontent.com/26530524/146271664-23fb4a9d-2f5a-4d0d-95fb-bb2c4df00e49.png) |
| ![image](https://user-images.githubusercontent.com/26530524/146271977-1b0cce46-2e88-44c1-8005-a124d19c3dd3.png) | ![image](https://user-images.githubusercontent.com/26530524/146271702-b5d14ca3-59b4-4b4b-9eb6-d2ecf1ada1fc.png) |

#### WP-Admin Screenshots

| Before | After |
| ------- | ---- |
| ![image](https://user-images.githubusercontent.com/26530524/146272103-bce588ba-397e-4708-93e3-227c2d4343c5.png) | ![image](https://user-images.githubusercontent.com/26530524/146272262-a6c32126-4e3e-43ab-8dc3-0214ae8935c7.png) |
| ![image](https://user-images.githubusercontent.com/26530524/146272126-d41c2675-1575-43f6-874d-5856bead8dd7.png) | ![image](https://user-images.githubusercontent.com/26530524/146272308-2ff42fe6-9d7e-42bc-acc6-ddca43208c95.png) |
| ![image](https://user-images.githubusercontent.com/26530524/146272154-1c315003-382b-47d7-b752-0b4566596330.png) | ![image](https://user-images.githubusercontent.com/26530524/146272345-f3e5e5d9-a95d-4874-9238-977554c9531a.png) |

Fixes #58911.
