### PR TITLE
Allow new DNS add/edit paths for domain-only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -28,6 +28,8 @@ import {
 	domainManagementTransferOut,
 	domainManagementTransferToOtherSite,
 	domainManagementRoot,
+	domainManagementDnsAddRecord,
+	domainManagementDnsEditRecord,
 } from 'calypso/my-sites/domains/paths';
 import {
 	emailManagement,
@@ -169,6 +171,8 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 	const allPaths = [
 		domainManagementContactsPrivacy,
 		domainManagementDns,
+		domainManagementDnsAddRecord,
+		domainManagementDnsEditRecord,
 		domainManagementEdit,
 		domainManagementEditContactInfo,
 		domainManagementList,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We introduced two new paths in the latest DNS page updates. We need to allow these paths to be used by the domain-only sites.

#### Testing instructions

Pick a domain-only site.
Make sure you can add a DNS record.
Make sure you can edit a DNS record.