### PR TITLE
Woo on all plans: Add a page view stat for the landing page

### DIFF
--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -4,6 +4,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { isLoaded as arePluginsLoaded } from 'calypso/state/plugins/installed/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import RequiredPluginsInstallView from './dashboard/required-plugins-install-view';
@@ -22,6 +23,7 @@ function WooCommerce() {
 		<div className="woocommerce">
 			<Main class="main" wideLayout>
 				<DocumentHead title={ translate( 'WooCommerce' ) } />
+				<PageViewTracker path="/woocommerce-installation/:site" title="WooCommerce Installation" />
 				<QuerySiteFeatures siteId={ siteId } />
 				<QueryJetpackPlugins siteIds={ [ siteId ] } />
 				{ areInstalledPluginsLoadedIntoState && <RequiredPluginsInstallView siteId={ siteId } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We weren't tracking the page views of the new Woo installation landing
page, so this change adds the PageViewTracker component, so that we can
see the number of impressions.

#### Testing instructions
* Open the console and run `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* View /woocommerce-installation/ with a test site, and notice there is no page view tracks event logged to the console.
* With this PR view the same page and check that a tracks event is logged to the console

<img width="992" alt="image" src="https://user-images.githubusercontent.com/96462/146931087-6e88089a-a433-4ae5-852d-51039e63026c.png">
