### PR TITLE
Video UI: Add useCourseData hook to share the logic of the computed data

### DIFF
--- a/client/data/courses/index.ts
+++ b/client/data/courses/index.ts
@@ -1,3 +1,4 @@
 export { COURSE_SLUGS } from './constants';
+export { default as useCourseData } from './use-course-data';
 export { default as useCourseQuery } from './use-course-query';
 export { default as useUpdateUserCourseProgressionMutation } from './use-update-user-course-progression-mutation';

--- a/client/data/courses/use-course-data.ts
+++ b/client/data/courses/use-course-data.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import useCourseQuery from './use-course-query';
+import type { Course, VideoSlug } from './types';
+
+interface Result {
+	course?: Course;
+	videoSlugs: VideoSlug[];
+	completedVideoSlugs: VideoSlug[];
+	isCourseComplete: boolean;
+}
+
+const useCourseData = ( courseSlug: string ): Result => {
+	const { data } = useCourseQuery( courseSlug );
+
+	const videoSlugs = useMemo( () => ( data?.videos ? Object.keys( data.videos ) : [] ), [
+		data?.videos,
+	] );
+
+	const completedVideoSlugs = useMemo( () => {
+		if ( ! data?.completions ) {
+			return [];
+		}
+
+		return Object.keys( data.completions ).filter(
+			( videoSlug ) => !! data.completions[ videoSlug ]
+		);
+	}, [ data?.completions ] );
+
+	const isCourseComplete = useMemo(
+		() => completedVideoSlugs.length > 0 && completedVideoSlugs.length === videoSlugs.length,
+		[ videoSlugs.length, completedVideoSlugs.length ]
+	);
+
+	return {
+		course: data,
+		videoSlugs,
+		completedVideoSlugs,
+		isCourseComplete,
+	};
+};
+
+export default useCourseData;

--- a/client/data/courses/use-course-query.js
+++ b/client/data/courses/use-course-query.js
@@ -5,7 +5,16 @@ const useCourseQuery = ( courseSlug, queryOptions = {} ) => {
 	return useQuery(
 		[ 'courses', courseSlug ],
 		() => wpcom.req.get( '/courses', { course_slug: courseSlug, apiNamespace: 'wpcom/v2' } ),
-		queryOptions
+		{
+			// Our course offering doesn't change that often, we don't need to
+			// re-fetch until the next page refresh.
+			staleTime: Infinity,
+			...queryOptions,
+			meta: {
+				persist: false,
+				...queryOptions.meta,
+			},
+		}
 	);
 };
 

--- a/client/data/courses/use-update-user-course-progression-mutation.js
+++ b/client/data/courses/use-update-user-course-progression-mutation.js
@@ -18,9 +18,9 @@ function useUpdateUserCourseProgressionMutation( queryOptions = {} ) {
 			),
 		{
 			...queryOptions,
-			onSuccess( ...args ) {
-				queryClient.invalidateQueries( [ 'course-progression', args.courseSlug ] );
-				queryOptions.onSuccess?.( ...args );
+			onSuccess( data, variables, context ) {
+				queryClient.invalidateQueries( [ 'courses', variables.courseSlug ] );
+				queryOptions.onSuccess?.( data, variables, context );
 			},
 		}
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As we want to integrate the video course with the Hero Flow, we want to re-use the logic of the computed data to avoid duplication. Thus, make `useCourseData` hook to share the data of `course`, `isCourseComplete`, `videoSlugs` and `completedVideoSlugs`.
* The reason why we cannot use the header/footer provided by video UI is that the signup framework has its own navigation bar and the functionality of the back, skip or continue (for draft your post) is behind that, so it's not easy to move those actions out of the framework. Therefore, we need the `isCourseComplete` to control the some behavior.

**Signup Framework Navigation Bar**

<img width="1300" alt="Screen Shot 2021-12-23 at 10 59 38 AM" src="https://user-images.githubusercontent.com/13596067/147181714-1c63f8c7-6ea8-4f10-95a7-bf8cc725ce97.png">

<img width="375" alt="Screen Shot 2021-12-23 at 11 00 22 AM" src="https://user-images.githubusercontent.com/13596067/147181763-14e406ba-2c15-4892-ae47-b85e9c055e84.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the calypso.live link on the comments of this PR.
* Click the Start Learning link on the Blog Like an Expert card
  <img width="600" src="https://user-images.githubusercontent.com/13596067/147180827-174b1b00-d21a-48ae-ac5e-08a05d74bdb1.png" />
* Verify the Videos UI works as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/58234
