### PR TITLE
Videos UI: Default to opening the first video in the course.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -64,7 +64,7 @@ const VideosUi = ( { HeaderBar, FooterBar, areVideosTranslated = true } ) => {
 				return;
 			}
 		}
-		const initialVideoId = 'find-theme';
+		const initialVideoId = videoSlugs[ 0 ];
 		setCurrentVideoKey( initialVideoId );
 		setSelectedChapterIndex( videoSlugs.indexOf( initialVideoId ) );
 	}, [ course, initialUserCourseProgression ] );


### PR DESCRIPTION
We currently have the default video slug hard-coded to `find-theme`, which only applies to our one available course at the moment. With more courses coming, this PR instead makes the default video slug the first video of whatever course is received.

Fixes https://github.com/Automattic/wp-calypso/issues/59301

**Testing Instructions**
* Open this branch with the calypso.live link.
* Go to My Home, and open the videos UI with the "Start learning" link.
* Verify it behaves correctly (this PR should cause no user-facing changes).