### PR TITLE
Checkout: fix alignment for small brand logos

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/payment-logo.tsx
+++ b/packages/composite-checkout/src/lib/payment-methods/payment-logo.tsx
@@ -30,9 +30,9 @@ export default function PaymentLogo( {
 			break;
 		case 'mastercard':
 			cardFieldIcon = (
-				<SmallBrandLogo isSummary={ isSummary }>
+				<BrandLogo isSummary={ isSummary }>
 					<MastercardLogo />
-				</SmallBrandLogo>
+				</BrandLogo>
 			);
 			break;
 		case 'amex':
@@ -44,23 +44,23 @@ export default function PaymentLogo( {
 			break;
 		case 'jcb':
 			cardFieldIcon = (
-				<SmallBrandLogo isSummary={ isSummary }>
+				<BrandLogo isSummary={ isSummary }>
 					<JcbLogo />
-				</SmallBrandLogo>
+				</BrandLogo>
 			);
 			break;
 		case 'diners':
 			cardFieldIcon = (
-				<SmallBrandLogo isSummary={ isSummary }>
+				<BrandLogo isSummary={ isSummary }>
 					<DinersLogo />
-				</SmallBrandLogo>
+				</BrandLogo>
 			);
 			break;
 		case 'unionpay':
 			cardFieldIcon = (
-				<SmallBrandLogo isSummary={ isSummary }>
+				<BrandLogo isSummary={ isSummary }>
 					<UnionpayLogo />
-				</SmallBrandLogo>
+				</BrandLogo>
 			);
 			break;
 		case 'discover':
@@ -105,14 +105,6 @@ const LockIconGraphic = styled( LockIcon )`
 	.rtl & {
 		right: auto;
 		left: 10px;
-	}
-`;
-
-const SmallBrandLogo = styled( BrandLogo )`
-	transform: translate( ${ ( props ) => ( props.isSummary ? '-10px, 4px' : '10px, 0' ) } );
-
-	.rtl & {
-		transform: translate( ${ ( props ) => ( props.isSummary ? '10px, 4px' : '-10px, 0' ) } );
 	}
 `;
 

--- a/packages/wpcom-checkout/src/payment-method-logos.tsx
+++ b/packages/wpcom-checkout/src/payment-method-logos.tsx
@@ -39,9 +39,9 @@ export function PaymentLogo( {
 			break;
 		case 'mastercard':
 			cardFieldIcon = (
-				<SmallBrandLogo isSummary={ isSummary }>
+				<BrandLogo isSummary={ isSummary }>
 					<MastercardLogo />
-				</SmallBrandLogo>
+				</BrandLogo>
 			);
 			break;
 		case 'amex':
@@ -53,23 +53,23 @@ export function PaymentLogo( {
 			break;
 		case 'jcb':
 			cardFieldIcon = (
-				<SmallBrandLogo isSummary={ isSummary }>
+				<BrandLogo isSummary={ isSummary }>
 					<JcbLogo />
-				</SmallBrandLogo>
+				</BrandLogo>
 			);
 			break;
 		case 'diners':
 			cardFieldIcon = (
-				<SmallBrandLogo isSummary={ isSummary }>
+				<BrandLogo isSummary={ isSummary }>
 					<DinersLogo />
-				</SmallBrandLogo>
+				</BrandLogo>
 			);
 			break;
 		case 'unionpay':
 			cardFieldIcon = (
-				<SmallBrandLogo isSummary={ isSummary }>
+				<BrandLogo isSummary={ isSummary }>
 					<UnionpayLogo />
-				</SmallBrandLogo>
+				</BrandLogo>
 			);
 			break;
 		case 'discover':
@@ -110,14 +110,6 @@ const LockIconGraphic = styled( LockIcon )`
 	.rtl & {
 		right: auto;
 		left: 10px;
-	}
-`;
-
-const SmallBrandLogo = styled( BrandLogo )`
-	transform: translate( ${ ( props ) => ( props.isSummary ? '-10px, 4px' : '10px, 0' ) } );
-
-	.rtl & {
-		transform: translate( ${ ( props ) => ( props.isSummary ? '10px, 4px' : '-10px, 0' ) } );
 	}
 `;
 


### PR DESCRIPTION
It seems like the styling for the `SmallBrandLogo` is no longer needed (probably because of other styling updates), and causes the alignment of the payment method logos to be incorrect. This removes the styling.

| Before | After |
| ----------- | ----------- |
| <img width="570" alt="Screen Shot 2021-12-28 at 11 51 37 AM" src="https://user-images.githubusercontent.com/942359/147589168-de5e036b-a3d7-4b95-8974-b674a1880ceb.png"> | <img width="570" alt="Screen Shot 2021-12-28 at 11 51 05 AM" src="https://user-images.githubusercontent.com/942359/147589208-dd86a915-03ea-43ce-b195-faa15fca3256.png"> |

**To test:**
- Make some purchases with smaller logo payment methods (Mastercard, JCB, Diners Club, Union Pay) in Checkout using Stripe's [testing card numbers](https://stripe.com/docs/testing#cards). You can do this quickly by renewing an existing purchase via `/me/purchases`
- Visit Checkout for a new purchase or renewal
- Verify that the card logos are aligned correctly