### PR TITLE
Revert "Woop landing page: enable woop flag in production"

### DIFF
--- a/client/my-sites/woocommerce/index.js
+++ b/client/my-sites/woocommerce/index.js
@@ -4,6 +4,7 @@ import { createElement } from 'react';
 import { makeLayout } from 'calypso/controller';
 import { getSiteFragment } from 'calypso/lib/route';
 import { siteSelection, navigation, sites } from 'calypso/my-sites/controller';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import {
 	getSelectedSiteWithFallback,
 	getSiteOption,
@@ -28,9 +29,9 @@ function setup( context, next ) {
 	const site = getSelectedSiteWithFallback( state );
 	const siteId = site ? site.ID : null;
 
-	// Redirect unless the woop feature flag is enabled.
+	// Only allow AT sites to access, unless the woop feature flag is enabled.
 	// todo: remove redirect and rely on plan eligibility checks in the landing page component
-	if ( ! isEnabled( 'woop' ) ) {
+	if ( ! isEnabled( 'woop' ) && ! isAtomicSite( state, siteId ) ) {
 		return page.redirect( `/home/${ site.slug }` );
 	}
 

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,8 +102,7 @@
 		"use-translation-chunks": true,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true,
-		"woop": true
+		"redirect-fallback-browsers": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -110,8 +110,7 @@
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true,
-		"woop": true
+		"redirect-fallback-browsers": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,8 +120,7 @@
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true,
-		"woop": true
+		"redirect-fallback-browsers": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#59274 in case of problems with the new WooCommerce Installation flow.

Test that you can only access /woocommerce-installation/{site-id} from an Atomic site.