### PR TITLE
Marketplace: Update CTA Button Text

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -228,7 +228,7 @@ const CTAButton = ( {
 					isMarketplaceProduct
 						? translate( 'Purchase and activate' )
 						: shouldUpgrade
-						? translate( 'Upgrade and install' )
+						? translate( 'Upgrade and activate' )
 						: translate( 'Install and activate' )
 				}
 			</Button>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -226,7 +226,7 @@ const CTAButton = ( {
 				{
 					// eslint-disable-next-line no-nested-ternary
 					isMarketplaceProduct
-						? translate( 'Pay and install' )
+						? translate( 'Purchase and activate' )
 						: shouldUpgrade
 						? translate( 'Upgrade and install' )
 						: translate( 'Install and activate' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update CTA button text from "Pay and install" to "Purchase and activate"

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to free site -> Plugins -> add new
* Click on any paid plugin.
* Verify CTA button text says "Purchase and activate" instead "Pay and install"

<img width="1083" alt="after" src="https://user-images.githubusercontent.com/351784/147566812-553946bd-ac8d-4191-8393-85350a0e5f2c.png">

* Go to free site -> Plugins -> add new
* Click on any free plugin.
* Verify CTA button text says "Upgrade and activate" instead "Upgrade and install"

<img width="1144" alt="Screen Shot 2021-12-28 at 10 37 23 PM" src="https://user-images.githubusercontent.com/351784/147625150-26f2f728-ea67-496a-8998-1ff21db15f5f.png">


Related to #59398
