### PR TITLE
Tag successful builds with `release-candidate`

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -322,6 +322,14 @@ object RunAllUnitTests : BuildType({
 				yarn workspaces foreach --verbose --parallel run storybook --ci --smoke-test
 			"""
 		}
+		bashNodeScript {
+			name = "Tag build"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
+			scriptContent = """
+				set -x
+				curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
+			""".trimIndent()
+		}
 	}
 
 	triggers {
@@ -342,7 +350,9 @@ object RunAllUnitTests : BuildType({
 			comparison = BuildFailureOnMetric.MetricComparison.MORE
 			threshold = 0
 			compareTo = build {
-				buildRule = lastSuccessful()
+				buildRule = buildWithTag {
+					tag = "release-candidate"
+				}
 			}
 			stopBuildOnFailure = true
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -327,7 +327,10 @@ object RunAllUnitTests : BuildType({
 			executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
 			scriptContent = """
 				set -x
-				curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
+
+				if [[ "%teamcity.build.branch.is_default%" == "true" ]] ; then
+					curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
+				fi
 			""".trimIndent()
 		}
 	}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -329,7 +329,7 @@ object RunAllUnitTests : BuildType({
 				set -x
 
 				if [[ "%teamcity.build.branch.is_default%" == "true" ]] ; then
-					curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
+					curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" "%teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/"
 				fi
 			""".trimIndent()
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tag successful `trunk` builds with the tag `release-candidate`.
* Fail a branch build if it contains more TypeScript error than the latest build tagged as `release-candidate`.

In other words, this PR fail branch builds that have more errors than trunk.
