### PR TITLE
Add loading state when lock/unlock domain is in progress

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -14,6 +14,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
+import Spinner from 'calypso/components/spinner';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
 import { DESIGNATED_AGENT, TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
@@ -232,13 +233,25 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 		);
 
 		return (
-			<FixedToggleControl
-				className="transfer-page__transfer-lock"
-				checked={ isDomainLocked }
-				disabled={ disabled }
-				onChange={ toggleDomainLock }
-				label={ label }
-			/>
+			<>
+				<FixedToggleControl
+					className="transfer-page__transfer-lock"
+					checked={ isDomainLocked }
+					disabled={ disabled }
+					onChange={ toggleDomainLock }
+					label={ label }
+				/>
+				{ isLockingOrUnlockingDomain && (
+					<div className="transfer-page__loader">
+						<Spinner size={ 16 } />
+						<p>
+							{ isDomainLocked
+								? __( 'We are unlocking your domain' )
+								: __( 'We are locking your domain' ) }
+						</p>
+					</div>
+				) }
+			</>
 		);
 	};
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -81,7 +81,7 @@
 			margin-bottom: 4px;
 			color: var( --studio-gray-80 );
 		}
-		
+
 		&-section-text {
 			color: var( --studio-gray-50 );
 			font-size: $font-body-small;
@@ -94,7 +94,7 @@
 			}
 		}
 	}
-	
+
 	.transfer-page__transfer-lock {
 		margin: 8px 0 16px;
 	}
@@ -132,9 +132,18 @@
 		.layout__column--main {
 			padding-right: 24px;
 		}
-	
+
 		.layout__column--sidebar {
 			padding-left: 24px;
+		}
+	}
+
+	&__loader {
+		display: flex;
+		margin-bottom: 16px;
+		> p {
+			margin-bottom: 0;
+			margin-left: 16px;
 		}
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR add a loading state when a user lock or unlock a domain transfer status.

## Screenshots
![lock](https://user-images.githubusercontent.com/2797601/147250042-83a1604d-92a8-45ef-8778-8e9d8e38d737.png)

![unlock](https://user-images.githubusercontent.com/2797601/147250058-aad46c73-7c89-4256-93db-3a64d9ec8329.png)

## Testing instructions
- Build this branch locally or open the live Calypso link
- Go to **Upgrades > Domains**
- Select one of your registered domains (eligible for lock transfer) and open the transfer page
- Unlock and lock the domain, and verify that the loading spinner and the message are rendered as in the screenshots (if you are locking the domain the message should be "_We are locking your domain_", if you are unlocking it the message should be "_We are unlocking your domain_")
