### PR TITLE
Breadcrumb: fixes first item color when no other items exist.

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -23,7 +23,7 @@ const StyledLi = styled.li`
 		--color-link: var( --studio-gray-80 );
 	}
 
-	:last-child {
+	:last-child:not( :first-child ) {
 		--color-link: var( --studio-gray-50 );
 	}
 `;

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -182,7 +182,7 @@ function PluginDetails( props ) {
 		// - change the first breadcrumb if prev page wasn't plugins page (eg activity log)
 		const navigationItems = [
 			{ label: translate( 'Plugins' ), href: `/plugins/${ selectedSite?.slug || '' }` },
-			{ label: fullPlugin.name },
+			{ label: fullPlugin.name, href: `/plugins/${ selectedSite?.slug }/${ fullPlugin.slug }` },
 		];
 
 		return navigationItems;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* fixes first item color when it also is the last.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="552" alt="SS 2021-12-28 at 17 42 01" src="https://user-images.githubusercontent.com/12430020/147582859-27ef71e4-1623-4855-9766-566ec4006654.png">|<img width="544" alt="SS 2021-12-28 at 17 41 42" src="https://user-images.githubusercontent.com/12430020/147582840-09239f2d-d3d6-4cda-bcc1-a583dfca2c4f.png">|

- visit https://wordpress.com/plugins
- inspect the Plugins color in the navigation header

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59519
