### PR TITLE
Plugin Details: Fix plugin sites list for paid plugins

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -80,8 +80,26 @@ const PluginDetailsCTA = ( {
 		return null;
 	}
 
+	// Check if user can manage plugins or no site is selected (all sites view).
 	if ( ! selectedSite || ! userCan( 'manage_options', selectedSite ) ) {
-		// Check if user can manage plugins.
+		if ( isMarketplaceProduct ) {
+			return (
+				<div className="plugin-details-CTA__container">
+					<div className="plugin-details-CTA__price align-right">
+						<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
+							{ ( { isFetching, price, period } ) =>
+								! isFetching && (
+									<>
+										{ price + ' ' }
+										<span className="plugin-details-CTA__period">{ period }</span>
+									</>
+								)
+							}
+						</PluginPrice>
+					</div>
+				</div>
+			);
+		}
 		return null;
 	}
 

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -10,6 +10,10 @@
 	color: var( --studio-gray-100 );
 	margin: 16px 0;
 	min-height: 48px;
+
+	&.align-right {
+		text-align: right;
+	}
 }
 
 .plugin-details-CTA__period {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -273,6 +273,7 @@ function PluginDetails( props ) {
 						<SitesListArea
 							fullPlugin={ fullPlugin }
 							isPluginInstalledOnsite={ isPluginInstalledOnsite }
+							billingPeriod={ billingPeriod }
 							{ ...props }
 						/>
 
@@ -301,7 +302,7 @@ function PluginDetails( props ) {
 	);
 }
 
-function SitesListArea( { fullPlugin: plugin, isPluginInstalledOnsite, ...props } ) {
+function SitesListArea( { fullPlugin: plugin, isPluginInstalledOnsite, billingPeriod, ...props } ) {
 	const translate = useTranslate();
 
 	const selectedSite = useSelector( getSelectedSite );
@@ -342,18 +343,17 @@ function SitesListArea( { fullPlugin: plugin, isPluginInstalledOnsite, ...props 
 					titlePrimary
 					showAdditionalHeaders
 				/>
-				{ plugin.wporg && (
-					<PluginSiteList
-						className="plugin-details__not-installed-on"
-						title={ getAvailabeOnTitle( {
-							translate,
-							selectedSite,
-							count: notInstalledSites.length,
-						} ) }
-						sites={ notInstalledSites }
-						plugin={ plugin }
-					/>
-				) }
+
+				<PluginSiteList
+					className="plugin-details__not-installed-on"
+					title={ getAvailabeOnTitle( {
+						translate,
+						selectedSite,
+					} ) }
+					sites={ notInstalledSites }
+					plugin={ plugin }
+					billingPeriod={ billingPeriod }
+				/>
 			</div>
 		</div>
 	);
@@ -373,15 +373,13 @@ function getInstalledOnTitle( { translate, selectedSite, count } ) {
 	return selectedSite ? installedOnSingleSiteTitle : installedOnMultiSiteTitle;
 }
 
-function getAvailabeOnTitle( { translate, selectedSite, count } ) {
+function getAvailabeOnTitle( { translate, selectedSite } ) {
 	const availableOnSingleSiteTitle = translate( 'Available sites', {
 		comment: 'header for list of sites a plugin can be installed on',
 	} );
 
-	const availabeOnMultiSiteTitle = translate( 'Available on %d site', 'Available on %d sites', {
+	const availabeOnMultiSiteTitle = translate( 'Available on', {
 		comment: 'header for list of sites a plugin can be installed on',
-		args: [ count ],
-		count,
 	} );
 
 	return selectedSite ? availableOnSingleSiteTitle : availabeOnMultiSiteTitle;

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -18,6 +18,7 @@ import { removePluginStatuses } from 'calypso/state/plugins/installed/status/act
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isCompatiblePlugin } from '../plugin-compatibility';
+import { getPeriodVariationValue } from '../plugin-price';
 
 import './style.scss';
 
@@ -147,6 +148,24 @@ export class PluginInstallButton extends Component {
 		return null;
 	}
 
+	renderMarketplaceButton() {
+		const { translate, selectedSite, plugin, billingPeriod } = this.props;
+		const variationPeriod = getPeriodVariationValue( billingPeriod );
+		const product_slug = plugin?.variations?.[ variationPeriod ]?.product_slug;
+
+		return (
+			<span className="plugin-install-button__install embed">
+				<Button
+					href={ `/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2` }
+				>
+					<Gridicon key="plus-icon" icon="plus-small" size={ 18 } />
+					<Gridicon icon="plugins" size={ 18 } />
+					{ translate( 'Purchase and activate' ) }
+				</Button>
+			</span>
+		);
+	}
+
 	renderButton() {
 		const { translate, isInstalling, isEmbed, disabled } = this.props;
 		const label = isInstalling ? translate( 'Installing…' ) : translate( 'Install' );
@@ -234,7 +253,11 @@ export class PluginInstallButton extends Component {
 			) : null;
 		}
 
-		return this.renderButton();
+		if ( ! plugin.isMarketplaceProduct ) {
+			return this.renderButton();
+		}
+
+		return this.renderMarketplaceButton();
 	}
 
 	render() {

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -20,7 +20,7 @@ import { getSitePurchases } from 'calypso/state/purchases/selectors';
 
 import './style.scss';
 
-const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedActions } ) => {
+const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedActions, ...props } ) => {
 	const translate = useTranslate();
 	const {
 		activation: canToggleActivation = true,
@@ -73,6 +73,7 @@ const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedAction
 							selectedSite={ site }
 							plugin={ plugin }
 							isInstalling={ installInProgress }
+							{ ...props }
 						/>
 					}
 				</div>

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -15,17 +15,27 @@ import isConnectedSecondaryNetworkSite from 'calypso/state/selectors/is-connecte
 
 import './style.scss';
 
-const PluginSiteList = ( props ) => {
+const PluginSiteList = ( {
+	sites,
+	plugin,
+	className,
+	titlePrimary,
+	title,
+	wporg,
+	showAdditionalHeaders,
+	...props
+} ) => {
 	const translate = useTranslate();
-	const siteIds = siteObjectsToSiteIds( props.sites );
+	const siteIds = siteObjectsToSiteIds( sites );
 	const sitesWithPlugin = useSelector( ( state ) =>
-		getSiteObjectsWithPlugin( state, siteIds, props.plugin.slug )
+		getSiteObjectsWithPlugin( state, siteIds, plugin.slug )
 	);
 	const sitesWithSecondarySites = useSelector( ( state ) =>
-		getSitesWithSecondarySites( state, props.sites )
+		getSitesWithSecondarySites( state, sites )
 	);
+
 	const pluginsOnSites = useSelector( ( state ) =>
-		getPluginOnSites( state, siteIds, props.plugin.slug )
+		getPluginOnSites( state, siteIds, plugin.slug )
 	);
 
 	const getSecondaryPluginSites = useCallback(
@@ -42,18 +52,18 @@ const PluginSiteList = ( props ) => {
 		[ pluginsOnSites, sitesWithPlugin ]
 	);
 
-	if ( ! props.sites || props.sites.length === 0 ) {
+	if ( ! sites || sites.length === 0 ) {
 		return null;
 	}
 	return (
-		<div className={ classNames( 'plugin-site-list', props.className ) }>
-			<div className={ classNames( 'plugin-site-list__title', { primary: props.titlePrimary } ) }>
-				{ props.title }
+		<div className={ classNames( 'plugin-site-list', className ) }>
+			<div className={ classNames( 'plugin-site-list__title', { primary: titlePrimary } ) }>
+				{ title }
 			</div>
 			<div className="plugin-site-list__content">
 				<div className="plugin-site-list__header">
 					<div className="plugin-site-list__header-title domain">{ translate( 'Domain' ) }</div>
-					{ props.showAdditionalHeaders && (
+					{ showAdditionalHeaders && (
 						<>
 							<div className="plugin-site-list__header-title">{ translate( 'Active' ) }</div>
 							<div className="plugin-site-list__header-title">{ translate( 'Autoupdates' ) }</div>
@@ -67,8 +77,9 @@ const PluginSiteList = ( props ) => {
 						key={ 'pluginSite' + site.ID }
 						site={ site }
 						secondarySites={ getSecondaryPluginSites( site, secondarySites ) }
-						plugin={ props.plugin }
-						wporg={ props.wporg }
+						plugin={ plugin }
+						wporg={ wporg }
+						{ ...props }
 					/>
 				) ) }
 			</div>

--- a/client/my-sites/plugins/plugin-site/plugin-site.jsx
+++ b/client/my-sites/plugins/plugin-site/plugin-site.jsx
@@ -3,9 +3,14 @@ import { connect } from 'react-redux';
 import PluginSiteJetpack from 'calypso/my-sites/plugins/plugin-site-jetpack';
 import PluginSiteNetwork from 'calypso/my-sites/plugins/plugin-site-network';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 
 const PluginSite = ( props ) => {
 	if ( ! props.site ) {
+		return null;
+	}
+
+	if ( props.plugin.isMarketplaceProduct && ! props.isWPCOM ) {
 		return null;
 	}
 
@@ -20,6 +25,7 @@ function mapStateToProps( state, ownProps ) {
 	const siteId = get( ownProps, 'site.ID' );
 	return {
 		isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
+		isWPCOM: getIsSiteWPCOM( state, siteId ),
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Displays available sites in all sites view
- Adds price
- Allows for "Purchase and activate"

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1600" alt="SS 2021-12-22 at 15 30 06" src="https://user-images.githubusercontent.com/12430020/147100220-61ced5a8-bb5f-4f2c-899c-2e79023d1bd0.png">|<img width="1596" alt="SS 2021-12-22 at 15 30 23" src="https://user-images.githubusercontent.com/12430020/147100261-4cf3197c-f7c5-49df-bb15-23674fae5880.png">|

- visit `https://wordpress.com/plugins/woocommerce-subscriptions`
- make sure that price is shown
- try buying the plugin for a site
- no Jetpack / Simple sites should appear in the list

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59292
