### PR TITLE
Unable to install Advanced Ads and other ad plugins

### DIFF
--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -500,9 +500,9 @@ describe( 'actions', () => {
 		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( '/rest/v1.1/sites/2916284/plugins/jetpack/install' )
+				.post( '/rest/v1.1/sites/2916284/plugins/install', { slug: 'jetpack' } )
 				.reply( 200, jetpackUpdated )
-				.post( '/rest/v1.1/sites/2916284/plugins/fake/install' )
+				.post( '/rest/v1.1/sites/2916284/plugins/install', { slug: 'fake' } )
 				.reply( 400, {
 					error: 'unknown_plugin',
 					message: 'Plugin file does not exist.',

--- a/packages/wpcom.js/src/lib/site.plugin.js
+++ b/packages/wpcom.js/src/lib/site.plugin.js
@@ -71,7 +71,10 @@ class SitePlugin {
 	 * @returns {Promise} Promise
 	 */
 	install( query, fn ) {
-		return this.wpcom.req.put( `${ this.pluginPath }/install`, query, fn );
+		const body = {
+			slug: this._slug,
+		};
+		return this.wpcom.req.post( `/install`, query, body, fn );
 	}
 
 	/**

--- a/packages/wpcom.js/src/lib/site.plugin.js
+++ b/packages/wpcom.js/src/lib/site.plugin.js
@@ -74,7 +74,7 @@ class SitePlugin {
 		const body = {
 			slug: this._slug,
 		};
-		return this.wpcom.req.post( `/install`, query, body, fn );
+		return this.wpcom.req.post( `${ root }/${ this._sid }/plugins/install`, query, body, fn );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Passes the plugin slug in a request body instead of a query parameter

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch `D72727` and sandbox `public-api`
* Visit a plugin page with `ads` in their name (eg. `/plugins/advanced-ads`)
* Open devtools and install the plugin
* Verify that the request is sent to the new endpoint with the plugin slug in the request body, and is successful:
  ![image](https://user-images.githubusercontent.com/11555574/148772081-1251c9c2-189c-4bce-b46a-85fea6c4f01e.png)
* Verify that the plugin is installed successfully

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58322
