### PR TITLE
Plugins Browser: fetch correct amount of wporg plugins.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -356,10 +356,8 @@ const SearchListView = ( {
 				},
 			} );
 
-		let pageSize;
-		if ( ! isEnabled( 'marketplace-v1' ) ) {
-			pageSize = SEARCH_RESULTS_LIST_LENGTH;
-		} else if ( pluginsPagination?.page === 1 ) {
+		let pageSize = SEARCH_RESULTS_LIST_LENGTH;
+		if ( isEnabled( 'marketplace-v1' ) && pluginsPagination?.page === 1 ) {
 			// Paid results appear only in the first page.
 			// Since the wporg results will always be an even number and paid results might be odd
 			// append one more wporg result if needed to fill the grid.
@@ -367,8 +365,6 @@ const SearchListView = ( {
 				SEARCH_RESULTS_LIST_LENGTH +
 				paidPluginsBySearchTerm?.length +
 				( paidPluginsBySearchTerm?.length % 2 );
-		} else {
-			pageSize = SEARCH_RESULTS_LIST_LENGTH;
 		}
 
 		const pluginItemsFeatch = ( page ) => {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -356,6 +356,10 @@ const SearchListView = ( {
 				},
 			} );
 
+		const paginationItemsFetch = isEnabled( 'marketplace-v1' )
+			? SEARCH_RESULTS_LIST_LENGTH - paidPluginsBySearchTerm?.length
+			: SEARCH_RESULTS_LIST_LENGTH;
+
 		return (
 			<>
 				<PluginsBrowserList
@@ -378,10 +382,10 @@ const SearchListView = ( {
 				{ pluginsPagination && (
 					<Pagination
 						page={ pluginsPagination.page }
-						perPage={ SEARCH_RESULTS_LIST_LENGTH }
+						perPage={ paginationItemsFetch }
 						total={ pluginsPagination.results }
 						pageClick={ ( page ) => {
-							dispatch( fetchPluginsList( null, page, searchTerm, SEARCH_RESULTS_LIST_LENGTH ) );
+							dispatch( fetchPluginsList( null, page, searchTerm, paginationItemsFetch ) );
 						} }
 						variant={ PaginationVariant.minimal }
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a temp fix that allows all wporg plugin results to be displayed by requesting the correct amount of wporg plugins. It appends 1 wporg result to fill the grid if needed.
The first page will show:
- all wpcom plugins
- 12 wporg plugins
- 1 more wporg plugin in case that wpcom plugins are odd in number.

Note: due to api.wordpress.org not having an `offset` property that we can use, the last item of the first page will be repeated as the first item in second page in case that wpcom plugins are odd in number. To avoid this, if needed, we need to drop the filling mechanism.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="973" alt="SS 2021-12-29 at 18 09 32" src="https://user-images.githubusercontent.com/12430020/147681698-a335d636-e569-4a1b-ab72-6ec1aa627d70.png">|<img width="887" alt="SS 2021-12-29 at 18 10 00" src="https://user-images.githubusercontent.com/12430020/147681726-f328183a-e938-4b07-bfce-1e23cd5fbb43.png">|

- visit `/plugins?s=subscriptions`
- see that Akismet appears

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59567
