### PR TITLE
E2E: Forcefully close the Welcome Tour popup

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -37,7 +37,10 @@ export class NewPostFlow {
 			this.isLoggedIn = true;
 		}
 
-		return new GutenbergEditorPage( this.page );
+		const gutenbergEditorPage = new GutenbergEditorPage( this.page );
+		await gutenbergEditorPage.waitUntilLoaded();
+
+		return gutenbergEditorPage;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -99,11 +99,13 @@ export class GutenbergEditorPage {
 	async forceDismissWelcomeTour(): Promise< void > {
 		const frame = await this.getEditorFrame();
 
-		await frame.waitForFunction( async () =>
-			( window as any ).wp.data
-				.select( 'automattic/wpcom-welcome-guide' )
-				.isWelcomeGuideStatusLoaded()
+		await frame.waitForFunction(
+			async () =>
+				await ( window as any ).wp.data
+					.select( 'automattic/wpcom-welcome-guide' )
+					.isWelcomeGuideStatusLoaded()
 		);
+
 		await frame.waitForFunction( async () => {
 			const actionPayload = await ( window as any ).wp.data
 				.dispatch( 'automattic/wpcom-welcome-guide' )

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -80,13 +80,13 @@ export class GutenbergEditorPage {
 	 * @returns {Promise<Frame>} iframe holding the editor.
 	 */
 	async waitUntilLoaded(): Promise< Frame > {
-		await this.forceDismissWelcomeTour();
 		const frame = await this.getEditorFrame();
 		// Traditionally we try to avoid waits not related to the current flow.
 		// However, we need a stable way to identify loading being done. NetworkIdle
 		// takes too long here, so the most reliable alternative is the title being
 		// visible.
 		await frame.waitForSelector( selectors.editorTitle );
+		await this.forceDismissWelcomeTour();
 
 		return frame;
 	}
@@ -98,6 +98,12 @@ export class GutenbergEditorPage {
 	 */
 	async forceDismissWelcomeTour(): Promise< void > {
 		const frame = await this.getEditorFrame();
+
+		await frame.waitForFunction( async () =>
+			( window as any ).wp.data
+				.select( 'automattic/wpcom-welcome-guide' )
+				.isWelcomeGuideStatusLoaded()
+		);
 		await frame.waitForFunction( async () => {
 			const actionPayload = await ( window as any ).wp.data
 				.dispatch( 'automattic/wpcom-welcome-guide' )

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -103,7 +103,7 @@ export class GutenbergEditorPage {
 				.dispatch( 'automattic/wpcom-welcome-guide' )
 				.setShowWelcomeGuide( false );
 
-			return ! actionPayload.show;
+			return actionPayload.show === false;
 		} );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

An alternative approach to https://github.com/Automattic/wp-calypso/pull/59164.

Forcefully close the Welcome Tour popup via the dedicated action dispatch. This seems to work consistently and doesn't require explicit waiting for the NUX request or interaction with the popup. 

Related: https://github.com/Automattic/wp-calypso/issues/57660

#### Testing instructions

The Welcome Tour popup should not be an issue for any E2E suite anymore.