### PR TITLE
style: Lint JSON codeblocks in Markdown files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -38,3 +38,4 @@ packages/calypso-color-schemes/js
 /client/server/devdocs/proptypes-index.json
 /client/server/bundler/assets.json
 /cached-requests.json
+/yarn-json-output.json

--- a/packages/babel-plugin-transform-wpcalypso-async/README.md
+++ b/packages/babel-plugin-transform-wpcalypso-async/README.md
@@ -12,9 +12,7 @@ Example Babel config file:
 
 ```json
 {
-	"plugins": [
-		[ "@automattic/transform-wpcalypso-async", { "async": true } ]
-	]
+	"plugins": [ [ "@automattic/transform-wpcalypso-async", { "async": true } ] ]
 }
 ```
 

--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -19,9 +19,11 @@ yarn add --dev @automattic/calypso-build
 Then, add a `build` script that invokes the `calypso-build` command:
 
 ```json
+{
 	"scripts": {
 		"build": "calypso-build ./src/editor.js"
 	}
+}
 ```
 
 Simple as that -- the only argument you really need to pass to `calypso-build` is an entry point file for your project. By default, this will create a `dist/` subfolder in your current working directory that will contain the built files -- typically one `.js`, one `.css`, and one `.rtl.css` file.
@@ -31,9 +33,11 @@ Simple as that -- the only argument you really need to pass to `calypso-build` i
 If you want your built files to go elsewhere, you can customize the output path as follows:
 
 ```json
+{
 	"scripts": {
 		"build": "calypso-build --output-path='./build' ./src/editor.js"
 	}
+}
 ```
 
 ### Multiple entry points
@@ -41,9 +45,11 @@ If you want your built files to go elsewhere, you can customize the output path 
 It's also possible to define more than one entry point (resulting in one bundle per entry point):
 
 ```json
+{
 	"scripts": {
 		"build": "calypso-build --output-path='./build' editor=./src/editor.js view=./src/view.js"
 	}
+}
 ```
 
 ### Command Line Interface based on Webpack's
@@ -57,9 +63,11 @@ It was our conscious decision to stick to Webpack's interface rather than coveri
 That `webpack.config.js` introduces one rather WordPress/Gutenberg specific "environment" option, `WP`, which you can set as follows:
 
 ```json
+{
 	"scripts": {
 		"build": "calypso-build ./src/editor.js --env WP"
 	}
+}
 ```
 
 The impact of this option is twofold:
@@ -99,9 +107,11 @@ module.exports = getWebpackConfig;
 `calypso-build` will automatically pick up your `webpack.config.js` if it's in the same directory that the command is called from. You can customize that filename and location using the `--config` option:
 
 ```json
+{
 	"scripts": {
 		"build": "calypso-build --config='./config-files/webpack.config.js' ./src/editor.js"
 	}
+}
 ```
 
 ## Advanced Usage: Use own PostCSS Config

--- a/packages/eslint-plugin-wpcalypso/README.md
+++ b/packages/eslint-plugin-wpcalypso/README.md
@@ -25,9 +25,7 @@ Simply extend the configuration from your project's `.eslintrc` configuration fi
 
 ```json
 {
-    "extends": [
-        "plugin:wpcalypso/recommended"
-    ]
+	"extends": [ "plugin:wpcalypso/recommended" ]
 }
 ```
 
@@ -35,9 +33,7 @@ Or, if your project uses React and you want to opt in to additional React-specif
 
 ```json
 {
-    "extends": [
-        "plugin:wpcalypso/react"
-    ]
+	"extends": [ "plugin:wpcalypso/react" ]
 }
 ```
 
@@ -55,9 +51,7 @@ First, add `wpcalypso` to the plugins section of your `.eslintrc` configuration 
 
 ```json
 {
-    "plugins": [
-        "wpcalypso"
-    ]
+	"plugins": [ "wpcalypso" ]
 }
 ```
 
@@ -65,9 +59,9 @@ Then configure the rules you want to use under the rules section.
 
 ```json
 {
-    "rules": {
-        "wpcalypso/rule-name": "error"
-    }
+	"rules": {
+		"wpcalypso/rule-name": "error"
+	}
 }
 ```
 

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -364,13 +364,19 @@ In order to reduce file-size, i18n-calypso allows the usage of hashed keys for l
 Instead of providing the full English text, like here:
 
 ```json
-{"":{"localeSlug":"de"},"Please enter a valid email address.":["","Bitte gib eine gültige E-Mail-Adresse ein."]}
+{
+	"": { "localeSlug": "de" },
+	"Please enter a valid email address.": [ "", "Bitte gib eine gültige E-Mail-Adresse ein." ]
+}
 ```
 
 just the hash is used for lookup, resulting in a shorter file.
 
 ```json
-{"":{"localeSlug":"de","key-hash":"sha1-1"},"d":["","Bitte gib eine gültige E-Mail-Adresse ein."]}
+{
+	"": { "localeSlug": "de", "key-hash": "sha1-1" },
+	"d": [ "", "Bitte gib eine gültige E-Mail-Adresse ein." ]
+}
 ```
 
 The generator of the jed file would usually try to choose the smallest hash length at which no hash collisions occur. In the above example a hash length of 1 (`d` short for `d2306dd8970ff616631a3501791297f31475e416`) is enough because there is only one string.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix lint errors in JSON codeblocks
* Exclude `yarn-json-output.json` from linting
