### PR TITLE
More Informative Scan: Minor layout fixes and wording changes

### DIFF
--- a/client/components/jetpack/threat-description-new/index.tsx
+++ b/client/components/jetpack/threat-description-new/index.tsx
@@ -36,7 +36,7 @@ class ThreatDescription extends PureComponent< Props > {
 				if ( isFixable ) {
 					return translate( 'How will we fix it?' );
 				}
-				return translate( 'Resolving the threat' );
+				return translate( 'How to resolve or handle this detection?' );
 
 				break;
 
@@ -92,7 +92,7 @@ class ThreatDescription extends PureComponent< Props > {
 		return (
 			<div className="threat-description-new">
 				<p className="threat-description-new__section-title">
-					<strong>{ translate( 'What is the problem?' ) }</strong>
+					<strong>{ translate( 'What did Jetpack find?' ) }</strong>
 				</p>
 				{ this.renderTextOrNode(
 					<p className="threat-description-new__section-text">{ problem }</p>

--- a/client/components/jetpack/threat-dialog-new/index.tsx
+++ b/client/components/jetpack/threat-dialog-new/index.tsx
@@ -84,6 +84,10 @@ const ThreatDialog: React.FC< Props > = ( {
 				<h3 className="threat-dialog-new__threat-title">
 					{ <ThreatFixHeader threat={ threat } action={ action } /> }
 				</h3>
+				{ action === 'ignore' &&
+					translate(
+						'By ignoring this threat you confirm that you have reviewed the detected code and assume the risks of keeping a potentially malicious file on your site. If you are unsure please request an estimate with Codeable.'
+					) }
 			</>
 		</ServerCredentialsWizardDialog>
 	);

--- a/client/components/jetpack/threat-fix-header/style.scss
+++ b/client/components/jetpack/threat-fix-header/style.scss
@@ -63,6 +63,7 @@
     font-weight: 600;
     font-size: $font-body-large;
     line-height: 24px;
+    overflow: scroll;
   }
 
   &__card-bottom {

--- a/client/components/jetpack/threat-item-header-new/style.scss
+++ b/client/components/jetpack/threat-item-header-new/style.scss
@@ -23,6 +23,7 @@
     font-weight: 600;
     font-size: $font-body-large;
     line-height: 24px;
+    overflow: scroll;
   }
 
   &__card-bottom {

--- a/client/components/jetpack/threat-item-header-new/style.scss
+++ b/client/components/jetpack/threat-item-header-new/style.scss
@@ -23,7 +23,9 @@
     font-weight: 600;
     font-size: $font-body-large;
     line-height: 24px;
-    overflow: scroll;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__card-bottom {

--- a/client/components/jetpack/threat-item-new/index.tsx
+++ b/client/components/jetpack/threat-item-new/index.tsx
@@ -116,6 +116,11 @@ const ThreatItem: React.FC< Props > = ( {
 		return (
 			<p className="threat-item-new threat-description__section-text">
 				{ getThreatFix( threat.fixable ) }
+				<p>
+					{ translate(
+						'Jetpack Scan is able to automatically fix this threat for you. Since it will replace the affected file or directory the site’s look-and-feel or features can be compromised. We recommend that you check if your latest backup was performed successfully in case a restore is needed.'
+					) }
+				</p>
 			</p>
 		);
 	}, [ contactSupportUrl, threat ] );

--- a/client/components/jetpack/threat-item-new/utils.ts
+++ b/client/components/jetpack/threat-item-new/utils.ts
@@ -9,12 +9,12 @@ export const getThreatMessage = ( threat: Threat ): string | i18nCalypso.Transla
 
 	switch ( getThreatType( threat ) ) {
 		case 'core':
-			return translate( 'Infected core file: %s', {
+			return translate( 'Compromised WordPress core file: %s', {
 				args: [ basename ],
 			} );
 
 		case 'file':
-			return translate( 'File contains malicious code: %s', {
+			return translate( 'Malicious code found in file: %s', {
 				args: [ basename ],
 			} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Handle overflow for long filenames
* Some wording changes

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a JP site with Scan and add a few threats (You can use the threat tester plugin to add a few innocuous threats for testing).
* Open the links provided in this PR.
* Open the scan page, append the `?flags=+jetpack/more-informative-scan` query string to your URL to activate the feature flag.
* Verify that the layout and text changes are ok.

