### PR TITLE
Fix typo in file path

### DIFF
--- a/client/components/jetpack/threat-item-new/index.tsx
+++ b/client/components/jetpack/threat-item-new/index.tsx
@@ -5,12 +5,12 @@ import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import ThreatItemHeader from 'calypso/components/jetpack/threat-item-header-new';
-import { Threat } from 'calypso/components/jetpack/threat-item-new-new/types';
 import { getThreatFix } from 'calypso/components/jetpack/threat-item-new/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import LogItem from '../log-item';
 import ThreatDescription from '../threat-description-new';
+import type { Threat } from 'calypso/components/jetpack/threat-item-new/types';
 
 import './style.scss';
 interface Props {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Solves `TS2307: Cannot find module 'calypso/components/jetpack/threat-item-new-new/types' or its corresponding type declarations` by fixing the typo in the path

