### PR TITLE
Add free month offer to the cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1208,15 +1208,21 @@ class CancelPurchaseForm extends Component {
 	};
 
 	fetchPurchaseExtendedStatus = async ( purchaseId ) => {
-		const res = await wpcom.req.get( {
-			path: `/purchases/${ purchaseId }/has-extended`,
-			apiNamespace: 'wpcom/v2',
-		} );
-
 		const newState = {
 			...this.state,
-			purchaseIsAlreadyExtended: res.has_extended,
 		};
+
+		try {
+			const res = await wpcom.req.get( {
+				path: `/purchases/${ purchaseId }/has-extendedd`,
+				apiNamespace: 'wpcom/v2',
+			} );
+
+			newState.purchaseIsAlreadyExtended = res.has_extended;
+		} catch {
+			// When the request fails, set the flag to true so the extra options don't show up to users.
+			newState.purchaseIsAlreadyExtended = true;
+		}
 
 		if ( newState.purchaseIsAlreadyExtended && newState.upsell === 'free-month-offer' ) {
 			newState.upsell = '';

--- a/client/components/marketing-survey/cancel-purchase-form/options-for-product.js
+++ b/client/components/marketing-survey/cancel-purchase-form/options-for-product.js
@@ -9,7 +9,14 @@ export const cancellationOptionsForPurchase = ( purchase ) => {
 		return [ 'noLongerWantToTransfer', 'couldNotCompleteTransfer', 'useDomainWithoutTransferring' ];
 	}
 
-	return [ 'couldNotInstall', 'tooHard', 'didNotInclude', 'onlyNeedFree' ];
+	return [
+		'couldNotInstall',
+		'tooHard',
+		'didNotInclude',
+		'onlyNeedFree',
+		'noTime',
+		'siteIsNotReady',
+	];
 };
 
 export const nextAdventureOptionsForPurchase = ( purchase ) => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/free-month-offer-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/free-month-offer-step.tsx
@@ -1,0 +1,39 @@
+import { getPlan } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { FunctionComponent } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+
+interface Props {
+	productSlug: string;
+}
+
+const FreeMonthOfferStep: FunctionComponent< Props > = ( { productSlug } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="free-month-offer-step">
+			<FormSectionHeading className="free-month-offer-step__heading">
+				{ translate( 'How about a free month?', {
+					comment:
+						'Title of a nudge that offers a free month to a user who is canceling their current subscription.',
+				} ) }
+			</FormSectionHeading>
+			<FormFieldset>
+				<p>
+					{ translate(
+						'We will give you a free month of %(planName)s plan to help you continue using the benefits.',
+						{ args: { planName: getPlan( productSlug )?.getTitle() } }
+					) }
+				</p>
+			</FormFieldset>
+		</div>
+	);
+};
+
+FreeMonthOfferStep.propTypes = {
+	productSlug: PropTypes.string.isRequired,
+};
+
+export default FreeMonthOfferStep;

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/free-month-offer-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/free-month-offer-step.tsx
@@ -17,13 +17,13 @@ const FreeMonthOfferStep: FunctionComponent< Props > = ( { productSlug } ) => {
 			<FormSectionHeading className="free-month-offer-step__heading">
 				{ translate( 'How about a free month?', {
 					comment:
-						'Title of a nudge that offers a free month to a user who is canceling their current subscription.',
+						'Title of a nudge that offers a free month to those who are canceling their current subscription.',
 				} ) }
 			</FormSectionHeading>
 			<FormFieldset>
 				<p>
 					{ translate(
-						'We will give you a free month of %(planName)s plan to help you continue using the benefits.',
+						'Need more time? Enjoy a month of your Premium subscription for free and continue building on your site.',
 						{ args: { planName: getPlan( productSlug )?.getTitle() } }
 					) }
 				</p>

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/free-month-offer-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/free-month-offer-step.tsx
@@ -23,7 +23,7 @@ const FreeMonthOfferStep: FunctionComponent< Props > = ( { productSlug } ) => {
 			<FormFieldset>
 				<p>
 					{ translate(
-						'Need more time? Enjoy a month of your Premium subscription for free and continue building on your site.',
+						'Need more time? Enjoy a month of your %(planName)s subscription for free and continue building on your site.',
 						{ args: { planName: getPlan( productSlug )?.getTitle() } }
 					) }
 				</p>

--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -60,3 +60,10 @@ export function enableAutoRenew( purchaseId, onComplete ) {
 		onComplete( success );
 	} );
 }
+
+export function extendPurchaseWithFreeMonth( purchaseId ) {
+	return wpcom.req.post( {
+		path: `/purchases/${ purchaseId }/extend`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR shows an extra step to the purchase cancellation flow to offer a free month to those whose current site is on a monthly plan.
* For more details, please check out the project thread pcbrnV-3Hn-p2

#### Testing instructions

* Make sure that D71954-code is applied to the sandboxed `public-api.wordpress.com`.
* Cancel the current monthly subscription.
  <img width="1255" alt="Cancel_Purchase_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/147485728-84f3a79d-fdb1-48a9-bbc4-70d0525dfd03.png">
* If you pick either of the new options - `My site is not ready` or `I don't have time` - the free month offer dialog shows up.
  <img width="669" alt="Cancel_Purchase_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/147485875-e94ce503-76a1-4ed3-845b-4d2ab27aa658.png">
* Click on `Get a free month` then the expiry date of the current monthly plan will be extended.

_Note 1: This is one-time offer. If you try it second time, you will see an error message._
_Note 2: The offer shows up only to monthly users._
