### PR TITLE
Onboarding medium importer

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -26,7 +26,13 @@ interface ImporterConfigMap {
 	[ key: string ]: ImporterConfig;
 }
 
-function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
+interface ImporterConfigArgs {
+	siteTitle?: string;
+}
+
+function getConfig(
+	args: ImporterConfigArgs = { siteTitle: '' }
+): { [ key: string ]: ImporterConfig } {
 	const importerConfig: ImporterConfigMap = {};
 
 	importerConfig.wordpress = {
@@ -38,9 +44,7 @@ function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
 		description: translate(
 			'Import posts, pages, and media from a WordPress export\u00A0file to {{b}}%(siteTitle)s{{/b}}.',
 			{
-				args: {
-					siteTitle,
-				},
+				args,
 				components: {
 					b: <strong />,
 				},
@@ -76,7 +80,7 @@ function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
 			{
 				args: {
 					importerName: 'Blogger',
-					siteTitle,
+					siteTitle: args.siteTitle,
 				},
 				components: {
 					b: <strong />,
@@ -113,9 +117,7 @@ function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
 			'Import posts, tags, images, and videos ' +
 				'from a Medium export file to {{b}}%(siteTitle)s{{/b}}.',
 			{
-				args: {
-					siteTitle,
-				},
+				args,
 				components: {
 					b: <strong />,
 				},
@@ -152,7 +154,7 @@ function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
 			{
 				args: {
 					importerName: 'Substack',
-					siteTitle,
+					siteTitle: args.siteTitle,
 				},
 				components: {
 					b: <strong />,
@@ -199,7 +201,7 @@ function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
 			{
 				args: {
 					importerName: 'Squarespace',
-					siteTitle,
+					siteTitle: args.siteTitle,
 				},
 				components: {
 					b: <strong />,
@@ -235,9 +237,7 @@ function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
 		description: translate(
 			'Import posts, pages, and media from your Wix.com site to {{b}}%(siteTitle)s{{/b}}.',
 			{
-				args: {
-					siteTitle,
-				},
+				args,
 				components: {
 					b: <strong />,
 				},
@@ -258,8 +258,8 @@ function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
 	return importerConfig;
 }
 
-export function getImporters( siteTitle = '' ) {
-	const importerConfig = getConfig( siteTitle );
+export function getImporters( args: ImporterConfigArgs = { siteTitle: '' } ) {
+	const importerConfig = getConfig( args );
 
 	if ( ! config.isEnabled( 'importers/substack' ) ) {
 		delete importerConfig.substack;
@@ -270,8 +270,8 @@ export function getImporters( siteTitle = '' ) {
 	return importers;
 }
 
-export function getImporterByKey( key: string, siteTitle = '' ) {
-	return filter( getImporters( siteTitle ), ( importer ) => importer.key === key )[ 0 ];
+export function getImporterByKey( key: string, args: ImporterConfigArgs = { siteTitle: '' } ) {
+	return filter( getImporters( args ), ( importer ) => importer.key === key )[ 0 ];
 }
 
 export default getConfig;

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -3,8 +3,31 @@ import { translate } from 'i18n-calypso';
 import { filter, orderBy, values } from 'lodash';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
-function getConfig( { siteTitle = '' } = {} ) {
-	const importerConfig = {};
+export interface ImporterOptionalURL {
+	title: React.ReactChild;
+	description: React.ReactChild;
+	invalidDescription: React.ReactChild;
+}
+
+export interface ImporterConfig {
+	engine: string;
+	key: string;
+	type: 'file' | 'url';
+	title: string;
+	icon: string;
+	description: React.ReactChild;
+	uploadDescription: React.ReactChild;
+	weight: number;
+	overrideDestination?: string;
+	optionalUrl?: ImporterOptionalURL;
+}
+
+interface ImporterConfigMap {
+	[ key: string ]: ImporterConfig;
+}
+
+function getConfig( siteTitle = '' ): { [ key: string ]: ImporterConfig } {
+	const importerConfig: ImporterConfigMap = {};
 
 	importerConfig.wordpress = {
 		engine: 'wordpress',
@@ -235,8 +258,8 @@ function getConfig( { siteTitle = '' } = {} ) {
 	return importerConfig;
 }
 
-export function getImporters( params = {} ) {
-	const importerConfig = getConfig( params );
+export function getImporters( siteTitle = '' ) {
+	const importerConfig = getConfig( siteTitle );
 
 	if ( ! config.isEnabled( 'importers/substack' ) ) {
 		delete importerConfig.substack;
@@ -247,8 +270,8 @@ export function getImporters( params = {} ) {
 	return importers;
 }
 
-export function getImporterByKey( key, params = {} ) {
-	return filter( getImporters( params ), ( importer ) => importer.key === key )[ 0 ];
+export function getImporterByKey( key: string, siteTitle = '' ) {
+	return filter( getImporters( siteTitle ), ( importer ) => importer.key === key )[ 0 ];
 }
 
 export default getConfig;

--- a/client/signup/steps/import-from/components/importer-drag/index.tsx
+++ b/client/signup/steps/import-from/components/importer-drag/index.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { includes } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -10,6 +11,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { ImportJob } from '../../types';
+import './style.scss';
 
 export interface Site {
 	ID: number;
@@ -47,7 +49,7 @@ const ImporterDrag: React.FunctionComponent< Props > = ( props ) => {
 	const isEnabled = appStates.DISABLED !== importerState;
 
 	return (
-		<div>
+		<div className={ classnames( 'importer-drag', `importer-drag-${ importerData?.engine }` ) }>
 			<ImporterHeader
 				importerStatus={ importerStatus }
 				icon={ importerData?.icon }

--- a/client/signup/steps/import-from/components/importer-drag/index.tsx
+++ b/client/signup/steps/import-from/components/importer-drag/index.tsx
@@ -1,0 +1,78 @@
+import { includes } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
+import { ImporterConfig } from 'calypso/lib/importer/importer-config';
+import ErrorPane from 'calypso/my-sites/importer/error-pane';
+import ImporterHeader from 'calypso/my-sites/importer/importer-header';
+import ImportingPane from 'calypso/my-sites/importer/importing-pane';
+import UploadingPane from 'calypso/my-sites/importer/uploading-pane';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { startImport } from 'calypso/state/imports/actions';
+import { appStates } from 'calypso/state/imports/constants';
+import { ImportJob } from '../../types';
+
+export interface Site {
+	ID: number;
+	name: string;
+	URL: string;
+}
+
+/**
+ * Module variables
+ */
+const importingStates = [
+	appStates.IMPORT_FAILURE,
+	appStates.IMPORT_SUCCESS,
+	appStates.IMPORTING,
+	appStates.MAP_AUTHORS,
+];
+
+const uploadingStates = [
+	appStates.UPLOAD_PROCESSING,
+	appStates.READY_FOR_UPLOAD,
+	appStates.UPLOAD_FAILURE,
+	appStates.UPLOAD_SUCCESS,
+	appStates.UPLOADING,
+];
+
+interface Props {
+	importerStatus: ImportJob;
+	importerData: ImporterConfig;
+	site: Site;
+	startImport: ( siteId: number, type: string ) => void;
+}
+const ImporterDrag: React.FunctionComponent< Props > = ( props ) => {
+	const { importerStatus, importerData, site /*, startImport*/ } = props;
+	const { errorData, importerState } = importerStatus;
+	const isEnabled = appStates.DISABLED !== importerState;
+
+	return (
+		<div>
+			<ImporterHeader
+				importerStatus={ importerStatus }
+				icon={ importerData?.icon }
+				title={ importerData?.title }
+				description={ importerData?.description }
+			/>
+			{ errorData && <ErrorPane type={ errorData.type } description={ errorData.description } /> }
+			{ includes( importingStates, importerState ) && (
+				<ImportingPane
+					importerStatus={ importerStatus }
+					sourceType={ importerData?.title }
+					site={ site }
+				/>
+			) }
+			{ includes( uploadingStates, importerState ) && (
+				<UploadingPane
+					isEnabled={ isEnabled }
+					description={ importerData?.uploadDescription }
+					importerStatus={ importerStatus }
+					site={ site }
+					optionalUrl={ importerData?.optionalUrl }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default connect( null, { recordTracksEvent, startImport } )( ImporterDrag );

--- a/client/signup/steps/import-from/components/importer-drag/style.scss
+++ b/client/signup/steps/import-from/components/importer-drag/style.scss
@@ -7,7 +7,7 @@
 		color: var( --studio-gray-40 );
 
 		.importer-header__service-title {
-			color: #101517;
+			color: var( --studio-gray-100 );
 		}
 	}
 
@@ -21,12 +21,12 @@
 
 			white-space: pre;
 			text-decoration: underline;
-			color: #101517;
+			color: var( --studio-gray-100 );
 		}
 	}
 
 	.importer__uploading-pane {
-		border-color: #c3c4c7;
+		border-color: var( --studio-gray-10 );
 		background-color: transparent;
 		border-radius: 4px;
 		color: var( --studio-gray-80 );

--- a/client/signup/steps/import-from/components/importer-drag/style.scss
+++ b/client/signup/steps/import-from/components/importer-drag/style.scss
@@ -1,0 +1,34 @@
+.importer-drag {
+	.social-logo {
+		border-radius: 4px;
+	}
+
+	.importer-header__service-info {
+		color: var( --studio-gray-40 );
+
+		.importer-header__service-title {
+			color: #101517;
+		}
+	}
+
+	.importer__uploading-pane-description {
+		color: var( --studio-gray-40 );
+
+		.inline-support-link {
+			&::before {
+				content: '\A';
+			}
+
+			white-space: pre;
+			text-decoration: underline;
+			color: #101517;
+		}
+	}
+
+	.importer__uploading-pane {
+		border-color: #c3c4c7;
+		background-color: transparent;
+		border-radius: 4px;
+		color: var( --studio-gray-80 );
+	}
+}

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -12,14 +12,13 @@ import {
 	isImporterStatusHydrated,
 } from 'calypso/state/imports/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getSiteId } from 'calypso/state/sites/selectors';
-import NotAuthorized from './components/not-authorized';
-import NotFound from './components/not-found';
-import { MediumImporter } from './medium';
 import { Importer, QueryObject, ImportJob } from './types';
 import { getImporterTypeForEngine } from './util';
 import WixImporter from './wix';
-
+import NotFound from './components/not-found';
+import { getSiteId, getSite } from 'calypso/state/sites/selectors';
+import NotAuthorized from './components/not-authorized';
+import MediumImporter from './medium';
 import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -30,6 +29,7 @@ interface Props {
 	stepSectionName: string;
 	queryObject: QueryObject;
 	siteId: number;
+	site: unknown;
 	siteSlug: string;
 	fromSite: string;
 	canImport: boolean;
@@ -41,6 +41,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const {
 		stepSectionName,
 		siteId,
+		site,
 		canImport,
 		siteSlug,
 		siteImports,
@@ -131,6 +132,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 											job={ getImportJob( engine ) }
 											run={ runImportInitially }
 											siteId={ siteId }
+											site={ site }
 											siteSlug={ siteSlug }
 											fromSite={ fromSite }
 										/>
@@ -168,6 +170,7 @@ export default connect(
 
 		return {
 			siteId,
+			site: getSite( state, siteId ),
 			siteSlug,
 			fromSite,
 			siteImports: getImporterStatusForSiteId( state, siteId ),

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -3,7 +3,7 @@ import page from 'page';
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
+import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { fetchImporterState } from 'calypso/state/imports/actions';
@@ -12,14 +12,15 @@ import {
 	isImporterStatusHydrated,
 } from 'calypso/state/imports/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { Importer, QueryObject, ImportJob } from './types';
-import { getImporterTypeForEngine } from './util';
-import WixImporter from './wix';
-import NotFound from './components/not-found';
-import { getSiteId, getSite } from 'calypso/state/sites/selectors';
+import { getSite, getSiteId } from 'calypso/state/sites/selectors';
+import { Site } from './components/importer-drag';
 import NotAuthorized from './components/not-authorized';
+import NotFound from './components/not-found';
 import MediumImporter from './medium';
 import './style.scss';
+import { Importer, ImportJob, QueryObject } from './types';
+import { getImporterTypeForEngine } from './util';
+import WixImporter from './wix';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -29,7 +30,7 @@ interface Props {
 	stepSectionName: string;
 	queryObject: QueryObject;
 	siteId: number;
-	site: unknown;
+	site: Site;
 	siteSlug: string;
 	fromSite: string;
 	canImport: boolean;
@@ -170,7 +171,7 @@ export default connect(
 
 		return {
 			siteId,
-			site: getSite( state, siteId ),
+			site: getSite( state, siteId ) as Site,
 			siteSlug,
 			fromSite,
 			siteImports: getImporterStatusForSiteId( state, siteId ),

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -4,32 +4,33 @@ import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import ImporterMedium from 'calypso/my-sites/importer/importer-medium';
-import { resetImport, startImport } from 'calypso/state/imports/actions';
+import { startImport, resetImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import DoneButton from '../components/done-button';
 import { Importer, ImportJob, ImportJobParams } from '../types';
-import './style.scss';
 import { getImporterTypeForEngine } from '../util';
+
+import './style.scss';
 
 interface Props {
 	job?: ImportJob;
 	run: boolean;
 	siteId: number;
+	site: unknown;
 	siteSlug: string;
 	fromSite: string;
-	importSite?: ( params: ImportJobParams ) => void;
-	startImport?: ( siteId: number, type: string ) => void;
-	resetImport?: ( siteId: number, importerId: string ) => void;
+	importSite: ( params: ImportJobParams ) => void;
+	startImport: ( siteId: number, type: string ) => void;
+	resetImport: ( siteId: number, importerId: string ) => void;
 }
 export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 	const importer: Importer = 'medium';
 	const { __ } = useI18n();
-	const { job, run, siteId, siteSlug, fromSite } = props;
-	// const importerConfig = getImporterByKey( 'importer-type-medium', { siteTitle: 'Medium' } );
+	const { job, siteId, site, siteSlug, fromSite, importSite, startImport, resetImport } = props;
 
 	/**
-	 ↓ Effects
+	 * Effects
 	 */
 	useEffect( runImport, [ job ] );
 
@@ -37,7 +38,7 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 	 ↓ Methods
 	 */
 	function runImport() {
-		if ( ! run ) return;
+		// if ( ! run ) return;
 
 		// If there is no existing import job, start a new
 		if ( job === undefined ) {
@@ -62,7 +63,7 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function checkIsSuccess() {
-		return job && job.importerState === appStates.IMPORT_SUCCESS;
+		return job?.importerState === appStates.IMPORT_SUCCESS;
 	}
 
 	function afterStartImport() {
@@ -73,7 +74,9 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 		<>
 			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
 				{ ( () => {
-					if ( checkIsSuccess() ) {
+					if ( ! job ) {
+						return;
+					} else if ( checkIsSuccess() ) {
 						/**
 						 * Complete screen
 						 */
@@ -98,9 +101,10 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 					 */
 					return (
 						<ImporterMedium
-							site={ props }
+							site={ site }
 							engine={ importer }
 							fromSite={ fromSite }
+							importerStatus={ job }
 							afterStartImport={ afterStartImport }
 						/>
 					);

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -1,14 +1,16 @@
 import { Hooray, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import ImporterMedium from 'calypso/my-sites/importer/importer-medium';
 import { resetImport, startImport } from 'calypso/state/imports/actions';
+import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import DoneButton from '../components/done-button';
 import { Importer, ImportJob, ImportJobParams } from '../types';
-
 import './style.scss';
+import { getImporterTypeForEngine } from '../util';
 
 interface Props {
 	job?: ImportJob;
@@ -23,10 +25,48 @@ interface Props {
 export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 	const importer: Importer = 'medium';
 	const { __ } = useI18n();
-	const { job, siteId, siteSlug } = props;
+	const { job, run, siteId, siteSlug, fromSite } = props;
+	// const importerConfig = getImporterByKey( 'importer-type-medium', { siteTitle: 'Medium' } );
+
+	/**
+	 ↓ Effects
+	 */
+	useEffect( runImport, [ job ] );
+
+	/**
+	 ↓ Methods
+	 */
+	function runImport() {
+		if ( ! run ) return;
+
+		// If there is no existing import job, start a new
+		if ( job === undefined ) {
+			startImport( siteId, getImporterTypeForEngine( importer ) );
+		} else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
+			importSite( prepareImportParams() );
+		}
+	}
+
+	function prepareImportParams(): ImportJobParams {
+		const targetSiteUrl = fromSite.startsWith( 'http' ) ? fromSite : 'https://' + fromSite;
+
+		return {
+			engine: importer,
+			importerStatus: job as ImportJob,
+			params: { engine: importer },
+			site: { ID: siteId },
+			targetSiteUrl,
+			supportedContent: [],
+			unsupportedContent: [],
+		};
+	}
 
 	function checkIsSuccess() {
-		return true;
+		return job && job.importerState === appStates.IMPORT_SUCCESS;
+	}
+
+	function afterStartImport() {
+		return;
 	}
 
 	return (
@@ -52,6 +92,18 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 							</Hooray>
 						);
 					}
+
+					/**
+					 * Upload section
+					 */
+					return (
+						<ImporterMedium
+							site={ props }
+							engine={ importer }
+							fromSite={ fromSite }
+							afterStartImport={ afterStartImport }
+						/>
+					);
 				} )() }
 			</div>
 		</>

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -1,23 +1,26 @@
 import { Hooray, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { translate, TranslateOptions } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import ImporterMedium from 'calypso/my-sites/importer/importer-medium';
-import { startImport, resetImport } from 'calypso/state/imports/actions';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import importerConfig from 'calypso/lib/importer/importer-config';
+import FileImporter from 'calypso/my-sites/importer/file-importer';
+import { resetImport, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import DoneButton from '../components/done-button';
+import { Site } from '../components/importer-drag';
 import { Importer, ImportJob, ImportJobParams } from '../types';
 import { getImporterTypeForEngine } from '../util';
-
 import './style.scss';
 
 interface Props {
 	job?: ImportJob;
 	run: boolean;
 	siteId: number;
-	site: unknown;
+	site: Site;
 	siteSlug: string;
 	fromSite: string;
 	importSite: ( params: ImportJobParams ) => void;
@@ -28,6 +31,9 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 	const importer: Importer = 'medium';
 	const { __ } = useI18n();
 	const { job, siteId, site, siteSlug, fromSite, importSite, startImport, resetImport } = props;
+	const importerData = importerConfig().medium;
+
+	populateMessages();
 
 	/**
 	 * Effects
@@ -66,8 +72,32 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 		return job?.importerState === appStates.IMPORT_SUCCESS;
 	}
 
-	function afterStartImport() {
-		return;
+	// Change the default messages
+	function populateMessages() {
+		const options: TranslateOptions = {
+			args: {
+				importerName: 'Medium',
+			},
+			components: {
+				supportLink: (
+					<InlineSupportLink supportContext="importers-medium" showIcon={ false }>
+						{ translate( 'Need help exporting your content?' ) }
+					</InlineSupportLink>
+				),
+			},
+		};
+
+		importerData.title = __( 'Import content from Medium' );
+
+		importerData.description = translate(
+			'Import your posts, tags, images, and videos from your %(importerName)s export file',
+			options
+		);
+
+		importerData.uploadDescription = translate(
+			'A %(importerName)s export file is a ZIP file containing several HTML files with your stories.',
+			options
+		);
 	}
 
 	return (
@@ -100,13 +130,7 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 					 * Upload section
 					 */
 					return (
-						<ImporterMedium
-							site={ site }
-							engine={ importer }
-							fromSite={ fromSite }
-							importerStatus={ job }
-							afterStartImport={ afterStartImport }
-						/>
+						<FileImporter site={ site } importerData={ importerData } importerStatus={ job } />
 					);
 				} )() }
 			</div>

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -1,17 +1,18 @@
-import { Hooray, SubTitle, Title } from '@automattic/onboarding';
+import { Hooray, Progress, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { translate, TranslateOptions } from 'i18n-calypso';
+import { translate, TranslateOptions, TranslateOptionsText } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { ProgressBar } from 'calypso/devdocs/design/playground-scope';
 import importerConfig from 'calypso/lib/importer/importer-config';
-import FileImporter from 'calypso/my-sites/importer/file-importer';
+import { calculateProgress } from 'calypso/my-sites/importer/importing-pane';
 import { resetImport, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import DoneButton from '../components/done-button';
-import { Site } from '../components/importer-drag';
+import ImporterDrag, { Site } from '../components/importer-drag';
 import { Importer, ImportJob, ImportJobParams } from '../types';
 import { getImporterTypeForEngine } from '../util';
 import './style.scss';
@@ -68,6 +69,10 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}
 
+	function checkProgress() {
+		return job?.importerState === appStates.IMPORTING;
+	}
+
 	function checkIsSuccess() {
 		return job?.importerState === appStates.IMPORT_SUCCESS;
 	}
@@ -87,7 +92,10 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 			},
 		};
 
-		importerData.title = __( 'Import content from Medium' );
+		importerData.title = translate( 'Import content from %(importerName)s', {
+			...options,
+			textOnly: true,
+		} as TranslateOptionsText ) as string;
 
 		importerData.description = translate(
 			'Import your posts, tags, images, and videos from your %(importerName)s export file',
@@ -124,13 +132,31 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 								/>
 							</Hooray>
 						);
+					} else if ( checkProgress() ) {
+						/**
+						 * Progress screen
+						 */
+						const progress = calculateProgress( job?.progress );
+						return (
+							<Progress>
+								<Title>{ __( 'Importing' ) }...</Title>
+								<ProgressBar
+									color={ 'black' }
+									compact={ true }
+									value={ Number.isNaN( progress ) ? 0 : progress }
+								/>
+								<SubTitle>
+									{ __( "This may take a few minutes. We'll notify you by email when it's done." ) }
+								</SubTitle>
+							</Progress>
+						);
 					}
 
 					/**
 					 * Upload section
 					 */
 					return (
-						<FileImporter site={ site } importerData={ importerData } importerStatus={ job } />
+						<ImporterDrag site={ site } importerData={ importerData } importerStatus={ job } />
 					);
 				} )() }
 			</div>

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -108,7 +108,8 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 		);
 
 		importerData.uploadDescription = translate(
-			'A %(importerName)s export file is a ZIP file containing several HTML files with your stories.',
+			'A %(importerName)s export file is a ZIP file containing several HTML files with your stories. ' +
+				'{{supportLink/}}',
 			options
 		);
 	}

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -12,6 +12,7 @@ import { resetImport, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import DoneButton from '../components/done-button';
+import GettingStartedVideo from '../components/getting-started-video';
 import ImporterDrag, { Site } from '../components/importer-drag';
 import { Importer, ImportJob, ImportJobParams } from '../types';
 import { getImporterTypeForEngine } from '../util';
@@ -75,6 +76,10 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 
 	function checkIsSuccess() {
 		return job?.importerState === appStates.IMPORT_SUCCESS;
+	}
+
+	function showVideoComponent() {
+		return checkProgress() || checkIsSuccess();
 	}
 
 	// Change the default messages
@@ -159,6 +164,8 @@ export const MediumImporter: React.FunctionComponent< Props > = ( props ) => {
 						<ImporterDrag site={ site } importerData={ importerData } importerStatus={ job } />
 					);
 				} )() }
+
+				{ showVideoComponent() && <GettingStartedVideo /> }
 			</div>
 		</>
 	);

--- a/client/signup/steps/import-from/types.ts
+++ b/client/signup/steps/import-from/types.ts
@@ -7,6 +7,7 @@ export type QueryObject = {
 export interface ImportJob {
 	importerId: string;
 	importerState: string;
+	statusMessage?: string;
 	type: string;
 	site: { ID: number };
 	customData: { [ key: string ]: any };

--- a/config/development.json
+++ b/config/development.json
@@ -64,7 +64,7 @@
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/import": true,
-		"gutenboarding/import-from-medium": false,
+		"gutenboarding/import-from-medium": true,
 		"gutenboarding/import-from-wix": true,
 		"help": true,
 		"home/layout-dev": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a Medium importer to onboarding flow, see: TAK5FpwTvfbENJDfHc7Aq1-fi
* New `ImporterDrag` component, which can be used with all the import flow that necessitates a file upload.
* Minor refactoring of `client/lib/importer/importer-config.js`

#### Testing instructions

* Go to https://medium.com/me/export
* Click "Export"
* Medium will send you a .zip with the exported site (it could take several minutes, depending on the size of the site)
* Enable the **gutenboarding/import-from-medium** feature flag (already enabled on development environment)
* Go to http://calypso.localhost:3000/start/importer/capture?siteSlug=YOUR-SITE
* Insert the Medium site URL
* Select the `.zip` file you have just downloaded

**Important notice**: Medium sends an email with a signed S3 URL. The file is wrongly uploaded to S3 with `text/html` MIME type instead of `application/zip`, so the browser could not start the download automatically. In this case, you need to force the download as `.zip`. Maybe it's a temporary bug.

This component will incorporate the changes on #59238.
