### PR TITLE
i18n: Use getters for translatable header titles on Signup steps screens

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -83,7 +83,9 @@ export function generateSteps( {
 			providesDependencies: [ 'themeSlugWithRepo', 'useThemeHeadstart' ],
 			apiRequestFunction: setThemeOnSite,
 			props: {
-				headerText: i18n.translate( 'Choose a theme for your new site.' ),
+				get headerText() {
+					return i18n.translate( 'Choose a theme for your new site.' );
+				},
 			},
 		},
 
@@ -98,8 +100,12 @@ export function generateSteps( {
 				showExampleSuggestions: false,
 				includeWordPressDotCom: false,
 				showSkipButton: true,
-				headerText: i18n.translate( 'Getting ready to launch, pick a domain' ),
-				subHeaderText: i18n.translate( 'Select a domain name for your website' ),
+				get headerText() {
+					return i18n.translate( 'Getting ready to launch, pick a domain' );
+				},
+				get subHeaderText() {
+					return i18n.translate( 'Select a domain name for your website' );
+				},
 			},
 			dependencies: [ 'siteSlug' ],
 		},
@@ -276,8 +282,12 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem' ],
 			props: {
-				headerText: i18n.translate( 'Getting ready to launch your website' ),
-				subHeaderText: i18n.translate( "Pick a plan that's right for you. Upgrade as you grow." ),
+				get headerText() {
+					return i18n.translate( 'Getting ready to launch your website' );
+				},
+				get subHeaderText() {
+					return i18n.translate( "Pick a plan that's right for you. Upgrade as you grow." );
+				},
 				isLaunchPage: true,
 			},
 		},
@@ -366,8 +376,12 @@ export function generateSteps( {
 			apiRequestFunction: createAccount,
 			providesToken: true,
 			props: {
-				headerText: i18n.translate( 'Create an account for Jetpack' ),
-				subHeaderText: i18n.translate( "You're moments away from connecting Jetpack." ),
+				get headerText() {
+					return i18n.translate( 'Create an account for Jetpack' );
+				},
+				get subHeaderText() {
+					return i18n.translate( "You're moments away from connecting Jetpack." );
+				},
 			},
 			providesDependencies: [ 'bearer_token', 'username' ],
 		},
@@ -428,10 +442,14 @@ export function generateSteps( {
 		'site-or-domain': {
 			stepName: 'site-or-domain',
 			props: {
-				headerText: i18n.translate( 'Choose how you want to use your domain.' ),
-				subHeaderText: i18n.translate(
-					"Don't worry you can easily add a site later if you're not ready."
-				),
+				get headerText() {
+					return i18n.translate( 'Choose how you want to use your domain.' );
+				},
+				get subHeaderText() {
+					return i18n.translate(
+						"Don't worry you can easily add a site later if you're not ready."
+					);
+				},
 			},
 			providesDependencies: [
 				'designType',
@@ -446,7 +464,9 @@ export function generateSteps( {
 			stepName: 'site-picker',
 			apiRequestFunction: createSiteOrDomain,
 			props: {
-				headerText: i18n.translate( 'Choose your site?' ),
+				get headerText() {
+					return i18n.translate( 'Choose your site?' );
+				},
 			},
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo' ],
 			dependencies: [ 'cartItem', 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo' ],
@@ -765,10 +785,14 @@ export function generateSteps( {
 		confirm: {
 			stepName: 'confirm',
 			props: {
-				headerTitle: i18n.translate( 'One final step' ),
-				headerDescription: i18n.translate(
-					'We’ve highlighted a few important details you should review before we create your store. '
-				),
+				get headerTitle() {
+					return i18n.translate( 'One final step' );
+				},
+				get headerDescription() {
+					return i18n.translate(
+						'We’ve highlighted a few important details you should review before we create your store. '
+					);
+				},
 			},
 			dependencies: [ 'site' ],
 			providesDependencies: [ 'siteConfirmed' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the current implementation the translate calls, that are used to define the translatable header titles on the signup steps screens, are only being fired once when the module is being loaded. Since translations are being loaded asynchronously, it's very like that they are still not loaded during the module initialization, and therefore the translate calls are resolved with the original English string.

* Use getters signup steps definitions for header props that use translate calls.

**Before:**
![CleanShot 2021-12-23 at 14 19 20](https://user-images.githubusercontent.com/2722412/147239727-1e22d513-5925-4975-bbb8-4a2c04fccb34.png)

**After:**
![CleanShot 2021-12-23 at 14 19 34](https://user-images.githubusercontent.com/2722412/147239741-70cc7f85-510e-40d7-99d3-7c7434ab4a08.png)


#### Testing instructions

1. Change Calypso UI to Mag-16 language.
2. Go to `/start/domain/domain-only`.
3. Enter a domain name in the search input and select any of the domain options.
4. Confirm the title and the sub title on the next screen are rendering translated.

Related to pcNC1U-41-p2#comment-82
