### PR TITLE
Marketplace: add correct business plan to cart.

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -249,7 +249,8 @@ function onClickInstallPlugin( {
 			// We also need to add a business plan to the cart.
 			return page(
 				`/checkout/${ selectedSite.slug }/${ product_slug },${ businessPlanToAdd(
-					selectedSite?.plan
+					selectedSite?.plan,
+					billingPeriod
 				) }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2`
 			);
 		}

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -4,6 +4,9 @@ import {
 	isEnterprise,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
+	PLAN_PREMIUM,
+	PLAN_PERSONAL,
+	PLAN_BLOGGER,
 } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
@@ -240,10 +243,10 @@ function onClickInstallPlugin( {
 		const product_slug = plugin?.variations?.[ variationPeriod ]?.product_slug;
 		if ( upgradeAndInstall ) {
 			// We also need to add a business plan to the cart.
-			const plan_slug =
-				billingPeriod === IntervalLength.MONTHLY ? PLAN_BUSINESS_MONTHLY : PLAN_BUSINESS;
 			return page(
-				`/checkout/${ selectedSite.slug }/${ product_slug },${ plan_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2`
+				`/checkout/${ selectedSite.slug }/${ product_slug },${ businessPlanToAdd(
+					selectedSite?.plan
+				) }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2`
 			);
 		}
 
@@ -257,12 +260,25 @@ function onClickInstallPlugin( {
 	if ( upgradeAndInstall ) {
 		// We also need to add a business plan to the cart.
 		return page(
-			`/checkout/${ selectedSite.slug }/${ PLAN_BUSINESS }?redirect_to=${ installPluginURL }#step2`
+			`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
+				selectedSite?.plan
+			) }?redirect_to=${ installPluginURL }#step2`
 		);
 	}
 
 	// No need to go through chekout, go to install page directly.
 	return page( installPluginURL );
+}
+
+// Return the correct business plan slug depending on current plan and pluginBillingPeriod
+function businessPlanToAdd( currentPlan, pluginBillingPeriod = null ) {
+	if ( [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BLOGGER ].includes( currentPlan.product_slug ) ) {
+		// since these plans are annual, return an annual business plan.
+		return PLAN_BUSINESS;
+	}
+
+	// Return annual plan if selected, monthly otherwise.
+	return pluginBillingPeriod === IntervalLength.ANNUALLY ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
 }
 
 export default PluginDetailsCTA;

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -7,6 +7,10 @@ import {
 	PLAN_PREMIUM,
 	PLAN_PERSONAL,
 	PLAN_BLOGGER,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_BLOGGER_2_YEARS,
+	PLAN_PERSONAL_2_YEARS,
 } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
@@ -272,13 +276,21 @@ function onClickInstallPlugin( {
 
 // Return the correct business plan slug depending on current plan and pluginBillingPeriod
 function businessPlanToAdd( currentPlan, pluginBillingPeriod = null ) {
-	if ( [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BLOGGER ].includes( currentPlan.product_slug ) ) {
-		// since these plans are annual, return an annual business plan.
-		return PLAN_BUSINESS;
+	switch ( currentPlan.product_slug ) {
+		case PLAN_PERSONAL_2_YEARS:
+		case PLAN_PREMIUM_2_YEARS:
+		case PLAN_BLOGGER_2_YEARS:
+			return PLAN_BUSINESS_2_YEARS;
+		case PLAN_PERSONAL:
+		case PLAN_PREMIUM:
+		case PLAN_BLOGGER:
+			return PLAN_BUSINESS;
+		default:
+			// Return annual plan if selected, monthly otherwise.
+			return pluginBillingPeriod === IntervalLength.ANNUALLY
+				? PLAN_BUSINESS
+				: PLAN_BUSINESS_MONTHLY;
 	}
-
-	// Return annual plan if selected, monthly otherwise.
-	return pluginBillingPeriod === IntervalLength.ANNUALLY ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
 }
 
 export default PluginDetailsCTA;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to determine the correct business plan (monthly / yearly, 2y) to be added to cart, it checks for current plan billing period. If current plan billing period is annually, it return an annual business plan.

If the current plan is free then returns the billing period selected from the paid plugin page OR monthly for free plugins.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1 - Free site, free plugin**
-> monthly

**Scenario 2 - Free site, paid plugin**
-> depending on plugin billing period switcher

**Scenario 3 - Personal / Premium / Blogger free/paid plugin**
-> depending on current plan period
-> monthly otherwise

**Scenario 4 - Higher plans paid plugin**
-> doesn't add a plan
-> adds the correct plugin billing period

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59302
