### PR TITLE
Domains page copy experiment (signup flow)

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1295,7 +1295,7 @@ class RegisterDomainStep extends Component {
 			<div className="register-domain-step__example-prompt">
 				<Icon icon={ tip } size={ 20 } />
 				{ isCopyExperiment
-					? 'You’ll see many choices below, including free options. And you can always change or upgrade it later.'
+					? 'You’ll see many options below. Or, you can choose a domain later and start with a free wordpress.com address.'
 					: translate( 'The best names are short and memorable' ) }
 			</div>
 		);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1290,11 +1290,13 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderBestNamesPrompt() {
-		const { translate } = this.props;
+		const { isCopyExperiment, translate } = this.props;
 		return (
 			<div className="register-domain-step__example-prompt">
 				<Icon icon={ tip } size={ 20 } />
-				{ translate( 'The best names are short and memorable' ) }
+				{ isCopyExperiment
+					? 'You’ll see many choices below, including free options. And you can always change or upgrade it later.'
+					: translate( 'The best names are short and memorable' ) }
 			</div>
 		);
 	}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -355,7 +355,7 @@ export default {
 			'ecommerce-monthly',
 		];
 		if ( signupFlows.includes( flowName ) ) {
-			await loadExperimentAssignment( 'domain_step_copy_test_202201' );
+			await loadExperimentAssignment( 'calypso_signup_domain_step_copy_test_202201_v2' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -355,7 +355,7 @@ export default {
 			'ecommerce-monthly',
 		];
 		if ( signupFlows.includes( flowName ) ) {
-			await loadExperimentAssignment( 'calypso_signup_domain_step_copy_test_202201_v2' );
+			loadExperimentAssignment( 'calypso_signup_domain_step_copy_test_202201_v2' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -341,6 +341,23 @@ export default {
 			loadExperimentAssignment( 'calypso_mobile_plans_page_with_billing' );
 		}
 
+		const signupFlows = [
+			'onboarding',
+			'launch-site',
+			'free',
+			'personal',
+			'premium',
+			'business',
+			'ecommerce',
+			'personal-monthly',
+			'premium-monthly',
+			'business-monthly',
+			'ecommerce-monthly',
+		];
+		if ( signupFlows.includes( flowName ) ) {
+			await loadExperimentAssignment( 'domain_step_copy_test_202201' );
+		}
+
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -179,7 +179,7 @@ class DomainsStep extends Component {
 	};
 
 	isExperiment() {
-		return this.state.experiment?.variationName === 'treatment';
+		return this.state.experiment?.variationName !== null;
 	}
 
 	isPurchasingTheme = () => {
@@ -680,7 +680,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( this.isExperiment ) {
+			if ( ! stepSectionName && this.isExperiment ) {
 				return 'A domain name is a first step in branding your website, and helps you choose your web address, too.';
 			}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -122,8 +122,6 @@ class DomainsStep extends Component {
 		this.setCurrentFlowStep = this.setCurrentFlowStep.bind( this );
 		this.state = {
 			currentStep: null,
-			experiment: null,
-			experimentLoaded: false,
 		};
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -179,7 +179,10 @@ class DomainsStep extends Component {
 	};
 
 	isExperiment() {
-		return this.state.experiment?.variationName !== null;
+		return (
+			'domain_step_copy_test_202201' === this.state.experiment?.experimentName &&
+			this.state.experiment?.variationName !== null
+		);
 	}
 
 	isPurchasingTheme = () => {
@@ -680,7 +683,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( ! stepSectionName && this.isExperiment ) {
+			if ( ! stepSectionName && this.isExperiment() ) {
 				return 'A domain name is a first step in branding your website, and helps you choose your web address, too.';
 			}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -123,6 +123,7 @@ class DomainsStep extends Component {
 		this.state = {
 			currentStep: null,
 			experiment: null,
+			experimentLoaded: false,
 		};
 	}
 
@@ -679,9 +680,6 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-<<<<<<< HEAD
-			return ! stepSectionName && translate( 'Enter some descriptive keywords to get started' );
-=======
 			if ( this.isExperiment ) {
 				return 'A domain name is a first step in branding your website, and helps you choose your web address, too.';
 			}
@@ -690,7 +688,6 @@ class DomainsStep extends Component {
 				! stepSectionName &&
 				translate( "Enter your site's name or some descriptive keywords to get started" )
 			);
->>>>>>> 0d1cef91aa (Domains page copy experiment (signup flow))
 		}
 
 		const subHeaderPropertyName = 'signUpFlowDomainsStepSubheader';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -493,7 +493,7 @@ class DomainsStep extends Component {
 		);
 	};
 
-	domainForm = () => {
+	domainForm = ( isDomainStepCopyTreatment ) => {
 		let initialState = {};
 		if ( this.props.step ) {
 			initialState = this.props.step.domainForm;
@@ -532,88 +532,59 @@ class DomainsStep extends Component {
 		const trueNamePromoTlds = TRUENAME_COUPONS.includes( this.props?.queryObject?.coupon )
 			? TRUENAME_TLDS
 			: null;
-		const domainTestEligibleSignupFlows = [
-				'onboarding',
-				'launch-site',
-				'free',
-				'personal',
-				'premium',
-				'business',
-				'ecommerce',
-				'personal-monthly',
-				'premium-monthly',
-				'business-monthly',
-				'ecommerce-monthly',
-			];
 
 		return (
-		<ProvideExperimentData
-			name="domain_step_copy_test_202201"
-			options={ {
-				isEligible: domainTestEligibleSignupFlows.includes( this.props.flowName ),
-			} }
-		>
-			{ ( isLoading, experimentAssignment ) => {
-				if ( isLoading ) {
-					return this.renderLoading();
-				}
-				const isTreatment = experimentAssignment?.variationName === 'treatment';
-
-				return (
-					<CalypsoShoppingCartProvider>
-						<RegisterDomainStep
-							key="domainForm"
-							path={ this.props.path }
-							initialState={ initialState }
-							onAddDomain={ this.handleAddDomain }
-							products={ this.props.productsList }
-							basePath={ this.props.path }
-							promoTlds={ trueNamePromoTlds }
-							mapDomainUrl={ this.getUseYourDomainUrl() }
-							transferDomainUrl={ this.getUseYourDomainUrl() }
-							useYourDomainUrl={ this.getUseYourDomainUrl() }
-							onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
-							onSave={ this.handleSave.bind( this, 'domainForm' ) }
-							offerUnavailableOption={ ! this.props.isDomainOnly }
-							isDomainOnly={ this.props.isDomainOnly }
-							analyticsSection={ this.getAnalyticsSection() }
-							domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-							includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
-							includeDotBlogSubdomain={
-								trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain()
-							}
-							isSignupStep
-							isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
-							showExampleSuggestions={ showExampleSuggestions }
-							suggestion={ initialQuery }
-							designType={ this.getDesignType() }
-							vendor={ getSuggestionsVendor( {
-								isSignup: true,
-								isDomainOnly: this.props.isDomainOnly,
-							} ) }
-							deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
-							selectedSite={ this.props.selectedSite }
-							showSkipButton={ this.props.showSkipButton }
-							vertical={ this.props.vertical }
-							onSkip={ this.handleSkip }
-							hideFreePlan={ this.handleSkip }
-							forceHideFreeDomainExplainerAndStrikeoutUi={
-								this.props.forceHideFreeDomainExplainerAndStrikeoutUi
-							}
-							isReskinned={ this.props.isReskinned }
-							isCopyExperiment={ isTreatment }
-							reskinSideContent={ this.getSideContent() }
-						/>
-					</CalypsoShoppingCartProvider>
-				);
-			} }
-		</ProvideExperimentData>
+			<CalypsoShoppingCartProvider>
+				<RegisterDomainStep
+					key="domainForm"
+					path={ this.props.path }
+					initialState={ initialState }
+					onAddDomain={ this.handleAddDomain }
+					products={ this.props.productsList }
+					basePath={ this.props.path }
+					promoTlds={ trueNamePromoTlds }
+					mapDomainUrl={ this.getUseYourDomainUrl() }
+					transferDomainUrl={ this.getUseYourDomainUrl() }
+					useYourDomainUrl={ this.getUseYourDomainUrl() }
+					onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
+					onSave={ this.handleSave.bind( this, 'domainForm' ) }
+					offerUnavailableOption={ ! this.props.isDomainOnly }
+					isDomainOnly={ this.props.isDomainOnly }
+					analyticsSection={ this.getAnalyticsSection() }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
+					includeDotBlogSubdomain={
+						trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain()
+					}
+					isSignupStep
+					isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
+					showExampleSuggestions={ showExampleSuggestions }
+					suggestion={ initialQuery }
+					designType={ this.getDesignType() }
+					vendor={ getSuggestionsVendor( {
+						isSignup: true,
+						isDomainOnly: this.props.isDomainOnly,
+					} ) }
+					deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
+					selectedSite={ this.props.selectedSite }
+					showSkipButton={ this.props.showSkipButton }
+					vertical={ this.props.vertical }
+					onSkip={ this.handleSkip }
+					hideFreePlan={ this.handleSkip }
+					forceHideFreeDomainExplainerAndStrikeoutUi={
+						this.props.forceHideFreeDomainExplainerAndStrikeoutUi
+					}
+					isReskinned={ this.props.isReskinned }
+					isCopyExperiment={ isDomainStepCopyTreatment }
+					reskinSideContent={ this.getSideContent() }
+				/>
+			</CalypsoShoppingCartProvider>
 		);
 	};
 
 	renderLoading() {
 		return (
-			<div className="plans__loading">
+			<div className="domains__loading">
 				<LoadingEllipsis active />
 			</div>
 		);
@@ -668,7 +639,7 @@ class DomainsStep extends Component {
 		);
 	};
 
-	getSubHeaderText() {
+	getSubHeaderText( isDomainStepCopyTreatment ) {
 		const {
 			flowName,
 			isAllDomains,
@@ -683,7 +654,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( ! stepSectionName && this.isExperiment() ) {
+			if ( ! stepSectionName && isDomainStepCopyTreatment ) {
 				return 'A domain name is a first step in branding your website, and helps you choose your web address, too.';
 			}
 
@@ -708,7 +679,7 @@ class DomainsStep extends Component {
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
-	getHeaderText() {
+	getHeaderText( isDomainStepCopyTreatment ) {
 		const {
 			headerText,
 			isAllDomains,
@@ -723,7 +694,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( this.isExperiment() && ! stepSectionName ) {
+			if ( isDomainStepCopyTreatment && ! stepSectionName ) {
 				return 'Find a domain';
 			}
 			return ! stepSectionName && translate( 'Choose a domain' );
@@ -738,7 +709,7 @@ class DomainsStep extends Component {
 		return this.props.isDomainOnly ? 'domain-first' : 'signup';
 	}
 
-	renderContent() {
+	renderContent( isDomainStepCopyTreatment ) {
 		let content;
 		let sideContent;
 
@@ -747,7 +718,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( ! this.props.stepSectionName || this.props.isDomainOnly ) {
-			content = this.domainForm();
+			content = this.domainForm( isDomainStepCopyTreatment );
 		}
 
 		if ( ! this.props.stepSectionName && this.props.isReskinned ) {
@@ -848,33 +819,62 @@ class DomainsStep extends Component {
 			}
 		}
 
-		const headerText = this.getHeaderText();
-		const fallbackSubHeaderText = this.getSubHeaderText();
+		const domainTestEligibleSignupFlows = [
+			'onboarding',
+			'launch-site',
+			'free',
+			'personal',
+			'premium',
+			'business',
+			'ecommerce',
+			'personal-monthly',
+			'premium-monthly',
+			'business-monthly',
+			'ecommerce-monthly',
+		];
 
 		return (
-			<StepWrapper
-				flowName={ this.props.flowName }
-				stepName={ this.props.stepName }
-				backUrl={ backUrl }
-				positionInFlow={ this.props.positionInFlow }
-				headerText={ headerText }
-				subHeaderText={ fallbackSubHeaderText }
-				isExternalBackUrl={ isExternalBackUrl }
-				fallbackHeaderText={ headerText }
-				fallbackSubHeaderText={ fallbackSubHeaderText }
-				stepContent={
-					<div>
-						{ ! this.props.productsLoaded && <QueryProductsList /> }
-						{ this.renderContent() }
-					</div>
-				}
-				allowBackFirstStep={ !! backUrl }
-				backLabelText={ backLabelText }
-				hideSkip={ true }
-				goToNextStep={ this.handleSkip }
-				align={ isReskinned ? 'left' : 'center' }
-				isWideLayout={ isReskinned }
-			/>
+			<ProvideExperimentData
+				name="calypso_signup_domain_step_copy_test_202201_v2"
+				options={ {
+					isEligible: domainTestEligibleSignupFlows.includes( this.props.flowName ),
+				} }
+			>
+				{ ( isLoading, experimentAssignment ) => {
+					if ( isLoading ) {
+						return this.renderLoading();
+					}
+					const isDomainStepCopyTreatment = experimentAssignment?.variationName === 'treatment';
+					const headerText = this.getHeaderText( isDomainStepCopyTreatment );
+					const fallbackSubHeaderText = this.getSubHeaderText( isDomainStepCopyTreatment );
+
+					return (
+						<StepWrapper
+							flowName={ this.props.flowName }
+							stepName={ this.props.stepName }
+							backUrl={ backUrl }
+							positionInFlow={ this.props.positionInFlow }
+							headerText={ headerText }
+							subHeaderText={ fallbackSubHeaderText }
+							isExternalBackUrl={ isExternalBackUrl }
+							fallbackHeaderText={ headerText }
+							fallbackSubHeaderText={ fallbackSubHeaderText }
+							stepContent={
+								<div>
+									{ ! this.props.productsLoaded && <QueryProductsList /> }
+									{ this.renderContent( isDomainStepCopyTreatment ) }
+								</div>
+							}
+							allowBackFirstStep={ !! backUrl }
+							backLabelText={ backLabelText }
+							hideSkip={ true }
+							goToNextStep={ this.handleSkip }
+							align={ isReskinned ? 'left' : 'center' }
+							isWideLayout={ isReskinned }
+						/>
+					);
+				} }
+			</ProvideExperimentData>
 		);
 	}
 }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -176,13 +176,6 @@ class DomainsStep extends Component {
 		} );
 	};
 
-	isExperiment() {
-		return (
-			'domain_step_copy_test_202201' === this.state.experiment?.experimentName &&
-			this.state.experiment?.variationName !== null
-		);
-	}
-
 	isPurchasingTheme = () => {
 		return this.props.queryObject && this.props.queryObject.premium;
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the test described at pbxNRc-18T-p2, using the Explat experiment `domain_step_copy_test_202112`.

Here's a screenshot of the experiment copy in place:
<img width="1465" alt="CleanShot 2021-12-16 at 10 42 21@2x" src="https://user-images.githubusercontent.com/35781181/146402451-9f64898b-ffd9-4a05-8bcf-5b94e46b95f0.png">


#### Testing instructions
* Checkout this PR and start calypso.
* Navigate to `/start/new` and proceed to the Domains step (can be either new or existing account)
* Assign yourself to the treatment variation of `domain_step_copy_test_202112`
* Confirm that test copy shows as expected.
* Test domain-only flows and confirm they still work as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
