### PR TITLE
Plugin Details: normalized fullPlugin data.

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -137,9 +137,9 @@ function PluginDetails( props ) {
 		};
 
 		return {
-			...plugin,
 			...wpcomPlugin,
 			...wporgPlugin,
+			...plugin,
 			isMarketplaceProduct,
 		};
 	}, [ plugin, wporgPlugin, wpComPluginData, isWpComPluginFetched, isMarketplaceProduct ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* when merging `wpcomPlugin`, `wporgPlugin` and `plugin` any same keys (like `id`) are overwritten with the last object value. `plugin` is the response from the site (when the plugin is already installed) and therefore should be considered the canonical response. That's why moving it to the end, passed the correct plugin `id` for any action needed like activate / deactivate

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit a paid and a free plugin that are already installed
* switch the activation toggle
* everything should work and you should receive a status notification

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59569
