### PR TITLE
woop: track click event from landing page

### DIFF
--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
@@ -38,6 +39,11 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 
 	function onCTAClickHandler() {
 		if ( isEnabled( 'woop' ) ) {
+			recordTracksEvent( 'calypso_woocommerce_dashboard_action_click', {
+				action: 'initial-setup',
+				feature: 'woop', // WooCommerce on Plans
+			} );
+
 			return page( `/start/woocommerce-install/?site=${ wpcomDomain }` );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Track event when the user starts the `woop` process. It has the same event name as the previous workflow but adds the feature property in order to segment the event.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the console and run `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* hard refresh!
* View /woocommerce-installation/ with a test site
* Confirm you see the `calypso_woocommerce_dashboard_action_click` event when click on the `Set up my store!` button.

![image](https://user-images.githubusercontent.com/77539/146961209-51a96813-254e-461a-bddf-d47937b1ffba.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
