### PR TITLE
Lint JSON files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -172,6 +172,25 @@ module.exports = {
 				'prettier/prettier': [ 'error', { parser: 'babel' } ],
 			},
 		},
+		{
+			files: [ '*.json' ],
+			parser: 'eslint-plugin-json-es',
+			plugins: [ 'eslint-plugin-json-es' ],
+			extends: [ 'plugin:eslint-plugin-json-es/recommended' ],
+			rules: {
+				'comma-dangle': 'off',
+				'json-es/no-comments': 'error',
+			},
+			overrides: [
+				{
+					// These files are parsed as jsonc (JSON With Comments)
+					files: [ 'tsconfig.json' ],
+					rules: {
+						'json-es/no-comments': 'off',
+					},
+				},
+			],
+		},
 	],
 	env: {
 		jest: true,

--- a/build-tools/tsconfig.json
+++ b/build-tools/tsconfig.json
@@ -7,9 +7,5 @@
 		"declarationDir": "dist/types",
 		"types": [ "node" ]
 	},
-	"include": [
-		"babel/**/*",
-		"lib/**/*",
-		"webpack/**/*",
-	]
+	"include": [ "babel/**/*", "lib/**/*", "webpack/**/*" ]
 }

--- a/package.json
+++ b/package.json
@@ -288,6 +288,7 @@
 		"@bartekbp/typescript-checkstyle": "^5.0.0",
 		"bunyan": "^1.8.15",
 		"eslint-nibble": "^8.0.0",
+		"eslint-plugin-json-es": "^1.5.4",
 		"husky": "^7.0.4"
 	},
 	"resolutions": {

--- a/packages/calypso-color-schemes/tsconfig.json
+++ b/packages/calypso-color-schemes/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"extends": "@automattic/calypso-typescript-config/js-package.json"
 }

--- a/packages/calypso-doctor/tsconfig.json
+++ b/packages/calypso-doctor/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"extends": "@automattic/calypso-typescript-config/js-package.json"
 }

--- a/packages/calypso-eslint-overrides/tsconfig.json
+++ b/packages/calypso-eslint-overrides/tsconfig.json
@@ -1,7 +1,4 @@
 {
 	"extends": "@automattic/calypso-typescript-config/js-package.json",
-	"files": [
-		"index.js",
-		"node.js",
-	]
+	"files": [ "index.js", "node.js" ]
 }

--- a/packages/calypso-storybook/tsconfig.json
+++ b/packages/calypso-storybook/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"extends": "@automattic/calypso-typescript-config/js-package.json"
 }

--- a/packages/effective-module-tree/tsconfig.json
+++ b/packages/effective-module-tree/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"extends": "@automattic/calypso-typescript-config/js-package.json"
 }

--- a/packages/magellan-mocha-plugin/tsconfig.json
+++ b/packages/magellan-mocha-plugin/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"extends": "@automattic/calypso-typescript-config/js-package.json"
 }

--- a/packages/material-design-icons/tsconfig.json
+++ b/packages/material-design-icons/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"extends": "@automattic/calypso-typescript-config/js-package.json"
 }

--- a/packages/webpack-extensive-lodash-replacement-plugin/tsconfig.json
+++ b/packages/webpack-extensive-lodash-replacement-plugin/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@automattic/calypso-typescript-config/js-package.json",
 	"compilerOptions": {
-		"types": ["node"]
+		"types": [ "node" ]
 	}
 }

--- a/packages/webpack-rtl-plugin/tsconfig.json
+++ b/packages/webpack-rtl-plugin/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@automattic/calypso-typescript-config/js-package.json",
 	"compilerOptions": {
-		"types": ["node"]
+		"types": [ "node" ]
 	}
 }

--- a/packages/wpcom.js/tsconfig.json
+++ b/packages/wpcom.js/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"extends": "@automattic/calypso-typescript-config/js-package.json"
 }

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -5,5 +5,10 @@
 		"noEmit": true, // just type checking, no output. The output is handled by babel.
 		"types": [ "jest", "node" ] // no mocha - we are only using TypeScript for the new Playwright scripts
 	},
-	"include": [ "specs/specs-playwright", "specs/specs-p2", "specs/constants.js", "lib/gutenberg/tracking" ]
+	"include": [
+		"specs/specs-playwright",
+		"specs/specs-p2",
+		"specs/constants.js",
+		"lib/gutenberg/tracking"
+	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16726,6 +16726,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-json-es@npm:^1.5.4":
+  version: 1.5.4
+  resolution: "eslint-plugin-json-es@npm:1.5.4"
+  dependencies:
+    eslint-visitor-keys: ^3.0.0
+    espree: ^9.0.0
+  peerDependencies:
+    eslint: ">= 7"
+  checksum: c557fd6b375a2cca07a62e36061b8992f4e8be28cd00ea2664dabf6dbb2bfe54151290962ee7b6ec96e9ad600b8e6521c838f189caa8ac150c217dfff1265738
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-jsx-a11y@npm:^6.4.1, eslint-plugin-jsx-a11y@npm:^6.5.1":
   version: 6.5.1
   resolution: "eslint-plugin-jsx-a11y@npm:6.5.1"
@@ -17140,7 +17152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^9.2.0":
+"espree@npm:^9.0.0, espree@npm:^9.2.0":
   version: 9.2.0
   resolution: "espree@npm:9.2.0"
   dependencies:
@@ -37824,6 +37836,7 @@ testarmada-magellan@11.0.10:
     eslint-plugin-inclusive-language: ^2.2.0
     eslint-plugin-jest: ^25.3.0
     eslint-plugin-jsdoc: ^37.2.2
+    eslint-plugin-json-es: ^1.5.4
     eslint-plugin-jsx-a11y: ^6.5.1
     eslint-plugin-md: ^1.0.19
     eslint-plugin-mocha: ^10.0.3


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds the capability to lint JSON files.

In a future PR I'd like to build on top of this and add specific lint rules for `package.json` (for example: enforce `workspace:^` dependencies or standardize on script names) and `tsconfig.json` (for example, ensure some common config options we want all packages to have)


#### Testing instructions

* Run `yarn eslint --ext .json .`, it shouldn't show any problem.

* Edit `package.json` and introduce some problems like adding comments, trailing commas, lots of empty lines between keys or long lines. Run `yarn eslint --ext .json .` and verify the errors are reported
