### PR TITLE
Remove deprecated code from product card features utils

### DIFF
--- a/client/my-sites/plans/jetpack-plans/build-card-features-from-item.ts
+++ b/client/my-sites/plans/jetpack-plans/build-card-features-from-item.ts
@@ -1,9 +1,8 @@
 import { Product } from '@automattic/calypso-products';
 import { getFeatureByKey } from 'calypso/lib/plans/features-list';
-import { getForCurrentCROIteration, Iterations } from './iterations';
 import objectIsPlan from './object-is-plan';
-import type { SelectorProductFeaturesItem, SelectorProductFeaturesSection } from './types';
-import type { Plan } from '@automattic/calypso-products';
+import type { SelectorProductFeaturesItem } from './types';
+import type { Plan, Feature } from '@automattic/calypso-products';
 
 /**
  * Feature utils.
@@ -12,42 +11,18 @@ import type { Plan } from '@automattic/calypso-products';
 /**
  * Builds the feature item of a product card, from a feature key.
  *
- * @param {string[]|string} featureKey Key of the feature
- * @param {object?} options Options
- * @param {string?} options.withoutDescription Whether to build the card with a description
- * @param {string?} options.withoutIcon Whether to build the card with an icon
- * @param {string?} variation Experiment variation
+ * @param {Feature[]|Feature} featureKey Key of the feature
  * @returns {SelectorProductFeaturesItem} Feature item
  */
 function buildCardFeatureItemFromFeatureKey(
-	featureKey: string[] | string,
-	options?: { withoutDescription?: boolean; withoutIcon?: boolean },
-	variation?: string
+	featureKey: Feature
 ): SelectorProductFeaturesItem | undefined {
-	let feature;
-	let subFeaturesKeys;
-
-	if ( Array.isArray( featureKey ) ) {
-		const [ key, subKeys ] = featureKey;
-
-		feature = getFeatureByKey( key );
-		subFeaturesKeys = subKeys;
-	} else {
-		feature = getFeatureByKey( featureKey );
-	}
+	const feature = getFeatureByKey( featureKey );
 
 	if ( feature ) {
 		return {
 			slug: feature.getSlug(),
-			icon: options?.withoutIcon ? undefined : feature.getIcon?.( variation ),
-			text: feature.getTitle( variation ),
-			description: options?.withoutDescription ? undefined : feature.getDescription?.(),
-			subitems: subFeaturesKeys
-				? subFeaturesKeys
-						.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
-						.filter( Boolean )
-				: undefined,
-			isHighlighted: feature.isHighlighted?.() ?? false,
+			text: feature.getTitle(),
 		};
 	}
 }
@@ -55,47 +30,35 @@ function buildCardFeatureItemFromFeatureKey(
 /**
  * Builds the feature items passed to the product card, from feature keys.
  *
- * @param {string[]} features Feature keys
- * @param {object?} options Options
- * @param {string?} variation Experiment variation
+ * @param {Feature[]} features Feature keys
  * @returns {SelectorProductFeaturesItem[]} Features
  */
-function buildCardFeaturesFromFeatureKeys(
-	features: string[],
-	options?: Record< string, unknown >,
-	variation?: Iterations
-): SelectorProductFeaturesItem[] {
+function buildCardFeaturesFromFeatureKeys( features: Feature[] ): SelectorProductFeaturesItem[] {
 	return features
-		.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
-		.filter( Boolean );
+		.map( ( f ) => buildCardFeatureItemFromFeatureKey( f ) )
+		.filter( Boolean ) as SelectorProductFeaturesItem[];
 }
 
 /**
- * Builds the feature items passed to the product card, from a plan, product, or object.
+ * Builds the feature items passed to the product card, from a plan, product, or features array.
  *
- * @param {Plan | Product | object} item Product, plan, or object
- * @param {object?} options Options
- * @param {string?} variation The current A/B test variation
- * @returns {SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[]} Features
+ * @param {Plan | Product | Feature[]} item Product, plan, or features array
+ * @returns {SelectorProductFeaturesItem[]} Features
  */
 export default function buildCardFeaturesFromItem(
-	item: Plan | Product | Record< string, unknown >,
-	options?: Record< string, unknown >,
-	variation?: Iterations
-): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
-	if ( objectIsPlan( item ) ) {
-		const features = item.getPlanCardFeatures?.();
-
-		if ( features ) {
-			return buildCardFeaturesFromFeatureKeys( features, options, variation );
-		}
-	} else if ( typeof item.getFeatures === 'function' ) {
-		const features = getForCurrentCROIteration( item.getFeatures );
-
-		if ( features ) {
-			return buildCardFeaturesFromFeatureKeys( features, options, variation );
-		}
+	item: Plan | Product | Feature[]
+): SelectorProductFeaturesItem[] {
+	if ( Array.isArray( item ) ) {
+		return buildCardFeaturesFromFeatureKeys( item );
 	}
 
-	return buildCardFeaturesFromFeatureKeys( item, options, variation );
+	let features;
+
+	if ( objectIsPlan( item as Plan ) ) {
+		features = ( item as Plan ).getPlanCardFeatures?.();
+	} else {
+		features = ( item as Product ).getFeatures?.();
+	}
+
+	return features ? buildCardFeaturesFromFeatureKeys( features ) : [];
 }

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -37,7 +37,6 @@ import {
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import buildCardFeaturesFromItem from './build-card-features-from-item';
-import type { Iterations } from './iterations';
 import type { SelectorProduct } from './types';
 import type { JetpackPlanSlug } from '@automattic/calypso-products';
 
@@ -53,9 +52,7 @@ export const ITEM_TYPE_PRODUCT = 'item-type-product';
 const CRM_ENTREPRENEUR_PRICE = 17;
 const CRM_ENTREPRENEUR_CURRENCY = 'USD';
 
-export const EXTERNAL_PRODUCT_CRM_FREE: ( variation: Iterations ) => SelectorProduct = (
-	variation
-) => ( {
+export const EXTERNAL_PRODUCT_CRM_FREE = (): SelectorProduct => ( {
 	productSlug: PRODUCT_JETPACK_CRM_FREE,
 	term: TERM_ANNUALLY,
 	type: ITEM_TYPE_PRODUCT,
@@ -75,34 +72,26 @@ export const EXTERNAL_PRODUCT_CRM_FREE: ( variation: Iterations ) => SelectorPro
 	description: translate( 'Build better relationships with your customers and clients.' ),
 	buttonLabel: translate( 'Start for free' ),
 	features: {
-		items: buildCardFeaturesFromItem(
-			[
-				FEATURE_CRM_NO_CONTACT_LIMITS,
-				FEATURE_CRM_PROPOSALS_AND_INVOICES,
-				FEATURE_CRM_INTEGRATED_WITH_WORDPRESS,
-			],
-			{ withoutDescription: true, withoutIcon: true },
-			variation
-		),
+		items: buildCardFeaturesFromItem( [
+			FEATURE_CRM_NO_CONTACT_LIMITS,
+			FEATURE_CRM_PROPOSALS_AND_INVOICES,
+			FEATURE_CRM_INTEGRATED_WITH_WORDPRESS,
+		] ),
 	},
 	hidePrice: true,
 	externalUrl:
 		'https://jetpackcrm.com/pricing?utm_source=jetpack&utm_medium=web&utm_campaign=pricing_i4&utm_content=pricing',
 } );
 
-export const EXTERNAL_PRODUCT_CRM_FREE_MONTHLY: ( variation: Iterations ) => SelectorProduct = (
-	variation
-) => ( {
-	...EXTERNAL_PRODUCT_CRM_FREE( variation ),
+export const EXTERNAL_PRODUCT_CRM_FREE_MONTHLY = (): SelectorProduct => ( {
+	...EXTERNAL_PRODUCT_CRM_FREE(),
 	term: TERM_MONTHLY,
 	productSlug: PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 	costProductSlug: PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 	monthlyProductSlug: PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 } );
 
-export const EXTERNAL_PRODUCT_CRM: ( variation: Iterations ) => SelectorProduct = (
-	variation
-) => ( {
+export const EXTERNAL_PRODUCT_CRM = (): SelectorProduct => ( {
 	productSlug: PRODUCT_JETPACK_CRM,
 	term: TERM_ANNUALLY,
 	type: ITEM_TYPE_PRODUCT,
@@ -122,25 +111,19 @@ export const EXTERNAL_PRODUCT_CRM: ( variation: Iterations ) => SelectorProduct 
 	),
 	buttonLabel: translate( 'Get CRM' ),
 	features: {
-		items: buildCardFeaturesFromItem(
-			[
-				FEATURE_CRM_LEADS_AND_FUNNEL,
-				FEATURE_CRM_PROPOSALS_AND_INVOICES,
-				FEATURE_CRM_TRACK_TRANSACTIONS,
-				FEATURE_CRM_NO_CONTACT_LIMITS,
-			],
-			{ withoutDescription: true, withoutIcon: true },
-			variation
-		),
+		items: buildCardFeaturesFromItem( [
+			FEATURE_CRM_LEADS_AND_FUNNEL,
+			FEATURE_CRM_PROPOSALS_AND_INVOICES,
+			FEATURE_CRM_TRACK_TRANSACTIONS,
+			FEATURE_CRM_NO_CONTACT_LIMITS,
+		] ),
 	},
 	hidePrice: true,
 	externalUrl: 'https://jetpackcrm.com/pricing/',
 } );
 
-export const EXTERNAL_PRODUCT_CRM_MONTHLY: ( variation: Iterations ) => SelectorProduct = (
-	variation
-) => ( {
-	...EXTERNAL_PRODUCT_CRM( variation ),
+export const EXTERNAL_PRODUCT_CRM_MONTHLY = (): SelectorProduct => ( {
+	...EXTERNAL_PRODUCT_CRM(),
 	productSlug: PRODUCT_JETPACK_CRM_MONTHLY,
 	term: TERM_MONTHLY,
 	displayTerm: TERM_ANNUALLY,
@@ -156,10 +139,7 @@ export const EXTERNAL_PRODUCTS_LIST = [
 ];
 
 // External Product slugs to SelectorProduct.
-export const EXTERNAL_PRODUCTS_SLUG_MAP: Record<
-	string,
-	( variation: Iterations ) => SelectorProduct
-> = {
+export const EXTERNAL_PRODUCTS_SLUG_MAP: Record< string, () => SelectorProduct > = {
 	[ PRODUCT_JETPACK_CRM_FREE ]: EXTERNAL_PRODUCT_CRM_FREE,
 	[ PRODUCT_JETPACK_CRM_FREE_MONTHLY ]: EXTERNAL_PRODUCT_CRM_FREE_MONTHLY,
 	[ PRODUCT_JETPACK_CRM ]: EXTERNAL_PRODUCT_CRM,

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -114,17 +114,7 @@ function itemToSelectorProduct(
 			categories: item.categories,
 			hidePrice: JETPACK_SEARCH_PRODUCTS.includes( item.product_slug ),
 			features: {
-				items:
-					getForCurrentCROIteration( ( variation: Iterations ) =>
-						buildCardFeaturesFromItem(
-							item,
-							{
-								withoutDescription: true,
-								withoutIcon: true,
-							},
-							variation
-						)
-					) || [],
+				items: buildCardFeaturesFromItem( item ),
 			},
 		};
 	} else if ( objectIsPlan( item ) ) {
@@ -150,10 +140,7 @@ function itemToSelectorProduct(
 			monthlyProductSlug,
 			term: item.term === TERM_BIENNIALLY ? TERM_ANNUALLY : item.term,
 			features: {
-				items:
-					getForCurrentCROIteration( ( variation: Iterations ) =>
-						buildCardFeaturesFromItem( item, undefined, variation )
-					) || [],
+				items: buildCardFeaturesFromItem( item ),
 			},
 			legacy: ! isResetPlan,
 		};

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -85,13 +85,8 @@ export type SelectorProductFeaturesItem = {
 	isDifferentiator?: boolean;
 };
 
-export type SelectorProductFeaturesSection = {
-	heading: TranslateResult;
-	list: SelectorProductFeaturesItem[];
-};
-
 export type SelectorProductFeatures = {
-	items: SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[];
+	items: SelectorProductFeaturesItem[];
 };
 
 export interface SelectorProduct extends SelectorProductCost {

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -97,6 +97,7 @@ export type Plan = BillingTerm & {
 	getDescription: () => TranslateResult;
 	getShortDescription?: () => TranslateResult;
 	getTagline?: () => TranslateResult;
+	getPlanCardFeatures?: () => Feature[];
 
 	/**
 	 * Features that are included as part of this plan.


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes outdated functionalities from the code that builds the product card features list.

### Implementation notes

At some point, we implemented nested features list, with custom icons instead of bullet points. This is no longer needed, and this PR removes the related code, fixing TS errors along the way. Running concurrent versions of the product cards is not something we require anymore either.

### Testing instructions

- Download the PR and run Calypso or cloud
- Visit the plans/pricing page
- Verify that it looks as in production

### Screenshots
<img width="388" alt="Screen Shot 2021-12-27 at 11 37 04 AM" src="https://user-images.githubusercontent.com/1620183/147490707-31aa9cad-f885-4f5b-82c3-7dc50de83825.png">

