### PR TITLE
Fix: apply signup styling and sub-header adjustments to reskinned non-onboarding flows

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -206,32 +206,28 @@ export class UserStep extends Component {
 			subHeaderText = translate( 'Welcome to the WordPress.com community.' );
 		}
 
-		if ( positionInFlow === 0 ) {
-			subHeaderText = translate( 'First, create your WordPress.com account.' );
+		if ( isReskinned && 0 === positionInFlow ) {
+			const loginUrl = login( {
+				isJetpack: 'jetpack-connect' === sectionName,
+				from,
+				redirectTo: getRedirectToAfterLoginUrl( this.props ),
+				locale,
+				oauth2ClientId: oauth2Client?.id,
+				wccomFrom,
+				isWhiteLogin: isReskinned,
+				signupUrl: window.location.pathname + window.location.search,
+			} );
 
-			if ( isReskinned ) {
-				const loginUrl = login( {
-					isJetpack: 'jetpack-connect' === sectionName,
-					from,
-					redirectTo: getRedirectToAfterLoginUrl( this.props ),
-					locale,
-					oauth2ClientId: oauth2Client?.id,
-					wccomFrom,
-					isWhiteLogin: isReskinned,
-					signupUrl: window.location.pathname + window.location.search,
-				} );
+			subHeaderText = translate(
+				'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
+				{
+					components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
+				}
+			);
+		}
 
-				subHeaderText = translate(
-					'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
-					{
-						components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
-					}
-				);
-			}
-
-			if ( this.props.userLoggedIn ) {
-				subHeaderText = '';
-			}
+		if ( this.props.userLoggedIn ) {
+			subHeaderText = '';
 		}
 
 		return subHeaderText;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -206,7 +206,7 @@ export class UserStep extends Component {
 			subHeaderText = translate( 'Welcome to the WordPress.com community.' );
 		}
 
-		if ( positionInFlow === 0 && flowName === 'onboarding' ) {
+		if ( positionInFlow === 0 ) {
 			subHeaderText = translate( 'First, create your WordPress.com account.' );
 
 			if ( isReskinned ) {

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -1,4 +1,4 @@
-body.is-section-signup.is-white-signup .signup.is-onboarding {
+body.is-section-signup.is-white-signup .signup {
 	.signup-form.is-horizontal {
 		.signup-form__terms-of-service-link,
 		.signup-form__terms-of-service-link a,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This addresses a few differences/issues found on reskinned non-onboarding plans (ex. free, premium, etc.)
* the sub-header text is different
* the text has a different color
* the social login ToC text is white-on-white
<img width="480" src="https://user-images.githubusercontent.com/2749938/146389206-cf544929-2c5a-47dd-a870-84daf45ae0ce.png">



#### Testing instructions
* Make sure you are logged out
* Go to the first step of a `non-onboarding` flow (ex. /start/premium) 
* The page should look like this
<img width="480" alt="Screenshot on 2021-12-16 at 16-20-15" src="https://user-images.githubusercontent.com/2749938/146389248-3a4a737a-b4e0-48d5-ae3c-8d5600d287c2.png">

* Go to the first step of the `onboarding` flow (ex. /start/onboarding) 
* The page should look as before
