### PR TITLE
Allow menu scrolling on site preview

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -279,7 +279,6 @@
 // Use all available space for the WebPreview component on /view
 .layout.is-section-preview {
 	height: 100%;
-	overflow: hidden;
 
 	.layout__primary {
 		height: 100%;

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -111,7 +111,7 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 					pinnedSidebarBottom = false;
 
 					// Calculate new offset position.
-					sidebarTop = scrollY + masterbarHeight - maxScroll;
+					sidebarTop = Math.max( 0, scrollY + masterbarHeight - maxScroll );
 					if ( contentHeight === secondaryElHeight + masterbarHeight ) {
 						// When content is originally shorter than the sidebar and
 						// we have already made it equal to the sidebar + masterbar

--- a/client/my-sites/preview/style.scss
+++ b/client/my-sites/preview/style.scss
@@ -10,7 +10,7 @@
 }
 
 .layout.is-section-preview .layout__content {
-	// overflow cannot be set on an ancestor to .web-prefix_toolbar otherwise that becomes the scrolling container
+	// overflow cannot be set on an ancestor to .web-preview_toolbar otherwise that becomes the scrolling container
 	// rather than the viewport, and this will inhibit sticky behaviour. See https://github.com/w3c/csswg-drafts/issues/865
 	overflow:initial;
 }

--- a/client/my-sites/preview/style.scss
+++ b/client/my-sites/preview/style.scss
@@ -3,8 +3,8 @@
 	max-width: none;
 
 	.web-preview__toolbar {
-		position:sticky;
-		z-index:1;
+		position: sticky;
+		z-index: 1;
 		top: var( --masterbar-height );
 	}
 }
@@ -12,5 +12,5 @@
 .layout.is-section-preview .layout__content {
 	// overflow cannot be set on an ancestor to .web-preview_toolbar otherwise that becomes the scrolling container
 	// rather than the viewport, and this will inhibit sticky behaviour. See https://github.com/w3c/csswg-drafts/issues/865
-	overflow:initial;
+	overflow: initial;
 }

--- a/client/my-sites/preview/style.scss
+++ b/client/my-sites/preview/style.scss
@@ -1,4 +1,16 @@
 .main.preview {
 	height: 100%;
 	max-width: none;
+
+	.web-preview__toolbar {
+		position:sticky;
+		z-index:1;
+		top: var( --masterbar-height );
+	}
+}
+
+.layout.is-section-preview .layout__content {
+	// overflow cannot be set on an ancestor to .web-prefix_toolbar otherwise that becomes the scrolling container
+	// rather than the viewport, and this will inhibit sticky behaviour. See https://github.com/w3c/csswg-drafts/issues/865
+	overflow:initial;
 }


### PR DESCRIPTION
When the site preview screen (/view/<domain>) was displayed on a desktop
window shorter than the menu (around 870px, depending upon the site, the
bottom of the menu wasn't accessible - scrolling the page only scrolled
the preview and not the menu.

This was happening due to an overflow:hidden rule on the element
containing most of the page.

It's been addressed by removing the overflow:hidden rule and also
changing the menu javascript so that when scrolling up it doesn't
overadjust the menu so that some of it appears off screen.

The downside is that double scrollbars may appear on the right hand
side.

Relates to #50631

#### Testing instructions
 1. Make the window height smaller than the sidebar so that some of it is displayed off-screen
 2. Click on the site name in the sidebar. That will load /view with the site preview iframe in the content area.
 3. Scroll down. You should be able to scroll to the bottom of the preview and the bottom of the menu
 4. Scroll up. You should be able to scroll to the top and see the whole of the menu
 5. The toolbar menu (with the browser width switcher, url and 'visit site' button) should remain stuck to the top of the screen

https://user-images.githubusercontent.com/93301/146340791-ba52a597-0433-41c6-bd33-ff675cdeca71.mp4


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50631
