### PR TITLE
Plugin Details: hides billing interval for installed plugins.

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -217,13 +217,16 @@ function PluginDetails( props ) {
 				navigationItems={ getNavigationItems() }
 				compactBreadcrumb={ ! isWide }
 			>
-				{ isEnabled( 'marketplace-v1' ) && isMarketplaceProduct && (
-					<BillingIntervalSwitcher
-						billingPeriod={ billingPeriod }
-						onChange={ setBillingPeriod }
-						compact={ ! isWide }
-					/>
-				) }
+				{ isEnabled( 'marketplace-v1' ) &&
+					isMarketplaceProduct &&
+					! requestingPluginsForSites &&
+					! isPluginInstalledOnsite && (
+						<BillingIntervalSwitcher
+							billingPeriod={ billingPeriod }
+							onChange={ setBillingPeriod }
+							compact={ ! isWide }
+						/>
+					) }
 			</FixedNavigationHeader>
 			<PluginNotices
 				pluginId={ fullPlugin.id }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* hides billing interval for installed plugins

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1597" alt="SS 2021-12-21 at 10 20 31" src="https://user-images.githubusercontent.com/12430020/146895766-c7e901ea-23f1-4d40-99a6-8084817d9266.png">|<img width="1596" alt="SS 2021-12-21 at 10 20 10" src="https://user-images.githubusercontent.com/12430020/146895699-cc6c34c1-1e2d-4790-b221-7782c8365ff7.png">|

- visit the details page of an installed paid plugin
- make sure that the billing interval switcher doesn't appear

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59300
