### PR TITLE
Fix Sass build on Windows

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -211,10 +211,19 @@ const webpackConfig = {
 					config: false,
 					plugins: [ autoprefixerPlugin() ],
 				},
-				prelude: `@use '${ path.join(
-					__dirname,
-					'assets/stylesheets/shared/_utils.scss'
-				) }' as *;`,
+				// Since `prelude` string will be appended to each Sass file
+				// We need to ensure that the import path (inside a sass file) is a posix path, regardless of the OS/platform
+				// Final result should be something like `@use 'client/assets/stylesheets/shared/_utils.scss' as *;`
+				prelude: `@use '${
+					path
+						// Path, relative to Node CWD
+						.relative(
+							process.cwd(),
+							path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' )
+						)
+						.split( path.sep ) // Break any path (posix/win32) by path separator
+						.join( path.posix.sep ) // Convert the path explicitly to posix to ensure imports work fine
+				}' as *;`,
 			} ),
 			{
 				include: path.join( __dirname, 'sections.js' ),


### PR DESCRIPTION
On Windows, when you I run `yarn start`, I see this error

```
ERROR in ../packages/social-previews/src/twitter-preview/style.scss
Module build failed (from ../node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ../node_modules/sass-loader/dist/cjs.js):
SassError: Can't find stylesheet to import.
  ╷
1 │ @use 'D:\Dev\a8c\wp-calypso\client\assets\stylesheets\shared\_utils.scss' as *;
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Source of the error is `prelude` in `SassConfig` in `module.rules` in `client/webpack.config.js`. Prelude just uses the absolute path of the sass file which errs on Windows, because you cannot use a windows path while importing one sass file into another.

#### Changes proposed in this Pull Request
* This PR makes that import path in `prelude` to be posix and relative to Node CWD directory. It works both for Windows and well as Linux.

#### Testing instructions

* Run `yarn start`
* Check if the build is successful.
