### PR TITLE
Uses marketplace-v1 for paid search results.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -357,7 +357,11 @@ const SearchListView = ( {
 		return (
 			<>
 				<PluginsBrowserList
-					plugins={ [ ...paidPluginsBySearchTerm, ...pluginsBySearchTerm ] }
+					plugins={
+						isEnabled( 'marketplace-v1' )
+							? [ ...paidPluginsBySearchTerm, ...pluginsBySearchTerm ]
+							: pluginsBySearchTerm
+					}
 					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
 					title={ searchTitle }
 					subtitle={ subtitle }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses marketplace-v1 for paid search results

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* add `?flags=-marketplace-v1`
* search results **should not include** paid plugins
* add `?flags=marketplace-v1`
* search results **should include** paid plugins

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
