### PR TITLE
Emails: Escape percent sign on Email Comparison pages

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -396,7 +396,7 @@ class EmailProvidersComparison extends Component {
 		const discount = productIsDiscounted ? (
 			<span className="email-providers-comparison__discount-with-renewal">
 				{ translate(
-					'%(discount)d% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
+					'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
 					{
 						args: {
 							discount: gSuiteProduct.sale_coupon.discount,
@@ -404,9 +404,9 @@ class EmailProvidersComparison extends Component {
 							standardPrice,
 						},
 						comment:
-							'%(discount)d is a numeric discount percentage, e.g. 40; ' +
-							'%(discountedPrice)s is a formatted, discounted price that the user will pay today, e.g. $3; ' +
-							'%(standardPrice)s is a formatted price, e.g. $5',
+							"%(discount)d is a numeric percentage discount (e.g. '50'), " +
+							"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
+							"%(standardPrice)s is a formatted price (e.g. '$5')",
 						components: {
 							span: <span />,
 						},

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -103,7 +103,7 @@ const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > =
 	const discount = productIsDiscounted ? (
 		<div className="google-workspace-card__discount-with-renewal">
 			{ translate(
-				'%(discount)d% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
+				'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
 				{
 					args: {
 						discount: gSuiteProduct.sale_coupon.discount,
@@ -111,9 +111,9 @@ const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > =
 						standardPrice: standardPriceForIntervalLength,
 					},
 					comment:
-						'%(discount)d is a numeric discount percentage, e.g. 40; ' +
-						'%(discountedPrice)s is a formatted, discounted price that the user will pay today, e.g. $3; ' +
-						'%(standardPrice)s is a formatted price, e.g. $5',
+						"%(discount)d is a numeric percentage discount (e.g. '50'), " +
+						"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
+						"%(standardPrice)s is a formatted price (e.g. '$5')",
 					components: {
 						span: <span />,
 					},

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -107,7 +107,7 @@ const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains
 				args: {
 					discount: googleWorkspaceProduct.sale_coupon.discount,
 				},
-				comment: '%(discount)d is a percentage discount, e.g. 50',
+				comment: "%(discount)d is a numeric percentage discount (e.g. '50')",
 			} ) }
 			tracksClickName="calypso_email_google_workspace_sale_banner_cta_click"
 			tracksImpressionName="calypso_email_google_workspace_sale_banner_impression"


### PR DESCRIPTION
This pull request is a follow-up of #59400 that fixes two translations from the `Email Comparison` pages where the percent sign would not be correctly escaped:

Old Email Comparison page | New Email Comparison page
------ | -----
![image](https://user-images.githubusercontent.com/594356/146757911-52922c0e-072f-4d83-9004-9b0cdaee5066.png) | ![image](https://user-images.githubusercontent.com/594356/146757815-3fa28d48-51ad-4236-bb9b-900aac0dfa34.png) <br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>

#### Testing instructions

1. Run `git checkout fix/translations-email-comparison-pages` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/59401#issuecomment-997815744)
2. Log into a WordPress.com account with a domain without emails
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click on the `Add Email` button of your domain to access the `Email Comparison` page
5. Assert that `50% off, €39 billed today, renews at €78` is shown in the Google Workspace section
6. Append `?flags=emails/new-email-comparison` to the url of the page, then reload the latter
7. Click on the `Annual` button
8. Assert that `50% off, €39 billed today, renews at €78` is shown in the Google Workspace section