### PR TITLE
Add "Edit Site" Quick Start link on FSE enabled sites

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -82,7 +82,7 @@ export const QuickLinks = ( {
 
 	const quickLinks = (
 		<div className="quick-links__boxes">
-			{ isFSEActive ? (
+			{ isFSEActive && canManageSite ? (
 				<ActionBox
 					href={ `/site-editor/${ siteSlug }` }
 					hideLinkIndicator

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -33,6 +33,7 @@ export const QuickLinks = ( {
 	canCustomize,
 	canSwitchThemes,
 	canManageSite,
+	canModerateComments,
 	customizeUrl,
 	isStaticHomePage,
 	showCustomizer,
@@ -99,7 +100,7 @@ export const QuickLinks = ( {
 				label={ translate( 'Write blog post' ) }
 				materialIcon="edit"
 			/>
-			{ ! isStaticHomePage && (
+			{ ! isStaticHomePage && canModerateComments && (
 				<ActionBox
 					href={ `/comments/${ siteSlug }` }
 					hideLinkIndicator
@@ -369,6 +370,7 @@ const mapStateToProps = ( state ) => {
 		canCustomize: canCurrentUser( state, siteId, 'customize' ),
 		canSwitchThemes: canCurrentUser( state, siteId, 'switch_themes' ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
+		canModerateComments: canCurrentUser( state, siteId, 'moderate_comments' ),
 		customizeUrl: getCustomizerUrl( state, siteId ),
 		menusUrl: getCustomizerUrl( state, siteId, 'menus' ),
 		isNewlyCreatedSite: isNewSite( state, siteId ),

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -55,8 +55,11 @@ export const QuickLinks = ( {
 	siteAdminUrl,
 	editHomePageUrl,
 	siteSlug,
+	blockEditorSettings,
 	areBlockEditorSettingsLoading,
 } ) => {
+	const isFSEActive = blockEditorSettings?.is_fse_active ?? false;
+
 	const translate = useTranslate();
 	const [
 		debouncedUpdateHomeQuickLinksToggleStatus,
@@ -64,16 +67,28 @@ export const QuickLinks = ( {
 		flushDebouncedUpdateHomeQuickLinksToggleStatus,
 	] = useDebouncedCallback( updateHomeQuickLinksToggleStatus, 1000 );
 
+	const customizerLinks =
+		isStaticHomePage && canEditPages ? (
+			<ActionBox
+				href={ editHomePageUrl }
+				hideLinkIndicator
+				onClick={ trackEditHomepageAction }
+				label={ translate( 'Edit homepage' ) }
+				materialIcon="laptop"
+			/>
+		) : null;
+
 	const quickLinks = (
 		<div className="quick-links__boxes">
-			{ Boolean( isStaticHomePage && canEditPages ) && (
+			{ isFSEActive ? (
 				<ActionBox
-					href={ editHomePageUrl }
+					href={ `/site-editor/${ siteSlug }` }
 					hideLinkIndicator
-					onClick={ trackEditHomepageAction }
-					label={ translate( 'Edit homepage' ) }
+					label={ translate( 'Edit site' ) }
 					materialIcon="laptop"
 				/>
+			) : (
+				customizerLinks
 			) }
 			<ActionBox
 				href={ `/post/${ siteSlug }` }

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -5,6 +5,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import anchorLogoIcon from 'calypso/assets/images/customer-home/anchor-logo-grey.svg';
 import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
 import FoldableCard from 'calypso/components/foldable-card';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { hasPaidEmailWithUs } from 'calypso/lib/emails';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -54,6 +55,7 @@ export const QuickLinks = ( {
 	siteAdminUrl,
 	editHomePageUrl,
 	siteSlug,
+	areBlockEditorSettingsLoading,
 } ) => {
 	const translate = useTranslate();
 	const [
@@ -188,6 +190,10 @@ export const QuickLinks = ( {
 			flushDebouncedUpdateHomeQuickLinksToggleStatus();
 		};
 	}, [] );
+
+	if ( areBlockEditorSettingsLoading ) {
+		return null;
+	}
 
 	return (
 		<FoldableCard
@@ -390,4 +396,10 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	};
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( QuickLinks );
+const ConnectedQuickLinks = connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	mergeProps
+)( QuickLinks );
+
+export default withBlockEditorSettings( ConnectedQuickLinks );

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -43,6 +43,7 @@ export const QuickLinks = ( {
 	trackAddPageAction,
 	trackManageCommentsAction,
 	trackEditMenusAction,
+	trackEditSiteAction,
 	trackCustomizeThemeAction,
 	trackChangeThemeAction,
 	trackDesignLogoAction,
@@ -84,6 +85,7 @@ export const QuickLinks = ( {
 				<ActionBox
 					href={ `/site-editor/${ siteSlug }` }
 					hideLinkIndicator
+					onClick={ trackEditSiteAction }
 					label={ translate( 'Edit site' ) }
 					materialIcon="laptop"
 				/>
@@ -276,6 +278,12 @@ const trackEditMenusAction = ( isStaticHomePage ) =>
 		bumpStat( 'calypso_customer_home', 'my_site_edit_menus' )
 	);
 
+const trackEditSiteAction = () =>
+	composeAnalytics(
+		recordTracksEvent( 'calypso_customer_home_my_site_site_editor_link' ),
+		bumpStat( 'calypso_customer_home', 'my_site_site_editor' )
+	);
+
 const trackCustomizeThemeAction = ( isStaticHomePage ) =>
 	composeAnalytics(
 		recordTracksEvent( 'calypso_customer_home_my_site_customize_theme_click', {
@@ -381,6 +389,7 @@ const mapDispatchToProps = {
 	trackAddPageAction,
 	trackManageCommentsAction,
 	trackEditMenusAction,
+	trackEditSiteAction,
 	trackCustomizeThemeAction,
 	trackChangeThemeAction,
 	trackDesignLogoAction,

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -64,56 +64,39 @@ export const QuickLinks = ( {
 
 	const quickLinks = (
 		<div className="quick-links__boxes">
-			{ isStaticHomePage && canEditPages ? (
-				<>
-					<ActionBox
-						href={ editHomePageUrl }
-						hideLinkIndicator
-						onClick={ trackEditHomepageAction }
-						label={ translate( 'Edit homepage' ) }
-						materialIcon="laptop"
-					/>
-					<ActionBox
-						href={ `/page/${ siteSlug }` }
-						hideLinkIndicator
-						onClick={ trackAddPageAction }
-						label={ translate( 'Add a page' ) }
-						materialIcon="insert_drive_file"
-					/>
-					<ActionBox
-						href={ `/post/${ siteSlug }` }
-						hideLinkIndicator
-						onClick={ trackWritePostAction }
-						label={ translate( 'Write blog post' ) }
-						materialIcon="edit"
-					/>
-				</>
-			) : (
-				<>
-					<ActionBox
-						href={ `/post/${ siteSlug }` }
-						hideLinkIndicator
-						onClick={ trackWritePostAction }
-						label={ translate( 'Write blog post' ) }
-						materialIcon="edit"
-					/>
-					<ActionBox
-						href={ `/comments/${ siteSlug }` }
-						hideLinkIndicator
-						onClick={ trackManageCommentsAction }
-						label={ translate( 'Manage comments' ) }
-						materialIcon="mode_comment"
-					/>
-					{ canEditPages && (
-						<ActionBox
-							href={ `/page/${ siteSlug }` }
-							hideLinkIndicator
-							onClick={ trackAddPageAction }
-							label={ translate( 'Add a page' ) }
-							materialIcon="insert_drive_file"
-						/>
-					) }
-				</>
+			{ Boolean( isStaticHomePage && canEditPages ) && (
+				<ActionBox
+					href={ editHomePageUrl }
+					hideLinkIndicator
+					onClick={ trackEditHomepageAction }
+					label={ translate( 'Edit homepage' ) }
+					materialIcon="laptop"
+				/>
+			) }
+			<ActionBox
+				href={ `/post/${ siteSlug }` }
+				hideLinkIndicator
+				onClick={ trackWritePostAction }
+				label={ translate( 'Write blog post' ) }
+				materialIcon="edit"
+			/>
+			{ ! isStaticHomePage && (
+				<ActionBox
+					href={ `/comments/${ siteSlug }` }
+					hideLinkIndicator
+					onClick={ trackManageCommentsAction }
+					label={ translate( 'Manage comments' ) }
+					materialIcon="mode_comment"
+				/>
+			) }
+			{ canEditPages && (
+				<ActionBox
+					href={ `/page/${ siteSlug }` }
+					hideLinkIndicator
+					onClick={ trackAddPageAction }
+					label={ translate( 'Add a page' ) }
+					materialIcon="insert_drive_file"
+				/>
 			) }
 			{ showCustomizer && canCustomize && (
 				<>


### PR DESCRIPTION
#### Testing instructions

- Check out this branch;
- Open Calypso;
- Select a site that has FSE enabled.

Check that "Edit Site" is shown as the first quick link in the dashboard.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59313.

#### Screenshot

![image](https://user-images.githubusercontent.com/26530524/146597972-9dccac47-6f24-4383-9bce-5d0a339eb1f8.png)

#### Additional information

I did some logic refactor on the quick links list. It made sense since most things were actually shared and the ternaries were confusing.

This also adds a `manage_comments` capability check to show the "Manage comments" link, since users without that capability can't take any action on comments (although they can see the comments).