### PR TITLE
Design Picker doesn't request long vertical preview of Kingsley

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -29,7 +29,16 @@ import './style.scss';
 
 // Ideally this data should come from the themes API, maybe by a tag that's applied to
 // themes? e.g. `link-in-bio` or `no-fold`
-const STATIC_PREVIEWS = [ 'bantry', 'sigler', 'miller', 'pollard', 'paxton', 'jones', 'baker' ];
+const STATIC_PREVIEWS = [
+	'bantry',
+	'sigler',
+	'miller',
+	'pollard',
+	'paxton',
+	'jones',
+	'baker',
+	'kingsley',
+];
 
 export default function DesignPickerStep( props ) {
 	const { flowName, stepName, isReskinned, queryParams, showDesignPickerCategories } = props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The recently launched Kingsley theme doesn't look right in the design picker.

<img width="1288" alt="Screenshot 2021-12-17 at 9 27 44 PM" src="https://user-images.githubusercontent.com/1500769/146514855-94429e81-e452-4b8b-ad15-a81c26026bdd.png">

* Adds `kingsley` to the list of themes that the design picker doesn't request a long vertical preview of

After the fix it looks like this
<img width="1288" alt="Screenshot 2021-12-17 at 9 38 07 PM" src="https://user-images.githubusercontent.com/1500769/146514915-104bc4c4-fb07-41e4-818e-98d9cf27f787.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply diff
* Navigate to design picker
* Look for Kingsley theme in the grid, you should be able to see the white-on-black text

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
