### PR TITLE
Shopping Cart: Prevent displaying cart messages again after page redirects

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -24,7 +24,7 @@ function CartMessage( { message }: { message: ResponseCartMessage } ): JSX.Eleme
 
 export default function CartMessages(): null {
 	const cartKey = useCartKey();
-	const { responseCart: cart, isLoading: isLoadingCart, reloadFromServer } = useShoppingCart(
+	const { responseCart: cart, isLoading: isLoadingCart, clearMessages } = useShoppingCart(
 		cartKey
 	);
 	const reduxDispatch = useDispatch();
@@ -45,7 +45,7 @@ export default function CartMessages(): null {
 
 	useDisplayCartMessages( {
 		cart,
-		reloadFromServer,
+		clearMessages,
 		isLoadingCart,
 		showErrorMessages,
 		showSuccessMessages,

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -24,7 +24,9 @@ function CartMessage( { message }: { message: ResponseCartMessage } ): JSX.Eleme
 
 export default function CartMessages(): null {
 	const cartKey = useCartKey();
-	const { responseCart: cart, isLoading: isLoadingCart } = useShoppingCart( cartKey );
+	const { responseCart: cart, isLoading: isLoadingCart, reloadFromServer } = useShoppingCart(
+		cartKey
+	);
 	const reduxDispatch = useDispatch();
 
 	const showErrorMessages = useCallback(
@@ -43,6 +45,7 @@ export default function CartMessages(): null {
 
 	useDisplayCartMessages( {
 		cart,
+		reloadFromServer,
 		isLoadingCart,
 		showErrorMessages,
 		showSuccessMessages,

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -46,6 +46,7 @@ Regardless, it's a good idea to always check `responseCart.messages.errors` and 
 - `replaceProductInCart: ( uuidToReplace: string, productPropertiesToChange: Partial< RequestCartProduct > ) => Promise<ResponseCart>`. A function that can replace one product in the cart with another, retaining the same UUID; useful for changing product variants.
 - `replaceProductsInCart: ( products: RequestCartProduct[] ) => Promise<ResponseCart>`. A function that replaces all the products in the cart with a new set of products. Can also be used to clear the cart.
 - `reloadFromServer: () => Promise<ResponseCart>`. A function to throw away the current cart cache and fetch it fresh from the shopping cart API.
+- `clearMessages: () => Promise<ResponseCart>`. A function to throw away the current `responseCart.messages`. This can be used to clear messages once they have been displayed.
 
 ## withShoppingCart
 

--- a/packages/shopping-cart/src/managers.ts
+++ b/packages/shopping-cart/src/managers.ts
@@ -125,6 +125,7 @@ const noopActions: ShoppingCartManagerActions = {
 	replaceProductInCart: noopCartAction,
 	replaceProductsInCart: noopCartAction,
 	reloadFromServer: () => Promise.resolve( emptyCart ),
+	clearMessages: () => Promise.resolve( emptyCart ),
 };
 export const noopManager: ShoppingCartManager = {
 	actions: noopActions,

--- a/packages/shopping-cart/src/shopping-cart-actions.ts
+++ b/packages/shopping-cart/src/shopping-cart-actions.ts
@@ -4,6 +4,7 @@ import type { DispatchAndWaitForValid, ShoppingCartManagerActions } from './type
 export function createActions( dispatch: DispatchAndWaitForValid ): ShoppingCartManagerActions {
 	return {
 		reloadFromServer: () => dispatch( { type: 'CART_RELOAD' } ),
+		clearMessages: () => dispatch( { type: 'CLEAR_MESSAGES' } ),
 		removeCoupon: () => dispatch( { type: 'REMOVE_COUPON' } ),
 		addProductsToCart: async ( products ) =>
 			dispatch( {

--- a/packages/shopping-cart/src/shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/shopping-cart-reducer.ts
@@ -140,6 +140,12 @@ function shoppingCartReducer(
 				loadingErrorType: undefined,
 			};
 
+		case 'CLEAR_MESSAGES':
+			return {
+				...state,
+				responseCart: { ...state.responseCart, messages: { errors: [], success: [] } },
+			};
+
 		case 'CLEAR_QUEUED_ACTIONS':
 			return { ...state, queuedActions: [] };
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -62,6 +62,8 @@ export type ReplaceProductInCart = (
 
 export type ReloadCartFromServer = () => Promise< ResponseCart >;
 
+export type ClearCartMessages = () => Promise< ResponseCart >;
+
 export type ReplaceProductsInCart = (
 	products: MinimalRequestCartProduct[]
 ) => Promise< ResponseCart >;
@@ -103,6 +105,7 @@ export type CouponStatus = 'fresh' | 'pending' | 'applied' | 'rejected';
 
 export type ShoppingCartAction =
 	| { type: 'CLEAR_QUEUED_ACTIONS' }
+	| { type: 'CLEAR_MESSAGES' }
 	| { type: 'UPDATE_LAST_VALID_CART' }
 	| { type: 'REMOVE_CART_ITEM'; uuidToRemove: string }
 	| { type: 'CART_PRODUCTS_ADD'; products: RequestCartProduct[] }
@@ -131,6 +134,7 @@ export interface ShoppingCartManagerActions {
 	replaceProductInCart: ReplaceProductInCart;
 	replaceProductsInCart: ReplaceProductsInCart;
 	reloadFromServer: ReloadCartFromServer;
+	clearMessages: ClearCartMessages;
 }
 
 export type ShoppingCartError = 'GET_SERVER_CART_ERROR' | 'SET_SERVER_CART_ERROR';

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -29,6 +29,27 @@ describe( 'ShoppingCartManager', () => {
 		} );
 	} );
 
+	it( 'clearMessages removes messages from the cart', async () => {
+		const mockGetCart = jest.fn().mockResolvedValue( {
+			...getEmptyResponseCart(),
+			messages: { errors: [ { code: 'test-error', message: 'Test Error' } ] },
+		} );
+		const cartManagerClient = createShoppingCartManagerClient( {
+			getCart: mockGetCart,
+			setCart,
+		} );
+		const manager = cartManagerClient.forCartKey( mainCartKey );
+		try {
+			await manager.fetchInitialCart();
+		} catch {}
+		const { responseCart: initialCart } = manager.getState();
+		expect( initialCart.messages.errors.length ).toBe( 1 );
+		await manager.actions.clearMessages();
+		const { responseCart } = manager.getState();
+		expect( responseCart.messages?.errors ?? [] ).toEqual( [] );
+		expect( responseCart.messages?.success ?? [] ).toEqual( [] );
+	} );
+
 	it( 'addProductsToCart adds the products to the cart if not queued', async () => {
 		const cartManagerClient = createShoppingCartManagerClient( {
 			getCart,

--- a/packages/wpcom-checkout/src/use-display-cart-messages.tsx
+++ b/packages/wpcom-checkout/src/use-display-cart-messages.tsx
@@ -3,17 +3,20 @@ import type {
 	ResponseCart,
 	ResponseCartMessages,
 	ResponseCartMessage,
+	ReloadCartFromServer,
 } from '@automattic/shopping-cart';
 
 export type ShowMessages = ( messages: ResponseCartMessage[] ) => void;
 
 export default function useDisplayCartMessages( {
 	cart,
+	reloadFromServer,
 	isLoadingCart,
 	showErrorMessages,
 	showSuccessMessages,
 }: {
 	cart: ResponseCart;
+	reloadFromServer: ReloadCartFromServer;
 	isLoadingCart: boolean;
 	showSuccessMessages: ShowMessages;
 	showErrorMessages: ShowMessages;
@@ -23,23 +26,26 @@ export default function useDisplayCartMessages( {
 	useEffect( () => {
 		displayCartMessages( {
 			cart,
+			reloadFromServer,
 			isLoadingCart,
 			previousCart: previousCart.current,
 			showErrorMessages,
 			showSuccessMessages,
 		} );
 		previousCart.current = cart;
-	}, [ cart, isLoadingCart, showErrorMessages, showSuccessMessages ] );
+	}, [ cart, reloadFromServer, isLoadingCart, showErrorMessages, showSuccessMessages ] );
 }
 
 function displayCartMessages( {
 	cart,
+	reloadFromServer,
 	isLoadingCart,
 	previousCart,
 	showErrorMessages,
 	showSuccessMessages,
 }: {
 	cart: ResponseCart;
+	reloadFromServer: ReloadCartFromServer;
 	isLoadingCart: boolean;
 	previousCart: ResponseCart | null;
 	showErrorMessages: ShowMessages;
@@ -50,20 +56,26 @@ function displayCartMessages( {
 		return;
 	}
 	const messages = getNewMessages( previousCart, newCart );
+	const areThereMessages = Boolean( messages.errors?.length || messages.success?.length );
+	if ( ! areThereMessages ) {
+		return;
+	}
 
 	const errorMessageCount = messages.errors?.length ?? 0;
 	const errorMessages = messages.errors;
 	if ( errorMessages && errorMessageCount > 0 ) {
 		showErrorMessages( errorMessages );
-		return;
 	}
 
 	const successMessageCount = messages.success?.length ?? 0;
 	const successMessages = messages.success;
 	if ( successMessages && successMessageCount > 0 ) {
 		showSuccessMessages( successMessages );
-		return;
 	}
+
+	// Clear messages from the cart so that other components that might call this
+	// function don't cause a message to be displayed more than once.
+	reloadFromServer();
 }
 
 // Compare two different cart objects and get the messages of newest one

--- a/packages/wpcom-checkout/src/use-display-cart-messages.tsx
+++ b/packages/wpcom-checkout/src/use-display-cart-messages.tsx
@@ -3,20 +3,20 @@ import type {
 	ResponseCart,
 	ResponseCartMessages,
 	ResponseCartMessage,
-	ReloadCartFromServer,
+	ClearCartMessages,
 } from '@automattic/shopping-cart';
 
 export type ShowMessages = ( messages: ResponseCartMessage[] ) => void;
 
 export default function useDisplayCartMessages( {
 	cart,
-	reloadFromServer,
+	clearMessages,
 	isLoadingCart,
 	showErrorMessages,
 	showSuccessMessages,
 }: {
 	cart: ResponseCart;
-	reloadFromServer: ReloadCartFromServer;
+	clearMessages: ClearCartMessages;
 	isLoadingCart: boolean;
 	showSuccessMessages: ShowMessages;
 	showErrorMessages: ShowMessages;
@@ -26,26 +26,26 @@ export default function useDisplayCartMessages( {
 	useEffect( () => {
 		displayCartMessages( {
 			cart,
-			reloadFromServer,
+			clearMessages,
 			isLoadingCart,
 			previousCart: previousCart.current,
 			showErrorMessages,
 			showSuccessMessages,
 		} );
 		previousCart.current = cart;
-	}, [ cart, reloadFromServer, isLoadingCart, showErrorMessages, showSuccessMessages ] );
+	}, [ cart, clearMessages, isLoadingCart, showErrorMessages, showSuccessMessages ] );
 }
 
 function displayCartMessages( {
 	cart,
-	reloadFromServer,
+	clearMessages,
 	isLoadingCart,
 	previousCart,
 	showErrorMessages,
 	showSuccessMessages,
 }: {
 	cart: ResponseCart;
-	reloadFromServer: ReloadCartFromServer;
+	clearMessages: ClearCartMessages;
 	isLoadingCart: boolean;
 	previousCart: ResponseCart | null;
 	showErrorMessages: ShowMessages;
@@ -75,7 +75,7 @@ function displayCartMessages( {
 
 	// Clear messages from the cart so that other components that might call this
 	// function don't cause a message to be displayed more than once.
-	reloadFromServer();
+	clearMessages();
 }
 
 // Compare two different cart objects and get the messages of newest one


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the shopping-cart endpoint returns data, it may return errors or success messages as part of the cart. Those messages are then typically displayed by the `CalypsoShoppingCartProvider` that's mounted on any calypso page which uses the cart. The user can dismiss the messages once they've been read.

However, the shopping cart manager keeps that cart data in state even if you redirect to another page (using an SPA redirect). Then if that new page renders `CalypsoShoppingCartProvider` it may see the messages in the cached cart and display them again. This will occur forever until either the page is reloaded or the cart is updated.

In this PR, we instead clear the cart messages once they have been displayed.

Fixes https://github.com/Automattic/wp-calypso/issues/59464

#### Testing instructions

- Add a domain and an email product to your cart and visit checkout.
- Click to remove _just_ the domain from your cart.
- Verify that you see the message: `G Suite has been removed from your cart because it is no longer valid (you may have removed the associated domain).` Dismiss this message by clicking the X adjacent to it.
- Click the "Go back" button or the "X" in the masterbar to return to another page.
- Click to visit the plans page.
- Verify that you don't see the message about G Suite again.