### PR TITLE
Woop: set last modified date of step/flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -419,7 +419,7 @@ export function generateFlows( {
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',
 			providesDependenciesInQuery: [ 'site' ],
-			lastModified: '2021-11-11',
+			lastModified: '2021-12-21',
 			disallowResume: false,
 		},
 	];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This problem updates the last modified date of the `woocommerce-install` flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check visually that the date has been updated to Dec 21, 2021.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
