### PR TITLE
build: Fail the build if the error delta is more than 0

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -340,6 +340,7 @@ object RunAllUnitTests : BuildType({
 			metric = BuildFailureOnMetric.MetricType.INSPECTION_ERROR_COUNT
 			units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
 			comparison = BuildFailureOnMetric.MetricComparison.MORE
+			threshold = 0
 			compareTo = build {
 				buildRule = lastSuccessful()
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fails the build if there are error diff is more than 0 compared with the previous successful build.

The default for `threshold` is 1, which end up meaing "Fail the build build if number of inspection errors - reference value > 1". This allow PRs to merge if they have 1 error.

Unfortunately this can't be tested until merge.