### PR TITLE
Add download option for VideoPress

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -89,8 +89,6 @@ class EditorMediaModalDetailFields extends Component {
 		// Update changes to local state immediately
 		this.props.onUpdate( itemId, modifiedChanges );
 
-		modifiedChanges.update_only = true;
-
 		// Save changes immediately or after a delay
 		if ( saveImmediately ) {
 			this.saveChange( siteId, itemId, modifiedChanges );

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -89,6 +89,8 @@ class EditorMediaModalDetailFields extends Component {
 		// Update changes to local state immediately
 		this.props.onUpdate( itemId, modifiedChanges );
 
+		modifiedChanges.update_only = true;
+
 		// Save changes immediately or after a delay
 		if ( saveImmediately ) {
 			this.saveChange( siteId, itemId, modifiedChanges );
@@ -122,6 +124,12 @@ class EditorMediaModalDetailFields extends Component {
 		const inputValue = '1' === this.getItemValue( 'display_embed' ) ? '0' : '1';
 
 		this.setFieldByName( 'display_embed', inputValue );
+	};
+
+	handleAllowDownloadOption = () => {
+		const inputValue = '1' === this.getItemValue( 'allow_download' ) ? '0' : '1';
+
+		this.setFieldByName( 'allow_download', inputValue );
 	};
 
 	getItemValue( attribute ) {
@@ -235,6 +243,38 @@ class EditorMediaModalDetailFields extends Component {
 		);
 	};
 
+	renderAllowDownloadOption = () => {
+		// Make sure this is actually a VideoPress video
+		const videopressGuid = this.getItemValue( 'videopress_guid' );
+		if ( ! videopressGuid ) {
+			return;
+		}
+
+		const allowDownloadKey = 'allow_download';
+		let allowDownload = this.getItemValue( allowDownloadKey );
+		if ( undefined === allowDownload ) {
+			allowDownload = 0;
+		}
+
+		return (
+			<EditorMediaModalFieldset legend={ this.props.translate( 'Download' ) }>
+				<FormLabel>
+					<FormCheckbox
+						id={ allowDownloadKey }
+						name={ allowDownloadKey }
+						checked={ allowDownload === '1' }
+						onChange={ this.handleAllowDownloadOption }
+					/>
+					<span>
+						{ this.props.translate(
+							'Display download option and allow viewers to download this video'
+						) }
+					</span>
+				</FormLabel>
+			</EditorMediaModalFieldset>
+		);
+	};
+
 	render() {
 		const { translate } = this.props;
 		return (
@@ -276,6 +316,7 @@ class EditorMediaModalDetailFields extends Component {
 				</EditorMediaModalFieldset>
 
 				{ this.renderShareEmbed() }
+				{ this.renderAllowDownloadOption() }
 				{ this.renderRating() }
 				{ this.renderVideoPressShortcode() }
 			</div>


### PR DESCRIPTION
Related to Automattic/greenhouse#1062

#### Changes proposed in this Pull Request

This PR adds an "allow download" button on VideoPress video attachments. 

#### Testing instructions

* On a local calypso instance  
* Sandbox a wpcom site and public-api.wordpress.com
* Apply the wpcom patch stack
    * phab co D72213
    * arc patch D72220
* Go to /media/<your_wpcom_site>.wordpress.com
* Select and edit or upload and edit a video with VideoPress
* ✅ The "download" checkbox should appear between the "share" and "rating" options
* Toggle the checkbox and reload the page
* ✅ The download option should be in the same state as before reloading the page
* ✅ No other setting should change

![Capture d’écran 2022-01-04 à 11 44 52](https://user-images.githubusercontent.com/1420594/148047633-17b40631-c34c-4816-ba1e-df768c03fc8b.png)


