### PR TITLE
Activity Log: Default to making entries visible if no display limits are set

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -190,13 +190,17 @@ class ActivityCardList extends Component {
 			siteId,
 		} = this.props;
 
-		const visibleLimitCutoffDate = ( applySiteOffset ?? moment )().subtract( visibleDays, 'days' );
-		const visibleLogs = logs.filter( ( log ) =>
-			( applySiteOffset ?? moment )( log.activityDate ).isSameOrAfter(
-				visibleLimitCutoffDate,
-				'day'
-			)
-		);
+		const visibleLimitCutoffDate = Number.isFinite( visibleDays )
+			? ( applySiteOffset ?? moment )().subtract( visibleDays, 'days' )
+			: undefined;
+		const visibleLogs = visibleLimitCutoffDate
+			? logs.filter( ( log ) =>
+					( applySiteOffset ?? moment )( log.activityDate ).isSameOrAfter(
+						visibleLimitCutoffDate,
+						'day'
+					)
+			  )
+			: logs;
 
 		const { page: requestedPage } = filter;
 		const pageCount = Math.ceil( visibleLogs.length / pageSize );


### PR DESCRIPTION
Resolves `7169-gh-Automattic/jpop-issues`.

#### Changes proposed in this Pull Request

* Add a conditional guard to detect when the selected site does not have a defined "visible days" policy for its Activity Log. In such cases, use the original list of log entries instead of filtering.

#### Testing instructions

1. Select a self-hosted Jetpack site that matches the following criteria:
  * does not have display limits for Activity Log events (i.e., any plan that predates storage-limited Backup); and
  * has events in its Activity Log before today.
2. In Calypso Green, go to `/activity-log/<your site>`.
3. Verify all past events are displayed, not just the most recent event.

##### Regression testing

1. To confirm the regression, visit `cloud.jetpack.com/activity-log/<your site>`. Verify that in this version of the Activity Log, only the most recent entry is visible for sites without Activity Log display limits.
2. Select another site with a storage/display-limited Backup plan. Verify the policies for this site work as intended (e.g., only 30 days of Activity Log history for Backup 10 GB).