### PR TITLE
Woo installer: check whether the site requires a plan before auto transferring

### DIFF
--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -61,16 +61,16 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		isTransferringBlocked,
 		isDataReady,
 		warnings,
-		isReadyForTransfer,
+		isReadyToStart,
 	} = useWooCommerceOnPlansEligibility( siteId );
 
 	useEffect( () => {
 		// Automatically start the transfer process when it's ready.
-		if ( siteId && isDataReady && isReadyForTransfer ) {
+		if ( isReadyToStart ) {
 			dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
 			goToStep( 'transfer' );
 		}
-	}, [ dispatch, goToStep, siteId, isDataReady, isReadyForTransfer ] );
+	}, [ dispatch, goToStep, siteId, isDataReady, isReadyToStart ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {
@@ -144,7 +144,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		);
 	}
 
-	if ( ! siteId || ! isDataReady || isReadyForTransfer ) {
+	if ( ! siteId || ! isDataReady || isReadyToStart ) {
 		return (
 			<div className="confirm__info-section">
 				<LoadingEllipsis />

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -61,17 +61,16 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		isTransferringBlocked,
 		isDataReady,
 		warnings,
-		isAtomicSite,
 		isReadyForTransfer,
 	} = useWooCommerceOnPlansEligibility( siteId );
 
 	useEffect( () => {
 		// Automatically start the transfer process when it's ready.
-		if ( siteId && isDataReady && ( isAtomicSite || isReadyForTransfer ) ) {
+		if ( siteId && isDataReady && isReadyForTransfer ) {
 			dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
 			goToStep( 'transfer' );
 		}
-	}, [ dispatch, goToStep, siteId, isDataReady, isAtomicSite, isReadyForTransfer ] );
+	}, [ dispatch, goToStep, siteId, isDataReady, isReadyForTransfer ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {
@@ -145,7 +144,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		);
 	}
 
-	if ( ! siteId || ! isDataReady || isAtomicSite || isReadyForTransfer ) {
+	if ( ! siteId || ! isDataReady || isReadyForTransfer ) {
 		return (
 			<div className="confirm__info-section">
 				<LoadingEllipsis />

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
@@ -41,6 +41,6 @@ The hook returns an object with the following properties:
 
 ### siteUpgrading
 
-### isReadyForTransfer
+### isReadyToStart
 
 ### isDataReady

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -16,7 +16,7 @@ import { requestProductsList } from 'calypso/state/products-list/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isAtomicSiteSelector from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 
 const TRANSFERRING_NOT_BLOCKERS = [
@@ -156,10 +156,12 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	const productName = upgradingPlan.product_name;
 
 	// Define whether the site is ready to be transferred.
+	const isAtomicSite = !! useSelector( ( state ) => isAtomicSiteSelector( state, siteId ) );
 	const isReadyForTransfer = transferringDataIsAvailable
 		? ! isTransferringBlocked && // there is not blocker from eligibility (holds).
 		  ! ( eligibilityWarnings && eligibilityWarnings.length ) && // there is not warnings from eligibility (warnings).
-		  ! requiresUpgrade // the site does not require an upgrade, based on store `woop` feature.
+		  ! requiresUpgrade && // the site does not require an upgrade, based on store `woop` feature.
+		  ! isAtomicSite // if the site is Anitomy, it's not ready for transfer.
 		: false;
 
 	const siteUpgrading = {
@@ -198,6 +200,6 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		siteUpgrading,
 		isDataReady: transferringDataIsAvailable,
 		isReadyForTransfer,
-		isAtomicSite: !! useSelector( ( state ) => isAtomicSite( state, siteId ) ),
+		isAtomicSite,
 	};
 }

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -155,6 +155,13 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 
 	const productName = upgradingPlan.product_name;
 
+	// Define whether the site is ready to be transferred.
+	const isReadyForTransfer = transferringDataIsAvailable
+		? ! isTransferringBlocked && // there is not blocker from eligibility (holds).
+		  ! ( eligibilityWarnings && eligibilityWarnings.length ) && // there is not warnings from eligibility (warnings).
+		  ! requiresUpgrade // the site does not require an upgrade, based on store `woop` feature.
+		: false;
+
 	const siteUpgrading = {
 		required: requiresUpgrade,
 		checkoutUrl: addQueryArgs(
@@ -190,9 +197,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		isTransferringBlocked,
 		siteUpgrading,
 		isDataReady: transferringDataIsAvailable,
-		isReadyForTransfer: transferringDataIsAvailable
-			? ! isTransferringBlocked && ! ( eligibilityWarnings && eligibilityWarnings.length )
-			: false,
+		isReadyForTransfer,
 		isAtomicSite: !! useSelector( ( state ) => isAtomicSite( state, siteId ) ),
 	};
 }

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -165,11 +165,8 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 */
 	let isReadyToStart = siteId && transferringDataIsAvailable;
 
-	if ( isAtomicSite ) {
-		// ... and also when the site is Atomic, ...
-		isReadyToStart = isReadyToStart && isAtomicSite;
-	} else {
-		// ...but when the site is not Atomic, ...
+	if ( ! isAtomicSite ) {
+		// when the site is not Atomic, ...
 		isReadyToStart =
 			isReadyToStart &&
 			! isTransferringBlocked && // there is no blockers from eligibility (holds).

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -161,20 +161,17 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 * the site is Ready to Start when:
 	 * - siteId is defined
 	 * - data is ready
-	 * ...
+	 * - does not require an upgrade, based on store `woop` feature
 	 */
-	// ...also check the site does not require an upgrade, based on store `woop` feature.
 	let isReadyToStart = siteId && transferringDataIsAvailable && ! requiresUpgrade;
 
+	// when the site is not Atomic, ...
 	if ( isReadyToStart && ! isAtomicSite ) {
-		// when the site is not Atomic, ...
 		isReadyToStart =
 			isReadyToStart &&
 			! isTransferringBlocked && // there is no blockers from eligibility (holds).
 			! ( eligibilityWarnings && eligibilityWarnings.length ); // there is no warnings from eligibility (warnings).
 	}
-
-
 
 	const siteUpgrading = {
 		required: requiresUpgrade,

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -158,10 +158,10 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	// Define whether the site is ready to be transferred.
 	const isAtomicSite = !! useSelector( ( state ) => isAtomicSiteSelector( state, siteId ) );
 	const isReadyForTransfer = transferringDataIsAvailable
-		? ! isTransferringBlocked && // there is not blocker from eligibility (holds).
-		  ! ( eligibilityWarnings && eligibilityWarnings.length ) && // there is not warnings from eligibility (warnings).
+		? ! isTransferringBlocked && // there is no blockers from eligibility (holds).
+		  ! ( eligibilityWarnings && eligibilityWarnings.length ) && // there is no warnings from eligibility (warnings).
 		  ! requiresUpgrade && // the site does not require an upgrade, based on store `woop` feature.
-		  ! isAtomicSite // if the site is Anitomy, it's not ready for transfer.
+		  ! isAtomicSite // if the site is Atomic, then it's not ready for transfer.
 		: false;
 
 	const siteUpgrading = {

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -91,12 +91,12 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		( { id } ) => id === 'wordpress_subdomain'
 	);
 
-	// Filter the Woop transferring blockers
+	// Filter the Woop transferring blockers.
 	const transferringBlockers = eligibilityHolds?.filter(
 		( hold ) => ! TRANSFERRING_NOT_BLOCKERS.includes( hold )
 	);
 
-	// Add blocked transfer hold when something is wrong in the transfer status.
+	// Add blocked-transfer-hold when something is wrong in the transfer status.
 	if (
 		! transferringBlockers?.includes( eligibilityHoldsConstants.BLOCKED_ATOMIC_TRANSFER ) &&
 		( isBlockByTransferStatus || isTransferStuck )
@@ -124,13 +124,24 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	const eligibilityNoProperPlan = eligibilityHolds?.includes(
 		eligibilityHoldsConstants.NO_BUSINESS_PLAN
 	);
+
+	/*
+	 * Check whether the `woop` feature is actve.`
+	 * It's defined by wpcom in the store product list.
+	 */
 	const isWoopFeatureActive = useSelector( ( state ) =>
 		hasActiveSiteFeature( state, siteId, FEATURE_WOOP )
 	);
+
+	/*
+	 * Feature available means although the site doesn't have the feature active,
+	 * it's available to be activated via buying a plan.
+	 */
 	const hasWoopFeatureAvailable = useSelector( ( state ) =>
 		hasAvailableSiteFeature( state, siteId, FEATURE_WOOP )
 	);
 
+	// The site requires upgrading when the feature is not active and available.
 	const requiresUpgrade = Boolean(
 		eligibilityNoProperPlan && ! isWoopFeatureActive && hasWoopFeatureAvailable
 	);

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -163,9 +163,10 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 * - data is ready
 	 * ...
 	 */
-	let isReadyToStart = siteId && transferringDataIsAvailable;
+	// ...also check the site does not require an upgrade, based on store `woop` feature.
+	let isReadyToStart = siteId && transferringDataIsAvailable && ! requiresUpgrade;
 
-	if ( ! isAtomicSite ) {
+	if ( isReadyToStart && ! isAtomicSite ) {
 		// when the site is not Atomic, ...
 		isReadyToStart =
 			isReadyToStart &&
@@ -173,8 +174,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 			! ( eligibilityWarnings && eligibilityWarnings.length ); // there is no warnings from eligibility (warnings).
 	}
 
-	// ...finally, the site does not require an upgrade, based on store `woop` feature.
-	isReadyToStart = isReadyToStart && ! requiresUpgrade;
+
 
 	const siteUpgrading = {
 		required: requiresUpgrade,

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -163,7 +163,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 * - data is ready
 	 * - does not require an upgrade, based on store `woop` feature
 	 */
-	let isReadyToStart = siteId && transferringDataIsAvailable && ! requiresUpgrade;
+	let isReadyToStart = !! ( siteId && transferringDataIsAvailable && ! requiresUpgrade );
 
 	// when the site is not Atomic, ...
 	if ( isReadyToStart && ! isAtomicSite ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Although the Woop installer takes care of the site plan, it isn't properly handled when the transfer process is triggered aytomatically. More details about the issue here https://github.com/Automattic/wp-calypso/issues/59515


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with a Simple site with a custom domain, no proper plan (Free, Personal, Premium)
* Walk through the Woo Installer flow: http://calypso.localhost:3000/woocommerce-installation/<simple-site-no-proper-plan>

**BEFORE**
It should try to transfer the site, but since the site doesn't have the proper plan, it will show the error page.

<img src="https://user-images.githubusercontent.com/77539/147244615-3bd51079-db0c-4b0e-8765-efe91f1690a7.png" width="500px" />

The issue is becasue of eligibility issue:
<img src="https://user-images.githubusercontent.com/77539/147244687-5eaf0b66-0599-4f00-b766-f31dee9a54dc.png" width="500px" />


**AFTER**
It should go to the checkout page, and once the site gets the proper plan, it should be transferred


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
