### PR TITLE
Checkout: remove redirect_to dependance.

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -70,19 +70,6 @@ export const leaveCheckout = ( {
 				return;
 			}
 		}
-
-		// Some places that open checkout (eg: purchase page renewals) return the
-		// user there after checkout by putting the previous page's path in the
-		// `redirect_to` query param. When leaving checkout via the close button,
-		// we probably want to return to that location also.
-		if ( searchParams.has( 'redirect_to' ) ) {
-			const redirectPath = searchParams.get( 'redirect_to' ) ?? '';
-			// Only allow redirecting to relative paths.
-			if ( redirectPath.match( /^\/(?!\/)/ ) ) {
-				navigate( redirectPath );
-				return;
-			}
-		}
 	} catch ( error ) {
 		// Silently ignore query string errors (eg: which may occur in IE since it doesn't support URLSearchParams).
 		// eslint-disable-next-line no-console


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims removes the `redirect_to` conditional when user leaves checkout. Since we have already implemented the `previousPath` check it shouldn't be needed.
https://github.com/Automattic/wp-calypso/blob/ff92f590e6b06d47e56c312c1ba2f723b03dae51/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts#L36-L43

Moreover, it **creates problems for flows that need this redirect to work only after checkout**. 

If a parameter is still needed, maybe we can utilize the new `cancel_to` which makes more sense?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `https://wordpress.com/plugins/woocommerce-subscriptions/[domain]` of an atomic site
* Click "Pay and install"
* After being redirected to checkout, click "X"
* You should be redirected to `https://wordpress.com/plugins/woocommerce-subscriptions/[domain]`

**Regressions?**
- visit `/purchases/subscriptions/[domain]` of an atomic site
- Click "Renew now" from a site-level purchase and confirm it returns you to the site-level purchase page after completing checkout

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59437
