### PR TITLE
Emails: Remove Lodash get() from client/my-sites/email

### DIFF
--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -1,7 +1,6 @@
 import { Button, Card } from '@automattic/components';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -40,7 +39,7 @@ import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsu
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AddEmailAddressesCardPlaceholder from './add-users-placeholder';
 
 import './style.scss';
@@ -285,14 +284,14 @@ GSuiteAddUsers.propTypes = {
 export default connect(
 	( state ) => {
 		const selectedSite = getSelectedSite( state );
-		const siteId = get( selectedSite, 'ID', null );
-		const domains = getDomainsBySiteId( state, siteId );
+		const selectedSiteId = getSelectedSiteId( state );
+		const domains = getDomainsBySiteId( state, selectedSiteId );
 
 		return {
 			currentRoute: getCurrentRoute( state ),
 			domains,
-			gsuiteUsers: getGSuiteUsers( state, siteId ),
-			isRequestingDomains: isRequestingSiteDomains( state, siteId ),
+			gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
+			isRequestingDomains: isRequestingSiteDomains( state, selectedSiteId ),
 			selectedSite,
 			userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 		};


### PR DESCRIPTION
This pull request removes the last usage of Lodash from the `client/my-sites/email` folder.

#### Testing instructions

1. Run `git checkout remove/lodash-get-from-emails` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/59492#issuecomment-999537247)
2. Log into a WordPress.com account that has a G Suite or Google Workspace account
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click that Google account to access the `Email Plan` page
5. Click the `Add new mailboxes` link
6. Assert that you can still purchase additional mailboxes