### PR TITLE
E2E: migrate Editor: Revisions to Playwright.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -14,6 +14,8 @@ const selectors = {
 		`${ sidebarParentSelector } .components-panel__body-toggle:has-text("${ sectionName }")`,
 	expandedSection: ( sectionName: EditorSidebarSection ) =>
 		`${ sidebarParentSelector } .is-opened .components-panel__body-toggle:has-text("${ sectionName }")`,
+	revisionsToggle: `${ sidebarParentSelector } .components-panel__body:has-text("Revisions")`,
+	revisionsModal: 'div.editor-revisions',
 	lastSection: `${ sidebarParentSelector } .components-panel__body >> nth=-1`,
 	categoryCheckbox: ( categoryName: string ) =>
 		`${ sidebarParentSelector } [aria-label=Categories] :text("${ categoryName }")`,
@@ -64,6 +66,14 @@ export class EditorSettingsSidebarComponent {
 		if ( ! ( await this.frame.isVisible( selectors.expandedSection( sectionName ) ) ) ) {
 			await this.frame.click( selectors.sectionToggle( sectionName ) );
 		}
+	}
+
+	/**
+	 * Clikcks on the Revisions section in the sidebar to show a revisions modal.
+	 */
+	async showRevisions(): Promise< void > {
+		await this.frame.click( selectors.revisionsToggle );
+		await this.frame.waitForSelector( selectors.revisionsModal );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -15,7 +15,6 @@ const selectors = {
 	expandedSection: ( sectionName: EditorSidebarSection ) =>
 		`${ sidebarParentSelector } .is-opened .components-panel__body-toggle:has-text("${ sectionName }")`,
 	revisionsToggle: `${ sidebarParentSelector } .components-panel__body:has-text("Revisions")`,
-	revisionsModal: 'div.editor-revisions',
 	lastSection: `${ sidebarParentSelector } .components-panel__body >> nth=-1`,
 	categoryCheckbox: ( categoryName: string ) =>
 		`${ sidebarParentSelector } [aria-label=Categories] :text("${ categoryName }")`,
@@ -73,7 +72,6 @@ export class EditorSettingsSidebarComponent {
 	 */
 	async showRevisions(): Promise< void > {
 		await this.frame.click( selectors.revisionsToggle );
-		await this.frame.waitForSelector( selectors.revisionsModal );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -11,5 +11,6 @@ export * from './editor-settings-sidebar-component';
 export * from './domain-search-component';
 export * from './isolated-block-editor-component';
 export * from './block-widget-editor-component';
+export * from './revisions-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/revisions-component.ts
+++ b/packages/calypso-e2e/src/lib/components/revisions-component.ts
@@ -1,0 +1,46 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	revisionNumber: ( index: number ) =>
+		`li.editor-revisions-list__revision:nth-last-child(${ index })`,
+	button: ( text: string ) => `.editor-revisions :has-text("${ text }")`,
+};
+
+/**
+ * Component representing the revisions modal within the Gutenberg editor.
+ */
+export class RevisionsComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Given an 1-indexed number, selects the revision in *chronological order*.
+	 *
+	 * For example, with 3 revisions:
+	 * 	- index: 1 will select the oldest revision.
+	 * 	- index: 3 will select the newest revision.
+	 *
+	 * @param {number} index 1-indexed revision number to select.
+	 */
+	async selectRevision( index: number ): Promise< void > {
+		await this.page.click( selectors.revisionNumber( index ) );
+		await this.page.waitForSelector( `${ selectors.revisionNumber( index ) }.is-selected` );
+	}
+
+	/**
+	 * Clicks on a button with given text.
+	 *
+	 * @param {string} text Text of the button to click.
+	 */
+	async clickButton( text: string ): Promise< void > {
+		await this.page.click( selectors.button( text ) );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/revisions-component.ts
+++ b/packages/calypso-e2e/src/lib/components/revisions-component.ts
@@ -3,7 +3,7 @@ import { Page } from 'playwright';
 const selectors = {
 	revisionNumber: ( index: number ) =>
 		`li.editor-revisions-list__revision:nth-last-child(${ index })`,
-	button: ( text: string ) => `.editor-revisions :has-text("${ text }")`,
+	button: ( text: string ) => `div[aria-modal="true"] button:has-text("${ text }")`,
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/components/revisions-component.ts
+++ b/packages/calypso-e2e/src/lib/components/revisions-component.ts
@@ -4,6 +4,9 @@ const selectors = {
 	revisionNumber: ( index: number ) =>
 		`li.editor-revisions-list__revision:nth-last-child(${ index })`,
 	button: ( text: string ) => `div[aria-modal="true"] button:has-text("${ text }")`,
+
+	// Diff viewer
+	diffViewer: ( text: string ) => `div.editor-revisions__dialog :text("${ text }")`,
 };
 
 /**
@@ -43,7 +46,7 @@ export class RevisionsComponent {
 	 * @param {string} text Text to check against the diff viewer.
 	 */
 	async validateTextInRevision( text: string ): Promise< void > {
-		await this.page.waitForSelector( `div.editor-revisions__dialog :text("${ text }")` );
+		await this.page.waitForSelector( selectors.diffViewer( text ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/revisions-component.ts
+++ b/packages/calypso-e2e/src/lib/components/revisions-component.ts
@@ -36,6 +36,17 @@ export class RevisionsComponent {
 	}
 
 	/**
+	 * Given a string of text, check whether the text is present in the Revisions modal.
+	 *
+	 * Note that this method does not check the nature of the text (addition, deletion).
+	 *
+	 * @param {string} text Text to check against the diff viewer.
+	 */
+	async validateTextInRevision( text: string ): Promise< void > {
+		await this.page.waitForSelector( `div.editor-revisions__dialog :text("${ text }")` );
+	}
+
+	/**
 	 * Clicks on a button with given text.
 	 *
 	 * @param {string} text Text of the button to click.

--- a/test/e2e/specs/specs-playwright/wp-editor__revisions.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__revisions.ts
@@ -1,0 +1,63 @@
+/**
+ * @group gutenberg
+ */
+
+import {
+	DataHelper,
+	LoginPage,
+	NewPostFlow,
+	GutenbergEditorPage,
+	EditorSettingsSidebarComponent,
+	RevisionsComponent,
+	setupHooks,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
+	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
+	let page: Page;
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log in', async function () {
+		const loginPage = new LoginPage( page );
+		await loginPage.login( { account: 'simpleSitePersonalPlanUser' } );
+	} );
+
+	it( 'Start new post', async function () {
+		const newPostFlow = new NewPostFlow( page );
+		await newPostFlow.newPostFromNavbar();
+	} );
+
+	it( 'Enter post title', async function () {
+		gutenbergEditorPage = new GutenbergEditorPage( page );
+		await gutenbergEditorPage.enterTitle( DataHelper.getRandomPhrase() );
+	} );
+
+	it.each( [ { revision: 1 }, { revision: 2 } ] )(
+		'Create revision %i',
+		async function ( { revision } ) {
+			await gutenbergEditorPage.enterText( `Revision ${ revision }` );
+			await gutenbergEditorPage.saveDraft();
+		}
+	);
+
+	it( 'View revisions', async function () {
+		const frame = await gutenbergEditorPage.getEditorFrame();
+		await gutenbergEditorPage.openSettings();
+		editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
+		await editorSettingsSidebarComponent.clickTab( 'Post' );
+		await editorSettingsSidebarComponent.showRevisions();
+	} );
+
+	it( 'Restore first revision', async function () {
+		const revisionsComponent = new RevisionsComponent( page );
+		await revisionsComponent.selectRevision( 1 );
+		await revisionsComponent.clickButton( 'Load' );
+		const text = await gutenbergEditorPage.getText();
+		expect( text ).toEqual( '' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the Selenium suites of `wp-calypso-gutenberg-post-editor-spec.js` to Playwright.

Key changes:
- implement new objects such as `RevisionsComponent`.
- migration of test suite to Playwright.

#### Testing instructions

WPCOM (build configuration has permanent failures unrelated to this change)
- [x] mobile
- [x] desktop

Closes https://github.com/Automattic/wp-calypso/issues/55952.
