### PR TITLE
i18n: Localize VirtualList component

### DIFF
--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -1,5 +1,6 @@
 import { AutoSizer, List } from '@automattic/react-virtualized';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { cloneElement, createRef, Component } from 'react';
@@ -14,7 +15,7 @@ function range( start, end ) {
 	return Array.from( { length }, ( _, i ) => i + start );
 }
 
-export default class VirtualList extends Component {
+class VirtualList extends Component {
 	static propTypes = {
 		items: PropTypes.array,
 		lastPage: PropTypes.number,
@@ -28,6 +29,7 @@ export default class VirtualList extends Component {
 		defaultRowHeight: PropTypes.number,
 		height: PropTypes.number,
 		scrollTop: PropTypes.number,
+		translate: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -117,7 +119,7 @@ export default class VirtualList extends Component {
 		if ( this.hasNoRows() ) {
 			return (
 				<div key="no-results" className="virtual-list__list-row is-empty">
-					No Results Found
+					{ this.props.translate( 'No results found.' ) }
 				</div>
 			);
 		}
@@ -188,3 +190,5 @@ export default class VirtualList extends Component {
 		);
 	}
 }
+
+export default localize( VirtualList );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Localize VirtualList component and wrap empty row message in translate call.
* Use different capitalization for empty rows message ("No results found.") as it's already translated.

**Before:**
![CleanShot 2021-12-20 at 18 18 14](https://user-images.githubusercontent.com/2722412/146798803-d5849530-a229-4b73-b5d7-b80b61a78a5a.png)

**After:**
![CleanShot 2021-12-20 at 18 17 55](https://user-images.githubusercontent.com/2722412/146798817-11139ee3-fbba-433d-bfe4-f2f511ef4be8.png)


#### Testing instructions

* Change UI to Mag-16 language.
* Go to `/settings/taxonomies/post_tag/{SITE}` and verify the empty rows message is translated. Might need search for non-existent tags.

Related to 356-gh-Automattic/i18n-issues
