### PR TITLE
Domain settings: add dns section

### DIFF
--- a/client/components/domains/layout/style.scss
+++ b/client/components/domains/layout/style.scss
@@ -4,15 +4,15 @@
 .two-columns-layout {
 	@include break-xlarge {
 		display: grid;
-		grid-template-columns: 1fr 315px;
+		grid-template-columns: minmax( 0, 1fr ) 315px;
 		column-gap: 48px;
 	}
 
 	&__content {
-		grid-column: 1 2;
+		grid-column: 1 / 2;
 	}
 
 	&__sidebar {
-		grid-column: 2 3;
+		grid-column: 2 / 3;
 	}
 }

--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -116,3 +116,27 @@ export type ResponseDomain = {
 	type: DomainType;
 	whoisUpdateUnmodifiableFields?: Array< string >;
 };
+
+export type DNSRecordType = 'MX' | 'A' | 'SRV' | 'TXT' | 'AAAA' | 'CNAME' | 'NS';
+
+export type DnsRecord = {
+	domain: string;
+	id: string;
+	name: string;
+	protected_field: boolean;
+	type: DNSRecordType;
+	target?: string;
+	data?: string;
+	weight?: number;
+	port?: number;
+	aux?: number;
+	service?: string;
+	protocol?: string;
+};
+
+export type Dns = {
+	hasLoadedFromServer: boolean;
+	isFetching: boolean;
+	isSubmittingForm: boolean;
+	records: Array< DnsRecord >;
+};

--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -117,14 +117,14 @@ export type ResponseDomain = {
 	whoisUpdateUnmodifiableFields?: Array< string >;
 };
 
-export type DNSRecordType = 'MX' | 'A' | 'SRV' | 'TXT' | 'AAAA' | 'CNAME' | 'NS';
+export type DnsRecordType = 'MX' | 'A' | 'SRV' | 'TXT' | 'AAAA' | 'CNAME' | 'NS';
 
 export type DnsRecord = {
 	domain: string;
 	id: string;
 	name: string;
 	protected_field: boolean;
-	type: DNSRecordType;
+	type: DnsRecordType;
 	target?: string;
 	data?: string;
 	weight?: number;
@@ -134,7 +134,7 @@ export type DnsRecord = {
 	protocol?: string;
 };
 
-export type Dns = {
+export type DnsRequest = {
 	hasLoadedFromServer: boolean;
 	isFetching: boolean;
 	isSubmittingForm: boolean;

--- a/client/my-sites/domains/domain-management/settings/dns/dns-record-item-placeholder.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/dns-record-item-placeholder.tsx
@@ -1,0 +1,13 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+const DnsRecordItemPlaceholder = (): JSX.Element => {
+	return (
+		<div className="dns-record-item is-placeholder">
+			<div className="dns-record-item__type" />
+			<div className="dns-record-item__name" />
+			<div className="dns-record-item__value" />
+		</div>
+	);
+};
+
+export default DnsRecordItemPlaceholder;

--- a/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
@@ -3,7 +3,6 @@ import { DnsRecordItemProps } from './types';
 
 const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ): JSX.Element => {
 	const translate = useTranslate();
-
 	const trimDot = ( str?: string ) => {
 		return str ? str.replace( /\.$/, '' ) : '';
 	};

--- a/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
@@ -4,8 +4,8 @@ import { DnsRecordItemProps } from './types';
 const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ): JSX.Element => {
 	const translate = useTranslate();
 
-	const trimDot = ( str: unknown ) => {
-		return typeof str === 'string' ? str.replace( /\.$/, '' ) : str;
+	const trimDot = ( str?: string ) => {
+		return str ? str.replace( /\.$/, '' ) : '';
 	};
 
 	const handledBy = () => {
@@ -62,8 +62,10 @@ const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ):
 	};
 
 	return (
-		<div>
-			{ dnsRecord.type } - { getName() } - { handledBy() }
+		<div className="dns-record-item">
+			<div className="dns-record-item__type">{ dnsRecord.type }</div>
+			<div className="dns-record-item__name">{ getName() }</div>
+			<div className="dns-record-item__value">{ handledBy() }</div>
 		</div>
 	);
 };

--- a/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
@@ -1,0 +1,71 @@
+import { useTranslate } from 'i18n-calypso';
+import { DnsRecordItemProps } from './types';
+
+const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ): JSX.Element => {
+	const translate = useTranslate();
+
+	const trimDot = ( str: unknown ) => {
+		return typeof str === 'string' ? str.replace( /\.$/, '' ) : str;
+	};
+
+	const handledBy = () => {
+		const { type, aux, port, weight } = dnsRecord;
+		const data = trimDot( dnsRecord.data );
+		const target = trimDot( dnsRecord.target );
+
+		// TODO: Remove this once we stop displaying the protected records
+		if ( dnsRecord.protected_field ) {
+			if ( 'MX' === type ) {
+				return translate( 'Mail handled by WordPress.com email forwarding' );
+			}
+
+			return translate( 'Handled by WordPress.com' );
+		}
+
+		switch ( type ) {
+			case 'MX':
+				return translate( '%(data)s with priority %(aux)d', {
+					args: {
+						data,
+						aux,
+					},
+					comment: '%(data)s is a hostname',
+				} );
+
+			case 'SRV':
+				return translate( '%(target)s:%(port)d, with priority %(aux)d and weight %(weight)d', {
+					args: {
+						target,
+						port,
+						aux,
+						weight,
+						comment: '%(target)s is a hostname',
+					},
+				} );
+		}
+
+		return data;
+	};
+
+	const getName = () => {
+		const { name, service, protocol, type } = dnsRecord;
+
+		if ( name.replace( /\.$/, '' ) === selectedDomainName ) {
+			return '@';
+		}
+
+		if ( 'SRV' === type ) {
+			return `_${ service }._${ protocol }.${ name }`;
+		}
+
+		return name;
+	};
+
+	return (
+		<div>
+			{ dnsRecord.type } - { getName() } - { handledBy() }
+		</div>
+	);
+};
+
+export default DnsRecordItem;

--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -1,6 +1,9 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
+import { domainConnect } from 'calypso/lib/domains/constants';
+import { DnsRecord, DNSRecordType } from 'calypso/lib/domains/types';
+import DnsRecordItem from './dns-record-item';
 import { DnsDetailsProps } from './types';
 
 const DnsDetails = ( {
@@ -10,12 +13,65 @@ const DnsDetails = ( {
 }: DnsDetailsProps ): JSX.Element => {
 	const showPlaceholder = ! dns.hasLoadedFromServer || isRequestingDomains;
 
+	// This could be moved to an utils file?
+	const isDomainConnectRecord = ( dnsRecord: DnsRecord ) => {
+		return (
+			domainConnect.DISCOVERY_TXT_RECORD_NAME === dnsRecord.name &&
+			domainConnect.API_URL === dnsRecord.data &&
+			'TXT' === dnsRecord.type
+		);
+	};
+
+	const getDomainConnectDnsRecord = () => {
+		const record = {
+			name: domainConnect.DISCOVERY_TXT_RECORD_NAME,
+			data: domainConnect.API_URL,
+			type: 'TXT' as DNSRecordType,
+			id: '',
+			domain: '',
+			protected_field: false,
+		};
+
+		return (
+			<DnsRecordItem
+				key={ 'domain-connect-record' }
+				dnsRecord={ record }
+				selectedDomainName={ selectedDomainName }
+			/>
+		);
+	};
+
+	const renderDomains = () => {
+		let domainConnectRecordIsEnabled = false;
+		const domains = dns.records.map( ( dnsRecord, index ) => {
+			if ( 'NS' === dnsRecord.type ) {
+				return;
+			}
+			if ( isDomainConnectRecord( dnsRecord ) ) {
+				domainConnectRecordIsEnabled = true;
+				return;
+			}
+			return (
+				<DnsRecordItem
+					key={ index }
+					dnsRecord={ dnsRecord }
+					selectedDomainName={ selectedDomainName }
+				/>
+			);
+		} );
+		return (
+			<>
+				{ domains }
+				{ domainConnectRecordIsEnabled && getDomainConnectDnsRecord() }
+			</>
+		);
+	};
+
 	return (
 		<>
 			<div className="dns-card">
-				{ /* DNS Placeholder */ }
 				<QueryDomainDns domain={ selectedDomainName } />
-				{ showPlaceholder ? 'Loading DNS' : 'DNS loaded' }
+				{ showPlaceholder ? 'Loading DNS' : renderDomains() }
 			</div>
 		</>
 	);

--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+const DnsDetails = (): JSX.Element => {
+	return <div className="dns-card">DNS Placeholder</div>;
+};
+
+export default DnsDetails;

--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -72,7 +72,10 @@ const DnsDetails = ( {
 			<>
 				{ domains }
 				{ domainConnectRecordIsEnabled && getDomainConnectDnsRecord() }
-				<Button href={ domainManagementDns( selectedSite.slug, selectedDomainName, currentRoute ) }>
+				<Button
+					className="dns-card__button"
+					href={ domainManagementDns( selectedSite.slug, selectedDomainName, currentRoute ) }
+				>
 					{ translate( 'Manage' ) }
 				</Button>
 			</>

--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -1,17 +1,25 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
 import { domainConnect } from 'calypso/lib/domains/constants';
 import { DnsRecord, DNSRecordType } from 'calypso/lib/domains/types';
+import { domainManagementDns } from 'calypso/my-sites/domains/paths';
 import DnsRecordItem from './dns-record-item';
 import { DnsDetailsProps } from './types';
+
+import './style.scss';
 
 const DnsDetails = ( {
 	dns,
 	isRequestingDomains,
 	selectedDomainName,
+	currentRoute,
+	selectedSite,
 }: DnsDetailsProps ): JSX.Element => {
 	const showPlaceholder = ! dns.hasLoadedFromServer || isRequestingDomains;
+	const translate = useTranslate();
 
 	// This could be moved to an utils file?
 	const isDomainConnectRecord = ( dnsRecord: DnsRecord ) => {
@@ -63,6 +71,9 @@ const DnsDetails = ( {
 			<>
 				{ domains }
 				{ domainConnectRecordIsEnabled && getDomainConnectDnsRecord() }
+				<Button href={ domainManagementDns( selectedSite.slug, selectedDomainName, currentRoute ) }>
+					{ translate( 'Manage' ) }
+				</Button>
 			</>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -1,7 +1,24 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-const DnsDetails = (): JSX.Element => {
-	return <div className="dns-card">DNS Placeholder</div>;
+import QueryDomainDns from 'calypso/components/data/query-domain-dns';
+import { DnsDetailsProps } from './types';
+
+const DnsDetails = ( {
+	dns,
+	isRequestingDomains,
+	selectedDomainName,
+}: DnsDetailsProps ): JSX.Element => {
+	const showPlaceholder = ! dns.hasLoadedFromServer || isRequestingDomains;
+
+	return (
+		<>
+			<div className="dns-card">
+				{ /* DNS Placeholder */ }
+				<QueryDomainDns domain={ selectedDomainName } />
+				{ showPlaceholder ? 'Loading DNS' : 'DNS loaded' }
+			</div>
+		</>
+	);
 };
 
 export default DnsDetails;

--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -7,6 +7,7 @@ import { domainConnect } from 'calypso/lib/domains/constants';
 import { DnsRecord, DNSRecordType } from 'calypso/lib/domains/types';
 import { domainManagementDns } from 'calypso/my-sites/domains/paths';
 import DnsRecordItem from './dns-record-item';
+import DnsRecordItemPlaceholder from './dns-record-item-placeholder';
 import { DnsDetailsProps } from './types';
 
 import './style.scss';
@@ -82,7 +83,15 @@ const DnsDetails = ( {
 		<>
 			<div className="dns-card">
 				<QueryDomainDns domain={ selectedDomainName } />
-				{ showPlaceholder ? 'Loading DNS' : renderDomains() }
+				{ showPlaceholder ? (
+					<>
+						<DnsRecordItemPlaceholder />
+						<DnsRecordItemPlaceholder />
+						<DnsRecordItemPlaceholder />
+					</>
+				) : (
+					renderDomains()
+				) }
 			</div>
 		</>
 	);

--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -4,11 +4,11 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
 import { domainConnect } from 'calypso/lib/domains/constants';
-import { DnsRecord, DNSRecordType } from 'calypso/lib/domains/types';
+import { DnsRecord, DnsRecordType } from 'calypso/lib/domains/types';
 import { domainManagementDns } from 'calypso/my-sites/domains/paths';
 import DnsRecordItem from './dns-record-item';
 import DnsRecordItemPlaceholder from './dns-record-item-placeholder';
-import { DnsDetailsProps } from './types';
+import type { DnsDetailsProps } from './types';
 
 import './style.scss';
 
@@ -35,7 +35,7 @@ const DnsDetails = ( {
 		const record = {
 			name: domainConnect.DISCOVERY_TXT_RECORD_NAME,
 			data: domainConnect.API_URL,
-			type: 'TXT' as DNSRecordType,
+			type: 'TXT' as DnsRecordType,
 			id: '',
 			domain: '',
 			protected_field: false,

--- a/client/my-sites/domains/domain-management/settings/dns/style.scss
+++ b/client/my-sites/domains/domain-management/settings/dns/style.scss
@@ -5,6 +5,17 @@
 .dns-record-item {
 	font-size: $font-body-small;
 	line-height: 1.7;
+	&.is-placeholder > div {
+		margin-bottom: 0.75em;
+		&::after {
+			animation: pulse-light 1.8s ease-in-out infinite;
+			background-color: var( --color-neutral-10 );
+			content: '';
+			display: block;
+			height: $font-body-small;
+
+		}
+	}
 	@include break-mobile {
 		display: flex;
 	}

--- a/client/my-sites/domains/domain-management/settings/dns/style.scss
+++ b/client/my-sites/domains/domain-management/settings/dns/style.scss
@@ -2,6 +2,12 @@
 @import '@automattic/typography/styles/variables';
 @import '@wordpress/base-styles/breakpoints';
 
+.dns-card {
+  &__button {
+    margin-top: 16px;
+  }
+}
+
 .dns-record-item {
 	font-size: $font-body-small;
 	line-height: 1.7;
@@ -13,7 +19,6 @@
 			content: '';
 			display: block;
 			height: $font-body-small;
-
 		}
 	}
 	@include break-mobile {
@@ -22,24 +27,33 @@
 	&__type {
 		overflow-wrap: break-word;
 		display: inline-block;
-		margin-right: 32px;
+		vertical-align: middle;
+		margin-right: 16px;
 		@include break-mobile {
-			flex-basis: 70px;
+			margin-right: 32px;
+			flex-basis: 60px;
 			flex-grow: 1;
 		}
 	}
 	&__name {
-		margin-right: 32px;
+		margin-right: 16px;
 		display: inline-block;
+		vertical-align: middle;
 		@include break-mobile {
-			flex-basis: 240px;
+			margin-right: 32px;
+			flex-basis: 140px;
 			flex-grow: 1;
 		}
 	}
 	&__value {
 		display: inline-block;
+		max-width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		vertical-align: middle;
 		@include break-mobile {
-			flex-basis: 440px;
+			flex-basis: 100%;
 			flex-grow: 1;
 		}
 	}

--- a/client/my-sites/domains/domain-management/settings/dns/style.scss
+++ b/client/my-sites/domains/domain-management/settings/dns/style.scss
@@ -1,0 +1,35 @@
+@import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+
+.dns-record-item {
+	font-size: $font-body-small;
+	line-height: 1.7;
+	@include break-mobile {
+		display: flex;
+	}
+	&__type {
+		overflow-wrap: break-word;
+		display: inline-block;
+		margin-right: 32px;
+		@include break-mobile {
+			flex-basis: 70px;
+			flex-grow: 1;
+		}
+	}
+	&__name {
+		margin-right: 32px;
+		display: inline-block;
+		@include break-mobile {
+			flex-basis: 240px;
+			flex-grow: 1;
+		}
+	}
+	&__value {
+		display: inline-block;
+		@include break-mobile {
+			flex-basis: 440px;
+			flex-grow: 1;
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/settings/dns/style.scss
+++ b/client/my-sites/domains/domain-management/settings/dns/style.scss
@@ -3,9 +3,9 @@
 @import '@wordpress/base-styles/breakpoints';
 
 .dns-card {
-  &__button {
-    margin-top: 16px;
-  }
+	&__button {
+		margin-top: 16px;
+	}
 }
 
 .dns-record-item {
@@ -13,13 +13,7 @@
 	line-height: 1.7;
 	&.is-placeholder > div {
 		margin-bottom: 0.75em;
-		&::after {
-			animation: pulse-light 1.8s ease-in-out infinite;
-			background-color: var( --color-neutral-10 );
-			content: '';
-			display: block;
-			height: $font-body-small;
-		}
+		@include placeholder();
 	}
 	@include break-mobile {
 		display: flex;
@@ -31,7 +25,7 @@
 		margin-right: 16px;
 		@include break-mobile {
 			margin-right: 32px;
-			flex-basis: 60px;
+			flex-basis: 90px;
 			flex-grow: 1;
 		}
 	}
@@ -41,8 +35,11 @@
 		vertical-align: middle;
 		@include break-mobile {
 			margin-right: 32px;
-			flex-basis: 140px;
+			flex-basis: 180px;
 			flex-grow: 1;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 	}
 	&__value {

--- a/client/my-sites/domains/domain-management/settings/dns/types.ts
+++ b/client/my-sites/domains/domain-management/settings/dns/types.ts
@@ -1,0 +1,5 @@
+export type DnsDetailsProps = {
+	dns: any;
+	isRequestingDomains: boolean;
+	selectedDomainName: string;
+};

--- a/client/my-sites/domains/domain-management/settings/dns/types.ts
+++ b/client/my-sites/domains/domain-management/settings/dns/types.ts
@@ -1,9 +1,12 @@
 import { Dns, DnsRecord } from 'calypso/lib/domains/types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 export type DnsDetailsProps = {
 	dns: Dns;
 	isRequestingDomains: boolean;
 	selectedDomainName: string;
+	selectedSite: SiteData;
+	currentRoute: string;
 };
 
 export type DnsRecordItemProps = {

--- a/client/my-sites/domains/domain-management/settings/dns/types.ts
+++ b/client/my-sites/domains/domain-management/settings/dns/types.ts
@@ -1,5 +1,12 @@
+import { Dns, DnsRecord } from 'calypso/lib/domains/types';
+
 export type DnsDetailsProps = {
-	dns: any;
+	dns: Dns;
 	isRequestingDomains: boolean;
+	selectedDomainName: string;
+};
+
+export type DnsRecordItemProps = {
+	dnsRecord: DnsRecord;
 	selectedDomainName: string;
 };

--- a/client/my-sites/domains/domain-management/settings/dns/types.ts
+++ b/client/my-sites/domains/domain-management/settings/dns/types.ts
@@ -1,8 +1,8 @@
-import { Dns, DnsRecord } from 'calypso/lib/domains/types';
+import { DnsRequest, DnsRecord } from 'calypso/lib/domains/types';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 export type DnsDetailsProps = {
-	dns: Dns;
+	dns: DnsRequest;
 	isRequestingDomains: boolean;
 	selectedDomainName: string;
 	selectedSite: SiteData;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -205,6 +205,7 @@ const Settings = ( {
 					dns={ dns }
 					isRequestingDomains={ isRequestingDomains }
 					selectedDomainName={ selectedDomainName }
+					selectedSite={ selectedSite }
 				/>
 			</Accordion>
 		);

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -19,12 +19,14 @@ import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/dom
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { requestWhois } from 'calypso/state/domains/management/actions';
 import { getWhoisData } from 'calypso/state/domains/management/selectors';
+import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import {
 	getByPurchaseId,
 	isFetchingSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import { isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-info';
 import DomainSecurityDetails from './cards/domain-security-details';
@@ -44,6 +46,8 @@ const Settings = ( {
 	isLoadingNameservers,
 	loadingNameserversError,
 	nameservers,
+	dns,
+	isRequestingDomains,
 	purchase,
 	requestWhois,
 	selectedDomainName,
@@ -197,7 +201,11 @@ const Settings = ( {
 				title={ translate( 'DNS records', { textOnly: true } ) }
 				subtitle={ translate( 'Connect your domain to other services', { textOnly: true } ) }
 			>
-				<DnsRecords />
+				<DnsRecords
+					dns={ dns }
+					isRequestingDomains={ isRequestingDomains }
+					selectedDomainName={ selectedDomainName }
+				/>
 			</Accordion>
 		);
 	};
@@ -326,7 +334,6 @@ export default connect(
 		const purchase = subscriptionId
 			? getByPurchaseId( state, parseInt( subscriptionId, 10 ) )
 			: null;
-
 		return {
 			whoisData: getWhoisData( state, ownProps.selectedDomainName ),
 			currentRoute: getCurrentRoute( state ),
@@ -334,6 +341,8 @@ export default connect(
 			isLoadingPurchase:
 				isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 			purchase: purchase && purchase.userId === currentUserId ? purchase : null,
+			dns: getDomainDns( state, ownProps.selectedDomainName ),
+			isRequestingDomains: isRequestingSiteDomains( state, ownProps.selectedSite.ID ),
 		};
 	},
 	{

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -206,6 +206,7 @@ const Settings = ( {
 					isRequestingDomains={ isRequestingDomains }
 					selectedDomainName={ selectedDomainName }
 					selectedSite={ selectedSite }
+					currentRoute={ currentRoute }
 				/>
 			</Accordion>
 		);

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -31,6 +31,7 @@ import DomainSecurityDetails from './cards/domain-security-details';
 import NameServersCard from './cards/name-servers-card';
 import RegisteredDomainDetails from './cards/registered-domain-details';
 import { getSslReadableStatus, isSecuredWithUs } from './helpers';
+import DnsRecords from './dns';
 import SetAsPrimary from './set-as-primary';
 import SettingsHeader from './settings-header';
 import type { SettingsPageConnectedProps, SettingsPageProps } from './types';
@@ -190,6 +191,17 @@ const Settings = ( {
 		);
 	};
 
+	const renderDnsRecords = () => {
+		return (
+			<Accordion
+				title={ translate( 'DNS records', { textOnly: true } ) }
+				subtitle={ translate( 'Connect your domain to other services', { textOnly: true } ) }
+			>
+				<DnsRecords />
+			</Accordion>
+		);
+	};
+
 	const renderSetAsPrimaryDomainSection = () => {
 		if ( ! domain ) {
 			return null;
@@ -271,6 +283,7 @@ const Settings = ( {
 				{ renderSetAsPrimaryDomainSection() }
 				{ renderContactInformationSecion() }
 				{ renderDomainSecuritySection() }
+				{ renderDnsRecords() }
 			</>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -17,9 +17,9 @@ import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain
 import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import { requestWhois } from 'calypso/state/domains/management/actions';
 import { getWhoisData } from 'calypso/state/domains/management/selectors';
-import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import {
 	getByPurchaseId,
 	isFetchingSitePurchases,
@@ -32,8 +32,8 @@ import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-in
 import DomainSecurityDetails from './cards/domain-security-details';
 import NameServersCard from './cards/name-servers-card';
 import RegisteredDomainDetails from './cards/registered-domain-details';
-import { getSslReadableStatus, isSecuredWithUs } from './helpers';
 import DnsRecords from './dns';
+import { getSslReadableStatus, isSecuredWithUs } from './helpers';
 import SetAsPrimary from './set-as-primary';
 import SettingsHeader from './settings-header';
 import type { SettingsPageConnectedProps, SettingsPageProps } from './types';
@@ -289,11 +289,11 @@ const Settings = ( {
 		return (
 			<>
 				{ renderDetailsSection() }
-				{ renderNameServersSection() }
 				{ renderSetAsPrimaryDomainSection() }
+				{ renderNameServersSection() }
+				{ renderDnsRecords() }
 				{ renderContactInformationSecion() }
 				{ renderDomainSecuritySection() }
-				{ renderDnsRecords() }
 			</>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -33,6 +33,8 @@ export type SettingsPageConnectedProps = {
 	isLoadingPurchase: boolean;
 	purchase: Purchase | null;
 	whoisData: WhoisData[];
+	dns: DnsRequest;
+	isRequestingDomains: boolean;
 };
 
 export type SettingsPageNameServerHocProps = {
@@ -44,8 +46,6 @@ export type SettingsPageNameServerHocProps = {
 
 export type SettingsPageConnectedDispatchProps = {
 	requestWhois: ( domain: string ) => void;
-	dns: DnsRequest;
-	isRequestingDomains: boolean;
 };
 
 export type SettingsHeaderProps = {

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -44,6 +44,8 @@ export type SettingsPageNameServerHocProps = {
 
 export type SettingsPageConnectedDispatchProps = {
 	requestWhois: ( domain: string ) => void;
+	dns: any;
+	isRequestingDomains: boolean;
 };
 
 export type SettingsHeaderProps = {

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -1,4 +1,4 @@
-import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { Dns, ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
@@ -44,7 +44,7 @@ export type SettingsPageNameServerHocProps = {
 
 export type SettingsPageConnectedDispatchProps = {
 	requestWhois: ( domain: string ) => void;
-	dns: any;
+	dns: Dns;
 	isRequestingDomains: boolean;
 };
 

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -1,4 +1,4 @@
-import type { Dns, ResponseDomain } from 'calypso/lib/domains/types';
+import type { DnsRequest, ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
@@ -44,7 +44,7 @@ export type SettingsPageNameServerHocProps = {
 
 export type SettingsPageConnectedDispatchProps = {
 	requestWhois: ( domain: string ) => void;
-	dns: Dns;
+	dns: DnsRequest;
 	isRequestingDomains: boolean;
 };
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR creates the DNS record section in the main domain settings page.

This is part of the domain settings pages redesign project detailed in pcYYhz-m2-p2.

![desktop](https://user-images.githubusercontent.com/2797601/147093005-d0243884-b53e-438d-b0d4-dd905b62802b.png)

<img width="403" alt="Schermata 2021-12-22 alle 13 29 37" src="https://user-images.githubusercontent.com/2797601/147093030-69c2d5c3-3687-4dd7-9b00-9305a3e859ee.png">

## Testing instructions

- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades > Domains"
- Select one of your domains
- Test these functionalities:
  - Expand DNS Record accordion and verify that DNS records are correctly rendered
  - Verify that "Manage" button brings to Manage DNS page
  - Also ensure that the mobile view looks correct