### PR TITLE
Domain: Improve loading performance of the all domains page

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -183,17 +183,8 @@ class AllDomains extends Component {
 	};
 
 	isLoading() {
-		const {
-			domainsList,
-			requestingFlatDomains,
-			allSitesDomainsQueried,
-			hasAllSitesLoaded,
-		} = this.props;
-		return (
-			! allSitesDomainsQueried ||
-			! hasAllSitesLoaded ||
-			( requestingFlatDomains && domainsList.length === 0 )
-		);
+		const { domainsList, requestingFlatDomains, hasAllSitesLoaded } = this.props;
+		return ! hasAllSitesLoaded || ( requestingFlatDomains && domainsList.length === 0 );
 	}
 
 	isRequestingSiteDomains() {
@@ -677,10 +668,6 @@ class AllDomains extends Component {
 		);
 	}
 
-	queryAllSitesDomains() {
-		return Object.keys( this.props.sites ).map( this.renderQuerySiteDomainsOnce );
-	}
-
 	renderDomainTableFilterButton() {
 		const { context } = this.props;
 
@@ -779,7 +766,6 @@ class AllDomains extends Component {
 				<div className="all-domains__form">{ this.renderActionForm() }</div>
 				<div className="all-domains__container">
 					<QueryAllDomains />
-					{ this.queryAllSitesDomains() }
 					<QueryUserPurchases />
 					<Main wideLayout>
 						<SidebarNavigation />
@@ -860,10 +846,6 @@ const getFilteredDomainsList = ( state, context ) => {
 	}
 };
 
-const hasQueriedAllSitesDomains = ( state, sites ) => {
-	return Object.keys( sites ).length === Object.keys( state.sites.domains.items ).length;
-};
-
 export default connect(
 	( state, { context } ) => {
 		const sites = getSitesById( state );
@@ -881,7 +863,6 @@ export default connect(
 			purchases: getUserPurchases( state ) || [],
 			hasLoadedUserPurchases: hasLoadedUserPurchasesFromServer( state ),
 			requestingFlatDomains: isRequestingAllDomains( state ),
-			allSitesDomainsQueried: hasQueriedAllSitesDomains( state, sites ),
 			requestingSiteDomains: getAllRequestingSiteDomains( state ),
 			sites,
 		};

--- a/client/state/all-domains/helpers.js
+++ b/client/state/all-domains/helpers.js
@@ -11,5 +11,6 @@ export const createLightSiteDomainObject = ( domain ) => {
 		name: String( domain.domain ),
 		registrationDate: String( domain.registration_date ),
 		type: getDomainType( domain ),
+		currentUserIsOwner: Boolean( domain.current_user_is_owner ),
 	};
 };

--- a/client/state/all-domains/schema.js
+++ b/client/state/all-domains/schema.js
@@ -13,6 +13,7 @@ export const allDomainsSchema = {
 			name: { type: 'string' },
 			registrationDate: { type: 'string' },
 			type: { type: 'string' },
+			currentUserIsOwner: { type: 'boolean' },
 		},
 	},
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the all domains page we do a `GET /all-domains/` query, which retrieves all the domains for all the sites of a user. So at least the initial domain list render should be quick, because the `all-domains` query is pretty fast even when you have many domains.

The weird behavior reported in [this comment in #58980](https://github.com/Automattic/wp-calypso/pull/58980#issuecomment-992244728) was happening because the `createLightSiteDomainObject` method was not processing the `current_user_is_owner` property - but it was already set for domains that were fully loaded in the global store before.

This PR adds this property and removes the `AllSitesDomains` query that was being done upfront and increased the page's load time.

These videos show the time difference to render the domains list:

- Before

https://user-images.githubusercontent.com/5324818/147292766-e1656bd2-fcfd-46ec-9f51-7c42e51fbc6c.mp4

- After

https://user-images.githubusercontent.com/5324818/147292791-3b080094-97a6-4d42-a160-71dc85bb39ab.mp4

### Testing instructions

- Open the live Calypso link or build this branch locally
- Clean your browser's application data (`Dev console > Application > Storage > Clear site data` in Chrome)
- Go to the all domains page with the "Owned by me" or "Owned by others" filter applied (`domains/manage?filter=owned-by-me` or `domains/manage?filter=owned-by-others`)
- Ensure all domains owned by you or others are loaded and shown correctly
