### PR TITLE
Editor: Keep showing placeholder until the editor is loaded

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -976,6 +976,8 @@ async function handleEditorLoaded( calypsoPort ) {
 				blockCount: blocks.length,
 			},
 		} );
+
+		calypsoPort.postMessage( { action: 'editorLoaded' } );
 	} );
 
 	preselectParentPage();
@@ -1194,5 +1196,11 @@ $( () => {
 	window.addEventListener( 'message', initPort, false );
 
 	//signal module loaded
-	sendMessage( { action: 'loaded' } );
+	sendMessage( {
+		action: 'loaded',
+		payload: {
+			// Notify `EditorLoaded` action is supported
+			isSupportEditorLoaded: true,
+		},
+	} );
 } );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -51,6 +51,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import * as T from 'calypso/types';
 import { sendSiteEditorBetaFeedback } from '../../lib/fse-beta/send-site-editor-beta-feedback';
 import Iframe from './iframe';
+import Main from './main';
 import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
 import { Placeholder } from './placeholder';
 import type { RequestCart } from '@automattic/shopping-cart';
@@ -717,8 +718,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 					properties={ this.getStatsProps() }
 				/>
 				<EditorDocumentHead />
-				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-				<div className="main main-column calypsoify is-iframe" role="main">
+				<Main>
 					{ ! isFullyLoaded && <Placeholder /> }
 					{ ( shouldLoadIframe || isIframeLoaded ) && (
 						<Iframe
@@ -741,7 +741,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 							style={ isFullyLoaded && isEditorLoaded ? undefined : { opacity: 0 } }
 						/>
 					) }
-				</div>
+				</Main>
 				<AsyncLoad
 					require="calypso/post-editor/editor-media-modal"
 					placeholder={ null }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -85,6 +85,7 @@ interface State {
 	classicBlockEditorId?: any;
 	gallery?: any;
 	isIframeLoaded: boolean;
+	isEditorLoaded: boolean;
 	currentIFrameUrl: string;
 	isMediaModalVisible: boolean;
 	isCheckoutModalVisible: boolean;
@@ -120,6 +121,7 @@ enum EditorActions {
 	GetCalypsoUrlInfo = 'getCalypsoUrlInfo',
 	TrackPerformance = 'trackPerformance',
 	SendSiteEditorBetaFeedback = 'sendSiteEditorBetaFeedback',
+	EditorLoaded = 'editorLoaded',
 }
 
 type ComponentProps = Props &
@@ -133,6 +135,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		isMediaModalVisible: false,
 		isCheckoutModalVisible: false,
 		isIframeLoaded: false,
+		isEditorLoaded: false,
 		currentIFrameUrl: '',
 		checkoutModalOptions: undefined,
 	};
@@ -236,7 +239,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			return;
 		}
 
-		const { action } = data;
+		const { action, payload } = data;
 
 		if (
 			WindowActions.Loaded === action &&
@@ -265,6 +268,11 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 
 			window.performance?.mark?.( 'iframe_loaded' );
 			this.setState( { isIframeLoaded: true, currentIFrameUrl: this.props.iframeUrl } );
+
+			// Set the isEditorLoaded to true directly if current version doesn't support `EditorLoaded` action.
+			if ( ! payload?.isSupportEditorLoaded ) {
+				this.setState( { isEditorLoaded: true } );
+			}
 
 			return;
 		}
@@ -491,6 +499,10 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 				() => ports[ 0 ].postMessage( 'error' )
 			);
 		}
+
+		if ( EditorActions.EditorLoaded === action ) {
+			this.setState( { isEditorLoaded: true } );
+		}
 	};
 
 	handlePostStatusChange = ( status: string ) => {
@@ -687,6 +699,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			allowedTypes,
 			multiple,
 			isIframeLoaded,
+			isEditorLoaded,
 			currentIFrameUrl,
 			checkoutModalOptions,
 		} = this.state;
@@ -694,6 +707,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		const isUsingClassicBlock = !! classicBlockEditorId;
 		const isCheckoutOverlayEnabled = config.isEnabled( 'post-editor/checkout-overlay' );
 		const { redirectTo, isFocusedLaunch, ...cartData } = checkoutModalOptions || {};
+		const isFullyLoaded = isIframeLoaded && isEditorLoaded;
 
 		return (
 			<Fragment>
@@ -705,7 +719,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 				<EditorDocumentHead />
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="main main-column calypsoify is-iframe" role="main">
-					{ ! isIframeLoaded && <Placeholder /> }
+					{ ! isFullyLoaded && <Placeholder /> }
 					{ ( shouldLoadIframe || isIframeLoaded ) && (
 						<Iframe
 							className={ isIframeLoaded ? 'is-loaded' : '' }
@@ -724,7 +738,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 							// before the user is the redirected to wp-admin.
 							// This styling hides the iframe until it loads or
 							// the redirect is executed.
-							style={ isIframeLoaded ? undefined : { opacity: 0 } }
+							style={ isFullyLoaded && isEditorLoaded ? undefined : { opacity: 0 } }
 						/>
 					) }
 				</div>

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -1,0 +1,10 @@
+import './style.scss';
+
+const Main = ( { children } ) => (
+	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+	<div className="main main-column calypsoify is-iframe" role="main">
+		{ children }
+	</div>
+);
+
+export default Main;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The white screen shows when
  * Waiting for the API response as we use `await Promise.all( checkPromises )` and it might take 1s to request the selected editor.
  * The iframe is loaded but the editor is not loaded.

For the first one, I make a change to render the placeholder while waiting for the response.

For the second one, I introduce the `EditorLoaded` event so that we can keep showing until the editor is loaded. However, if the `wpcom-editor-plugin` is not up to date, the calypso iframe won't receive that event. Thus, I also introduce another variable `isSupportEditorLoaded` to detect `EditorLoaded` action is supported to ensure the state will resolve to true.

**Post Editor**

| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/13596067/147231712-f7a91e68-3b68-416b-92ab-5444ad96fb70.mov" /> | <video src="https://user-images.githubusercontent.com/13596067/147231727-b25383da-e0a6-4545-8ac3-227c154cf505.mov" /> |

**Site Editor**

| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/13596067/147231751-d4b5f391-5444-4838-9964-6a19589ca3b0.mov" /> | <video src="https://user-images.githubusercontent.com/13596067/147231764-03fce19b-c0c9-4292-a413-a7e7b4645045.mov" /> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to site/page/post editor
* Ensure that the blank screen won't show after the loading placeholder disappears

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


