### PR TITLE
Retired themes: Add link to support doc

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -157,6 +157,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/themes/',
 		post_id: 2278,
 	},
+	'themes-retired': {
+		link: 'https://wordpress.com/support/themes/retired-themes/',
+		post_id: 189792,
+	},
 	'themes-switch': {
 		link: 'https://wordpress.com/support/changing-themes/',
 		post_id: 184023,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -589,6 +589,7 @@ class ThemeSheet extends Component {
 					<div className="theme__retired-theme-message-details">
 						<div className="theme__retired-theme-message-details-title">
 							{ this.props.translate( 'This theme is retired' ) }
+							<InlineSupportLink supportContext="themes-retired" showText={ false } />
 						</div>
 						<div>
 							{ this.props.translate(

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -500,6 +500,12 @@
 	.theme__retired-theme-message-details-title {
 		font-size: $font-title-small;
 	}
+
+	.inline-support-link .gridicon {
+		height: 18px;
+		width: 18px;
+		color: inherit;
+	}
 }
 
 .theme__sheet-footer-line {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a link to the official "Retired themes" support doc inside the "This theme is retired" notice:
<img width="621" alt="Screen Shot 2021-12-22 at 15 34 06" src="https://user-images.githubusercontent.com/1233880/147109016-607d2b21-6778-4f1b-970d-e375cd9889d7.png">

We hope that with this info users will be less likely to contact support when they see a theme has been retired.

Props to @donalirl for the suggestion in p7DVsv-dqj-p2#comment-38980.

#### Testing instructions

- Use the Calypso live link below.
- Visit a retired theme (e.g. `/themes/redhill`).
- Make sure there is `?` icon displayed next to the "This theme is retired" title.
- Click on it.
- Make sure it opens the support doc about "Retired themes".