### PR TITLE
Domains: Show IPS tag component when transferring .uk domains out

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -133,7 +133,7 @@ class SelectIpsTag extends Component {
 	}
 
 	renderIpsTagSelect() {
-		const { saveStatus, selectedDomainName, translate } = this.props;
+		const { redesign, saveStatus, selectedDomainName, translate } = this.props;
 
 		return (
 			<div>
@@ -159,7 +159,11 @@ class SelectIpsTag extends Component {
 					suggestions={ this.getSuggestions() }
 					suggest={ this.handleSuggestionClick }
 				/>
-				<FormButton onClick={ this.popOverDialog } disabled={ 'saving' === saveStatus }>
+				<FormButton
+					onClick={ this.popOverDialog }
+					disabled={ 'saving' === saveStatus }
+					isPrimary={ ! redesign }
+				>
 					{ translate( 'Submit' ) }
 				</FormButton>
 
@@ -211,23 +215,29 @@ class SelectIpsTag extends Component {
 	}
 
 	render() {
-		const { translate, saveStatus } = this.props;
+		const { translate, saveStatus, redesign } = this.props;
+
+		const content = (
+			<>
+				<p>
+					{ translate(
+						"{{strong}}.uk{{/strong}} domains are transferred by setting the domain's IPS tag here to the " +
+							'value provided by the new registrar and then contacting the {{em}}new registrar{{/em}} to ' +
+							'complete the transfer.',
+						{ components: { strong: <strong />, em: <em /> } }
+					) }
+				</p>
+				{ 'success' === saveStatus ? this.renderGoToGainingRegistrar() : this.renderIpsTagSelect() }
+			</>
+		);
+
+		if ( redesign ) {
+			return content;
+		}
 
 		return (
 			<div>
-				<Card>
-					<p>
-						{ translate(
-							"{{strong}}.uk{{/strong}} domains are transferred by setting the domain's IPS tag here to the " +
-								'value provided by the new registrar and then contacting the {{em}}new registrar{{/em}} to ' +
-								'complete the transfer.',
-							{ components: { strong: <strong />, em: <em /> } }
-						) }
-					</p>
-					{ 'success' === saveStatus
-						? this.renderGoToGainingRegistrar()
-						: this.renderIpsTagSelect() }
-				</Card>
+				<Card>{ content }</Card>
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -15,10 +15,11 @@ import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
-import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
+import { getSelectedDomain, getTopLevelOfTld, isMappedDomain } from 'calypso/lib/domains';
 import { DESIGNATED_AGENT, TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
 import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
+import SelectIpsTag from 'calypso/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag';
 import {
 	domainManagementEdit,
 	domainManagementList,
@@ -261,19 +262,33 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 		return __( 'This domain cannot be locked.' );
 	};
 
-	const renderAdvancedTransferOptions = () => {
-		if ( isMapping ) {
-			return null;
-		}
+	const renderUkTransferOptions = () => {
+		return <SelectIpsTag selectedDomainName={ selectedDomainName } redesign />;
+	};
 
+	const renderCommonTldTransferOptions = () => {
 		return (
-			<Card className="transfer-page__advanced-transfer-options">
-				<CardHeading size={ 16 }>Advanced Options</CardHeading>
+			<>
 				<p>{ renderTransferMessage() }</p>
 				{ renderTransferLock() }
 				<Button primary={ false } busy={ isRequestingTransferCode } onClick={ requestTransferCode }>
 					{ __( 'Get authorization code' ) }
 				</Button>
+			</>
+		);
+	};
+
+	const renderAdvancedTransferOptions = () => {
+		if ( isMapping ) {
+			return null;
+		}
+
+		const topLevelOfTld = getTopLevelOfTld( selectedDomainName );
+
+		return (
+			<Card className="transfer-page__advanced-transfer-options">
+				<CardHeading size={ 16 }>{ __( 'Advanced Options' ) }</CardHeading>
+				{ topLevelOfTld !== 'uk' ? renderCommonTldTransferOptions() : renderUkTransferOptions() }
 			</Card>
 		);
 	};

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -119,6 +119,10 @@
 		.card-heading {
 			margin: 0;
 		}
+
+		.search-card {
+			padding: 0;
+		}
 	}
 
 	.transfer-page__transfer-lock-placeholder {


### PR DESCRIPTION
### Changes proposed in this Pull Request

When redesigning the domain transfer components, we overlooked the IPS tag functionality to transfer *.uk domains out. See issue p2MSmN-8TR-p2. This PR updates the new transfer page component to show the IPS search component in place of the `Get authorization code` button for .uk domains.

#### Screenshots

- New transfer page for a .uk domain:

![Markup on 2021-12-22 at 20:27:47](https://user-images.githubusercontent.com/5324818/147166207-4fc29026-2a10-472e-a0eb-563862b2abe1.png)

- Old transfer page for a .uk domain:

<img width="748" alt="Screen Shot 2021-12-22 at 20 16 35" src="https://user-images.githubusercontent.com/5324818/147166217-55cf66d0-a28c-4b2a-a575-c8db7e78e4b5.png">

### Testing instructions

- Open the live Calypso link or build this branch locally
- Go to Upgrades > Domains
- Select a registered *.uk domain
- Open the transfer options
- Ensure the IPS tag search card is shown instead of the regular "Transfer lock" and "Get authorization code" card
