### PR TITLE
Stats: fix vertical scroll for fixed table header

### DIFF
--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -430,14 +430,10 @@ ul.module-header-actions {
 		 */
 		th:first-child {
 			width: 34px; // 24 (margin-left) + 12 (margin-right) + 1 (border) + 34 = 70
-			transform: translateX( -70px );
 			background: var( --color-surface );
-			position: fixed;
+			position: sticky;
+			left: 0;
 			z-index: z-index( 'root', '.module-content-table tbody th:first-child' );
-		}
-
-		.module-content-table-scroll {
-			margin-left: 70px;
 		}
 
 		th,


### PR DESCRIPTION
This uses `position: sticky` instead of `position: fixed` for the fixed table column on the annual stats page.

Fixes: #48650

**To test:**
- visit `http://calypso.localhost:3000/stats/day/annualstats/[site]` (or the attached testing link)
- narrow the browser window
- verify that when scrolling horizontally, the year column stays visible
- shorten the browser to the point that you can scroll vertically
- verify that when scrolling vertically, the year column stays aligned with its rows
- repeat in a few different browsers