### PR TITLE
Add detection and enable renewals in the cart for the Titan yearly product 

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -536,7 +536,7 @@ export function getRenewalItemFromProduct(
 	}
 
 	if ( isTitanMail( product ) ) {
-		cartItem = titanMailMonthly( product );
+		cartItem = titanMailProduct( product, slug );
 	}
 
 	if ( isSiteRedirect( product ) ) {

--- a/packages/calypso-products/src/constants/titan.ts
+++ b/packages/calypso-products/src/constants/titan.ts
@@ -1,2 +1,4 @@
 export const TITAN_MAIL_MONTHLY_SLUG = 'wp_titan_mail_monthly';
 export const TITAN_MAIL_YEARLY_SLUG = 'wp_titan_mail_yearly';
+
+export const TITAN_MAIL_SLUGS = <const>[ TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG ];

--- a/packages/calypso-products/src/is-titan-mail.ts
+++ b/packages/calypso-products/src/is-titan-mail.ts
@@ -1,7 +1,7 @@
 import { camelOrSnakeSlug } from './camel-or-snake-slug';
-import { TITAN_MAIL_MONTHLY_SLUG } from './constants';
+import { TITAN_MAIL_SLUGS } from './constants';
 import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
 
 export function isTitanMail( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
-	return camelOrSnakeSlug( product ) === TITAN_MAIL_MONTHLY_SLUG;
+	return ( TITAN_MAIL_SLUGS as ReadonlyArray< string > ).includes( camelOrSnakeSlug( product ) );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `isTitanMail` to recognize the yearly product variation
* Enable renewals for the Titan yearly product


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select a Professional Email Annual product ( i.e billing properties )
* Select `Renew` or `Renew Now`
* Confirm that it's added to the cart successfully
* Confirm that the renewal succeeds

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


