### PR TITLE
Enable Purchases section in Jetpack cloud

### DIFF
--- a/client/components/jetpack/portal-nav/style.scss
+++ b/client/components/jetpack/portal-nav/style.scss
@@ -1,4 +1,6 @@
-.portal-nav {
+// Making sure the styles below overwrite the .section-nav rules by increasing the selector
+// specificity with .section-nav, since we can't rely on the order stylesheets are loaded.
+.portal-nav.section-nav {
 	flex: 1 1 180px;
 	max-width: 280px;
 	margin: 0;

--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -1,7 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import SidebarItem from 'calypso/layout/sidebar/item';
-import { settingsPath } from 'calypso/lib/jetpack/paths';
+import { settingsPath, purchasesPath } from 'calypso/lib/jetpack/paths';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -27,6 +28,10 @@ export default ( { path } ) => {
 		canCurrentUser( state, siteId, 'manage_options' )
 	);
 
+	const shouldShowPurchases =
+		isEnabled( 'jetpack/purchases' ) &&
+		useSelector( ( state ) => canCurrentUser( state, siteId, 'own_site' ) );
+
 	return (
 		<>
 			<JetpackSidebarMenuItems
@@ -47,6 +52,17 @@ export default ( { path } ) => {
 					link={ settingsPath( siteSlug ) }
 					onNavigate={ onNavigate }
 					selected={ itemLinkMatches( [ settingsPath( siteSlug ) ], path ) }
+				/>
+			) }
+			{ shouldShowPurchases && (
+				<SidebarItem
+					customIcon={ <JetpackIcons icon="money" /> }
+					label={ translate( 'Purchases', {
+						comment: 'Jetpack sidebar navigation item',
+					} ) }
+					link={ purchasesPath( siteSlug ) }
+					onNavigate={ onNavigate }
+					selected={ itemLinkMatches( [ purchasesPath( siteSlug ) ], path ) }
 				/>
 			) }
 		</>

--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -1,9 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import { settingsPath, purchasesPath } from 'calypso/lib/jetpack/paths';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
+import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -29,7 +29,7 @@ export default ( { path } ) => {
 	);
 
 	const shouldShowPurchases =
-		isEnabled( 'jetpack/purchases' ) &&
+		isSectionNameEnabled( 'site-purchases' ) &&
 		useSelector( ( state ) => canCurrentUser( state, siteId, 'own_site' ) );
 
 	return (

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -2,22 +2,26 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'calypso/lib/url';
 
 const backupBasePath = () => '/backup';
-export const backupPath = ( siteSlug?: string, query = {} ) => {
+export const backupPath = ( siteSlug?: string, query = {} ): string => {
 	const path = siteSlug ? `${ backupBasePath() }/${ siteSlug }` : backupBasePath();
 	return addQueryArgs( query, path );
 };
 
 const scanBasePath = () => '/scan';
-export const scanPath = ( siteSlug?: string ) =>
+export const scanPath = ( siteSlug?: string ): string =>
 	siteSlug ? `${ scanBasePath() }/${ siteSlug }` : scanBasePath();
 
 const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : '/settings/jetpack' );
 
-export const settingsPath = ( siteSlug?: string, section?: string ) =>
+export const settingsPath = ( siteSlug?: string, section?: string ): string =>
 	`${ settingsBasePath() }${ section ? '/' + section : '' }${ siteSlug ? '/' + siteSlug : '' }`;
 
-export const settingsHostSelectionPath = ( siteSlug?: string ) =>
+export const settingsHostSelectionPath = ( siteSlug?: string ): string =>
 	settingsPath( siteSlug, 'host-selection' );
 
-export const settingsCredentialsPath = ( siteSlug: string, host: string ) =>
+export const settingsCredentialsPath = ( siteSlug: string, host: string ): string =>
 	settingsPath( siteSlug, `credentials/${ host }` );
+
+const purchasesBasePath = () => '/purchases';
+export const purchasesPath = ( siteSlug?: string ): string =>
+	siteSlug ? `${ purchasesBasePath() }/${ siteSlug }` : purchasesBasePath();

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -25,6 +25,7 @@ import moment from 'moment';
 import page from 'page';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import { errorNotice } from 'calypso/state/notices/actions';
 
@@ -163,7 +164,7 @@ function handleRenewNowClick( purchase, siteSlug, options = {} ) {
 	}
 	debug( 'handling renewal click', purchase, siteSlug, renewItem, renewalUrl );
 
-	page( renewalUrl );
+	page( isJetpackCloud() ? `https://wordpress.com${ renewalUrl }` : renewalUrl );
 }
 
 /**

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -45,6 +45,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	getDomainRegistrationAgreementUrl,
 	getDisplayName,
@@ -648,7 +649,9 @@ class ManagePurchase extends Component {
 				<span className="manage-purchase__description">{ this.getPurchaseDescription() }</span>
 
 				<span className="manage-purchase__settings-link">
-					{ site && <ProductLink purchase={ purchase } selectedSite={ site } /> }
+					{ ! isJetpackCloud() && site && (
+						<ProductLink purchase={ purchase } selectedSite={ site } />
+					) }
 				</span>
 
 				{ registrationAgreementUrl && (

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -1,10 +1,12 @@
 import config from '@automattic/calypso-config';
 import { useStripe } from '@automattic/calypso-stripe';
+import colorStudio from '@automattic/color-studio';
 import { Card, Gridicon } from '@automattic/components';
 import {
 	CheckoutProvider,
 	CheckoutPaymentMethods,
 	CheckoutSubmitButton,
+	checkoutTheme,
 } from '@automattic/composite-checkout';
 import { useElements, CardNumberElement } from '@stripe/react-stripe-js';
 import classNames from 'classnames';
@@ -35,6 +37,10 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
+
+const { colors } = colorStudio;
+const jetpackColors = isJetpackCloud() ? { highlight: colors[ 'Jetpack Green 50' ] } : {};
+const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
 function useLogError( message: string ): CheckoutPageErrorCallback {
 	return useCallback(
@@ -150,6 +156,7 @@ export default function PaymentMethodSelector( {
 				currentlyAssignedPaymentMethodId,
 				paymentMethods
 			) }
+			theme={ theme }
 		>
 			<Card
 				className={ classNames( 'payment-method-selector__content', {

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -7,12 +7,14 @@ import {
 	CheckoutSubmitButton,
 } from '@automattic/composite-checkout';
 import { useElements, CardNumberElement } from '@stripe/react-stripe-js';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice from 'calypso/components/notice';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { creditCardHasAlreadyExpired } from 'calypso/lib/purchases';
 import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
@@ -149,7 +151,11 @@ export default function PaymentMethodSelector( {
 				paymentMethods
 			) }
 		>
-			<Card className="payment-method-selector__content">
+			<Card
+				className={ classNames( 'payment-method-selector__content', {
+					'is-jetpack-cloud': isJetpackCloud(),
+				} ) }
+			>
 				<QueryPaymentCountries />
 				{ currentPaymentMethodNotAvailable && purchase && (
 					<CurrentPaymentMethodNotAvailableNotice purchase={ purchase } />

--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -41,6 +41,8 @@
 	.checkout-submit-button .checkout-button {
 		width: auto;
 
+		background-color: var( --color-accent );
+
 		&:focus {
 			outline: var( --color-primary-light ) solid 2px;
 		}

--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -57,14 +57,6 @@
 /* Jetpack cloud overwrites */
 
 .payment-method-selector__content.is-jetpack-cloud {
-	[class*='RadioButtonWrapper']::before {
-		border-color: var( --studio-jetpack-green-50 );
-	}
-
-	[class*='Label']::after {
-		background-color: var( --studio-jetpack-green-50 );
-	}
-
 	.components-checkbox-control__input[type='checkbox']:checked {
 		background-color: var( --studio-jetpack-green-50 );
 	}

--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -53,3 +53,23 @@
 	font-size: $font-body-small;
 	font-style: italic;
 }
+
+/* Jetpack cloud overwrites */
+
+.payment-method-selector__content.is-jetpack-cloud {
+	[class*='RadioButtonWrapper']::before {
+		border-color: var( --studio-jetpack-green-50 );
+	}
+
+	[class*='Label']::after {
+		background-color: var( --studio-jetpack-green-50 );
+	}
+
+	.components-checkbox-control__input[type='checkbox']:checked {
+		background-color: var( --studio-jetpack-green-50 );
+	}
+
+	.checkout-submit-button .checkout-button {
+		background-color: var( --studio-jetpack-green-50 );
+	}
+}

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -9,6 +9,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	isExpired,
 	isExpiring,
@@ -34,7 +35,13 @@ export class PlanBillingPeriod extends Component {
 			current_plan: purchase.productSlug,
 			upgrading_to: yearlyPlanSlug,
 		} );
-		page( '/checkout/' + purchase.domain + '/' + yearlyPlanSlug );
+		page(
+			( isJetpackCloud() ? 'https://wordpress.com' : '' ) +
+				'/checkout/' +
+				purchase.domain +
+				'/' +
+				yearlyPlanSlug
+		);
 	};
 
 	renderYearlyBillingInformation() {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -3,6 +3,8 @@
 	padding-inline-start: 16px;
 	padding-inline-end: 16px;
 
+	color: var( --color-link );
+
 	.card__link-indicator {
 		right: 16px;
 

--- a/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
+++ b/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import wpcom from 'calypso/lib/wp';
 import { updateStoredCardIsBackupComplete } from 'calypso/state/stored-cards/actions';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
@@ -82,6 +83,11 @@ export default function PaymentMethodBackupToggle( { card }: { card: StoredCard 
 								showText={ false }
 								supportContext="backup_payment_methods"
 								iconSize={ 16 }
+								supportLink={
+									isJetpackCloud()
+										? 'https://wordpress.com/support/payment/#manage-payment-methods'
+										: null
+								}
 							/>
 						),
 					},

--- a/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
+++ b/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
@@ -85,7 +85,7 @@ export default function PaymentMethodBackupToggle( { card }: { card: StoredCard 
 								iconSize={ 16 }
 								supportLink={
 									isJetpackCloud()
-										? 'https://wordpress.com/support/payment/#manage-payment-methods'
+										? 'https://wordpress.com/support/payment/#backup-payment-methods'
 										: null
 								}
 							/>

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -1,5 +1,7 @@
 import { CompactCard } from '@automattic/components';
+import classNames from 'classnames';
 import { FunctionComponent } from 'react';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import PaymentMethodDetails from './payment-method-details';
 import type { PaymentMethod as PaymentMethodType } from 'calypso/lib/checkout/payment-methods';
 
@@ -11,7 +13,11 @@ interface Props {
 
 const PaymentMethod: FunctionComponent< Props > = ( { card, children } ) => {
 	return (
-		<CompactCard className="payment-method__wrapper">
+		<CompactCard
+			className={ classNames( 'payment-method__wrapper', {
+				'is-jetpack-cloud': isJetpackCloud(),
+			} ) }
+		>
 			<div className="payment-method">
 				{ card ? <PaymentMethodDetails { ...card } /> : children }
 			</div>

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -77,7 +77,6 @@
 	font-size: 0.875rem;
 }
 
-
 .payment-method-delete-dialog {
 	&.dialog {
 		max-width: 440px;
@@ -97,5 +96,13 @@
 		margin: 4px 32px 4px 16px;
 		order: unset;
 		width: auto;
+	}
+}
+
+/* Jetpack cloud overwrites */
+
+.payment-method__wrapper.is-jetpack-cloud {
+	.components-checkbox-control__input[type='checkbox']:checked {
+		background-color: var( --studio-jetpack-green-50 );
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -88,9 +88,9 @@ export default function getThankYouPageUrl( {
 	debug( 'starting getThankYouPageUrl' );
 
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
-	// (i.e. on WordPress.com), the same site as the cart's site, or a Jetpack or WP.com
-	// site's block editor (in wp-admin). This is required for Jetpack's (and WP.com's)
-	// paid blocks Upgrade Nudge.
+	// (i.e. on WordPress.com), the same site as the cart's site, a Jetpack cloud URL,
+	// or a Jetpack or WP.com site's block editor (in wp-admin). This is required for Jetpack's
+	// (and WP.com's) paid blocks Upgrade Nudge.
 	if ( redirectTo ) {
 		const { protocol, hostname, port, pathname, query } = parseUrl( redirectTo, true, true );
 
@@ -119,6 +119,12 @@ export default function getThankYouPageUrl( {
 			debug( 'returning sanitized internal redirectTo', redirectTo );
 			return sanitizedRedirectTo;
 		}
+
+		if ( hostname === 'cloud.jetpack.com' ) {
+			debug( 'returning Jetpack cloud redirectTo', redirectTo );
+			return redirectTo;
+		}
+
 		debug( 'ignorning redirectTo', redirectTo );
 	}
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -829,6 +829,16 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=concierge' );
 	} );
 
+	it( 'redirects to a Jetpack cloud redirectTo', () => {
+		const redirectTo =
+			'http://cloud.jetpack.com/purchases/add-payment-method/fast-hummingbird.jurassic.ninja';
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			redirectTo,
+		} );
+		expect( url ).toBe( redirectTo );
+	} );
+
 	describe( 'Professional Email upsell', () => {
 		const domains = [
 			{

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -13,6 +13,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { showMasterbar } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getPurchaseURLCallback } from './get-purchase-url-callback';
 import getViewTrackerPath from './get-view-tracker-path';
@@ -101,6 +102,17 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 			}
 		},
 		[ highlightedProducts ]
+	);
+
+	useEffect(
+		() => () => {
+			// Show masterbar back when pricing page unmounts, to prevent it from disappearing
+			// from the previous page when hitting the browser back button.
+			if ( isJetpackCloud() ) {
+				dispatch( showMasterbar() );
+			}
+		},
+		[]
 	);
 
 	const createProductURL = getPurchaseURLCallback( siteSlug, urlQueryArgs );

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -11,6 +11,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { BillingHistoryContent } from 'calypso/me/purchases/billing-history/main';
 import {
@@ -64,20 +65,22 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 			<DocumentHead title={ titles.billingHistory } />
 			<PageViewTracker path="/purchases/billing-history" title="Billing History" />
 			<QueryBillingTransactions />
-			<FormattedHeader
-				brandFont
-				className="billing-history__page-heading"
-				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
-					'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="billing" showIcon={ false } />,
-						},
-					}
-				) }
-				align="left"
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					brandFont
+					className="billing-history__page-heading"
+					headerText={ titles.sectionTitle }
+					subHeaderText={ translate(
+						'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="billing" showIcon={ false } />,
+							},
+						}
+					) }
+					align="left"
+				/>
+			) }
 			<PurchasesNavigation sectionTitle={ 'Billing History' } siteSlug={ siteSlug } />
 
 			<CheckoutErrorBoundary
@@ -89,9 +92,11 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 					getReceiptUrlFor={ getReceiptUrlForReceiptId }
 				/>
 			</CheckoutErrorBoundary>
-			<CompactCard href="/me/purchases/billing">
-				{ translate( 'View all billing history and receipts' ) }
-			</CompactCard>
+			{ ! isJetpackCloud() && (
+				<CompactCard href="/me/purchases/billing">
+					{ translate( 'View all billing history and receipts' ) }
+				</CompactCard>
+			) }
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -8,6 +8,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { logToLogstash } from 'calypso/lib/logstash';
 import CancelPurchase from 'calypso/me/purchases/cancel-purchase';
 import ConfirmCancelDomain from 'calypso/me/purchases/confirm-cancel-domain';
@@ -54,20 +55,22 @@ export function Purchases(): JSX.Element {
 		<Main wideLayout className="purchases">
 			<MySitesSidebarNavigation />
 			<DocumentHead title={ titles.sectionTitle } />
-			<FormattedHeader
-				brandFont
-				className="purchases__page-heading"
-				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
-					'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
-						},
-					}
-				) }
-				align="left"
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					brandFont
+					className="purchases__page-heading"
+					headerText={ titles.sectionTitle }
+					subHeaderText={ translate(
+						'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
+							},
+						}
+					) }
+					align="left"
+				/>
+			) }
 			<PurchasesNavigation sectionTitle={ 'Active Upgrades' } siteSlug={ siteSlug } />
 
 			<CheckoutErrorBoundary
@@ -89,16 +92,19 @@ export function PurchaseDetails( {
 } ): JSX.Element {
 	const translate = useTranslate();
 	const logPurchasesError = useLogPurchasesError( 'site level purchase details load error' );
+	const redirectTo = getManagePurchaseUrlFor( siteSlug, purchaseId );
 
 	return (
 		<Main wideLayout className="purchases manage-purchase">
 			<DocumentHead title={ titles.managePurchase } />
-			<FormattedHeader
-				brandFont
-				className="purchases__page-heading"
-				headerText={ titles.sectionTitle }
-				align="left"
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					brandFont
+					className="purchases__page-heading"
+					headerText={ titles.sectionTitle }
+					align="left"
+				/>
+			) }
 			<PageViewTracker
 				path="/purchases/subscriptions/:site/:purchaseId"
 				title="Purchases > Manage Purchase"
@@ -114,7 +120,7 @@ export function PurchaseDetails( {
 					siteSlug={ siteSlug }
 					showHeader={ false }
 					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-					redirectTo={ getManagePurchaseUrlFor( siteSlug, purchaseId ) }
+					redirectTo={ isJetpackCloud() ? `https://cloud.jetpack.com${ redirectTo }` : redirectTo }
 					getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 					getAddNewPaymentMethodUrlFor={ getAddNewPaymentMethodUrlFor }
 					getChangePaymentMethodUrlFor={ getChangeOrAddPaymentMethodUrlFor }
@@ -138,12 +144,14 @@ export function PurchaseCancel( {
 	return (
 		<Main wideLayout className="purchases">
 			<DocumentHead title={ titles.cancelPurchase } />
-			<FormattedHeader
-				brandFont
-				className="purchases__page-heading"
-				headerText={ titles.sectionTitle }
-				align="left"
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					brandFont
+					className="purchases__page-heading"
+					headerText={ titles.sectionTitle }
+					align="left"
+				/>
+			) }
 
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
@@ -176,12 +184,14 @@ export function PurchaseChangePaymentMethod( {
 	return (
 		<Main wideLayout className="purchases">
 			<DocumentHead title={ titles.changePaymentMethod } />
-			<FormattedHeader
-				brandFont
-				className="purchases__page-heading"
-				headerText={ titles.sectionTitle }
-				align="left"
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					brandFont
+					className="purchases__page-heading"
+					headerText={ titles.sectionTitle }
+					align="left"
+				/>
+			) }
 
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
@@ -211,12 +221,14 @@ export function PurchaseCancelDomain( {
 	return (
 		<Main wideLayout className="purchases">
 			<DocumentHead title={ titles.confirmCancelDomain } />
-			<FormattedHeader
-				brandFont
-				className="purchases__page-heading"
-				headerText={ titles.sectionTitle }
-				align="left"
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					brandFont
+					className="purchases__page-heading"
+					headerText={ titles.sectionTitle }
+					align="left"
+				/>
+			) }
 
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -15,6 +15,7 @@ import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
@@ -59,22 +60,24 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ): JSX.Elemen
 			<MySitesSidebarNavigation />
 			<DocumentHead title={ titles.paymentMethods } />
 			<PageViewTracker path="/purchases/payment-methods" title="Payment Methods" />
-			<FormattedHeader
-				brandFont
-				className="payment-methods__page-heading"
-				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
-					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: (
-								<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
-							),
-						},
-					}
-				) }
-				align="left"
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					brandFont
+					className="payment-methods__page-heading"
+					headerText={ titles.sectionTitle }
+					subHeaderText={ translate(
+						'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
+								),
+							},
+						}
+					) }
+					align="left"
+				/>
+			) }
 			<PurchasesNavigation sectionTitle={ 'Payment Methods' } siteSlug={ siteSlug } />
 
 			<CheckoutErrorBoundary
@@ -128,12 +131,14 @@ function SiteLevelAddNewPaymentMethodForm( { siteSlug }: { siteSlug: string } ):
 				title={ String( titles.addPaymentMethod ) }
 			/>
 			<DocumentHead title={ titles.addPaymentMethod } />
-			<FormattedHeader
-				brandFont
-				className="payment-methods__page-heading"
-				headerText={ titles.sectionTitle }
-				align="left"
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					brandFont
+					className="payment-methods__page-heading"
+					headerText={ titles.sectionTitle }
+					align="left"
+				/>
+			) }
 
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }

--- a/client/my-sites/purchases/subscriptions/index.tsx
+++ b/client/my-sites/purchases/subscriptions/index.tsx
@@ -1,8 +1,8 @@
 import { useSelector } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
-import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AccountLevelPurchaseLinks from './account-level-purchase-links';
 import SubscriptionsContent from './subscriptions-content';
@@ -11,12 +11,12 @@ export default function Subscriptions() {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	return (
-		<Main wideLayout className="subscriptions">
+		<div className="subscriptions">
 			<QuerySitePurchases siteId={ selectedSiteId } />
 			<QueryStoredCards />
 			<PageViewTracker path="/purchases/subscriptions" title="Subscriptions" />
 			<SubscriptionsContent />
-			<AccountLevelPurchaseLinks />
-		</Main>
+			{ ! isJetpackCloud() && <AccountLevelPurchaseLinks /> }
+		</div>
 	);
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -48,6 +48,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
+		"jetpack/user-licensing": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -72,7 +72,8 @@
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
 		"jetpack-search": true,
-		"scan": true
+		"scan": true,
+		"site-purchases": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -40,6 +40,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
+		"jetpack/user-licensing": true,
 		"jetpack/redirect-legacy-plans": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
@@ -64,7 +65,8 @@
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
 		"jetpack-search": true,
-		"scan": true
+		"scan": true,
+		"site-purchases": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud"

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -45,6 +45,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
+		"jetpack/user-licensing": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,
@@ -69,7 +70,8 @@
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
 		"jetpack-search": true,
-		"scan": true
+		"scan": true,
+		"site-purchases": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds the _Purchases_ section that's already present in Calypso to Jetpack cloud.

_Note: the section is only added in development at the moment_.

Fixes 1164141197617539-as-1201046286910953

### Implementation notes

This PR is a minimum viable implementation of this section in cloud. Later feedback will help us determine if it provides a good experience in cloud or if we'll need to iterate on it.

Here's what differs in the cloud implementation:
- Formatted headers and descriptive texts are absent, to match the current UI of cloud.
- The _View all purchases_ and _View all billing history and receipts_ links are removed as well. They direct to the WordPress profile, and we want to avoid users switching between platforms.

### Testing instructions

#### Testing scenarios
- Site with a free plan
- Site with a monthly subscription (so that we can test the upgrade to yearly feature)
- Site with a lesser product or plan subscription (so that we can test the upgrade to a better product)

#### Regression testing

- Download the PR and run Calypso blue
- Make sure you have a self-hosted site with a Jetpack subscription
- Visit `/purchases/subscriptions/:site`
- Check that the _Active Upgrades_, _Billing History_, and _Payment Methods_ sections looks and behaves as in production
- Make sure you tested the 3 scenarios mentioned above

#### Cloud implementation

- Download the PR and run cloud
- Make sure you have a self-hosted site with a Jetpack subscription
- Check that you can see the _Purchases_ section in the sidebar navigation
- Check that the _Active Upgrades_, _Billing History_, and _Payment Methods_ sections looks and behaves as expected, keeping in mind the differences mentioned in the implementation notes
- Make sure you tested the 3 scenarios mentioned above

_Note: in development, it's normal that you're redirected to `wordpress.com` after having renewed a subscription._

### Screenshots

_Purchases_ section in Jetpack cloud
<img width="686" alt="Screen Shot 2021-12-17 at 10 19 19 AM" src="https://user-images.githubusercontent.com/1620183/146566581-2453c495-827b-4e4b-9638-47d75122e3ba.png">

