### PR TITLE
Prevent Widowed Text on Marketplace Plugin description

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { preventWidows } from 'calypso/lib/formatting';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import './style.scss';
 
@@ -21,7 +22,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 			<div className="plugin-details-header__container">
 				<div className="plugin-details-header__name">{ plugin.name }</div>
 				<div className="plugin-details-header__description">
-					{ plugin.short_description || plugin.description }
+					{ preventWidows( plugin.short_description || plugin.description ) }
 				</div>
 				<div className="plugin-details-header__additional-info">
 					<div className="plugin-details-header__info">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The plugin's short description is processed by the `preventWidows` function.

#### Testing instructions

- Go to free site -> Plugins -> add new
- Click on Xero plugin.
- The plugin's short description should not have [widowed words](https://en.wikipedia.org/wiki/Widows_and_orphans).

Before:
<img width="1073" alt="Screen Shot 2021-12-28 at 11 06 15 PM" src="https://user-images.githubusercontent.com/351784/147627039-c66c9786-aaa5-4b55-ba71-c63a4590d9ad.png">

After:
<img width="1062" alt="Screen Shot 2021-12-28 at 11 19 12 PM" src="https://user-images.githubusercontent.com/351784/147627066-a05f9522-2923-467b-a2eb-459042a83887.png">

Related to #58506 
