### PR TITLE
Improve Calypso My Plan Messaging for non-plan owner site-admins

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/included-in-plan.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/included-in-plan.tsx
@@ -7,7 +7,7 @@ const IncludedInPlan: React.FC = () => {
 	return (
 		<p className="display-price__you-own-this">
 			<Gridicon className="display-price__you-own-this-icon" icon="checkmark-circle" size={ 48 } />
-			{ translate( 'Part of your current plan' ) }
+			{ translate( 'Part of the current plan' ) }
 		</p>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/display-price/owned.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/owned.tsx
@@ -6,7 +6,7 @@ const Owned: React.FC = () => {
 	return (
 		<p className="display-price__you-own-this">
 			<Gridicon className="display-price__you-own-this-icon" icon="checkmark-circle" size={ 48 } />
-			{ translate( 'You own this product' ) }
+			{ translate( 'Active on your site' ) }
 		</p>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -148,27 +148,26 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 						{ preventWidows( disabledMessage ) }
 					</p>
 				) }
-				{ ! isDisabled &&
-					( buttonURL ? (
-						<Button
-							primary={ buttonPrimary }
-							className="jetpack-product-card__button"
-							onClick={ onButtonClick }
-							href={ buttonURL }
-							disabled={ isDeprecated }
-						>
-							{ buttonLabel }
-						</Button>
-					) : (
-						<Button
-							primary={ buttonPrimary }
-							className="jetpack-product-card__button"
-							onClick={ onButtonClick }
-							disabled={ isDeprecated }
-						>
-							{ buttonLabel }
-						</Button>
-					) ) }
+				{ buttonURL ? (
+					<Button
+						primary={ buttonPrimary }
+						className="jetpack-product-card__button"
+						onClick={ onButtonClick }
+						href={ isDisabled ? '#' : buttonURL }
+						disabled={ isDisabled }
+					>
+						{ buttonLabel }
+					</Button>
+				) : (
+					<Button
+						primary={ buttonPrimary }
+						className="jetpack-product-card__button"
+						onClick={ onButtonClick }
+						disabled={ isDisabled }
+					>
+						{ buttonLabel }
+					</Button>
+				) }
 
 				{ description && <p className="jetpack-product-card__description">{ description }</p> }
 				{ item.features && item.features.items.length > 0 && (

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -30,6 +30,7 @@ import {
 } from 'calypso/lib/purchases';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
+import OwnerInfo from './owner-Info';
 
 import 'calypso/me/purchases/style.scss';
 
@@ -398,7 +399,12 @@ class PurchaseItem extends Component {
 				) }
 
 				<div className="purchase-item__information purchases-layout__information">
-					<div className="purchase-item__title">{ getDisplayName( purchase ) }</div>
+					<div className="purchase-item__title">
+						{ getDisplayName( purchase ) }
+						&nbsp;
+						<OwnerInfo purchase={ purchase } />
+					</div>
+
 					<div className="purchase-item__purchase-type">{ this.getPurchaseType() }</div>
 				</div>
 

--- a/client/me/purchases/purchase-item/owner-Info.tsx
+++ b/client/me/purchases/purchase-item/owner-Info.tsx
@@ -1,0 +1,47 @@
+import { localize, useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import InfoPopover from 'calypso/components/info-popover';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { AppState } from 'calypso/types';
+
+import './style.scss';
+
+type InjectedProps = {
+	isProductOwner: boolean;
+};
+
+type NeedsProps = {
+	purchase: Purchase | undefined;
+};
+
+export type OwnerInfoProps = InjectedProps & NeedsProps;
+
+export const OwnerInfo: React.FC< OwnerInfoProps > = ( { isProductOwner } ) => {
+	const translate = useTranslate();
+
+	if ( isProductOwner ) {
+		return null;
+	}
+
+	return (
+		<InfoPopover className="owner-Info__pop-over">
+			<span>
+				{ translate(
+					'To manage this subscription, log in to the WordPress.com account that purchased it or contact the owner.'
+				) }
+			</span>
+		</InfoPopover>
+	);
+};
+
+export default connect< InjectedProps, unknown, NeedsProps, AppState >(
+	( state: AppState, { purchase }: NeedsProps ): InjectedProps => {
+		const userId = getCurrentUserId( state );
+		const isProductOwner = Boolean( purchase && purchase.userId === userId );
+
+		return {
+			isProductOwner,
+		};
+	}
+)( localize( OwnerInfo ) );

--- a/client/me/purchases/purchase-item/owner-Info.tsx
+++ b/client/me/purchases/purchase-item/owner-Info.tsx
@@ -5,8 +5,6 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { AppState } from 'calypso/types';
 
-import './style.scss';
-
 type InjectedProps = {
 	isProductOwner: boolean;
 };

--- a/client/me/purchases/purchase-item/owner-Info.tsx
+++ b/client/me/purchases/purchase-item/owner-Info.tsx
@@ -25,7 +25,7 @@ export const OwnerInfo: React.FC< OwnerInfoProps > = ( { isProductOwner } ) => {
 	}
 
 	return (
-		<InfoPopover className="owner-Info__pop-over">
+		<InfoPopover className="owner-Info__pop-over" showOnHover>
 			<span>
 				{ translate(
 					'To manage this subscription, log in to the WordPress.com account that purchased it or contact the owner.'

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -1,3 +1,0 @@
-button.owner-Info__pop-over {
-	line-height: 1;
-}

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -1,0 +1,3 @@
+button.owner-Info__pop-over {
+	line-height: 1;
+}

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -57,7 +57,6 @@
 	}
 }
 
-
 /* Purchase listing
 ================================================== */
 .purchases-list-header.card {
@@ -132,6 +131,9 @@
 .purchase-item__title {
 	color: var( --color-neutral-80 );
 	overflow: hidden;
+	.owner-Info__pop-over {
+		vertical-align: middle;
+	}
 }
 
 .purchase-item__purchase-type {

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -175,6 +175,13 @@
 	.button ~ .button {
 		margin-inline-start: 8px;
 	}
+	.button {
+		line-height: inherit;
+	}
+	.owner-Info__pop-over {
+		font-size: inherit;
+		vertical-align: inherit;
+	}
 }
 
 .my-plan-card__header .backup-storage-space.card {

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -33,7 +33,9 @@ import {
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 } from 'calypso/lib/purchases';
 import { managePurchase } from 'calypso/me/purchases/paths';
+import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-Info';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isJetpackCloudEligible from 'calypso/state/selectors/is-jetpack-cloud-eligible';
 import {
@@ -58,6 +60,7 @@ class PurchasesListing extends Component {
 		selectedSiteId: PropTypes.number,
 		selectedSiteSlug: PropTypes.string,
 		purchases: PropTypes.array,
+		currentUserId: PropTypes.number,
 
 		// From withLocalizedMoment() HoC
 		moment: PropTypes.func.isRequired,
@@ -170,7 +173,7 @@ class PurchasesListing extends Component {
 	}
 
 	getActionButton( purchase ) {
-		const { selectedSiteSlug, translate } = this.props;
+		const { selectedSiteSlug, translate, currentUserId } = this.props;
 
 		// No action button if there's no site selected.
 		if ( ! selectedSiteSlug || ! purchase ) {
@@ -203,10 +206,22 @@ class PurchasesListing extends Component {
 		if ( purchase.autoRenew && ! shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
 			label = translate( 'Renew now' );
 		}
+		const isProductOwner = Boolean( purchase && purchase.userId === currentUserId );
 
 		return (
-			<Button href={ this.props.getManagePurchaseUrlFor( selectedSiteSlug, purchase.id ) } compact>
+			<Button
+				href={
+					// Reason for making it '#' is to ensure that it gets rendered as <a /> and not as <button />
+					// If it's rendered as <button />, `OwnerInfo` uses `InfoPopover` and that also renders a button
+					// we can't render <button /> inside another <button />
+					isProductOwner ? this.props.getManagePurchaseUrlFor( selectedSiteSlug, purchase.id ) : '#'
+				}
+				disabled={ ! isProductOwner }
+				compact
+			>
 				{ label }
+				&nbsp;
+				<OwnerInfo purchase={ purchase } />
 			</Button>
 		);
 	}
@@ -397,5 +412,6 @@ export default connect( ( state ) => {
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 		isCloudEligible: isJetpackCloudEligible( state, selectedSiteId ),
+		currentUserId: getCurrentUserId( state ),
 	};
 } )( localize( withLocalizedMoment( PurchasesListing ) ) );


### PR DESCRIPTION
Completes `1164141197617539-as-1200817463256708`

#### Changes proposed in this Pull Request

* Create a new `OwnerInfo` component that renders an info icon to show a message on hover/click.
* Render the `OwnerInfo` component on **My Plan** and **Purchases** pages to inform secondary administrators that they are not plan owners.
* Disable **Manage Subscription/Plan** buttons for secondary admins.
* Change `'You own this product'` to `'Active on your site'` and `'Part of your current plan'` to `'Part of the current plan'` for active plans on pricing grid.

#### Testing instructions

_NOTE: Try the following test instructions for at least a **Backup** purchase or a **Security** purchase._

* Open Calypso Blue, select a self-hosted Jetpack site.
* Add a secondary admin to the site and login to the new admin account.
* Visit the **Upgrades > Purchases** page.
* Find the info icon beside purchase item title and hover over it to see the popover.
* Visit the **Upgrades > Plans** page and select **My plan** tab.
* Check the disabled **Manage Subscription/Plan** button and the info icon beside it.
* Goto **Plans** tab and check **Manage Subscription/Plan** button for the active plan and the info icon beside it.
* Also check the changed pricing labels here (i.e. "Active on your site" or "Part of the current plan").
* Now login to the plan owner account and see that no info icon is displayed.


**Screenshots**
<img width="886" alt="image" src="https://user-images.githubusercontent.com/18226415/147337292-b2ae7b25-bd6d-44ed-a947-523ddfc0a812.png">
<img width="821" alt="image" src="https://user-images.githubusercontent.com/18226415/147337314-a34afaf6-ea3f-4d1a-a730-4396002ac91d.png">
<img width="829" alt="image" src="https://user-images.githubusercontent.com/18226415/147337326-2f2de323-515d-4ca9-8b28-c98381b76df7.png">
