### PR TITLE
Sidebar: Removed all tracking events from non unified-nav sidebar menu item clicks.

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -171,7 +171,6 @@ export class MySitesSidebar extends Component {
 					tipTarget="backup"
 					label="Backup"
 					link={ `https://cloud.jetpack.com/backup/${ site.slug }` }
-					onNavigate={ () => this.trackMenuItemClick( 'backup' ) }
 				/>
 			);
 		}
@@ -182,7 +181,6 @@ export class MySitesSidebar extends Component {
 					tipTarget="scan"
 					label="Scan"
 					link={ `https://cloud.jetpack.com/scan/${ site.slug }` }
-					onNavigate={ () => this.trackMenuItemClick( 'scan' ) }
 				/>
 			);
 		}
@@ -205,11 +203,6 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	trackStatsClick = () => {
-		this.trackMenuItemClick( 'stats' );
-		this.onNavigate();
-	};
-
 	stats() {
 		const { site, siteId, canUserViewStats, path, translate } = this.props;
 
@@ -228,7 +221,7 @@ export class MySitesSidebar extends Component {
 					path
 				) }
 				link={ statsLink }
-				onNavigate={ this.trackStatsClick }
+				onNavigate={ this.onNavigate }
 				materialIcon="bar_chart"
 			>
 				<StatsSparkline className="sidebar__sparkline" siteId={ siteId } />
@@ -236,11 +229,6 @@ export class MySitesSidebar extends Component {
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
-
-	trackCustomerHomeClick = () => {
-		this.trackMenuItemClick( 'customer-home' );
-		this.onNavigate();
-	};
 
 	customerHome() {
 		const {
@@ -269,7 +257,7 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				materialIcon="home"
 				tipTarget="myhome"
-				onNavigate={ this.trackCustomerHomeClick }
+				onNavigate={ this.onNavigate }
 				label={ label }
 				selected={ itemLinkMatches( [ '/home' ], path ) }
 				link={ '/home' + siteSuffix }
@@ -285,11 +273,6 @@ export class MySitesSidebar extends Component {
 			</SidebarItem>
 		);
 	}
-
-	trackActivityClick = () => {
-		this.trackMenuItemClick( 'activity' );
-		this.onNavigate();
-	};
 
 	activity() {
 		const {
@@ -333,16 +316,11 @@ export class MySitesSidebar extends Component {
 				label={ activityLabel }
 				selected={ itemLinkMatches( [ '/activity-log' ], path ) }
 				link={ activityLink }
-				onNavigate={ this.trackActivityClick }
+				onNavigate={ this.onNavigate }
 				expandSection={ this.expandToolsSection }
 			/>
 		);
 	}
-
-	trackEarnClick = () => {
-		this.trackMenuItemClick( 'earn' );
-		this.onNavigate();
-	};
 
 	earn() {
 		const { site, canUserUseEarn } = this.props;
@@ -366,27 +344,12 @@ export class MySitesSidebar extends Component {
 				label={ translate( 'Earn' ) }
 				selected={ itemLinkMatches( '/earn', path ) }
 				link={ '/earn' + this.props.siteSuffix }
-				onNavigate={ this.trackEarnClick }
+				onNavigate={ this.onNavigate }
 				tipTarget="earn"
 				expandSection={ this.expandToolsSection }
 			/>
 		);
 	}
-
-	trackMigrateClick = () => {
-		this.trackMenuItemClick( 'migrate' );
-		this.onNavigate();
-	};
-
-	trackCustomizeClick = () => {
-		this.trackMenuItemClick( 'customize' );
-		this.onNavigate();
-	};
-
-	trackPurchasesClick = () => {
-		this.trackMenuItemClick( 'purchases' );
-		this.onNavigate();
-	};
 
 	themes() {
 		const { path, site, translate, canUserEditThemeOptions } = this.props;
@@ -401,7 +364,7 @@ export class MySitesSidebar extends Component {
 				tipTarget="themes"
 				selected={ itemLinkMatches( '/customize', path ) }
 				link={ this.props.customizeUrl }
-				onNavigate={ this.trackCustomizeClick }
+				onNavigate={ this.onNavigate }
 				preloadSectionName="customize"
 				forceInternalLink
 				expandSection={ this.expandDesignSection }
@@ -452,7 +415,7 @@ export class MySitesSidebar extends Component {
 				label={ translate( 'Customize' ) }
 				selected={ itemLinkMatches( '/customize', path ) }
 				link={ this.props.customizeUrl }
-				onNavigate={ this.trackCustomizeClick }
+				onNavigate={ this.onNavigate }
 				preloadSectionName="customize"
 				materialIcon="gesture"
 			/>
@@ -487,7 +450,7 @@ export class MySitesSidebar extends Component {
 						label={ translate( 'Customize' ) }
 						selected={ itemLinkMatches( '/customize', path ) }
 						link={ this.props.customizeUrl }
-						onNavigate={ this.trackCustomizeClick }
+						onNavigate={ this.onNavigate }
 						preloadSectionName="customize"
 						forceInternalLink={ ! this.props.isJetpack || this.props.isAtomicSite }
 						expandSection={ this.expandDesignSection }
@@ -505,7 +468,7 @@ export class MySitesSidebar extends Component {
 					label={ translate( 'Themes' ) }
 					selected={ itemLinkMatches( themesLink, path ) }
 					link={ themesLink }
-					onNavigate={ this.trackCustomizeClick }
+					onNavigate={ this.onNavigate }
 					preloadSectionName="themes"
 					forceInternalLink
 					expandSection={ this.expandDesignSection }
@@ -513,11 +476,6 @@ export class MySitesSidebar extends Component {
 			</Fragment>
 		);
 	}
-
-	trackDomainsClick = () => {
-		this.trackMenuItemClick( 'domains' );
-		this.onNavigate();
-	};
 
 	domains() {
 		const { path, translate, canUserManageOptions } = this.props;
@@ -545,7 +503,7 @@ export class MySitesSidebar extends Component {
 				label={ translate( 'Domains' ) }
 				selected={ itemLinkMatches( [ '/domains', '/email' ], path ) }
 				link={ domainsLink }
-				onNavigate={ this.trackDomainsClick }
+				onNavigate={ this.onNavigate }
 				preloadSectionName="domains"
 				tipTarget="domains"
 				expandSection={ this.expandDomains }
@@ -589,7 +547,7 @@ export class MySitesSidebar extends Component {
 					link={
 						this.props.site ? '/purchases/subscriptions/' + this.props.site.slug : '/me/purchases'
 					}
-					onNavigate={ this.trackPurchasesClick }
+					onNavigate={ this.onNavigate }
 					preloadSectionName="site-purchases"
 					forceInternalLink
 					expandSection={ this.expandUpgradesSection }
@@ -631,7 +589,7 @@ export class MySitesSidebar extends Component {
 				tipTarget="plans"
 				selected={ itemLinkMatches( '/plans', path ) }
 				link={ '/plans' + siteSuffix }
-				onNavigate={ this.trackPlanClick }
+				onNavigate={ this.onNavigate }
 				preloadSectionName="plans"
 				forceInternalLink
 				expandSection={ this.expandUpgradesSection }
@@ -646,9 +604,6 @@ export class MySitesSidebar extends Component {
 	}
 
 	trackWooCommerceNavItemClick = ( menuItemName, experience, plan ) => {
-		// Log the general Tracks event
-		this.trackMenuItemClick( menuItemName );
-
 		// Log a single Tracks event for Store/WooCommerce nav item clicks,
 		// so that easy comparisons can be made between them.
 		this.props.recordTracksEvent( 'calypso_woocommerce_nav_item_click', {
@@ -769,25 +724,6 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	trackMenuItemClick = ( menuItemName ) => {
-		this.props.recordTracksEvent(
-			'calypso_mysites_sidebar_' + menuItemName.replace( /-/g, '_' ) + '_clicked'
-		);
-	};
-
-	trackPlanClick = () => {
-		this.trackMenuItemClick( 'plan' );
-		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
-			cta_name: 'sidebar_upgrade_default',
-		} );
-		this.onNavigate();
-	};
-
-	trackMarketingClick = () => {
-		this.trackMenuItemClick( 'marketing' );
-		this.onNavigate();
-	};
-
 	marketing() {
 		const { path, site } = this.props;
 		const marketingLink = '/marketing' + this.props.siteSuffix;
@@ -809,18 +745,13 @@ export class MySitesSidebar extends Component {
 				label={ this.props.translate( 'Marketing' ) }
 				selected={ itemLinkMatches( '/marketing', path ) }
 				link={ marketingLink }
-				onNavigate={ this.trackMarketingClick }
+				onNavigate={ this.onNavigate }
 				preloadSectionName="marketing"
 				tipTarget="marketing"
 				expandSection={ this.expandToolsSection }
 			/>
 		);
 	}
-
-	trackHostingClick = () => {
-		this.trackMenuItemClick( 'hosting' );
-		this.onNavigate();
-	};
 
 	hosting() {
 		const { translate, path, siteSuffix, canViewAtomicHosting } = this.props;
@@ -838,17 +769,12 @@ export class MySitesSidebar extends Component {
 				label={ translate( 'Hosting Configuration' ) }
 				selected={ itemLinkMatches( '/hosting-config', path ) }
 				link={ `/hosting-config${ siteSuffix }` }
-				onNavigate={ this.trackHostingClick }
+				onNavigate={ this.onNavigate }
 				preloadSectionName="hosting"
 				expandSection={ this.expandManageSection }
 			/>
 		);
 	}
-
-	trackPeopleClick = () => {
-		this.trackMenuItemClick( 'people' );
-		this.onNavigate();
-	};
 
 	users() {
 		const { translate, path, site, canUserListUsers } = this.props;
@@ -862,18 +788,13 @@ export class MySitesSidebar extends Component {
 				label={ translate( 'People' ) }
 				selected={ itemLinkMatches( '/people', path ) }
 				link={ '/people/team' + this.props.siteSuffix }
-				onNavigate={ this.trackPeopleClick }
+				onNavigate={ this.onNavigate }
 				preloadSectionName="people"
 				tipTarget="people"
 				expandSection={ this.expandManageSection }
 			/>
 		);
 	}
-
-	trackSettingsClick = () => {
-		this.trackMenuItemClick( 'settings' );
-		this.onNavigate();
-	};
 
 	siteSettings() {
 		const { path, site, canUserManageOptions } = this.props;
@@ -892,7 +813,7 @@ export class MySitesSidebar extends Component {
 				label={ this.props.translate( 'Settings' ) }
 				selected={ itemLinkMatches( '/settings', path ) }
 				link={ siteSettingsLink }
-				onNavigate={ this.trackSettingsClick }
+				onNavigate={ this.onNavigate }
 				preloadSectionName="settings"
 				tipTarget="settings"
 				expandSection={ this.expandManageSection }
@@ -948,7 +869,6 @@ export class MySitesSidebar extends Component {
 	}
 
 	trackWpadminClick = () => {
-		this.trackMenuItemClick( 'wpadmin' );
 		this.props.recordGoogleEvent( 'Sidebar', 'Clicked WP Admin' );
 	};
 
@@ -972,11 +892,6 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	trackDomainSettingsClick = () => {
-		this.trackMenuItemClick( 'domain_settings' );
-		this.onNavigate();
-	};
-
 	canViewAdminSections = () => {
 		const { isAllSitesView, canUserManageOptions, canUserManagePlugins } = this.props;
 
@@ -997,7 +912,7 @@ export class MySitesSidebar extends Component {
 						selected={ itemLinkMatches( '/domains', this.props.path ) }
 						label={ this.props.translate( 'Settings' ) }
 						link={ '/domains/manage' + this.props.siteSuffix }
-						onNavigate={ this.trackDomainSettingsClick }
+						onNavigate={ this.onNavigate }
 						tipTarget="settings"
 					/>
 				</SidebarMenu>

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -639,12 +639,7 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label={ translate( 'Store' ) }
 				link={ storeLink }
-				onNavigate={ this.trackWooCommerceNavItemClick.bind(
-					this,
-					'store',
-					'wpadmin-woocommerce-core',
-					site.plan.product_slug
-				) }
+				onNavigate={ this.onNavigate }
 				materialIcon="shopping_cart"
 				forceInternalLink
 				className="sidebar__store"

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -603,27 +603,6 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	trackWooCommerceNavItemClick = ( menuItemName, experience, plan ) => {
-		// Log a single Tracks event for Store/WooCommerce nav item clicks,
-		// so that easy comparisons can be made between them.
-		this.props.recordTracksEvent( 'calypso_woocommerce_nav_item_click', {
-			nav_item: menuItemName,
-			experience,
-			plan,
-			nav_item_experience_plan_combo: `${ menuItemName }__${ experience }__${ plan }`,
-		} );
-
-		// Continue to log the old individual Tracks events so that existing analysis
-		// using them still function.
-		if ( menuItemName === 'store' ) {
-			this.props.recordTracksEvent( 'calypso_woocommerce_store_nav_item_click' );
-		} else if ( menuItemName === 'woocommerce' ) {
-			this.props.recordTracksEvent( 'calypso_woocommerce_store_woo_core_item_click' );
-		}
-
-		this.onNavigate();
-	};
-
 	store() {
 		const { translate, site, canUserUseWooCommerceCoreStore, isSiteWpcomStore } = this.props;
 
@@ -713,12 +692,7 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label="WooCommerce"
 				link={ storeLink }
-				onNavigate={ this.trackWooCommerceNavItemClick.bind(
-					this,
-					'woocommerce',
-					'wpadmin-woocommerce-core',
-					site.plan.product_slug
-				) }
+				onNavigate={ this.onNavigate }
 				materialIcon="shopping_cart"
 			/>
 		);


### PR DESCRIPTION
I've removed all the calypso_mysites_sidebar_*_click events generated by clicking on menu items of the non-unified-nav sidebar.
I've also fixed a small issue, when the user clicked on the 'Domains' menu, we were triggering a nudge cta click event, even though the menu item clearly isn't a nudge. Now we aren't sending that event.

#### Changes proposed in this Pull Request

* Removed menu item click events in the non-unified-nav sidebar.
* The domains menu doesn't trigger a nudge cta click event.

Related to #50847

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
##### Test that no tracking events are being sent for the menu item clicks.
1. Open the Calypso live image in your browser and then.
2. Open Chrome's inspector and add the following line to the console: localStorage.debug='calypso:analytics'
3. Make sure that Chrome's console is logging all levels and not just errors and warnings.
4. Reload the page.
5. Now add ?disable-nav-unification to the URL and you should be in the non-nav-unification version.
6. Click on a Calypso link, in Chrome's console you shouldn't see any menu item click tracking being triggered.

##### Test that the domain menu item isn't triggering a nudge click tracking event.
1. Follow the previous steps up until step 5.
2. Click on the domain menu item.
3. Check Chrome's console and make sure that no nudge click event (calypso_domain_credit_reminder_click) is being tracked.
4. [Optional] Check that the domain nudge triggers a calypso_domain_credit_reminder_click tracking event.

#### Test evidence
https://user-images.githubusercontent.com/1989914/146971524-a785f14f-fb26-45e5-a264-605bbe9e9ea3.mp4


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

