### PR TITLE
Gutenboarding design picker: add Ames, Jackson, and Kingsley themes

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -1,6 +1,26 @@
 {
 	"featured": [
 		{
+			"title": "Ames",
+			"slug": "ames",
+			"template": "ames",
+			"theme": "ames",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Ames",
+			"slug": "ames",
+			"template": "ames",
+			"theme": "ames",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": false,
+			"features": []
+		},
+		{
 			"title": "Arbutus",
 			"slug": "arbutus",
 			"template": "arbutus",
@@ -15,6 +35,46 @@
 			"slug": "arbutus",
 			"template": "arbutus",
 			"theme": "arbutus",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": false,
+			"features": []
+		},
+		{
+			"title": "Jackson",
+			"slug": "jackson",
+			"template": "jackson",
+			"theme": "jackson",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Jackson",
+			"slug": "jackson",
+			"template": "jackson",
+			"theme": "jackson",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": false,
+			"features": []
+		},
+		{
+			"title": "Kingsley",
+			"slug": "kingsley",
+			"template": "kingsley",
+			"theme": "kingsley",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Kingsley",
+			"slug": "kingsley",
+			"template": "kingsley",
+			"theme": "kingsley",
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": false,

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -68,6 +68,7 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
+			"preview": "static",
 			"features": []
 		},
 		{

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -79,6 +79,7 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": false,
+			"preview": "static",
 			"features": []
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the recently launched Ames, Jackson, and Kingsley themes to the design step of /new site creation

#### Testing instructions

* Go to /new to create a new site
* Make sure you see Ames, Jackson, and Kingsley themes on the design selection step, for both the FSE Beta and regular flows
* Create a site with each of the themes in the FSE Beta flow and make sure they work as expected with the Site editor
