### PR TITLE
Videos UI: Better cache handling.

### DIFF
--- a/client/data/courses/use-course-query.js
+++ b/client/data/courses/use-course-query.js
@@ -6,12 +6,10 @@ const useCourseQuery = ( courseSlug, queryOptions = {} ) => {
 		[ 'courses', courseSlug ],
 		() => wpcom.req.get( '/courses', { course_slug: courseSlug, apiNamespace: 'wpcom/v2' } ),
 		{
-			// Our course offering doesn't change that often, we don't need to
-			// re-fetch until the next page refresh.
-			staleTime: Infinity,
+			refetchOnReconnect: true,
+			refetchOnWindowFocus: false,
 			...queryOptions,
 			meta: {
-				persist: false,
 				...queryOptions.meta,
 			},
 		}


### PR DESCRIPTION
This PR derives from [a discussion](https://github.com/Automattic/wp-calypso/pull/58234#discussion_r773655790) on how to handle caching/refetching.

This uses two react query options: `refetchOnReconnect` and `refetchOnWindowFocus`. The intended result is that a refetch is triggered every time the VideoUI component is loaded but DO NOT refetch on window focus.

### Testing
1. Apply this patch.
2. Open the Video UI from the card.
3. Verify that the query is executed.
4. Change tabs and verify that when you come back the query is not executed again.
5. Verify that after closing and reopening the popup the query is re-executed.