### PR TITLE
Videos UI: remove retry: false from query.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -16,7 +16,7 @@ const VideosUi = ( { HeaderBar, FooterBar, areVideosTranslated = true } ) => {
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
 
 	const courseSlug = 'blogging-quick-start';
-	const { data: course } = useCourseQuery( courseSlug, { retry: false } );
+	const { data: course } = useCourseQuery( courseSlug );
 	const { updateUserCourseProgression } = useUpdateUserCourseProgressionMutation();
 
 	const initialUserCourseProgression = useMemo( () => course?.completions ?? [], [ course ] );


### PR DESCRIPTION
This addresses a [comment](https://github.com/Automattic/wp-calypso/pull/58234#discussion_r773665438) that pointed out that the `retry: false` was not needed. Indeed, that comment is correct, the `retry: false` was added to try out something at the beginning  of the project and never removed. This PR removes it.

### Testing
1. Go to the calypso.live link on the comments of this PR.
1. Click the `Start Learning` link on the `Blog Like an Expert` card: ![image](https://user-images.githubusercontent.com/375980/147133051-033a5014-d9ef-496e-94de-0830ad3182e1.png)
2. Verify the Videos UI works as expected.