### PR TITLE
Allow deletion of SMTP forwarding MX record

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -21,7 +21,7 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 			{ actions.map( ( action ) => {
 				return (
 					<PopoverMenuItem
-						disabled={ record.protected_field }
+						disabled={ action.disabled }
 						key={ key++ }
 						onClick={ () => action.callback( record ) }
 					>

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -27,6 +27,7 @@ class DnsRecordsList extends Component {
 	};
 
 	disableRecordAction = {
+		disabled: false,
 		icon: (
 			<MaterialIcon
 				icon="do_not_disturb"
@@ -39,6 +40,7 @@ class DnsRecordsList extends Component {
 	};
 
 	enableRecordAction = {
+		disabled: false,
 		icon: (
 			<Icon
 				icon={ redo }
@@ -51,6 +53,7 @@ class DnsRecordsList extends Component {
 	};
 
 	recordInfoAction = {
+		disabled: false,
 		icon: (
 			<Icon
 				icon={ info }
@@ -63,6 +66,7 @@ class DnsRecordsList extends Component {
 	};
 
 	editRecordAction = {
+		disabled: false,
 		icon: (
 			<Icon
 				icon={ edit }
@@ -76,6 +80,7 @@ class DnsRecordsList extends Component {
 	};
 
 	deleteRecordAction = {
+		disabled: false,
 		icon: (
 			<Icon
 				icon={ trash }
@@ -191,7 +196,10 @@ class DnsRecordsList extends Component {
 			];
 		}
 
-		return [ this.editRecordAction, this.deleteRecordAction ];
+		return [
+			{ ...this.editRecordAction, disabled: record.protected_field },
+			{ ...this.deleteRecordAction, disabled: record.protected_field && 'MX' !== record.type },
+		];
 	}
 
 	getDomainConnectDnsRecord( enabled ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We need to allow deletion of the SMTP forwarding MX record to allow users to set their own MX records.

#### Testing instructions

Set up SMTP forwarding on a domain.
Make sure that the delete action is enabled for the MX record labeled `Mail handled by WordPress.com email forwarding`
Make sure that the edit action for this record is disabled
Make sure that the edit and delete actions are disabled for the other (A and CNAME) protected records
Make sure that the edit and delete actions are enabled for the other records

When you delete the MX forwarding record, make sure you get the dialog informing you that this will delete your email forwards.

When you delete the record, make sure that the email forwards are removed.
