### PR TITLE
Emails: Comparison table additions

### DIFF
--- a/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/index.tsx
@@ -1,21 +1,211 @@
+import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import InfoPopover from 'calypso/components/info-popover';
+import Main from 'calypso/components/main';
+import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import type { TranslateResult } from 'i18n-calypso';
 
+import './style.scss';
+
 export type EmailProviderFeatures = {
+	id: string;
 	header: string;
+	headerLogo: string;
+	headerLogoIsGridIcon?: boolean;
 	tools: TranslateResult;
 	storage: TranslateResult;
 	importing: TranslateResult;
+	selectCallback?: () => void;
+	subtitle: TranslateResult;
 	support: TranslateResult;
-	selectCallback: () => void;
+	footerBadge?: string;
+	learnMore: string | null;
 };
 
 type ComparisonTableProps = {
+	className: string;
 	emailProviders: EmailProviderFeatures[];
+	showFeatureNames?: boolean;
 };
 
-const ComparisonTable: FunctionComponent< ComparisonTableProps > = () => {
-	return <p> New component </p>;
+const ComparisonTable: FunctionComponent< ComparisonTableProps > = ( {
+	className,
+	emailProviders,
+	showFeatureNames = true,
+} ) => {
+	const showCallbackRow = emailProviders.some( ( provider ) => provider.selectCallback );
+	const logoComponentProvider = ( provider: EmailProviderFeatures ) =>
+		provider.headerLogoIsGridIcon ? (
+			<Gridicon className="comparison-table__header-logo" icon={ provider.headerLogo } />
+		) : (
+			<img
+				alt={ provider.header }
+				src={ provider.headerLogo }
+				className="comparison-table__header-logo"
+			/>
+		);
+
+	const tableHeaderComponent = (
+		<thead>
+			<tr className="comparison-table__header-row">
+				{ showFeatureNames && (
+					<th id="empty-row" className="comparison-table__header-column-empty" />
+				) }
+				{ emailProviders.map( ( emailProviderFeature, index ) => {
+					return (
+						<th
+							id={ emailProviderFeature.id }
+							className="comparison-table__header-column"
+							key={ `comparison-table__header-column-${ index }` }
+						>
+							<div className="comparison-table__header">
+								{ logoComponentProvider( emailProviderFeature ) }
+								<div className="comparison-table__header-container">
+									<h1 className="comparison-table__header-title wp-brand-font">
+										{ emailProviderFeature.header }
+									</h1>
+									<p className="comparison-table__header-subtitle">
+										{ emailProviderFeature.subtitle }
+									</p>
+								</div>
+							</div>
+						</th>
+					);
+				} ) }
+			</tr>
+		</thead>
+	);
+
+	const featuresColumn = [
+		{
+			name: translate( 'Tools' ),
+			key: 'tools',
+			popover: (
+				<InfoPopover position="right" showOnHover>
+					Placeholder
+				</InfoPopover>
+			),
+		},
+		{
+			name: translate( 'Storage' ),
+			key: 'storage',
+			popover: (
+				<InfoPopover position="right" showOnHover>
+					Placeholder
+				</InfoPopover>
+			),
+		},
+		{
+			name: translate( 'Importing' ),
+			key: 'importing',
+			popover: (
+				<InfoPopover position="right" showOnHover>
+					Placeholder
+				</InfoPopover>
+			),
+		},
+		{
+			name: translate( 'Support' ),
+			key: 'support',
+			popover: (
+				<InfoPopover position="right" showOnHover>
+					Placeholder
+				</InfoPopover>
+			),
+		},
+		{
+			wrapper: ( content: string, href = '' ) => (
+				<a href={ href } className="comparison-table__learn-more">
+					{ content }
+				</a>
+			),
+			key: 'learnMore',
+			description: translate( 'Learn more', { textOnly: true } ),
+			popover: null,
+		},
+		{
+			key: 'footerBadge',
+		},
+	];
+
+	const tableBodyComponent = (
+		<tbody>
+			{ featuresColumn.map( ( feature, index ) => {
+				return (
+					<tr
+						className="comparison-table__body-row"
+						key={ `comparison-table__body-row-${ index }` }
+					>
+						{ showFeatureNames && (
+							<td className="comparison-table__feature-name" headers="empty-row">
+								{ feature.name } { feature.popover }
+							</td>
+						) }
+						{ emailProviders.map( ( emailProviderFeature, index ) => {
+							const providerFeature =
+								emailProviderFeature[ feature.key as keyof EmailProviderFeatures ];
+
+							const featureProp =
+								providerFeature && feature.key === 'footerBadge' ? (
+									<img
+										src={ emailProviderFeature[ feature.key ] }
+										alt={ emailProviderFeature.header }
+									/>
+								) : (
+									providerFeature
+								);
+							return (
+								<td
+									className="comparison-table__feature-description"
+									headers={ emailProviderFeature.id }
+									key={ `comparison-table__feature-description-${ index }` }
+								>
+									{ providerFeature && feature.wrapper
+										? feature.wrapper(
+												feature.description,
+												emailProviderFeature.learnMore ?? undefined
+										  )
+										: featureProp }
+								</td>
+							);
+						} ) }
+					</tr>
+				);
+			} ) }
+			{ showCallbackRow && (
+				<tr className="comparison-table__select">
+					<td className="comparison-table__select" headers="empty-row" />
+					{ emailProviders.map( ( provider ) => {
+						return (
+							<td
+								className="comparison-table__feature-description comparison-table__select"
+								headers={ provider.id }
+							>
+								<FullWidthButton primary onClick={ provider.selectCallback }>
+									{ translate( 'Select' ) }
+								</FullWidthButton>
+							</td>
+						);
+					} ) }
+				</tr>
+			) }
+		</tbody>
+	);
+
+	const tableComponent = (
+		<table className="comparison-table__table">
+			{ tableHeaderComponent }
+			{ tableBodyComponent }
+		</table>
+	);
+
+	return (
+		<Main wideLayout className={ classnames( className, 'comparison-table__main' ) }>
+			{ tableComponent }
+		</Main>
+	);
 };
 
 export default ComparisonTable;

--- a/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/style.scss
+++ b/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/style.scss
@@ -1,0 +1,83 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.comparison-table__feature-name {
+
+	.info-popover {
+		margin-left: 4px;
+	}
+	padding-top: 24px;
+	padding-bottom: 24px;
+	color: var( --color-text-subtle );
+	display: flex;
+	justify-content: flex-end;
+}
+
+.comparison-table__feature-description {
+	padding-left: 60px;
+	padding-top: 24px;
+	padding-bottom: 24px;
+	vertical-align: middle;
+
+	.is-primary {
+		width: 75%;
+	}
+}
+
+.comparison-table__body-row:nth-last-child( n+4 ) {
+	border-bottom-color: var( --color-neutral-10 );
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
+}
+
+.comparison-table__table {
+	border-collapse: collapse;
+	table-layout: auto;
+	width: 100%;
+}
+
+.comparison-table__header-column-empty {
+	width: auto;
+	white-space:nowrap;
+}
+
+
+.comparison-table__select {
+	padding-top: 24px;
+}
+
+.comparison-table__header {
+	display: flex;
+	flex-direction: row;
+	padding-right: 12px;
+}
+
+.comparison-table__header-logo {
+	height: 48px;
+	width: 48px;
+	padding-right: 12px;
+}
+
+.comparison-table__header-container {
+
+	.comparison-table__header-title {
+		font-size: $font-title-medium;
+	}
+
+	.comparison-table__header-subtitle {
+		font-weight: normal;
+		font-size: $font-body;
+	}
+}
+
+.comparison-table__main {
+	padding: 0 20px 20px;
+
+	@include break-mobile {
+		padding: 0 24px 24px;
+	}
+}
+
+.comparison-table__learn-more {
+	color: var( --color-accent );
+}

--- a/client/my-sites/email/email-providers-in-depth-comparison/data.ts
+++ b/client/my-sites/email/email-providers-in-depth-comparison/data.ts
@@ -1,23 +1,43 @@
 import { translate } from 'i18n-calypso';
+import emailForwarding from 'calypso/assets/images/email-providers/forwarding.svg';
+import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
+import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
 import { EmailProviderFeatures } from 'calypso/my-sites/email/email-providers-in-depth-comparison/comparison-table';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 export const professionalEmailFeatures: EmailProviderFeatures = {
+	id: 'professional-email',
 	header: 'Professional Email',
-	tools: translate( 'Integrated email management, Inbox, calendar and contacts' ),
-	storage: translate( '30GB storage' ),
+	headerLogo: 'my-sites',
+	footerBadge: poweredByTitanLogo,
+	headerLogoIsGridIcon: true,
 	importing: translate( 'One-click import of existing emails and contacts' ),
+	learnMore: 'link-to-professional-email',
+	storage: translate( '30GB storage' ),
+	tools: translate( 'Integrated email management, Inbox, calendar and contacts' ),
+	subtitle: translate( 'Integrated email solution for your WordPress.com site' ),
 	support: translate( '24/7 support via email' ),
-	selectCallback: noop,
 };
 
 export const googleWorkspaceFeatures: EmailProviderFeatures = {
+	id: 'google-workspace',
 	header: 'Google Workspace',
-	tools: translate( 'Gmail, Calendar, Meet, Chat, Drive, Docs, Sheets, Slides and more' ),
-	storage: translate( '30GB storage' ),
+	headerLogo: googleWorkspaceIcon,
 	importing: translate( 'Easy to import your existing emails and contacts' ),
+	learnMore: 'link-to-google-workspace',
+	storage: translate( '30GB storage' ),
+	tools: translate( 'Gmail, Calendar, Meet, Chat, Drive, Docs, Sheets, Slides and more' ),
+	subtitle: translate( 'Gmail and other productivity tools from Google' ),
 	support: translate( '24/7 support via email' ),
-	selectCallback: noop,
+};
+
+export const emailForwardingFeatures: EmailProviderFeatures = {
+	id: 'email-forwarding',
+	header: 'Email Forwarding',
+	headerLogo: emailForwarding,
+	importing: '-',
+	learnMore: '',
+	storage: '-',
+	subtitle: translate( 'Forward your email at your custom domain to another address' ),
+	support: translate( '24/7 support via email' ),
+	tools: '-',
 };

--- a/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
@@ -1,9 +1,14 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import ComparisonTable from 'calypso/my-sites/email/email-providers-in-depth-comparison/comparison-table';
 import {
+	emailForwardingFeatures,
 	professionalEmailFeatures,
 	googleWorkspaceFeatures,
 } from 'calypso/my-sites/email/email-providers-in-depth-comparison/data';
+
+import './style.scss';
 
 type EmailProvidersInDepthComparisonProps = {
 	comparisonContext: string;
@@ -13,8 +18,27 @@ type EmailProvidersInDepthComparisonProps = {
 };
 
 const EmailProvidersInDepthComparison: FunctionComponent< EmailProvidersInDepthComparisonProps > = () => {
+	const translate = useTranslate();
 	return (
-		<ComparisonTable emailProviders={ [ professionalEmailFeatures, googleWorkspaceFeatures ] } />
+		<>
+			<h1 className="email-providers-in-depth-comparison__header wp-brand-font">
+				{ translate( 'See how they compare' ) }{ ' ' }
+			</h1>
+			<ComparisonTable
+				className="email-providers-in-depth-comparison__main"
+				emailProviders={ [
+					professionalEmailFeatures,
+					googleWorkspaceFeatures,
+					emailForwardingFeatures,
+				] }
+				showFeatureNames={ false }
+			/>
+			<div className="email-providers-in-depth-comparison__button-container">
+				<Button className="email-providers-in-depth-comparison__button" primary>
+					{ translate( 'Get started' ) }
+				</Button>
+			</div>
+		</>
 	);
 };
 

--- a/client/my-sites/email/email-providers-in-depth-comparison/style.scss
+++ b/client/my-sites/email/email-providers-in-depth-comparison/style.scss
@@ -1,0 +1,20 @@
+.email-providers-in-depth-comparison__header {
+	font-size: xxx-large;
+	margin-bottom: 64px;
+	text-align: center;
+}
+
+.comparison-table__header {
+	.gridicons-my-sites {
+		width: 72px;
+		fill: var( --color-wordpress-com );
+	}
+}
+
+.email-providers-in-depth-comparison__button-container {
+	text-align: center;
+}
+
+.email-providers-in-depth-comparison__button {
+	width: 25%;
+}

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -44,3 +44,29 @@
 .email-providers-stacked-comparison__how-they-compare {
 	text-align: center;
 }
+
+.email-providers-stacked-comparison__in-depth-header {
+	display: flex;
+	flex-direction: row;
+	padding-right: 12px;
+}
+
+.email-providers-stacked-comparison__in-depth-logo {
+	height: 48px;
+	width: 48px;
+	padding-right: 12px;
+}
+
+.email-providers-stacked-comparison__in-depth-header-container {
+
+	.email-providers-stacked-comparison__in-depth-header-title {
+		font-size: $font-title-medium;
+	}
+
+	.email-providers-stacked-comparison__in-depth-header-subtitle {
+		font-weight: normal;
+		font-size: $font-body;
+	}
+}
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Code added to show features in the newly created component for the email providers comparison.

This code does not add mobile support yet. It will added in a further pull request in order to do not make huge reviews.

As an alternative suggested by @stephanethomas here is another [pull request](https://github.com/Automattic/wp-calypso/pull/59543) with CSS Grid option

#### Testing instructions

1. Go to a site with domains without email subscription
2. Click on 'Add email' for the desired site
3. Once you are in the comparison page, add at the end the following flag: `?flags=emails/new-email-comparison`
4. Click then in the "see how they compare" in the top of the screen

![image](https://user-images.githubusercontent.com/5689927/147257346-bec925ab-4f58-42fc-85dd-dc53d64177f8.png)

**REMARKS**

There is a property that shows/hides the first column, if we show the first columnist looks like this:
![image](https://user-images.githubusercontent.com/5689927/147257927-d3f3d160-f083-4491-a43f-9a7f3b61b22d.png)

Related to {1200182182542585-1201539393037967}
