### PR TITLE
Plugin Details: Fix plugin sites list

### DIFF
--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -18,6 +18,8 @@
 	}
 
 	.plugin-action__label {
+		display: flex;
+		align-items: center;
 		@include breakpoint-deprecated( '<480px' ) {
 			color: var( --color-neutral-70 );
 		}
@@ -83,7 +85,8 @@
 	margin-left: 16px;
 }
 
-.plugin-activate-toggle, .plugin-autoupdate-toggle {
+.plugin-activate-toggle,
+.plugin-autoupdate-toggle {
 	.components-toggle-control {
 		display: flex;
 		.components-base-control__field {

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -57,10 +57,16 @@ export class PluginAutoUpdateToggle extends Component {
 	};
 
 	getDisabledInfo() {
-		const { site, wporg, translate } = this.props;
+		const { site, wporg, translate, isMarketplaceProduct } = this.props;
 		if ( ! site ) {
 			// we don't have enough info
 			return null;
+		}
+
+		if ( isMarketplaceProduct ) {
+			return translate(
+				'This plugin is auto managed and therefore will auto update to the latest stable version.'
+			);
 		}
 
 		if ( ! wporg ) {
@@ -141,6 +147,7 @@ export class PluginAutoUpdateToggle extends Component {
 			translate,
 			hideLabel,
 			toggleExtraContent,
+			isMarketplaceProduct,
 		} = this.props;
 		if ( ! site.jetpack ) {
 			return null;
@@ -154,10 +161,10 @@ export class PluginAutoUpdateToggle extends Component {
 
 		return (
 			<PluginAction
-				disabled={ disabled }
+				disabled={ isMarketplaceProduct ? true : disabled } // Marketplace products are auto-managed.
 				label={ label }
 				className="plugin-autoupdate-toggle"
-				status={ plugin.autoupdate }
+				status={ isMarketplaceProduct ? true : plugin.autoupdate } // Marketplace products are auto-managed.
 				action={ this.toggleAutoUpdates }
 				inProgress={ inProgress }
 				disabledInfo={ getDisabledInfo }
@@ -175,11 +182,13 @@ PluginAutoUpdateToggle.propTypes = {
 	plugin: PropTypes.object.isRequired,
 	wporg: PropTypes.bool,
 	disabled: PropTypes.bool,
+	isMarketplaceProduct: PropTypes.bool,
 };
 
 PluginAutoUpdateToggle.defaultProps = {
 	isMock: false,
 	disabled: false,
+	isMarketplaceProduct: false,
 };
 
 export default connect(

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -210,6 +210,11 @@ class PluginRemoveButton extends Component {
 			return null;
 		}
 
+		if ( this.props.isMarketplaceProduct ) {
+			// Marketplace products are auto-managed.
+			return null;
+		}
+
 		if ( this.props.plugin.slug === 'jetpack' ) {
 			return null;
 		}

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -85,7 +85,14 @@ const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedAction
 		<>
 			{ plugin.isMarketplaceProduct && <QuerySitePurchases siteId={ site.ID } /> }
 			<div className="plugin-site-jetpack__container">
-				<div className="plugin-site-jetpack__domain">{ site.domain }</div>
+				<div className="plugin-site-jetpack__domain">
+					{ site.domain }
+					{ ( isAutoManaged || plugin.isMarketplaceProduct ) && (
+						<div className="plugin-site-jetpack__automanage-notice">
+							{ translate( 'Auto-managed on this site' ) }
+						</div>
+					) }
+				</div>
 				{ canToggleActivation && (
 					<PluginActivateToggle
 						site={ site }
@@ -102,42 +109,53 @@ const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedAction
 						toggleExtraContent={
 							! isMobileLayout && <PluginUpdateIndicator site={ site } plugin={ plugin } expanded />
 						}
+						isMarketplaceProduct={ plugin.isMarketplaceProduct }
 					/>
 				) }
-				{ isAutoManaged ? (
-					<div className="plugin-site-jetpack__automanage-notice">
-						{ translate( 'Auto-managed on this site' ) }
-					</div>
-				) : (
-					<div className="plugin-site-jetpack__action plugin-action last-actions">
-						{ ! isMobileLayout && canToggleRemove && (
-							<PluginRemoveButton plugin={ pluginOnSite } site={ site } />
-						) }
-						{ ( isMobileLayout || settingsLink || currentPurchase ) && (
-							<EllipsisMenu position={ 'bottom' }>
-								{ currentPurchase?.id && (
-									<PopoverMenuItem
-										icon="credit-card"
-										href={ `/me/purchases/${ site.domain }/${ currentPurchase.id }` }
-									>
-										{ translate( 'Manage Subscription' ) }
-									</PopoverMenuItem>
-								) }
-								{ settingsLink && (
-									<PopoverMenuItem icon="cog" href={ settingsLink }>
-										{ translate( 'Settings' ) }
-									</PopoverMenuItem>
-								) }
-								{ isMobileLayout && (
-									<>
-										<PluginUpdateIndicator site={ site } plugin={ plugin } expanded menuItem />
-										<PluginRemoveButton plugin={ pluginOnSite } site={ site } menuItem />
-									</>
-								) }
-							</EllipsisMenu>
-						) }
-					</div>
-				) }
+
+				<div className="plugin-site-jetpack__action plugin-action last-actions">
+					{ ! isMobileLayout && canToggleRemove && (
+						<PluginRemoveButton
+							plugin={ pluginOnSite }
+							site={ site }
+							isMarketplaceProduct={ plugin.isMarketplaceProduct }
+						/>
+					) }
+					{ ( isMobileLayout || settingsLink || currentPurchase ) && (
+						<EllipsisMenu position={ 'bottom' }>
+							{ currentPurchase?.id && (
+								<PopoverMenuItem
+									icon="credit-card"
+									href={ `/me/purchases/${ site.domain }/${ currentPurchase.id }` }
+								>
+									{ translate( 'Manage Subscription' ) }
+								</PopoverMenuItem>
+							) }
+							{ settingsLink && (
+								<PopoverMenuItem icon="cog" href={ settingsLink }>
+									{ translate( 'Settings' ) }
+								</PopoverMenuItem>
+							) }
+							{ isMobileLayout && (
+								<>
+									<PluginUpdateIndicator
+										site={ site }
+										plugin={ plugin }
+										expanded
+										menuItem
+										isMarketplaceProduct={ plugin.isMarketplaceProduct }
+									/>
+									<PluginRemoveButton
+										plugin={ pluginOnSite }
+										site={ site }
+										menuItem
+										isMarketplaceProduct={ plugin.isMarketplaceProduct }
+									/>
+								</>
+							) }
+						</EllipsisMenu>
+					) }
+				</div>
 			</div>
 		</>
 	);

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -57,14 +57,16 @@
 		button.ellipsis-menu__toggle {
 			padding: 0;
 		}
+
+		.ellipsis-menu {
+			margin-left: auto;
+		}
 	}
 
 	.plugin-site-jetpack__automanage-notice {
-		flex: 1 1 0;
 		color: var( --color-neutral-light );
 		font-size: $font-body-extra-small;
 		line-height: 1;
-		text-align: center;
 	}
 
 	.plugin-site-jetpack__install-button {
@@ -101,13 +103,6 @@
 			.plugin-remove-button__remove-link {
 				display: none;
 			}
-		}
-
-		.plugin-site-jetpack__automanage-notice {
-			order: 2;
-			flex: 90%;
-			text-align: left;
-			padding-bottom: 10px;
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -103,6 +103,10 @@ class PluginSiteUpdateIndicator extends Component {
 		if ( ! this.props.site || ! this.props.plugin ) {
 			return;
 		}
+		if ( this.props.isMarketplaceProduct ) {
+			// Marketplace products are auto-managed.
+			return null;
+		}
 		if (
 			this.props.site.canUpdateFiles &&
 			( ( this.props.pluginOnSite.update && ! this.props.pluginOnSite.update.recentlyUpdated ) ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hides remove plugin for Marketplace plugins
* Shows auto-updates as enabled and disables the toggle for Marketplace plugins

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="706" alt="SS 2021-12-24 at 11 30 31" src="https://user-images.githubusercontent.com/12430020/147340264-9816216d-bfd5-4c8d-840c-65def27d1d1f.png">|<img width="703" alt="SS 2021-12-24 at 11 30 07" src="https://user-images.githubusercontent.com/12430020/147340241-5a890e87-774e-4f64-af92-385e4f0d0262.png">|

* visit an installed Marketplace plugin
* observe the changes are in effect
* visit an installed wporg plugin 
* you should be able to switch "auto-updates" or click "remove"

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59444
