### PR TITLE
server: Read API keys from env vars

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -37,7 +37,7 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 	const bootstrappedLocaleSlug = window?.i18nLanguageManifest?.locale?.[ '' ]?.localeSlug;
 
 	if ( window.i18nLocaleStrings ) {
-		// Use the locale translation data that were boostrapped by the server
+		// Use the locale translation data that were bootstrapped by the server
 		const localeData = JSON.parse( window.i18nLocaleStrings );
 
 		i18n.setLocale( localeData );
@@ -65,5 +65,5 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
 	}
 
-	// If user is logged out and translations are not boostrapped, we assume default locale
+	// If user is logged out and translations are not bootstrapped, we assume default locale
 };

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -72,5 +72,19 @@ module.exports = function ( configPath, defaultOpts ) {
 		process.env.WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY ??
 		serverData.wpcom_calypso_support_session_rest_api_key;
 
+	if (
+		data.features &&
+		data.features[ 'wpcom-user-bootstrap' ] &&
+		! (
+			serverData.wpcom_calypso_rest_api_key || serverData.wpcom_calypso_support_session_rest_api_key
+		)
+	) {
+		console.error(
+			'Disabling server-side user-bootstrapping because of missing wpcom_calypso_rest_api_key or wpcom_calypso_support_session_rest_api_key'
+		);
+		serverData.features[ 'wpcom-user-bootstrap' ] = false;
+		clientData.features[ 'wpcom-user-bootstrap' ] = false;
+	}
+
 	return { serverData, clientData };
 };

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -75,12 +75,10 @@ module.exports = function ( configPath, defaultOpts ) {
 	if (
 		data.features &&
 		data.features[ 'wpcom-user-bootstrap' ] &&
-		! (
-			serverData.wpcom_calypso_rest_api_key || serverData.wpcom_calypso_support_session_rest_api_key
-		)
+		! serverData.wpcom_calypso_rest_api_key
 	) {
 		console.error(
-			'Disabling server-side user-bootstrapping because of missing wpcom_calypso_rest_api_key or wpcom_calypso_support_session_rest_api_key'
+			'Disabling server-side user-bootstrapping because of missing wpcom_calypso_rest_api_key'
 		);
 		serverData.features[ 'wpcom-user-bootstrap' ] = false;
 		clientData.features[ 'wpcom-user-bootstrap' ] = false;

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -57,15 +57,6 @@ module.exports = function ( configPath, defaultOpts ) {
 		} );
 	}
 
-	if (
-		secretsPath !== realSecretsPath &&
-		data.features &&
-		data.features[ 'wpcom-user-bootstrap' ]
-	) {
-		console.error( 'Disabling server-side user-bootstrapping because of a missing secrets.json' );
-		data.features[ 'wpcom-user-bootstrap' ] = false;
-	}
-
 	// `protocol`, `hostname` and `port` config values can be overridden by env variables
 	data.protocol = process.env.PROTOCOL || data.protocol;
 	data.hostname = process.env.HOST || data.hostname;

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -65,5 +65,12 @@ module.exports = function ( configPath, defaultOpts ) {
 	const serverData = Object.assign( {}, data, getDataFromFile( secretsPath ) );
 	const clientData = Object.assign( {}, data );
 
+	// Optionally override API secrets with env values, only for server data
+	serverData.wpcom_calypso_rest_api_key =
+		process.env.WPCOM_CALYPSO_REST_API_KEY ?? serverData.wpcom_calypso_rest_api_key;
+	serverData.wpcom_calypso_support_session_rest_api_key =
+		process.env.WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY ??
+		serverData.wpcom_calypso_support_session_rest_api_key;
+
 	return { serverData, clientData };
 };

--- a/client/server/config/test/parser.js
+++ b/client/server/config/test/parser.js
@@ -1,10 +1,18 @@
 import parser from '@automattic/calypso-config/parser';
 import mockFs from 'mock-fs';
 
+const withEnv = ( env = {} ) => {
+	for ( const [ k, v ] of Object.entries( env ) ) {
+		process.env[ k ] = v;
+	}
+};
+
 function setValidSecrets() {
 	mockFs( {
 		'/valid-path/secrets.json': JSON.stringify( {
 			secret: 'very',
+			wpcom_calypso_rest_api_key: 'rest_api',
+			wpcom_calypso_support_session_rest_api_key: 'session_api',
 		} ),
 		'/valid-path/empty-secrets.json': JSON.stringify( {
 			secret: 'fromempty',
@@ -36,22 +44,17 @@ function setValidEnvFiles() {
 	} );
 }
 
-function setEmptySecrets() {
-	mockFs( {
-		'/valid-path/empty-secrets.json': JSON.stringify( {
-			secret: 'fromempty',
-		} ),
-		'/valid-path/_shared.json': JSON.stringify( {
-			features: {
-				'wpcom-user-bootstrap': true,
-			},
-		} ),
-	} );
-}
-
 describe( 'parser', () => {
+	let realProcessEnv;
+	beforeEach( () => {
+		realProcessEnv = { ...process.env };
+	} );
+
 	afterEach( () => {
 		mockFs.restore();
+		for ( const [ env, value ] of Object.entries( realProcessEnv ) ) {
+			process.env[ env ] = value;
+		}
 	} );
 
 	test( 'should return empty objects for an invalid path', () => {
@@ -111,15 +114,16 @@ describe( 'parser', () => {
 		expect( data ).toHaveProperty( 'features.disabledFeature2', true );
 	} );
 
-	test( 'should explicitly set user-bootstrapping to false if there are no real secrets', () => {
-		setEmptySecrets();
-		const errorSpy = jest.fn();
-		global.console = { error: errorSpy };
+	test( 'should override secrets with env vars', () => {
+		withEnv( {
+			WPCOM_CALYPSO_REST_API_KEY: 'foo',
+			WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY: 'bar',
+		} );
+		setValidSecrets();
 
-		const { serverData, clientData } = parser( '/valid-path' );
+		const { serverData } = parser( '/valid-path' );
 
-		expect( serverData.features[ 'wpcom-user-bootstrap' ] ).toBe( false );
-		expect( clientData.features[ 'wpcom-user-bootstrap' ] ).toBe( false );
-		expect( errorSpy ).toHaveBeenCalledTimes( 1 );
+		expect( serverData.wpcom_calypso_rest_api_key ).toBe( 'foo' );
+		expect( serverData.wpcom_calypso_support_session_rest_api_key ).toBe( 'bar' );
 	} );
 } );

--- a/client/server/user-bootstrap/index.js
+++ b/client/server/user-bootstrap/index.js
@@ -60,7 +60,7 @@ export default async function getBootstrappedUser( request ) {
 		const supportSessionApiKey = getSupportSessionApiKey();
 		if ( typeof supportSessionApiKey !== 'string' ) {
 			throw new Error(
-				'Unable to boostrap user because of invalid SUPPORT SESSION API key in secrets.json'
+				'Unable to bootstrap user because of invalid SUPPORT SESSION API key in secrets.json'
 			);
 		}
 
@@ -74,7 +74,7 @@ export default async function getBootstrappedUser( request ) {
 		const apiKey = getApiKey();
 
 		if ( typeof apiKey !== 'string' ) {
-			throw new Error( 'Unable to boostrap user because of invalid API key in secrets.json' );
+			throw new Error( 'Unable to bootstrap user because of invalid API key in secrets.json' );
 		}
 
 		const hmac = crypto.createHmac( 'md5', apiKey );

--- a/client/server/user-bootstrap/index.js
+++ b/client/server/user-bootstrap/index.js
@@ -16,11 +16,8 @@ const apiQuery = new URLSearchParams( {
 } );
 const url = `${ API_PATH }?${ apiQuery.toString() }`;
 
-const getApiKey = () =>
-	process.env.WPCOM_CALYPSO_REST_API_KEY ?? config( 'wpcom_calypso_rest_api_key' );
-const getSupportSessionApiKey = () =>
-	process.env.WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY ??
-	config( 'wpcom_calypso_support_session_rest_api_key' );
+const getApiKey = () => config( 'wpcom_calypso_rest_api_key' );
+const getSupportSessionApiKey = () => config( 'wpcom_calypso_support_session_rest_api_key' );
 
 /**
  * Requests the current user for user bootstrap.

--- a/client/server/user-bootstrap/index.js
+++ b/client/server/user-bootstrap/index.js
@@ -16,8 +16,11 @@ const apiQuery = new URLSearchParams( {
 } );
 const url = `${ API_PATH }?${ apiQuery.toString() }`;
 
-const getApiKey = () => config( 'wpcom_calypso_rest_api_key' );
-const getSupportSessionApiKey = () => config( 'wpcom_calypso_support_session_rest_api_key' );
+const getApiKey = () =>
+	process.env.WPCOM_CALYPSO_REST_API_KEY ?? config( 'wpcom_calypso_rest_api_key' );
+const getSupportSessionApiKey = () =>
+	process.env.WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY ??
+	config( 'wpcom_calypso_support_session_rest_api_key' );
 
 /**
  * Requests the current user for user bootstrap.

--- a/client/server/user-bootstrap/test/index.js
+++ b/client/server/user-bootstrap/test/index.js
@@ -129,7 +129,6 @@ describe( 'User bootstrap', () => {
 
 	describe( 'with support session header', () => {
 		let request;
-		let upstreamRequest;
 
 		beforeEach( () => {
 			request = mockRequest( {
@@ -140,7 +139,7 @@ describe( 'User bootstrap', () => {
 					'x-support-session': 'session-id',
 				},
 			} );
-			upstreamRequest = configureUpstreamRequest( {
+			configureUpstreamRequest( {
 				headers: {
 					// Hardcoded value resulting from hashing "key" + "session-id"
 					Authorization: 'X-WPCALYPSO-SUPPORT-SESSION bc8844a622734cad18a2ec733e11b296',
@@ -172,7 +171,6 @@ describe( 'User bootstrap', () => {
 
 	describe( 'with auth session', () => {
 		let request;
-		let upstreamRequest;
 
 		beforeEach( () => {
 			request = mockRequest( {
@@ -180,7 +178,7 @@ describe( 'User bootstrap', () => {
 					wordpress_logged_in: 'auth-cookie',
 				},
 			} );
-			upstreamRequest = configureUpstreamRequest( {
+			configureUpstreamRequest( {
 				headers: {
 					// Hardcoded value resulting from hashing "key" + "auth-cookie"
 					Authorization: 'X-WPCALYPSO 26be6ad9e36fde3770b1e81a559db109',

--- a/client/server/user-bootstrap/test/index.js
+++ b/client/server/user-bootstrap/test/index.js
@@ -35,6 +35,12 @@ const withConfig = ( keys ) => {
 	config.mockImplementation( ( key ) => keys[ key ] );
 };
 
+/**
+ * These tests rely on nock to intercept the requets and return a pre-defined response.
+ *
+ * If `getBootstrappedUser()` sends a request that doesn't match any of the requests configured in `nock`, it will throw. In most
+ * tests we just assert that `getBootstrappedUser()` returns a resolved promise, as it proves that it sent the expected request.
+ */
 describe( 'User bootstrap', () => {
 	beforeEach( () => {
 		// Default value for most tests. Some tests will overwrite this to simulate missing key
@@ -73,7 +79,7 @@ describe( 'User bootstrap', () => {
 	} );
 
 	it( 'sets the user agent in the upstream request', async () => {
-		const upstreamRequest = configureUpstreamRequest( {
+		configureUpstreamRequest( {
 			headers: {
 				'User-Agent': 'WordPress.com Calypso',
 			},
@@ -84,13 +90,11 @@ describe( 'User bootstrap', () => {
 			},
 		} );
 
-		await getBootstrappedUser( request );
-
-		expect( upstreamRequest.isDone() ).toBe( true );
+		await expect( getBootstrappedUser( request ) ).resolves.not.toThrow();
 	} );
 
 	it( 'sets the geo country code in the upstream request', async () => {
-		const upstreamRequest = configureUpstreamRequest( {
+		configureUpstreamRequest( {
 			headers: {
 				'X-Forwarded-GeoIP-Country-Code': 'es',
 			},
@@ -104,13 +108,11 @@ describe( 'User bootstrap', () => {
 			},
 		} );
 
-		await getBootstrappedUser( request );
-
-		expect( upstreamRequest.isDone() ).toBe( true );
+		await expect( getBootstrappedUser( request ) ).resolves.not.toThrow();
 	} );
 
 	it( 'sets the support session cookie', async () => {
-		const upstreamRequest = configureUpstreamRequest( {
+		configureUpstreamRequest( {
 			headers: {
 				cookie: ( val ) => val.includes( 'support_session_id=session-id' ),
 			},
@@ -122,9 +124,7 @@ describe( 'User bootstrap', () => {
 			},
 		} );
 
-		await getBootstrappedUser( request );
-
-		expect( upstreamRequest.isDone() ).toBe( true );
+		await expect( getBootstrappedUser( request ) ).resolves.not.toThrow();
 	} );
 
 	describe( 'with support session header', () => {
@@ -166,9 +166,7 @@ describe( 'User bootstrap', () => {
 				wpcom_calypso_support_session_rest_api_key: 'key',
 			} );
 
-			await getBootstrappedUser( request );
-
-			expect( upstreamRequest.isDone() ).toBe( true );
+			await expect( getBootstrappedUser( request ) ).resolves.not.toThrow();
 		} );
 	} );
 
@@ -206,9 +204,7 @@ describe( 'User bootstrap', () => {
 				wpcom_calypso_rest_api_key: 'key',
 			} );
 
-			await getBootstrappedUser( request );
-
-			expect( upstreamRequest.isDone() ).toBe( true );
+			await expect( getBootstrappedUser( request ) ).resolves.not.toThrow();
 		} );
 	} );
 
@@ -252,7 +248,7 @@ describe( 'User bootstrap', () => {
 	} );
 
 	it( 'adds bootstrapped property to the response', async () => {
-		const upstreamRequest = configureUpstreamRequest();
+		configureUpstreamRequest();
 
 		const request = mockRequest( {
 			cookies: {
@@ -262,7 +258,6 @@ describe( 'User bootstrap', () => {
 
 		const user = await getBootstrappedUser( request );
 
-		expect( upstreamRequest.isDone() ).toBe( true );
 		expect( user.bootstrapped ).toBe( true );
 	} );
 

--- a/client/server/user-bootstrap/test/index.js
+++ b/client/server/user-bootstrap/test/index.js
@@ -1,0 +1,361 @@
+import { IncomingMessage } from 'http';
+import config from '@automattic/calypso-config';
+import nock from 'nock';
+import getBootstrappedUser from '../index';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const impl = jest.fn();
+	impl.isEnabled = jest.fn();
+	return impl;
+} );
+
+const mockRequest = ( { cookies = {}, headers = {} } = {} ) => {
+	return Object.assign( new IncomingMessage(), {
+		body: {},
+		cookies,
+		query: {},
+		params: {},
+		get: jest.fn().mockImplementation( ( key ) => headers[ key ] ),
+	} );
+};
+
+const configureUpstreamRequest = ( {
+	headers = {},
+	response = { ID: '1' },
+	respondWithError = false,
+} = {} ) => {
+	return nock( 'https://public-api.wordpress.com', {
+		reqheaders: headers,
+	} )
+		.get( '/rest/v1/me?meta=flags' )
+		.reply( respondWithError ? 500 : 200, response );
+};
+
+const withConfig = ( keys ) => {
+	config.mockImplementation( ( key ) => keys[ key ] );
+};
+
+const withEnv = ( env = {} ) => {
+	for ( const [ k, v ] of Object.entries( env ) ) {
+		process.env[ k ] = v;
+	}
+};
+
+describe( 'User bootstrap', () => {
+	const realProcessEnv = { ...process.env };
+
+	beforeEach( () => {
+		// Default value for most tests. Some tests will overwrite this to simulate missing key
+		withConfig( {
+			wpcom_calypso_rest_api_key: 'key',
+		} );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.resetAllMocks();
+		for ( const [ env, value ] of Object.entries( realProcessEnv ) ) {
+			process.env[ env ] = value;
+		}
+	} );
+
+	it( 'throws if there is no auth cookie', async () => {
+		const request = mockRequest( { cookies: {} } );
+
+		await expect( getBootstrappedUser( request ) ).rejects.toThrow(
+			new Error( 'Cannot bootstrap without an auth cookie' )
+		);
+	} );
+
+	it( 'throws if there is supportSessionHeader and supportSessionCookie', async () => {
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+				support_session_id: 'session-id',
+			},
+			headers: {
+				'x-support-session': 'session-id',
+			},
+		} );
+
+		await expect( getBootstrappedUser( request ) ).rejects.toThrow(
+			new Error( 'Cannot bootstrap with both a support session header and support session cookie.' )
+		);
+	} );
+
+	it( 'sets the user agent in the upstream request', async () => {
+		const upstreamRequest = configureUpstreamRequest( {
+			headers: {
+				'User-Agent': 'WordPress.com Calypso',
+			},
+		} );
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+			},
+		} );
+
+		await getBootstrappedUser( request );
+
+		expect( upstreamRequest.isDone() ).toBe( true );
+	} );
+
+	it( 'sets the geo country code in the upstream request', async () => {
+		const upstreamRequest = configureUpstreamRequest( {
+			headers: {
+				'X-Forwarded-GeoIP-Country-Code': 'es',
+			},
+		} );
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+			},
+			headers: {
+				'x-geoip-country-code': 'es',
+			},
+		} );
+
+		await getBootstrappedUser( request );
+
+		expect( upstreamRequest.isDone() ).toBe( true );
+	} );
+
+	it( 'sets the auth session cookie', async () => {
+		const upstreamRequest = configureUpstreamRequest( {
+			headers: {
+				cookie: 'wordpress_logged_in=auth-cookie',
+			},
+		} );
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+			},
+		} );
+
+		await getBootstrappedUser( request );
+
+		expect( upstreamRequest.isDone() ).toBe( true );
+	} );
+
+	it( 'sets the support session cookie', async () => {
+		const upstreamRequest = configureUpstreamRequest( {
+			headers: {
+				cookie: ( val ) => val.includes( 'support_session_id=session-id' ),
+			},
+		} );
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+				support_session_id: 'session-id',
+			},
+		} );
+
+		await getBootstrappedUser( request );
+
+		expect( upstreamRequest.isDone() ).toBe( true );
+	} );
+
+	describe( 'with support session header', () => {
+		let request;
+		let upstreamRequest;
+
+		beforeEach( () => {
+			request = mockRequest( {
+				cookies: {
+					wordpress_logged_in: 'auth-cookie',
+				},
+				headers: {
+					'x-support-session': 'session-id',
+				},
+			} );
+			upstreamRequest = configureUpstreamRequest( {
+				headers: {
+					// Hardcoded value resulting from hashing "key" + "session-id"
+					Authorization: 'X-WPCALYPSO-SUPPORT-SESSION bc8844a622734cad18a2ec733e11b296',
+					'x-support-session': 'session-id',
+				},
+			} );
+		} );
+
+		it( 'throws if there is no support session API key', async () => {
+			withConfig( {
+				wpcom_calypso_support_session_rest_api_key: undefined,
+			} );
+
+			await expect( getBootstrappedUser( request ) ).rejects.toThrow(
+				new Error(
+					'Unable to boostrap user because of invalid SUPPORT SESSION API key in secrets.json'
+				)
+			);
+		} );
+
+		it( 'sets the authorization header', async () => {
+			withConfig( {
+				wpcom_calypso_support_session_rest_api_key: 'key',
+			} );
+
+			await getBootstrappedUser( request );
+
+			expect( upstreamRequest.isDone() ).toBe( true );
+		} );
+
+		it( 'reads support session API key from env variables', async () => {
+			withConfig( {
+				wpcom_calypso_support_session_rest_api_key: undefined,
+			} );
+			withEnv( {
+				WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY: 'key',
+			} );
+
+			await getBootstrappedUser( request );
+
+			expect( upstreamRequest.isDone() ).toBe( true );
+		} );
+
+		it( 'support session API key from env variable overrides config', async () => {
+			withConfig( {
+				wpcom_calypso_support_session_rest_api_key: 'old_key',
+			} );
+			withEnv( {
+				WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY: 'key',
+			} );
+
+			await getBootstrappedUser( request );
+
+			expect( upstreamRequest.isDone() ).toBe( true );
+		} );
+	} );
+
+	describe( 'with auth session', () => {
+		let request;
+		let upstreamRequest;
+
+		beforeEach( () => {
+			request = mockRequest( {
+				cookies: {
+					wordpress_logged_in: 'auth-cookie',
+				},
+			} );
+			upstreamRequest = configureUpstreamRequest( {
+				headers: {
+					// Hardcoded value resulting from hashing "key" + "auth-cookie"
+					Authorization: 'X-WPCALYPSO 26be6ad9e36fde3770b1e81a559db109',
+				},
+			} );
+		} );
+
+		it( 'throws if there is no API key', async () => {
+			withConfig( {
+				wpcom_calypso_rest_api_key: undefined,
+			} );
+
+			await expect( getBootstrappedUser( request ) ).rejects.toThrow(
+				new Error( 'Unable to boostrap user because of invalid API key in secrets.json' )
+			);
+		} );
+
+		it( 'sets the authorization header', async () => {
+			withConfig( {
+				wpcom_calypso_rest_api_key: 'key',
+			} );
+
+			await getBootstrappedUser( request );
+
+			expect( upstreamRequest.isDone() ).toBe( true );
+		} );
+
+		it( 'reads API key from env variables', async () => {
+			withConfig( {
+				wpcom_calypso_rest_api_key: undefined,
+			} );
+			withEnv( {
+				WPCOM_CALYPSO_REST_API_KEY: 'key',
+			} );
+
+			await getBootstrappedUser( request );
+
+			expect( upstreamRequest.isDone() ).toBe( true );
+		} );
+
+		it( 'API key from env variable overrides config', async () => {
+			withConfig( {
+				wpcom_calypso_rest_api_key: 'old_key',
+			} );
+			withEnv( {
+				WPCOM_CALYPSO_REST_API_KEY: 'key',
+			} );
+
+			await getBootstrappedUser( request );
+
+			expect( upstreamRequest.isDone() ).toBe( true );
+		} );
+	} );
+
+	it( 'returns the user from the response', async () => {
+		configureUpstreamRequest( {
+			response: {
+				ID: '1',
+				username: 'test',
+			},
+		} );
+
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+			},
+		} );
+
+		const user = await getBootstrappedUser( request );
+
+		expect( user.ID ).toBe( '1' );
+		expect( user.username ).toBe( 'test' );
+	} );
+
+	it( 'filters out invalid properties', async () => {
+		configureUpstreamRequest( {
+			response: {
+				ID: '1',
+				unknown_field: 'test',
+			},
+		} );
+
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+			},
+		} );
+
+		const user = await getBootstrappedUser( request );
+
+		expect( user.unknown_field ).toBe( undefined );
+	} );
+
+	it( 'adds bootstrapped property to the response', async () => {
+		const upstreamRequest = configureUpstreamRequest();
+
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+			},
+		} );
+
+		const user = await getBootstrappedUser( request );
+
+		expect( upstreamRequest.isDone() ).toBe( true );
+		expect( user.bootstrapped ).toBe( true );
+	} );
+
+	it( "throws if the request doesn't have a response", async () => {
+		configureUpstreamRequest( {
+			respondWithError: true,
+		} );
+
+		const request = mockRequest( {
+			cookies: {
+				wordpress_logged_in: 'auth-cookie',
+			},
+		} );
+
+		await expect( getBootstrappedUser( request ) ).rejects.toThrow();
+	} );
+} );

--- a/client/server/user-bootstrap/test/index.js
+++ b/client/server/user-bootstrap/test/index.js
@@ -156,7 +156,7 @@ describe( 'User bootstrap', () => {
 
 			await expect( getBootstrappedUser( request ) ).rejects.toThrow(
 				new Error(
-					'Unable to boostrap user because of invalid SUPPORT SESSION API key in secrets.json'
+					'Unable to bootstrap user because of invalid SUPPORT SESSION API key in secrets.json'
 				)
 			);
 		} );
@@ -197,7 +197,7 @@ describe( 'User bootstrap', () => {
 			} );
 
 			await expect( getBootstrappedUser( request ) ).rejects.toThrow(
-				new Error( 'Unable to boostrap user because of invalid API key in secrets.json' )
+				new Error( 'Unable to bootstrap user because of invalid API key in secrets.json' )
 			);
 		} );
 


### PR DESCRIPTION
## Background

See pMz3w-ebz-p2


## Changes proposed in this Pull Request

* Changes user bootstrap code to read API keys from env variables as well.
* Adds unit tests

## Testing instructions

### Preparation

* Edit `config/development.json` and set `wpcom-user-bootstrap` to `true`
* Follow the instructions under "Force login cookie on the server" from PCYsg-5YE-p2
* Build Calypso with `NODE_ENV=production CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true MINIFY=false yarn build` (it will take a few minutes)
* Open `http://calypso.localhost:3000`, it should be unauthenticated. Run the JS command `document.cookie='wordpress_logged_in=<your-cookie-value>'`. Reload http://calypso.localhost:3000 and verify you are authenticated.

### Testing

Run each one of the following scenarios and verify that you are logged in, and you can use the DevTools inspector to verify there is a `currentUser` global variable in the page payload.

I'm not sure how to test the Support Sessions with `calypso.localhost` (@brandonpayton ?), but given this is one-line change I'm confident they will work.

### Scenario 1 - secrets.json (old behaviour)

* Make sure you have `wpcom_calypso_rest_api_key` and  `wpcom_calypso_support_session_rest_api_key` in your `secrets.json` file
* Start calypso with `node build/server.js`
* Load http://calypso.localhost:300

### Scenario 2 - env vars (new behaviour)

* Make sure you *don't* have `wpcom_calypso_rest_api_key` and  `wpcom_calypso_support_session_rest_api_key` in your `secrets.json` file
* Start calypso with `WPCOM_CALYPSO_REST_API_KEY=... WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY=... node build/server.js`. Use the values from the previous scenario. (security tip: if you start the command with a space it shouldn't be stored in your shell history).
* Load http://calypso.localhost:300

### Scenario 3 - combination

* Create the secret keys in `secrets.json` with *wrong* values.
* Start calypso with `WPCOM_CALYPSO_REST_API_KEY=... WPCOM_CALYPSO_SUPPORT_SESSION_REST_API_KEY=... node build/server.js`. Use the values from the previous scenario. (security tip: if you start the command with a space it shouldn't be stored in your shell history).
* Load http://calypso.localhost:300
