### PR TITLE
Welcome tour: visually align media on mobile with desktop

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -129,6 +129,7 @@ $welcome-tour-card-media-extra-padding: 14%;
 		padding-top: math.percentage( math.div( math.ceil( math.div( 1, 1.53 ) * 100 ), 100 ) ); // img width:height ratio (1:1.53)
 		position: relative;
 		width: 100%;
+        // TODO CLK: use welcome-tour-card class to keep specific to welcome tour
 		background-color: #e7eaeb;
 
 		img {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -138,8 +138,8 @@ $welcome-tour-card-media-extra-padding: 14%;
 			top: 0;
 			width: 100%;
 		}
-    // TODO CLK: use welcome-tour-card class to keep specific to welcome tour
-		&.with-extra-padding img {
+    	// TODO CLK: use welcome-tour-card class to keep specific to welcome tour
+		&.is-with-extra-padding img {
 			left: $welcome-tour-card-media-extra-padding;
 			top: $welcome-tour-card-media-extra-padding;
 			width: 100% - $welcome-tour-card-media-extra-padding;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -171,6 +171,7 @@ $welcome-tour-card-media-extra-padding: 14%;
 	padding: $grid-unit-15;
 	right: 0;
 	z-index: 1; // z-index is needed because overlay controls are written before components-card__media, and so ends up under the image
+    // TODO CLK: use welcome-tour-card class to keep specific to welcome tour
 	position: absolute;
 
 	.components-button {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -5,6 +5,7 @@
 @import '@wordpress/base-styles/z-index';
 
 $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: replace with standard color
+$welcome-tour-card-media-extra-padding: 14%;
 
 .welcome-tour-card__heading {
 	font-size: 1.125rem; /* stylelint-disable-line */
@@ -128,12 +129,19 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 		padding-top: math.percentage( math.div( math.ceil( math.div( 1, 1.53 ) * 100 ), 100 ) ); // img width:height ratio (1:1.53)
 		position: relative;
 		width: 100%;
+		background-color: #e7eaeb;
 
 		img {
 			left: 0;
 			position: absolute;
 			top: 0;
 			width: 100%;
+		}
+
+		&.with-extra-padding img {
+			left: $welcome-tour-card-media-extra-padding;
+			top: $welcome-tour-card-media-extra-padding;
+			width: 100% - $welcome-tour-card-media-extra-padding;
 		}
 	}
 
@@ -163,6 +171,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	padding: $grid-unit-15;
 	right: 0;
 	z-index: 1; // z-index is needed because overlay controls are written before components-card__media, and so ends up under the image
+	position: absolute;
 
 	.components-button {
 		width: 32px;
@@ -195,10 +204,6 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 			}
 		}
 	}
-}
-
-.welcome-tour-card__overlay-controls__absolute {
-	position: absolute;
 }
 
 .welcome-tour-card__next-btn {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -5,7 +5,7 @@
 @import '@wordpress/base-styles/z-index';
 
 $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: replace with standard color
-$welcome-tour-card-media-extra-padding: 14%;
+$welcome-tour-card-media-extra-padding: 14%; // temporary value, to match the padding of the desktop instructional graphics
 
 .welcome-tour-card__heading {
 	font-size: 1.125rem; /* stylelint-disable-line */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -137,7 +137,7 @@ $welcome-tour-card-media-extra-padding: 14%;
 			top: 0;
 			width: 100%;
 		}
-
+    // TODO CLK: use welcome-tour-card class to keep specific to welcome tour
 		&.with-extra-padding img {
 			left: $welcome-tour-card-media-extra-padding;
 			top: $welcome-tour-card-media-extra-padding;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -130,7 +130,7 @@ $welcome-tour-card-media-extra-padding: 14%;
 		position: relative;
 		width: 100%;
         // TODO CLK: use welcome-tour-card class to keep specific to welcome tour
-		background-color: #e7eaeb;
+		background-color: #e7eaeb; // the color of the background used in desktop graphics
 
 		img {
 			left: 0;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -36,7 +36,7 @@ function WelcomeTourCard( {
 	isGutenboarding,
 	setInitialFocusedElement,
 } ) {
-	const { description, heading, imgSrc } = cardContent;
+	const { description, heading, imgSrc, imgNeedsPadding } = cardContent;
 	const isLastStep = currentStepIndex === lastStepIndex;
 
 	// Ensure tracking is recorded once per slide view
@@ -54,12 +54,15 @@ function WelcomeTourCard( {
 			is_gutenboarding: isGutenboarding,
 		} );
 	} );
+	const cardMediaClass = classNames( 'welcome-tour-card__media', {
+		'with-extra-padding': isMobile() && imgNeedsPadding,
+	} );
 
 	return (
 		<Card className="welcome-tour-card" isElevated>
 			<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			{ /* TODO: Update selector for images in @wordpress/components/src/card/styles/card-styles.js */ }
-			<CardMedia className="welcome-tour-card__media">
+			<CardMedia className={ cardMediaClass }>
 				<picture>
 					{ imgSrc.mobile && (
 						<source
@@ -155,12 +158,8 @@ function CardNavigation( {
 }
 
 function CardOverlayControls( { onMinimize, onDismiss } ) {
-	const buttonClasses = classNames( 'welcome-tour-card__overlay-controls', {
-		'welcome-tour-card__overlay-controls__absolute': ! isMobile(),
-	} );
-
 	return (
-		<div className={ buttonClasses }>
+		<div className="welcome-tour-card__overlay-controls">
 			<Flex>
 				<Button
 					label={ __( 'Minimize Tour', 'full-site-editing' ) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -54,9 +54,9 @@ function WelcomeTourCard( {
 			is_gutenboarding: isGutenboarding,
 		} );
 	} );
-    // TODO CLK: welcome tour only mod for mobile fixes
+	// TODO CLK: welcome tour only mod for mobile fixes
 	const cardMediaClass = classNames( 'welcome-tour-card__media', {
-		'with-extra-padding': isMobile() && imgNeedsPadding,
+		'is-with-extra-padding': isMobile() && imgNeedsPadding,
 	} );
 
 	return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -54,6 +54,7 @@ function WelcomeTourCard( {
 			is_gutenboarding: isGutenboarding,
 		} );
 	} );
+    // TODO CLK: welcome tour only mod for mobile fixes
 	const cardMediaClass = classNames( 'welcome-tour-card__media', {
 		'with-extra-padding': isMobile() && imgNeedsPadding,
 	} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -82,6 +82,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				),
 				imgSrc: getTourAssets( 'welcome' ),
 				animation: null,
+				imgNeedsPadding: true,
 			},
 		},
 		{
@@ -106,6 +107,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				),
 				imgSrc: getTourAssets( 'addBlock' ),
 				animation: 'block-inserter',
+				imgNeedsPadding: true,
 			},
 		},
 		{
@@ -127,6 +129,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				description: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
 				imgSrc: getTourAssets( 'moreOptions' ),
 				animation: null,
+				imgNeedsPadding: true,
 			},
 		},
 		{
@@ -145,6 +148,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				description: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
 				imgSrc: getTourAssets( 'moveBlock' ),
 				animation: 'undo-button',
+				imgNeedsPadding: true,
 			},
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert the welcome tour header positioning change introduced as a mobile fix in https://github.com/Automattic/wp-calypso/pull/59052
* Add optional padding to welcome tour instructional graphics

#### Testing instructions
* Sync ETK following FG instructions
* Open the editor and welcome tour on mobile
* Note the padding added via CSS for slides 1,3,5,7
* <s>Note how the padding is aligned with slide 6 that is basically the graphic used on desktop with build-in padding</s> Even if the Undo slide will be removed in https://github.com/Automattic/wp-calypso/pull/59296, we use it as a reference for proportions

### Screenshots
#### Before 
<img width="300" alt="Screenshot 2021-12-16 at 18 40 22" src="https://user-images.githubusercontent.com/14192054/146412497-1fc4272f-ab22-49e3-9928-bbcbb0b63383.png">

#### After
<img width="300" alt="Screenshot 2021-12-16 at 13 09 08" src="https://user-images.githubusercontent.com/14192054/146362111-a320b75c-3aeb-42ef-a3ee-9b9c27367df7.png">

#### After (large mobile screen)
<img width="300" alt="Screenshot 2021-12-16 at 13 08 49" src="https://user-images.githubusercontent.com/14192054/146362112-8f8a6158-0a15-4bbe-93de-900b72cd74d4.png">

#### Demo
https://user-images.githubusercontent.com/14192054/146362097-c6d9cda9-9787-4b86-9a85-caeee291e159.mov

Related to #55826
Related thread: p1639497273123400-slack-C029WSAQMT9