### PR TITLE
Video UI: fix long video titles

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -109,7 +109,6 @@
 		}
 
 		max-width: 1280px;
-		margin: 0 auto;
 		padding: 64px 20px 97px;
 
 		h3 {
@@ -352,6 +351,7 @@
 		}
 
 		.videos-ui__body {
+			margin: 0 auto;
 			max-width: 1160px;
 			padding: 0 20px 80px;
 			h3 {


### PR DESCRIPTION
When the video title is long the accordion doesn't resize correctly on <= break-medium. This PR fixes that. 

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/147578089-07e36aa5-3bb2-4bf9-b35c-58e943a388b4.png) | ![image](https://user-images.githubusercontent.com/375980/147578141-336314bc-faf8-47fb-8b48-ecf56e17d021.png) |

### Testing
* Set up your account to spanish, since the video titles in this language are longer.
* Go to the calypso.live link on the comments of this PR.
* Click the Start Learning link on the Blog Like an Expert card
  <img width="600" src="https://user-images.githubusercontent.com/13596067/147180827-174b1b00-d21a-48ae-ac5e-08a05d74bdb1.png" />
* Verify the Videos UI looks correctly on mobile.