### PR TITLE
More Informative Scan: Layout fixes

### DIFF
--- a/client/components/jetpack/fix-all-threats-dialog-new/index.tsx
+++ b/client/components/jetpack/fix-all-threats-dialog-new/index.tsx
@@ -3,7 +3,7 @@ import { translate } from 'i18n-calypso';
 import { useMemo, useState, useEffect } from 'react';
 import ServerCredentialsWizardDialog from 'calypso/components/jetpack/server-credentials-wizard-dialog';
 import ThreatFixHeader from 'calypso/components/jetpack/threat-fix-header';
-import { FixableThreat } from 'calypso/components/jetpack/threat-item/types';
+import { FixableThreat, Threat } from 'calypso/components/jetpack/threat-item/types';
 
 import './style.scss';
 

--- a/client/components/jetpack/scan-threats-new/index.tsx
+++ b/client/components/jetpack/scan-threats-new/index.tsx
@@ -226,8 +226,8 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 
 	return (
 		<>
-			<Card>
-				<SecurityIcon icon={ securityIcon } />
+			<Card className="scan-threats-new__card-header">
+				<SecurityIcon icon={ securityIcon } className="scan-threats-new security-icon-new" />
 				<h1 className="scan-threats-new scan__header">{ headerMessage }</h1>
 				<p className="scan-threats-new__header-message">
 					{ headerSummary }{ ' ' }
@@ -283,23 +283,28 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 							isPlaceholder={ false }
 						/>
 					) ) }
-				<div className="scan-threats-new__low-risk">
-					<FoldableCard header={ <ThreatLowRiskItemHeader threatCount={ countMap.low } /> }>
-						{ highSeverityThreats &&
-							lowSeverityThreats &&
-							lowSeverityThreats.map( ( threat ) => (
-								<ThreatItem
-									key={ threat.id }
-									threat={ threat }
-									onFixThreat={ () => openDialog( 'fix', threat ) }
-									onIgnoreThreat={ () => openDialog( 'ignore', threat ) }
-									isFixing={ isFixing( threat ) }
-									contactSupportUrl={ contactSupportUrl( site.URL ) }
-									isPlaceholder={ false }
-								/>
-							) ) }
-					</FoldableCard>
-				</div>
+				{ lowSeverityThreats.length > 0 && (
+					<div className="scan-threats-new__low-risk">
+						<FoldableCard
+							clickableHeader={ true }
+							header={ <ThreatLowRiskItemHeader threatCount={ countMap.low } /> }
+						>
+							{ highSeverityThreats &&
+								lowSeverityThreats &&
+								lowSeverityThreats.map( ( threat ) => (
+									<ThreatItem
+										key={ threat.id }
+										threat={ threat }
+										onFixThreat={ () => openDialog( 'fix', threat ) }
+										onIgnoreThreat={ () => openDialog( 'ignore', threat ) }
+										isFixing={ isFixing( threat ) }
+										contactSupportUrl={ contactSupportUrl( site.URL ) }
+										isPlaceholder={ false }
+									/>
+								) ) }
+						</FoldableCard>
+					</div>
+				) }
 			</div>
 
 			{ ! error && (

--- a/client/components/jetpack/scan-threats-new/style.scss
+++ b/client/components/jetpack/scan-threats-new/style.scss
@@ -5,8 +5,14 @@
 		margin: 0;
 	}
 
+	&__card-header {
+		flex: none;
+		padding: 32px;
+	}
+
 	&__header-message {
 		display: flex;
+		padding-bottom: 8px;
 	}
 
 	&__low-risk {
@@ -25,6 +31,11 @@
 		.foldable-card.is-expanded .foldable-card__content {
 				padding: 0;
 		}
+	}
+
+	&.scan__header {
+		margin-top: 24px;
+		margin-bottom: 16px;
 	}
 
 	&__error {
@@ -101,7 +112,6 @@
 
 	&__buttons {
 		display: flex;
-		margin-bottom: 8px;
 		border-top: 1px solid var( --studio-gray-5 );
 		padding-top: 32px;
 		flex-direction: space-between;

--- a/client/components/jetpack/threat-dialog-new/index.tsx
+++ b/client/components/jetpack/threat-dialog-new/index.tsx
@@ -79,10 +79,7 @@ const ThreatDialog: React.FC< Props > = ( {
 							args: { severity: getThreatSeverityText( threat ) },
 						} ) }
 
-					{ action === 'ignore' &&
-						translate( 'Jetpack will ignore the %(severity)s threat:', {
-							args: { severity: getThreatSeverityText( threat ) },
-						} ) }
+					{ action === 'ignore' && translate( 'Jetpack will ignore the threat:' ) }
 				</p>
 				<h3 className="threat-dialog-new__threat-title">
 					{ <ThreatFixHeader threat={ threat } action={ action } /> }

--- a/client/components/jetpack/threat-dialog-new/index.tsx
+++ b/client/components/jetpack/threat-dialog-new/index.tsx
@@ -74,12 +74,18 @@ const ThreatDialog: React.FC< Props > = ( {
 		>
 			<>
 				<p>
-					{ translate( 'Jetpack will fix the %(severity)s threat item:', {
-						args: { severity: getThreatSeverityText( threat ) },
-					} ) }
+					{ action === 'fix' &&
+						translate( 'Jetpack will fix the %(severity)s threat:', {
+							args: { severity: getThreatSeverityText( threat ) },
+						} ) }
+
+					{ action === 'ignore' &&
+						translate( 'Jetpack will ignore the %(severity)s threat:', {
+							args: { severity: getThreatSeverityText( threat ) },
+						} ) }
 				</p>
 				<h3 className="threat-dialog-new__threat-title">
-					{ <ThreatFixHeader threat={ threat } /> }
+					{ <ThreatFixHeader threat={ threat } action={ action } /> }
 				</h3>
 			</>
 		</ServerCredentialsWizardDialog>

--- a/client/components/jetpack/threat-fix-header/index.tsx
+++ b/client/components/jetpack/threat-fix-header/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { FixableThreat } from 'calypso/components/jetpack/threat-item-new/types';
@@ -12,9 +13,15 @@ interface Props {
 	threat: FixableThreat;
 	fixAllDialog?: bool;
 	onCheckFix?: callable;
+	action: 'fix' | 'ignore';
 }
 
-export default function ThreatFixHeader( { threat, fixAllDialog, onCheckFix } ): React.FC< Props > {
+export default function ThreatFixHeader( {
+	threat,
+	fixAllDialog,
+	onCheckFix,
+	action,
+} ): React.FC< Props > {
 	const [ checkedFix, setCheckedFix ] = useState( true );
 
 	const checkFix = ( event ) => {
@@ -42,7 +49,8 @@ export default function ThreatFixHeader( { threat, fixAllDialog, onCheckFix } ):
 					) }
 				>
 					<Gridicon className="threat-fix-header__warning-icon" icon="info-outline" size={ 18 } />
-					{ getThreatFix( threat.fixable ) }
+					{ action === 'fix' && getThreatFix( threat.fixable ) }
+					{ action === 'ignore' && translate( 'Jetpack will ignore the threat.' ) }
 				</span>
 			</div>
 			<div className="threat-fix-header__autofix-checkbox">

--- a/client/components/jetpack/threat-fix-header/index.tsx
+++ b/client/components/jetpack/threat-fix-header/index.tsx
@@ -11,7 +11,7 @@ import './style.scss';
 
 interface Props {
 	threat: FixableThreat;
-	fixAllDialog?: bool;
+	fixAllDialog?: boolean;
 	onCheckFix?: callable;
 	action: 'fix' | 'ignore';
 }

--- a/client/components/jetpack/threat-item-new/style.scss
+++ b/client/components/jetpack/threat-item-new/style.scss
@@ -20,6 +20,7 @@
 		flex-direction: column;
 		height: 121px;
 		flex-grow: 1;
+		line-height: 16px;
 
 		@include breakpoint-deprecated( '>960px' ) {
 			flex-wrap: nowrap;

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -351,14 +351,19 @@ class ScanPage extends Component< Props > {
 	render() {
 		const { siteId, siteSettingsUrl } = this.props;
 		const isJetpackPlatform = isJetpackCloud();
+		let mainClass = 'scan';
 
 		if ( ! siteId ) {
 			return;
 		}
 
+		if ( isEnabled( 'jetpack/more-informative-scan' ) ) {
+			mainClass = 'scan-new';
+		}
+
 		return (
 			<Main
-				className={ classNames( 'scan', {
+				className={ classNames( mainClass, {
 					is_jetpackcom: isJetpackPlatform,
 				} ) }
 			>

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -7,6 +7,11 @@
 	}
 }
 
+.scan-new.is_jetpackcom.main {
+	padding-left: 0;
+	padding-right: 0;
+}
+
 .scan__content p {
 	font-size: $font-body;
 	margin-bottom: 16px;
@@ -35,6 +40,20 @@
 	display: block;
 	margin: 0 auto;
 	width: 48px;
+
+	// To align vertically with .backup-upsell__icon-header
+	padding: 9px 0;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: 0;
+	}
+}
+
+.security-icon-new {
+	display: block;
+	margin: 0 auto;
+	width: 40px;
+	height: 48px;
 
 	// To align vertically with .backup-upsell__icon-header
 	padding: 9px 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Layout fixes for header card
* Layout spacing fixes for Calypso Green
* Stop showing the low threat cards if no low threats are present
* Make entire low threat card clickable like the other threat cards
* Some improved messaging when ignoring threats

Design reference (p6TEKc-5tS-p2)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a JP site with Scan and add a few threats (You can use the threat tester plugin to add a few innocuous threats for testing).
* Go to the scan section of both Calypso Blue and Calypso Green (To test Calypso Green you need to run yarn start start-jetpack-cloud and then go to http://jetpack.cloud.localhost:3000 on your browser) and check out the threat listing page.
* Verify that the layout matches the design specs linked above.

