### PR TITLE
Updated subdomain change warning copy.

### DIFF
--- a/client/components/eligibility-warnings/domain-warning/index.tsx
+++ b/client/components/eligibility-warnings/domain-warning/index.tsx
@@ -18,9 +18,10 @@ const DomainEligibilityWarning = ( {
 			{ sprintf(
 				/* translators: %s: The wordpress domain (ex.: myawesomeblog.wordpress.com) */
 				__(
-					'By installing this product your subdomain will change. Your old subdomain (%s) will no longer work. You can change it to a custom domain at anytime in the future.'
+					'By installing this product your subdomain will change. Your old subdomain (%1$s) will redirect to your new subdomain (%2$s). You can change it to a custom domain at anytime in the future.'
 				),
-				wpcomDomain
+				wpcomDomain,
+				stagingDomain
 			) }
 		</p>
 	</Card>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When asked to confirm subdomain name change, change warning copy from "will no longer work" to "will redirect to your new subdomain example.wpcomstaging.com".

#### Testing instructions

- Checkout this branch git checkout 
- Visit the WooCommerce installation page on a simple site with any plan. http://calypso.localhost:3000/woocommerce-installation/example.wordpress.com
- Click "Set up my store!

The warning copy should have changed to:

> By installing this product your subdomain will change. Your old subdomain (example.wordpress.com) will redirect to your new subdomain (example.wpcomstaging.com). You can change it to a custom domain at anytime in the future.

<table><tr>
<td width="50%"><h2>Before</h2><img src="https://user-images.githubusercontent.com/140841/146985266-ea150d9c-02f5-4b8f-bfb4-947a11aa3105.png" /></td>
<td><h2>After</h2><img src="https://user-images.githubusercontent.com/140841/146985047-23d97ab3-e3cb-408d-9e98-e77a5e799138.png" /></td>
</tr></table>

Related to #59455
