### PR TITLE
Enable purchases section in cloud in production

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -65,7 +65,8 @@
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
 		"jetpack-search": true,
-		"scan": true
+		"scan": true,
+		"site-purchases": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR enables the _Purchases_ section in Jetpack cloud in production. Implementation was conducted in #59324.

### Implementation notes

This PR is a minimum viable implementation of this section in cloud. Later feedback will help us determine if it provides a good experience in cloud or if we'll need to iterate on it.

Here's what differs in the cloud implementation:
- Formatted headers and descriptive texts are absent, to match the current UI of cloud.
- The _View all purchases_ and _View all billing history and receipts_ links are removed as well. They direct to the WordPress profile, and we want to avoid users switching between platforms.

### Testing instructions

Test the following in staging.

#### Testing scenarios

- Site with a free plan
- Site with a monthly subscription (so that we can test the upgrade to yearly feature)
- Site with a lesser product or plan subscription (so that we can test the upgrade to a better product)

#### Regression testing in WordPress.com

- Make sure you have a self-hosted site with a Jetpack subscription
- Visit `https://wordpress.com/purchases/subscriptions/:site`
- Check that the _Active Upgrades_, _Billing History_, and _Payment Methods_ sections looks and behaves as expected
- Make sure you tested the 3 scenarios mentioned above

#### Cloud implementation

- Make sure you have a self-hosted site with a Jetpack subscription
- Visit `https://cloud.jetpack.com/purchases/subscriptions/:site`
- Check that you can see the _Purchases_ section in the sidebar navigation
- Check that the _Active Upgrades_, _Billing History_, and _Payment Methods_ sections looks and behaves as expected, keeping in mind the differences mentioned in the implementation notes
- Make sure you tested the 3 scenarios mentioned above
