### PR TITLE
Tour Kit: Added custom CSS classes for each step

### DIFF
--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -108,6 +108,7 @@ The main API for configuring a tour is the config object. See example usage and 
 
 - `referenceElements` (optional): A set of `deskop` & `mobile` selectors to render the step near.
 - `meta`: Arbitrary object that encloses the content we want to render for each step.
+- `className` (optional): Optional CSS class applied to a step.
 
 `config.closeHandler`: The callback responsible for closing the tour.
 
@@ -132,7 +133,7 @@ The main API for configuring a tour is the config object. See example usage and 
 
 `config.options` (optional):
 
-- `className`: Optional CSS class to enclose the main tour frame with.
+- `className`: Optional CSS class to enclose the main tour frame with. If provided, implementations will also receive a CSS class `.[className]__step` in the step renderers.
 
 - `effects`: An object to enable/disable/combine various tour effects:
 

--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -13,6 +13,8 @@ A tour is made up of the following components:
 - A number of `steps`, made up of:
   - some arbitrary metadata
   - a set of optional reference elements selectors for rendering a step near
+  - a set of options:
+	- className: optional custom CSS class that will be applied to the step
 - Two renderers (used as render props internally):
   - a step renderer (React component/function passed a set of properties)
   - a minimized view renderer (for rendering a minimized view instead of closing)

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -176,17 +176,19 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 					{ ! isMinimized ? (
 						<TourKitStep
 							config={ config }
+							steps={ config.steps }
 							currentStepIndex={ currentStepIndex }
 							onMinimize={ handleMinimize }
 							onDismiss={ handleDismiss }
-							onNextStepProgression={ handleNextStepProgression }
-							onPreviousStepProgression={ handlePreviousStepProgression }
+							onNext={ handleNextStepProgression }
+							onPrevious={ handlePreviousStepProgression }
 							onGoToStep={ handleGoToStep }
 							setInitialFocusedElement={ setInitialFocusedElement }
 						/>
 					) : (
 						<TourKitMinimized
 							config={ config }
+							steps={ config.steps }
 							currentStepIndex={ currentStepIndex }
 							onMaximize={ handleMaximize }
 							onDismiss={ handleDismiss }

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -11,6 +11,7 @@ import usePopperHandler from '../hooks/use-popper-handler';
 import KeyboardNavigation from './keyboard-navigation';
 import Overlay from './tour-kit-overlay';
 import Spotlight from './tour-kit-spotlight';
+import TourKitStep from './tour-kit-step';
 import type { Config, Callback } from '../types';
 
 interface Props {
@@ -171,29 +172,18 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 					{ showArrowIndicator() && (
 						<div className="tour-kit-frame__arrow" data-popper-arrow { ...arrowPositionProps } />
 					) }
-					{ ! isMinimized ? (
-						<>
-							{ config.renderers.tourStep( {
-								steps: config.steps,
-								currentStepIndex,
-								onDismiss: handleDismiss,
-								onNext: handleNextStepProgression,
-								onPrevious: handlePreviousStepProgression,
-								onMinimize: handleMinimize,
-								setInitialFocusedElement,
-								onGoToStep: handleGoToStep,
-							} ) }
-						</>
-					) : (
-						<>
-							{ config.renderers.tourMinimized( {
-								steps: config.steps,
-								currentStepIndex,
-								onMaximize: handleMaximize,
-								onDismiss: handleDismiss,
-							} ) }
-						</>
-					) }
+					<TourKitStep
+						config={ config }
+						currentStepIndex={ currentStepIndex }
+						isMinimized={ isMinimized }
+						onMinimize={ handleMinimize }
+						onMaximize={ handleMaximize }
+						onDismiss={ handleDismiss }
+						onNextStepProgression={ handleNextStepProgression }
+						onPreviousStepProgression={ handlePreviousStepProgression }
+						onGoToStep={ handleGoToStep }
+						setInitialFocusedElement={ setInitialFocusedElement }
+					/>
 				</div>
 			</div>
 		</>

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  */
 import usePopperHandler from '../hooks/use-popper-handler';
 import KeyboardNavigation from './keyboard-navigation';
+import TourKitMinimized from './tour-kit-minimized';
 import Overlay from './tour-kit-overlay';
 import Spotlight from './tour-kit-spotlight';
 import TourKitStep from './tour-kit-step';
@@ -172,18 +173,25 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 					{ showArrowIndicator() && (
 						<div className="tour-kit-frame__arrow" data-popper-arrow { ...arrowPositionProps } />
 					) }
-					<TourKitStep
-						config={ config }
-						currentStepIndex={ currentStepIndex }
-						isMinimized={ isMinimized }
-						onMinimize={ handleMinimize }
-						onMaximize={ handleMaximize }
-						onDismiss={ handleDismiss }
-						onNextStepProgression={ handleNextStepProgression }
-						onPreviousStepProgression={ handlePreviousStepProgression }
-						onGoToStep={ handleGoToStep }
-						setInitialFocusedElement={ setInitialFocusedElement }
-					/>
+					{ ! isMinimized ? (
+						<TourKitStep
+							config={ config }
+							currentStepIndex={ currentStepIndex }
+							onMinimize={ handleMinimize }
+							onDismiss={ handleDismiss }
+							onNextStepProgression={ handleNextStepProgression }
+							onPreviousStepProgression={ handlePreviousStepProgression }
+							onGoToStep={ handleGoToStep }
+							setInitialFocusedElement={ setInitialFocusedElement }
+						/>
+					) : (
+						<TourKitMinimized
+							config={ config }
+							currentStepIndex={ currentStepIndex }
+							onMaximize={ handleMaximize }
+							onDismiss={ handleDismiss }
+						/>
+					) }
 				</div>
 			</div>
 		</>

--- a/packages/tour-kit/src/components/tour-kit-minimized.tsx
+++ b/packages/tour-kit/src/components/tour-kit-minimized.tsx
@@ -1,23 +1,22 @@
 /**
  * Internal Dependencies
  */
+import { MinimizedTourRendererProps } from '../types';
 import type { Config } from '../types';
 
-interface Props {
+interface Props extends MinimizedTourRendererProps {
 	config: Config;
-	currentStepIndex: number;
-	onMaximize: () => void;
-	onDismiss: ( target: string ) => () => void;
 }
 
 const TourKitMinimized: React.FunctionComponent< Props > = ( {
 	config,
+	steps,
 	currentStepIndex,
 	onMaximize,
 	onDismiss,
 } ) => {
 	return config.renderers.tourMinimized( {
-		steps: config.steps,
+		steps,
 		currentStepIndex,
 		onMaximize,
 		onDismiss,

--- a/packages/tour-kit/src/components/tour-kit-minimized.tsx
+++ b/packages/tour-kit/src/components/tour-kit-minimized.tsx
@@ -1,0 +1,27 @@
+/**
+ * Internal Dependencies
+ */
+import type { Config } from '../types';
+
+interface Props {
+	config: Config;
+	currentStepIndex: number;
+	onMaximize: () => void;
+	onDismiss: ( target: string ) => () => void;
+}
+
+const TourKitMinimized: React.FunctionComponent< Props > = ( {
+	config,
+	currentStepIndex,
+	onMaximize,
+	onDismiss,
+} ) => {
+	return config.renderers.tourMinimized( {
+		steps: config.steps,
+		currentStepIndex,
+		onMaximize,
+		onDismiss,
+	} );
+};
+
+export default TourKitMinimized;

--- a/packages/tour-kit/src/components/tour-kit-step.tsx
+++ b/packages/tour-kit/src/components/tour-kit-step.tsx
@@ -10,68 +10,43 @@ import type { Config } from '../types';
 interface Props {
 	config: Config;
 	currentStepIndex: number;
-	isMinimized: boolean;
 	onMinimize: () => void;
-	onMaximize: () => void;
 	onDismiss: ( target: string ) => () => void;
 	onNextStepProgression: () => void;
 	onPreviousStepProgression: () => void;
-	setInitialFocusedElement: React.Dispatch< React.SetStateAction< HTMLElement | null > >;
 	onGoToStep: ( stepIndex: number ) => void;
+	setInitialFocusedElement: React.Dispatch< React.SetStateAction< HTMLElement | null > >;
 }
 
 const TourKitStep: React.FunctionComponent< Props > = ( {
 	config,
 	currentStepIndex,
-	isMinimized,
 	onMinimize,
-	onMaximize,
 	onDismiss,
 	onNextStepProgression,
 	onPreviousStepProgression,
 	setInitialFocusedElement,
 	onGoToStep,
 } ) => {
-	const getStepCssClassFromId = () => {
-		const sanitizedId = config.steps[ currentStepIndex ].id
-			?.trim()
-			.toLowerCase()
-			.replace( /[^a-z0-9]/gi, '-' );
-
-		return sanitizedId ? `tour-kit-step__${ sanitizedId }` : '';
-	};
-
 	const classNames = classnames(
 		'tour-kit-step',
 		`is-step-${ currentStepIndex }`,
-		getStepCssClassFromId()
+		config.options?.className ? `${ config.options?.className }__step` : '',
+		config.steps[ currentStepIndex ].className
 	);
 
 	return (
 		<div className={ classNames }>
-			{ ! isMinimized ? (
-				<>
-					{ config.renderers.tourStep( {
-						steps: config.steps,
-						currentStepIndex,
-						onDismiss,
-						onNext: onNextStepProgression,
-						onPrevious: onPreviousStepProgression,
-						onMinimize,
-						setInitialFocusedElement,
-						onGoToStep,
-					} ) }
-				</>
-			) : (
-				<>
-					{ config.renderers.tourMinimized( {
-						steps: config.steps,
-						currentStepIndex,
-						onMaximize,
-						onDismiss,
-					} ) }
-				</>
-			) }
+			{ config.renderers.tourStep( {
+				steps: config.steps,
+				currentStepIndex,
+				onDismiss,
+				onNext: onNextStepProgression,
+				onPrevious: onPreviousStepProgression,
+				onMinimize,
+				setInitialFocusedElement,
+				onGoToStep,
+			} ) }
 		</div>
 	);
 };

--- a/packages/tour-kit/src/components/tour-kit-step.tsx
+++ b/packages/tour-kit/src/components/tour-kit-step.tsx
@@ -5,26 +5,20 @@ import classnames from 'classnames';
 /**
  * Internal Dependencies
  */
-import type { Config } from '../types';
+import type { Config, TourStepRendererProps } from '../types';
 
-interface Props {
+interface Props extends TourStepRendererProps {
 	config: Config;
-	currentStepIndex: number;
-	onMinimize: () => void;
-	onDismiss: ( target: string ) => () => void;
-	onNextStepProgression: () => void;
-	onPreviousStepProgression: () => void;
-	onGoToStep: ( stepIndex: number ) => void;
-	setInitialFocusedElement: React.Dispatch< React.SetStateAction< HTMLElement | null > >;
 }
 
 const TourKitStep: React.FunctionComponent< Props > = ( {
 	config,
+	steps,
 	currentStepIndex,
 	onMinimize,
 	onDismiss,
-	onNextStepProgression,
-	onPreviousStepProgression,
+	onNext,
+	onPrevious,
 	setInitialFocusedElement,
 	onGoToStep,
 } ) => {
@@ -38,11 +32,11 @@ const TourKitStep: React.FunctionComponent< Props > = ( {
 	return (
 		<div className={ classNames }>
 			{ config.renderers.tourStep( {
-				steps: config.steps,
+				steps,
 				currentStepIndex,
 				onDismiss,
-				onNext: onNextStepProgression,
-				onPrevious: onPreviousStepProgression,
+				onNext,
+				onPrevious,
 				onMinimize,
 				setInitialFocusedElement,
 				onGoToStep,

--- a/packages/tour-kit/src/components/tour-kit-step.tsx
+++ b/packages/tour-kit/src/components/tour-kit-step.tsx
@@ -1,0 +1,79 @@
+/**
+ * External Dependencies
+ */
+import classnames from 'classnames';
+/**
+ * Internal Dependencies
+ */
+import type { Config } from '../types';
+
+interface Props {
+	config: Config;
+	currentStepIndex: number;
+	isMinimized: boolean;
+	onMinimize: () => void;
+	onMaximize: () => void;
+	onDismiss: ( target: string ) => () => void;
+	onNextStepProgression: () => void;
+	onPreviousStepProgression: () => void;
+	setInitialFocusedElement: React.Dispatch< React.SetStateAction< HTMLElement | null > >;
+	onGoToStep: ( stepIndex: number ) => void;
+}
+
+const TourKitStep: React.FunctionComponent< Props > = ( {
+	config,
+	currentStepIndex,
+	isMinimized,
+	onMinimize,
+	onMaximize,
+	onDismiss,
+	onNextStepProgression,
+	onPreviousStepProgression,
+	setInitialFocusedElement,
+	onGoToStep,
+} ) => {
+	const getStepCssClassFromId = () => {
+		const sanitizedId = config.steps[ currentStepIndex ].id
+			?.trim()
+			.toLowerCase()
+			.replace( /[^a-z0-9]/gi, '-' );
+
+		return sanitizedId ? `tour-kit-step__${ sanitizedId }` : '';
+	};
+
+	const classNames = classnames(
+		'tour-kit-step',
+		`is-step-${ currentStepIndex }`,
+		getStepCssClassFromId()
+	);
+
+	return (
+		<div className={ classNames }>
+			{ ! isMinimized ? (
+				<>
+					{ config.renderers.tourStep( {
+						steps: config.steps,
+						currentStepIndex,
+						onDismiss,
+						onNext: onNextStepProgression,
+						onPrevious: onPreviousStepProgression,
+						onMinimize,
+						setInitialFocusedElement,
+						onGoToStep,
+					} ) }
+				</>
+			) : (
+				<>
+					{ config.renderers.tourMinimized( {
+						steps: config.steps,
+						currentStepIndex,
+						onMaximize,
+						onDismiss,
+					} ) }
+				</>
+			) }
+		</div>
+	);
+};
+
+export default TourKitStep;

--- a/packages/tour-kit/src/components/tour-kit-step.tsx
+++ b/packages/tour-kit/src/components/tour-kit-step.tsx
@@ -26,7 +26,7 @@ const TourKitStep: React.FunctionComponent< Props > = ( {
 		'tour-kit-step',
 		`is-step-${ currentStepIndex }`,
 		config.options?.className ? `${ config.options?.className }__step` : '',
-		config.steps[ currentStepIndex ].className
+		config.steps[ currentStepIndex ].options?.className
 	);
 
 	return (

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -1,6 +1,7 @@
 import type { Modifier } from 'react-popper';
 
 export type Step = {
+	id?: string;
 	referenceElements?: {
 		desktop?: string;
 		mobile?: string;

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -1,7 +1,6 @@
 import type { Modifier } from 'react-popper';
 
 export type Step = {
-	className?: string;
 	referenceElements?: {
 		desktop?: string;
 		mobile?: string;
@@ -12,6 +11,9 @@ export type Step = {
 		// | HTMLElement
 		// | string
 		// | ...
+	};
+	options?: {
+		className?: string;
 	};
 };
 

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -1,7 +1,7 @@
 import type { Modifier } from 'react-popper';
 
 export type Step = {
-	id?: string;
+	className?: string;
 	referenceElements?: {
 		desktop?: string;
 		mobile?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In Tour Kit:
- created `tour-kit-step` component
- each step will have the following css classes:
-- `tour-kit-step`
-- `is-step-{Current step index}`
-- if the tour has a custom CSS class, then `{Custom CSS class}__step`
-- optionally, the CSS class provided in the config for the step

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout branch
2. Sync ETK (PCYsg-ly5-p2)
3. Provide a custom CSS class for the tour, and add a CSS class in one of the steps in`calypso/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js like:
```
{
	referenceElements: referencePositioning && referenceElements[ 0 ],
	meta: { ... },
        options: {
		className: 'custom-css-class',
	},
},
```
4. Check that the step has the correct CSS classes:
- `tour-kit-step`
- `is-step-[CURRENT STEP INDEX]`
- `{Tour CSS class}__step`
- The CSS class provided to the step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59347
Fixes #59347