### PR TITLE
Launch Checklist: Point Edit Homepage link to the Site Editor if site editor is enabled

### DIFF
--- a/client/state/selectors/get-front-page-editor-url.js
+++ b/client/state/selectors/get-front-page-editor-url.js
@@ -1,4 +1,6 @@
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 import getSiteFrontPage from 'calypso/state/sites/selectors/get-site-front-page';
 
 /**
@@ -14,5 +16,10 @@ export default function getFrontPageEditorUrl( state, siteId ) {
 	if ( 0 === frontPageId ) {
 		return false;
 	}
+
+	if ( isSiteUsingCoreSiteEditor( state, siteId ) ) {
+		return getSiteEditorUrl( state, siteId );
+	}
+
 	return getEditorUrl( state, siteId, frontPageId, 'page' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The following CTA button should point to the Site Editor for FSE Beta sites. With the latest Gutenberg updates the Editor got moved to the Appearance sub-menu, so it's harder for users to find now.

<img width="1075" alt="Screenshot 2021-12-16 at 18 43 06" src="https://user-images.githubusercontent.com/1182160/146422175-aea29a2f-474b-40e9-bc24-62a489d1f767.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up local calypso dev environment
* Apply this PR
* Visit the homepage for a site with core FSE enabled
* Verify that the Edit Homepage link points to the site editor
* Disable the site editor from the Appearance > Site Editor submenu
* Verify that the Edit Homepage link points to the post editor
* Switch to a site without core FSE enabled
* Verify that the Edit Homepage link points to the post editor

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/59312
