### PR TITLE
Domains: Create name servers component in domain settings page

### DIFF
--- a/client/components/domains/accordion/types.ts
+++ b/client/components/domains/accordion/types.ts
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 export type AccordionProps = {
 	children?: ReactNode;
 	title: string;
-	subtitle?: string;
+	subtitle?: string | React.ReactNode;
 	expanded?: boolean;
 
 	isPlaceholder?: boolean;

--- a/client/data/domains/nameservers/use-domain-nameservers-query.js
+++ b/client/data/domains/nameservers/use-domain-nameservers-query.js
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query';
 import wp from 'calypso/lib/wp';
 
-const useDomainNameserversQuery = ( domainName ) =>
+const useDomainNameserversQuery = ( domainName, enabled ) =>
 	useQuery(
 		[ 'domain-nameservers', domainName ],
 		() => wp.req.get( `/domains/${ domainName }/nameservers/` ),
-		{ refetchOnWindowFocus: false }
+		{ enabled, refetchOnWindowFocus: false }
 	);
 
 export default useDomainNameserversQuery;

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -42,8 +42,12 @@ const EditContactInfoPage = ( {
 	};
 
 	const renderBreadcrumbs = () => {
+		if ( ! selectedSite ) {
+			return null;
+		}
+
 		const previousPath = domainManagementEdit(
-			selectedSite?.slug,
+			selectedSite.slug,
 			selectedDomainName,
 			currentRoute
 		);
@@ -51,7 +55,7 @@ const EditContactInfoPage = ( {
 		const items = [
 			{
 				label: translate( 'Domains' ),
-				href: domainManagementList( selectedSite?.slug, currentRoute ),
+				href: domainManagementList( selectedSite.slug, currentRoute ),
 			},
 			{
 				label: selectedDomainName,

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -23,6 +23,8 @@ class CustomNameserversForm extends PureComponent {
 		onSubmit: PropTypes.func.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		submitDisabled: PropTypes.bool.isRequired,
+		notice: PropTypes.element,
+		redesign: PropTypes.bool,
 	};
 
 	popularHostsMessage() {
@@ -96,21 +98,52 @@ class CustomNameserversForm extends PureComponent {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { redesign } = this.props;
 
 		if ( ! this.props.nameservers ) {
 			return null;
 		}
 
+		if ( redesign ) {
+			return <div className="name-servers__custom-nameservers-form">{ this.renderContent() }</div>;
+		}
+
 		return (
 			<Card compact className="name-servers__custom-nameservers-form">
-				<strong>{ translate( 'Use custom name servers:' ) }</strong>
+				{ this.renderContent() }
+			</Card>
+		);
+	}
+
+	renderContent() {
+		const { notice, redesign, translate } = this.props;
+
+		const title = redesign
+			? translate( 'Enter your custom name servers' )
+			: translate( 'Use custom name servers:' );
+		const subtitle = translate( '{{link}}Look up{{/link}} the name servers for popular hosts', {
+			components: {
+				link: (
+					<a
+						href={ CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ this.handleLookUpClick }
+					/>
+				),
+			},
+		} );
+
+		return (
+			<>
+				<strong>{ title }</strong>
+				{ redesign && <p>{ subtitle }</p> }
 
 				<form>
 					{ this.rows() }
-					{ this.popularHostsMessage() }
-
-					<div>
+					{ ! redesign && this.popularHostsMessage() }
+					{ redesign && notice }
+					<div className='name-servers__custom-nameservers-form-buttons'>
 						<FormButton
 							isPrimary
 							onClick={ this.handleSubmit }
@@ -124,7 +157,7 @@ class CustomNameserversForm extends PureComponent {
 						</FormButton>
 					</div>
 				</form>
-			</Card>
+			</>
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -20,6 +20,7 @@ class CustomNameserversForm extends PureComponent {
 	static propTypes = {
 		nameservers: PropTypes.array,
 		onChange: PropTypes.func.isRequired,
+		onCancel: PropTypes.func,
 		onSubmit: PropTypes.func.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		submitDisabled: PropTypes.bool.isRequired,
@@ -152,9 +153,15 @@ class CustomNameserversForm extends PureComponent {
 							{ translate( 'Save custom name servers' ) }
 						</FormButton>
 
-						<FormButton type="button" isPrimary={ false } onClick={ this.handleReset }>
-							{ translate( 'Reset to defaults' ) }
-						</FormButton>
+						{ ! redesign ? (
+							<FormButton type="button" isPrimary={ false } onClick={ this.handleReset }>
+								{ translate( 'Reset to defaults' ) }
+							</FormButton>
+						) : (
+							<FormButton type="button" isPrimary={ false } onClick={ this.handleCancel }>
+								{ translate( 'Cancel' ) }
+							</FormButton>
+						) }
 					</div>
 				</form>
 			</>
@@ -175,6 +182,11 @@ class CustomNameserversForm extends PureComponent {
 		this.props.resetToDefaultsClick( this.props.selectedDomainName );
 
 		this.props.onReset();
+	};
+
+	handleCancel = ( event ) => {
+		event.preventDefault();
+		this.props.onCancel();
 	};
 }
 

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -137,13 +137,13 @@ class CustomNameserversForm extends PureComponent {
 		return (
 			<>
 				<strong>{ title }</strong>
-				{ redesign && <p>{ subtitle }</p> }
+				{ redesign && <p className="name-servers__custom-nameservers-subtitle">{ subtitle }</p> }
 
 				<form>
 					{ this.rows() }
 					{ ! redesign && this.popularHostsMessage() }
 					{ redesign && notice }
-					<div className='name-servers__custom-nameservers-form-buttons'>
+					<div className="name-servers__custom-nameservers-form-buttons">
 						<FormButton
 							isPrimary
 							onClick={ this.handleSubmit }

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -99,12 +99,8 @@
 	}
 }
 
-.name-servers__custom-nameservers-row + .notice {
-	margin-top: 16px;
-}
-
-.name-servers__custom-nameservers-row + .name-servers__custom-nameservers-form-buttons {
-	margin-top: 24px;
+.name-servers__custom-nameservers-row + .custom-name-servers-notice {
+	margin-top: 8px;
 }
 
 .name-servers__custom-nameservers-form-buttons {
@@ -112,6 +108,7 @@
 	flex-wrap: wrap;
 	column-gap: 16px;
 	row-gap: 8px;
+	margin-top: 24px;
 
 	.button {
 		margin: 0;

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -98,3 +98,11 @@
 		}
 	}
 }
+
+.name-servers__custom-nameservers-row + .notice {
+	margin-top: 16px;
+}
+
+.name-servers__custom-nameservers-row + .name-servers__custom-nameservers-form-buttons {
+	margin-top: 24px;
+}

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -106,3 +106,14 @@
 .name-servers__custom-nameservers-row + .name-servers__custom-nameservers-form-buttons {
 	margin-top: 24px;
 }
+
+.name-servers__custom-nameservers-form-buttons {
+	display: flex;
+	flex-wrap: wrap;
+	column-gap: 16px;
+	row-gap: 8px;
+
+	.button {
+		margin: 0;
+	}
+}

--- a/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
+++ b/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import useDomainNameserversQuery from 'calypso/data/domains/nameservers/use-domain-nameservers-query';
 import useUpdateNameserversMutation from 'calypso/data/domains/nameservers/use-update-nameservers-mutation';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 const noticeOptions = {
@@ -13,10 +14,13 @@ const noticeOptions = {
 
 const withDomainNameservers = createHigherOrderComponent( ( Wrapped ) => {
 	const WithDomainNameservers = ( props ) => {
-		const { selectedDomainName } = props;
+		const { domain, selectedDomainName } = props;
 		const dispatch = useDispatch();
 		const translate = useTranslate();
-		const { data, isLoading, isError, error } = useDomainNameserversQuery( selectedDomainName );
+		const { data, isLoading, isError, error } = useDomainNameserversQuery(
+			selectedDomainName,
+			domain?.type === domainTypes.REGISTERED // Only registered domains can have their name servers updated
+		);
 		const { updateNameservers } = useUpdateNameserversMutation( selectedDomainName, {
 			onSuccess() {
 				dispatch(

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -54,6 +54,9 @@ const NameServersCard = ( {
 	const [ nameservers, setNameservers ] = useState( nameserversProps || null );
 	const [ shouldPersistNameServers, setShouldPersistNameServers ] = useState( false );
 	const [ isEditingNameServers, setIsEditingNameServers ] = useState( false );
+	const [ nameServersBeforeEditing, setNameServersBeforeEditing ] = useState< string[] | null >(
+		null
+	);
 
 	useEffect( () => {
 		setNameservers( nameserversProps );
@@ -139,6 +142,7 @@ const NameServersCard = ( {
 
 	const handleToggle = () => {
 		if ( hasWpcomNameservers() ) {
+			setNameServersBeforeEditing( nameservers );
 			setNameservers( [] );
 			setIsEditingNameServers( true );
 		} else {
@@ -177,6 +181,16 @@ const NameServersCard = ( {
 		setIsEditingNameServers( false );
 	};
 
+	const editCustomNameServers = () => {
+		setIsEditingNameServers( true );
+		setNameServersBeforeEditing( nameservers );
+	};
+
+	const handleCancel = () => {
+		setIsEditingNameServers( false );
+		setNameservers( nameServersBeforeEditing || [] );
+	};
+
 	const renderCustomNameserversForm = () => {
 		if ( ! nameservers || hasWpcomNameservers() || isPendingTransfer() ) {
 			return null;
@@ -199,6 +213,7 @@ const NameServersCard = ( {
 					selectedSite={ selectedSite }
 					selectedDomainName={ selectedDomainName }
 					onChange={ handleChange }
+					onCancel={ handleCancel }
 					onReset={ handleReset }
 					onSubmit={ handleSubmit }
 					submitDisabled={ isLoading() }
@@ -213,13 +228,7 @@ const NameServersCard = ( {
 				{ nameservers.map( ( nameserver ) => (
 					<p key={ nameserver }>{ nameserver }</p>
 				) ) }
-				<Button
-					onClick={ () => {
-						setIsEditingNameServers( true );
-					} }
-				>
-					Edit custom name servers
-				</Button>
+				<Button onClick={ editCustomNameServers }>Edit custom name servers</Button>
 			</div>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -23,10 +23,10 @@ import NameServersToggle from './name-servers-toggle';
 
 import './style.scss';
 
-const NameServers = ( props ) => {
+const NameServersCard = ( props ) => {
 	const translate = useTranslate();
 	const [ nameservers, setNameservers ] = useState( props.nameservers || null );
-	const [ shouldUpdateNameservers, setShouldUpdateNameservers ] = useState( false ); // TODO: Rename this
+	const [ shouldPersistNameservers, setShouldUpdateNameservers ] = useState( false );
 	const [ isEditingNameservers, setIsEditingNameservers ] = useState( false );
 
 	useEffect( () => {
@@ -36,14 +36,13 @@ const NameServers = ( props ) => {
 	}, [ props.isLoadingNameservers ] );
 
 	useEffect( () => {
-		if ( shouldUpdateNameservers ) {
+		if ( shouldPersistNameservers ) {
 			props.updateNameservers( nameservers );
 			setShouldUpdateNameservers( false );
 		}
-	}, [ nameservers ] );
+	}, [ shouldPersistNameservers, nameservers ] );
 
 	// static propTypes = {
-	// 	domains: PropTypes.array.isRequired,
 	// 	isRequestingSiteDomains: PropTypes.bool.isRequired,
 	// 	nameservers: PropTypes.array,
 	// 	selectedDomainName: PropTypes.string.isRequired,
@@ -147,10 +146,6 @@ const NameServers = ( props ) => {
 		}
 	};
 
-	const saveNameservers = () => {
-		props.updateNameservers( nameservers );
-	};
-
 	const renderCustomNameserversForm = () => {
 		if ( hasWpcomNameservers() || isPendingTransfer() ) {
 			return null;
@@ -226,7 +221,7 @@ const NameServers = ( props ) => {
 	};
 
 	const handleSubmit = () => {
-		saveNameservers();
+		props.updateNameservers( nameservers );
 		setIsEditingNameservers( false );
 	};
 
@@ -271,4 +266,4 @@ const customNameServersLearnMoreClick = ( domainName ) =>
 
 export default connect( null, {
 	customNameServersLearnMoreClick,
-} )( NameServers );
+} )( NameServersCard );

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@automattic/components';
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import Notice from 'calypso/components/notice';
 import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
 import NonPrimaryDomainPlanUpsell from 'calypso/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell';
@@ -117,21 +117,31 @@ const NameServersCard = ( {
 			return null;
 		}
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<Notice status="is-warning" showDismiss={ false }>
-				{ translate(
-					'By using custom name servers, you will manage your DNS records with your new provider, not WordPress.com.'
-				) }{ ' ' }
-				<a
-					href={ CHANGE_NAME_SERVERS }
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ handleLearnMoreClick }
-				>
-					{ translate( 'Learn more.' ) }
-				</a>
-			</Notice>
+			<div className="custom-name-servers-notice">
+				<Icon
+					icon={ info }
+					size={ 18 }
+					className="custom-name-servers-notice__icon gridicon"
+					viewBox="2 2 20 20"
+				/>
+				<div className="custom-name-servers-notice__message">
+					{ translate(
+						'By using custom name servers, you will manage your DNS records with your new provider, not WordPress.com.'
+					) }{ ' ' }
+					<a
+						href={ CHANGE_NAME_SERVERS }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ handleLearnMoreClick }
+					>
+						{ translate( 'Learn more.' ) }
+					</a>
+				</div>
+			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	};
 
 	const resetToWpcomNameservers = () => {

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
@@ -24,6 +24,7 @@ import NameServersToggle from './name-servers-toggle';
 import './style.scss';
 
 const NameServersCard = ( props ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ nameservers, setNameservers ] = useState( props.nameservers || null );
 	const [ shouldPersistNameservers, setShouldUpdateNameservers ] = useState( false );
@@ -111,7 +112,7 @@ const NameServersCard = ( props ) => {
 	};
 
 	const handleLearnMoreClick = () => {
-		props.customNameServersLearnMoreClick( props.selectedDomainName );
+		dispatch( customNameServersLearnMoreClick( props.selectedDomainName ) );
 	};
 
 	const renderWpcomNameserversToggle = () => {
@@ -264,6 +265,4 @@ const customNameServersLearnMoreClick = ( domainName ) =>
 		)
 	);
 
-export default connect( null, {
-	customNameServersLearnMoreClick,
-} )( NameServersCard );
+export default NameServersCard;

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -20,6 +20,7 @@ import {
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
 import NameServersToggle from './name-servers-toggle';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { NameServersCardProps } from './types';
 
 import './style.scss';
@@ -41,10 +42,8 @@ const NameServersCard = ( {
 	const [ isEditingNameservers, setIsEditingNameservers ] = useState( false );
 
 	useEffect( () => {
-		if ( isLoadingNameservers === false ) {
-			setNameservers( nameserversProps );
-		}
-	}, [ isLoadingNameservers ] );
+		setNameservers( nameserversProps );
+	}, [ nameserversProps ] );
 
 	useEffect( () => {
 		if ( shouldPersistNameservers ) {
@@ -151,11 +150,10 @@ const NameServersCard = ( {
 	};
 
 	const renderCustomNameserversForm = () => {
-		if ( hasWpcomNameservers() || isPendingTransfer() ) {
+		if ( ! nameservers || hasWpcomNameservers() || isPendingTransfer() ) {
 			return null;
 		}
 
-		// TODO: Check how this one appears
 		if ( needsVerification() ) {
 			return (
 				<IcannVerificationCard
@@ -184,7 +182,7 @@ const NameServersCard = ( {
 
 		return (
 			<div className="name-servers-card__name-server-list">
-				{ nameservers!.map( ( nameserver ) => (
+				{ nameservers.map( ( nameserver ) => (
 					<p key={ nameserver }>{ nameserver }</p>
 				) ) }
 				<Button
@@ -198,7 +196,7 @@ const NameServersCard = ( {
 		);
 	};
 
-	const renderPlanUpsellForNonPrimaryDomain = ( domain ) => {
+	const renderPlanUpsellForNonPrimaryDomain = ( domain: ResponseDomain ) => {
 		return (
 			<NonPrimaryDomainPlanUpsell
 				tracksImpressionName="calypso_non_primary_domain_ns_plan_upsell_impression"
@@ -216,7 +214,7 @@ const NameServersCard = ( {
 		return domain.isPendingIcannVerification;
 	};
 
-	const handleChange = ( nameservers ) => {
+	const handleChange = ( nameservers: string[] ) => {
 		setNameservers( nameservers );
 	};
 
@@ -229,13 +227,14 @@ const NameServersCard = ( {
 		setIsEditingNameservers( false );
 	};
 
+	if ( isLoading() ) {
+		return <p className="name-servers-card__loading" />;
+	}
+
 	if ( loadingNameserversError ) {
 		return <FetchError selectedDomainName={ selectedDomainName } />;
 	}
 
-	if ( isLoading() ) {
-		return <>LOADING</>;
-	}
 
 	return (
 		<div className="name-servers-card">

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -117,6 +117,19 @@ const NameServersCard = ( {
 			return null;
 		}
 
+		const link = (
+			<a
+				href={ CHANGE_NAME_SERVERS }
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={ handleLearnMoreClick }
+			/>
+		);
+		const notice = translate(
+			'By using custom name servers, you will manage your DNS records with your new provider, not WordPress.com. {{link}}Learn more{{/link}}',
+			{ components: { link } }
+		);
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="custom-name-servers-notice">
@@ -126,19 +139,7 @@ const NameServersCard = ( {
 					className="custom-name-servers-notice__icon gridicon"
 					viewBox="2 2 20 20"
 				/>
-				<div className="custom-name-servers-notice__message">
-					{ translate(
-						'By using custom name servers, you will manage your DNS records with your new provider, not WordPress.com.'
-					) }{ ' ' }
-					<a
-						href={ CHANGE_NAME_SERVERS }
-						target="_blank"
-						rel="noopener noreferrer"
-						onClick={ handleLearnMoreClick }
-					>
-						{ translate( 'Learn more.' ) }
-					</a>
-				</div>
+				<div className="custom-name-servers-notice__message">{ notice }</div>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -67,16 +67,12 @@ const NameServersCard = ( {
 	}, [ shouldPersistNameservers, nameservers ] );
 
 	const hasWpcomNameservers = () => {
-		if ( ! nameserversProps ) {
-			return true;
-		}
-
 		if ( ! nameservers || nameservers.length === 0 ) {
 			return false;
 		}
 
 		return nameservers.every( ( nameserver ) => {
-			return ! nameserver || WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
+			return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
 		} );
 	};
 
@@ -136,12 +132,9 @@ const NameServersCard = ( {
 	};
 
 	const resetToWpcomNameservers = () => {
-		if ( ! nameservers || nameservers.length === 0 ) {
-			setNameservers( WPCOM_DEFAULT_NAMESERVERS );
-		} else {
-			setNameservers( WPCOM_DEFAULT_NAMESERVERS );
-			setShouldPersistNameservers( true );
-		}
+		setNameservers( WPCOM_DEFAULT_NAMESERVERS );
+		setShouldPersistNameservers( true );
+		setIsEditingNameservers( false );
 	};
 
 	const handleToggle = () => {
@@ -162,7 +155,7 @@ const NameServersCard = ( {
 			<NameServersToggle
 				selectedDomainName={ selectedDomainName }
 				onToggle={ handleToggle }
-				enabled={ hasWpcomNameservers() }
+				enabled={ hasWpcomNameservers() && ! isEditingNameservers }
 			/>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -52,19 +52,19 @@ const NameServersCard = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ nameservers, setNameservers ] = useState( nameserversProps || null );
-	const [ shouldPersistNameservers, setShouldPersistNameservers ] = useState( false );
-	const [ isEditingNameservers, setIsEditingNameservers ] = useState( false );
+	const [ shouldPersistNameServers, setShouldPersistNameServers ] = useState( false );
+	const [ isEditingNameServers, setIsEditingNameServers ] = useState( false );
 
 	useEffect( () => {
 		setNameservers( nameserversProps );
 	}, [ nameserversProps ] );
 
 	useEffect( () => {
-		if ( shouldPersistNameservers ) {
+		if ( shouldPersistNameServers ) {
 			updateNameservers( nameservers || [] );
-			setShouldPersistNameservers( false );
+			setShouldPersistNameServers( false );
 		}
-	}, [ shouldPersistNameservers, nameservers ] );
+	}, [ shouldPersistNameServers, nameservers ] );
 
 	const hasWpcomNameservers = () => {
 		if ( ! nameservers || nameservers.length === 0 ) {
@@ -133,14 +133,14 @@ const NameServersCard = ( {
 
 	const resetToWpcomNameservers = () => {
 		setNameservers( WPCOM_DEFAULT_NAMESERVERS );
-		setShouldPersistNameservers( true );
-		setIsEditingNameservers( false );
+		setShouldPersistNameServers( true );
+		setIsEditingNameServers( false );
 	};
 
 	const handleToggle = () => {
 		if ( hasWpcomNameservers() ) {
 			setNameservers( [] );
-			setIsEditingNameservers( true );
+			setIsEditingNameServers( true );
 		} else {
 			resetToWpcomNameservers();
 		}
@@ -155,7 +155,7 @@ const NameServersCard = ( {
 			<NameServersToggle
 				selectedDomainName={ selectedDomainName }
 				onToggle={ handleToggle }
-				enabled={ hasWpcomNameservers() && ! isEditingNameservers }
+				enabled={ hasWpcomNameservers() && ! isEditingNameServers }
 			/>
 		);
 	};
@@ -174,7 +174,7 @@ const NameServersCard = ( {
 
 	const handleSubmit = () => {
 		updateNameservers( nameservers || [] );
-		setIsEditingNameservers( false );
+		setIsEditingNameServers( false );
 	};
 
 	const renderCustomNameserversForm = () => {
@@ -192,7 +192,7 @@ const NameServersCard = ( {
 			);
 		}
 
-		if ( isEditingNameservers ) {
+		if ( isEditingNameServers ) {
 			return (
 				<CustomNameserversForm
 					nameservers={ nameservers }
@@ -215,7 +215,7 @@ const NameServersCard = ( {
 				) ) }
 				<Button
 					onClick={ () => {
-						setIsEditingNameservers( true );
+						setIsEditingNameServers( true );
 					} }
 				>
 					Edit custom name servers

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
@@ -1,80 +1,20 @@
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
+import { useDispatch } from 'react-redux';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
+import type { NameServersToggleProps } from './types';
 
-const NameserversToggle = ( props ) => {
-	const translate = useTranslate();
-	// static propTypes = {
-	// 	onToggle: PropTypes.func.isRequired,
-	// 	enabled: PropTypes.bool.isRequired,
-	// };
-
-	const handleToggle = () => {
-		props.wpcomNameServersToggleButtonClick( props.selectedDomainName, ! props.enabled );
-		props.onToggle();
-	};
-
-	const renderExplanation = () => {
-		if ( ! props.enabled ) {
-			return null;
-		}
-
-		return (
-			<p className="name-servers__explanation">
-				{ translate(
-					'Name servers point your domain to the right website host, like WordPress.com. ' +
-						'{{a}}Learn more.{{/a}}',
-					{
-						components: {
-							a: (
-								<a
-									href={ CHANGE_NAME_SERVERS }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ handleLearnMoreClick }
-								/>
-							),
-						},
-					}
-				) }
-			</p>
-		);
-	};
-
-	const handleLearnMoreClick = () => {
-		props.wpcomNameServersLearnMoreClick( props.selectedDomainName );
-	};
-
-	return (
-		<>
-			<form className="name-servers__toggle">
-				<ToggleControl
-					id="wp-nameservers"
-					name="wp-nameservers"
-					onChange={ handleToggle }
-					checked={ props.enabled }
-					value="active"
-					label={ translate( 'Point to WordPress.com name servers' ) }
-				/>
-			</form>
-			{ /* { renderExplanation() } */ }
-		</>
-	);
-};
-
-const wpcomNameServersToggleButtonClick = ( domainName, enabled ) => {
+const wpcomNameServersToggleButtonClick = ( domainName: string, enabled: boolean ) => {
 	const state = enabled ? 'On' : 'Off';
 
 	return composeAnalytics(
 		recordGoogleEvent(
 			'Domain Management',
-			`Click Toggle Button in "Use WordPress.com Name Servers" Section to "${ state }" in Name Servers and DNS`,
+			`Click Toggle Button in "Use WordPress.com Name Servers" Section to "${ state }" in domain settings`,
 			'Domain Name',
 			domainName
 		),
@@ -88,21 +28,27 @@ const wpcomNameServersToggleButtonClick = ( domainName, enabled ) => {
 	);
 };
 
-const wpcomNameServersLearnMoreClick = ( domainName ) =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Management',
-			'Clicked "Learn More" link in "Use WordPress.com Name Servers" Section in Name Servers and DNS',
-			'Domain Name',
-			domainName
-		),
-		recordTracksEvent(
-			'calypso_domain_management_name_servers_wpcom_name_servers_learn_more_click',
-			{ domain_name: domainName }
-		)
-	);
+const NameserversToggle = ( { enabled, onToggle, selectedDomainName }: NameServersToggleProps ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
 
-export default connect( null, {
-	wpcomNameServersLearnMoreClick,
-	wpcomNameServersToggleButtonClick,
-} )( NameserversToggle );
+	const handleToggle = () => {
+		dispatch( wpcomNameServersToggleButtonClick( selectedDomainName, ! enabled ) );
+		onToggle();
+	};
+
+	return (
+		<form className="name-servers-toggle">
+			<ToggleControl
+				id="wp-nameservers"
+				name="wp-nameservers"
+				onChange={ handleToggle }
+				checked={ enabled }
+				value="active"
+				label={ translate( 'Point to WordPress.com name servers' ) }
+			/>
+		</form>
+	);
+};
+
+export default NameserversToggle;

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
@@ -1,4 +1,3 @@
-import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
@@ -40,11 +40,8 @@ const NameserversToggle = ( { enabled, onToggle, selectedDomainName }: NameServe
 	return (
 		<form className="name-servers-toggle">
 			<ToggleControl
-				id="wp-nameservers"
-				name="wp-nameservers"
 				onChange={ handleToggle }
 				checked={ enabled }
-				value="active"
 				label={ translate( 'Point to WordPress.com name servers' ) }
 			/>
 		</form>

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
@@ -1,0 +1,109 @@
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
+
+const NameserversToggle = ( props ) => {
+	const translate = useTranslate();
+	// static propTypes = {
+	// 	onToggle: PropTypes.func.isRequired,
+	// 	enabled: PropTypes.bool.isRequired,
+	// };
+
+	const handleToggle = () => {
+		props.wpcomNameServersToggleButtonClick( props.selectedDomainName, ! props.enabled );
+		props.onToggle();
+	};
+
+	const renderExplanation = () => {
+		if ( ! props.enabled ) {
+			return null;
+		}
+
+		return (
+			<p className="name-servers__explanation">
+				{ translate(
+					'Name servers point your domain to the right website host, like WordPress.com. ' +
+						'{{a}}Learn more.{{/a}}',
+					{
+						components: {
+							a: (
+								<a
+									href={ CHANGE_NAME_SERVERS }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ handleLearnMoreClick }
+								/>
+							),
+						},
+					}
+				) }
+			</p>
+		);
+	};
+
+	const handleLearnMoreClick = () => {
+		props.wpcomNameServersLearnMoreClick( props.selectedDomainName );
+	};
+
+	return (
+		<>
+			<form className="name-servers__toggle">
+				<ToggleControl
+					id="wp-nameservers"
+					name="wp-nameservers"
+					onChange={ handleToggle }
+					checked={ props.enabled }
+					value="active"
+					label={ translate( 'Point to WordPress.com name servers' ) }
+				/>
+			</form>
+			{ /* { renderExplanation() } */ }
+		</>
+	);
+};
+
+const wpcomNameServersToggleButtonClick = ( domainName, enabled ) => {
+	const state = enabled ? 'On' : 'Off';
+
+	return composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			`Click Toggle Button in "Use WordPress.com Name Servers" Section to "${ state }" in Name Servers and DNS`,
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent(
+			'calypso_domain_management_name_servers_wpcom_name_servers_toggle_button_click',
+			{
+				domain_name: domainName,
+				enabled,
+			}
+		)
+	);
+};
+
+const wpcomNameServersLearnMoreClick = ( domainName ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Learn More" link in "Use WordPress.com Name Servers" Section in Name Servers and DNS',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent(
+			'calypso_domain_management_name_servers_wpcom_name_servers_learn_more_click',
+			{ domain_name: domainName }
+		)
+	);
+
+export default connect( null, {
+	wpcomNameServersLearnMoreClick,
+	wpcomNameServersToggleButtonClick,
+} )( NameserversToggle );

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
@@ -88,8 +88,7 @@ const NameServers = ( props ) => {
 		return (
 			<Notice status="is-warning" showDismiss={ false }>
 				{ translate(
-					'Your domain must use WordPress.com name servers for your ' +
-						'WordPress.com site to load & other features to be available.'
+					'By using custom name servers, you will manage your DNS records with your new provider, not WordPress.com.'
 				) }{ ' ' }
 				<a
 					href={ CHANGE_NAME_SERVERS }
@@ -166,6 +165,8 @@ const NameServers = ( props ) => {
 				onReset={ handleReset }
 				onSubmit={ handleSubmit }
 				submitDisabled={ isLoading() }
+				notice={ warning() }
+				redesign
 			/>
 		);
 	};
@@ -217,7 +218,6 @@ const NameServers = ( props ) => {
 				selectedSite={ props.selectedSite }
 				allowedRules={ [ 'pendingTransfer' ] }
 			/>
-			{ warning() }
 			{ planUpsellForNonPrimaryDomain( props.domain ) }
 			{ wpcomNameserversToggle() }
 			{ customNameservers() }

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
@@ -13,7 +14,6 @@ import {
 } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import CustomNameserversForm from 'calypso/my-sites/domains/domain-management/name-servers/custom-nameservers-form';
 import FetchError from 'calypso/my-sites/domains/domain-management/name-servers/fetch-error';
-import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -26,6 +26,7 @@ import './style.scss';
 const NameServers = ( props ) => {
 	const translate = useTranslate();
 	const [ nameservers, setNameservers ] = useState( props.nameservers || null );
+	const [ isEditingNameservers, setIsEditingNameservers ] = useState( false );
 
 	useEffect( () => {
 		if ( props.isLoadingNameservers === false ) {
@@ -141,7 +142,7 @@ const NameServers = ( props ) => {
 		props.updateNameservers( nameservers );
 	};
 
-	const renderCustomNameservers = () => {
+	const renderCustomNameserversForm = () => {
 		if ( hasWpcomNameservers() || isPendingTransfer() ) {
 			return null;
 		}
@@ -157,18 +158,35 @@ const NameServers = ( props ) => {
 			);
 		}
 
+		if ( isEditingNameservers ) {
+			return (
+				<CustomNameserversForm
+					nameservers={ nameservers }
+					selectedSite={ props.selectedSite }
+					selectedDomainName={ props.selectedDomainName }
+					onChange={ handleChange }
+					onReset={ handleReset }
+					onSubmit={ handleSubmit }
+					submitDisabled={ isLoading() }
+					notice={ warning() }
+					redesign
+				/>
+			);
+		}
+
 		return (
-			<CustomNameserversForm
-				nameservers={ nameservers }
-				selectedSite={ props.selectedSite }
-				selectedDomainName={ props.selectedDomainName }
-				onChange={ handleChange }
-				onReset={ handleReset }
-				onSubmit={ handleSubmit }
-				submitDisabled={ isLoading() }
-				notice={ warning() }
-				redesign
-			/>
+			<div className="name-servers-card__name-server-list">
+				{ nameservers.map( ( nameserver ) => (
+					<p key={ nameserver }>{ nameserver }</p>
+				) ) }
+				<Button
+					onClick={ () => {
+						setIsEditingNameservers( true );
+					} }
+				>
+					Edit custom name servers
+				</Button>
+			</div>
 		);
 	};
 
@@ -200,6 +218,7 @@ const NameServers = ( props ) => {
 
 	const handleSubmit = () => {
 		saveNameservers();
+		setIsEditingNameservers( false );
 	};
 
 	// render()
@@ -221,7 +240,7 @@ const NameServers = ( props ) => {
 			/>
 			{ renderPlanUpsellForNonPrimaryDomain( props.domain ) }
 			{ renderWpcomNameserversToggle() }
-			{ renderCustomNameservers() }
+			{ renderCustomNameserversForm() }
 		</div>
 	);
 	// /render
@@ -243,4 +262,4 @@ const customNameServersLearnMoreClick = ( domainName ) =>
 
 export default connect( null, {
 	customNameServersLearnMoreClick,
-} )( withDomainNameservers( NameServers ) );
+} )( NameServers );

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
@@ -106,7 +106,7 @@ const NameServers = ( props ) => {
 		props.customNameServersLearnMoreClick( props.selectedDomainName );
 	};
 
-	const wpcomNameserversToggle = () => {
+	const renderWpcomNameserversToggle = () => {
 		if ( isPendingTransfer() ) {
 			return null;
 		}
@@ -141,11 +141,12 @@ const NameServers = ( props ) => {
 		props.updateNameservers( nameservers );
 	};
 
-	const customNameservers = () => {
+	const renderCustomNameservers = () => {
 		if ( hasWpcomNameservers() || isPendingTransfer() ) {
 			return null;
 		}
 
+		// TODO: Check how this one appears
 		if ( needsVerification() ) {
 			return (
 				<IcannVerificationCard
@@ -171,7 +172,7 @@ const NameServers = ( props ) => {
 		);
 	};
 
-	const planUpsellForNonPrimaryDomain = ( domain ) => {
+	const renderPlanUpsellForNonPrimaryDomain = ( domain ) => {
 		return (
 			<NonPrimaryDomainPlanUpsell
 				tracksImpressionName="calypso_non_primary_domain_ns_plan_upsell_impression"
@@ -218,9 +219,9 @@ const NameServers = ( props ) => {
 				selectedSite={ props.selectedSite }
 				allowedRules={ [ 'pendingTransfer' ] }
 			/>
-			{ planUpsellForNonPrimaryDomain( props.domain ) }
-			{ wpcomNameserversToggle() }
-			{ customNameservers() }
+			{ renderPlanUpsellForNonPrimaryDomain( props.domain ) }
+			{ renderWpcomNameserversToggle() }
+			{ renderCustomNameservers() }
 		</div>
 	);
 	// /render

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
@@ -211,7 +211,7 @@ const NameServers = ( props ) => {
 	}
 
 	return (
-		<>
+		<div className="name-servers-card">
 			<DomainWarnings
 				domain={ props.domain }
 				position="domain-name-servers"
@@ -221,7 +221,7 @@ const NameServers = ( props ) => {
 			{ planUpsellForNonPrimaryDomain( props.domain ) }
 			{ wpcomNameserversToggle() }
 			{ customNameservers() }
-		</>
+		</div>
 	);
 	// /render
 };

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
@@ -26,6 +26,7 @@ import './style.scss';
 const NameServers = ( props ) => {
 	const translate = useTranslate();
 	const [ nameservers, setNameservers ] = useState( props.nameservers || null );
+	const [ shouldUpdateNameservers, setShouldUpdateNameservers ] = useState( false ); // TODO: Rename this
 	const [ isEditingNameservers, setIsEditingNameservers ] = useState( false );
 
 	useEffect( () => {
@@ -33,6 +34,13 @@ const NameServers = ( props ) => {
 			setNameservers( props.nameservers );
 		}
 	}, [ props.isLoadingNameservers ] );
+
+	useEffect( () => {
+		if ( shouldUpdateNameservers ) {
+			props.updateNameservers( nameservers );
+			setShouldUpdateNameservers( false );
+		}
+	}, [ nameservers ] );
 
 	// static propTypes = {
 	// 	domains: PropTypes.array.isRequired,
@@ -124,6 +132,7 @@ const NameServers = ( props ) => {
 	const handleToggle = () => {
 		if ( hasWpcomNameservers() ) {
 			setNameservers( [] );
+			setIsEditingNameservers( true );
 		} else {
 			resetToWpcomNameservers();
 		}
@@ -134,7 +143,7 @@ const NameServers = ( props ) => {
 			setNameservers( WPCOM_DEFAULT_NAMESERVERS );
 		} else {
 			setNameservers( WPCOM_DEFAULT_NAMESERVERS );
-			saveNameservers();
+			setShouldUpdateNameservers( true );
 		}
 	};
 

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers.tsx
@@ -1,0 +1,245 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import Notice from 'calypso/components/notice';
+import { CHANGE_NAME_SERVERS } from 'calypso/lib/url/support';
+import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
+import NonPrimaryDomainPlanUpsell from 'calypso/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell';
+import IcannVerificationCard from 'calypso/my-sites/domains/domain-management/components/icann-verification';
+import {
+	WPCOM_DEFAULT_NAMESERVERS,
+	WPCOM_DEFAULT_NAMESERVERS_REGEX,
+	CLOUDFLARE_NAMESERVERS_REGEX,
+} from 'calypso/my-sites/domains/domain-management/name-servers/constants';
+import CustomNameserversForm from 'calypso/my-sites/domains/domain-management/name-servers/custom-nameservers-form';
+import FetchError from 'calypso/my-sites/domains/domain-management/name-servers/fetch-error';
+import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
+import NameServersToggle from './name-servers-toggle';
+
+import './style.scss';
+
+const NameServers = ( props ) => {
+	const translate = useTranslate();
+	const [ nameservers, setNameservers ] = useState( props.nameservers || null );
+
+	useEffect( () => {
+		if ( props.isLoadingNameservers === false ) {
+			setNameservers( props.nameservers );
+		}
+	}, [ props.isLoadingNameservers ] );
+
+	// static propTypes = {
+	// 	domains: PropTypes.array.isRequired,
+	// 	isRequestingSiteDomains: PropTypes.bool.isRequired,
+	// 	nameservers: PropTypes.array,
+	// 	selectedDomainName: PropTypes.string.isRequired,
+	// 	selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+	// };
+
+	const hasWpcomNameservers = () => {
+		if ( ! props.nameservers ) {
+			return true;
+		}
+
+		if ( ! nameservers || nameservers.length === 0 ) {
+			return false;
+		}
+
+		return nameservers.every( ( nameserver ) => {
+			return ! nameserver || WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
+		} );
+	};
+
+	const hasCloudflareNameservers = () => {
+		if ( ! nameservers || nameservers.length === 0 ) {
+			return false;
+		}
+
+		return nameservers.every( ( nameserver ) => {
+			return ! nameserver || CLOUDFLARE_NAMESERVERS_REGEX.test( nameserver );
+		} );
+	};
+
+	const isLoading = () => {
+		return props.isRequestingSiteDomains || props.isLoadingNameservers;
+	};
+
+	const isPendingTransfer = () => {
+		return props.domain.pendingTransfer || false;
+	};
+
+	const warning = () => {
+		if (
+			hasWpcomNameservers() ||
+			hasCloudflareNameservers() ||
+			isPendingTransfer() ||
+			needsVerification() ||
+			! nameservers ||
+			! nameservers.length
+		) {
+			return null;
+		}
+
+		return (
+			<Notice status="is-warning" showDismiss={ false }>
+				{ translate(
+					'Your domain must use WordPress.com name servers for your ' +
+						'WordPress.com site to load & other features to be available.'
+				) }{ ' ' }
+				<a
+					href={ CHANGE_NAME_SERVERS }
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ handleLearnMoreClick }
+				>
+					{ translate( 'Learn more.' ) }
+				</a>
+			</Notice>
+		);
+	};
+
+	const handleLearnMoreClick = () => {
+		props.customNameServersLearnMoreClick( props.selectedDomainName );
+	};
+
+	const wpcomNameserversToggle = () => {
+		if ( isPendingTransfer() ) {
+			return null;
+		}
+
+		return (
+			<NameServersToggle
+				selectedDomainName={ props.selectedDomainName }
+				onToggle={ handleToggle }
+				enabled={ hasWpcomNameservers() }
+			/>
+		);
+	};
+
+	const handleToggle = () => {
+		if ( hasWpcomNameservers() ) {
+			setNameservers( [] );
+		} else {
+			resetToWpcomNameservers();
+		}
+	};
+
+	const resetToWpcomNameservers = () => {
+		if ( ! nameservers || nameservers.length === 0 ) {
+			setNameservers( WPCOM_DEFAULT_NAMESERVERS );
+		} else {
+			setNameservers( WPCOM_DEFAULT_NAMESERVERS );
+			saveNameservers();
+		}
+	};
+
+	const saveNameservers = () => {
+		props.updateNameservers( nameservers );
+	};
+
+	const customNameservers = () => {
+		if ( hasWpcomNameservers() || isPendingTransfer() ) {
+			return null;
+		}
+
+		if ( needsVerification() ) {
+			return (
+				<IcannVerificationCard
+					selectedDomainName={ props.selectedDomainName }
+					selectedSiteSlug={ props.selectedSite.slug }
+					explanationContext="name-servers"
+				/>
+			);
+		}
+
+		return (
+			<CustomNameserversForm
+				nameservers={ nameservers }
+				selectedSite={ props.selectedSite }
+				selectedDomainName={ props.selectedDomainName }
+				onChange={ handleChange }
+				onReset={ handleReset }
+				onSubmit={ handleSubmit }
+				submitDisabled={ isLoading() }
+			/>
+		);
+	};
+
+	const planUpsellForNonPrimaryDomain = ( domain ) => {
+		return (
+			<NonPrimaryDomainPlanUpsell
+				tracksImpressionName="calypso_non_primary_domain_ns_plan_upsell_impression"
+				tracksClickName="calypso_non_primary_domain_ns_plan_upsell_click"
+				domain={ domain }
+			/>
+		);
+	};
+
+	const needsVerification = () => {
+		if ( props.isRequestingSiteDomains ) {
+			return false;
+		}
+
+		return props.domain.isPendingIcannVerification;
+	};
+
+	const handleChange = ( nameservers ) => {
+		setNameservers( nameservers );
+	};
+
+	const handleReset = () => {
+		resetToWpcomNameservers();
+	};
+
+	const handleSubmit = () => {
+		saveNameservers();
+	};
+
+	// render()
+	if ( props.loadingNameserversError ) {
+		return <FetchError selectedDomainName={ props.selectedDomainName } />;
+	}
+
+	if ( isLoading() ) {
+		return <>LOADING</>;
+	}
+
+	return (
+		<>
+			<DomainWarnings
+				domain={ props.domain }
+				position="domain-name-servers"
+				selectedSite={ props.selectedSite }
+				allowedRules={ [ 'pendingTransfer' ] }
+			/>
+			{ warning() }
+			{ planUpsellForNonPrimaryDomain( props.domain ) }
+			{ wpcomNameserversToggle() }
+			{ customNameservers() }
+		</>
+	);
+	// /render
+};
+
+const customNameServersLearnMoreClick = ( domainName ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Learn More" link in "Custom Name Servers" Form in Name Servers and DNS',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent(
+			'calypso_domain_management_name_servers_custom_name_servers_learn_more_click',
+			{ domain_name: domainName }
+		)
+	);
+
+export default connect( null, {
+	customNameServersLearnMoreClick,
+} )( withDomainNameservers( NameServers ) );

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -53,6 +53,12 @@
 }
 
 .name-servers-card {
+	margin-top: 16px;
+
+	@include break-mobile {
+		margin-top: 0;
+	}
+
 	&__loading {
 		@include placeholder();
 	}

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -68,4 +68,15 @@
 	.name-servers__custom-nameservers-subtitle {
 		color: var( --studio-gray-50 );
 	}
+
+	.name-servers-card__name-server-list {
+		p {
+			font-size: $font-body-small;
+			margin-bottom: 0;
+		}
+
+		p + .button {
+			margin-top: 24px;
+		}
+	}
 }

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -53,6 +53,21 @@
 }
 
 .name-servers-card {
+	&__loading {
+		@include placeholder();
+	}
+
+	&__name-server-list {
+		p {
+			font-size: $font-body-small;
+			margin-bottom: 0;
+		}
+
+		p + .button {
+			margin-top: 24px;
+		}
+	}
+
 	.components-base-control__field {
 		margin-bottom: 16px;
 	}
@@ -67,16 +82,5 @@
 
 	.name-servers__custom-nameservers-subtitle {
 		color: var( --studio-gray-50 );
-	}
-
-	.name-servers-card__name-server-list {
-		p {
-			font-size: $font-body-small;
-			margin-bottom: 0;
-		}
-
-		p + .button {
-			margin-top: 24px;
-		}
 	}
 }

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -37,17 +37,10 @@
 			color: var( --studio-gray-50 );
 		}
 
-        .details-card__autorenew-placeholder {
-            display: block;
-            width: 80px;
-            @include placeholder();
-        }
-
-		.components-base-control__field {
-			margin-bottom: 4px;
-		}
-		.components-toggle-control__label {
-			font-size: $font-body-small;
+		.details-card__autorenew-placeholder {
+			display: block;
+			width: 80px;
+			@include placeholder();
 		}
 
 		& .button {
@@ -56,5 +49,23 @@
 		& .button:not( :first-child ) {
 			margin-left: 16px;
 		}
+	}
+}
+
+.name-servers-card {
+	.components-base-control__field {
+		margin-bottom: 16px;
+	}
+
+	.components-toggle-control__label {
+		font-size: $font-body-small;
+	}
+
+	.name-servers__custom-nameservers-form {
+		font-size: $font-body-small;
+	}
+
+	.name-servers__custom-nameservers-subtitle {
+		color: var( --studio-gray-50 );
 	}
 }

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -90,3 +90,25 @@
 		color: var( --studio-gray-50 );
 	}
 }
+
+// TODO: This should be extracted into a new component
+.custom-name-servers-notice {
+	flex-basis: 100%;
+	background-color: var( --studio-gray-0 );
+	display: flex;
+	align-items: center;
+	padding: 8px;
+	gap: 8px;
+	border-radius: 2px;
+
+	&__icon.gridicon {
+		min-width: 18px;
+		fill: var( --studio-orange-40 );
+	}
+
+	&__message {
+		font-weight: 400;
+		font-size: $font-body-small;
+		color: var( --studio-gray-80 );
+	}
+}

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -13,15 +13,15 @@ export type NameServersCardProps = {
 	domain: ResponseDomain;
 	isLoadingNameservers: boolean;
 	isRequestingSiteDomains: boolean;
-	loadingNameserversError: any; // TODO;
+	loadingNameserversError: boolean;
 	nameservers: string[] | null;
 	selectedDomainName: string;
 	selectedSite: SiteData;
-	updateNameservers: any; // TODO;
+	updateNameservers: ( nameServers: string[] ) => void;
 };
 
 export type NameServersToggleProps = {
 	enabled: boolean;
-	onToggle: any; // TODO;
+	onToggle: () => void;
 	selectedDomainName: string;
 };

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -8,3 +8,14 @@ export type DetailsCardProps = {
 	purchase: Purchase | null;
 	selectedSite: SiteData;
 };
+
+export type NameServersCardProps = {
+	domain: ResponseDomain;
+	isLoadingNameservers: boolean;
+	isRequestingSiteDomains: boolean;
+	loadingNameserversError: any; // TODO;
+	nameservers: string[] | null;
+	selectedDomainName: string;
+	selectedSite: SiteData;
+	updateNameservers: any; // TODO;
+};

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -19,3 +19,9 @@ export type NameServersCardProps = {
 	selectedSite: SiteData;
 	updateNameservers: any; // TODO;
 };
+
+export type NameServersToggleProps = {
+	enabled: boolean;
+	onToggle: any; // TODO;
+	selectedDomainName: string;
+};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -159,6 +159,10 @@ const Settings = ( {
 	};
 
 	const renderNameServersSection = () => {
+		if ( domain.type !== domainTypes.REGISTERED ) {
+			return null;
+		}
+
 		return (
 			<Accordion
 				title={ translate( 'Name servers', { textOnly: true } ) }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -13,6 +13,8 @@ import DomainDeleteInfoCard from 'calypso/my-sites/domains/domain-management/com
 import DomainEmailInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/email';
 import DomainTransferInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/transfer';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
+import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
+import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { requestWhois } from 'calypso/state/domains/management/actions';
@@ -38,11 +40,14 @@ const Settings = ( {
 	domain,
 	domains,
 	isLoadingPurchase,
+	isLoadingNameservers,
+	loadingNameserversError,
+	nameservers,
 	purchase,
+	requestWhois,
 	selectedDomainName,
 	selectedSite,
 	whoisData,
-	requestWhois,
 }: SettingsPageProps ): JSX.Element => {
 	const translate = useTranslate();
 
@@ -125,13 +130,38 @@ const Settings = ( {
 		}
 	};
 
-	const renderNameServersSection = () => {
-		const subtitle = domain.hasWpcomNameservers
+	const areAllWpcomNameServers = () => {
+		if ( ! nameservers || nameservers.length === 0 ) {
+			return false;
+		}
+
+		return nameservers.every( ( nameserver ) => {
+			return ! nameserver || WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
+		} );
+	};
+
+	const getNameServerSectionSubtitle = () => {
+		if ( isLoadingNameservers ) {
+			return <p className="name-servers-card__loading" />;
+		}
+
+		if ( loadingNameserversError ) {
+			return translate( 'There was an error loading the name servers for this domain', {
+				textOnly: true,
+			} );
+		}
+
+		return areAllWpcomNameServers()
 			? translate( 'Your domain is pointing to WordPress.com', { textOnly: true } )
 			: translate( 'Your domain is pointing to custom name servers', { textOnly: true } );
+	};
 
+	const renderNameServersSection = () => {
 		return (
-			<Accordion title={ translate( 'Name servers', { textOnly: true } ) } subtitle={ subtitle }>
+			<Accordion
+				title={ translate( 'Name servers', { textOnly: true } ) }
+				subtitle={ getNameServerSectionSubtitle() }
+			>
 				<NameServers
 					domain={ domain }
 					selectedSite={ selectedSite }
@@ -234,7 +264,7 @@ const Settings = ( {
 	}
 
 	return (
-		<Main wideLayout className="settings">
+		<Main wideLayout className="domain-settings-page">
 			{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
@@ -265,4 +295,4 @@ export default connect(
 	{
 		requestWhois,
 	}
-)( Settings );
+)( withDomainNameservers( Settings ) ); // TODO: Check if the NS call will fail for transfers or domain connections

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -302,4 +302,4 @@ export default connect(
 	{
 		requestWhois,
 	}
-)( withDomainNameservers( Settings ) ); // TODO: Check if the NS call will fail for transfers or domain connections
+)( withDomainNameservers( Settings ) );

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -26,6 +26,7 @@ import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-info';
 import DomainSecurityDetails from './cards/domain-security-details';
+import NameServers from './cards/name-servers';
 import RegisteredDomainDetails from './cards/registered-domain-details';
 import { getSslReadableStatus, isSecuredWithUs } from './helpers';
 import SetAsPrimary from './set-as-primary';
@@ -124,6 +125,22 @@ const Settings = ( {
 		}
 	};
 
+	const renderNameServersSection = () => {
+		const subtitle = domain.hasWpcomNameservers
+			? translate( 'Your domain is pointing to WordPress.com', { textOnly: true } )
+			: translate( 'Your domain is pointing to custom name servers', { textOnly: true } );
+
+		return (
+			<Accordion title={ translate( 'Name servers', { textOnly: true } ) } subtitle={ subtitle }>
+				<NameServers
+					domain={ domain }
+					selectedSite={ selectedSite }
+					selectedDomainName={ selectedDomainName }
+				/>
+			</Accordion>
+		);
+	};
+
 	const renderSetAsPrimaryDomainSection = () => {
 		return <SetAsPrimary domain={ domain } selectedSite={ selectedSite } key="set-as-primary" />;
 	};
@@ -195,6 +212,7 @@ const Settings = ( {
 		return (
 			<>
 				{ renderDetailsSection() }
+				{ renderNameServersSection() }
 				{ renderSetAsPrimaryDomainSection() }
 				{ renderContactInformationSecion() }
 				{ renderDomainSecuritySection() }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -136,13 +136,14 @@ const Settings = ( {
 			return false;
 		}
 
-		return nameservers.every( ( nameserver ) => {
+		return nameservers.every( ( nameserver: string ) => {
 			return ! nameserver || WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
 		} );
 	};
 
 	const getNameServerSectionSubtitle = () => {
 		if ( isLoadingNameservers ) {
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			return <p className="name-servers-card__loading" />;
 		}
 
@@ -165,11 +166,11 @@ const Settings = ( {
 			>
 				<NameServersCard
 					domain={ domain }
-					selectedSite={ selectedSite }
-					selectedDomainName={ selectedDomainName }
 					isLoadingNameservers={ isLoadingNameservers }
 					loadingNameserversError={ loadingNameserversError }
 					nameservers={ nameservers }
+					selectedSite={ selectedSite }
+					selectedDomainName={ selectedDomainName }
 					updateNameservers={ updateNameservers }
 				/>
 			</Accordion>
@@ -269,6 +270,7 @@ const Settings = ( {
 	}
 
 	return (
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="domain-settings-page">
 			{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -47,6 +47,7 @@ const Settings = ( {
 	requestWhois,
 	selectedDomainName,
 	selectedSite,
+	updateNameservers,
 	whoisData,
 }: SettingsPageProps ): JSX.Element => {
 	const translate = useTranslate();
@@ -166,6 +167,10 @@ const Settings = ( {
 					domain={ domain }
 					selectedSite={ selectedSite }
 					selectedDomainName={ selectedDomainName }
+					isLoadingNameservers={ isLoadingNameservers }
+					loadingNameserversError={ loadingNameserversError }
+					nameservers={ nameservers }
+					updateNameservers={ updateNameservers }
 				/>
 			</Accordion>
 		);

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -28,7 +28,7 @@ import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-info';
 import DomainSecurityDetails from './cards/domain-security-details';
-import NameServers from './cards/name-servers';
+import NameServersCard from './cards/name-servers-card';
 import RegisteredDomainDetails from './cards/registered-domain-details';
 import { getSslReadableStatus, isSecuredWithUs } from './helpers';
 import SetAsPrimary from './set-as-primary';
@@ -163,7 +163,7 @@ const Settings = ( {
 				title={ translate( 'Name servers', { textOnly: true } ) }
 				subtitle={ getNameServerSectionSubtitle() }
 			>
-				<NameServers
+				<NameServersCard
 					domain={ domain }
 					selectedSite={ selectedSite }
 					selectedDomainName={ selectedDomainName }

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -10,7 +10,6 @@
 
 .settings-header {
 	&__container {
-
 		&-title {
 			display: flex;
 			flex-wrap: wrap;
@@ -21,11 +20,11 @@
 			// Higher specificity needed to override .formatted-header.is-left-align media-query styles
 			header.settings-header__title {
 				margin: 8px 0;
-	
+
 				&::first-letter {
 					text-transform: uppercase;
 				}
-	
+
 				.formatted-header__title {
 					font-weight: 400;
 					margin: 0;
@@ -77,11 +76,11 @@
 				&--success {
 					background: rgba( 184, 230, 191, 0.6 );
 					color: var( --studio-green-80 );
-					
+
 					svg {
 						fill: var( --studio-green-80 );
 					}
-					
+
 					.settings-header__badge-indicator svg {
 						fill: var( --studio-green-50 );
 					}
@@ -90,7 +89,7 @@
 				&--warning {
 					background: var( --studio-orange-0 );
 					color: var( --studio-yellow-80 );
-					
+
 					svg {
 						fill: var( --studio-orange-40 );
 					}
@@ -99,7 +98,7 @@
 				&--premium {
 					background: var( --studio-yellow-10 );
 					color: var( --studio-yellow-80 );
-					
+
 					svg {
 						fill: var( --studio-yellow-80 );
 						margin-right: 0;
@@ -110,7 +109,7 @@
 				&--neutral {
 					background: rgba( 220, 220, 222, 0.6 );
 					color: var( --studio-gray-80 );
-					
+
 					svg {
 						fill: var( --studio-gray-80 );
 					}
@@ -123,6 +122,7 @@
 .domain-settings-page {
 	.name-servers-card__loading {
 		@include placeholder();
-		width: 100%;
+		margin-top: 4px;
+		margin-bottom: 0;
 	}
 }

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -119,3 +119,10 @@
 		}
 	}
 }
+
+.domain-settings-page {
+	.name-servers-card__loading {
+		@include placeholder();
+		width: 100%;
+	}
+}

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -32,6 +32,7 @@ export type SettingsPageConnectedProps = {
 	domain: ResponseDomain;
 	isLoadingPurchase: boolean;
 	purchase: Purchase | null;
+	whoisData: WhoisData[];
 };
 
 export type SettingsPageNameServerHocProps = {
@@ -39,7 +40,6 @@ export type SettingsPageNameServerHocProps = {
 	loadingNameserversError: boolean;
 	nameservers: string[] | null;
 	updateNameservers: ( nameServers: string[] ) => void;
-	whoisData: WhoisData[];
 };
 
 export type SettingsPageConnectedDispatchProps = {

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -31,6 +31,9 @@ export type SettingsPageConnectedProps = {
 	currentRoute: string;
 	domain: ResponseDomain;
 	isLoadingPurchase: boolean;
+	isLoadingNameservers: boolean;
+	loadingNameserversError: any; // TODO
+	nameservers: string[] | null;
 	purchase: Purchase | null;
 
 	whoisData: WhoisData[];

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -31,10 +31,13 @@ export type SettingsPageConnectedProps = {
 	currentRoute: string;
 	domain: ResponseDomain;
 	isLoadingPurchase: boolean;
+	purchase: Purchase | null;
+};
+
+export type SettingsPageNameServerHocProps = {
 	isLoadingNameservers: boolean;
 	loadingNameserversError: boolean;
 	nameservers: string[] | null;
-	purchase: Purchase | null;
 	updateNameservers: ( nameServers: string[] ) => void;
 	whoisData: WhoisData[];
 };
@@ -49,4 +52,5 @@ export type SettingsHeaderProps = {
 
 export type SettingsPageProps = SettingsPagePassedProps &
 	SettingsPageConnectedProps &
-	SettingsPageConnectedDispatchProps;
+	SettingsPageConnectedDispatchProps &
+	SettingsPageNameServerHocProps;

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -32,10 +32,10 @@ export type SettingsPageConnectedProps = {
 	domain: ResponseDomain;
 	isLoadingPurchase: boolean;
 	isLoadingNameservers: boolean;
-	loadingNameserversError: any; // TODO
+	loadingNameserversError: boolean;
 	nameservers: string[] | null;
 	purchase: Purchase | null;
-	updateNameservers: any; // TODO
+	updateNameservers: ( nameServers: string[] ) => void;
 	whoisData: WhoisData[];
 };
 

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -35,7 +35,7 @@ export type SettingsPageConnectedProps = {
 	loadingNameserversError: any; // TODO
 	nameservers: string[] | null;
 	purchase: Purchase | null;
-
+	updateNameservers: any; // TODO
 	whoisData: WhoisData[];
 };
 

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -69,6 +69,10 @@ export function domainManagementRoot() {
 	return '/domains/manage';
 }
 
+/**
+ * @param {string?} siteName
+ * @param {string?} relativeTo
+ */
 export function domainManagementList( siteName, relativeTo = null ) {
 	if ( isUnderDomainManagementAll( relativeTo ) || isUnderEmailManagementAll( relativeTo ) ) {
 		return domainManagementRoot();
@@ -150,6 +154,11 @@ export function domainManagementSiteRedirect( siteName, domainName, relativeTo =
 	return domainManagementEditBase( siteName, domainName, 'redirect', relativeTo );
 }
 
+/**
+ * @param {string} siteName
+ * @param {string} domainName
+ * @param {string?} relativeTo
+ */
 export function domainManagementTransfer( siteName, domainName, relativeTo = null ) {
 	return domainManagementTransferBase( siteName, domainName, '', relativeTo );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR creates the name servers card in the main domain settings page. It is basically an updated, functional adaptation of the `domains/domain-management/name-servers` and `domains/domain-management/name-servers/wpcom-nameservers-toggle` components with some improvements.

This is part of the domain settings pages redesign project detailed in pcYYhz-m2-p2.

#### Screenshots

- New section:

![Markup on 2021-12-20 at 23:52:30](https://user-images.githubusercontent.com/5324818/146864825-0d40ffc8-5069-47e7-91d1-75e46fbba515.png)

- New section with custom name servers form open:

<img width="715" alt="Screen Shot 2021-12-20 at 23 53 47" src="https://user-images.githubusercontent.com/5324818/146864846-387bb5ee-ded5-40bc-ab38-d2d0faecf154.png">

<img width="704" alt="Screen Shot 2021-12-20 at 23 55 53" src="https://user-images.githubusercontent.com/5324818/146864879-77b10748-37fe-42e2-b8b0-7ecc2e0fee85.png">

- New section with custom name servers saved:

<img width="706" alt="Screen Shot 2021-12-20 at 23 54 13" src="https://user-images.githubusercontent.com/5324818/146864907-2aa84603-e3b6-46da-9a14-942e825a5100.png">

- Old page:

![Markup on 2021-12-21 at 00:07:25](https://user-images.githubusercontent.com/5324818/146864924-a8b46e70-b4a7-4014-bb67-a89a3b822f44.png)

- Old page with custom name servers form open:

<img width="1019" alt="Screen Shot 2021-12-21 at 00 07 58" src="https://user-images.githubusercontent.com/5324818/146864949-0879504f-b4c9-4d07-a5cf-4e8aff0062c3.png">

### Testing instructions

- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades > Domains"
- Select one of your domains

All the original functionalities should be working the same, so please try to:
- Set custom name servers
  - Add up to 4 name servers
- Reset to WPCOM name servers after setting custom name servers by enabling the "Point to WPCOM" toggle again
- Start changing name servers and then cancel editing
- Save invalid name servers (empty list or invalid domains) and ensure they are not saved
- Check different site types (simple, atomic, domain-only) and domain types (registered, mapped, transfer) - only **registered** domains should show the name servers card
- Also ensure that the mobile view looks correct
