### PR TITLE
ICFY: Remove build step which uploads missing file

### DIFF
--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-        run: yarn install
+        run: yarn install --inline-builds
       - name: Build ICFY stats
         env:
           NODE_ENV: production

--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -21,12 +21,6 @@ jobs:
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
         run: yarn install
-      - name: Capture yarn logs
-        uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: yarn-logs
-          path: yarn-error.log
       - name: Build ICFY stats
         env:
           NODE_ENV: production


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When `yarn install` fails in ICFY, the step attempts to upload the error-log file. Unfortunately, this file was removed in yarn 2, so this fails. ([Here's an example](https://github.com/Automattic/wp-calypso/runs/4540389300?check_suite_focus=true#step:6:7).)

```sh
Error: Path does not exist /home/runner/work/wp-calypso/wp-calypso/yarn-error.log
```
One thing we could do is pipe all yarn output into this file ourselves, but do we need to save the file? It seems to me, we can find all the information we need in the normal yarn output. Were we using this file for anything specific?

#### Testing instructions
- ICFY should pass.
