### PR TITLE
Update stacked email comparison styles

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -18,6 +18,7 @@ const noop = () => {};
 const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) => {
 	const {
 		children,
+		className,
 		description,
 		detailsExpanded,
 		expandButtonLabel,
@@ -67,7 +68,7 @@ const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) =
 
 	return (
 		<PromoCard
-			className={ classnames( 'email-providers-stacked-comparison__provider-card', {
+			className={ classnames( 'email-providers-stacked-comparison__provider-card', className, {
 				'is-expanded': detailsExpanded,
 			} ) }
 			image={ logo }

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -107,6 +107,7 @@ $width-left-panel-card: 55%;
 }
 
 .email-provider-stacked-card__title-price-badge {
+	font-size: $font-body-small;
 	margin-top: 0.5em;
 	width: 100%;
 
@@ -142,6 +143,14 @@ $width-left-panel-card: 55%;
 
 		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: row;
+		}
+
+		.action-panel__body {
+			color: var( --color-text );
+
+			p {
+				margin-bottom: 0.5em;
+			}
 		}
 
 		.action-panel__figure {
@@ -263,6 +272,7 @@ $width-left-panel-card: 55%;
 .email-provider-stacked-card__title-container {
 	display: flex;
 	flex-direction: column;
+	font-size: $font-body-small;
 	max-width: 100%;
 
 	@include break-xlarge {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -119,9 +119,12 @@ $width-left-panel-card: 55%;
 }
 
 .email-provider-stacked-card__title-price-badge {
+	margin-top: 0.5em;
 	width: 100%;
-	margin-left: 10px;
+
 	@include break-large {
+		margin-left: 10px;
+		margin-top: 0;
 		width: $width-right-panel-card;
 	}
 }

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -127,6 +127,18 @@ $width-left-panel-card: 55%;
 		margin-top: 0;
 		width: $width-right-panel-card;
 	}
+
+	.promo-card__price {
+		.price__cost {
+			.provider-cards__price-with-interval-price-discounted {
+				text-decoration: line-through;
+			}
+
+			.provider-cards__price-with-interval-sale-price {
+				color: var( --studio-green-50 );
+			}
+		}
+	}
 }
 
 .email-provider-stacked-card__provider-form-and-right-panel {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -110,7 +110,7 @@ $width-left-panel-card: 55%;
 	margin-top: 0.5em;
 	width: 100%;
 
-	@include break-large {
+	@include break-xlarge {
 		margin-left: 10px;
 		margin-top: 0;
 		width: $width-right-panel-card;
@@ -180,21 +180,21 @@ $width-left-panel-card: 55%;
 		display: flex;
 		flex-direction: column;
 
-		@include break-large {
+		@include break-xlarge {
 			flex-direction: row;
 		}
 
 		.email-provider-stacked-card__provider-card-main-details {
 			margin-top: 12px;
 
-			@include break-large {
+			@include break-xlarge {
 				margin-left: 10px;
 			}
 
 			.button {
 				width: 100%;
 
-				@include break-large {
+				@include break-xlarge {
 					width: 100%;
 				}
 			}
@@ -203,7 +203,7 @@ $width-left-panel-card: 55%;
 
 	&.is-expanded {
 		.email-provider-stacked-card__header .email-provider-stacked-card__title-price-badge {
-			@include break-large {
+			@include break-xlarge {
 				width: $width-right-panel-card-expanded;
 			}
 		}
@@ -219,13 +219,13 @@ $width-left-panel-card: 55%;
 			margin-top: 1em;
 			line-height: 1.5;
 
-			@include break-large {
+			@include break-xlarge {
 				flex-direction: row;
 			}
 		}
 
 		.email-provider-stacked-card__provider-form {
-			@include break-large {
+			@include break-xlarge {
 				min-width: $width-left-panel-card;
 				max-width: $width-left-panel-card;
 			}
@@ -244,7 +244,7 @@ $width-left-panel-card: 55%;
 }
 
 .email-provider-stacked-card__provider-right-panel {
-	@include break-large {
+	@include break-xlarge {
 		margin-left: 24px;
 	}
 
@@ -265,7 +265,7 @@ $width-left-panel-card: 55%;
 	flex-direction: column;
 	max-width: 100%;
 
-	@include break-large {
+	@include break-xlarge {
 		width: $width-left-panel-card;
 	}
 
@@ -277,25 +277,22 @@ $width-left-panel-card: 55%;
 
 .email-provider-stacked-card__provider-form > * .form-text-input-with-affixes {
 	flex-direction: column;
+
 	.form-text-input-with-affixes__suffix {
 		border-top-width: 0;
-		border-left-width: 1px;
-		border-left-style: solid;
-		border-left-color: var( --color-neutral-10 );
+		border-left: 1px solid var( --color-neutral-10 );
 		display: inline-block;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 
-	@include break-xlarge {
+	@include break-wide {
 		flex-direction: row;
 
 		.form-text-input-with-affixes__suffix {
 			border-left-width: 0;
 			border-top-width: 1px;
-			border-top-style: solid;
-			border-left-color: var( --color-neutral-10 );
 		}
 	}
 }

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -292,9 +292,8 @@ $width-left-panel-card: 55%;
 		border-top-width: 0;
 		border-left: 1px solid var( --color-neutral-10 );
 		display: inline-block;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		white-space: normal;
+		word-break: break-all;
 	}
 
 	@include break-wide {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -106,18 +106,6 @@ $width-left-panel-card: 55%;
 	}
 }
 
-.email-providers-stacked-comparison__provider-card {
-	padding-top: 36px;
-	.action-panel__title {
-		.promo-card__title-badge {
-			width: 100%;
-			display: flex;
-			background-color: initial;
-			margin: 0;
-		}
-	}
-}
-
 .email-provider-stacked-card__title-price-badge {
 	margin-top: 0.5em;
 	width: 100%;
@@ -145,67 +133,49 @@ $width-left-panel-card: 55%;
 	display: none;
 }
 
-.is-expanded {
-	.email-provider-stacked-card__provider-expand-cta {
-		display: none;
-	}
+.email-providers-stacked-comparison__provider-card {
+	padding-top: 36px;
 
-	.email-provider-stacked-card__provider-form-and-right-panel {
+	&.card.action-panel.promo-card {
 		display: flex;
 		flex-direction: column;
-		justify-content: start;
-		margin-top: 1em;
-		line-height: 1.5;
 
-		@include break-large {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: row;
 		}
-	}
 
-	.email-provider-stacked-card__provider-form {
-
-		@include break-large {
-			min-width: $width-left-panel-card;
-			max-width: $width-left-panel-card;
-		}
-
-		> .form-fieldset {
+		.action-panel__figure {
+			display: flex;
+			flex-direction: row;
 			margin-bottom: 0;
-		}
+			margin-top: 3px;
+			padding-right: 12px;
+			text-align: left;
 
-		.email-providers-stacked-comparison__titan-mailbox-action-skip {
+			@include breakpoint-deprecated( '<660px' ) {
+				max-width: 100%;
+				padding-right: 0;
+			}
+
 			@include break-mobile {
-				margin-left: 1em;
+				order: 1;
+
+				&.align-left {
+					order: -1;
+				}
 			}
 		}
 	}
-}
 
-.email-provider-stacked-card__provider-right-panel {
-	@include break-large {
-		margin-left: 24px;
+	.action-panel__title {
+		.promo-card__title-badge {
+			width: 100%;
+			display: flex;
+			background-color: initial;
+			margin: 0;
+		}
 	}
 
-	img {
-		margin-top: 1em;
-	}
-}
-
-.email-provider-stacked-card__title {
-	margin-top: 4px;
-	font-size: 1.25rem;
-	line-height: 24px;
-	color: var( --color-neutral-70 );
-}
-
-.email-provider-stacked-card__title-container {
-	p {
-		margin-bottom: 0;
-		margin-right: 10px;
-	}
-}
-
-.email-providers-stacked-comparison__provider-card {
 	.email-provider-stacked-card__header {
 		display: flex;
 		flex-direction: column;
@@ -232,20 +202,62 @@ $width-left-panel-card: 55%;
 	}
 
 	&.is-expanded {
-		.email-provider-stacked-card__header {
-			flex-direction: column;
+		.email-provider-stacked-card__header .email-provider-stacked-card__title-price-badge {
+			@include break-large {
+				width: $width-right-panel-card-expanded;
+			}
+		}
 
-			@include break-small {
+		.email-provider-stacked-card__provider-expand-cta {
+			display: none;
+		}
+
+		.email-provider-stacked-card__provider-form-and-right-panel {
+			display: flex;
+			flex-direction: column;
+			justify-content: start;
+			margin-top: 1em;
+			line-height: 1.5;
+
+			@include break-large {
 				flex-direction: row;
 			}
+		}
 
-			.email-provider-stacked-card__title-price-badge {
-				@include break-small {
-					width: $width-right-panel-card-expanded;
+		.email-provider-stacked-card__provider-form {
+			@include break-large {
+				min-width: $width-left-panel-card;
+				max-width: $width-left-panel-card;
+			}
+
+			> .form-fieldset {
+				margin-bottom: 0;
+			}
+
+			.email-providers-stacked-comparison__titan-mailbox-action-skip {
+				@include break-mobile {
+					margin-left: 1em;
 				}
 			}
 		}
 	}
+}
+
+.email-provider-stacked-card__provider-right-panel {
+	@include break-large {
+		margin-left: 24px;
+	}
+
+	img {
+		margin-top: 1em;
+	}
+}
+
+.email-provider-stacked-card__title {
+	margin-top: 4px;
+	font-size: 1.25rem;
+	line-height: 24px;
+	color: var( --color-neutral-70 );
 }
 
 .email-provider-stacked-card__title-container {
@@ -256,39 +268,10 @@ $width-left-panel-card: 55%;
 	@include break-large {
 		width: $width-left-panel-card;
 	}
-}
 
-.card.action-panel.promo-card.email-providers-stacked-comparison__provider-card {
-	display: flex;
-	flex-direction: column;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		flex-direction: row;
-	}
-
-	.action-panel__figure {
-		display: flex;
-		margin-top: 3px;
-		flex-direction: row;
-		text-align: left;
+	p {
 		margin-bottom: 0;
-		padding-right: 12px;
-		.professional-email-card__logo {
-			min-width: 48px;
-		}
-
-		@include breakpoint-deprecated( '<660px' ) {
-			max-width: 100%;
-			padding-right: 0;
-		}
-
-		@include break-mobile {
-			order: 1;
-
-			&.align-left {
-				order: -1;
-			}
-		}
+		margin-right: 10px;
 	}
 }
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.scss
@@ -16,3 +16,7 @@
 	height: 48px;
 	padding-right: 12px;
 }
+
+.google-workspace-card__discount-with-renewal .gridicon {
+	vertical-align: bottom;
+}

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -141,7 +141,6 @@ const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > =
 		<PriceBadge
 			additionalPriceInformationComponent={ discount }
 			priceComponent={ priceWithInterval }
-			className={ 'google-workspace-card' }
 		/>
 	);
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -57,6 +57,7 @@ const getGoogleFeatures = () => {
 };
 
 const googleWorkspaceCardInformation: ProviderCard = {
+	className: 'google-workspace-card',
 	detailsExpanded: false,
 	expandButtonLabel: translate( 'Select' ),
 	onExpandedChange: noop,

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-badge.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-badge.tsx
@@ -1,25 +1,20 @@
-import React, { FunctionComponent, ReactElement } from 'react';
 import PromoCardPrice from 'calypso/components/promo-section/promo-card/price';
+import type { FunctionComponent, ReactElement } from 'react';
 
 type PriceBadgeProps = {
 	additionalPriceInformationComponent?: ReactElement | null;
-	className: string;
 	priceComponent: ReactElement;
 };
 
 const PriceBadge: FunctionComponent< PriceBadgeProps > = ( props ) => {
-	const { additionalPriceInformationComponent, className, priceComponent } = props;
-
-	const priceBadgeClass = `${ className }__price-badge`;
-
-	const additionalPriceInformationClass = `${ className }__provider-additional-price-information`;
+	const { additionalPriceInformationComponent, priceComponent } = props;
 
 	return (
-		<div className={ priceBadgeClass }>
+		<div className="provider-cards__price-badge">
 			<PromoCardPrice
 				formattedPrice={ priceComponent }
 				additionalPriceInformation={
-					<span className={ additionalPriceInformationClass }>
+					<span className="provider-cards__provider-additional-price-information">
 						{ additionalPriceInformationComponent }
 					</span>
 				}

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
@@ -11,20 +11,9 @@
 	}
 }
 
-.professional-email-card__keep-main-price {
-	color: var( --studio-green-50 );
-	text-decoration: none;
-}
-
-.professional-email-card__price-badge {
-	.promo-card__price {
-		margin-top: 12px;
-
-		.price__discount {
-			text-decoration: line-through;
-			color: var( --studio-gray-60 );
-		}
-	}
+.professional-email-card .provider-cards__price-badge .promo-card__price .price__discount {
+		text-decoration: line-through;
+		color: var( --studio-gray-60 );
 }
 
 .professional-email-card__discount.badge {

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
@@ -4,6 +4,7 @@
 .professional-email-card__logo {
 	color: var( --color-wordpress-com );
 	height: 48px;
+	min-width: 48px;
 	width: 48px;
 
 	@include breakpoint-deprecated( '<660px' ) {

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -58,6 +58,7 @@ const getTitanFeatures = () => {
 };
 
 const professionalEmailCardInformation: ProviderCard = {
+	className: 'professional-email-card',
 	detailsExpanded: true,
 	expandButtonLabel: translate( 'Select' ),
 	onExpandedChange: noop,

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -170,7 +170,7 @@ const ProfessionalEmailCard: FunctionComponent< EmailProvidersStackedCardProps >
 					{ translate( '3 months free' ) }
 				</div>
 			) }
-			<PriceBadge priceComponent={ priceWithInterval } className={ 'professional-email-card' } />
+			<PriceBadge priceComponent={ priceWithInterval } />
 		</>
 	);
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -7,6 +7,7 @@ export interface ProviderCard {
 	additionalPriceInformation?: TranslateResult;
 	badge?: ReactElement;
 	billingPeriod?: TranslateResult;
+	className?: string;
 	description: TranslateResult;
 	detailsExpanded?: boolean;
 	discount?: ReactElement | null;

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -6,20 +6,6 @@
 	text-align: center;
 }
 
-.email-provider-stacked-card__title-price-badge {
-	.promo-card__price {
-		.price__cost {
-			.provider-cards__price-with-interval-price-discounted {
-				text-decoration: line-through;
-			}
-
-			.provider-cards__price-with-interval-sale-price {
-				color: var( --studio-green-50 );
-			}
-		}
-	}
-}
-
 .email-providers-stacked-comparison__main {
 	padding: 0 20px 20px;
 

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -6,19 +6,6 @@
 	text-align: center;
 }
 
-.mail-providers-stacked-comparison__provider-card.promo-card {
-	.action-panel__figure {
-		float: right;
-		max-width: 208px;
-		margin-bottom: 0.5em;
-		margin-top: 0;
-
-		img {
-			max-width: 36px;
-		}
-	}
-}
-
 .email-provider-stacked-card__title-price-badge {
 	.promo-card__price {
 		.price__cost {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR mostly performs some important housekeeping on the stacked email comparison components to improve their styles and layout for smaller screen sizes. The PR ends up tackling quite a few issues:
 * Keep the vertical layout until 1280px, and switch to the side-by-side layout above that width
 * Also update some other styles to stay in sync with this breakpoint (some margins were off due to a mismatch)
 * Ensure that we specify a consistent text colour and font size for text in the cards
 * Remove dynamic generation of classnames in the `PriceBadge` component
 * Shift the vertical alignment for the (i) icon to be more flush with the small text
 * Co-locate CSS for `EmailProvidersStackedCard`
 * Relocate some CSS selectors to be in the file for the corresponding component
 * Remove an invalid `className` prop specification for a `PriceInterval` component instance
 * Removed some CSS blocks that did not apply to any elements, including one with a mis-spelled selector

#### Testing instructions

* Run this branch locally or via the live instance
* Try to add email for a domain you already own
* Add `?flags=emails/new-email-comparison` to the URL
* Experiment with different screen widths and verify you get a good experience at all of them. Some key widths include:
  - Mobile widths (i.e. <480px wide)
  - Smaller tablet widths (~600px - ~775px wide)
  - Medium screen widths (~780px - ~1100px wide)
  - Wide screens (>1100px, but especially >1280px)
* While at various widths, check that no items get mis-aligned between the expanded and contracted cards (especially the prices)
* Make sure the domain name field doesn't cover the feature list (though it's possible this could still occur for really long domain names)

#### Screenshots

<img width="1098" alt="Screenshot 2021-12-28 at 21 30 34" src="https://user-images.githubusercontent.com/3376401/147600707-5c7118b8-e8d4-4b8e-988f-252f139e2331.png">
<img width="533" alt="Screenshot 2021-12-28 at 21 09 23" src="https://user-images.githubusercontent.com/3376401/147600719-118da19a-bec3-4971-92da-d9781c573593.png">
<img width="770" alt="Screenshot 2021-12-28 at 21 08 15" src="https://user-images.githubusercontent.com/3376401/147600721-f7df519d-8cc8-41fd-94df-2b97067ff599.png">
<img width="1026" alt="Screenshot 2021-12-28 at 21 06 33" src="https://user-images.githubusercontent.com/3376401/147600724-363975bf-b671-487d-befe-e74fe55a24cf.png">

