### PR TITLE
Update the plugin install direct access screen to allow the user to continue the plugin installation.

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -60,7 +60,7 @@ const fetchWPCOMPlugin = ( slug: string ) => {
 export const useWPCOMPlugin = (
 	slug: string,
 	{ enabled = true, staleTime = 1000 * 60 * 60 * 2, refetchOnMount = true }: UseQueryOptions = {}
-): UseQueryResult => {
+): UseQueryResult< any > => {
 	return useQuery( getCacheKey( slug ), () => fetchWPCOMPlugin( slug ), {
 		select: ( data ) => normalizePluginData( { detailsFetched: Date.now() }, data ),
 		enabled: enabled,

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -1,4 +1,5 @@
 import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -52,6 +53,7 @@ const MarketplacePluginInstall = ( {
 	const [ atomicFlow, setAtomicFlow ] = useState( false );
 	const [ nonInstallablePlanError, setNonInstallablePlanError ] = useState( false );
 	const [ noDirectAccessError, setNoDirectAccessError ] = useState( false );
+	const [ directInstallationAllowed, setDirectInstallationAllowed ] = useState( false );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
@@ -153,7 +155,7 @@ const MarketplacePluginInstall = ( {
 	// Installing plugin flow startup
 	useEffect( () => {
 		if (
-			marketplacePluginInstallationInProgress &&
+			( marketplacePluginInstallationInProgress || directInstallationAllowed ) &&
 			! isUploadFlow &&
 			! initializeInstallFlow &&
 			wporgPlugin &&
@@ -179,6 +181,7 @@ const MarketplacePluginInstall = ( {
 		}
 	}, [
 		marketplacePluginInstallationInProgress,
+		directInstallationAllowed,
 		isUploadFlow,
 		initializeInstallFlow,
 		selectedSite,
@@ -251,7 +254,7 @@ const MarketplacePluginInstall = ( {
 				/>
 			);
 		}
-		if ( isUploadFlow && noDirectAccessError ) {
+		if ( isUploadFlow && noDirectAccessError && ! directInstallationAllowed ) {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
@@ -264,17 +267,26 @@ const MarketplacePluginInstall = ( {
 				/>
 			);
 		}
-		if ( noDirectAccessError ) {
+		if ( noDirectAccessError && ! directInstallationAllowed ) {
 			return (
 				<EmptyContent
-					illustration="/calypso/images/illustrations/error.svg"
-					title={ null }
-					line={ translate(
-						'This URL should not be accessed directly. Please click the Install button on the plugin page.'
-					) }
-					action={ translate( 'Go to the plugin page' ) }
-					actionURL={ `/plugins/${ productSlug }/${ selectedSite?.slug }` }
-				/>
+					className="marketplace-plugin-install__direct-install-container"
+					illustration={ wporgPlugin?.icon || '/calypso/images/illustrations/error.svg' }
+					illustrationWidth={ wporgPlugin?.icon && 128 }
+					title={ wporgPlugin?.name || productSlug }
+					line={ translate( 'Do you want to install the plugin %(plugin)s?', {
+						args: { plugin: wporgPlugin?.name || productSlug },
+					} ) }
+				>
+					<div className="marketplace-plugin-install__direct-install-actions">
+						<Button href={ `/plugins/${ productSlug }/${ selectedSite?.slug }` }>
+							{ translate( 'Go to the plugin page' ) }
+						</Button>
+						<Button primary onClick={ () => setDirectInstallationAllowed( true ) }>
+							{ translate( 'Install plugin' ) }
+						</Button>
+					</div>
+				</EmptyContent>
 			);
 		}
 		if ( pluginExists ) {

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/style.scss
@@ -33,3 +33,25 @@ body.is-section-marketplace.theme-default.color-scheme {
 		max-width: 509px;
 	}
 }
+
+.marketplace-plugin-install__direct-install-container {
+	margin-top: 0;
+	padding-top: 0;
+
+	.empty-content__title {
+		margin-bottom: 30px;
+	}
+
+	.empty-content__line {
+		margin-bottom: 20px;
+	}
+
+	.marketplace-plugin-install__direct-install-actions {
+		display: flex;
+		justify-content: center;
+
+		.button.is-primary {
+			margin-left: 10px;
+		}
+	}
+}

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
@@ -141,6 +142,7 @@ function PluginDetails( props ) {
 			...wpcomPlugin,
 			...wporgPlugin,
 			...plugin,
+			fetched: wpcomPlugin?.fetched || wporgPlugin?.fetched,
 			isMarketplaceProduct,
 		};
 	}, [ plugin, wporgPlugin, wpComPluginData, isWpComPluginFetched, isMarketplaceProduct ] );
@@ -215,6 +217,7 @@ function PluginDetails( props ) {
 			<DocumentHead title={ getPageTitle() } />
 			<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
 			<SidebarNavigation />
+			<QueryJetpackPlugins siteIds={ siteIds } />
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QueryProductsList persist />
 			<FixedNavigationHeader


### PR DESCRIPTION
### Changes proposed in this Pull Request

Update the plugin install direct access screen to allow the user to continue the plugin installation.

Read more at pdh6GB-e9-p2.

### Demo

|Before | After|
|-------|------|
|![](https://user-images.githubusercontent.com/11555574/143490217-78c1a504-725f-4028-bfc6-f79af694e67e.png)|![Kapture 2021-12-17 at 12 10 55](https://user-images.githubusercontent.com/5039531/146574858-077d42f7-ea34-467a-9b83-c32779bd0b48.gif)|

### Testing instructions
#### Focal
* Go to the plugin installation URL: `/marketplace/{plugin}/install/{site}`
* Confirm you see the button `Install plugin` and click on it
* Verify if the installation proceeds and succeeds 
* Check if you get redirected to the thank you page

#### Happy path 
* Go to the plugin details page `/plugins/{slug}` of an uninstalled plugin. Eg: `/plugins/wordpress-seo`
* Click on `Install and activate`
* Check if the installation works well.

----

Related to #58297