### PR TITLE
[ETK/error-reporting] Reactivate Sentry for 1% of WPCOM simple site users

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -1,5 +1,8 @@
+import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
 import apiFetch from '@wordpress/api-fetch';
 
+const shouldActivateSentry = window.A8C_ETK_ErrorReporting_Config?.shouldActivateSentry === 'true';
 /**
  * Errors that happened before this script had a chance to load
  * are captured in a global array. See `./index.php`.
@@ -7,39 +10,64 @@ import apiFetch from '@wordpress/api-fetch';
 const headErrors = window._jsErr || [];
 const headErrorHandler = window._headJsErrorHandler;
 
-const reportError = ( { error } ) => {
-	// Sanitized error event objects do not include a nested error attribute. In
-	// that case, we return early to prevent a needless TypeError when defining
-	// `data`, below. Also, sanitized errors don't include any useful information,
-	// so the sensible thing to do is to completely ignore them.
-	if ( ! error ) {
-		return;
-	}
+function activateSentry() {
+	Sentry.init( {
+		dsn: 'https://658ae291b00242148af6b76494d4a49a@o248881.ingest.sentry.io/5876245',
+		integrations: [ new Integrations.BrowserTracing() ],
 
-	const data = {
-		message: error.message,
-		trace: error.stack,
-		url: document.location.href,
-		feature: 'wp-admin',
+		// Set tracesSampleRate to 1.0 to capture 100%
+		// of transactions for performance monitoring.
+		// We recommend adjusting this value in production
+		tracesSampleRate: 1.0,
+	} );
+
+	// We still need to report the head errors, if any.
+	headErrors.forEach( ( error ) => Sentry.captureException( error ) );
+	Sentry.flush().then( () => delete window._jsErr );
+}
+
+// Activate the home-brew error-reporting
+function activateHomebrewErrorReporting() {
+	const reportError = ( { error } ) => {
+		// Sanitized error event objects do not include a nested error attribute. In
+		// that case, we return early to prevent a needless TypeError when defining
+		// `data`, below. Also, sanitized errors don't include any useful information,
+		// so the sensible thing to do is to completely ignore them.
+		if ( ! error ) {
+			return;
+		}
+
+		const data = {
+			message: error.message,
+			trace: error.stack,
+			url: document.location.href,
+			feature: 'wp-admin',
+		};
+
+		return (
+			apiFetch( {
+				global: true,
+				path: '/rest/v1.1/js-error',
+				method: 'POST',
+				data: { error: JSON.stringify( data ) },
+			} )
+				// eslint-disable-next-line no-console
+				.catch( () => console.error( 'Error: Unable to record the error in Logstash.' ) )
+		);
 	};
 
-	return (
-		apiFetch( {
-			global: true,
-			path: '/rest/v1.1/js-error',
-			method: 'POST',
-			data: { error: JSON.stringify( data ) },
-		} )
-			// eslint-disable-next-line no-console
-			.catch( () => console.error( 'Error: Unable to record the error in Logstash.' ) )
-	);
-};
+	window.addEventListener( 'error', reportError );
 
-window.addEventListener( 'error', reportError );
+	// We still need to report the head errors, if any.
+	Promise.allSettled( headErrors.map( reportError ) ).then( () => delete window._jsErr );
+}
 
-// Remove the head handler as it's not needed anymore after we set the main one above
+if ( shouldActivateSentry ) {
+	activateSentry();
+} else {
+	activateHomebrewErrorReporting();
+}
+
+// Remove the head handler as it's not needed anymore after we set the main one above (either Sentry or homebrew)
 window.removeEventListener( 'error', headErrorHandler );
 delete window._headJsErrorHandler;
-
-// We still need to report the head errors, if any.
-Promise.allSettled( headErrors.map( reportError ) ).then( () => delete window._jsErr );

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -41,31 +41,23 @@ function add_crossorigin_to_script_els( $tag ) {
 }
 
 /**
- * Enqueue assets
+ * Temporary function to feature flag Sentry by segment. We'll be testing
+ * it on production (simple sites) for a while to see if it's feasible to
+ * activate it for all sites and perhaps get rid of our custom solution.
+ * If it works well, we'll activate for all simple sites and look into.
+ * activating it for WoA, too.
+ *
+ * @param int $user_id the user id.
+ * @return bool
  */
-function enqueue_script() {
-	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/error-reporting.asset.php';
-	$script_dependencies = isset( $asset_file['dependencies'] ) ? $asset_file['dependencies'] : array();
-	$script_version      = isset( $asset_file['version'] ) ? $asset_file['version'] : filemtime( plugin_dir_path( __FILE__ ) . 'dist/error-reporting.js' );
+function user_in_sentry_test_segment( $user_id ) {
+	$current_segment = 1; // segment of existing users that will get this feature in %.
+	$user_segment    = $user_id % 100;
 
-	wp_enqueue_script(
-		'a8c-fse-error-reporting-script',
-		plugins_url( 'dist/error-reporting.js', __FILE__ ),
-		$script_dependencies,
-		$script_version,
-		true
-	);
-}
-
-/**
- * Effectivelly activates the error reporting module by setting the necessary hooks.
- */
-function activate_error_reporting() {
-	add_action( 'admin_print_scripts', __NAMESPACE__ . '\head_error_handler' );
-	add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_crossorigin_to_script_els', 99, 2 );
-	// We load as last as possible for perf reasons. The head handler will
-	// capture errors until the main handler is loaded.
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_script', 99 );
+	// We get the last two digits of the user id and that will be used to decide in what
+	// segment the user is. i.e if current_segment is 10, then only ids that end in < 10
+	// will be considered part of the segment.
+	return $user_segment < $current_segment;
 }
 
 /**
@@ -77,8 +69,66 @@ function is_atomic() {
 	return defined( 'IS_ATOMIC' ) && IS_ATOMIC;
 }
 
+/**
+ * Return whether Sentry should be activated for a given user.
+ *
+ * In this phase, a12s have the possibility of configuring what error reporter to choose
+ * through the sticker. a12s shouldn not be covered by the segment logic.
+ *
+ * Regular users have the error reporter chosen based on the segmentation logic, only.
+ *
+ * @param int $user_id The user id. Used to check if the user is A8C or in
+ * the Sentry test segment.
+ * @param int $blog_id The blog ID. Usually the value of `get_current_blog_id`.
+ * Used to check if the sticker is applied if user is A8C.
+ */
+function should_activate_sentry( $user_id, $blog_id ) {
+	return ( is_automattician( $user_id ) && has_blog_sticker( 'error-reporting-use-sentry', $blog_id ) )
+		|| ( ! is_automattician( $user_id ) && user_in_sentry_test_segment( $user_id ) );
+}
+
+/**
+ * Enqueue assets
+ */
+function enqueue_script() {
+	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/error-reporting.asset.php';
+	$script_dependencies = isset( $asset_file['dependencies'] ) ? $asset_file['dependencies'] : array();
+	$script_version      = isset( $asset_file['version'] ) ? $asset_file['version'] : filemtime( plugin_dir_path( __FILE__ ) . 'dist/error-reporting.js' );
+	$script_id           = 'a8c-fse-error-reporting-script';
+
+	wp_enqueue_script(
+		$script_id,
+		plugins_url( 'dist/error-reporting.js', __FILE__ ),
+		$script_dependencies,
+		$script_version,
+		true
+	);
+
+	wp_localize_script(
+		$script_id,
+		'A8C_ETK_ErrorReporting_Config',
+		array(
+			'shouldActivateSentry' => should_activate_sentry( get_current_user_id(), get_current_blog_id() ) ? 'true' : 'false',
+		)
+	);
+}
+
+/**
+ * Setup the error reporting module by setting the necessary hooks. Whether or not we get the
+ * homebrew version or Sentry is decided inside the `enqueue_script` function, stored in a bool
+ * var, and passed over to the clientside script (index.js) which will then use this value to
+ * decide what tool to activate.
+ */
+function setup_error_reporting() {
+	add_action( 'admin_print_scripts', __NAMESPACE__ . '\head_error_handler', 0 );
+	add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_crossorigin_to_script_els', 99, 2 );
+	// We load as last as possible for perf reasons. The head handler will
+	// capture errors until the main handler is loaded.
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_script', 99 );
+}
+
 // We don't want to activate this module in AT just yet. See https://wp.me/p4TIVU-9DI#comment-10922.
 // @todo Remove once we have a version that works for WPCOM simple sites and WoA.
 if ( ! is_atomic() ) {
-	activate_error_reporting();
+	setup_error_reporting();
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/bootstrap.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/bootstrap.php
@@ -61,3 +61,24 @@ remove_filter( 'wp_die_handler', 'fail_if_died' );
 
 // Don't let deprecation notices cause tests to fail.
 PHPUnit\Framework\Error\Deprecated::$enabled = false;
+
+// Global function stubs that might be needed by all tests.
+
+/**
+ * Stub for the `is_automattician` function.
+ *
+ * This function is only used by the `class-errorreporting-activation-test.php`
+ * test at the moment. It needs to be defined here because for some reason it's
+ * not loaded by default globally in the test env,and since it's when the error
+ * reporting php module is loaded, and since all modules are loaded here for
+ * each test, defining it globally here is needed in order to not break the
+ * tests due to it being undefined.
+ *
+ * Check the `class-errorreporting-activation-test.php` test to make sense
+ * of the implementation here.
+ *
+ * @param int $user_id The user id.
+ */
+function is_automattician( $user_id ) {
+	return ( 8898 === $user_id || 8808 === $user_id );
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Error Reporting Activation Test File.
+ *
+ * Unit-tests the Sentry/homebrew error reporting activation logic.
+ * This test file should be ephemeral and will be removed once we
+ * decide which solution to use.
+ *
+ * The rest of the error reporting module is easier to test manually,
+ * and harder (and probably not worth the time and effort) to write
+ * automated tests for. In fact, if we choose to use Sentry, then
+ * it'll pretty much only add a snippet (maybe with some additional
+ * conditional logic for WoA).
+ *
+ * I think this provides for a good pragmatic balance in giving
+ * us confidence. -Marcelo.
+ *
+ * @package full-site-editing-plugin
+ */
+
+namespace A8C\FSE\ErrorReporting;
+
+use PHPUnit\Framework\TestCase;
+
+// Stub for the `is_automattician` function is in `bootstrap.php`.
+// See comments there for more info.
+
+/**
+ * Stub for the has_blog_sticker function
+ *
+ * @param noop $sticker Not used.
+ * @param int  $blog_id The blog id.
+ */
+function has_blog_sticker( $sticker, $blog_id ) {
+	if ( 7731 === $blog_id ) {
+		return true;
+	}
+	if ( 7732 === $blog_id ) {
+		return false;
+	}
+}
+
+/**
+ * Class ErrorReporting_Activation_Test
+ */
+class ErrorReporting_Activation_Test extends TestCase {
+	/**
+	 * This should match the pct in `user_in_sentry_test_segment()` in
+	 * `../error-reporting/index.php`
+	 *
+	 * @var int $current_segment
+	 */
+	private $current_segment = 1;
+	/**
+	 * A dummy id that represents an a11n user. It's used in the `is_automattician`
+	 * stub defined above.
+	 *
+	 * @var int $a11n_user_id
+	 */
+	private $a11n_user_id = 8898;
+	/**
+	 * A dummy id that represents an a11n user that would fall in the segment.
+	 * It's used in the `is_automattician` stub defined above.
+	 *
+	 * @var int $a11n_user_id
+	 */
+	private $a11n_user_id_in_segment = 8808;
+	/**
+	 * A dummy id that represents a regular non-a11n user.
+	 *
+	 * @var int $a11n_user_id
+	 */
+	private $regular_user_id = 6600;
+	/**
+	 * A dummy id that represents an a11n user. It's used in the `is_automattician`
+	 * stub defined above.
+	 *
+	 * The sticker we're faking here is the `error-reporting-use-sentry`.
+	 * See: https://github.com/Automattic/wp-calypso/pull/54257.
+	 *
+	 * @var int $blog_with_sticker_id
+	 */
+	private $blog_with_sticker_id = 7731;
+
+	/**
+	 * A dummy id that represents an blog that has a sticker. It's used in the
+	 * `has_blog_sticker` defined above.
+	 *
+	 * @var int $blog_without_sticker_id
+	 */
+	private $blog_without_sticker_id = 7732;
+	/**
+	 * Represents a blog id we don't care about.Communicates that the id is not
+	 * really relevant in the given test context
+	 *
+	 * @var int $blog_noop_id
+	 */
+	private $blog_noop_id = 7733;
+
+	/**
+	 * Tests that the `should_activate_sentry` function returns `true` for an a11n
+	 * user id if the current blog has the sticker applied.
+	 */
+	public function test_should_activate_sentry_is_true_if_a11n_with_sticker() {
+		$this->assertTrue( should_activate_sentry( $this->a11n_user_id, $this->blog_with_sticker_id ) );
+	}
+
+	/**
+	 * Tests that the `should_activate_sentry` function returns `false` for an a11n
+	 * user id if the current blog does not have the sticker applied.
+	 */
+	public function test_should_activate_sentry_is_false_if_a11n_without_sticker() {
+		$this->assertFalse( should_activate_sentry( $this->a11n_user_id, $this->blog_without_sticker_id ) );
+	}
+
+	/**
+	 * Tests that the `should_activate_sentry` function returns `false` for an a11n
+	 * user that tested false for the sentry sticker but accidentally falls in the
+	 * test segment. A12s without the sticker that fall in the segment should not
+	 * have Sentry activated.
+	 */
+	public function test_should_activate_sentry_is_false_if_a11n_without_sticker_and_in_sentry_segment() {
+		$this->assertFalse( should_activate_sentry( $this->a11n_user_id_in_segment, $this->blog_without_sticker_id ) );
+	}
+
+	/**
+	 * Tests that the `should_activate_sentry` function returns `true` for the ids that fall
+	 * inside the segment.
+	 */
+	public function test_should_activate_sentry_is_true_if_regular_user_in_sentry_segment() {
+		for ( $i = $this->regular_user_id; $i < $this->regular_user_id + $this->current_segment; $i++ ) {
+			$this->assertTrue( should_activate_sentry( $i, $this->blog_noop_id ) );
+		}
+	}
+	/**
+	 * Tests that the `should_activate_sentry` function returns `false` for the ids that fall outside
+	 * the test segment.
+	 */
+	public function test_should_activate_sentry_is_false_if_regular_user_outside_sentry_segment() {
+		for ( $i = $this->regular_user_id + $this->current_segment; $i <= $this->regular_user_id + 99; $i++ ) {
+			$this->assertFalse( should_activate_sentry( $i, $this->blog_noop_id ) );
+		}
+	}
+}

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -66,6 +66,8 @@
 		"@babel/core": "^7.16.5",
 		"@emotion/react": "^11.4.1",
 		"@popperjs/core": "^2.10.2",
+		"@sentry/browser": "^6.16.1",
+		"@sentry/tracing": "^6.16.1",
 		"@wordpress/a11y": "^3.2.4",
 		"@wordpress/api-fetch": "^5.2.6",
 		"@wordpress/base-styles": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,6 +1405,8 @@ __metadata:
     "@babel/core": ^7.16.5
     "@emotion/react": ^11.4.1
     "@popperjs/core": ^2.10.2
+    "@sentry/browser": ^6.16.1
+    "@sentry/tracing": ^6.16.1
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
     "@types/node": ^15.0.2
@@ -4899,6 +4901,83 @@ __metadata:
     lodash.merge: ^4.4.0
     postcss: ^5.0.21
   checksum: 6d7891d5c46060e0735f0d09ebddd7c3228834f0c8150795d7c4c6a64c0c205009cfa06b1db04e234fe143054078157ba459abd5f26206b37ea470565fd60fec
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:^6.16.1":
+  version: 6.16.1
+  resolution: "@sentry/browser@npm:6.16.1"
+  dependencies:
+    "@sentry/core": 6.16.1
+    "@sentry/types": 6.16.1
+    "@sentry/utils": 6.16.1
+    tslib: ^1.9.3
+  checksum: 108166ffbd89a5457622fbde8e805626f57c9b697926e180eb9ef3924a3a79781f90161276c8ca9c4e6b184a86f52ce335ef5cd600b11098748ab1ef6529434a
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:6.16.1":
+  version: 6.16.1
+  resolution: "@sentry/core@npm:6.16.1"
+  dependencies:
+    "@sentry/hub": 6.16.1
+    "@sentry/minimal": 6.16.1
+    "@sentry/types": 6.16.1
+    "@sentry/utils": 6.16.1
+    tslib: ^1.9.3
+  checksum: 7ef965c3258c1140a4571160e37b28c66c31be57fa13fe7fe14cfa92c43259c156cd98d2a69fdf587a9a9ac52b72fa370fc57c81ff0de11fc3c96737ca8d9990
+  languageName: node
+  linkType: hard
+
+"@sentry/hub@npm:6.16.1":
+  version: 6.16.1
+  resolution: "@sentry/hub@npm:6.16.1"
+  dependencies:
+    "@sentry/types": 6.16.1
+    "@sentry/utils": 6.16.1
+    tslib: ^1.9.3
+  checksum: afc6bc4c0b94813d1af49727fcf64273cacd6f4b663930ef695bcff164d211ab8cd7e20eb077f2a6b9837a5430d2c9ac6e78d9094aa88b86e352facf7883a159
+  languageName: node
+  linkType: hard
+
+"@sentry/minimal@npm:6.16.1":
+  version: 6.16.1
+  resolution: "@sentry/minimal@npm:6.16.1"
+  dependencies:
+    "@sentry/hub": 6.16.1
+    "@sentry/types": 6.16.1
+    tslib: ^1.9.3
+  checksum: e5a3a561fc77cfe23ca6b61e4bbe70afe6efc8bd5679ccc152c7928ca21d2a36ec50bee5c5b1dae123a9c239a6aae8ade8273a6410a2e4d280d795ee76430b9c
+  languageName: node
+  linkType: hard
+
+"@sentry/tracing@npm:^6.16.1":
+  version: 6.16.1
+  resolution: "@sentry/tracing@npm:6.16.1"
+  dependencies:
+    "@sentry/hub": 6.16.1
+    "@sentry/minimal": 6.16.1
+    "@sentry/types": 6.16.1
+    "@sentry/utils": 6.16.1
+    tslib: ^1.9.3
+  checksum: 840cde58fd31fad1853edcb98c394aa1bedc87ff35e5130d58fa5aa049be898d907d1aacf1fc4ff165b5c7ec56b57b5cc96d7992b2815b2ea199fd278cebad35
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:6.16.1":
+  version: 6.16.1
+  resolution: "@sentry/types@npm:6.16.1"
+  checksum: 0df3b6ee70ee504b74dfa8e8dc19007c9504a570966690b5db924f551b8437d1c034a25d4ecccfcebd811bf59e19ed255b694ac565868d3d35db86778213685f
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:6.16.1":
+  version: 6.16.1
+  resolution: "@sentry/utils@npm:6.16.1"
+  dependencies:
+    "@sentry/types": 6.16.1
+    tslib: ^1.9.3
+  checksum: 252572187c8386ef4119ac58ecf9109a899e208c7a95766a7546c11d4abc17bd83d7d65a806f0f7f7e21e613903beb55d8972f21918f65083fee40ecb3996049
   languageName: node
   linkType: hard
 
@@ -35835,6 +35914,13 @@ testarmada-magellan@11.0.10:
   version: 1.11.2
   resolution: "tslib@npm:1.11.2"
   checksum: 19c6407249e67107eef12c0ab0a9786a08d1c5db50919ac3496e975990a4e2f4d5338242fc6130f236639942efc16d5b98d8264629c1b387432cc938d092e171
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^1.9.3":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: 69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -35910,14 +35910,14 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"tslib@npm:1.11.2, tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0":
+"tslib@npm:1.11.2":
   version: 1.11.2
   resolution: "tslib@npm:1.11.2"
   checksum: 19c6407249e67107eef12c0ab0a9786a08d1c5db50919ac3496e975990a4e2f4d5338242fc6130f236639942efc16d5b98d8264629c1b387432cc938d092e171
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.9.3":
+"tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/54951. Now that the DPA is in place, we can proceed with the Sentry experiment in WPCOM. More details about the experiment and why it was reverted in the following P2: p4TIVU-9LC-p2. The DPA signing has been announced here: p9qBZ1-1j0-p2#comment-12987.

#### Changes proposed in this Pull Request

* Reverts the Sentry revert, reactivating it for 1% of WPCOM simple site users.

#### Testing instructions

Follow the testing instructions in the original PR: https://github.com/Automattic/wp-calypso/pull/54257.

Related to https://github.com/Automattic/wp-calypso/pull/54257 and https://github.com/Automattic/wp-calypso/pull/54951.

cc @Automattic/team-calypso 