### PR TITLE
Plugins Search: prepend wpcom plugins

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -35,7 +35,7 @@ export const useWPCOMPlugins = (
 	searchTerm?: string,
 	{ enabled = true, staleTime = 1000 * 60 * 60 * 24, refetchOnMount = false }: UseQueryOptions = {}
 ): UseQueryResult => {
-	return useQuery( getCacheKey( type ), () => fetchWPCOMPlugins( type, searchTerm ), {
+	return useQuery( getCacheKey( type + searchTerm ), () => fetchWPCOMPlugins( type, searchTerm ), {
 		select: ( data ) => normalizePluginsList( data.results ),
 		enabled: enabled,
 		staleTime: staleTime,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* prepends the paid results to the search list. They will be shown first in every page of the search results.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="952" alt="SS 2021-12-24 at 12 58 17" src="https://user-images.githubusercontent.com/12430020/147347089-43911b3c-d061-4729-acf8-16384f8a1201.png">|<img width="953" alt="SS 2021-12-24 at 12 57 31" src="https://user-images.githubusercontent.com/12430020/147347055-d163de76-8317-40c7-a8fe-434e4201693f.png">|

- visit https://wordpress.com/plugins?s=woocommerce
- see that all 6 paid plugins appear
- change the search term to `table`
- only "Table rate shipping" should appear from paid results
- open the network tab in dev tools and filter by `marketplace`
- observe that a network request is fired only when search term changes. Using the same search term should use cached results.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58654
