### PR TITLE
Jetpack Search: Refactor away from `UNSAFE_` methods

### DIFF
--- a/client/jetpack-connect/search.jsx
+++ b/client/jetpack-connect/search.jsx
@@ -60,14 +60,11 @@ export class SearchPurchase extends Component {
 		this.setState( { candidateSites } );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( this.props.url ) {
 			this.checkUrl( cleanUrl( this.props.url ) );
 		}
-	}
 
-	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: 'jp_lp',
 			cta_id: this.props.ctaId,

--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -60,14 +60,11 @@ export class SearchPurchase extends Component {
 		this.setState( { candidateSites } );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( this.props.url ) {
 			this.checkUrl( cleanUrl( this.props.url ), true );
 		}
-	}
 
-	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: 'jp_lp',
 			cta_id: this.props.ctaId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the two different paths to purchase a search product away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

Note: there's massive duplication between the 2 affected components, also reuse of a major part of the `jetpack-connect` section inside the `purchase-product` section, so this is a great candidate for follow-up cleanup.

#### Testing instructions
* Go to `/purchase-product/jetpack_search` and verify that the form does not start submitting automatically.
* Go to `/jetpack/connect/jetpack_search` and verify that the form does not start submitting automatically.
* Go to `/purchase-product/jetpack_search?url=SOME_URL` where `SOME_URL` is the URL of a Jetpack site (connected or not)
* Verify that the form still starts submitting automatically.
* Go to `/jetpack/connect/jetpack_search?url=SOME_URL` where `SOME_URL` is the URL of a Jetpack site (connected or not)
* Verify that the form still starts submitting automatically.