### PR TITLE
Fit floating submenu width to its content

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -135,14 +135,14 @@ function unload_helpers() {
  * @return void
  */
 function add_submenu() {
-	add_theme_page(
+	add_options_page(
 		__( 'Full Site Editing (beta)', 'full-site-editing' ),
 		sprintf(
 		/* translators: %s: "beta" label. */
 			__( 'Full Site Editing %s', 'full-site-editing' ),
 			'<span class="awaiting-mod">' . esc_html__( 'beta', 'full-site-editing' ) . '</span>'
 		),
-		'edit_theme_options',
+		'manage_options',
 		'site-editor-toggle',
 		__NAMESPACE__ . '\menu_page'
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -136,10 +136,10 @@ function unload_helpers() {
  */
 function add_submenu() {
 	add_theme_page(
-		__( 'Site Editor (beta)', 'full-site-editing' ),
+		__( 'Full Site Editing (beta)', 'full-site-editing' ),
 		sprintf(
 		/* translators: %s: "beta" label. */
-			__( 'Site Editor %s', 'full-site-editing' ),
+			__( 'Full Site Editing %s', 'full-site-editing' ),
 			'<span class="awaiting-mod">' . esc_html__( 'beta', 'full-site-editing' ) . '</span>'
 		),
 		'edit_theme_options',
@@ -243,7 +243,7 @@ function menu_page() {
 		id="site-editor-toggle"
 		class="wrap"
 	>
-	<h1><?php esc_html_e( 'Site Editor (beta)', 'full-site-editing' ); ?></h1>
+	<h1><?php esc_html_e( 'Full Site Editing (beta)', 'full-site-editing' ); ?></h1>
 	<?php settings_errors(); ?>
 	<form method="post" action="options.php">
 		<?php settings_fields( 'site-editor-toggle' ); ?>

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -612,7 +612,8 @@ $font-size: rem( 14px );
 				bottom: auto;
 				position: absolute;
 				left: var( --sidebar-width-max );
-				width: 160px;
+				min-width: 160px;
+				width: fit-content;
 				box-shadow: 0 3px 5px rgba( 0, 0, 0, 0.2 );
 
 				> ul {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -613,7 +613,7 @@ $font-size: rem( 14px );
 				position: absolute;
 				left: var( --sidebar-width-max );
 				min-width: 160px;
-				width: fit-content;
+				width: max-content;
 				box-shadow: 0 3px 5px rgba( 0, 0, 0, 0.2 );
 
 				> ul {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Do not restrict the width of the submenu so that content does not move to the next line.

#### Testing instructions

- Check out this branch;
- Open Calypso;
- Try adding a long submenu item to any menu.

Verify that the submenu width adapts to the content's width.

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/26530524/146271702-b5d14ca3-59b4-4b4b-9eb6-d2ecf1ada1fc.png) | ![image](https://user-images.githubusercontent.com/26530524/146272760-9308b552-ffcf-444f-8de0-fa001a290e4d.png) |

Related to #59272.