### PR TITLE
Woo on Plans: atomic state error handling 

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -69,16 +69,11 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 * - status code value is one of: [ `active`,...] @todo: add more codes.
 	 * - is_stuck value is True.
 	 */
-	const { transfer } = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
+	const { transfer, error: transferError } = useSelector( ( state ) =>
+		getLatestAtomicTransfer( state, siteId )
+	);
 	const isTransferStuck = transfer?.is_stuck || false;
-
-	// todo this probably isn't valid anymore
-	const transferStatus = transfer?.status || '';
-	const isBlockByTransferStatus =
-		( Number.isInteger( Number( transferStatus ) ) &&
-			transferStatus &&
-			5 === Math.floor( Number( transferStatus ) / 100 ) ) ||
-		[ 'active' ].includes( transferStatus );
+	const isBlockByTransferStatus = transferError && transferError?.status >= 500;
 
 	/*
 	 * Filter warnings:
@@ -111,7 +106,8 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	}
 
 	const transferringDataIsAvailable =
-		typeof transferringBlockers !== 'undefined' && typeof transferStatus !== 'undefined';
+		typeof transferringBlockers !== 'undefined' &&
+		( typeof transfer !== 'undefined' || typeof transferError !== 'undefined' );
 
 	/*
 	 * Check whether the site transferring is blocked.

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -66,7 +66,6 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 * Inspect transfer to detect blockers.
 	 * It's considered blocked when:
 	 * - status code value has the 5xx shape.
-	 * - status code value is one of: [ `active`,...] @todo: add more codes.
 	 * - is_stuck value is True.
 	 */
 	const { transfer, error: transferError } = useSelector( ( state ) =>

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -69,10 +69,11 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 * - status code value is one of: [ `active`,...] @todo: add more codes.
 	 * - is_stuck value is True.
 	 */
-	const transfer = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
-	const isTransferStuck = transfer?.is_stuck;
+	const { transfer } = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
+	const isTransferStuck = transfer?.is_stuck || false;
 
-	const transferStatus = transfer?.status;
+	// todo this probably isn't valid anymore
+	const transferStatus = transfer?.status || '';
 	const isBlockByTransferStatus =
 		( Number.isInteger( Number( transferStatus ) ) &&
 			transferStatus &&

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -24,15 +24,14 @@ export default function InstallPlugins( {
 	const dispatch = useDispatch();
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const softwareStatus = useSelector( ( state ) =>
+	const { status } = useSelector( ( state ) =>
 		getAtomicSoftwareStatus( state, siteId, 'woo-on-plans' )
 	);
 
 	// Used to implement a timeout threshold for the install to complete.
 	const [ isTimeout, setIsTimeout ] = useState( false );
-
-	const softwareApplied = softwareStatus?.applied;
-	const softwareError = softwareStatus?.error;
+	const softwareApplied = status?.applied;
+	const softwareError = status?.error;
 	const wcAdmin = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) ) ?? '/';
 
 	const installFailed = isTimeout || softwareError;

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -30,13 +30,13 @@ export default function InstallPlugins( {
 	);
 
 	// Used to implement a timeout threshold for the install to complete.
-	const [ isTimeout, setIsTimeout ] = useState( false );
-	
+	const [ isTimeoutError, setIsTimeoutError ] = useState( false );
+
 	const softwareApplied = !! softwareStatus?.applied;
 
 	const wcAdmin = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) ) ?? '/';
 
-	const installFailed = isTimeout || softwareError;
+	const installFailed = isTimeoutError || softwareError;
 
 	const [ progress, setProgress ] = useState( 0.6 );
 	// Install Woo on plans software set
@@ -69,7 +69,7 @@ export default function InstallPlugins( {
 		}
 
 		const timeId = setTimeout( () => {
-			setIsTimeout( true );
+			setIsTimeoutError( true );
 			onFailure();
 		}, TIMEOUT_LIMIT );
 
@@ -89,7 +89,7 @@ export default function InstallPlugins( {
 			setProgress( progress + 0.2 );
 			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
 		},
-		!! softwareError || softwareApplied ? null : 3000
+		!! installFailed || softwareApplied ? null : 3000
 	);
 
 	// Redirect to wc-admin once software installation is confirmed.

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -45,13 +45,8 @@ export default function InstallPlugins( {
 			return;
 		}
 
-		// Do not dispatch when something went wrong.
-		if ( installFailed ) {
-			return;
-		}
-
 		dispatch( requestAtomicSoftwareInstall( siteId, 'woo-on-plans' ) );
-	}, [ dispatch, siteId, installFailed ] );
+	}, [ dispatch, siteId ] );
 
 	// Call onFailure callback when install fails.
 	useEffect( () => {

--- a/client/state/atomic/software/actions.ts
+++ b/client/state/atomic/software/actions.ts
@@ -2,7 +2,6 @@ import {
 	ATOMIC_SOFTWARE_INITIATE_INSTALL,
 	ATOMIC_SOFTWARE_REQUEST_STATUS,
 	ATOMIC_SOFTWARE_SET_STATUS,
-	ATOMIC_SOFTWARE_SET_ERROR,
 } from 'calypso/state/action-types';
 import 'calypso/state/data-layer/wpcom/sites/atomic/software';
 import 'calypso/state/atomic/init';

--- a/client/state/atomic/software/actions.ts
+++ b/client/state/atomic/software/actions.ts
@@ -13,6 +13,13 @@ export interface AtomicSoftwareStatus {
 	applied: boolean;
 }
 
+export interface AtomicSoftwareError {
+	name: string; // "NotFoundError"
+	status: number; // 404
+	message: string; // "Transfer not found"
+	code: string; // "no_transfer_record"
+}
+
 /**
  * Initiate plugin install and activation.
  *
@@ -66,10 +73,14 @@ export const setAtomicSoftwareStatus = (
  *
  * @param {number} siteId The site id to which the status belongs.
  * @param {string} softwareSet The software set slug.*
- * @param {object} error The error of the install.
+ * @param {AtomicSoftwareError} error The error of the install.
  * @returns {object} An action object
  */
-export const setAtomicSoftwareError = ( siteId: number, softwareSet: string, error: object ) =>
+export const setAtomicSoftwareError = (
+	siteId: number,
+	softwareSet: string,
+	error: AtomicSoftwareError
+) =>
 	( {
 		type: ATOMIC_SOFTWARE_SET_STATUS,
 		siteId,

--- a/client/state/atomic/software/actions.ts
+++ b/client/state/atomic/software/actions.ts
@@ -86,3 +86,19 @@ export const setAtomicSoftwareError = (
 		softwareSet,
 		error,
 	} as const );
+
+/**
+ * Clean the install status.
+ *
+ * @param {number} siteId The site id to which the status belongs.
+ * @param {string} softwareSet The software set slug.*
+ * @returns {object} An action object
+ */
+export const cleanAtomicSoftwareStatus = ( siteId: number, softwareSet: string ) =>
+	( {
+		type: ATOMIC_SOFTWARE_SET_STATUS,
+		siteId,
+		softwareSet,
+		status: null,
+		error: null,
+	} as const );

--- a/client/state/atomic/software/actions.ts
+++ b/client/state/atomic/software/actions.ts
@@ -11,7 +11,6 @@ export interface AtomicSoftwareStatus {
 	blog_id: number;
 	software_set: Record< string, { path: string; state: string } >;
 	applied: boolean;
-	error?: string;
 }
 
 /**
@@ -26,12 +25,6 @@ export const requestAtomicSoftwareInstall = ( siteId: number, softwareSet: strin
 		type: ATOMIC_SOFTWARE_INITIATE_INSTALL,
 		siteId,
 		softwareSet,
-		meta: {
-			dataLayer: {
-				trackRequest: true,
-				requestKey: `${ ATOMIC_SOFTWARE_INITIATE_INSTALL }-${ siteId }-${ softwareSet }`,
-			},
-		},
 	} as const );
 
 /**
@@ -78,7 +71,7 @@ export const setAtomicSoftwareStatus = (
  */
 export const setAtomicSoftwareError = ( siteId: number, softwareSet: string, error: object ) =>
 	( {
-		type: ATOMIC_SOFTWARE_SET_ERROR,
+		type: ATOMIC_SOFTWARE_SET_STATUS,
 		siteId,
 		softwareSet,
 		error,

--- a/client/state/atomic/software/reducer.js
+++ b/client/state/atomic/software/reducer.js
@@ -6,10 +6,10 @@ function software( state = {}, action ) {
 	switch ( action.type ) {
 		case ATOMIC_SOFTWARE_SET_STATUS:
 			return {
-				...state,
 				siteId: action.siteId,
 				softwareSet: action.softwareSet,
-				...action?.status,
+				status: action?.status || null,
+				error: action?.error || null,
 			};
 
 		case ATOMIC_SOFTWARE_SET_ERROR:

--- a/client/state/atomic/software/reducer.js
+++ b/client/state/atomic/software/reducer.js
@@ -1,5 +1,5 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { ATOMIC_SOFTWARE_SET_STATUS, ATOMIC_SOFTWARE_SET_ERROR } from 'calypso/state/action-types';
+import { ATOMIC_SOFTWARE_SET_STATUS } from 'calypso/state/action-types';
 import { keyedReducer } from 'calypso/state/utils';
 
 function software( state = {}, action ) {
@@ -10,14 +10,6 @@ function software( state = {}, action ) {
 				softwareSet: action.softwareSet,
 				status: action?.status || null,
 				error: action?.error || null,
-			};
-
-		case ATOMIC_SOFTWARE_SET_ERROR:
-			return {
-				...state,
-				siteId: action.siteId,
-				softwareSet: action.softwareSet,
-				error: action.error,
 			};
 	}
 	return state;

--- a/client/state/atomic/software/selectors.ts
+++ b/client/state/atomic/software/selectors.ts
@@ -6,4 +6,5 @@ export const getAtomicSoftwareStatus = (
 	state: AppState,
 	siteId: number,
 	softwareSet: string
-): AtomicSoftwareStatus => state?.atomicSoftware?.[ siteId ]?.[ softwareSet ] || {};
+): { status: AtomicSoftwareStatus; error: Error } =>
+	state?.atomicSoftware?.[ siteId ]?.[ softwareSet ] || { status: null, error: null };

--- a/client/state/atomic/software/selectors.ts
+++ b/client/state/atomic/software/selectors.ts
@@ -1,4 +1,4 @@
-import type { AtomicSoftwareStatus } from './actions';
+import type { AtomicSoftwareStatus, AtomicSoftwareError } from './actions';
 import type { AppState } from 'calypso/types';
 import 'calypso/state/atomic/init';
 
@@ -6,5 +6,5 @@ export const getAtomicSoftwareStatus = (
 	state: AppState,
 	siteId: number,
 	softwareSet: string
-): { status: AtomicSoftwareStatus; error: Error } =>
-	state?.atomicSoftware?.[ siteId ]?.[ softwareSet ] || { status: null, error: null };
+): { status?: AtomicSoftwareStatus; error?: AtomicSoftwareError } =>
+	state?.atomicSoftware?.[ siteId ]?.[ softwareSet ] || {};

--- a/client/state/atomic/transfers/actions.ts
+++ b/client/state/atomic/transfers/actions.ts
@@ -17,6 +17,13 @@ export interface AtomicTransfer {
 	in_lossless_revert: boolean;
 }
 
+export interface AtomicTransferError {
+	name: string; // "NotFoundError"
+	status: number; // 404
+	message: string; // "Transfer not found"
+	code: string; // "no_transfer_record"
+}
+
 /**
  * Initiate Atomic transfer, optionally with software set install.
  *
@@ -61,7 +68,7 @@ export const setLatestAtomicTransfer = ( siteId: number, transfer: AtomicTransfe
 		transfer,
 	} as const );
 
-export const setLatestAtomicTransferError = ( siteId: number, error: Error ) =>
+export const setLatestAtomicTransferError = ( siteId: number, error: AtomicTransferError ) =>
 	( {
 		type: ATOMIC_TRANSFER_SET_LATEST,
 		siteId,

--- a/client/state/atomic/transfers/actions.ts
+++ b/client/state/atomic/transfers/actions.ts
@@ -15,7 +15,6 @@ export interface AtomicTransfer {
 	is_stuck: boolean;
 	is_stuck_reset: boolean;
 	in_lossless_revert: boolean;
-	error?: string;
 }
 
 /**
@@ -34,12 +33,6 @@ export const initiateAtomicTransfer = (
 		type: ATOMIC_TRANSFER_INITIATE_TRANSFER,
 		siteId,
 		softwareSet,
-		meta: {
-			dataLayer: {
-				trackRequest: true,
-				requestKey: `${ ATOMIC_TRANSFER_INITIATE_TRANSFER }-${ siteId }-${ softwareSet }`,
-			},
-		},
 	} as const );
 
 /**
@@ -66,4 +59,11 @@ export const setLatestAtomicTransfer = ( siteId: number, transfer: AtomicTransfe
 		type: ATOMIC_TRANSFER_SET_LATEST,
 		siteId,
 		transfer,
+	} as const );
+
+export const setLatestAtomicTransferError = ( siteId: number, error: Error ) =>
+	( {
+		type: ATOMIC_TRANSFER_SET_LATEST,
+		siteId,
+		error,
 	} as const );

--- a/client/state/atomic/transfers/reducer.js
+++ b/client/state/atomic/transfers/reducer.js
@@ -5,7 +5,11 @@ import { keyedReducer } from 'calypso/state/utils';
 function transfers( state = {}, action ) {
 	switch ( action.type ) {
 		case ATOMIC_TRANSFER_SET_LATEST:
-			return { ...state, siteId: action.siteId, ...action.transfer };
+			return {
+				siteId: action.siteId,
+				transfer: action?.transfer || null,
+				error: action?.error || null,
+			};
 	}
 	return state;
 }

--- a/client/state/atomic/transfers/selectors.ts
+++ b/client/state/atomic/transfers/selectors.ts
@@ -3,5 +3,8 @@ import type { AppState } from 'calypso/types';
 
 import 'calypso/state/atomic/init';
 
-export const getLatestAtomicTransfer = ( state: AppState, siteId: number ): AtomicTransfer =>
-	state?.atomicTransfers?.[ siteId ] || {};
+export const getLatestAtomicTransfer = (
+	state: AppState,
+	siteId: number
+): { transfer: AtomicTransfer; error: Error } =>
+	state?.atomicTransfers?.[ siteId ] || { transfer: null, error: null };

--- a/client/state/atomic/transfers/selectors.ts
+++ b/client/state/atomic/transfers/selectors.ts
@@ -1,4 +1,4 @@
-import type { AtomicTransfer } from './actions';
+import type { AtomicTransfer, AtomicTransferError } from './actions';
 import type { AppState } from 'calypso/types';
 
 import 'calypso/state/atomic/init';
@@ -6,5 +6,5 @@ import 'calypso/state/atomic/init';
 export const getLatestAtomicTransfer = (
 	state: AppState,
 	siteId: number
-): { transfer: AtomicTransfer; error: Error } =>
-	state?.atomicTransfers?.[ siteId ] || { transfer: null, error: null };
+): { transfer?: AtomicTransfer; error?: AtomicTransferError } =>
+	state?.atomicTransfers?.[ siteId ] || {};

--- a/client/state/data-layer/wpcom/sites/atomic/software/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/software/index.js
@@ -14,6 +14,7 @@ import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-f
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
 const installSoftware = ( action ) => [
+	// Clean up the status in case it's an installing reattempt.
 	cleanAtomicSoftwareStatus( action.siteId, action.softwareSet ),
 	http(
 		{

--- a/client/state/data-layer/wpcom/sites/atomic/software/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/software/index.js
@@ -1,4 +1,3 @@
-import { translate } from 'i18n-calypso';
 import {
 	ATOMIC_SOFTWARE_INITIATE_INSTALL,
 	ATOMIC_SOFTWARE_REQUEST_STATUS,
@@ -12,7 +11,6 @@ import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'calypso/state/notices/actions';
 
 const installSoftware = ( action ) =>
 	http(
@@ -36,9 +34,6 @@ const receiveInstallError = ( action, error ) => [
 		context: 'atomic_software_install',
 		error: error.error,
 	} ),
-	errorNotice(
-		translate( "Sorry, we've hit a snag. Please contact support so we can help you out." )
-	),
 	setAtomicSoftwareError( action.siteId, action.softwareSet, error ),
 ];
 

--- a/client/state/data-layer/wpcom/sites/atomic/software/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/software/index.js
@@ -6,13 +6,15 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	setAtomicSoftwareStatus,
 	setAtomicSoftwareError,
+	cleanAtomicSoftwareStatus,
 } from 'calypso/state/atomic/software/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
-const installSoftware = ( action ) =>
+const installSoftware = ( action ) => [
+	cleanAtomicSoftwareStatus( action.siteId, action.softwareSet ),
 	http(
 		{
 			apiNamespace: 'wpcom/v2',
@@ -21,7 +23,8 @@ const installSoftware = ( action ) =>
 			body: {}, // have to have an empty body to make wpcom-http happy
 		},
 		action
-	);
+	),
+];
 
 const receiveInstallResponse = () => [
 	recordTracksEvent( 'calypso_atomic_software_install_inititate_success', {

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -1,11 +1,12 @@
-import { translate } from 'i18n-calypso';
 import { ATOMIC_TRANSFER_INITIATE_TRANSFER } from 'calypso/state/action-types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { setLatestAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
+import {
+	setLatestAtomicTransfer,
+	setLatestAtomicTransferError,
+} from 'calypso/state/atomic/transfers/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'calypso/state/notices/actions';
 
 const initiateAtomicTransfer = ( action ) =>
 	http(
@@ -24,10 +25,11 @@ const initiateAtomicTransfer = ( action ) =>
 		action
 	);
 
-const receiveResponse = () => [
+const receiveResponse = ( action, transfer ) => [
 	recordTracksEvent( 'calypso_atomic_transfer_inititate_success', {
 		context: 'atomic_transfer',
 	} ),
+	setLatestAtomicTransfer( action.siteId, transfer ),
 ];
 
 const receiveError = ( action, error ) => [
@@ -35,10 +37,7 @@ const receiveError = ( action, error ) => [
 		context: 'atomic_transfer',
 		error: error.error,
 	} ),
-	errorNotice(
-		translate( "Sorry, we've hit a snag. Please contact support so we can help you out." )
-	),
-	setLatestAtomicTransfer( action.siteId, error ),
+	setLatestAtomicTransferError( action.siteId, error ),
 ];
 
 registerHandlers( 'state/data-layer/wpcom/sites/atomic/transfers', {

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/latest/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/latest/index.js
@@ -1,5 +1,8 @@
 import { ATOMIC_TRANSFER_REQUEST_LATEST } from 'calypso/state/action-types';
-import { setLatestAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
+import {
+	setLatestAtomicTransfer,
+	setLatestAtomicTransferError,
+} from 'calypso/state/atomic/transfers/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
@@ -16,11 +19,10 @@ const requestLatestAtomicTransfer = ( action ) =>
 		action
 	);
 
-const receiveError = ( action, error ) => [ setLatestAtomicTransfer( action.siteId, error ) ];
-
-const receiveResponse = ( action, response ) => [
-	setLatestAtomicTransfer( action.siteId, response ),
+const receiveResponse = ( action, transfer ) => [
+	setLatestAtomicTransfer( action.siteId, transfer ),
 ];
+const receiveError = ( action, error ) => [ setLatestAtomicTransferError( action.siteId, error ) ];
 
 registerHandlers( 'state/data-layer/wpcom/sites/atomic/transfers/latest', {
 	[ ATOMIC_TRANSFER_REQUEST_LATEST ]: [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reworks error handling to make distinction between handled and unhandled errors (e.g. 404 transfer not found while waiting for a transfer to complete isn't an error, it's just a signal to keep polling.)
* Main aim here is to split error / status states up to make usage of the responses a bit cleaner.
* Clean the installing status before triggering the installing action.

#### Testing instructions

* Should be no change, error handling with D71706-code applied should be a bit better. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
