### PR TITLE
Fix/swipeable vertical scroll

### DIFF
--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -126,6 +126,12 @@ export const Swipeable = ( {
 
 			const verticalDelta = dragPosition.y - dragStartData.y;
 			if ( Math.abs( verticalDelta ) > absoluteDelta ) {
+				delete pagesStyle.transform;
+				setPagesStyle( {
+					...pagesStyle,
+					transitionDuration: TRANSITION_DURATION,
+				} );
+				setDragStartData( null );
 				return;
 			}
 

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -124,6 +124,11 @@ export const Swipeable = ( {
 			const absoluteDelta = Math.abs( delta );
 			const velocity = absoluteDelta / ( dragPosition.timeStamp - dragStartData.timeStamp );
 
+			const verticalDelta = dragPosition.y - dragStartData.y;
+			if ( Math.abs( verticalDelta ) > Math.abs( delta ) ) {
+				return;
+			}
+
 			const hasMetThreshold =
 				absoluteDelta > OFFSET_THRESHOLD_PERCENTAGE * containerWidth ||
 				velocity > VELOCITY_THRESHOLD;

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -172,7 +172,12 @@ export const Swipeable = ( {
 
 			const dragPosition = getDragPositionAndTime( event );
 			const delta = dragPosition.x - dragStartData.x;
+			const absoluteDelta = Math.abs( delta );
 			const offset = getOffset( currentPage ) + delta;
+
+			if ( absoluteDelta > 3 ) {
+				return;
+			}
 
 			// Allow for swipe left or right
 			if (

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -183,6 +183,8 @@ export const Swipeable = ( {
 			const absoluteDelta = Math.abs( delta );
 			const offset = getOffset( currentPage ) + delta;
 
+			// The user needs to swipe horizontally more then 2 px in order for the canvase to be dragging.
+			// We do this so that the user can scroll vertically smother.
 			if ( absoluteDelta < 3 ) {
 				return;
 			}

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -175,7 +175,7 @@ export const Swipeable = ( {
 			const absoluteDelta = Math.abs( delta );
 			const offset = getOffset( currentPage ) + delta;
 
-			if ( absoluteDelta > 3 ) {
+			if ( absoluteDelta < 3 ) {
 				return;
 			}
 

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -125,7 +125,9 @@ export const Swipeable = ( {
 			const velocity = absoluteDelta / ( dragPosition.timeStamp - dragStartData.timeStamp );
 
 			const verticalDelta = dragPosition.y - dragStartData.y;
-			if ( Math.abs( verticalDelta ) > absoluteDelta ) {
+			const isVerticalScrollDetected =
+				Math.abs( verticalDelta ) > absoluteDelta || dragPosition.x === 0;
+			if ( isVerticalScrollDetected ) {
 				delete pagesStyle.transform;
 				setPagesStyle( {
 					...pagesStyle,

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -125,7 +125,7 @@ export const Swipeable = ( {
 			const velocity = absoluteDelta / ( dragPosition.timeStamp - dragStartData.timeStamp );
 
 			const verticalDelta = dragPosition.y - dragStartData.y;
-			if ( Math.abs( verticalDelta ) > Math.abs( delta ) ) {
+			if ( Math.abs( verticalDelta ) > absoluteDelta ) {
 				return;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the swipeable component so that it responds less to vertical swiping. 
Currently, when you swipe vertically you can trigger a page change action that is not intended. 
THis Pr fixes this by making sure that we only move the next page when we swipe more horizontally than virtically. 
We also check that we swiped more then 3px before we start the move the things horizontally. 

Before:

https://user-images.githubusercontent.com/115071/147169264-59f71f4c-7048-4ec6-a0b0-b1ff90161f71.mp4


After:

https://user-images.githubusercontent.com/115071/147169271-54821ecb-1659-44b1-bab5-0a925985f7a8.mp4

#### Testing instructions

* Load up this PR 
* Does the swiping on the home page (/home ) work as expected across different browsers and different view sizes. 

