### PR TITLE
composite-checkout: Do not call CheckoutProvider callbacks unless status changes

### DIFF
--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -205,24 +205,38 @@ function useCallEventCallbacks( {
 	const paymentErrorRef = useRef( onPaymentError );
 	paymentErrorRef.current = onPaymentError;
 
+	const prevFormStatus = useRef< FormStatus >();
+	const prevTransactionStatus = useRef< TransactionStatus >();
+
 	useEffect( () => {
-		if ( paymentCompleteRef.current && formStatus === FormStatus.COMPLETE ) {
-			debug( "form status is complete so I'm calling onPaymentComplete" );
+		if (
+			paymentCompleteRef.current &&
+			formStatus === FormStatus.COMPLETE &&
+			formStatus !== prevFormStatus.current
+		) {
+			debug( "form status changed to complete so I'm calling onPaymentComplete" );
 			paymentCompleteRef.current( { paymentMethodId, transactionLastResponse } );
 		}
+		prevFormStatus.current = formStatus;
 	}, [ formStatus, transactionLastResponse, paymentMethodId ] );
 
 	useEffect( () => {
-		if ( paymentRedirectRef.current && transactionStatus === TransactionStatus.REDIRECTING ) {
-			debug( "transaction status is redirecting so I'm calling onPaymentRedirect" );
+		if (
+			paymentRedirectRef.current &&
+			transactionStatus === TransactionStatus.REDIRECTING &&
+			transactionStatus !== prevTransactionStatus.current
+		) {
+			debug( "transaction status changed to redirecting so I'm calling onPaymentRedirect" );
 			paymentRedirectRef.current( { paymentMethodId, transactionLastResponse } );
 		}
-	}, [ transactionStatus, paymentMethodId, transactionLastResponse ] );
-
-	useEffect( () => {
-		if ( paymentErrorRef.current && transactionStatus === TransactionStatus.ERROR ) {
-			debug( "transaction status is error so I'm calling onPaymentError" );
+		if (
+			paymentErrorRef.current &&
+			transactionStatus === TransactionStatus.ERROR &&
+			transactionStatus !== prevTransactionStatus.current
+		) {
+			debug( "transaction status changed to error so I'm calling onPaymentError" );
 			paymentErrorRef.current( { paymentMethodId, transactionError } );
 		}
-	}, [ transactionStatus, paymentMethodId, transactionError ] );
+		prevTransactionStatus.current = transactionStatus;
+	}, [ transactionStatus, paymentMethodId, transactionLastResponse, transactionError ] );
 }

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -271,7 +271,7 @@ describe( 'CheckoutProvider', () => {
 			expect( onPaymentRedirect ).not.toBeCalled();
 		} );
 
-		it( 'does not call onPaymentRedirect twice when transaction status is complete even if callback changes', () => {
+		it( 'does not call onPaymentRedirect twice when transaction status is redirecting even if callback changes', () => {
 			const onPaymentRedirect = jest.fn();
 			const { getByText, rerender } = render(
 				<MyCheckout onPaymentRedirect={ () => onPaymentRedirect() } />

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -174,6 +174,16 @@ describe( 'CheckoutProvider', () => {
 			expect( getByText( 'Form Complete' ) ).toBeInTheDocument();
 			expect( onPaymentComplete ).toBeCalled();
 		} );
+
+		it( 'does not call onPaymentComplete twice when form status is complete even if callback changes', () => {
+			const onPaymentComplete = jest.fn();
+			const { getByText, rerender } = render(
+				<MyCheckout onPaymentComplete={ () => onPaymentComplete() } />
+			);
+			fireEvent.click( getByText( 'Complete' ) );
+			rerender( <MyCheckout onPaymentComplete={ () => onPaymentComplete() } /> );
+			expect( onPaymentComplete.mock.calls.length ).toBe( 1 );
+		} );
 	} );
 
 	describe( 'with transactionStatus directly', () => {
@@ -261,6 +271,16 @@ describe( 'CheckoutProvider', () => {
 			expect( onPaymentRedirect ).not.toBeCalled();
 		} );
 
+		it( 'does not call onPaymentRedirect twice when transaction status is complete even if callback changes', () => {
+			const onPaymentRedirect = jest.fn();
+			const { getByText, rerender } = render(
+				<MyCheckout onPaymentRedirect={ () => onPaymentRedirect() } />
+			);
+			fireEvent.click( getByText( 'Redirect' ) );
+			rerender( <MyCheckout onPaymentRedirect={ () => onPaymentRedirect() } /> );
+			expect( onPaymentRedirect.mock.calls.length ).toBe( 1 );
+		} );
+
 		it( 'calls onPaymentRedirect when transaction status is redirecting', () => {
 			const onPaymentRedirect = jest.fn();
 			const { getByText } = render( <MyCheckout onPaymentRedirect={ onPaymentRedirect } /> );
@@ -284,12 +304,22 @@ describe( 'CheckoutProvider', () => {
 			expect( onPaymentError ).not.toBeCalled();
 		} );
 
-		it( 'calls onPaymentError when transaction status is redirecting', () => {
+		it( 'calls onPaymentError when transaction status is error', () => {
 			const onPaymentError = jest.fn();
 			const { getByText } = render( <MyCheckout onPaymentError={ onPaymentError } /> );
 			fireEvent.click( getByText( 'Cause Error' ) );
 			expect( getByText( 'Showing Error' ) ).toBeInTheDocument();
 			expect( onPaymentError ).toBeCalled();
+		} );
+
+		it( 'does not call onPaymentError twice when transaction status is error even if callback changes', () => {
+			const onPaymentError = jest.fn();
+			const { getByText, rerender } = render(
+				<MyCheckout onPaymentError={ () => onPaymentError() } />
+			);
+			fireEvent.click( getByText( 'Cause Error' ) );
+			rerender( <MyCheckout onPaymentError={ () => onPaymentError() } /> );
+			expect( onPaymentError.mock.calls.length ).toBe( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It's possible (and [even likely](https://github.com/Automattic/wp-calypso/blob/aae5e45748fc4302494e8f89e5d595cd3635e4b4/client/me/purchases/manage-purchase/payment-method-selector/index.tsx#L120-L123)) that the callback functions passed to `CheckoutProvider` might not be memoized properly, or that other conditions might cause them to change on renders that occur after they have been called. Since those callback functions are necessarily dependencies for the `useEffect` hooks that call them, if they change they may cause the callbacks to be called more than once even if the status that triggers them has not changed.

This PR modifies `CheckoutProvider` so that it will only call `onPaymentComplete`, `onPaymentRedirect` and `onPaymentError` once per each status change that triggers the call. It does this by removing the callbacks from the list of dependencies (always using the latest) and by making sure that we only call the callbacks if the status differs from its previous value.

#### Testing instructions

Automated tests.