### PR TITLE
Welcome Tour: Different description if on mobile

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -36,7 +36,7 @@ function WelcomeTourCard( {
 	isGutenboarding,
 	setInitialFocusedElement,
 } ) {
-	const { description, heading, imgSrc, imgNeedsPadding } = cardContent;
+	const { descriptions, heading, imgSrc, imgNeedsPadding } = cardContent;
 	const isLastStep = currentStepIndex === lastStepIndex;
 
 	// Ensure tracking is recorded once per slide view
@@ -58,6 +58,8 @@ function WelcomeTourCard( {
 	const cardMediaClass = classNames( 'welcome-tour-card__media', {
 		'is-with-extra-padding': isMobile() && imgNeedsPadding,
 	} );
+
+	const description = descriptions[ isMobile() ? 'mobile' : 'desktop' ] ?? descriptions.desktop;
 
 	return (
 		<Card className="welcome-tour-card" isElevated>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -1,7 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, hasTranslation } from '@wordpress/i18n';
 
 function getTourAssets( key ) {
 	const CDN_PREFIX = 'https://s0.wp.com/i/editor-welcome-tour';
@@ -52,10 +52,17 @@ function getTourDescriptions( key, localeSlug = null ) {
 				'Click + to open the inserter. Then click the block you want to add.',
 				'full-site-editing'
 			),
-			mobile: __(
-				'Tap + to open the inserter. Then tap the block you want to add.',
-				'full-site-editing'
-			),
+			mobile:
+				localeSlug === 'en' ||
+				hasTranslation?.( 'Tap + to open the inserter. Then tap the block you want to add.' )
+					? __(
+							'Tap + to open the inserter. Then tap the block you want to add.',
+							'full-site-editing'
+					  )
+					: __(
+							'Click + to open the inserter. Then click the block you want to add.',
+							'full-site-editing'
+					  ),
 		},
 		makeBold: {
 			desktop: __(
@@ -66,7 +73,10 @@ function getTourDescriptions( key, localeSlug = null ) {
 		},
 		moreOptions: {
 			desktop: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
-			mobile: __( 'Tap the settings icon to see even more options.', 'full-site-editing' ),
+			mobile:
+				localeSlug === 'en' || hasTranslation?.( 'Tap the settings icon to see even more options.' )
+					? __( 'Tap the settings icon to see even more options.', 'full-site-editing' )
+					: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
 		},
 		undo: {
 			desktop: __( "Click the Undo button if you've made a mistake.", 'full-site-editing' ),
@@ -74,7 +84,11 @@ function getTourDescriptions( key, localeSlug = null ) {
 		},
 		moveBlock: {
 			desktop: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
-			mobile: __( 'To move blocks around, tap the up and down arrows.', 'full-site-editing' ),
+			mobile:
+				localeSlug === 'en' ||
+				hasTranslation?.( 'To move blocks around, tap the up and down arrows.' )
+					? __( 'To move blocks around, tap the up and down arrows.', 'full-site-editing' )
+					: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
 		},
 		finish: {
 			desktop: createInterpolateElement(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -31,6 +31,80 @@ function getTourAssets( key ) {
 	return tourAssets[ key ];
 }
 
+function getTourDescriptions( key, localeSlug = null ) {
+	const tourDescriptions = {
+		welcome: {
+			desktop: __(
+				'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
+				'full-site-editing'
+			),
+			mobile: null,
+		},
+		allBlocks: {
+			desktop: __(
+				'In the WordPress Editor, paragraphs, images, and videos are all blocks.',
+				'full-site-editing'
+			),
+			mobile: null,
+		},
+		addBlocks: {
+			desktop: __(
+				'Click + to open the inserter. Then click the block you want to add.',
+				'full-site-editing'
+			),
+			mobile: __(
+				'Tap + to open the inserter. Then tap the block you want to add.',
+				'full-site-editing'
+			),
+		},
+		makeBold: {
+			desktop: __(
+				'Use the toolbar to change the appearance of a selected block. Try making it bold.',
+				'full-site-editing'
+			),
+			mobile: null,
+		},
+		moreOptions: {
+			desktop: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
+			mobile: __( 'Tap the settings icon to see even more options.', 'full-site-editing' ),
+		},
+		undo: {
+			desktop: __( "Click the Undo button if you've made a mistake.", 'full-site-editing' ),
+			mobile: null,
+		},
+		moveBlock: {
+			desktop: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
+			mobile: __( 'To move blocks around, tap the up and down arrows.', 'full-site-editing' ),
+		},
+		finish: {
+			desktop: createInterpolateElement(
+				__(
+					"You've learned the basics. Remember, your site is private until you <link_to_launch_site_docs>decide to launch</link_to_launch_site_docs>. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",
+					'full-site-editing'
+				),
+				{
+					link_to_launch_site_docs: (
+						<ExternalLink
+							href={ localizeUrl(
+								'https://wordpress.com/support/settings/privacy-settings/#launch-your-site',
+								localeSlug
+							) }
+						/>
+					),
+					link_to_editor_docs: (
+						<ExternalLink
+							href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/', localeSlug ) }
+						/>
+					),
+				}
+			),
+			mobile: null,
+		},
+	};
+
+	return tourDescriptions[ key ];
+}
+
 const referenceElements = [
 	{
 		desktop: null,
@@ -75,10 +149,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 0 ],
 			meta: {
 				heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
-				description: __(
-					'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
-					'full-site-editing'
-				),
+				descriptions: getTourDescriptions( 'welcome' ),
 				imgSrc: getTourAssets( 'welcome' ),
 				animation: null,
 				imgNeedsPadding: true,
@@ -88,10 +159,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 1 ],
 			meta: {
 				heading: __( 'Everything is a block', 'full-site-editing' ),
-				description: __(
-					'In the WordPress Editor, paragraphs, images, and videos are all blocks.',
-					'full-site-editing'
-				),
+				descriptions: getTourDescriptions( 'allBlocks' ),
 				imgSrc: getTourAssets( 'allBlocks' ),
 				animation: null,
 			},
@@ -100,10 +168,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 2 ],
 			meta: {
 				heading: __( 'Adding a new block', 'full-site-editing' ),
-				description: __(
-					'Click + to open the inserter. Then click the block you want to add.',
-					'full-site-editing'
-				),
+				descriptions: getTourDescriptions( 'addBlocks' ),
 				imgSrc: getTourAssets( 'addBlock' ),
 				animation: 'block-inserter',
 				imgNeedsPadding: true,
@@ -113,10 +178,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 3 ],
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
-				description: __(
-					'Use the toolbar to change the appearance of a selected block. Try making it bold.',
-					'full-site-editing'
-				),
+				descriptions: getTourDescriptions( 'makeBold' ),
 				imgSrc: getTourAssets( 'makeBold' ),
 				animation: null,
 			},
@@ -125,7 +187,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 4 ],
 			meta: {
 				heading: __( 'More Options', 'full-site-editing' ),
-				description: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
+				descriptions: getTourDescriptions( 'moreOptions' ),
 				imgSrc: getTourAssets( 'moreOptions' ),
 				animation: null,
 				imgNeedsPadding: true,
@@ -135,7 +197,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 5 ],
 			meta: {
 				heading: __( 'Undo any mistake', 'full-site-editing' ),
-				description: __( "Click the Undo button if you've made a mistake.", 'full-site-editing' ),
+				descriptions: getTourDescriptions( 'undo' ),
 				imgSrc: getTourAssets( 'undo' ),
 				animation: 'undo-button',
 				isDesktopOnly: true,
@@ -145,7 +207,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 6 ],
 			meta: {
 				heading: __( 'Drag & drop', 'full-site-editing' ),
-				description: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
+				descriptions: getTourDescriptions( 'moveBlock' ),
 				imgSrc: getTourAssets( 'moveBlock' ),
 				animation: 'undo-button',
 				imgNeedsPadding: true,
@@ -155,30 +217,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 7 ],
 			meta: {
 				heading: __( 'Congratulations!', 'full-site-editing' ),
-				description: createInterpolateElement(
-					__(
-						"You've learned the basics. Remember, your site is private until you <link_to_launch_site_docs>decide to launch</link_to_launch_site_docs>. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",
-						'full-site-editing'
-					),
-					{
-						link_to_launch_site_docs: (
-							<ExternalLink
-								href={ localizeUrl(
-									'https://wordpress.com/support/settings/privacy-settings/#launch-your-site',
-									localeSlug
-								) }
-							/>
-						),
-						link_to_editor_docs: (
-							<ExternalLink
-								href={ localizeUrl(
-									'https://wordpress.com/support/wordpress-editor/',
-									localeSlug
-								) }
-							/>
-						),
-					}
-				),
+				descriptions: getTourDescriptions( 'finish', localeSlug ),
 				imgSrc: getTourAssets( 'finish' ),
 				animation: 'block-inserter',
 			},

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -31,94 +31,6 @@ function getTourAssets( key ) {
 	return tourAssets[ key ];
 }
 
-function getTourDescriptions( key, localeSlug = null ) {
-	const tourDescriptions = {
-		welcome: {
-			desktop: __(
-				'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
-				'full-site-editing'
-			),
-			mobile: null,
-		},
-		allBlocks: {
-			desktop: __(
-				'In the WordPress Editor, paragraphs, images, and videos are all blocks.',
-				'full-site-editing'
-			),
-			mobile: null,
-		},
-		addBlocks: {
-			desktop: __(
-				'Click + to open the inserter. Then click the block you want to add.',
-				'full-site-editing'
-			),
-			mobile:
-				localeSlug === 'en' ||
-				hasTranslation?.( 'Tap + to open the inserter. Then tap the block you want to add.' )
-					? __(
-							'Tap + to open the inserter. Then tap the block you want to add.',
-							'full-site-editing'
-					  )
-					: __(
-							'Click + to open the inserter. Then click the block you want to add.',
-							'full-site-editing'
-					  ),
-		},
-		makeBold: {
-			desktop: __(
-				'Use the toolbar to change the appearance of a selected block. Try making it bold.',
-				'full-site-editing'
-			),
-			mobile: null,
-		},
-		moreOptions: {
-			desktop: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
-			mobile:
-				localeSlug === 'en' || hasTranslation?.( 'Tap the settings icon to see even more options.' )
-					? __( 'Tap the settings icon to see even more options.', 'full-site-editing' )
-					: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
-		},
-		undo: {
-			desktop: __( "Click the Undo button if you've made a mistake.", 'full-site-editing' ),
-			mobile: null,
-		},
-		moveBlock: {
-			desktop: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
-			mobile:
-				localeSlug === 'en' ||
-				hasTranslation?.( 'To move blocks around, tap the up and down arrows.' )
-					? __( 'To move blocks around, tap the up and down arrows.', 'full-site-editing' )
-					: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
-		},
-		finish: {
-			desktop: createInterpolateElement(
-				__(
-					"You've learned the basics. Remember, your site is private until you <link_to_launch_site_docs>decide to launch</link_to_launch_site_docs>. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",
-					'full-site-editing'
-				),
-				{
-					link_to_launch_site_docs: (
-						<ExternalLink
-							href={ localizeUrl(
-								'https://wordpress.com/support/settings/privacy-settings/#launch-your-site',
-								localeSlug
-							) }
-						/>
-					),
-					link_to_editor_docs: (
-						<ExternalLink
-							href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/', localeSlug ) }
-						/>
-					),
-				}
-			),
-			mobile: null,
-		},
-	};
-
-	return tourDescriptions[ key ];
-}
-
 const referenceElements = [
 	{
 		desktop: null,
@@ -163,7 +75,13 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 0 ],
 			meta: {
 				heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
-				descriptions: getTourDescriptions( 'welcome' ),
+				descriptions: {
+					desktop: __(
+						'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
+						'full-site-editing'
+					),
+					mobile: null,
+				},
 				imgSrc: getTourAssets( 'welcome' ),
 				animation: null,
 				imgNeedsPadding: true,
@@ -173,7 +91,13 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 1 ],
 			meta: {
 				heading: __( 'Everything is a block', 'full-site-editing' ),
-				descriptions: getTourDescriptions( 'allBlocks' ),
+				descriptions: {
+					desktop: __(
+						'In the WordPress Editor, paragraphs, images, and videos are all blocks.',
+						'full-site-editing'
+					),
+					mobile: null,
+				},
 				imgSrc: getTourAssets( 'allBlocks' ),
 				animation: null,
 			},
@@ -182,7 +106,23 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 2 ],
 			meta: {
 				heading: __( 'Adding a new block', 'full-site-editing' ),
-				descriptions: getTourDescriptions( 'addBlocks' ),
+				descriptions: {
+					desktop: __(
+						'Click + to open the inserter. Then click the block you want to add.',
+						'full-site-editing'
+					),
+					mobile:
+						localeSlug === 'en' ||
+						hasTranslation?.( 'Tap + to open the inserter. Then tap the block you want to add.' )
+							? __(
+									'Tap + to open the inserter. Then tap the block you want to add.',
+									'full-site-editing'
+							  )
+							: __(
+									'Click + to open the inserter. Then click the block you want to add.',
+									'full-site-editing'
+							  ),
+				},
 				imgSrc: getTourAssets( 'addBlock' ),
 				animation: 'block-inserter',
 				imgNeedsPadding: true,
@@ -192,7 +132,13 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 3 ],
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
-				descriptions: getTourDescriptions( 'makeBold' ),
+				descriptions: {
+					desktop: __(
+						'Use the toolbar to change the appearance of a selected block. Try making it bold.',
+						'full-site-editing'
+					),
+					mobile: null,
+				},
 				imgSrc: getTourAssets( 'makeBold' ),
 				animation: null,
 			},
@@ -201,7 +147,14 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 4 ],
 			meta: {
 				heading: __( 'More Options', 'full-site-editing' ),
-				descriptions: getTourDescriptions( 'moreOptions' ),
+				descriptions: {
+					desktop: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
+					mobile:
+						localeSlug === 'en' ||
+						hasTranslation?.( 'Tap the settings icon to see even more options.' )
+							? __( 'Tap the settings icon to see even more options.', 'full-site-editing' )
+							: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
+				},
 				imgSrc: getTourAssets( 'moreOptions' ),
 				animation: null,
 				imgNeedsPadding: true,
@@ -211,7 +164,10 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 5 ],
 			meta: {
 				heading: __( 'Undo any mistake', 'full-site-editing' ),
-				descriptions: getTourDescriptions( 'undo' ),
+				descriptions: {
+					desktop: __( "Click the Undo button if you've made a mistake.", 'full-site-editing' ),
+					mobile: null,
+				},
 				imgSrc: getTourAssets( 'undo' ),
 				animation: 'undo-button',
 				isDesktopOnly: true,
@@ -221,7 +177,14 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 6 ],
 			meta: {
 				heading: __( 'Drag & drop', 'full-site-editing' ),
-				descriptions: getTourDescriptions( 'moveBlock' ),
+				descriptions: {
+					desktop: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
+					mobile:
+						localeSlug === 'en' ||
+						hasTranslation?.( 'To move blocks around, tap the up and down arrows.' )
+							? __( 'To move blocks around, tap the up and down arrows.', 'full-site-editing' )
+							: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
+				},
 				imgSrc: getTourAssets( 'moveBlock' ),
 				animation: 'undo-button',
 				imgNeedsPadding: true,
@@ -231,7 +194,33 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			referenceElements: referencePositioning && referenceElements[ 7 ],
 			meta: {
 				heading: __( 'Congratulations!', 'full-site-editing' ),
-				descriptions: getTourDescriptions( 'finish', localeSlug ),
+				descriptions: {
+					desktop: createInterpolateElement(
+						__(
+							"You've learned the basics. Remember, your site is private until you <link_to_launch_site_docs>decide to launch</link_to_launch_site_docs>. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",
+							'full-site-editing'
+						),
+						{
+							link_to_launch_site_docs: (
+								<ExternalLink
+									href={ localizeUrl(
+										'https://wordpress.com/support/settings/privacy-settings/#launch-your-site',
+										localeSlug
+									) }
+								/>
+							),
+							link_to_editor_docs: (
+								<ExternalLink
+									href={ localizeUrl(
+										'https://wordpress.com/support/wordpress-editor/',
+										localeSlug
+									) }
+								/>
+							),
+						}
+					),
+					mobile: null,
+				},
 				imgSrc: getTourAssets( 'finish' ),
 				animation: 'block-inserter',
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the Welcome Tour, change the `description` element in `meta` to `descriptions`, an object containing a description for desktop and one for mobile.
Then, in `tour-card` it will be decided which one to show, based on viewport

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync ETK (follow FG)
* Verify that  slides 3, 5 and 6 (in mobile mode) are tailored for mobile

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56708
Fixes #56708

#### Translation screenshots

Tap + to open the inserter. Then tap the block you want to add.
![image](https://user-images.githubusercontent.com/52076348/148762051-a54bc6e8-a886-4be4-aa65-2da4e8a09bbb.png)

Tap the settings icon to see even more options.
![image](https://user-images.githubusercontent.com/52076348/148762120-e76be139-105a-4f39-9168-09f164c44214.png)

To move blocks around, tap the up and down arrows.
![image](https://user-images.githubusercontent.com/52076348/148762174-8ebca4e1-7545-4d61-ada7-bf8fa505b2d9.png)




