### PR TITLE
Color schemes: Fix Midnight colors

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -11,23 +11,6 @@ WP Admin Midnight Definition:
 $base-color: #363b3f;
 $highlight-color: #e14d43;
 $notification-color: #69a8bb;
-
-Created this definition in color-studio to generate 0-100 shades:
-    {
-      name: 'Midnight',
-      default: 50,
-      specs: {
-        hue_start: 200,
-        hue_end: 210,
-        hue_curve: 'easeOutSine',
-        sat_steps: [
-          8, 27, 56, 80, 100, 100, 100, 100, 100, 100, 100, 100
-        ],
-        lum_steps: [
-          96, 96, 95, 94, 87, 75.1, 61.6, 49, 40.5, 31, 20, 11
-        ]
-      }
-    }
 */
 
 .color-scheme.is-midnight,
@@ -44,96 +27,69 @@ Created this definition in color-studio to generate 0-100 shades:
 	--theme-highlight-color-rgb: 225, 77, 67; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
 	--theme-notification-color: #69a8bb; /* Direct from wp-admin */
 
-	--midnight-blue-0: #e1eef5;
-	--midnight-blue-5: #b3ddf5;
-	--midnight-blue-10: #6bbff2;
-	--midnight-blue-20: #30a2f0;
-	--midnight-blue-30: #007fde;
-	--midnight-blue-40: #006ac0;
-	--midnight-blue-50: #00549d;
-	--midnight-blue-60: #00417d;
-	--midnight-blue-70: #003567;
-	--midnight-blue-80: #00284f;
-	--midnight-blue-90: #001a33;
-	--midnight-blue-100: #000e1c;
-	--midnight-blue: #00549d;
-	--midnight-blue-0-rgb: 225, 238, 245;
-	--midnight-blue-5-rgb: 179, 221, 245;
-	--midnight-blue-10-rgb: 107, 191, 242;
-	--midnight-blue-20-rgb: 48, 162, 240;
-	--midnight-blue-30-rgb: 0, 127, 222;
-	--midnight-blue-40-rgb: 0, 106, 192;
-	--midnight-blue-50-rgb: 0, 84, 157;
-	--midnight-blue-60-rgb: 0, 65, 125;
-	--midnight-blue-70-rgb: 0, 53, 103;
-	--midnight-blue-80-rgb: 0, 40, 79;
-	--midnight-blue-90-rgb: 0, 26, 51;
-	--midnight-blue-100-rgb: 0, 14, 28;
-	--midnight-blue-rgb: 0, 84, 157;
-
 	/* Primary */
 	--color-primary: var( --theme-highlight-color );
 	--color-primary-rgb: var( --theme-highlight-color-rgb );
-	--color-primary-dark: var( --midnight-blue-70 );
-	--color-primary-dark-rgb: var( --midnight-blue-70-rgb );
-	--color-primary-light: var( --midnight-blue-30 );
-	--color-primary-light-rgb: var( --midnight-blue-30-rgb );
-	--color-primary-0: var( --midnight-blue-0 );
-	--color-primary-0-rgb: var( --midnight-blue-0-rgb );
-	--color-primary-5: var( --midnight-blue-5 );
-	--color-primary-5-rgb: var( --midnight-blue-5-rgb );
-	--color-primary-10: var( --midnight-blue-10 );
-	--color-primary-10-rgb: var( --midnight-blue-10-rgb );
-	--color-primary-20: var( --midnight-blue-20 );
-	--color-primary-20-rgb: var( --midnight-blue-20-rgb );
-	--color-primary-30: var( --midnight-blue-30 );
-	--color-primary-30-rgb: var( --midnight-blue-30-rgb );
-	--color-primary-40: var( --midnight-blue-40 );
-	--color-primary-40-rgb: var( --midnight-blue-40-rgb );
-	--color-primary-50: var( --midnight-blue-50 );
-	--color-primary-50-rgb: var( --midnight-blue-50-rgb );
-	--color-primary-60: var( --midnight-blue-60 );
-	--color-primary-60-rgb: var( --midnight-blue-60-rgb );
-	--color-primary-70: var( --midnight-blue-70 );
-	--color-primary-70-rgb: var( --midnight-blue-70-rgb );
-	--color-primary-80: var( --midnight-blue-80 );
-	--color-primary-80-rgb: var( --midnight-blue-80-rgb );
-	--color-primary-90: var( --midnight-blue-90 );
-	--color-primary-90-rgb: var( --midnight-blue-90-rgb );
-	--color-primary-100: var( --midnight-blue-100 );
-	--color-primary-100-rgb: var( --midnight-blue-100-rgb );
+	--color-primary-dark: var( --studio-red-70 );
+	--color-primary-dark-rgb: var( --studio-red-70-rgb );
+	--color-primary-light: var( --studio-red-30 );
+	--color-primary-light-rgb: var( --studio-red-30-rgb );
+	--color-primary-0: var( --studio-red-0 );
+	--color-primary-0-rgb: var( --studio-red-0-rgb );
+	--color-primary-5: var( --studio-red-5 );
+	--color-primary-5-rgb: var( --studio-red-5-rgb );
+	--color-primary-10: var( --studio-red-10 );
+	--color-primary-10-rgb: var( --studio-red-10-rgb );
+	--color-primary-20: var( --studio-red-20 );
+	--color-primary-20-rgb: var( --studio-red-20-rgb );
+	--color-primary-30: var( --studio-red-30 );
+	--color-primary-30-rgb: var( --studio-red-30-rgb );
+	--color-primary-40: var( --studio-red-40 );
+	--color-primary-40-rgb: var( --studio-red-40-rgb );
+	--color-primary-50: var( --studio-red-50 );
+	--color-primary-50-rgb: var( --studio-red-50-rgb );
+	--color-primary-60: var( --studio-red-60 );
+	--color-primary-60-rgb: var( --studio-red-60-rgb );
+	--color-primary-70: var( --studio-red-70 );
+	--color-primary-70-rgb: var( --studio-red-70-rgb );
+	--color-primary-80: var( --studio-red-80 );
+	--color-primary-80-rgb: var( --studio-red-80-rgb );
+	--color-primary-90: var( --studio-red-90 );
+	--color-primary-90-rgb: var( --studio-red-90-rgb );
+	--color-primary-100: var( --studio-red-100 );
+	--color-primary-100-rgb: var( --studio-red-100-rgb );
 
 	/* Accent */
 	--color-accent: var( --theme-highlight-color );
 	--color-accent-rgb: var( --theme-highlight-color-rgb );
-	--color-accent-dark: var( --midnight-blue-70 );
-	--color-accent-dark-rgb: var( --midnight-blue-70-rgb );
-	--color-accent-light: var( --midnight-blue-30 );
-	--color-accent-light-rgb: var( --midnight-blue-30-rgb );
-	--color-accent-0: var( --midnight-blue-0 );
-	--color-accent-0-rgb: var( --midnight-blue-0-rgb );
-	--color-accent-5: var( --midnight-blue-5 );
-	--color-accent-5-rgb: var( --midnight-blue-5-rgb );
-	--color-accent-10: var( --midnight-blue-10 );
-	--color-accent-10-rgb: var( --midnight-blue-10-rgb );
-	--color-accent-20: var( --midnight-blue-20 );
-	--color-accent-20-rgb: var( --midnight-blue-20-rgb );
-	--color-accent-30: var( --midnight-blue-30 );
-	--color-accent-30-rgb: var( --midnight-blue-30-rgb );
-	--color-accent-40: var( --midnight-blue-40 );
-	--color-accent-40-rgb: var( --midnight-blue-40-rgb );
-	--color-accent-50: var( --midnight-blue-50 );
-	--color-accent-50-rgb: var( --midnight-blue-50-rgb );
-	--color-accent-60: var( --midnight-blue-60 );
-	--color-accent-60-rgb: var( --midnight-blue-60-rgb );
-	--color-accent-70: var( --midnight-blue-70 );
-	--color-accent-70-rgb: var( --midnight-blue-70-rgb );
-	--color-accent-80: var( --midnight-blue-80 );
-	--color-accent-80-rgb: var( --midnight-blue-80-rgb );
-	--color-accent-90: var( --midnight-blue-90 );
-	--color-accent-90-rgb: var( --midnight-blue-90-rgb );
-	--color-accent-100: var( --midnight-blue-100 );
-	--color-accent-100-rgb: var( --midnight-blue-100-rgb );
+	--color-accent-dark: var( --studio-red-70 );
+	--color-accent-dark-rgb: var( --studio-red-70-rgb );
+	--color-accent-light: var( --studio-red-30 );
+	--color-accent-light-rgb: var( --studio-red-30-rgb );
+	--color-accent-0: var( --studio-red-0 );
+	--color-accent-0-rgb: var( --studio-red-0-rgb );
+	--color-accent-5: var( --studio-red-5 );
+	--color-accent-5-rgb: var( --studio-red-5-rgb );
+	--color-accent-10: var( --studio-red-10 );
+	--color-accent-10-rgb: var( --studio-red-10-rgb );
+	--color-accent-20: var( --studio-red-20 );
+	--color-accent-20-rgb: var( --studio-red-20-rgb );
+	--color-accent-30: var( --studio-red-30 );
+	--color-accent-30-rgb: var( --studio-red-30-rgb );
+	--color-accent-40: var( --studio-red-40 );
+	--color-accent-40-rgb: var( --studio-red-40-rgb );
+	--color-accent-50: var( --studio-red-50 );
+	--color-accent-50-rgb: var( --studio-red-50-rgb );
+	--color-accent-60: var( --studio-red-60 );
+	--color-accent-60-rgb: var( --studio-red-60-rgb );
+	--color-accent-70: var( --studio-red-70 );
+	--color-accent-70-rgb: var( --studio-red-70-rgb );
+	--color-accent-80: var( --studio-red-80 );
+	--color-accent-80-rgb: var( --studio-red-80-rgb );
+	--color-accent-90: var( --studio-red-90 );
+	--color-accent-90-rgb: var( --studio-red-90-rgb );
+	--color-accent-100: var( --studio-red-100 );
+	--color-accent-100-rgb: var( --studio-red-100-rgb );
 
 	/* Masterbar */
 	--color-masterbar-background: var( --theme-base-color );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49205

#### Changes proposed in this Pull Request

When we updated the Midnight color scheme in Calypso to match the WP Admin counterpart (https://github.com/Automattic/wp-calypso/pull/47791), we mistakenly created the shades of the primary and accent colors as blue variants (old main color of the Calypso color scheme), instead of red/orange variants (new main color of the WP Admin color scheme).

I noted that the existing red shades from Color Studio work quite well with the WP Admin palette, so this PR replaces the wrong blue shades with red shades from Color Studio.

Before | After
--- | ---
<img width="648" alt="Screen Shot 2021-12-22 at 11 22 54" src="https://user-images.githubusercontent.com/1233880/147079266-f1d40f78-5ecb-4185-8a16-01416ccc28fb.png"> | <img width="643" alt="Screen Shot 2021-12-22 at 11 23 00" src="https://user-images.githubusercontent.com/1233880/147079270-ba47fcd7-cfc9-4490-ab2b-ceb5db861a7d.png">
(Hover state) <img width="572" alt="Screen Shot 2021-12-22 at 11 23 27" src="https://user-images.githubusercontent.com/1233880/147079284-5e6f22dd-6259-4af6-8deb-57210723027a.png"> | (Hover state) <img width="577" alt="Screen Shot 2021-12-22 at 11 23 37" src="https://user-images.githubusercontent.com/1233880/147079321-52a78b51-85de-4e5b-a7fc-8259140dd79e.png">
(Focus state)<br><img width="122" alt="Screen Shot 2021-12-22 at 11 24 10" src="https://user-images.githubusercontent.com/1233880/147079410-9ca83301-ec6b-4ad3-b627-b54a61c805bb.png"> | (Focus state)<br><img width="131" alt="Screen Shot 2021-12-22 at 11 24 17" src="https://user-images.githubusercontent.com/1233880/147079436-b323cd85-e271-430f-816c-172cf4fd9904.png">
<img width="291" alt="Screen Shot 2021-12-22 at 11 24 53" src="https://user-images.githubusercontent.com/1233880/147079472-f909cea7-d4f8-4a73-8877-7486e4082c5a.png"> | <img width="294" alt="Screen Shot 2021-12-22 at 11 24 57" src="https://user-images.githubusercontent.com/1233880/147079506-2c69129b-3d66-4941-bb28-8e0356ee33b4.png">
(Focus state) <img width="573" alt="Screen Shot 2021-12-22 at 11 25 36" src="https://user-images.githubusercontent.com/1233880/147079531-1ae6fd9c-5eb0-499f-a70d-03172cdfb60e.png"> | (Focus state) <img width="576" alt="Screen Shot 2021-12-22 at 11 25 40" src="https://user-images.githubusercontent.com/1233880/147079552-81919ce4-b93c-4413-91ef-cfca6af1a2c6.png">
<img width="58" alt="Screen Shot 2021-12-22 at 11 44 25" src="https://user-images.githubusercontent.com/1233880/147081909-18aad9cd-da8c-4339-9269-d69d6428c1e0.png"> | <img width="76" alt="Screen Shot 2021-12-22 at 11 43 59" src="https://user-images.githubusercontent.com/1233880/147081924-b6ec6e45-7a6e-4b75-aecf-236b734fdeb1.png">


#### Testing instructions

- Use the Calypso live link below.
- Go to `/me/account`.
- Switch to the Midnight theme.
- Go to `/devdocs/design`.
- Take a look at the components.
- Make sure the new red shades look good in the components.
