### PR TITLE
E2E: Add coverage for post permalink replacement in the Click to Tweet block

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/click-to-tweet-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/click-to-tweet-block.ts
@@ -47,7 +47,7 @@ export class ClicktoTweetBlock {
 	): Promise< void > {
 		// Ensure the actual URL, not the placeholder for post permalink is present.
 		// See D71837-code.
-		await page.waitForSelector( `${ selectors.block } a:not[href*="post_permalink"]` );
+		await page.waitForSelector( `${ selectors.block } a:not([href*="post_permalink"])` );
 
 		for await ( const content of contents ) {
 			await page.waitForSelector( `${ selectors.block } :text("${ content.toString() }")` );

--- a/packages/calypso-e2e/src/lib/blocks/click-to-tweet-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/click-to-tweet-block.ts
@@ -45,6 +45,10 @@ export class ClicktoTweetBlock {
 		page: Page,
 		contents: ( string | number )[]
 	): Promise< void > {
+		// Ensure the actual URL, not the placeholder for post permalink is present.
+		// See D71837-code.
+		await page.waitForSelector( `${ selectors.block } a:not[href*="post_permalink"]` );
+
 		for await ( const content of contents ) {
 			await page.waitForSelector( `${ selectors.block } :text("${ content.toString() }")` );
 		}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -427,7 +427,7 @@ export class GutenbergEditorPage {
 		const frame = await this.getEditorFrame();
 
 		await Promise.all( [
-			this.page.waitForNavigation( { waitUntil: 'networkidle', url: url } ),
+			this.page.waitForNavigation( { url } ),
 			frame.click( selectors.viewButton ),
 		] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add coverage for the Click to Tweet block permalink URL presence, as described in D71837-code.

#### Testing instructions

ClickToTweet validation spec should **fail** until D71837-code is in merged.