### PR TITLE
Domain settings: remove margin bottom from expanded cards

### DIFF
--- a/client/components/domains/accordion/style.scss
+++ b/client/components/domains/accordion/style.scss
@@ -5,7 +5,7 @@
 	.is-placeholder {
 		@include placeholder();
 	}
-	.foldable-card {
+	.card.foldable-card {
 		margin: 0;
 		&.is-expanded {
 			margin: 0;


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR remove bottom margin from accordions in Domain settings page, when they are expanded.

![before](https://user-images.githubusercontent.com/2797601/147259487-f2757fb2-44cc-4b73-8d27-c4967fa4ee84.png)

![after](https://user-images.githubusercontent.com/2797601/147259504-f248a495-4869-48fe-b4aa-81cc6cb06d50.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to **Upgrades > Domains**
- Select one of your registered or mapped domains
- Ensure that there is no margin under expanded cards.