### PR TITLE
Domains: Fix name servers toggle intermittently not working

### DIFF
--- a/client/data/domains/nameservers/use-domain-nameservers-query.js
+++ b/client/data/domains/nameservers/use-domain-nameservers-query.js
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query';
 import wp from 'calypso/lib/wp';
 
-const useDomainNameserversQuery = ( domainName, enabled ) =>
+const useDomainNameserversQuery = ( domainName ) =>
 	useQuery(
 		[ 'domain-nameservers', domainName ],
 		() => wp.req.get( `/domains/${ domainName }/nameservers/` ),
-		{ enabled, refetchOnWindowFocus: false }
+		{ refetchOnWindowFocus: false }
 	);
 
 export default useDomainNameserversQuery;

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -310,7 +310,7 @@ class NameServers extends Component {
 			return false;
 		}
 
-		return getSelectedDomain( this.props ).isPendingIcannVerification;
+		return getSelectedDomain( this.props )?.isPendingIcannVerification;
 	}
 
 	handleChange = ( nameservers ) => {

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -359,6 +359,12 @@ const customNameServersLearnMoreClick = ( domainName ) =>
 		)
 	);
 
-export default connect( ( state ) => ( { currentRoute: getCurrentRoute( state ) } ), {
-	customNameServersLearnMoreClick,
-} )( localize( withDomainNameservers( NameServers ) ) );
+export default connect(
+	( state, props ) => ( {
+		currentRoute: getCurrentRoute( state ),
+		domain: getSelectedDomain( props ),
+	} ),
+	{
+		customNameServersLearnMoreClick,
+	}
+)( localize( withDomainNameservers( NameServers ) ) );

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -360,9 +360,8 @@ const customNameServersLearnMoreClick = ( domainName ) =>
 	);
 
 export default connect(
-	( state, props ) => ( {
+	( state ) => ( {
 		currentRoute: getCurrentRoute( state ),
-		domain: getSelectedDomain( props ),
 	} ),
 	{
 		customNameServersLearnMoreClick,

--- a/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
+++ b/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import useDomainNameserversQuery from 'calypso/data/domains/nameservers/use-domain-nameservers-query';
 import useUpdateNameserversMutation from 'calypso/data/domains/nameservers/use-update-nameservers-mutation';
-import { type as domainTypes } from 'calypso/lib/domains/constants';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 const noticeOptions = {
@@ -14,13 +13,10 @@ const noticeOptions = {
 
 const withDomainNameservers = createHigherOrderComponent( ( Wrapped ) => {
 	const WithDomainNameservers = ( props ) => {
-		const { domain, selectedDomainName } = props;
+		const { selectedDomainName } = props;
 		const dispatch = useDispatch();
 		const translate = useTranslate();
-		const { data, isLoading, isError, error } = useDomainNameserversQuery(
-			selectedDomainName,
-			domain.type === domainTypes.REGISTERED // Only registered domains can have their name servers updated
-		);
+		const { data, isLoading, isError, error } = useDomainNameserversQuery( selectedDomainName );
 		const { updateNameservers } = useUpdateNameserversMutation( selectedDomainName, {
 			onSuccess() {
 				dispatch(

--- a/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
+++ b/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
@@ -19,7 +19,7 @@ const withDomainNameservers = createHigherOrderComponent( ( Wrapped ) => {
 		const translate = useTranslate();
 		const { data, isLoading, isError, error } = useDomainNameserversQuery(
 			selectedDomainName,
-			domain?.type === domainTypes.REGISTERED // Only registered domains can have their name servers updated
+			domain.type === domainTypes.REGISTERED // Only registered domains can have their name servers updated
 		);
 		const { updateNameservers } = useUpdateNameserversMutation( selectedDomainName, {
 			onSuccess() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

#59430 added a small modification to `useDomainNameserversQuery`, which is used in the `withDomainNameservers` HOC: a domain type verification was added so that the query was only made for registered domains. However, the original `NameServers` component did not have a `domain` property set 🤦 causing the name servers toggle to not work correctly when a domain was not already loaded.

This PR fixes this problem by removing the condition to only do the query for registered domains - we'll come back to that at a later time.

### Testing instructions

- Go to the name servers settings page for a custom domain
- Open your developer console, clear all site data (`Application > Storage > Clear site data` in Chrome)
- Reload the page and ensure the name servers toggle works normally
