### PR TITLE
Welcome tour: hide 'Undo' slide on mobile

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -4,6 +4,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useLocale } from '@automattic/i18n-utils';
 import TourKit from '@automattic/tour-kit';
+import { isMobile } from '@automattic/viewport';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useMemo } from '@wordpress/element';
 /**
@@ -61,7 +62,9 @@ function WelcomeTour() {
 	const isWelcomeTourNext = () => {
 		return new URLSearchParams( document.location.search ).has( 'welcome-tour-next' );
 	};
-	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext() );
+	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext() ).filter(
+		( step ) => ! ( step.meta.isDesktopOnly && isMobile() )
+	);
 	const { setJustMaximized } = useWelcomeTourContext();
 
 	// Preload card images

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -57,7 +57,6 @@ const referenceElements = [
 			'.edit-post-header .edit-post-header__settings .interface-pinned-items > button:nth-child(1)',
 	},
 	{
-		mobile: '.edit-post-header .edit-post-header__toolbar .components-button.editor-history__undo',
 		desktop: '.edit-post-header .edit-post-header__toolbar .components-button.editor-history__undo',
 	},
 	{
@@ -136,6 +135,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				description: __( "Click the Undo button if you've made a mistake.", 'full-site-editing' ),
 				imgSrc: getTourAssets( 'undo' ),
 				animation: 'undo-button',
+				isDesktopOnly: true,
 			},
 		},
 		{


### PR DESCRIPTION
Since the functionality is hidden on mobile, we should only display the 'Undo' slide on desktop (wider screens). The upcoming 'List View' slide ( https://github.com/Automattic/wp-calypso/issues/56709 ) will be displayed in a similar way.

<img width="200" alt="Screenshot 2021-12-16 at 13 53 40" src="https://user-images.githubusercontent.com/14192054/146367119-84f739c9-dcf3-409d-9b84-3e1a6cf51857.png">

#### Changes proposed in this Pull Request

* Remove the 'Undo' slide on mobile because the functionality is not available.

#### Testing instructions

* Sync ETK following FG instructions
* Open the editor and welcome tour on mobile
* The 'Undo' slide should no longer be displayed (it's the 6th one on desktop)
