### PR TITLE
Domains: Create new domain privacy card

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -2,6 +2,7 @@
 import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { sslStatuses } from 'calypso/lib/domains/constants';
+import { getSslReadableStatus } from '../../helpers';
 import type { DetailsCardProps } from '../types';
 
 import './style.scss';
@@ -33,18 +34,6 @@ const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | nu
 		}
 	};
 
-	const getSslSubtitle = () => {
-		switch ( sslStatus ) {
-			case sslStatuses.SSL_ACTIVE:
-				return translate( 'SSL certificate active' );
-			case sslStatuses.SSL_PENDING:
-				return translate( 'SSL certificate pending' );
-			case sslStatuses.SSL_DISABLED:
-			default:
-				return translate( 'Problem with SSL certificate' );
-		}
-	};
-
 	const sslStatusMessage = getSslStatusMessage();
 
 	return (
@@ -56,7 +45,7 @@ const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | nu
 			>
 				<>
 					<Icon icon={ lock } size={ 18 } viewBox="0 0 22 22" />
-					{ getSslSubtitle() }
+					{ getSslReadableStatus( domain ) }
 				</>
 			</div>
 			<div className="domain-security-details__description">

--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { Icon, lock } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { sslStatuses } from 'calypso/lib/domains/constants';
+import type { DetailsCardProps } from '../types';
+
+import './style.scss';
+
+const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | null => {
+	const translate = useTranslate();
+
+	const { pointsToWpcom, sslStatus } = domain;
+
+	if ( ! pointsToWpcom || ! sslStatus ) {
+		return null;
+	}
+
+	const getSslStatusMessage = () => {
+		switch ( sslStatus ) {
+			case sslStatuses.SSL_ACTIVE:
+				return null;
+			case sslStatuses.SSL_PENDING:
+				return translate(
+					'It may take up to a few hours hours to add an SSL certificate to your site. If you are not seeing it yet, give it some time to take effect.',
+					{ textOnly: true }
+				);
+			case sslStatuses.SSL_DISABLED:
+			default:
+				return translate(
+					'There is an issue with your certificate. Contact us to {{a}}learn more{{/a}}.',
+					{ components: { a: <a href="#" /> } }
+				);
+		}
+	};
+
+	const getSslSubtitle = () => {
+		switch ( sslStatus ) {
+			case sslStatuses.SSL_ACTIVE:
+				return translate( 'SSL certificate active' );
+			case sslStatuses.SSL_PENDING:
+				return translate( 'SSL certificate pending' );
+			case sslStatuses.SSL_DISABLED:
+			default:
+				return translate( 'Problem with SSL certificate' );
+		}
+	};
+
+	const sslStatusMessage = getSslStatusMessage();
+
+	return (
+		<div className="domain-security-details__card">
+			<div
+				className={ `domain-security-details__icon domain-security-details__icon--${
+					sslStatuses.SSL_ACTIVE === sslStatus ? 'success' : 'warning'
+				}` }
+			>
+				<>
+					<Icon icon={ lock } size={ 18 } viewBox="0 0 22 22" />
+					{ getSslSubtitle() }
+				</>
+			</div>
+			<div className="domain-security-details__description">
+				{ sslStatusMessage && (
+					<p className="domain-security-details__description-message">{ sslStatusMessage }</p>
+				) }
+				<div className="domain-security-details__description-help-text">
+					{ translate(
+						'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. {{a}}Learn more{{/a}}',
+						{ components: { a: <a href="#" /> } }
+					) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default DomainSecurityDetails;

--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { sslStatuses } from 'calypso/lib/domains/constants';
+import { CONTACT, HTTPS_SSL } from 'calypso/lib/url/support';
 import { getSslReadableStatus } from '../../helpers';
 import type { DetailsCardProps } from '../types';
 
@@ -29,7 +29,7 @@ const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | nu
 			default:
 				return translate(
 					'There is an issue with your certificate. Contact us to {{a}}learn more{{/a}}.',
-					{ components: { a: <a href="#" /> } }
+					{ components: { a: <a href={ CONTACT } /> } }
 				);
 		}
 	};
@@ -55,7 +55,7 @@ const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | nu
 				<div className="domain-security-details__description-help-text">
 					{ translate(
 						'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. {{a}}Learn more{{/a}}',
-						{ components: { a: <a href="#" /> } }
+						{ components: { a: <a href={ HTTPS_SSL } /> } }
 					) }
 				</div>
 			</div>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -2,7 +2,7 @@ import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { sslStatuses } from 'calypso/lib/domains/constants';
 import { CONTACT, HTTPS_SSL } from 'calypso/lib/url/support';
-import { getSslReadableStatus } from '../../helpers';
+import { getSslReadableStatus, isSecuredWithUs } from '../../helpers';
 import type { DetailsCardProps } from '../types';
 
 import './style.scss';
@@ -10,11 +10,11 @@ import './style.scss';
 const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
 
-	const { pointsToWpcom, sslStatus } = domain;
-
-	if ( ! pointsToWpcom || ! sslStatus ) {
+	if ( ! isSecuredWithUs( domain ) ) {
 		return null;
 	}
+
+	const { sslStatus } = domain;
 
 	const getSslStatusMessage = () => {
 		switch ( sslStatus ) {

--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/style.scss
@@ -15,7 +15,7 @@
         svg {
             margin: 0 8px 0 3px;
         }
-        
+
         &--warning {
             svg {
                 fill: var( --studio-orange-40 );

--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/style.scss
@@ -1,0 +1,31 @@
+.domain-security-details {
+    &__card {
+        font-size: $font-body-small;
+        color: var( --studio-gray-80 );
+        display: flex;
+        flex-direction: column;
+        row-gap: 8px;
+    }
+
+    &__icon {
+        display: flex;
+        align-items: center;
+        font-weight: 500;
+
+        svg {
+            margin: 0 8px 0 3px;
+        }
+        
+        &--warning {
+            svg {
+                fill: var( --studio-orange-40 );
+            }
+        }
+
+        &--success {
+            svg {
+                fill: var( --studio-green-50 );
+            }
+        }
+    }
+}

--- a/client/my-sites/domains/domain-management/settings/helpers.ts
+++ b/client/my-sites/domains/domain-management/settings/helpers.ts
@@ -1,0 +1,27 @@
+import { __ } from '@wordpress/i18n';
+import { sslStatuses } from 'calypso/lib/domains/constants';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+const sslReadableStatus = {
+	get ACTIVE() {
+		return __( 'SSL certificate active' );
+	},
+	get PENDING() {
+		return __( 'SSL certificate pending' );
+	},
+	get DISABLED() {
+		return __( 'Problem with SSL certificate' );
+	},
+} as const;
+
+export const getSslReadableStatus = ( { sslStatus }: ResponseDomain ): string => {
+	switch ( sslStatus ) {
+		case sslStatuses.SSL_ACTIVE:
+			return sslReadableStatus.ACTIVE;
+		case sslStatuses.SSL_PENDING:
+			return sslReadableStatus.PENDING;
+		case sslStatuses.SSL_DISABLED:
+		default:
+			return sslReadableStatus.DISABLED;
+	}
+};

--- a/client/my-sites/domains/domain-management/settings/helpers.ts
+++ b/client/my-sites/domains/domain-management/settings/helpers.ts
@@ -14,6 +14,9 @@ const sslReadableStatus = {
 	},
 } as const;
 
+export const isSecuredWithUs = ( { pointsToWpcom, sslStatus }: ResponseDomain ) =>
+	pointsToWpcom && sslStatus;
+
 export const getSslReadableStatus = ( { sslStatus }: ResponseDomain ): string => {
 	switch ( sslStatus ) {
 		case sslStatuses.SSL_ACTIVE:

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -23,7 +23,7 @@ import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import DomainSecurityDetails from './cards/domain-security-details';
 import RegisteredDomainDetails from './cards/registered-domain-details';
-import { getSslReadableStatus } from './helpers';
+import { getSslReadableStatus, isSecuredWithUs } from './helpers';
 import SetAsPrimary from './set-as-primary';
 import SettingsHeader from './settings-header';
 import type { SettingsPageConnectedProps, SettingsPageProps } from './types';
@@ -63,16 +63,7 @@ const Settings = ( {
 	};
 
 	const renderSecurityAccordion = () => {
-		const domainSecurityCard = (
-			<DomainSecurityDetails
-				domain={ domain }
-				selectedSite={ selectedSite }
-				purchase={ purchase }
-				isLoadingPurchase={ isLoadingPurchase }
-			/>
-		);
-
-		if ( ! domainSecurityCard ) return null;
+		if ( ! isSecuredWithUs( domain ) ) return null;
 
 		return (
 			<Accordion
@@ -80,7 +71,12 @@ const Settings = ( {
 				subtitle={ getSslReadableStatus( domain ) }
 				key="security"
 			>
-				{ domainSecurityCard }
+				<DomainSecurityDetails
+					domain={ domain }
+					selectedSite={ selectedSite }
+					purchase={ purchase }
+					isLoadingPurchase={ isLoadingPurchase }
+				/>
 			</Accordion>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -86,7 +86,7 @@ const Settings = ( {
 		};
 
 		return (
-			<Accordion title={ translate( 'Domain security' ) } subtitle={ getSubtitle() } expanded>
+			<Accordion title={ translate( 'Domain security' ) } subtitle={ getSubtitle() } key="security">
 				{ domainSecurityCard }
 			</Accordion>
 		);
@@ -99,6 +99,7 @@ const Settings = ( {
 				<Accordion
 					title={ translate( 'Details', { textOnly: true } ) }
 					subtitle={ translate( 'Registration and auto-renew', { textOnly: true } ) }
+					key="main"
 					expanded
 				>
 					<RegisteredDomainDetails
@@ -114,6 +115,7 @@ const Settings = ( {
 				<Accordion
 					title={ translate( 'Details', { textOnly: true } ) }
 					subtitle={ translate( 'Domain connection details', { textOnly: true } ) }
+					key="main"
 					expanded
 				>
 					<ConnectedDomainDetails

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -6,7 +6,7 @@ import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layo
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
-import { type as domainTypes } from 'calypso/lib/domains/constants';
+import { sslStatuses, type as domainTypes } from 'calypso/lib/domains/constants';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainDeleteInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/delete';
 import DomainEmailInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/email';
@@ -21,6 +21,7 @@ import {
 } from 'calypso/state/purchases/selectors';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import ConnectedDomainDetails from './cards/connected-domain-details';
+import DomainSecurityDetails from './cards/domain-security-details';
 import RegisteredDomainDetails from './cards/registered-domain-details';
 import SetAsPrimary from './set-as-primary';
 import SettingsHeader from './settings-header';
@@ -60,9 +61,41 @@ const Settings = ( {
 		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
 	};
 
+	const renderSecurityAccordion = () => {
+		const domainSecurityCard = (
+			<DomainSecurityDetails
+				domain={ domain }
+				selectedSite={ selectedSite }
+				purchase={ purchase }
+				isLoadingPurchase={ isLoadingPurchase }
+			/>
+		);
+
+		if ( ! domainSecurityCard ) return null;
+
+		const getSubtitle = () => {
+			switch ( domain.sslStatus ) {
+				case sslStatuses.SSL_ACTIVE:
+					return translate( 'SSL certificate active', { textOnly: true } );
+				case sslStatuses.SSL_PENDING:
+					return translate( 'SSL certificate pending', { textOnly: true } );
+				case sslStatuses.SSL_DISABLED:
+				default:
+					return translate( 'Problem with SSL certificate', { textOnly: true } );
+			}
+		};
+
+		return (
+			<Accordion title={ translate( 'Domain security' ) } subtitle={ getSubtitle() } expanded>
+				{ domainSecurityCard }
+			</Accordion>
+		);
+	};
+
 	const renderDetailsSection = () => {
+		const accordions: JSX.Element[] = [];
 		if ( domain.type === domainTypes.REGISTERED ) {
-			return (
+			accordions.push(
 				<Accordion
 					title={ translate( 'Details', { textOnly: true } ) }
 					subtitle={ translate( 'Registration and auto-renew', { textOnly: true } ) }
@@ -77,7 +110,7 @@ const Settings = ( {
 				</Accordion>
 			);
 		} else if ( domain.type === domainTypes.MAPPED ) {
-			return (
+			accordions.push(
 				<Accordion
 					title={ translate( 'Details', { textOnly: true } ) }
 					subtitle={ translate( 'Domain connection details', { textOnly: true } ) }
@@ -93,7 +126,12 @@ const Settings = ( {
 			);
 		}
 
-		return null;
+		const securityAccordion = renderSecurityAccordion();
+		if ( securityAccordion ) {
+			accordions.push( securityAccordion );
+		}
+
+		return accordions;
 	};
 
 	const renderSetAsPrimaryDomainSection = () => {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -76,7 +76,7 @@ const Settings = ( {
 
 		return (
 			<Accordion
-				title={ translate( 'Domain security' ) }
+				title={ translate( 'Domain security', { textOnly: true } ) }
 				subtitle={ getSslReadableStatus( domain ) }
 				key="security"
 			>
@@ -86,9 +86,8 @@ const Settings = ( {
 	};
 
 	const renderDetailsSection = () => {
-		const accordions: JSX.Element[] = [];
 		if ( domain.type === domainTypes.REGISTERED ) {
-			accordions.push(
+			return (
 				<Accordion
 					title={ translate( 'Details', { textOnly: true } ) }
 					subtitle={ translate( 'Registration and auto-renew', { textOnly: true } ) }
@@ -104,7 +103,7 @@ const Settings = ( {
 				</Accordion>
 			);
 		} else if ( domain.type === domainTypes.MAPPED ) {
-			accordions.push(
+			return (
 				<Accordion
 					title={ translate( 'Details', { textOnly: true } ) }
 					subtitle={ translate( 'Domain connection details', { textOnly: true } ) }
@@ -120,17 +119,14 @@ const Settings = ( {
 				</Accordion>
 			);
 		}
-
-		const securityAccordion = renderSecurityAccordion();
-		if ( securityAccordion ) {
-			accordions.push( securityAccordion );
-		}
-
-		return accordions;
 	};
 
 	const renderSetAsPrimaryDomainSection = () => {
-		return <SetAsPrimary domain={ domain } selectedSite={ selectedSite } />;
+		return <SetAsPrimary domain={ domain } selectedSite={ selectedSite } key="set-as-primary" />;
+	};
+
+	const renderDomainSecuritySection = () => {
+		return renderSecurityAccordion();
 	};
 
 	const renderMainContent = () => {
@@ -139,6 +135,7 @@ const Settings = ( {
 			<>
 				{ renderDetailsSection() }
 				{ renderSetAsPrimaryDomainSection() }
+				{ renderDomainSecuritySection() }
 			</>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -6,7 +6,7 @@ import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layo
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
-import { sslStatuses, type as domainTypes } from 'calypso/lib/domains/constants';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DomainDeleteInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/delete';
 import DomainEmailInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/email';
@@ -23,6 +23,7 @@ import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import DomainSecurityDetails from './cards/domain-security-details';
 import RegisteredDomainDetails from './cards/registered-domain-details';
+import { getSslReadableStatus } from './helpers';
 import SetAsPrimary from './set-as-primary';
 import SettingsHeader from './settings-header';
 import type { SettingsPageConnectedProps, SettingsPageProps } from './types';
@@ -73,20 +74,12 @@ const Settings = ( {
 
 		if ( ! domainSecurityCard ) return null;
 
-		const getSubtitle = () => {
-			switch ( domain.sslStatus ) {
-				case sslStatuses.SSL_ACTIVE:
-					return translate( 'SSL certificate active', { textOnly: true } );
-				case sslStatuses.SSL_PENDING:
-					return translate( 'SSL certificate pending', { textOnly: true } );
-				case sslStatuses.SSL_DISABLED:
-				default:
-					return translate( 'Problem with SSL certificate', { textOnly: true } );
-			}
-		};
-
 		return (
-			<Accordion title={ translate( 'Domain security' ) } subtitle={ getSubtitle() } key="security">
+			<Accordion
+				title={ translate( 'Domain security' ) }
+				subtitle={ getSslReadableStatus( domain ) }
+				key="security"
+			>
 				{ domainSecurityCard }
 			</Accordion>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR creates the new redesigned main domain info component, which is shown on the domain settings page for domains that point to WordPress.com. This is part of the domain management pages redesign project detailed in pcYYhz-m2-p2.

#### Preview
##### Active 
![image](https://user-images.githubusercontent.com/18705930/146463539-18efacdd-44e8-4bf7-9193-a726a5e087d3.png)

##### Pending
![image](https://user-images.githubusercontent.com/18705930/146463698-d9a57201-4fca-4884-bd42-a5871ef6522f.png)

##### Disabled
![image](https://user-images.githubusercontent.com/18705930/146463728-b8f23355-5d51-45c0-b74a-ca8cb1d733f3.png)

#### Testing instructions

- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades > Domains"
- Select one of your domains
- Ensure that:
  - The card is not shown if the domain doesn't point to WordPress.com
  - The links are pointing to the right pages (Contact Us and HTTPS/SSL)
  - Each SSL status shows the right version of the component, same as in the screenshots
  - The mobile view looks correct