### PR TITLE
Videos UI - Remove API persistence when fetching course information

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -16,7 +16,7 @@ const VideosUi = ( { HeaderBar, FooterBar, areVideosTranslated = true } ) => {
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
 
 	const courseSlug = 'blogging-quick-start';
-	const { data: course } = useCourseQuery( courseSlug, { retry: false } );
+	const { data: course } = useCourseQuery( courseSlug, { retry: false, meta: { persist: false } } );
 	const { updateUserCourseProgression } = useUpdateUserCourseProgressionMutation();
 
 	const initialUserCourseProgression = useMemo( () => course?.completions ?? [], [ course ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the Videos UI, disabling the persistence setting for the query to the courses API; this allows the interface to immediately reflect any updates made to the data via the upcoming new management interface.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this diff to local Calypso.
* Sandbox the API and comment out line 104 in `wp-content/mu-plugins/courses.php` (so the API falls back to the management plugin content).
* Reorder the course videos in the management interface and then reload Calypso. Verify that the videos UI immediately reflects the updated content order.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1639675542235900-slack-C029SB8JT8S