### PR TITLE
Checkout: Remove product_id requirement for sending products to cart

### DIFF
--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -1,6 +1,4 @@
 import page from 'page';
-import { DefaultRootState } from 'react-redux';
-import { Dispatch } from 'redux';
 import {
 	transferDomainError,
 	useMyDomainInputMode as inputMode,
@@ -9,22 +7,19 @@ import {
 	AuthCodeValidationError,
 	AuthCodeValidationHandler,
 } from 'calypso/components/domains/connect-domain-step/types';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { domainTransfer, updatePrivacyForDomain } from 'calypso/lib/cart-values/cart-items';
 import { startInboundTransfer } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import wpcom from 'calypso/lib/wp';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { domainManagementTransferIn } from 'calypso/my-sites/domains/paths';
-import { getProductsList } from 'calypso/state/products-list/selectors';
 
 const noop = () => null;
 export const transferDomainAction: AuthCodeValidationHandler = (
 	{ selectedSite, verificationData, domain, ...props },
 	onDone = noop
-) => async ( _: Dispatch< never >, getState: () => DefaultRootState ) => {
+) => async () => {
 	const mode = ( props as Record< string, string > ).initialMode;
-	const productsList = getProductsList( getState() );
 	const transferrableStatuses = [
 		domainAvailability.TRANSFERRABLE,
 		domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE,
@@ -74,7 +69,7 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 
 			await cartManagerClient
 				.forCartKey( selectedSite.ID.toString() )
-				.actions.addProductsToCart( [ fillInSingleCartItemAttributes( transfer, productsList ) ] );
+				.actions.addProductsToCart( [ transfer ] );
 			return page( '/checkout/' + selectedSite.slug );
 		};
 

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -51,6 +51,7 @@ import type {
 	RequestCartProduct,
 	RequestCartProductExtra,
 	GSuiteProductUser,
+	MinimalRequestCartProduct,
 } from '@automattic/shopping-cart';
 
 export function getAllCartItems( cart: ResponseCart ): ResponseCartProduct[] {
@@ -250,22 +251,19 @@ export function supportsPrivacyProtectionPurchase(
 	return product?.is_privacy_protection_product_purchase_allowed ?? false;
 }
 
-export type IncompleteRequestCartProduct = Partial< RequestCartProduct > &
-	Pick< RequestCartProduct, 'product_slug' >;
-
 /**
  * Creates a new shopping cart item for a domain.
  *
  * @param {string} productSlug - the unique string that identifies the product
  * @param {string} domain - domain name
  * @param {string|undefined} [source] - optional source for the domain item, e.g. `getdotblog`.
- * @returns {IncompleteRequestCartProduct} the new item
+ * @returns {MinimalRequestCartProduct} the new item
  */
 export function domainItem(
 	productSlug: string,
 	domain: string,
 	source?: string
-): IncompleteRequestCartProduct {
+): MinimalRequestCartProduct {
 	const extra = source ? { extra: { source: source } } : undefined;
 
 	return Object.assign(
@@ -282,9 +280,9 @@ export function domainItem(
  *
  * @param {string} themeSlug - the unique string that identifies the product
  * @param {string} [source] - optional source for the domain item, e.g. `getdotblog`.
- * @returns {IncompleteRequestCartProduct} the new item
+ * @returns {MinimalRequestCartProduct} the new item
  */
-export function themeItem( themeSlug: string, source?: string ): IncompleteRequestCartProduct {
+export function themeItem( themeSlug: string, source?: string ): MinimalRequestCartProduct {
 	return {
 		product_slug: 'premium_theme',
 		meta: themeSlug,
@@ -302,7 +300,7 @@ export function domainRegistration( properties: {
 	domain: string;
 	source?: string;
 	extra?: RequestCartProductExtra;
-} ): IncompleteRequestCartProduct {
+} ): MinimalRequestCartProduct {
 	return {
 		...domainItem( properties.productSlug, properties.domain, properties.source ),
 		...( properties.extra ? { extra: properties.extra } : {} ),
@@ -315,7 +313,7 @@ export function domainRegistration( properties: {
 export function domainMapping( properties: {
 	domain: string;
 	source?: string;
-} ): IncompleteRequestCartProduct {
+} ): MinimalRequestCartProduct {
 	return domainItem( 'domain_map', properties.domain, properties.source );
 }
 
@@ -325,7 +323,7 @@ export function domainMapping( properties: {
 export function siteRedirect( properties: {
 	domain?: string;
 	source?: string;
-} ): IncompleteRequestCartProduct {
+} ): MinimalRequestCartProduct {
 	if ( ! properties.domain ) {
 		throw new Error( 'Site redirect product requires a domain' );
 	}
@@ -339,7 +337,7 @@ export function domainTransfer( properties: {
 	domain: string;
 	source?: string;
 	extra: RequestCartProductExtra;
-} ): IncompleteRequestCartProduct {
+} ): MinimalRequestCartProduct {
 	return {
 		...domainItem( domainProductSlugs.TRANSFER_IN, properties.domain, properties.source ),
 		...( properties.extra ? { extra: properties.extra } : {} ),
@@ -364,7 +362,7 @@ export function googleApps(
 		quantity?: number | null;
 		users?: GSuiteProductUser[];
 	} & ( WithCamelCaseSlug | WithSnakeCaseSlug )
-): IncompleteRequestCartProduct {
+): MinimalRequestCartProduct {
 	const { quantity, new_quantity, users } = properties;
 
 	const domainName = 'meta' in properties ? properties.meta : properties.domain;
@@ -390,7 +388,7 @@ export function googleAppsExtraLicenses( properties: {
 	domain: string;
 	source?: string;
 	users: GSuiteProductUser[];
-} ): IncompleteRequestCartProduct {
+} ): MinimalRequestCartProduct {
 	const item = domainItem( GSUITE_EXTRA_LICENSE_SLUG, properties.domain, properties.source );
 
 	return {
@@ -413,7 +411,7 @@ export interface TitanProductProps {
 function titanMailProduct(
 	properties: TitanProductProps,
 	productSlug: string
-): IncompleteRequestCartProduct {
+): MinimalRequestCartProduct {
 	const domainName = properties.meta ?? properties.domain;
 
 	if ( ! domainName ) {
@@ -430,14 +428,14 @@ function titanMailProduct(
 /**
  * Creates a new shopping cart item for Titan Mail Yearly.
  */
-export function titanMailYearly( properties: TitanProductProps ): IncompleteRequestCartProduct {
+export function titanMailYearly( properties: TitanProductProps ): MinimalRequestCartProduct {
 	return titanMailProduct( properties, TITAN_MAIL_YEARLY_SLUG );
 }
 
 /**
  * Creates a new shopping cart item for Titan Mail Monthly.
  */
-export function titanMailMonthly( properties: TitanProductProps ): IncompleteRequestCartProduct {
+export function titanMailMonthly( properties: TitanProductProps ): MinimalRequestCartProduct {
 	return titanMailProduct( properties, TITAN_MAIL_MONTHLY_SLUG );
 }
 
@@ -449,37 +447,37 @@ export function hasTitanMail( cart: ResponseCart ): boolean {
 	return getAllCartItems( cart ).some( isTitanMail );
 }
 
-export function customDesignItem(): IncompleteRequestCartProduct {
+export function customDesignItem(): MinimalRequestCartProduct {
 	return {
 		product_slug: 'custom-design',
 	};
 }
 
-export function noAdsItem(): IncompleteRequestCartProduct {
+export function noAdsItem(): MinimalRequestCartProduct {
 	return {
 		product_slug: 'no-adverts/no-adverts.php',
 	};
 }
 
-export function videoPressItem(): IncompleteRequestCartProduct {
+export function videoPressItem(): MinimalRequestCartProduct {
 	return {
 		product_slug: 'videopress',
 	};
 }
 
-export function unlimitedSpaceItem(): IncompleteRequestCartProduct {
+export function unlimitedSpaceItem(): MinimalRequestCartProduct {
 	return {
 		product_slug: 'unlimited_space',
 	};
 }
 
-export function unlimitedThemesItem(): IncompleteRequestCartProduct {
+export function unlimitedThemesItem(): MinimalRequestCartProduct {
 	return {
 		product_slug: 'unlimited_themes',
 	};
 }
 
-export function spaceUpgradeItem( slug: string ): IncompleteRequestCartProduct {
+export function spaceUpgradeItem( slug: string ): MinimalRequestCartProduct {
 	return {
 		product_slug: slug,
 	};
@@ -488,7 +486,7 @@ export function spaceUpgradeItem( slug: string ): IncompleteRequestCartProduct {
 /**
  * Creates a new shopping cart item for a jetpack product.
  */
-export function jetpackProductItem( slug: string ): IncompleteRequestCartProduct {
+export function jetpackProductItem( slug: string ): MinimalRequestCartProduct {
 	return {
 		product_slug: slug,
 	};
@@ -521,7 +519,7 @@ export function getRenewalItemFromProduct(
 			users?: GSuiteProductUser[];
 		},
 	properties: { domain?: string }
-): IncompleteRequestCartProduct {
+): MinimalRequestCartProduct {
 	const slug = camelOrSnakeSlug( product );
 	let cartItem;
 
@@ -583,7 +581,7 @@ export function getRenewalItemFromProduct(
 /**
  * Returns a renewal CartItem object from the given cartItem and properties.
  */
-export function getRenewalItemFromCartItem< T extends Partial< RequestCartProduct > >(
+export function getRenewalItemFromCartItem< T extends MinimalRequestCartProduct >(
 	cartItem: T,
 	properties: { id: string | number }
 ): T {
@@ -606,7 +604,7 @@ export function hasDomainInCart( cart: ResponseCart, domain: string ): boolean {
 /**
  * Changes presence of a privacy protection for the given domain cart item.
  */
-export function updatePrivacyForDomain< T extends IncompleteRequestCartProduct >(
+export function updatePrivacyForDomain< T extends MinimalRequestCartProduct >(
 	item: T,
 	value: boolean
 ): T {

--- a/client/lib/cart-values/index.ts
+++ b/client/lib/cart-values/index.ts
@@ -1,12 +1,7 @@
 import { isCredits, isDomainRedemption } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { hasRenewalItem } from './cart-items';
-import type {
-	ResponseCart,
-	ResponseCartProduct,
-	RequestCartProduct,
-	MinimalRequestCartProduct,
-} from '@automattic/shopping-cart';
+import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 
 export function canRemoveFromCart( cart: ResponseCart, cartItem: ResponseCartProduct ): boolean {
 	if ( isCredits( cartItem ) ) {
@@ -18,26 +13,6 @@ export function canRemoveFromCart( cart: ResponseCart, cartItem: ResponseCartPro
 	}
 
 	return true;
-}
-
-export type RequestCartProductWithoutId = Partial< RequestCartProduct > &
-	Pick< RequestCartProduct, 'product_slug' >;
-
-/**
- * Add a product_id to a incomplete RequestCartProduct
- */
-export function fillInSingleCartItemAttributes(
-	cartItem: RequestCartProductWithoutId,
-	products: Record< string, { product_id: number } >
-): MinimalRequestCartProduct {
-	if ( ( cartItem as RequestCartProduct ).product_id ) {
-		return cartItem as RequestCartProduct;
-	}
-	const product = products[ cartItem.product_slug ];
-	if ( ! product?.product_id ) {
-		throw new Error( `Cannot fill in product ID for ${ cartItem.product_slug }` );
-	}
-	return { ...cartItem, product_id: product.product_id };
 }
 
 /**

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -9,7 +9,7 @@ import {
 	isGoogleWorkspaceProductSlug,
 	isGSuiteProductSlug,
 } from 'calypso/lib/gsuite';
-import type { IncompleteRequestCartProduct } from 'calypso/lib/cart-values/cart-items';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 // exporting these in the big export below causes trouble
 export interface GSuiteNewUserField {
@@ -350,7 +350,7 @@ const getItemsForCart = (
 	domains: { name: string; googleAppsSubscription?: { status?: string } }[],
 	productSlug: string,
 	users: GSuiteNewUser[]
-): IncompleteRequestCartProduct[] => {
+): MinimalRequestCartProduct[] => {
 	const usersGroupedByDomain: { [ domain: string ]: GSuiteProductUser[] } = mapValues(
 		groupBy( users, 'domain.value' ),
 		( groupedUsers ) => groupedUsers.map( transformUserForCart )

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -6,7 +6,6 @@ import debugFactory from 'debug';
 import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import {
 	updatePrivacyForDomain,
 	supportsPrivacyProtectionPurchase,
@@ -488,10 +487,9 @@ function processItemCart(
 	}
 }
 
-function prepareItemForAddingToCart( item, state ) {
-	const productsList = getProductsList( state );
+function prepareItemForAddingToCart( item ) {
 	return {
-		...fillInSingleCartItemAttributes( item, productsList ),
+		...item,
 		extra: {
 			...item.extra,
 			context: 'signup',

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -19,7 +19,7 @@ import {
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { RequestCartProduct } from '@automattic/shopping-cart';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -49,7 +49,7 @@ interface SelectedSite {
 
 interface Props {
 	cart: PartialCart;
-	addItemToCart: ( item: Partial< RequestCartProduct > ) => void;
+	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 }
 
 const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemToCart } ) => {

--- a/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
@@ -5,12 +5,12 @@ import { useSelector } from 'react-redux';
 import CartFreeUserPlanUpsell from 'calypso/my-sites/checkout/cart/cart-free-user-plan-upsell';
 import UpcomingRenewalsReminder from 'calypso/my-sites/checkout/cart/upcoming-renewals-reminder';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { ResponseCart, RequestCartProduct } from '@automattic/shopping-cart';
+import type { ResponseCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 export type PartialCart = Pick< ResponseCart, 'products' >;
 interface Props {
 	responseCart: PartialCart;
-	addItemToCart: ( item: Partial< RequestCartProduct > ) => void;
+	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	isCartPendingUpdate: boolean;
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -47,7 +47,7 @@ import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from '../components/item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
-import type { RemoveProductFromCart, RequestCartProduct } from '@automattic/shopping-cart';
+import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
@@ -131,7 +131,7 @@ export default function WPCheckout( {
 	siteId: number | undefined;
 	siteUrl: string | undefined;
 	countriesList: CountryListItem[];
-	addItemToCart: ( item: Partial< RequestCartProduct > ) => void;
+	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	showErrorMessageBriefly: ( error: string ) => void;
 	isLoggedOutCart: boolean;
 	infoMessage?: JSX.Element;

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -25,7 +25,6 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import wp from 'calypso/lib/wp';
 import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
@@ -38,7 +37,6 @@ import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
-import { getProductsList } from 'calypso/state/products-list/selectors';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -396,8 +394,6 @@ export default function CompositeCheckout( {
 		checkoutFlow
 	);
 
-	const products = useSelector( ( state ) => getProductsList( state ) );
-
 	const changePlanLength = useCallback(
 		( uuidToReplace, newProductSlug, newProductId ) => {
 			reduxDispatch(
@@ -413,15 +409,12 @@ export default function CompositeCheckout( {
 		[ replaceProductInCart, reduxDispatch ]
 	);
 
-	// Often products are added using just the product_slug but missing the
-	// product_id; this adds it.
-	const addItemWithEssentialProperties = useCallback(
+	const addItemAndLog = useCallback(
 		( cartItem ) => {
-			const adjustedItem = fillInSingleCartItemAttributes( cartItem, products );
-			recordAddEvent( adjustedItem );
-			addProductsToCart( [ adjustedItem ] );
+			recordAddEvent( cartItem );
+			addProductsToCart( [ cartItem ] );
 		},
-		[ addProductsToCart, products ]
+		[ addProductsToCart ]
 	);
 
 	const includeDomainDetails = contactDetailsType === 'domain';
@@ -798,7 +791,7 @@ export default function CompositeCheckout( {
 					siteId={ updatedSiteId }
 					siteUrl={ updatedSiteSlug }
 					countriesList={ countriesList }
-					addItemToCart={ addItemWithEssentialProperties }
+					addItemToCart={ addItemAndLog }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					isLoggedOutCart={ !! isLoggedOutCart }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -12,7 +12,6 @@ import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useReducer } from 'react';
 import { useSelector } from 'react-redux';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList, isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getCartFromLocalStorage from '../lib/get-cart-from-local-storage';
@@ -218,7 +217,6 @@ function useAddProductsFromLocalStorage( {
 	const products: Record<
 		string,
 		{
-			product_id: number;
 			product_slug: string;
 		}
 	> = useSelector( getProductsList );
@@ -233,7 +231,7 @@ function useAddProductsFromLocalStorage( {
 		}
 
 		const productsForCart: RequestCartProduct[] = getCartFromLocalStorage().map( ( product ) =>
-			createRequestCartProduct( fillInSingleCartItemAttributes( product, products ) )
+			createRequestCartProduct( product )
 		);
 
 		if ( productsForCart.length < 1 ) {
@@ -301,7 +299,7 @@ function useAddRenewalItems( {
 					} );
 					return null;
 				}
-				return createRenewalItemToAddToCart( productSlug, product.product_id, subscriptionId );
+				return createRenewalItemToAddToCart( productSlug, subscriptionId );
 			} )
 			.filter( isValueTruthy );
 
@@ -356,7 +354,6 @@ function useAddProductFromSlug( {
 	const products: Record<
 		string,
 		{
-			product_id: number;
 			product_slug: string;
 		}
 	> = useSelector( getProductsList );
@@ -401,7 +398,6 @@ function useAddProductFromSlug( {
 			createItemToAddToCart( {
 				productSlug: product.product_slug,
 				productAlias: product.internal_product_alias,
-				productId: product.product_id,
 				isJetpackCheckout,
 				jetpackSiteSlug,
 				jetpackPurchaseToken,
@@ -468,7 +464,6 @@ function getProductSlugFromAlias( productAlias: string ): string {
 
 function createRenewalItemToAddToCart(
 	productAlias: string,
-	productId: string | number,
 	purchaseId: string | number | undefined | null
 ): RequestCartProduct | null {
 	const [ slug, meta ] = productAlias.split( ':' );
@@ -489,7 +484,6 @@ function createRenewalItemToAddToCart(
 		quantity: null,
 		volume: 1,
 		product_slug: productSlug,
-		product_id: parseInt( String( productId ), 10 ),
 		extra: renewalItemExtra,
 	};
 }
@@ -522,19 +516,17 @@ function getJetpackSearchForSite( productAlias: string, isJetpackNotAtomic: bool
 function createItemToAddToCart( {
 	productSlug,
 	productAlias,
-	productId,
 	isJetpackCheckout,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 }: {
 	productSlug: string;
-	productId: number;
 	productAlias: string;
 	isJetpackCheckout?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 } ): RequestCartProduct {
-	debug( 'creating product with', productSlug, productAlias, productId );
+	debug( 'creating product with', productSlug, productAlias );
 	const [ , meta ] = productAlias.split( ':' );
 	// Some meta values contain slashes, so we decode them
 	const cartMeta = meta ? decodeProductFromUrl( meta ) : '';
@@ -543,7 +535,6 @@ function createItemToAddToCart( {
 		debug( 'creating theme product' );
 		return addContextToProduct(
 			createRequestCartProduct( {
-				product_id: productId,
 				product_slug: productSlug,
 				meta: cartMeta,
 			} )
@@ -554,7 +545,6 @@ function createItemToAddToCart( {
 		debug( 'creating domain mapping product' );
 		return addContextToProduct(
 			createRequestCartProduct( {
-				product_id: productId,
 				product_slug: productSlug,
 				meta: cartMeta,
 			} )
@@ -563,7 +553,6 @@ function createItemToAddToCart( {
 
 	return addContextToProduct(
 		createRequestCartProduct( {
-			product_id: productId,
 			product_slug: productSlug,
 			extra: { isJetpackCheckout, jetpackSiteSlug, jetpackPurchaseToken },
 		} )

--- a/client/my-sites/checkout/composite-checkout/lib/get-cart-from-local-storage.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-cart-from-local-storage.ts
@@ -1,8 +1,8 @@
-import { IncompleteRequestCartProduct } from 'calypso/lib/cart-values/cart-items';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 // Used by signup; see https://github.com/Automattic/wp-calypso/pull/44206
 // These products are likely missing product_id.
-export default function getCartFromLocalStorage(): IncompleteRequestCartProduct[] {
+export default function getCartFromLocalStorage(): MinimalRequestCartProduct[] {
 	try {
 		return JSON.parse( window.localStorage.getItem( 'shoppingCart' ) || '[]' );
 	} catch ( err ) {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -312,10 +312,10 @@ export async function mockSetCartEndpoint( _, requestCart ) {
 
 function convertRequestProductToResponseProduct( currency ) {
 	return ( product ) => {
-		const { product_id } = product;
+		const { product_slug } = product;
 
-		switch ( product_id ) {
-			case 1009: // WPCOM Personal Bundle
+		switch ( product_slug ) {
+			case 'personal-bundle': // WPCOM Personal Bundle
 				return {
 					product_id: 1009,
 					product_name: 'WordPress.com Personal',
@@ -332,7 +332,7 @@ function convertRequestProductToResponseProduct( currency ) {
 					volume: 1,
 					extra: {},
 				};
-			case 5:
+			case 'domain_map':
 				return {
 					product_id: 5,
 					product_name: 'Domain Mapping',
@@ -349,7 +349,7 @@ function convertRequestProductToResponseProduct( currency ) {
 					volume: 1,
 					extra: {},
 				};
-			case 6:
+			case 'domain_reg':
 				return {
 					product_id: 6,
 					product_name: 'Domain Registration',
@@ -366,7 +366,7 @@ function convertRequestProductToResponseProduct( currency ) {
 					volume: 1,
 					extra: {},
 				};
-			case 9:
+			case 'gapps':
 				return {
 					product_id: 9,
 					product_name: 'G Suite',
@@ -383,7 +383,7 @@ function convertRequestProductToResponseProduct( currency ) {
 					volume: 1,
 					extra: {},
 				};
-			case 39:
+			case 'premium_theme':
 				return {
 					product_id: 39,
 					product_name: 'Premium Theme: Ovation',
@@ -399,7 +399,7 @@ function convertRequestProductToResponseProduct( currency ) {
 					volume: 1,
 					extra: {},
 				};
-			case 371:
+			case 'concierge-session':
 				return {
 					product_id: 371,
 					product_name: 'Support Session',
@@ -415,7 +415,7 @@ function convertRequestProductToResponseProduct( currency ) {
 					volume: 1,
 					extra: {},
 				};
-			case 2106:
+			case 'jetpack_scan':
 				return {
 					product_id: 2106,
 					product_name: 'Jetpack Scan Daily',
@@ -432,7 +432,7 @@ function convertRequestProductToResponseProduct( currency ) {
 					volume: 1,
 					extra: {},
 				};
-			case 2100:
+			case 'jetpack_backup_daily':
 				return {
 					product_id: 2100,
 					product_name: 'Jetpack Backup (Daily)',
@@ -452,8 +452,8 @@ function convertRequestProductToResponseProduct( currency ) {
 		}
 
 		return {
-			product_id: product_id,
-			product_name: `Unknown mocked product: ${ product_id }`,
+			product_id: Math.ceil( Math.random() * 3000 ),
+			product_name: `Unknown mocked product: ${ product_slug }`,
 			product_slug: 'unknown',
 			currency: currency,
 			is_domain_registration: false,

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
@@ -3,7 +3,6 @@ import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
 import Badge from 'calypso/components/badge';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -11,7 +10,6 @@ import FormInputValidation from 'calypso/components/forms/form-input-validation'
 import FormLabel from 'calypso/components/forms/form-label';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
 import {
 	areAllMailboxesValid,
@@ -19,7 +17,6 @@ import {
 	transformMailboxForCart,
 	validateMailboxes,
 } from 'calypso/lib/titan/new-mailbox';
-import { getProductsList } from 'calypso/state/products-list/selectors';
 
 import './style.scss';
 
@@ -45,7 +42,6 @@ const ProfessionalEmailUpsell = ( {
 	setCartItem = noopWithCallback,
 } ) => {
 	const translate = useTranslate();
-	const productsList = useSelector( getProductsList );
 
 	const [ mailboxData, setMailboxData ] = useState( buildNewTitanMailbox( domainName, false ) );
 	const [ showAllErrors, setShowAllErrors ] = useState( false );
@@ -108,9 +104,7 @@ const ProfessionalEmailUpsell = ( {
 			},
 		} );
 
-		setCartItem( fillInSingleCartItemAttributes( cartItem, productsList ), () =>
-			handleClickAccept( 'accept' )
-		);
+		setCartItem( cartItem, () => handleClickAccept( 'accept' ) );
 	};
 
 	return (

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -15,7 +15,6 @@ import EmailVerificationGate from 'calypso/components/email-verification/email-v
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import {
 	hasPlan,
 	hasDomainInCart,
@@ -93,9 +92,7 @@ class DomainSearch extends Component {
 
 	handleAddTransfer = ( domain ) => {
 		this.props.shoppingCartManager
-			.addProductsToCart( [
-				fillInSingleCartItemAttributes( domainTransfer( { domain } ), this.props.productsList ),
-			] )
+			.addProductsToCart( [ domainTransfer( { domain } ) ] )
 			.then( () => {
 				this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
 			} );
@@ -148,9 +145,7 @@ class DomainSearch extends Component {
 		}
 
 		this.props.shoppingCartManager
-			.addProductsToCart( [
-				fillInSingleCartItemAttributes( registration, this.props.productsList ),
-			] )
+			.addProductsToCart( [ registration ] )
 			.then( () => page( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ) ) );
 	}
 

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import DomainProductPrice from 'calypso/components/domains/domain-product-price';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { hasProduct, siteRedirect } from 'calypso/lib/cart-values/cart-items';
 import { canRedirect } from 'calypso/lib/domains';
 import { withoutHttp } from 'calypso/lib/url';
@@ -124,13 +123,9 @@ class SiteRedirectStep extends Component {
 	};
 
 	addSiteRedirectToCart = ( domain ) => {
-		this.props.shoppingCartManager
-			.addProductsToCart( [
-				fillInSingleCartItemAttributes( siteRedirect( { domain } ), this.props.products ),
-			] )
-			.then( () => {
-				this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
-			} );
+		this.props.shoppingCartManager.addProductsToCart( [ siteRedirect( { domain } ) ] ).then( () => {
+			this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
+		} );
 	};
 
 	getValidationErrorMessage = ( domain, error ) => {

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -10,7 +10,6 @@ import MapDomainStep from 'calypso/components/domains/map-domain-step';
 import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
 import HeaderCake from 'calypso/components/header-cake';
 import Notice from 'calypso/components/notice';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import wpcom from 'calypso/lib/wp';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
@@ -71,13 +70,10 @@ export class MapDomain extends Component {
 
 		this.props.shoppingCartManager
 			.addProductsToCart( [
-				fillInSingleCartItemAttributes(
-					domainRegistration( {
-						productSlug: suggestion.product_slug,
-						domain: suggestion.domain_name,
-					} ),
-					this.props.productsList
-				),
+				domainRegistration( {
+					productSlug: suggestion.product_slug,
+					domain: suggestion.domain_name,
+				} ),
 			] )
 			.then( () => {
 				this.isMounted && page( '/checkout/' + selectedSiteSlug );

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -4,11 +4,9 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import QueryProductsList from 'calypso/components/data/query-products-list';
 import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
 import Notice from 'calypso/components/notice';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import {
 	domainRegistration,
 	domainTransfer,
@@ -17,7 +15,6 @@ import {
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
-import { getProductsList } from 'calypso/state/products-list/selectors';
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
 import {
 	getSelectedSite,
@@ -33,7 +30,6 @@ export class TransferDomain extends Component {
 		cart: PropTypes.object.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		isSiteUpgradeable: PropTypes.bool,
-		productsList: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object,
 		selectedSiteId: PropTypes.number,
 		selectedSiteSlug: PropTypes.string,
@@ -62,17 +58,14 @@ export class TransferDomain extends Component {
 	};
 
 	addDomainToCart = ( suggestion ) => {
-		const { selectedSiteSlug, shoppingCartManager, productsList } = this.props;
+		const { selectedSiteSlug, shoppingCartManager } = this.props;
 
 		shoppingCartManager
 			.addProductsToCart( [
-				fillInSingleCartItemAttributes(
-					domainRegistration( {
-						productSlug: suggestion.product_slug,
-						domain: suggestion.domain_name,
-					} ),
-					productsList
-				),
+				domainRegistration( {
+					productSlug: suggestion.product_slug,
+					domain: suggestion.domain_name,
+				} ),
 			] )
 			.then( () => {
 				page( '/checkout/' + selectedSiteSlug );
@@ -109,11 +102,9 @@ export class TransferDomain extends Component {
 			transfer = updatePrivacyForDomain( transfer, true );
 		}
 
-		shoppingCartManager
-			.addProductsToCart( [ fillInSingleCartItemAttributes( transfer, this.props.productsList ) ] )
-			.then( () => {
-				page( '/checkout/' + selectedSiteSlug );
-			} );
+		shoppingCartManager.addProductsToCart( [ transfer ] ).then( () => {
+			page( '/checkout/' + selectedSiteSlug );
+		} );
 	};
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -169,7 +160,6 @@ export class TransferDomain extends Component {
 
 		return (
 			<span>
-				<QueryProductsList />
 				{ errorMessage && <Notice status="is-error" text={ errorMessage } /> }
 
 				<TransferDomainStep
@@ -194,5 +184,4 @@ export default connect( ( state ) => ( {
 	selectedSiteSlug: getSelectedSiteSlug( state ),
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
-	productsList: getProductsList( state ),
 } ) )( withCartKey( withShoppingCart( TransferDomain ) ) );

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -26,7 +26,6 @@ import Notice from 'calypso/components/notice';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
 import {
 	canCurrentUserAddEmail,
@@ -67,7 +66,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import {
@@ -107,7 +106,6 @@ class EmailProvidersComparison extends Component {
 		hasCartDomain: PropTypes.bool,
 		isGSuiteSupported: PropTypes.bool.isRequired,
 		isSubmittingEmailForward: PropTypes.bool,
-		productsList: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object,
 		titanMailProduct: PropTypes.object,
 	};
@@ -224,7 +222,7 @@ class EmailProvidersComparison extends Component {
 			return;
 		}
 
-		const { productsList, selectedSite, shoppingCartManager } = this.props;
+		const { selectedSite, shoppingCartManager } = this.props;
 
 		const cartItem = titanMailMonthly( {
 			domain: domainName,
@@ -237,14 +235,12 @@ class EmailProvidersComparison extends Component {
 
 		this.setState( { addingToCart: true } );
 
-		shoppingCartManager
-			.addProductsToCart( [ fillInSingleCartItemAttributes( cartItem, productsList ) ] )
-			.then( () => {
-				if ( this.isMounted ) {
-					this.setState( { addingToCart: false } );
-					page( '/checkout/' + selectedSite.slug );
-				}
-			} );
+		shoppingCartManager.addProductsToCart( [ cartItem ] ).then( () => {
+			if ( this.isMounted ) {
+				this.setState( { addingToCart: false } );
+				page( '/checkout/' + selectedSite.slug );
+			}
+		} );
 	};
 
 	onGoogleUsersChange = ( changedUsers ) => {
@@ -288,17 +284,13 @@ class EmailProvidersComparison extends Component {
 			return;
 		}
 
-		const { productsList, selectedSite, shoppingCartManager } = this.props;
+		const { selectedSite, shoppingCartManager } = this.props;
 		const domains = domain ? [ domain ] : [];
 
 		this.setState( { addingToCart: true } );
 
 		shoppingCartManager
-			.addProductsToCart(
-				getItemsForCart( domains, gSuiteProduct.product_slug, googleUsers ).map( ( item ) =>
-					fillInSingleCartItemAttributes( item, productsList )
-				)
-			)
+			.addProductsToCart( getItemsForCart( domains, gSuiteProduct.product_slug, googleUsers ) )
 			.then( () => {
 				if ( this.isMounted ) {
 					this.setState( { addingToCart: false } );
@@ -848,7 +840,6 @@ export default connect(
 			hasCartDomain,
 			isSubmittingEmailForward: isAddingEmailForward( state, ownProps.selectedDomainName ),
 			isGSuiteSupported,
-			productsList: getProductsList( state ),
 			requestingSiteDomains: isRequestingSiteDomains( state, domainName ),
 			selectedSite,
 			shouldPromoteGoogleWorkspace:

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -11,7 +11,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import InfoPopover from 'calypso/components/info-popover';
-import { IncompleteRequestCartProduct } from 'calypso/lib/cart-values/cart-items';
 import { canCurrentUserAddEmail, getSelectedDomain } from 'calypso/lib/domains';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
@@ -36,6 +35,7 @@ import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { addToCartAndCheckout, recordTracksEventAddToCartClick, IntervalLength } from './utils';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 import './google-workspace-card.scss';
 
@@ -183,7 +183,7 @@ const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > =
 
 		setAddingToCart( true );
 
-		const cartItems: IncompleteRequestCartProduct[] = getItemsForCart(
+		const cartItems: MinimalRequestCartProduct[] = getItemsForCart(
 			domains,
 			gSuiteProduct.productSlug,
 			googleUsers

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -4,7 +4,7 @@ import {
 } from '@automattic/calypso-products';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { translate } from 'i18n-calypso';
-import React, { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { connect } from 'react-redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -32,7 +32,7 @@ import {
 } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { addToCartAndCheckout, recordTracksEventAddToCartClick, IntervalLength } from './utils';
@@ -42,7 +42,9 @@ import './google-workspace-card.scss';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-const identityMap = ( item: any ) => item;
+function identityMap< T >( item: T ): T {
+	return item;
+}
 
 const getGoogleFeatures = () => {
 	return [
@@ -152,7 +154,6 @@ const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > =
 			gSuiteProductMonthly,
 			gSuiteProductYearly,
 			hasCartDomain,
-			productsList,
 			selectedSite,
 			shoppingCartManager,
 			source,
@@ -191,7 +192,6 @@ const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > =
 		addToCartAndCheckout(
 			shoppingCartManager,
 			cartItems[ 0 ],
-			productsList,
 			setAddingToCart,
 			selectedSite?.slug ?? ''
 		);
@@ -244,7 +244,6 @@ export default connect( ( state, ownProps: EmailProvidersStackedCardProps ) => {
 		domain,
 		domainName: resolvedDomainName,
 		hasCartDomain,
-		productsList: getProductsList( state ),
 		selectedSite,
 		gSuiteProductYearly: getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY ),
 		gSuiteProductMonthly: getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY ),

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -2,7 +2,7 @@ import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from '@automattic/cal
 import { Gridicon } from '@automattic/components';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { translate } from 'i18n-calypso';
-import React, { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { connect } from 'react-redux';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
 import {
@@ -34,7 +34,7 @@ import {
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { addToCartAndCheckout, IntervalLength, recordTracksEventAddToCartClick } from './utils';
@@ -82,7 +82,6 @@ const ProfessionalEmailCard: FunctionComponent< EmailProvidersStackedCardProps >
 		titanMailMonthlyProduct,
 		titanMailYearlyProduct,
 		comparisonContext,
-		productsList,
 		shoppingCartManager,
 		selectedSite,
 		source,
@@ -146,7 +145,6 @@ const ProfessionalEmailCard: FunctionComponent< EmailProvidersStackedCardProps >
 		addToCartAndCheckout(
 			shoppingCartManager,
 			cartItem,
-			productsList,
 			setAddingToCart,
 			selectedSite?.slug ?? ''
 		);
@@ -217,7 +215,6 @@ export default connect( ( state, ownProps: EmailProvidersStackedCardProps ) => {
 		domain,
 		selectedDomainName: resolvedDomainName,
 		hasCartDomain,
-		productsList: getProductsList( state ),
 		selectedSite,
 		titanMailMonthlyProduct: getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG ),
 		titanMailYearlyProduct: getProductBySlug( state, TITAN_MAIL_YEARLY_SLUG ),

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/utils.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/utils.tsx
@@ -5,7 +5,6 @@ import {
 } from '@automattic/shopping-cart';
 import page from 'page';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { IncompleteRequestCartProduct } from 'calypso/lib/cart-values/cart-items';
 
 export enum IntervalLength {
@@ -16,14 +15,13 @@ export enum IntervalLength {
 export const addToCartAndCheckout = (
 	shoppingCartManager: ShoppingCartManagerActions,
 	cartItem: RequestCartProduct | IncompleteRequestCartProduct,
-	productList: Record< string, { product_id: number } >,
 	setAddingToCart: ( addingToCart: boolean ) => void,
 	selectedSite: string
 ): void => {
 	setAddingToCart( true );
 
 	shoppingCartManager
-		.addProductsToCart( [ fillInSingleCartItemAttributes( cartItem, productList ) ] )
+		.addProductsToCart( [ cartItem ] )
 		.then( ( response: ResponseCart ) => {
 			setAddingToCart( false );
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/utils.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/utils.tsx
@@ -1,11 +1,11 @@
-import {
+import page from 'page';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type {
 	RequestCartProduct,
 	ResponseCart,
 	ShoppingCartManagerActions,
+	MinimalRequestCartProduct,
 } from '@automattic/shopping-cart';
-import page from 'page';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { IncompleteRequestCartProduct } from 'calypso/lib/cart-values/cart-items';
 
 export enum IntervalLength {
 	ANNUALLY = 'annually',
@@ -14,7 +14,7 @@ export enum IntervalLength {
 
 export const addToCartAndCheckout = (
 	shoppingCartManager: ShoppingCartManagerActions,
-	cartItem: RequestCartProduct | IncompleteRequestCartProduct,
+	cartItem: RequestCartProduct | MinimalRequestCartProduct,
 	setAddingToCart: ( addingToCart: boolean ) => void,
 	selectedSite: string
 ): void => {

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -15,7 +15,6 @@ import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import {
 	getEligibleGSuiteDomain,
 	getGoogleMailServiceFamily,
@@ -37,7 +36,6 @@ import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
-import { getProductsList } from 'calypso/state/products-list/selectors/get-products-list';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
@@ -80,11 +78,7 @@ class GSuiteAddUsers extends Component {
 
 		if ( canContinue ) {
 			this.props.shoppingCartManager
-				.addProductsToCart(
-					getItemsForCart( domains, getProductSlug( productType ), users ).map( ( item ) =>
-						fillInSingleCartItemAttributes( item, this.props.productsList )
-					)
-				)
+				.addProductsToCart( getItemsForCart( domains, getProductSlug( productType ), users ) )
 				.then( () => {
 					this.isMounted && page( '/checkout/' + selectedSite.slug );
 				} );
@@ -299,7 +293,6 @@ export default connect(
 			domains,
 			gsuiteUsers: getGSuiteUsers( state, siteId ),
 			isRequestingDomains: isRequestingSiteDomains( state, siteId ),
-			productsList: getProductsList( state ),
 			selectedSite,
 			userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 		};

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -12,7 +12,6 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
@@ -40,7 +39,7 @@ import TitanMailboxPricingNotice from 'calypso/my-sites/email/titan-add-mailboxe
 import TitanUnusedMailboxesNotice from 'calypso/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
-import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import {
 	getDomainsBySiteId,
@@ -158,9 +157,7 @@ class TitanAddMailboxes extends Component {
 			this.setState( { isAddingToCart: true } );
 
 			this.props.shoppingCartManager
-				.addProductsToCart( [
-					fillInSingleCartItemAttributes( this.getCartItem(), this.props.productsList ),
-				] )
+				.addProductsToCart( [ this.getCartItem() ] )
 				.then( () => {
 					if ( this.isMounted ) {
 						this.setState( { isAddingToCart: false } );
@@ -307,7 +304,6 @@ export default connect(
 			selectedSite,
 			isLoadingDomains,
 			currentRoute: getCurrentRoute( state ),
-			productsList: getProductsList( state ),
 			maxTitanMailboxCount: hasTitanMailWithUs( selectedDomain )
 				? getMaxTitanMailboxCount( selectedDomain )
 				: 0,

--- a/client/my-sites/marketplace/pages/marketplace-domain-upsell/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-domain-upsell/index.tsx
@@ -12,7 +12,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -23,7 +22,6 @@ import {
 } from 'calypso/my-sites/marketplace/constants';
 import theme from 'calypso/my-sites/marketplace/theme';
 import { setPrimaryDomainCandidate } from 'calypso/state/marketplace/purchase-flow/actions';
-import { getProductsList } from 'calypso/state/products-list/selectors';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -75,7 +73,6 @@ function CalypsoWrappedMarketplaceDomainUpsell(): JSX.Element {
 	const { addProductsToCart, removeProductFromCart } = useShoppingCart( cartKey );
 	const previousPath = useSelector( getPreviousPath );
 	const selectedSite = useSelector( getSelectedSite );
-	const products = useSelector( getProductsList );
 	const domainObject = useSelector( ( state ) =>
 		getWpComDomainBySiteId( state, selectedSite?.ID )
 	);
@@ -85,7 +82,7 @@ function CalypsoWrappedMarketplaceDomainUpsell(): JSX.Element {
 	const translate = useTranslate();
 
 	useEffect( () => {
-		setIsExpandedBasketView( isDesktop() );
+		setIsExpandedBasketView( isDesktop() ?? false );
 		selectedSite && dispatch( fetchSiteDomains( selectedSite.ID ) );
 	}, [ setIsExpandedBasketView, selectedSite, dispatch ] );
 
@@ -117,9 +114,7 @@ function CalypsoWrappedMarketplaceDomainUpsell(): JSX.Element {
 		}
 
 		//Then add the new domain
-		const responseCart = await addProductsToCart( [
-			fillInSingleCartItemAttributes( domainProduct, products ),
-		] );
+		const responseCart = await addProductsToCart( [ domainProduct ] );
 		const productAdded = responseCart.products.find(
 			( { product_slug: added_product_slug } ) => added_product_slug === product_slug
 		);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -35,7 +35,6 @@ import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
 import SpinnerLine from 'calypso/components/spinner-line';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { getDiscountByName } from 'calypso/lib/discounts';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
@@ -52,7 +51,6 @@ import {
 	getPlanSlug,
 	getDiscountedRawPrice,
 } from 'calypso/state/plans/selectors';
-import { getProductsList } from 'calypso/state/products-list/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
@@ -591,7 +589,6 @@ export class PlanFeatures extends Component {
 			selectedSiteSlug,
 			shoppingCartManager,
 			redirectToAddDomainFlow,
-			productsList,
 		} = this.props;
 
 		const {
@@ -621,15 +618,12 @@ export class PlanFeatures extends Component {
 			// redirect to the "add a domain" page.
 			shoppingCartManager
 				.addProductsToCart( [
-					fillInSingleCartItemAttributes(
-						{
-							product_slug: productSlug,
-							extra: {
-								afterPurchaseUrl: redirectTo ?? undefined,
-							},
+					{
+						product_slug: productSlug,
+						extra: {
+							afterPurchaseUrl: redirectTo ?? undefined,
 						},
-						productsList
-					),
+					},
 				] )
 				.then( () => {
 					if ( withDiscount && this.isMounted ) {
@@ -1075,7 +1069,6 @@ const ConnectedPlanFeatures = connect(
 		const purchaseId = getCurrentPlanPurchaseId( state, siteId );
 
 		return {
-			productsList: getProductsList( state ),
 			canPurchase,
 			isJetpack,
 			planProperties,

--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -3,8 +3,8 @@ import type { RequestCartProduct, MinimalRequestCartProduct } from './types';
 export default function createRequestCartProduct(
 	properties: MinimalRequestCartProduct
 ): RequestCartProduct {
-	if ( ! properties.product_slug || ! properties.product_id ) {
-		throw new Error( 'Both product_slug and product_id are required for request cart products' );
+	if ( ! properties.product_slug ) {
+		throw new Error( 'product_slug is required for request cart products' );
 	}
 	return {
 		meta: '',

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -202,7 +202,7 @@ export type RequestCartTaxData = null | {
 
 export interface RequestCartProduct {
 	product_slug: string;
-	product_id: number;
+	product_id?: number;
 	meta: string;
 	volume: number;
 	quantity: number | null;
@@ -210,7 +210,7 @@ export interface RequestCartProduct {
 }
 
 export type MinimalRequestCartProduct = Partial< RequestCartProduct > &
-	Pick< RequestCartProduct, 'product_slug' | 'product_id' >;
+	Pick< RequestCartProduct, 'product_slug' >;
 
 export interface ResponseCart< P = ResponseCartProduct > {
 	blog_id: number | string;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -371,6 +371,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	auth_code?: string;
+	privacy_available?: boolean;
 }
 
 export interface GSuiteProductUser {

--- a/packages/shopping-cart/test/use-shopping-cart.tsx
+++ b/packages/shopping-cart/test/use-shopping-cart.tsx
@@ -93,16 +93,16 @@ describe( 'useShoppingCart', () => {
 			} );
 		} );
 
-		it( 'throws an error if the product is missing a product_id', async () => {
+		it( 'throws an error if the product is missing a product_slug', async () => {
 			render(
 				<MockProvider>
-					<TestComponent products={ [ { product_slug: planOne.product_slug } ] } />
+					<TestComponent products={ [ { product_id: planOne.product_id } ] } />
 				</MockProvider>
 			);
 			fireEvent.click( screen.getByText( 'Click me' ) );
 			await waitFor( () => {
 				expect( testRunErrors ).toHaveLength( 1 );
-				expect( String( testRunErrors[ 0 ] ) ).toMatch( /product_id/ );
+				expect( String( testRunErrors[ 0 ] ) ).toMatch( /product_slug/ );
 			} );
 		} );
 
@@ -307,14 +307,14 @@ describe( 'useShoppingCart', () => {
 			expect( screen.getByText( planTwo.product_name ) ).toBeInTheDocument();
 		} );
 
-		it( 'throws an error if a product is missing a product_id', async () => {
+		it( 'throws an error if a product is missing a product_slug', async () => {
 			mockGetCart.mockResolvedValue( {
 				...emptyResponseCart,
 				products: [ planOne ],
 			} );
 			render(
 				<MockProvider getCartOverride={ mockGetCart }>
-					<TestComponent products={ [ { product_slug: planTwo.product_slug } ] } />
+					<TestComponent products={ [ { product_id: planTwo.product_id } ] } />
 				</MockProvider>
 			);
 			await waitFor( () => screen.getByTestId( 'product-list' ) );
@@ -322,7 +322,7 @@ describe( 'useShoppingCart', () => {
 			fireEvent.click( screen.getByText( 'Click me' ) );
 			await waitFor( () => {
 				expect( testRunErrors ).toHaveLength( 1 );
-				expect( String( testRunErrors[ 0 ] ) ).toMatch( /product_id/ );
+				expect( String( testRunErrors[ 0 ] ) ).toMatch( /product_slug/ );
 			} );
 			expect( screen.getByText( planOne.product_name ) ).toBeInTheDocument();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When sending products to the shopping cart endpoint, it is required that they have a `product_slug` and a `product_id`. However, since most of the code in calypso operates on the `product_slug`, it requires a lot of effort to add a product with an ID. Typically we have to query the products endpoint, find the matching product by slug, and then apply that product's ID. This also makes TypeScript types confusing because we need a type for the intermediate stage of having all required data _except_ for `product_id` and another type for the data _with_ `product_id`.

In D71913-code, we make `product_id` optional and rely on `product_slug` alone (`product_id` will still be added but the adding will occur inside the endpoint). 

This PR removes the requirement of `product_id` in the `@automattic/shopping-cart` package and updates many places in the code that previously added the property such that they no longer do.

#### Testing instructions

This touches many areas of the codebase by removing the `fillInSingleCartItemAttributes` function but (as long as there are no syntax errors) as long as one of them works, all of them should work, because the only thing that function did was to add a `product_id`.

- Apply D71913-code and sandbox the API.
- Add a product to your cart (we should test different products like new plans, renewals, domains, signup, etc.) and visit checkout.
- Verify that the product you added shows up correctly in checkout.