### PR TITLE
Domains: Make renewal/expiry text translatable in domains list in mobile view

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -152,21 +152,27 @@ class DomainRow extends PureComponent {
 	}
 
 	renderMobileExtraInfo( expiryDate, domainTypeText ) {
-		const { domain } = this.props;
+		const { domain, translate } = this.props;
 
 		let extraInfo = '';
 		if ( domainTypeText ) {
 			extraInfo = domainTypeText;
 		} else if ( domain.expired ) {
 			if ( expiryDate ) {
-				extraInfo = 'Expired on ' + expiryDate.format( 'LL' );
+				extraInfo = translate( 'Expired on %(expiryDate)s', {
+					args: { expiryDate: expiryDate.format( 'LL' ) },
+				} );
 			} else {
-				extraInfo = 'Expired';
+				extraInfo = translate( 'Expired' );
 			}
 		} else if ( domain.isAutoRenewing && domain.autoRenewalDate ) {
-			extraInfo = 'Renews on ' + moment.utc( domain.autoRenewalDate ).format( 'LL' );
+			extraInfo = translate( 'Renews on %(renewalDate)s', {
+				args: { renewalDate: moment.utc( domain.autoRenewalDate ).format( 'LL' ) },
+			} );
 		} else if ( expiryDate ) {
-			extraInfo = 'Expires on ' + expiryDate.format( 'LL' );
+			extraInfo = translate( 'Expires on %(expiryDate)s', {
+				args: { expiryDate: expiryDate.format( 'LL' ) },
+			} );
 		}
 
 		return <div className="domain-row__mobile-extra-info">{ extraInfo }</div>;


### PR DESCRIPTION
### Changes proposed in this Pull Request

I realized that I added some untranslatable strings in #57253 🤦 These strings are only shown in mobile view and present some extra info about the renewal/expiration date of each domain in a site's domains list. Check the following screenshot:

![Markup on 2021-12-16 at 20:16:52](https://user-images.githubusercontent.com/5324818/146463331-4c76b4ed-3866-49d0-bc2e-35c8a496050f.png)

The snippets pointed by arrows are some of the untranslatable ones. This PR fixes this issue by making these strings translatable.

### Testing instructions

- Code inspection
- There should be no visible change when you visit a sites domains list (`Upgrades > Domains`). The strings should read the same until the next translation round is processed