### PR TITLE
i18n: Escape percentage sign on Google Workspace sale banner

### DIFF
--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -103,7 +103,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 				currentRoute,
 				'google-sale'
 			) }
-			title={ translate( 'Get %(discount)d% off Google Workspace for a limited time!', {
+			title={ translate( 'Get %(discount)d%% off Google Workspace for a limited time!', {
 				args: {
 					discount: googleWorkspaceProduct.sale_coupon.discount,
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Escape the percentage sign on Google Workspace sale banner.

**Before:**
`Get %(discount)d% off Google Workspace for a limited time!`

**After:**
`Get %(discount)d%% off Google Workspace for a limited time!`

Translations from the previous original will be copied.

#### Testing instructions

* Review changed string.

Related to p1639859001181000-slack-C02AED43D
