### PR TITLE
Videos UI - style updates for language notification

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -99,6 +99,19 @@ const VideosUi = ( { HeaderBar, FooterBar, areVideosTranslated = true } ) => {
 		<div className="videos-ui">
 			<div className="videos-ui__header">
 				<HeaderBar course={ course } />
+
+				{ currentVideo && shouldShowVideoTranslationNotice && (
+					<Notice onDismissClick={ () => setShouldShowVideoTranslationNotice( false ) }>
+						{ translate(
+							'These videos are currently only available in English. Please {{supportLink}}let us know{{/supportLink}} if you would like them translated.',
+							{
+								components: {
+									supportLink: <a href="mailto:support@wordpress.com" />,
+								},
+							}
+						) }
+					</Notice>
+				) }
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
 						<h2>{ translate( 'Watch five videos.' ) }</h2>
@@ -132,18 +145,6 @@ const VideosUi = ( { HeaderBar, FooterBar, areVideosTranslated = true } ) => {
 			>
 				<div className="videos-ui__body-title">
 					<h3>{ course && course.title }</h3>
-					{ currentVideo && shouldShowVideoTranslationNotice && (
-						<Notice onDismissClick={ () => setShouldShowVideoTranslationNotice( false ) }>
-							{ translate(
-								'These videos are currently only available in English. Please {{supportLink}}let us know{{/supportLink}} if you would like them translated.',
-								{
-									components: {
-										supportLink: <a href="mailto:support@wordpress.com" />,
-									},
-								}
-							) }
-						</Notice>
-					) }
 				</div>
 				<div className="videos-ui__video-content">
 					{ ! currentVideo && <div className="videos-ui__video-placeholder" /> }

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -14,6 +14,13 @@
 		color: #fff;
 	}
 
+	.notice {
+		background-color: #2d3338;
+		.notice__icon-wrapper {
+			background: none;
+		}
+	}
+
 	.videos-ui__header {
 		background: #151b1e;
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.1 );
@@ -98,10 +105,6 @@
 		h3 {
 			font-size: $font-title-medium;
 			margin-bottom: 24px;
-		}
-
-		.notice {
-			background-color: #1d262a;
 		}
 
 		.videos-ui__video-content {
@@ -316,6 +319,10 @@
 	}
 
 	@include break-xlarge {
+		.notice {
+			max-width: 1160px;
+			margin: auto;
+		}
 		.videos-ui__header {
 			.videos-ui__header-content {
 				max-width: 1160px;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -16,8 +16,18 @@
 
 	.notice {
 		background-color: #2d3338;
+		border-radius: 4px;
 		.notice__icon-wrapper {
 			background: none;
+		}
+		.notice__dismiss {
+			display: flex;
+			align-items: center;
+
+			svg {
+				width: 15px;
+				height: 15px;
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the language translation notification introduced in #59155, adding some style and positioning updates as suggested in #58206.

![image](https://user-images.githubusercontent.com/13437011/146422439-8b2944e7-44c0-40f5-923b-9fc278adcf05.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to local.
* Sandbox the API.
* Comment out the `&& false` on `client/components/videos-ui/index.jsx:31`, which is added to hide the notification until we have gotten it translated.
* Verify that when you have English language set for your account, the notification does not display in the Videos UI modal, but that it does when other languages are enabled.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58206
