### PR TITLE
Atomic: allow getAutomatedTransfer to work with undefined state

### DIFF
--- a/client/state/automated-transfer/selectors/get-automated-transfer.ts
+++ b/client/state/automated-transfer/selectors/get-automated-transfer.ts
@@ -5,4 +5,4 @@ import 'calypso/state/automated-transfer/init';
 const emptyData = {};
 
 export const getAutomatedTransfer = ( state: AppState, siteId: number | null ) =>
-	siteId ? state.automatedTransfer?.[ siteId ] ?? emptyData : emptyData;
+	siteId ? state?.automatedTransfer?.[ siteId ] ?? emptyData : emptyData;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A change in https://github.com/Automattic/wp-calypso/pull/59594 made it so that the selector `getAutomatedTransfer()` no longer uses lodash's `get`, but assumes that there is some state. Since `get()` makes no such assumption, this was an unintentional change. This PR allows the selector to work even if `state` is undefined.

#### Testing instructions

None.