### PR TITLE
My home: open Anchor link in a new tab

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/podcasting/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/podcasting/index.jsx
@@ -14,6 +14,7 @@ const Podcasting = () => {
 			) }
 			actionText={ translate( 'Create an Anchor account' ) }
 			actionUrl={ `https://anchor.fm/wordpressdotcom` }
+			actionTarget="_blank"
 			illustration={ podcastingIllustration }
 			taskId={ TASK_PODCASTING }
 		/>


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/59367

Makes external service CTAs consistent (test also Cloudflare CTA)

#### Changes proposed in this Pull Request

* Open Anchor FM my home banner in a new tab

#### Testing instructions

- Create a new site or pick an old one
- Open my home
- Find Anchor FM banner via carousel on top
- Click on CTA
- Should open in new tab
- Going through the flow, it isn't impacted by being in a new tab vs the same window

