### PR TITLE
Woop landing page: remove header link

### DIFF
--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -29,7 +29,7 @@ const images = [ { src: Image01 }, { src: Image02 }, { src: Image03 }, { src: Im
 
 const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId } ) => {
 	const { __ } = useI18n();
-	const navigationItems = [ { label: 'WooCommerce', href: `/woocommerce-installation` } ];
+	const navigationItems = [ { label: 'WooCommerce' } ];
 	const ctaRef = useRef( null );
 
 	const { isTransferringBlocked, wpcomDomain, isDataReady } = useWooCommerceOnPlansEligibility(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the `href` of the link

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /woocommerce-installation/{site-id}
* Check that you can't click "WooCommerce" at the top.

<img width="727" alt="Screen Shot 2021-12-17 at 9 16 38 AM" src="https://user-images.githubusercontent.com/1689238/146578058-9287e07e-2f27-43bc-9f58-32cf5ec9f2cf.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59357
