### PR TITLE
Remove link to deeper email comparisons

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@automattic/calypso-products';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
-import React, { FunctionComponent, useState } from 'react';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
@@ -27,6 +27,7 @@ import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { FunctionComponent } from 'react';
 
 import './style.scss';
 

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -42,5 +42,6 @@
 }
 
 .email-providers-stacked-comparison__how-they-compare {
+	display: none;
 	text-align: center;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR hides the text that lets users compare our email solutions more deeply, because the target page is not yet complete. We can unhide the text when the target page is working.
* The PR also removes an import of `React` and switches an import to a type import.

#### Testing instructions

* Run this branch locally or via the Calypso live instance
* Start the process of adding email for an existing domain and get to the email comparison page. Note that you need to be on the URL with `purchase` in it for the flag on the new UI to be displayed.
* Add `?flags=emails/new-email-comparison` to the URL
* Verify that the "Not sure how to start? See how they compare" subtitle is not visible.

##### Screenshots

| Before | After |
| -------|------|
| <img width="1011" alt="Screenshot 2021-12-28 at 21 42 54" src="https://user-images.githubusercontent.com/3376401/147602017-d93b4baf-5ece-4272-9eeb-a06028812073.png"> | <img width="1011" alt="Screenshot 2021-12-28 at 21 42 35" src="https://user-images.githubusercontent.com/3376401/147602090-3447434f-75b1-4370-a760-cf22f6308fa4.png"> |
