### PR TITLE
Payments: Reload the stripe configuration when PaymentMethodSelector submitted

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
@@ -13,12 +13,21 @@ interface Props {
 	translate: ReturnType< typeof useTranslate >;
 	stripe: Stripe | null;
 	stripeConfiguration: StripeConfiguration | null;
+	setupIntentId: string | undefined;
 	element: StripeCardNumberElement | undefined;
 	dispatch: CalypsoDispatch;
 }
 
 export async function assignNewCardProcessor(
-	{ useAsPrimaryPaymentMethod, translate, stripe, stripeConfiguration, dispatch, element }: Props,
+	{
+		useAsPrimaryPaymentMethod,
+		translate,
+		stripe,
+		stripeConfiguration,
+		setupIntentId,
+		dispatch,
+		element,
+	}: Props,
 	submitData: unknown
 ): Promise< PaymentProcessorResponse > {
 	dispatch( recordFormSubmitEvent() );
@@ -27,7 +36,7 @@ export async function assignNewCardProcessor(
 		if ( ! isNewCardDataValid( submitData ) ) {
 			throw new Error( 'Credit Card data is missing your full name.' );
 		}
-		if ( ! stripe || ! stripeConfiguration ) {
+		if ( ! stripe || ! stripeConfiguration || ! setupIntentId ) {
 			throw new Error( 'Cannot assign payment method if Stripe is not loaded' );
 		}
 		if ( ! element ) {
@@ -43,7 +52,7 @@ export async function assignNewCardProcessor(
 			formFieldValues,
 			stripe,
 			element,
-			stripeConfiguration
+			setupIntentId
 		);
 		const token = tokenResponse.payment_method;
 
@@ -71,12 +80,12 @@ async function createStripeSetupIntentAsync(
 	},
 	stripe: Stripe,
 	element: StripeCardNumberElement,
-	stripeConfiguration: StripeConfiguration
+	setupIntentId: string
 ): Promise< StripeSetupIntent > {
 	const paymentDetailsForStripe = {
 		name,
 	};
-	return createStripeSetupIntent( stripe, element, stripeConfiguration, paymentDetailsForStripe );
+	return createStripeSetupIntent( stripe, element, setupIntentId, paymentDetailsForStripe );
 }
 
 function isNewCardDataValid( data: unknown ): data is NewCardSubmitData {

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -1,4 +1,8 @@
-import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import {
+	StripeHookProvider,
+	StripeSetupIntentIdProvider,
+	useStripe,
+} from '@automattic/calypso-stripe';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -82,7 +86,9 @@ export default function AccountLevelAddNewPaymentMethodWrapper() {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<AddNewPaymentMethod />
+			<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
+				<AddNewPaymentMethod />
+			</StripeSetupIntentIdProvider>
 		</StripeHookProvider>
 	);
 }

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -81,11 +81,7 @@ function AddNewPaymentMethod() {
 export default function AccountLevelAddNewPaymentMethodWrapper() {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
-		<StripeHookProvider
-			locale={ locale }
-			configurationArgs={ { needs_intent: true } }
-			fetchStripeConfiguration={ getStripeConfiguration }
-		>
+		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
 			<AddNewPaymentMethod />
 		</StripeHookProvider>
 	);

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -1,4 +1,5 @@
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useMemo, useEffect } from 'react';
@@ -22,7 +23,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 
 function AddNewPaymentMethod() {
 	const goToPaymentMethods = () => page( paymentMethods );
-	const addPaymentMethodTitle = titles.addPaymentMethod;
+	const addPaymentMethodTitle = String( titles.addPaymentMethod );
 
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
@@ -33,11 +34,13 @@ function AddNewPaymentMethod() {
 		stripe,
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
-		activePayButtonText: translate( 'Save card' ),
+		activePayButtonText: String( translate( 'Save card' ) ),
 		allowUseForAllSubscriptions: true,
 		initialUseForAllSubscriptions: true,
 	} );
-	const paymentMethodList = useMemo( () => [ stripeMethod ].filter( Boolean ), [ stripeMethod ] );
+	const paymentMethodList = useMemo( () => [ stripeMethod ].filter( isValueTruthy ), [
+		stripeMethod,
+	] );
 	const reduxDispatch = useDispatch();
 	useEffect( () => {
 		if ( stripeLoadingError ) {
@@ -75,7 +78,7 @@ function AddNewPaymentMethod() {
 	);
 }
 
-export default function AccountLevelAddNewPaymentMethodWrapper( props ) {
+export default function AccountLevelAddNewPaymentMethodWrapper() {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider
@@ -83,7 +86,7 @@ export default function AccountLevelAddNewPaymentMethodWrapper( props ) {
 			configurationArgs={ { needs_intent: true } }
 			fetchStripeConfiguration={ getStripeConfiguration }
 		>
-			<AddNewPaymentMethod { ...props } />
+			<AddNewPaymentMethod />
 		</StripeHookProvider>
 	);
 }

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -1,4 +1,8 @@
-import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import {
+	StripeHookProvider,
+	StripeSetupIntentIdProvider,
+	useStripe,
+} from '@automattic/calypso-stripe';
 import page from 'page';
 import { Fragment, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -126,12 +130,10 @@ function getChangePaymentMethodTitleCopy( currentPaymentMethodId: string ): stri
 export default function ChangePaymentMethodWrapper( props: ChangePaymentMethodProps ): JSX.Element {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
-		<StripeHookProvider
-			locale={ locale }
-			configurationArgs={ { needs_intent: true } }
-			fetchStripeConfiguration={ getStripeConfiguration }
-		>
-			<ChangePaymentMethod { ...props } />
+		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
+			<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
+				<ChangePaymentMethod { ...props } />
+			</StripeSetupIntentIdProvider>
 		</StripeHookProvider>
 	);
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -93,8 +93,9 @@ export async function assignNewCardProcessor(
 		}
 
 		// If we've reached this point in the code and anything after this fails,
-		// we must regenerate the payment intent, which is done by calling
-		// reloadStripeConfiguration from `@automattic/calypso-stripe`.
+		// we must regenerate the payment intent, which is done by calling `reload`
+		// as returned by `useStripeSetupIntentId` from
+		// `@automattic/calypso-stripe`.
 
 		if ( purchase ) {
 			const result = await updateCreditCard( {

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -86,6 +86,10 @@ export async function assignNewCardProcessor(
 			throw new Error( String( translate( 'Failed to add card.' ) ) );
 		}
 
+		// If we've reached this point in the code and anything after this fails,
+		// we must regenerate the payment intent, which is done by calling
+		// reloadStripeConfiguration from `@automattic/calypso-stripe`.
+
 		if ( purchase ) {
 			const result = await updateCreditCard( {
 				purchase,

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -9,7 +9,11 @@ import { useTranslate } from 'i18n-calypso';
 import wp from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateCreditCard, saveCreditCard } from './stored-payment-method-api';
-import type { StripeConfiguration, StripeSetupIntent } from '@automattic/calypso-stripe';
+import type {
+	StripeSetupIntentId,
+	StripeConfiguration,
+	StripeSetupIntent,
+} from '@automattic/calypso-stripe';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
 import type { Purchase } from 'calypso/lib/purchases/types';
@@ -41,6 +45,7 @@ export async function assignNewCardProcessor(
 		translate,
 		stripe,
 		stripeConfiguration,
+		stripeSetupIntentId,
 		cardNumberElement,
 		reduxDispatch,
 		eventSource,
@@ -49,6 +54,7 @@ export async function assignNewCardProcessor(
 		translate: ReturnType< typeof useTranslate >;
 		stripe: Stripe | null;
 		stripeConfiguration: StripeConfiguration | null;
+		stripeSetupIntentId: StripeSetupIntentId | undefined;
 		cardNumberElement: StripeCardNumberElement | undefined;
 		reduxDispatch: CalypsoDispatch;
 		eventSource?: string;
@@ -59,7 +65,7 @@ export async function assignNewCardProcessor(
 		if ( ! isNewCardDataValid( submitData ) ) {
 			throw new Error( 'Credit Card data is missing country' );
 		}
-		if ( ! stripe || ! stripeConfiguration ) {
+		if ( ! stripe || ! stripeConfiguration || ! stripeSetupIntentId ) {
 			throw new Error( 'Cannot assign payment method if Stripe is not loaded' );
 		}
 		if ( ! cardNumberElement ) {
@@ -79,7 +85,7 @@ export async function assignNewCardProcessor(
 			formFieldValues,
 			stripe,
 			cardNumberElement,
-			stripeConfiguration
+			stripeSetupIntentId
 		);
 		const token = tokenResponse.payment_method;
 		if ( ! token ) {
@@ -127,7 +133,7 @@ async function createStripeSetupIntentAsync(
 	},
 	stripe: Stripe,
 	cardNumberElement: StripeCardNumberElement,
-	stripeConfiguration: StripeConfiguration
+	setupIntentId: StripeSetupIntentId
 ): Promise< StripeSetupIntent > {
 	const paymentDetailsForStripe = {
 		name,
@@ -139,7 +145,7 @@ async function createStripeSetupIntentAsync(
 	return createStripeSetupIntent(
 		stripe,
 		cardNumberElement,
-		stripeConfiguration,
+		setupIntentId,
 		paymentDetailsForStripe
 	);
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -32,6 +32,7 @@ import {
 	useHandleRedirectChangeError,
 	useHandleRedirectChangeComplete,
 } from './url-event-handlers';
+import type { ReloadStripeConfiguration } from '@automattic/calypso-stripe';
 import type { CheckoutPageErrorCallback, PaymentMethod } from '@automattic/composite-checkout';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
@@ -74,14 +75,25 @@ export default function PaymentMethodSelector( {
 } ): JSX.Element {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
-	const { isStripeLoading, stripe, stripeConfiguration, stripeLoadingError } = useStripe();
+	const {
+		isStripeLoading,
+		stripe,
+		stripeConfiguration,
+		stripeLoadingError,
+		reloadStripeConfiguration,
+	} = useStripe();
 	const currentlyAssignedPaymentMethodId = getPaymentMethodIdFromPayment( purchase?.payment );
+
+	useEffect( () => {
+		// Regenerate the setup intent on mount just in case it's somehow been used before this was mounted.
+		reloadStripeConfiguration();
+	}, [ reloadStripeConfiguration ] );
 
 	const showRedirectMessage = useCallback( () => {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
 	}, [ reduxDispatch, translate ] );
 
-	const showErrorMessage = useCallback(
+	const handleChangeError = useCallback(
 		( { transactionError }: { transactionError: string | null } ) => {
 			reduxDispatch(
 				errorNotice(
@@ -89,8 +101,10 @@ export default function PaymentMethodSelector( {
 						translate( 'There was a problem assigning that payment method. Please try again.' )
 				)
 			);
+			// We need to regenerate the setup intent if the form was submitted.
+			reloadStripeConfiguration();
 		},
-		[ reduxDispatch, translate ]
+		[ reduxDispatch, translate, reloadStripeConfiguration ]
 	);
 
 	const showSuccessMessage = useCallback(
@@ -111,9 +125,17 @@ export default function PaymentMethodSelector( {
 			'There was a problem assigning that payment method. Please try again.'
 		);
 		reduxDispatch( errorNotice( message ) );
+		// We need to regenerate the setup intent if the form was submitted.
+		reloadStripeConfiguration();
 	} );
 	useHandleRedirectChangeComplete( () => {
-		onPaymentSelectComplete( { successCallback, translate, showSuccessMessage, purchase } );
+		onPaymentSelectComplete( {
+			successCallback,
+			translate,
+			showSuccessMessage,
+			purchase,
+			reloadStripeConfiguration,
+		} );
 	} );
 
 	useEffect( () => {
@@ -126,11 +148,17 @@ export default function PaymentMethodSelector( {
 
 	return (
 		<CheckoutProvider
-			onPaymentComplete={ () =>
-				onPaymentSelectComplete( { successCallback, translate, showSuccessMessage, purchase } )
-			}
+			onPaymentComplete={ () => {
+				onPaymentSelectComplete( {
+					successCallback,
+					translate,
+					showSuccessMessage,
+					purchase,
+					reloadStripeConfiguration,
+				} );
+			} }
 			onPaymentRedirect={ showRedirectMessage }
-			onPaymentError={ showErrorMessage }
+			onPaymentError={ handleChangeError }
 			onPageLoadError={ logError }
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {
@@ -202,17 +230,21 @@ function onPaymentSelectComplete( {
 	translate,
 	showSuccessMessage,
 	purchase,
+	reloadStripeConfiguration,
 }: {
 	successCallback: () => void;
 	translate: ReturnType< typeof useTranslate >;
 	showSuccessMessage: ( message: string | TranslateResult ) => void;
 	purchase?: Purchase | undefined;
+	reloadStripeConfiguration: ReloadStripeConfiguration;
 } ) {
 	if ( purchase ) {
 		showSuccessMessage( translate( 'Your payment method has been set.' ) );
 	} else {
 		showSuccessMessage( translate( 'Your payment method has been added successfully.' ) );
 	}
+	// We need to regenerate the setup intent if the form was submitted.
+	reloadStripeConfiguration();
 	successCallback();
 }
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -32,7 +32,7 @@ import {
 	useHandleRedirectChangeError,
 	useHandleRedirectChangeComplete,
 } from './url-event-handlers';
-import type { ReloadStripeConfiguration } from '@automattic/calypso-stripe';
+import type { ReloadSetupIntentId } from '@automattic/calypso-stripe';
 import type { CheckoutPageErrorCallback, PaymentMethod } from '@automattic/composite-checkout';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
@@ -237,7 +237,7 @@ function onPaymentSelectComplete( {
 	translate: ReturnType< typeof useTranslate >;
 	showSuccessMessage: ( message: string | TranslateResult ) => void;
 	purchase?: Purchase | undefined;
-	reloadSetupIntentId: ReloadStripeConfiguration;
+	reloadSetupIntentId: ReloadSetupIntentId;
 } ) {
 	if ( purchase ) {
 		showSuccessMessage( translate( 'Your payment method has been set.' ) );

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -1,5 +1,9 @@
 import config from '@automattic/calypso-config';
-import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import {
+	StripeHookProvider,
+	StripeSetupIntentIdProvider,
+	useStripe,
+} from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -168,12 +172,10 @@ export function SiteLevelAddNewPaymentMethod(
 ): JSX.Element {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
-		<StripeHookProvider
-			locale={ locale }
-			configurationArgs={ { needs_intent: true } }
-			fetchStripeConfiguration={ getStripeConfiguration }
-		>
-			<SiteLevelAddNewPaymentMethodForm { ...props } />
+		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
+			<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
+				<SiteLevelAddNewPaymentMethodForm { ...props } />
+			</StripeSetupIntentIdProvider>
 		</StripeHookProvider>
 	);
 }

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -10,8 +10,8 @@ You'll need to wrap this context provider around any component that wishes to us
 
 - `children: JSX.Element`
 - `fetchStripeConfiguration: GetStripeConfiguration` A function to fetch the stripe configuration from the WP.com HTTP API.
-- `configurationArgs?: undefined | null | GetStripeConfigurationArgs` Options to pass to the fetchStripeConfiguration function, specifically `country` and/or `needs_intent`, the latter of which can be used to request a payment intent for adding a new card without a purchase.
-- `locale?: undefined | string` An optional locale string used to localize error messages for the Stripe elements fields.
+- `configurationArgs?: null | GetStripeConfigurationArgs` Options to pass to the fetchStripeConfiguration function, specifically `country`.
+- `locale?: string` An optional locale string used to localize error messages for the Stripe elements fields.
 
 ## useStripe
 
@@ -21,7 +21,18 @@ A React hook that allows access to Stripe.js. This returns an object with the fo
 - `stripeConfiguration: null | StripeConfiguration` The object containing the data returned by the wpcom stripe configuration endpoint. May include a payment intent.
 - `isStripeLoading: boolean` A boolean that is true if stripe is currently being loaded.
 - `stripeLoadingError: undefined | null | Error` An optional object that will be set if there is an error loading stripe.
-- `reloadStripeConfiguration: ReloadStripeConfiguration` A function that can be called to force the stripe configuration to reload.
+
+## useStripeSetupIntentId
+
+A React hook that allows access to creating a setup intent ID that can be passed to createStripeSetupIntent. This returns an object with the following properties:
+
+- `setupIntentId: StripeSetupIntentId | undefined`. The setup intent ID.
+- `error: undefined | null | Error`. An error, if one exists.
+- `reload: ReloadStripeConfiguration`. A function that can be used to reload the setupIntentId, which should be done if it is used at all (even if it fails).
+
+## createStripeSetupIntent
+
+A function that can be used to create a Stripe setup intent with a setup intent ID and a Stripe credit card field.
 
 ## withStripeProps
 

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -13,6 +13,13 @@ You'll need to wrap this context provider around any component that wishes to us
 - `configurationArgs?: null | GetStripeConfigurationArgs` Options to pass to the fetchStripeConfiguration function, specifically `country`.
 - `locale?: string` An optional locale string used to localize error messages for the Stripe elements fields.
 
+## StripeSetupIntentIdProvider
+
+You'll need to wrap this context provider around any component that wishes to use `useStripeSetupIntentId`. It accepts the following props:
+
+- `children: JSX.Element`
+- `fetchStripeConfiguration: GetStripeSetupIntentId` A function to fetch the stripe configuration from the WP.com HTTP API. It will be passed `{needs_intent: true}`.
+
 ## useStripe
 
 A React hook that allows access to Stripe.js. This returns an object with the following properties:
@@ -26,9 +33,9 @@ A React hook that allows access to Stripe.js. This returns an object with the fo
 
 A React hook that allows access to creating a setup intent ID that can be passed to createStripeSetupIntent. This returns an object with the following properties:
 
-- `setupIntentId: StripeSetupIntentId | undefined`. The setup intent ID.
+- `setupIntentId: string | undefined`. The setup intent ID.
 - `error: undefined | null | Error`. An error, if one exists.
-- `reload: ReloadStripeConfiguration`. A function that can be used to reload the setupIntentId, which should be done if it is used at all (even if it fails).
+- `reload: () => void`. A function that can be used to reload the setupIntentId, which should be done if it is used at all (even if it fails).
 
 ## createStripeSetupIntent
 

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -37,7 +37,7 @@ export interface StripeConfiguration {
 	processor_id: string;
 }
 
-export type ReloadStripeConfiguration = () => void;
+export type ReloadSetupIntentId = () => void;
 
 export type StripeLoadingError = undefined | null | Error;
 
@@ -51,7 +51,7 @@ export interface StripeData {
 export interface StripeSetupIntentIdData {
 	setupIntentId: StripeSetupIntentId | undefined;
 	error: StripeLoadingError;
-	reload: ReloadStripeConfiguration;
+	reload: ReloadSetupIntentId;
 }
 
 export type StripeSetupIntentId = string;
@@ -431,7 +431,7 @@ function useFetchSetupIntentId(
 ): {
 	setupIntentId: StripeSetupIntentId | undefined;
 	error: undefined | Error;
-	reload: ReloadStripeConfiguration;
+	reload: ReloadSetupIntentId;
 } {
 	const [ stripeReloadCount, setReloadCount ] = useState< number >( 0 );
 	const [ error, setError ] = useState< undefined | Error >();

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -35,7 +35,6 @@ export interface StripeConfiguration {
 	js_url: string;
 	public_key: string;
 	processor_id: string;
-	setup_intent_id: null | string;
 }
 
 export type ReloadStripeConfiguration = () => void;
@@ -47,14 +46,22 @@ export interface StripeData {
 	stripeConfiguration: null | StripeConfiguration;
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
-	reloadStripeConfiguration: ReloadStripeConfiguration;
 }
+
+export interface StripeSetupIntentIdData {
+	setupIntentId: StripeSetupIntentId | undefined;
+	error: StripeLoadingError;
+	reload: ReloadStripeConfiguration;
+}
+
+export type StripeSetupIntentId = string;
 
 export type StripeSetupIntent = SetupIntent;
 
 export type StripeAuthenticationResponse = { status?: string; redirect_url?: string };
 
 const StripeContext = createContext< StripeData | undefined >( undefined );
+const StripeSetupIntentContext = createContext< StripeSetupIntentIdData | undefined >( undefined );
 
 export interface UseStripeJs {
 	stripe: Stripe | null;
@@ -62,10 +69,10 @@ export interface UseStripeJs {
 	stripeLoadingError: StripeLoadingError;
 }
 
-export type GetStripeConfigurationArgs = { country?: string; needs_intent?: boolean };
+export type GetStripeConfigurationArgs = { country?: string };
 export type GetStripeConfiguration = (
-	requestArgs: GetStripeConfigurationArgs
-) => Promise< StripeConfiguration >;
+	requestArgs: GetStripeConfigurationArgs & { needs_intent?: boolean }
+) => Promise< StripeConfiguration & { setup_intent_id: StripeSetupIntentId | undefined } >;
 
 export type StripePaymentRequestHandler = ( event: StripePaymentRequestHandlerEvent ) => void;
 
@@ -205,19 +212,13 @@ export async function createStripePaymentMethod(
 export async function createStripeSetupIntent(
 	stripe: Stripe,
 	element: StripeCardNumberElement,
-	stripeConfiguration: StripeConfiguration,
+	setupIntentId: StripeSetupIntentId,
 	paymentDetails: PaymentDetails
 ): Promise< StripeSetupIntent > {
 	debug( 'creating setup intent...', paymentDetails );
-	if ( ! stripeConfiguration.setup_intent_id ) {
-		debug( 'Unable to create setup intent; missing intent ID' );
-		throw new StripeConfigurationError(
-			'There is a problem with the payment method system configuration.'
-		);
-	}
 	let stripeResponse;
 	try {
-		stripeResponse = await stripe.confirmCardSetup( stripeConfiguration.setup_intent_id, {
+		stripeResponse = await stripe.confirmCardSetup( setupIntentId, {
 			payment_method: {
 				card: element,
 				billing_details: paymentDetails,
@@ -366,21 +367,6 @@ function useStripeJs(
  * React custom Hook for loading the Stripe Configuration
  *
  * This is internal. You probably actually want the useStripe hook.
- *
- * Returns an object with two properties: `stripeConfiguration`, and
- * `reloadStripeConfiguration`.
- *
- * `stripeConfiguration` is an object as returned by the stripe configuration
- * endpoint, possibly including a Setup Intent if one was requested (via
- * `needs_intent`).
- *
- * If there is a stripe error, it may be necessary to reload the configuration
- * since (for example) a Setup Intent may need to be recreated. You can force
- * the configuration to reload by calling `reloadStripeConfiguration()`.
- *
- * @param {Function} fetchStripeConfiguration A function that will fetch the stripe configuration from the HTTP API
- * @param {object} [requestArgs] (optional) Can include `country` or `needs_intent`
- * @returns {object} See above
  */
 function useStripeConfiguration(
 	fetchStripeConfiguration: GetStripeConfiguration,
@@ -388,16 +374,10 @@ function useStripeConfiguration(
 ): {
 	stripeConfiguration: StripeConfiguration | null;
 	stripeConfigurationError: undefined | Error;
-	reloadStripeConfiguration: ReloadStripeConfiguration;
 } {
-	const [ stripeReloadCount, setReloadCount ] = useState< number >( 0 );
 	const [ stripeConfigurationError, setStripeConfigurationError ] = useState< undefined | Error >();
 	const [ stripeConfiguration, setStripeConfiguration ] = useState< null | StripeConfiguration >(
 		null
-	);
-	const reloadStripeConfiguration = useCallback(
-		() => setReloadCount( ( count ) => count + 1 ),
-		[]
 	);
 	const memoizedRequestArgs = useMemoCompare( requestArgs, areRequestArgsEqual );
 
@@ -408,12 +388,6 @@ function useStripeConfiguration(
 			.then( ( configuration ) => {
 				if ( ! isSubscribed ) {
 					return;
-				}
-				if ( memoizedRequestArgs?.needs_intent && ! configuration.setup_intent_id ) {
-					debug( 'invalid stripe configuration; missing setup_intent_id', configuration );
-					throw new StripeConfigurationError(
-						'Error loading new payment method configuration. Received invalid data from the server.'
-					);
 				}
 				if (
 					! configuration.js_url ||
@@ -434,8 +408,58 @@ function useStripeConfiguration(
 		return () => {
 			isSubscribed = false;
 		};
-	}, [ memoizedRequestArgs, stripeReloadCount, fetchStripeConfiguration ] );
-	return { stripeConfiguration, stripeConfigurationError, reloadStripeConfiguration };
+	}, [ memoizedRequestArgs, fetchStripeConfiguration ] );
+	return { stripeConfiguration, stripeConfigurationError };
+}
+
+const setupIntentRequestArgs = { needs_intent: true };
+
+/**
+ * React custom Hook for loading a Stripe setup intent id
+ *
+ * This is internal. You probably actually want the useStripeSetupIntentId hook.
+ *
+ * If there is a stripe error, it may be necessary to reload the configuration
+ * since a Setup Intent may need to be recreated. You can force the
+ * configuration to reload by calling `reload()`.
+ */
+function useFetchSetupIntentId(
+	fetchStripeConfiguration: GetStripeConfiguration
+): {
+	setupIntentId: StripeSetupIntentId | undefined;
+	error: undefined | Error;
+	reload: ReloadStripeConfiguration;
+} {
+	const [ stripeReloadCount, setReloadCount ] = useState< number >( 0 );
+	const [ error, setError ] = useState< undefined | Error >();
+	const [ setupIntentId, setSetupIntentId ] = useState< undefined | StripeSetupIntentId >();
+	const reload = useCallback( () => setReloadCount( ( count ) => count + 1 ), [] );
+
+	useEffect( () => {
+		debug( 'loading stripe setup intent id' );
+		let isSubscribed = true;
+		fetchStripeConfiguration( setupIntentRequestArgs )
+			.then( ( configuration ) => {
+				if ( ! isSubscribed ) {
+					return;
+				}
+				if ( ! configuration?.setup_intent_id ) {
+					debug( 'invalid stripe configuration; missing setup_intent_id', configuration );
+					throw new StripeConfigurationError(
+						'Error loading new payment method configuration. Received invalid data from the server.'
+					);
+				}
+				debug( 'stripe configuration received', configuration );
+				setSetupIntentId( configuration.setup_intent_id );
+			} )
+			.catch( ( error ) => {
+				setError( error );
+			} );
+		return () => {
+			isSubscribed = false;
+		};
+	}, [ stripeReloadCount, fetchStripeConfiguration ] );
+	return { setupIntentId, error, reload };
 }
 
 function areRequestArgsEqual(
@@ -445,20 +469,25 @@ function areRequestArgsEqual(
 	if ( next?.country !== previous?.country ) {
 		return false;
 	}
-	if ( next?.needs_intent !== previous?.needs_intent ) {
-		return false;
-	}
 	return true;
 }
 
 function StripeHookProviderInnerWrapper( {
 	stripeData,
+	stripeSetupIntentData,
 	children,
 }: {
 	stripeData: StripeData;
+	stripeSetupIntentData: StripeSetupIntentIdData;
 	children: JSX.Element;
 } ): JSX.Element {
-	return <StripeContext.Provider value={ stripeData }>{ children }</StripeContext.Provider>;
+	return (
+		<StripeContext.Provider value={ stripeData }>
+			<StripeSetupIntentContext.Provider value={ stripeSetupIntentData }>
+				{ children }
+			</StripeSetupIntentContext.Provider>
+		</StripeContext.Provider>
+	);
 }
 
 export function StripeHookProvider( {
@@ -472,11 +501,11 @@ export function StripeHookProvider( {
 	configurationArgs?: undefined | null | GetStripeConfigurationArgs;
 	locale?: undefined | string;
 } ): JSX.Element {
-	const {
-		stripeConfiguration,
-		stripeConfigurationError,
-		reloadStripeConfiguration,
-	} = useStripeConfiguration( fetchStripeConfiguration, configurationArgs );
+	const { stripeConfiguration, stripeConfigurationError } = useStripeConfiguration(
+		fetchStripeConfiguration,
+		configurationArgs
+	);
+	const setupIntentData = useFetchSetupIntentId( fetchStripeConfiguration );
 	const { stripe, isStripeLoading, stripeLoadingError } = useStripeJs(
 		stripeConfiguration,
 		stripeConfigurationError,
@@ -488,12 +517,14 @@ export function StripeHookProvider( {
 		stripeConfiguration,
 		isStripeLoading,
 		stripeLoadingError,
-		reloadStripeConfiguration,
 	};
 
 	return (
 		<Elements stripe={ stripe }>
-			<StripeHookProviderInnerWrapper stripeData={ stripeData }>
+			<StripeHookProviderInnerWrapper
+				stripeData={ stripeData }
+				stripeSetupIntentData={ setupIntentData }
+			>
 				{ children }
 			</StripeHookProviderInnerWrapper>
 		</Elements>
@@ -513,7 +544,6 @@ export function StripeHookProvider( {
  * - stripeConfiguration: the object containing the data returned by the wpcom stripe configuration endpoint
  * - isStripeLoading: a boolean that is true if stripe is currently being loaded
  * - stripeLoadingError: an optional object that will be set if there is an error loading stripe
- * - reloadStripeConfiguration: a function that can be called with a value to force the stripe configuration to reload
  *
  * @returns {StripeData} See above
  */
@@ -521,6 +551,21 @@ export function useStripe(): StripeData {
 	const stripeData = useContext( StripeContext );
 	if ( ! stripeData ) {
 		throw new Error( 'useStripe can only be used inside a StripeHookProvider' );
+	}
+	return stripeData;
+}
+
+/**
+ * Custom hook to access a Stripe setup intent ID
+ *
+ * First you must wrap a parent component in `StripeHookProvider`. Then you can
+ * call this hook in any sub-component to get access to the setup intent ID
+ * which can be passed to `createStripeSetupIntent`.
+ */
+export function useStripeSetupIntentId(): StripeSetupIntentIdData {
+	const stripeData = useContext( StripeSetupIntentContext );
+	if ( ! stripeData ) {
+		throw new Error( 'useStripeSetupIntentId can only be used inside a StripeHookProvider' );
 	}
 	return stripeData;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This recreates the Stripe setup intent every time the `PaymentMethodSelector` form is submitted. This was once the behavior of the "add credit card" form, but that appears to have been lost when refactoring to `PaymentMethodSelector`.

In order to do this properly, this modifies the `@automattic/calypso-stripe` package to move fetching of the Stripe Payment Intent ID into its own provider and hook instead of being a side effect of loading the Stripe configuration. This is because they're really unrelated even though they come from the same endpoint; if they're part of the same data structure, then any time you reload the setup intent, it will also recreate the configuration, causing the `stripe` object to be recreated as well. This can have far-reaching effects since the `stripe` object is used to create the form fields on a page.

Fixes 617-gh-Automattic/payments-shilling

#### Testing instructions

- First, break the ability to save new credit cards by applying D72020-code to your sandbox and sandboxing the API.
- Visit `/me/purchases/add-payment-method`.
- Fill out the new credit card form and submit it.
- Verify that you get the error displayed `Error authorizing credit card. Please Contact Support quoting error...`.
- Submit the form again (without reloading the page).
- Verify that you get the same error displayed.
- Revert the changes to your sandbox to fix the endpoint.
- Submit the form a third time (without reloading the page).
- Verify that the card is added successfully.

Repeat the test on `/purchases/add-payment-method/YOUR-SITE-HERE`

Repeat the test on the "Change Payment Method" page which you can access by clicking on an active subscription at `/me/purchases`, then clicking "Change Payment Method".