### PR TITLE
Onboarding WordPress importer: Setup logic for switching between chosen import types

### DIFF
--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -169,6 +169,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 											job={ getImportJob( engine ) }
 											siteId={ siteId }
 											siteSlug={ siteSlug }
+											fromSite={ fromSite }
 										/>
 									);
 								}

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -164,7 +164,13 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 									/**
 									 * WordPress importer
 									 */
-									return <WordpressImporter job={ getImportJob( engine ) } />;
+									return (
+										<WordpressImporter
+											job={ getImportJob( engine ) }
+											siteId={ siteId }
+											siteSlug={ siteSlug }
+										/>
+									);
 								}
 							} )() }
 						</div>

--- a/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
+++ b/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
@@ -1,6 +1,7 @@
 import { NextButton } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import page from 'page';
 import React from 'react';
 import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
@@ -20,7 +21,11 @@ interface Props {
 
 export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { isSiteJetpack } = props;
+	const { siteSlug, isSiteJetpack } = props;
+
+	function installJetpack( siteSlug: string ) {
+		page( `/jetpack/connect/?url=${ siteSlug }` );
+	}
 
 	return (
 		<div className={ classnames( 'import-layout', 'content-chooser' ) }>
@@ -45,9 +50,7 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 					</ActionCard>
 					{ ! isSiteJetpack && (
 						<SelectItems
-							onSelect={ () => {
-								// install jetpack
-							} }
+							onSelect={ () => installJetpack( siteSlug ) }
 							items={ [
 								{
 									key: 'jetpack',

--- a/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
+++ b/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
@@ -2,16 +2,25 @@ import { NextButton } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React from 'react';
+import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { jetpack } from 'calypso/signup/icons';
 import SelectItems from 'calypso/signup/select-items';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 
 import './style.scss';
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-export const ContentChooser: React.FunctionComponent = () => {
+interface Props {
+	siteId: number;
+	siteSlug: string;
+	isSiteJetpack: boolean;
+}
+
+export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
+	const { isSiteJetpack } = props;
 
 	return (
 		<div className={ classnames( 'import-layout', 'content-chooser' ) }>
@@ -28,29 +37,31 @@ export const ContentChooser: React.FunctionComponent = () => {
 			<div className={ 'import-layout__column' }>
 				<div>
 					<ActionCard
-						classNames={ classnames( 'list__importer-option', { 'is-disabled': true } ) }
+						classNames={ classnames( 'list__importer-option', { 'is-disabled': ! isSiteJetpack } ) }
 						headerText={ __( 'Everything' ) }
 						mainText={ __( "All your site's content, themes, plugins, users and settings" ) }
 					>
-						<NextButton disabled>{ __( 'Continue' ) }</NextButton>
+						<NextButton disabled={ ! isSiteJetpack }>{ __( 'Continue' ) }</NextButton>
 					</ActionCard>
-					<SelectItems
-						onSelect={ () => {
-							// install jetpack
-						} }
-						items={ [
-							{
-								key: 'jetpack',
-								title: __( 'Jetpack required' ),
-								description: __(
-									'You need to have Jetpack installed on your site to be able to import everything.'
-								),
-								icon: jetpack,
-								actionText: __( 'Install Jetpack' ),
-								value: '',
-							},
-						] }
-					/>
+					{ ! isSiteJetpack && (
+						<SelectItems
+							onSelect={ () => {
+								// install jetpack
+							} }
+							items={ [
+								{
+									key: 'jetpack',
+									title: __( 'Jetpack required' ),
+									description: __(
+										'You need to have Jetpack installed on your site to be able to import everything.'
+									),
+									icon: jetpack,
+									actionText: __( 'Install Jetpack' ),
+									value: '',
+								},
+							] }
+						/>
+					) }
 					<ActionCard
 						classNames={ classnames( 'list__importer-option', { 'is-disabled': false } ) }
 						headerText={ __( 'Content only' ) }
@@ -63,3 +74,9 @@ export const ContentChooser: React.FunctionComponent = () => {
 		</div>
 	);
 };
+
+export default connect( ( state, ownProps: Props ) => {
+	return {
+		isSiteJetpack: !! isJetpackSite( state, ownProps.siteId ),
+	};
+} )( ContentChooser );

--- a/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
+++ b/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
@@ -20,6 +20,7 @@ interface Props {
 	onContentOnlySelection: () => void;
 	onContentEverythingSelection: () => void;
 }
+export type WPImportType = 'everything' | 'content_only';
 
 export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();

--- a/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
+++ b/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
@@ -1,7 +1,6 @@
 import { NextButton } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import page from 'page';
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
@@ -17,11 +16,19 @@ interface Props {
 	siteId: number;
 	siteSlug: string;
 	fromSite: string;
+	onJetpackSelection: () => void;
+	onContentOnlySelection: () => void;
+	onContentEverythingSelection: () => void;
 }
 
 export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { fromSite } = props;
+	const {
+		fromSite,
+		onJetpackSelection,
+		onContentOnlySelection,
+		onContentEverythingSelection,
+	} = props;
 
 	/**
 	 ↓ Fields
@@ -42,10 +49,6 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 			.get( { apiVersion: '1.2' } )
 			.then( ( site: any ) => setHasOriginSiteJetpackConnected( site && site.capabilities ) )
 			.catch( () => setHasOriginSiteJetpackConnected( false ) );
-	}
-
-	function installJetpack( site: string ) {
-		page( `https://wordpress.com/jetpack/connect/?url=${ site }` );
 	}
 
 	return (
@@ -69,13 +72,16 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 						headerText={ __( 'Everything' ) }
 						mainText={ __( "All your site's content, themes, plugins, users and settings" ) }
 					>
-						<NextButton disabled={ ! hasOriginSiteJetpackConnected }>
+						<NextButton
+							disabled={ ! hasOriginSiteJetpackConnected }
+							onClick={ onContentEverythingSelection }
+						>
 							{ __( 'Continue' ) }
 						</NextButton>
 					</ActionCard>
 					{ ! hasOriginSiteJetpackConnected && (
 						<SelectItems
-							onSelect={ () => installJetpack( fromSite ) }
+							onSelect={ onJetpackSelection }
 							items={ [
 								{
 									key: 'jetpack',
@@ -95,7 +101,7 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 						headerText={ __( 'Content only' ) }
 						mainText={ __( 'Import posts, pages, comments, and media.' ) }
 					>
-						<NextButton>{ __( 'Continue' ) }</NextButton>
+						<NextButton onClick={ onContentOnlySelection }>{ __( 'Continue' ) }</NextButton>
 					</ActionCard>
 				</div>
 			</div>

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ImportJob } from '../types';
-import { ContentChooser } from './content-chooser';
+import ContentChooser from './content-chooser';
 
 import './style.scss';
 
@@ -8,10 +8,12 @@ import './style.scss';
 
 interface Props {
 	job?: ImportJob;
+	siteId: number;
+	siteSlug: string;
 }
 
-export const WordpressImporter: React.FunctionComponent< Props > = () => {
-	return <ContentChooser />;
+export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => {
+	return <ContentChooser { ...props } />;
 };
 
 export default WordpressImporter;

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -1,3 +1,4 @@
+import page from 'page';
 import React from 'react';
 import { ImportJob } from '../types';
 import ContentChooser from './content-chooser';
@@ -10,10 +11,35 @@ interface Props {
 	job?: ImportJob;
 	siteId: number;
 	siteSlug: string;
+	fromSite: string;
 }
 
 export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => {
-	return <ContentChooser { ...props } />;
+	const { fromSite } = props;
+
+	/**
+	 ↓ Methods
+	 */
+	function runMigrationProcess() {
+		// run migration process
+	}
+
+	function runContentUploadProcess() {
+		// run content upload process
+	}
+
+	function installJetpack() {
+		page( `https://wordpress.com/jetpack/connect/?url=${ fromSite }` );
+	}
+
+	return (
+		<ContentChooser
+			onJetpackSelection={ installJetpack }
+			onContentOnlySelection={ runContentUploadProcess }
+			onContentEverythingSelection={ runMigrationProcess }
+			{ ...props }
+		/>
+	);
 };
 
 export default WordpressImporter;

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -1,14 +1,6 @@
-import { NextButton } from '@automattic/onboarding';
-import { useI18n } from '@wordpress/react-i18n';
-import classnames from 'classnames';
 import React from 'react';
 import { ImportJob } from '../types';
 import { ContentChooser } from './content-chooser';
-import ActionCard from 'calypso/components/action-card';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { jetpack } from '../../../icons';
-import SelectItems from '../../../select-items';
-import { ImportJob } from '../types';
 
 import './style.scss';
 

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -1,6 +1,14 @@
+import { NextButton } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import React from 'react';
 import { ImportJob } from '../types';
 import { ContentChooser } from './content-chooser';
+import ActionCard from 'calypso/components/action-card';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { jetpack } from '../../../icons';
+import SelectItems from '../../../select-items';
+import { ImportJob } from '../types';
 
 import './style.scss';
 

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -20,16 +20,17 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	/**
 	 ↓ Methods
 	 */
+
+	function installJetpack() {
+		page( `https://wordpress.com/jetpack/connect/?url=${ fromSite }` );
+	}
+
 	function runMigrationProcess() {
 		// run migration process
 	}
 
 	function runContentUploadProcess() {
 		// run content upload process
-	}
-
-	function installJetpack() {
-		page( `https://wordpress.com/jetpack/connect/?url=${ fromSite }` );
 	}
 
 	return (

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -1,7 +1,7 @@
 import page from 'page';
-import React from 'react';
+import React, { useState } from 'react';
 import { ImportJob } from '../types';
-import ContentChooser from './content-chooser';
+import ContentChooser, { WPImportType } from './content-chooser';
 
 import './style.scss';
 
@@ -18,28 +18,38 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	const { fromSite } = props;
 
 	/**
+	 ↓ Fields
+	 */
+	const [ chosenType, setChosenType ] = useState< WPImportType >();
+
+	/**
 	 ↓ Methods
 	 */
-
 	function installJetpack() {
 		page( `https://wordpress.com/jetpack/connect/?url=${ fromSite }` );
 	}
 
 	function runMigrationProcess() {
-		// run migration process
+		setChosenType( 'everything' );
 	}
 
 	function runContentUploadProcess() {
-		// run content upload process
+		setChosenType( 'content_only' );
 	}
 
 	return (
-		<ContentChooser
-			onJetpackSelection={ installJetpack }
-			onContentOnlySelection={ runContentUploadProcess }
-			onContentEverythingSelection={ runMigrationProcess }
-			{ ...props }
-		/>
+		<>
+			{ chosenType === undefined && (
+				<ContentChooser
+					onJetpackSelection={ installJetpack }
+					onContentOnlySelection={ runContentUploadProcess }
+					onContentEverythingSelection={ runMigrationProcess }
+					{ ...props }
+				/>
+			) }
+			{ chosenType === 'everything' && <div>Import everything</div> }
+			{ chosenType === 'content_only' && <div>Import Content only</div> }
+		</>
 	);
 };
 

--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -70,6 +70,7 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 	const goToImporterPage = ( platform: ImporterPlatform ): void => {
 		let importerUrl;
 		if (
+			( platform === 'wordpress' && isEnabled( 'gutenboarding/import-from-wordpress' ) ) ||
 			( platform === 'medium' && isEnabled( 'gutenboarding/import-from-medium' ) ) ||
 			( platform === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) )
 		) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hydrated ContentChooser screen.
* Prepared screen to switch between chosen import types. For now, there are only placeholder screens for the selected types. (Everything vs. Content Only)
* Shown Jetpack installation block, and the logic is to redirect to the Jetpack installation page if Jetpack is not installed on the site of origin.

#### Testing instructions
- Go to `/start/from/importing/wordpress?from={ORIGIN_WP_SITE}&to={SLUG}.wordpress.com`
- Check if Jetpack is installed
- Check screen switching between selection of import "Everything" or "Content only"

This is just the first version of screen hydration, we'll continue working on flow improvements. The small chunks are only because of easier review.

#### Screenshot
<img width="1174" alt="Screenshot 2021-12-27 at 10 46 58" src="https://user-images.githubusercontent.com/1241413/147460349-5c5a5dba-90a0-497e-a719-00e16c4b84fb.png">

Related to #59042
