### PR TITLE
Disable CTA for paid plugins for jetpack sites

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -124,6 +124,11 @@ const PluginDetailsCTA = ( {
 		return null;
 	}
 
+	// disable paid plugin cta for jetpack sites
+	if ( isJetpackSelfHosted && isMarketplaceProduct ) {
+		return null;
+	}
+
 	return (
 		<div className="plugin-details-CTA__container">
 			<div className="plugin-details-CTA__price">

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -124,11 +124,6 @@ const PluginDetailsCTA = ( {
 		return null;
 	}
 
-	// disable paid plugin cta for jetpack sites
-	if ( isJetpackSelfHosted && isMarketplaceProduct ) {
-		return null;
-	}
-
 	return (
 		<div className="plugin-details-CTA__container">
 			<div className="plugin-details-CTA__price">
@@ -205,10 +200,20 @@ const CTAButton = ( {
 	hasEligibilityMessages,
 	isMarketplaceProduct,
 	billingPeriod,
+	isJetpackSelfHosted,
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ showEligibility, setShowEligibility ] = useState( false );
+
+	// disable paid plugin cta for jetpack sites
+	if ( isJetpackSelfHosted && isMarketplaceProduct ) {
+		return (
+			<p className="plugin-details-CTA__not-available">
+				{ translate( 'This plugin is supported only in WordPress.com sites for the moment.' ) }
+			</p>
+		);
+	}
 
 	return (
 		<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- Disable rendering of paid plugin CTA when it's jetpack site

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Visit [wordpress.com/plugins/woocommerce-bookings/[JETPACK_SITE]](wordpress.com/plugins/woocommerce-bookings/[JETPACK_SITE])
- Verify that plugin installation CTA is not displayed.

Before:
![](https://cloudup.com/ixE6GEs2BRS+)

After:
![](https://cloudup.com/i_m70pGp-ba+)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoids
using the "fixes" keyword and instead, attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59232 
