### PR TITLE
Config: Remove unused` jetpack/blocks/beta` feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -76,7 +76,6 @@
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
-		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,6 @@
 		"inline-help": true,
 		"i18n/empathy-mode": true,
 		"jetpack/api-cache": true,
-		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -54,7 +54,6 @@
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
-		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the `jetpack/blocks/beta` feature flag as it's been unused since #32112. 

#### Testing instructions

Verify the feature flag is not in use.