### PR TITLE
Welcome Tour: Steps custom css and refactor images that need extra padding

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -216,12 +216,14 @@ $welcome-tour-card-media-extra-padding: 14%; // temporary value, to match the pa
 	width: 100%;
 }
 
-.tour-kit-frame.is-mobile {
-	.tour-kit-step__welcome, .tour-kit-step__addblock, .tour-kit-step__moreoptions, .tour-kit-step__moveblock {
-		 .components-card__media img {
-			left: $welcome-tour-card-media-extra-padding;
-			top: $welcome-tour-card-media-extra-padding;
-			width: 100% - $welcome-tour-card-media-extra-padding;
+.wpcom-editor-welcome-tour.is-mobile {
+	.wpcom-editor-welcome-tour__step {
+		&.is-with-extra-padding {
+			.components-card__media img {
+				left: $welcome-tour-card-media-extra-padding;
+				top: $welcome-tour-card-media-extra-padding;
+				width: 100% - $welcome-tour-card-media-extra-padding;
+			}
 		}
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -138,12 +138,6 @@ $welcome-tour-card-media-extra-padding: 14%; // temporary value, to match the pa
 			top: 0;
 			width: 100%;
 		}
-    	// TODO CLK: use welcome-tour-card class to keep specific to welcome tour
-		&.is-with-extra-padding img {
-			left: $welcome-tour-card-media-extra-padding;
-			top: $welcome-tour-card-media-extra-padding;
-			width: 100% - $welcome-tour-card-media-extra-padding;
-		}
 	}
 
 	.components-guide__page-control {
@@ -220,4 +214,14 @@ $welcome-tour-card-media-extra-padding: 14%; // temporary value, to match the pa
 	height: auto;
 	max-width: 100%;
 	width: 100%;
+}
+
+.tour-kit-frame.is-mobile {
+	.tour-kit-step__welcome, .tour-kit-step__addblock, .tour-kit-step__moreoptions, .tour-kit-step__moveblock {
+		 .components-card__media img {
+			left: $welcome-tour-card-media-extra-padding;
+			top: $welcome-tour-card-media-extra-padding;
+			width: 100% - $welcome-tour-card-media-extra-padding;
+		}
+	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -55,15 +55,11 @@ function WelcomeTourCard( {
 		} );
 	} );
 
-	const cardMediaClass = classNames( 'welcome-tour-card__media' );
-
-	const description = descriptions[ isMobile() ? 'mobile' : 'desktop' ] ?? descriptions.desktop;
-
 	return (
 		<Card className="welcome-tour-card" isElevated>
 			<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			{ /* TODO: Update selector for images in @wordpress/components/src/card/styles/card-styles.js */ }
-			<CardMedia className={ cardMediaClass }>
+			<CardMedia className={ 'welcome-tour-card__media' }>
 				<picture>
 					{ imgSrc.mobile && (
 						<source

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { getMediaQueryList, MOBILE_BREAKPOINT } from '@automattic/viewport';
+import { getMediaQueryList, isMobile, MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -36,7 +36,7 @@ function WelcomeTourCard( {
 	isGutenboarding,
 	setInitialFocusedElement,
 } ) {
-	const { description, heading, imgSrc } = cardContent;
+	const { descriptions, heading, imgSrc } = cardContent;
 	const isLastStep = currentStepIndex === lastStepIndex;
 
 	// Ensure tracking is recorded once per slide view
@@ -54,6 +54,8 @@ function WelcomeTourCard( {
 			is_gutenboarding: isGutenboarding,
 		} );
 	} );
+
+	const description = descriptions[ isMobile() ? 'mobile' : 'desktop' ] ?? descriptions.desktop;
 
 	return (
 		<Card className="welcome-tour-card" isElevated>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { getMediaQueryList, isMobile, MOBILE_BREAKPOINT } from '@automattic/viewport';
+import { getMediaQueryList, MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -36,7 +36,7 @@ function WelcomeTourCard( {
 	isGutenboarding,
 	setInitialFocusedElement,
 } ) {
-	const { descriptions, heading, imgSrc, imgNeedsPadding } = cardContent;
+	const { description, heading, imgSrc } = cardContent;
 	const isLastStep = currentStepIndex === lastStepIndex;
 
 	// Ensure tracking is recorded once per slide view
@@ -54,10 +54,8 @@ function WelcomeTourCard( {
 			is_gutenboarding: isGutenboarding,
 		} );
 	} );
-	// TODO CLK: welcome tour only mod for mobile fixes
-	const cardMediaClass = classNames( 'welcome-tour-card__media', {
-		'is-with-extra-padding': isMobile() && imgNeedsPadding,
-	} );
+
+	const cardMediaClass = classNames( 'welcome-tour-card__media' );
 
 	const description = descriptions[ isMobile() ? 'mobile' : 'desktop' ] ?? descriptions.desktop;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -88,7 +88,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
-			id: 'allBlocks',
 			referenceElements: referencePositioning && referenceElements[ 1 ],
 			meta: {
 				heading: __( 'Everything is a block', 'full-site-editing' ),
@@ -130,7 +129,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
-			id: 'makeBold',
 			referenceElements: referencePositioning && referenceElements[ 3 ],
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
@@ -163,7 +161,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
-			id: 'undo',
 			referenceElements: referencePositioning && referenceElements[ 5 ],
 			meta: {
 				heading: __( 'Undo any mistake', 'full-site-editing' ),
@@ -194,7 +191,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
-			id: 'finish',
 			referenceElements: referencePositioning && referenceElements[ 7 ],
 			meta: {
 				heading: __( 'Congratulations!', 'full-site-editing' ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -89,6 +89,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			className: 'is-with-extra-padding',
 		},
 		{
+			id: 'allBlocks',
 			referenceElements: referencePositioning && referenceElements[ 1 ],
 			meta: {
 				heading: __( 'Everything is a block', 'full-site-editing' ),
@@ -131,6 +132,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			className: 'is-with-extra-padding',
 		},
 		{
+			id: 'makeBold',
 			referenceElements: referencePositioning && referenceElements[ 3 ],
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
@@ -164,6 +166,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			className: 'is-with-extra-padding',
 		},
 		{
+			id: 'undo',
 			referenceElements: referencePositioning && referenceElements[ 5 ],
 			meta: {
 				heading: __( 'Undo any mistake', 'full-site-editing' ),
@@ -195,6 +198,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			className: 'is-with-extra-padding',
 		},
 		{
+			id: 'finish',
 			referenceElements: referencePositioning && referenceElements[ 7 ],
 			meta: {
 				heading: __( 'Congratulations!', 'full-site-editing' ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -85,7 +85,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				},
 				imgSrc: getTourAssets( 'welcome' ),
 				animation: null,
-				imgNeedsPadding: true,
 			},
 		},
 		{
@@ -128,7 +127,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				},
 				imgSrc: getTourAssets( 'addBlock' ),
 				animation: 'block-inserter',
-				imgNeedsPadding: true,
 			},
 		},
 		{
@@ -162,7 +160,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				},
 				imgSrc: getTourAssets( 'moreOptions' ),
 				animation: null,
-				imgNeedsPadding: true,
 			},
 		},
 		{
@@ -194,7 +191,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				},
 				imgSrc: getTourAssets( 'moveBlock' ),
 				animation: 'undo-button',
-				imgNeedsPadding: true,
 			},
 		},
 		{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -72,7 +72,6 @@ const referenceElements = [
 function getTourSteps( localeSlug, referencePositioning ) {
 	return [
 		{
-			id: 'welcome',
 			referenceElements: referencePositioning && referenceElements[ 0 ],
 			meta: {
 				heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
@@ -86,7 +85,9 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				imgSrc: getTourAssets( 'welcome' ),
 				animation: null,
 			},
-			className: 'is-with-extra-padding',
+			options: {
+				className: 'is-with-extra-padding',
+			},
 		},
 		{
 			referenceElements: referencePositioning && referenceElements[ 1 ],
@@ -104,7 +105,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
-			id: 'addBlock',
 			referenceElements: referencePositioning && referenceElements[ 2 ],
 			meta: {
 				heading: __( 'Adding a new block', 'full-site-editing' ),
@@ -128,7 +128,9 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				imgSrc: getTourAssets( 'addBlock' ),
 				animation: 'block-inserter',
 			},
-			className: 'is-with-extra-padding',
+			options: {
+				className: 'is-with-extra-padding',
+			},
 		},
 		{
 			referenceElements: referencePositioning && referenceElements[ 3 ],
@@ -146,7 +148,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
-			id: 'moreOptions',
 			referenceElements: referencePositioning && referenceElements[ 4 ],
 			meta: {
 				heading: __( 'More Options', 'full-site-editing' ),
@@ -161,7 +162,9 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				imgSrc: getTourAssets( 'moreOptions' ),
 				animation: null,
 			},
-			className: 'is-with-extra-padding',
+			options: {
+				className: 'is-with-extra-padding',
+			},
 		},
 		{
 			referenceElements: referencePositioning && referenceElements[ 5 ],
@@ -177,7 +180,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
-			id: 'moveBlock',
 			referenceElements: referencePositioning && referenceElements[ 6 ],
 			meta: {
 				heading: __( 'Drag & drop', 'full-site-editing' ),
@@ -192,7 +194,9 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				imgSrc: getTourAssets( 'moveBlock' ),
 				animation: 'undo-button',
 			},
-			className: 'is-with-extra-padding',
+			options: {
+				className: 'is-with-extra-padding',
+			},
 		},
 		{
 			referenceElements: referencePositioning && referenceElements[ 7 ],

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -72,6 +72,7 @@ const referenceElements = [
 function getTourSteps( localeSlug, referencePositioning ) {
 	return [
 		{
+			id: 'welcome',
 			referenceElements: referencePositioning && referenceElements[ 0 ],
 			meta: {
 				heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
@@ -88,6 +89,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
+			id: 'allBlocks',
 			referenceElements: referencePositioning && referenceElements[ 1 ],
 			meta: {
 				heading: __( 'Everything is a block', 'full-site-editing' ),
@@ -103,6 +105,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
+			id: 'addBlock',
 			referenceElements: referencePositioning && referenceElements[ 2 ],
 			meta: {
 				heading: __( 'Adding a new block', 'full-site-editing' ),
@@ -129,6 +132,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
+			id: 'makeBold',
 			referenceElements: referencePositioning && referenceElements[ 3 ],
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
@@ -144,6 +148,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
+			id: 'moreOptions',
 			referenceElements: referencePositioning && referenceElements[ 4 ],
 			meta: {
 				heading: __( 'More Options', 'full-site-editing' ),
@@ -161,6 +166,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
+			id: 'undo',
 			referenceElements: referencePositioning && referenceElements[ 5 ],
 			meta: {
 				heading: __( 'Undo any mistake', 'full-site-editing' ),
@@ -174,6 +180,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
+			id: 'moveBlock',
 			referenceElements: referencePositioning && referenceElements[ 6 ],
 			meta: {
 				heading: __( 'Drag & drop', 'full-site-editing' ),
@@ -191,6 +198,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 		},
 		{
+			id: 'finish',
 			referenceElements: referencePositioning && referenceElements[ 7 ],
 			meta: {
 				heading: __( 'Congratulations!', 'full-site-editing' ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -89,7 +89,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			className: 'is-with-extra-padding',
 		},
 		{
-			id: 'allBlocks',
 			referenceElements: referencePositioning && referenceElements[ 1 ],
 			meta: {
 				heading: __( 'Everything is a block', 'full-site-editing' ),
@@ -132,7 +131,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			className: 'is-with-extra-padding',
 		},
 		{
-			id: 'makeBold',
 			referenceElements: referencePositioning && referenceElements[ 3 ],
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
@@ -166,7 +164,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			className: 'is-with-extra-padding',
 		},
 		{
-			id: 'undo',
 			referenceElements: referencePositioning && referenceElements[ 5 ],
 			meta: {
 				heading: __( 'Undo any mistake', 'full-site-editing' ),
@@ -198,7 +195,6 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			className: 'is-with-extra-padding',
 		},
 		{
-			id: 'finish',
 			referenceElements: referencePositioning && referenceElements[ 7 ],
 			meta: {
 				heading: __( 'Congratulations!', 'full-site-editing' ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -86,6 +86,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				imgSrc: getTourAssets( 'welcome' ),
 				animation: null,
 			},
+			className: 'is-with-extra-padding',
 		},
 		{
 			referenceElements: referencePositioning && referenceElements[ 1 ],
@@ -127,6 +128,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				imgSrc: getTourAssets( 'addBlock' ),
 				animation: 'block-inserter',
 			},
+			className: 'is-with-extra-padding',
 		},
 		{
 			referenceElements: referencePositioning && referenceElements[ 3 ],
@@ -159,6 +161,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				imgSrc: getTourAssets( 'moreOptions' ),
 				animation: null,
 			},
+			className: 'is-with-extra-padding',
 		},
 		{
 			referenceElements: referencePositioning && referenceElements[ 5 ],
@@ -189,6 +192,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				imgSrc: getTourAssets( 'moveBlock' ),
 				animation: 'undo-button',
 			},
+			className: 'is-with-extra-padding',
 		},
 		{
 			referenceElements: referencePositioning && referenceElements[ 7 ],

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -2,7 +2,6 @@ import React from 'react';
 import type { Modifier } from 'react-popper';
 
 export type Step = {
-	className?: string;
 	referenceElements?: {
 		desktop?: string;
 		mobile?: string;

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Modifier } from 'react-popper';
 
 export type Step = {
+	id?: string;
 	referenceElements?: {
 		desktop?: string;
 		mobile?: string;

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Modifier } from 'react-popper';
 
 export type Step = {
-	id?: string;
+	className?: string;
 	referenceElements?: {
 		desktop?: string;
 		mobile?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added custom CSS classes to steps of the Welcome Tour that need extra padding
* Remove the need for `imgNeedsPadding` introduced in `https://github.com/Automattic/wp-calypso/pull/59294`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout branch, then `yarn dev --sync` from the `apps/editing-toolkit` folder to sync the welcome tour to the sandbox
- Open the editor and welcome tour on mobile. (See the image if welcome tour doesn't show)
![image](https://user-images.githubusercontent.com/52076348/149171787-c15feea0-bc0d-441a-ab19-d79bfe40ad51.png)
- Check that slides 1,3,5,6 have the new CSS class `is-with-extra-padding`, which adds some needed padding 

#### What we not expect
![image](https://user-images.githubusercontent.com/52076348/149172009-8095a4ad-2ff4-49ad-9132-71bb938bb004.png)

#### What we expect
![image](https://user-images.githubusercontent.com/52076348/149172260-a9963a2f-e697-4110-b241-a9b356f46e40.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59439
Fixes #59439
Closes #59345