### PR TITLE
Videos UI: Add types & constants.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -5,17 +5,21 @@ import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
 import Notice from 'calypso/components/notice';
-import useCourseQuery from 'calypso/data/courses/use-course-query';
+import { COURSE_SLUGS, useCourseQuery } from 'calypso/data/courses';
 import useUpdateUserCourseProgressionMutation from 'calypso/data/courses/use-update-user-course-progression-mutation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import VideoPlayer from './video-player';
 import './style.scss';
 
-const VideosUi = ( { HeaderBar, FooterBar, areVideosTranslated = true } ) => {
+const VideosUi = ( {
+	courseSlug = COURSE_SLUGS.BLOGGING_QUICK_START,
+	HeaderBar,
+	FooterBar,
+	areVideosTranslated = true,
+} ) => {
 	const translate = useTranslate();
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
 
-	const courseSlug = 'blogging-quick-start';
 	const { data: course } = useCourseQuery( courseSlug );
 	const { updateUserCourseProgression } = useUpdateUserCourseProgressionMutation();
 

--- a/client/data/courses/constants.ts
+++ b/client/data/courses/constants.ts
@@ -1,0 +1,5 @@
+import type { CourseSlug } from './types';
+
+export const COURSE_SLUGS: { [ key: string ]: CourseSlug } = Object.freeze( {
+	BLOGGING_QUICK_START: 'blogging-quick-start',
+} );

--- a/client/data/courses/index.ts
+++ b/client/data/courses/index.ts
@@ -1,0 +1,3 @@
+export { COURSE_SLUGS } from './constants';
+export { default as useCourseQuery } from './use-course-query';
+export { default as useUpdateUserCourseProgressionMutation } from './use-update-user-course-progression-mutation';

--- a/client/data/courses/types.ts
+++ b/client/data/courses/types.ts
@@ -1,0 +1,24 @@
+export type CourseSlug = 'blogging-quick-start';
+
+export type VideoSlug = string;
+
+export interface CourseVideo {
+	title: string;
+	description: string;
+	duration_seconds: string;
+	poster: string;
+	url: string;
+	completed_seconds: string;
+}
+
+export interface Course {
+	title: string;
+	slug: string;
+	cta: {
+		description: string;
+		action: string;
+		url: string;
+	};
+	videos: CourseVideo[];
+	completions: { [ key in VideoSlug ]: boolean | boolean[] };
+}

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
@@ -2,6 +2,7 @@ import { BlankCanvas } from 'calypso/components/blank-canvas';
 import VideosUi from 'calypso/components/videos-ui';
 import ModalFooterBar from 'calypso/components/videos-ui/modal-footer-bar';
 import ModalHeaderBar from 'calypso/components/videos-ui/modal-header-bar';
+import { COURSE_SLUGS } from 'calypso/data/courses';
 
 import './style.scss';
 
@@ -13,6 +14,7 @@ const BloggingQuickStartModal = ( props ) => {
 			<BlankCanvas className={ 'blogging-quick-start-modal' }>
 				<BlankCanvas.Content>
 					<VideosUi
+						courseSlug={ COURSE_SLUGS.BLOGGING_QUICK_START }
 						HeaderBar={ ( headerProps ) => (
 							<ModalHeaderBar onClose={ onClose } { ...headerProps } />
 						) }


### PR DESCRIPTION
This PR extracts the types & constants definition from this other one: https://github.com/Automattic/wp-calypso/pull/59514. Having it this way allows us to merge this changes and lets https://github.com/Automattic/wp-calypso/pull/59514 to just focus on `useCourseData` hook.

### Testing
* Go to the calypso.live link on the comments of this PR.
* Click the Start Learning link on the Blog Like an Expert card
  <img width="600" src="https://user-images.githubusercontent.com/13596067/147180827-174b1b00-d21a-48ae-ac5e-08a05d74bdb1.png" />
* Verify the Videos UI works as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/58234
