### PR TITLE
Plugin Details: Add manage subscription link 

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -140,8 +140,9 @@ function PluginDetails( props ) {
 			...plugin,
 			...wpcomPlugin,
 			...wporgPlugin,
+			isMarketplaceProduct,
 		};
-	}, [ plugin, wporgPlugin, wpComPluginData, isWpComPluginFetched ] );
+	}, [ plugin, wporgPlugin, wpComPluginData, isWpComPluginFetched, isMarketplaceProduct ] );
 
 	const existingPlugin = useMemo( () => {
 		if (

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -179,7 +179,11 @@ class PluginRemoveButton extends Component {
 
 		if ( this.props.menuItem ) {
 			return (
-				<PopoverMenuItem onClick={ handleClick } className="plugin-remove-button__remove-button">
+				<PopoverMenuItem
+					onClick={ handleClick }
+					icon="trash"
+					className="plugin-remove-button__remove-button"
+				>
 					{ label }
 				</PopoverMenuItem>
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds manage subscription link if plugin subscription is bought for paid plugins
* Also adds the available grid icons for "Settings" and "Manage Subscription" (note: they are not the same as in figma)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1161" alt="SS 2021-12-21 at 12 00 04" src="https://user-images.githubusercontent.com/12430020/146910569-9ed3da1b-8037-4b33-8b23-3049f6e69951.png">|<img width="1151" alt="SS 2021-12-21 at 11 59 45" src="https://user-images.githubusercontent.com/12430020/146910530-58cf9866-b41c-4ae6-af0b-61516fc789b0.png">|

* visit the plugin details of an already bought plugin
* click the ellipsis menu
* click "Manage Subscription"
* make sure you are landed in the correct subscription

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58995
