### PR TITLE
[GB 12.2.x][wpcom-block-editor][tracking] Fix the `wpcom-block-editor-list-view-select` tracking event

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-list-view-select.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-list-view-select.js
@@ -8,7 +8,7 @@ import tracksRecordEvent from './track-record-event';
  */
 export default () => ( {
 	id: 'wpcom-block-editor-list-view-select',
-	selector: '[aria-label="Block navigation structure"] [role="row"]:not(.is-selected) button',
+	selector: '[aria-label="Block navigation structure"] [role="row"]:not(.is-selected) a',
 	type: 'click',
 	capture: true,
 	handler: async () => {


### PR DESCRIPTION
Each element item in the Block's list view in Gutenberg 12.2 now uses an anchor instead of a button as the main clickable element. 

#### Changes proposed in this Pull Request

*  Fix selector for the `wpcom-block-editor-list-view` tracking event should be updated accordingly or the event won't be bound/captured.

**WARNING:** This should not be deployed before Gutenberg 12.2 is activated on production.

#### Testing instructions

1. Sandbox `widgets.wp.com`
1. Force the `isE2Etest` function to return `true`;
1. Sync the `wpcom-block-editor` lib to your sandbox by running `yarn dev --sync` from `wp-calypso/apps/wpcom-block-editor`;
1. Start a new page in your sandboxed simple site, add a few blocks;
1. Click the `List View` toggle in the top bar (see video below) to switch to the block list view;
1. In the iframe context selector, make sure to select the wp-admin context and run `window._e2eEventsStack`, inspect the returned array;
1. Now click some of the block items in the list view
1. Run `window._e2eEventsStack` again and you should see one or more `wpcom-block-editor-list-view` elements (depending on how many blocks you selected by clicking the items in the list view)


https://user-images.githubusercontent.com/81248/146820971-dfab9957-d974-4313-a431-a4b065063f9e.mp4




Related to https://github.com/Automattic/wp-calypso/pull/59418 and https://github.com/Automattic/wp-calypso/issues/59151.

cc @Automattic/cylon 
