### PR TITLE
/start/free: Remove striked out renew price 

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -165,17 +165,7 @@ class DomainProductPrice extends Component {
 			'is-free-domain': showStrikedOutPrice,
 			'domain-product-price__domain-step-signup-flow': showStrikedOutPrice,
 		} );
-
 		const productPriceClassName = showStrikedOutPrice ? '' : 'domain-product-price__price';
-
-		const renewalPrice = showStrikedOutPrice && (
-			<div className="domain-product-price__renewal-price">
-				{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
-					args: { cost: price },
-					components: { small: <small /> },
-				} ) }
-			</div>
-		);
 
 		return (
 			<div className={ className }>
@@ -185,7 +175,6 @@ class DomainProductPrice extends Component {
 						components: { small: <small /> },
 					} ) }
 				</span>
-				{ renewalPrice }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In `/start/free` flow's domains step, the striked out "Renews at ..." line is confusing since the renewal price is not clear. 
<img width="1019" alt="Screenshot 2021-12-24 at 2 19 38 PM" src="https://user-images.githubusercontent.com/1269602/147344350-bd45af31-8aee-41c3-a9e0-187b9b9da97b.png">


* In other places where we allow to purchase a domain, like the domain-only signup flow, and the Add Domains page in Calypso, we don't show a renewal price. **This PR adopts the same method to remove the renewal price line from the `/start/free` flow's domains step.**

<img width="952" alt="Screenshot 2021-12-24 at 2 20 53 PM" src="https://user-images.githubusercontent.com/1269602/147344412-7f1e56a3-ac2f-4947-9743-ae0273509adc.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/start/free` and verify that the "Renews at .." price is removed
* Verify that the domains step UI is unchanged for other flows - e.g `/start` onboarding flow, `/start/premium`, and also the UI in "Add domains" page in Calypso.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
