### PR TITLE
Don't show the plan features page in the setup site flow

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -240,6 +240,11 @@ export default function getThankYouPageUrl( {
 		return redirectUrlForPostCheckoutUpsell;
 	}
 
+	if ( urlFromCookie?.startsWith( '/start/setup-site' ) ) {
+		debug( 'skipping thank you page for setup site flow' );
+		return urlFromCookie;
+	}
+
 	// Display mode is used to show purchase specific messaging, for e.g. the Schedule Session button
 	// when purchasing a concierge session or when purchasing the Ultimate Traffic Guide
 	const displayModeParam = getDisplayModeParamFromCart( cart );

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from '@emotion/react';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useMemo, useState } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import { useFormStatusManager } from '../lib/form-status';
 import { LineItemsProvider } from '../lib/line-items';
@@ -195,8 +195,17 @@ function useCallEventCallbacks( {
 	paymentMethodId: string | null;
 	transactionLastResponse: PaymentProcessorResponseData;
 } ): void {
+	// Ensure that onPaymentComplete is only called once per checkout so that the URL
+	// retrieved from the signup destination cookie will be used correctly.
+	const didOnPaymentComplete = useRef( false );
+
 	useEffect( () => {
-		if ( onPaymentComplete && formStatus === FormStatus.COMPLETE ) {
+		if (
+			onPaymentComplete &&
+			formStatus === FormStatus.COMPLETE &&
+			! didOnPaymentComplete.current
+		) {
+			didOnPaymentComplete.current = true;
 			debug( "form status is complete so I'm calling onPaymentComplete" );
 			onPaymentComplete( { paymentMethodId, transactionLastResponse } );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Continue on with the setup site flow rather than showing a plan features "Thank You" page.

Fixes https://github.com/Automattic/wp-calypso/issues/56303
Fixes https://github.com/Automattic/wp-calypso/issues/59351

* Ensure that onPaymentComplete is only called once per checkout was required to make this work. (this needs to be thoroughly tested or work out if we can achieve the same result without changing this behaviour) 

#### Testing instructions
With an existing user, navigate to `/start` choose a domain and choose the `personal` plan.
Complete the checkout (I paid with free credits). 
Previously you would see the plan features page https://github.com/Automattic/wp-calypso/issues/56303
Now you will see the intent gathering step of the blogger onboarding flow

Also test with new users on all plans https://github.com/Automattic/wp-calypso/issues/59351

Test that checkout works normally if purchasing/upgrading a plan from within calypso. When purchasing the personal plan, the plan features page should still be shown.

For bonus points, test checkouts with mocked credit card payment, purchasing a domain, an eCommerce site, etc.

