### PR TITLE
Domains: Prevent name servers from being fetched on every window focus

### DIFF
--- a/client/data/domains/nameservers/use-domain-nameservers-query.js
+++ b/client/data/domains/nameservers/use-domain-nameservers-query.js
@@ -2,8 +2,10 @@ import { useQuery } from 'react-query';
 import wp from 'calypso/lib/wp';
 
 const useDomainNameserversQuery = ( domainName ) =>
-	useQuery( [ 'domain-nameservers', domainName ], () =>
-		wp.req.get( `/domains/${ domainName }/nameservers/` )
+	useQuery(
+		[ 'domain-nameservers', domainName ],
+		() => wp.req.get( `/domains/${ domainName }/nameservers/` ),
+		{ refetchOnWindowFocus: false }
 	);
 
 export default useDomainNameserversQuery;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the `useDomainNameserversQuery`, which is used in the `WithDomainNameservers` component, preventing name servers from being fetched from the backend on every window focus.

This video shows that every time the windows is focused, a new `nameservers` call is done to the backend. Also, almost every render of the `NameServers` component, which is wrapped by the `WithDomainNameservers` HOC component, resulted in a new call to the same `nameververs` endpoint. With this PR's update, that call will be done only once.

https://user-images.githubusercontent.com/5324818/146973496-5e531a53-5069-4594-99ad-488e0302ba71.mp4

### Testing instructions

- Open the live Calypso link or build this branch locally
- Access a domain's name servers configuration page (Upgrade > Domains > Select a domain > Change your name servers & DNS records)
	- If you prefer, access `/domain/manage/<domain>/name-servers/<site_slug>` directly
- Open your developer console's network tab and filter calls with "nameservers"
- Click around the page, change tabs, and go back to the name servers page
- Ensure that no new "nameservers" calls are made
