### PR TITLE
Checkout: If removeProductFromCart fails, turn off isRemovingProductFromCart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -50,15 +50,21 @@ export default function useRemoveFromCartAndRedirect(
 	const removeProductFromCartAndMaybeRedirect = useCallback(
 		( uuid: string ) => {
 			setIsRemovingFromCart( true );
-			return removeProductFromCart( uuid ).then( ( cart: ResponseCart ) => {
-				if ( cart.products.length === 0 ) {
-					redirectDueToEmptyCart();
-					// Don't turn off isRemovingProductFromCart if we are redirecting so that the loading page remains active.
+			return removeProductFromCart( uuid )
+				.then( ( cart: ResponseCart ) => {
+					if ( cart.products.length === 0 ) {
+						redirectDueToEmptyCart();
+						// Don't turn off isRemovingProductFromCart if we are redirecting so that the loading page remains active.
+						return cart;
+					}
+					isMounted.current && setIsRemovingFromCart( false );
 					return cart;
-				}
-				isMounted.current && setIsRemovingFromCart( false );
-				return cart;
-			} );
+				} )
+				.catch( ( error ) => {
+					isMounted.current && setIsRemovingFromCart( false );
+					// Re-throw error so that the consumer of this action can treat it the same as removeProductFromCart
+					throw error;
+				} );
 		},
 		[ redirectDueToEmptyCart, removeProductFromCart ]
 	);


### PR DESCRIPTION
#### Background

https://github.com/Automattic/wp-calypso/pull/58834 changed cart actions such that they will reject their promises if the cart returns any error messages. One such action is the removal function exposed by `useRemoveFromCartAndRedirect` in checkout.

https://github.com/Automattic/wp-calypso/blob/77238537a28244bfcf4bdd3c2be1380b11892ce4/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts#L53-L61

Previously, if there was an error returned by the cart endpoint, the `then` of this action would still trigger, and the user might be redirected away from checkout while a separate component would display the error to the user. After https://github.com/Automattic/wp-calypso/pull/58834, however, the action rejects, and no redirect will occur; more importantly, the internal state that is used to determine if a removal is in-progress is never resolved. This means that checkout will show a loading state forever.

We do not show the empty cart page if we are in the process of deleting to avoid a flash of the empty cart page before the expected redirect:

https://github.com/Automattic/wp-calypso/blob/77238537a28244bfcf4bdd3c2be1380b11892ce4/client/my-sites/checkout/composite-checkout/composite-checkout.tsx#L879-L881

#### Changes in this PR

Here we modify `useRemoveFromCartAndRedirect` to catch errors and disable the internal loading state, allowing checkout to display an empty cart page as it would normally.

Fixes https://github.com/Automattic/wp-calypso/issues/59414 (partially)

#### Screenshots

Before:
![146788136-2996edf5-e49f-49f5-80dd-3d90aacb592b](https://user-images.githubusercontent.com/2036909/146811062-e1f2a6a6-a7a3-438f-ab93-f07dac29dc7b.png)

After:

<img width="997" alt="Screen Shot 2021-12-20 at 12 45 51 PM" src="https://user-images.githubusercontent.com/2036909/146811006-d8925df2-67df-4b8c-b2f1-06dc6e10f1bf.png">


#### Testing instructions

- Visit `/domains/add/YOUR-SITE-HERE`
- Add a domain to your cart and add an email account to your cart as well.
- When you reach checkout, remove just the domain from your cart.
- Verify that you see the error message about the email product being removed, but that you also see the empty cart page.