### PR TITLE
Use discount price to calculate annual price in signup flow 

### DIFF
--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -436,6 +436,11 @@ export default connect(
 					);
 				}
 
+				const rawPriceAnnual =
+					null !== discountPrice
+						? discountPrice * 12
+						: getPlanRawPrice( state, planProductId, false );
+
 				return {
 					availableForPurchase,
 					cartItemForPlan: getCartItemForPlan( getPlanSlug( state, planProductId ) ),
@@ -452,7 +457,7 @@ export default connect(
 					hideMonthly: false,
 					primaryUpgrade: popular || plans.length === 1,
 					rawPrice,
-					rawPriceAnnual: getPlanRawPrice( state, planProductId, false ),
+					rawPriceAnnual,
 					rawPriceForMonthlyPlan,
 					relatedMonthlyPlan,
 					annualPricePerMonth,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This ensures that the calculated "billed as ... annually" prices, from the signup flow, are based on the discounted price if it's available.

<img width="240" alt="146540870-18c611d6-3e97-491d-ab98-7e9ec13ad6a1" src="https://user-images.githubusercontent.com/2749938/146763032-a6cc9120-c6dd-4073-b0e9-5f1cffb1f3a5.png">

#### Testing instructions
* Set your currency so that it contains discounted prices (ex. INR, MXN, PHP)
* Head to https://wordpress.com/start and begin afresh signup
* Proceed to the plans step of the signup flow
* Make sure amount from the "billed as ... annually" lines match 12 * discounted price
<img width="420" alt="Screenshot on 2021-12-20 at 12-50-43" src="https://user-images.githubusercontent.com/2749938/146762671-3e3bae3a-ec4b-43b8-905e-130009819fe0.png">

* Check that other price values are not affected
* Also try out a currency without discounts (ex. USD, EUR, GBP)

Related to #59349
