### PR TITLE
Design Picker: Include premium themes

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, {
 	FeaturedPicksButtons,
+	PremiumBadge,
 	getAvailableDesigns,
 	useCategorization,
 } from '@automattic/design-picker';
@@ -11,8 +12,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useMemo } from 'react';
 import * as React from 'react';
-import JetpackLogo from 'calypso/components/jetpack-logo'; // @TODO: extract to @automattic package
-import Badge from '../../components/badge';
 import useStepNavigation from '../../hooks/use-step-navigation';
 import { useTrackStep } from '../../hooks/use-track-step';
 import { useIsAnchorFm } from '../../path';
@@ -75,7 +74,6 @@ const Header: React.FunctionComponent = () => {
 };
 
 const Designs: React.FunctionComponent = () => {
-	const { __ } = useI18n();
 	const locale = useLocale();
 	const { goNext } = useStepNavigation();
 	const { setSelectedDesign, setFonts, resetFonts, setRandomizedDesigns } = useDispatch(
@@ -175,12 +173,7 @@ const Designs: React.FunctionComponent = () => {
 				isGridMinimal={ isAnchorFmSignup }
 				locale={ locale }
 				onSelect={ onSelect }
-				premiumBadge={
-					<Badge className="designs__premium-badge">
-						<JetpackLogo className="designs__premium-badge-logo" size={ 20 } />
-						<span className="designs__premium-badge-text">{ __( 'Premium' ) }</span>
-					</Badge>
-				}
+				premiumBadge={ <PremiumBadge /> }
 				categorization={ isDesignPickerCategoriesEnabled ? categorization : undefined }
 				categoriesHeading={ isDesignPickerCategoriesEnabled && <Header /> }
 				categoriesFooter={

--- a/client/landing/gutenboarding/onboarding-block/designs/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/designs/style.scss
@@ -20,36 +20,6 @@
 		flex-grow: 1;
 	}
 
-	.designs__premium-badge {
-		background-color: var( --studio-gray-80 );
-		/* stylelint-disable-next-line */
-		border-radius: 1em;
-		color: var( --studio-white );
-		margin: 0;
-		padding: 2px 8px;
-		white-space: nowrap;
-	}
-
-	.designs__premium-badge-logo {
-		height: auto;
-		margin-left: -4px;
-		width: 14px;
-
-		.jetpack-logo__icon-circle {
-			fill: transparent;
-		}
-
-		.jetpack-logo__icon-triangle {
-			fill: var( --studio-white );
-		}
-	}
-
-	.designs__premium-badge-text {
-		display: inline-block;
-		margin-top: -0.05em;
-		text-transform: uppercase;
-	}
-
 	.designs__has-categories {
 		@include onboarding-heading-padding;
 		margin-bottom: 0;

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -43,9 +43,10 @@ export default function DesignPickerStep( props ) {
 		siteId,
 	} = props;
 
-	const hasUnlimitedPremiumThemes = useSelector( ( state ) =>
-		hasFeature( state, siteId, FEATURE_PREMIUM_THEMES )
-	);
+	const { userLoggedIn, hasUnlimitedPremiumThemes } = useSelector( ( state ) => ( {
+		userLoggedIn: isUserLoggedIn( state ),
+		hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_PREMIUM_THEMES ),
+	} ) );
 
 	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
 	const useFeaturedPicksButtons =
@@ -89,8 +90,6 @@ export default function DesignPickerStep( props ) {
 			timeoutID && window.clearTimeout( timeoutID );
 		};
 	}, [ props.stepSectionName ] );
-
-	const userLoggedIn = useSelector( isUserLoggedIn );
 
 	const { designs, featuredPicksDesigns } = useMemo( () => {
 		return {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -133,7 +133,7 @@ export default function DesignPickerStep( props ) {
 		const locale = ! userLoggedIn ? getLocaleSlug() : '';
 
 		recordTracksEvent( 'calypso_signup_design_preview_select', {
-			theme: `pub/${ _selectedDesign.theme }`,
+			theme: _selectedDesign?.stylesheet ?? `pub/${ _selectedDesign.theme }`,
 			template: _selectedDesign.template,
 			flow: props.flowName,
 			intent: props.signupDependencies.intent,
@@ -145,7 +145,7 @@ export default function DesignPickerStep( props ) {
 
 	function submitDesign( _selectedDesign = selectedDesign ) {
 		recordTracksEvent( 'calypso_signup_select_design', {
-			theme: `pub/${ _selectedDesign?.theme }`,
+			theme: _selectedDesign?.stylesheet ?? `pub/${ _selectedDesign?.theme }`,
 			template: _selectedDesign?.template,
 			flow: props.flowName,
 			intent: props.signupDependencies.intent,

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -42,10 +42,12 @@ export default function DesignPickerStep( props ) {
 		sitePlanSlug,
 	} = props;
 
-	const [ userLoggedIn, isPremiumThemesAvailable ] = useSelector( ( state ) => [
-		isUserLoggedIn( state ),
-		planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
-	] );
+	const isPremiumThemesAvailable = useMemo(
+		() => planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
+		[ sitePlanSlug ]
+	);
+
+	const userLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
 
 	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
 	const useFeaturedPicksButtons =

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
+import { planHasFeature, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
 import DesignPicker, {
 	FeaturedPicksButtons,
 	PremiumBadge,
@@ -24,7 +24,6 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import DIFMThemes from '../difm-design-picker/themes';
 import LetUsChoose from './let-us-choose';
 import PreviewToolbar from './preview-toolbar';
@@ -40,12 +39,12 @@ export default function DesignPickerStep( props ) {
 		showLetUsChoose,
 		hideFullScreenPreview,
 		hideDesignTitle,
-		siteId,
+		sitePlanSlug,
 	} = props;
 
-	const { userLoggedIn, hasUnlimitedPremiumThemes } = useSelector( ( state ) => ( {
+	const { userLoggedIn, isPremiumThemesAvailable } = useSelector( ( state ) => ( {
 		userLoggedIn: isUserLoggedIn( state ),
-		hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_PREMIUM_THEMES ),
+		isPremiumThemesAvailable: planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
 	} ) );
 
 	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
@@ -59,7 +58,7 @@ export default function DesignPickerStep( props ) {
 	const scrollTop = useRef( 0 );
 
 	const { data: apiThemes = [] } = useThemeDesignsQuery(
-		{ tier: hasUnlimitedPremiumThemes ? 'all' : 'free' },
+		{ tier: isPremiumThemesAvailable ? 'all' : 'free' },
 		{ enabled: ! props.useDIFMThemes }
 	);
 

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -42,10 +42,10 @@ export default function DesignPickerStep( props ) {
 		sitePlanSlug,
 	} = props;
 
-	const { userLoggedIn, isPremiumThemesAvailable } = useSelector( ( state ) => ( {
-		userLoggedIn: isUserLoggedIn( state ),
-		isPremiumThemesAvailable: planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
-	} ) );
+	const [ userLoggedIn, isPremiumThemesAvailable ] = useSelector( ( state ) => [
+		isUserLoggedIn( state ),
+		planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
+	] );
 
 	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
 	const useFeaturedPicksButtons =

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
 import DesignPicker, {
 	FeaturedPicksButtons,
+	PremiumBadge,
 	isBlankCanvasDesign,
 	getDesignUrl,
 	useCategorization,
@@ -22,6 +24,7 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import DIFMThemes from '../difm-design-picker/themes';
 import LetUsChoose from './let-us-choose';
 import PreviewToolbar from './preview-toolbar';
@@ -37,7 +40,12 @@ export default function DesignPickerStep( props ) {
 		showLetUsChoose,
 		hideFullScreenPreview,
 		hideDesignTitle,
+		siteId,
 	} = props;
+
+	const hasUnlimitedPremiumThemes = useSelector( ( state ) =>
+		hasFeature( state, siteId, FEATURE_PREMIUM_THEMES )
+	);
 
 	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
 	const useFeaturedPicksButtons =
@@ -50,7 +58,7 @@ export default function DesignPickerStep( props ) {
 	const scrollTop = useRef( 0 );
 
 	const { data: apiThemes = [] } = useThemeDesignsQuery(
-		{ tier: 'free' },
+		{ tier: hasUnlimitedPremiumThemes ? 'all' : 'free' },
 		{ enabled: ! props.useDIFMThemes }
 	);
 
@@ -158,6 +166,7 @@ export default function DesignPickerStep( props ) {
 					'design-picker-step__has-categories': showDesignPickerCategories,
 				} ) }
 				highResThumbnails
+				premiumBadge={ <PremiumBadge /> }
 				categorization={ showDesignPickerCategories ? categorization : undefined }
 				categoriesHeading={
 					<FormattedHeader

--- a/client/state/themes/actions/recommended-themes.js
+++ b/client/state/themes/actions/recommended-themes.js
@@ -26,13 +26,13 @@ export function receiveRecommendedThemes( themes, filter ) {
  * @param {string} filter A filter string for a theme query
  * @returns {Function} Action thunk
  */
-export function getRecommendedThemes( filter ) {
+export function getRecommendedThemes( filter, tier = '' ) {
 	return async ( dispatch ) => {
 		dispatch( { type: RECOMMENDED_THEMES_FETCH, filter } );
 		const query = {
 			search: '',
 			number: 50,
-			tier: '',
+			tier,
 			filter,
 			apiVersion: '1.2',
 		};

--- a/client/state/themes/actions/recommended-themes.js
+++ b/client/state/themes/actions/recommended-themes.js
@@ -26,13 +26,13 @@ export function receiveRecommendedThemes( themes, filter ) {
  * @param {string} filter A filter string for a theme query
  * @returns {Function} Action thunk
  */
-export function getRecommendedThemes( filter, tier = '' ) {
+export function getRecommendedThemes( filter ) {
 	return async ( dispatch ) => {
 		dispatch( { type: RECOMMENDED_THEMES_FETCH, filter } );
 		const query = {
 			search: '',
 			number: 50,
-			tier,
+			tier: '',
 			filter,
 			apiVersion: '1.2',
 		};

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { MShotsImage } from '@automattic/onboarding';
-import { Button, Tooltip } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -53,7 +53,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	locale,
 	onSelect,
 	design,
-	premiumBadge,
+	premiumBadge = null,
 	highRes,
 	disabled,
 	hideDesignTitle,
@@ -105,14 +105,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					{ ! hideDesignTitle && (
 						<span className="design-picker__option-name">{ designTitle }</span>
 					) }
-					{ design.is_premium && premiumBadge && (
-						<Tooltip
-							position="bottom center"
-							text={ __( 'Requires a Personal plan or above', __i18n_text_domain__ ) }
-						>
-							<div className="design-picker__premium-container">{ premiumBadge }</div>
-						</Tooltip>
-					) }
+					{ design.is_premium && premiumBadge }
 				</span>
 			</span>
 		</button>

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -1,0 +1,33 @@
+import { Gridicon } from '@automattic/components';
+import { Tooltip } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import type { FunctionComponent } from 'react';
+
+import './style.scss';
+
+interface Props {
+	className?: string;
+}
+
+const PremiumBadge: FunctionComponent< Props > = ( { className } ) => {
+	const { __ } = useI18n();
+
+	return (
+		<Tooltip
+			position="top center"
+			text={ __(
+				'Premium themes are built by professional designers with quality, functionality, and ease of use in mind.',
+				__i18n_text_domain__
+			) }
+		>
+			<div className={ classNames( 'premium-badge', className ) }>
+				{ /*  eslint-disable-next-line wpcalypso/jsx-gridicon-size */ }
+				<Gridicon className="premium-badge__logo" icon="star" size={ 14 } />
+				<span>{ __( 'Premium' ) }</span>
+			</div>
+		</Tooltip>
+	);
+};
+
+export default PremiumBadge;

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -18,7 +18,7 @@ const PremiumBadge: FunctionComponent< Props > = ( { className } ) => {
 			position="top center"
 			delay={ 300 }
 			text={ __(
-				'Premium themes are built by professional designers with quality, functionality, and ease of use in mind.',
+				'Let your site stand out from the crowd with a modern and stylish Premium theme.',
 				__i18n_text_domain__
 			) }
 		>

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -16,6 +16,7 @@ const PremiumBadge: FunctionComponent< Props > = ( { className } ) => {
 	return (
 		<Tooltip
 			position="top center"
+			delay={ 300 }
 			text={ __(
 				'Premium themes are built by professional designers with quality, functionality, and ease of use in mind.',
 				__i18n_text_domain__

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -16,6 +16,7 @@ const PremiumBadge: FunctionComponent< Props > = ( { className } ) => {
 	return (
 		<Tooltip
 			position="top center"
+			// @ts-expect-error: @types/wordpress__components doesn't align with latest @wordpress/components
 			delay={ 300 }
 			text={ __(
 				'Let your site stand out from the crowd with a modern and stylish Premium theme.',

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -31,6 +31,7 @@
 			max-width: 300px;
 			width: max-content;
 			padding: 8px 10px;
+			text-align: start;
 		}
 	}
 }

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -1,0 +1,36 @@
+.premium-badge {
+	display: inline-flex;
+	align-items: center;
+	height: 20px;
+	line-height: 20px;
+	padding: 0 10px 0 9px;
+	border-radius: 20px; /* stylelint-disable-line scales/radii */
+	margin-left: 10px;
+	box-sizing: border-box;
+	font-size: 0.75rem;
+	color: var( --studio-white );
+	background: var( --studio-black );
+	z-index: 1;
+
+	.design-picker .design-picker__option-meta & {
+		min-height: 0;
+	}
+
+	.premium-badge__logo {
+		margin-top: -1px;
+		margin-right: 3px;
+	}
+
+	.components-tooltip .components-popover__content {
+		border-radius: 4px;
+		margin: 8px;
+		background-color: var( --studio-gray-100 );
+		white-space: pre-line;
+
+		> div {
+			max-width: 300px;
+			width: max-content;
+			padding: 8px 10px;
+		}
+	}
+}

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -203,16 +203,6 @@
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */
 		margin-top: -0.1em;
 	}
-
-	.design-picker__premium-container {
-		margin-left: 6px;
-		/* stylelint-disable-next-line */
-		font-size: rem( 10px ); //typography-exception
-
-		.components-popover__content {
-			background-color: var( --studio-gray-80 );
-		}
-	}
 }
 
 // dark theme styles

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -52,7 +52,7 @@ export function useThemeDesignsQuery(
 	);
 }
 
-function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
+function apiThemeToDesign( { id, name, taxonomies, stylesheet, template }: any ): Design {
 	// Designs use a "featured" term in the theme_picks taxonomy. For example: Blank Canvas
 	const isFeaturedPicks = !! taxonomies?.theme_picks?.find(
 		( { slug }: any ) => slug === 'featured'
@@ -66,7 +66,7 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
 		is_premium: stylesheet && stylesheet.startsWith( 'premium/' ),
 		is_featured_picks: isFeaturedPicks,
 		slug: id,
-		template: id,
+		template,
 		theme: id,
 		title: name,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -52,7 +52,7 @@ export function useThemeDesignsQuery(
 	);
 }
 
-function apiThemeToDesign( { id, name, taxonomies, stylesheet, template }: any ): Design {
+function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
 	// Designs use a "featured" term in the theme_picks taxonomy. For example: Blank Canvas
 	const isFeaturedPicks = !! taxonomies?.theme_picks?.find(
 		( { slug }: any ) => slug === 'featured'
@@ -65,8 +65,9 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet, template }: any )
 		features: [],
 		is_premium: stylesheet && stylesheet.startsWith( 'premium/' ),
 		is_featured_picks: isFeaturedPicks,
+		stylesheet,
 		slug: id,
-		template,
+		template: id,
 		theme: id,
 		title: name,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -1,6 +1,7 @@
 export { default } from './components';
 
 export { default as FeaturedPicksButtons } from './components/featured-picks-buttons';
+export { default as PremiumBadge } from './components/premium-badge';
 export {
 	availableDesignsConfig,
 	getAvailableDesigns,

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -21,6 +21,7 @@ export interface Design {
 	is_alpha?: boolean;
 	is_fse?: boolean;
 	is_premium: boolean;
+	stylesheet?: string;
 	slug: string;
 	template: string;
 	theme: string;

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -23,6 +23,7 @@ jest.mock( '../available-designs-config', () => {
 		slug: 'mock-design-slug',
 		template: 'mock-design-template',
 		theme: 'mock-design-theme',
+		stylesheet: 'pub/mock-design-theme',
 		fonts: {
 			headings: 'Arvo',
 			base: 'Cabin',
@@ -34,9 +35,10 @@ jest.mock( '../available-designs-config', () => {
 
 	const mockDesignWithoutFonts: Design = {
 		title: 'Mock',
-		slug: 'mock-premium-design-slug',
-		template: 'mock-premium-design-template',
-		theme: 'mock-premium-design-theme',
+		slug: 'mock-design-slug',
+		template: 'mock-design-template',
+		theme: 'mock-design-theme',
+		stylesheet: 'pub/mock-design-theme',
 		categories: [ { slug: 'featured', name: 'Featured' } ],
 		is_premium: false,
 		features: [],
@@ -47,6 +49,7 @@ jest.mock( '../available-designs-config', () => {
 		slug: 'mock-premium-design-slug',
 		template: 'mock-premium-design-template',
 		theme: 'mock-premium-design-theme',
+		stylesheet: 'premium/mock-premium-design-theme',
 		fonts: {
 			headings: 'Arvo',
 			base: 'Cabin',
@@ -58,9 +61,10 @@ jest.mock( '../available-designs-config', () => {
 
 	const mockDesignFse: Design = {
 		title: 'Mock',
-		slug: 'mock-premium-design-slug',
-		template: 'mock-premium-design-template',
-		theme: 'mock-premium-design-theme',
+		slug: 'mock-design-slug',
+		template: 'mock-design-template',
+		theme: 'mock-design-theme',
+		stylesheet: 'pub/mock-design-theme',
 		fonts: {
 			headings: 'Arvo',
 			base: 'Cabin',
@@ -73,9 +77,10 @@ jest.mock( '../available-designs-config', () => {
 
 	const mockDesignAlpha: Design = {
 		title: 'Mock',
-		slug: 'mock-premium-design-alpha-slug',
-		template: 'mock-premium-design-alpha-template',
-		theme: 'mock-premium-design-alpha-theme',
+		slug: 'mock-design-alpha-slug',
+		template: 'mock-design-alpha-template',
+		theme: 'mock-design-alpha-theme',
+		stylesheet: 'pub/mock-design-alpha-theme',
 		fonts: {
 			headings: 'Arvo',
 			base: 'Cabin',
@@ -91,9 +96,20 @@ jest.mock( '../available-designs-config', () => {
 		slug: 'mock-blank-canvas-design-slug',
 		template: 'mock-blank-canvas-design-template',
 		theme: 'mock-blank-canvas-design-theme',
+		stylesheet: 'pub/mock-blank-canvas-design-theme',
 		categories: [ { slug: 'featured', name: 'Featured' } ],
 		is_premium: false,
 		is_featured_picks: true,
+		features: [],
+	};
+
+	const mockDesignMissingStylesheet: Design = {
+		title: 'Mock',
+		slug: 'mock-design-slug',
+		template: 'mock-design-template',
+		theme: 'mock-design-theme',
+		categories: [ { slug: 'featured', name: 'Featured' } ],
+		is_premium: false,
 		features: [],
 	};
 
@@ -106,6 +122,7 @@ jest.mock( '../available-designs-config', () => {
 				mockDesignFse,
 				mockDesignAlpha,
 				mockDesignBlankCanvas,
+				mockDesignMissingStylesheet,
 			],
 		},
 	};
@@ -119,7 +136,7 @@ describe( 'Design Picker design utils', () => {
 			const mockDesign = availableDesignsConfig.featured[ 0 ];
 
 			expect( getDesignUrl( mockDesign, mockLocale ) ).toEqual(
-				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesign.theme }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&site_title=${ mockDesign.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesign.stylesheet }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&site_title=${ mockDesign.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
 			);
 		} );
 
@@ -127,7 +144,16 @@ describe( 'Design Picker design utils', () => {
 			const mockDesignWithoutFonts = availableDesignsConfig.featured[ 1 ];
 
 			expect( getDesignUrl( mockDesignWithoutFonts, mockLocale ) ).toEqual(
-				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesignWithoutFonts.theme }/${ mockDesignWithoutFonts.template }?site_title=${ mockDesignWithoutFonts.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesignWithoutFonts.stylesheet }/${ mockDesignWithoutFonts.template }?site_title=${ mockDesignWithoutFonts.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+			);
+		} );
+
+		// This test is for legacy code. The theme repo wasn't part of the endpoint URL in v1 of the API.
+		it( 'assumes the theme is in the public repo when the design config is missing the stylesheet property', () => {
+			const mockDesignMissingStylesheet = availableDesignsConfig.featured[ 6 ];
+
+			expect( getDesignUrl( mockDesignMissingStylesheet, mockLocale ) ).toEqual(
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/pub/${ mockDesignMissingStylesheet.theme }/${ mockDesignMissingStylesheet.template }?site_title=${ mockDesignMissingStylesheet.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
 			);
 		} );
 	} );
@@ -146,6 +172,7 @@ describe( 'Design Picker design utils', () => {
 			const mockDesignPremium = availableDesignsConfig.featured[ 2 ];
 			const mockDesignAlpha = availableDesignsConfig.featured[ 4 ];
 			const mockDesignBlankCanvas = availableDesignsConfig.featured[ 5 ];
+			const mockDesignMissingStylesheet = availableDesignsConfig.featured[ 6 ];
 			expect( getAvailableDesigns( { includeAlphaDesigns: true, useFseDesigns: false } ) ).toEqual(
 				{
 					featured: [
@@ -155,6 +182,7 @@ describe( 'Design Picker design utils', () => {
 						mockDesignWithoutFonts,
 						mockDesignPremium,
 						mockDesignAlpha,
+						mockDesignMissingStylesheet,
 					],
 				}
 			);
@@ -174,6 +202,7 @@ describe( 'Design Picker design utils', () => {
 			const mockDesignWithoutFonts = availableDesignsConfig.featured[ 1 ];
 			const mockDesignPremium = availableDesignsConfig.featured[ 2 ];
 			const mockDesignBlankCanvas = availableDesignsConfig.featured[ 5 ];
+			const mockDesignMissingStylesheet = availableDesignsConfig.featured[ 6 ];
 			expect( getAvailableDesigns( { includeAlphaDesigns: false, useFseDesigns: false } ) ).toEqual(
 				{
 					featured: [
@@ -182,6 +211,7 @@ describe( 'Design Picker design utils', () => {
 						mockDesign,
 						mockDesignWithoutFonts,
 						mockDesignPremium,
+						mockDesignMissingStylesheet,
 					],
 				}
 			);

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -119,7 +119,7 @@ describe( 'Design Picker design utils', () => {
 			const mockDesign = availableDesignsConfig.featured[ 0 ];
 
 			expect( getDesignUrl( mockDesign, mockLocale ) ).toEqual(
-				`https://public-api.wordpress.com/rest/v1/template/demo/${ mockDesign.theme }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&site_title=${ mockDesign.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesign.theme }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&site_title=${ mockDesign.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
 			);
 		} );
 
@@ -127,7 +127,7 @@ describe( 'Design Picker design utils', () => {
 			const mockDesignWithoutFonts = availableDesignsConfig.featured[ 1 ];
 
 			expect( getDesignUrl( mockDesignWithoutFonts, mockLocale ) ).toEqual(
-				`https://public-api.wordpress.com/rest/v1/template/demo/${ mockDesignWithoutFonts.theme }/${ mockDesignWithoutFonts.template }?site_title=${ mockDesignWithoutFonts.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesignWithoutFonts.theme }/${ mockDesignWithoutFonts.template }?site_title=${ mockDesignWithoutFonts.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -11,12 +11,13 @@ export const getDesignUrl = (
 	locale: string,
 	options: DesignUrlOptions = {}
 ): string => {
+	const repo = encodeURIComponent( design.is_premium ? 'premium' : 'pub' );
 	const theme = encodeURIComponent( design.theme );
 	const template = encodeURIComponent( design.template );
 
-	// e.g. https://public-api.wordpress.com/rest/v1/template/demo/rockfield/rockfield?font_headings=Playfair%20Display&font_base=Fira%20Sans&site_title=Rockfield&viewport_height=700&language=en
+	// e.g. https://public-api.wordpress.com/rest/v1.1/template/demo/pub/rockfield/rockfield?font_headings=Playfair%20Display&font_base=Fira%20Sans&site_title=Rockfield&viewport_height=700&language=en
 	return addQueryArgs(
-		`https://public-api.wordpress.com/rest/v1/template/demo/${ theme }/${ template }`,
+		`https://public-api.wordpress.com/rest/v1.1/template/demo/${ repo }/${ theme }/${ template }`,
 		{
 			font_headings: design.fonts?.headings,
 			font_base: design.fonts?.base,

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -11,7 +11,7 @@ export const getDesignUrl = (
 	locale: string,
 	options: DesignUrlOptions = {}
 ): string => {
-	const repo = encodeURIComponent( design.is_premium ? 'premium' : 'pub' );
+	const repo = design.stylesheet ? design.stylesheet.split( '/' )[ 0 ] : 'pub';
 	const theme = encodeURIComponent( design.theme );
 	const template = encodeURIComponent( design.template );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Check the premium themes are available for the user by `planHasFeature` utils and then determine the value of the `tier` should be `all` or `free`
* Add `PremiumBadge` component in the Design Picker package and pass `PremiumBadge` as a prop of the Design Picker

**Example of the premium badge and the hover behavior**

![image](https://user-images.githubusercontent.com/13596067/146359128-3900c15e-ce41-4176-96b0-47ae4e96b0ef.png)

![image](https://user-images.githubusercontent.com/13596067/149879637-6f008da4-1008-4a31-8ade-04776ba756d4.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D72672-code to your sandbox to ensure the theme demo API v1.1 is in your sandbox. Note that the mshot image might be broken as D72672-code should be shipped first.
* Follow D71467-code to add your user id into the whitelist in your sandbox
* Go to `/start/setup-site/intent?siteSlug=<your_site>&flags=themes/premium`
* Select “build”
* Check the premium themes are showing on the page and you can select that theme if the plan is premium or above
* Check the premium themes won't show on the page if the plan is free or personal

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/59025