### PR TITLE
Link to the correct email path from the new domain listing page

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -300,14 +300,18 @@ class DomainRow extends PureComponent {
 	/* eslint-enable jsx-a11y/anchor-is-valid */
 
 	addEmailClick = ( event ) => {
-		const { trackAddEmailClick, domain } = this.props;
+		const { currentRoute, domain, site, trackAddEmailClick } = this.props;
 		event.stopPropagation();
 
 		trackAddEmailClick( domain ); // analytics/tracks
-		this.goToEmailPage( event, true );
+
+		this.goToEmailPage(
+			event,
+			emailManagementPurchaseNewEmailAccount( site.slug, domain.domain, currentRoute )
+		);
 	};
 
-	goToEmailPage = ( event, isAddClick = false ) => {
+	goToEmailPage = ( event, targetPath ) => {
 		const { currentRoute, disabled, domain, site } = this.props;
 		event.stopPropagation();
 		event.preventDefault();
@@ -316,8 +320,8 @@ class DomainRow extends PureComponent {
 			return;
 		}
 
-		const emailPath = isAddClick
-			? emailManagementPurchaseNewEmailAccount( site.slug, domain.domain, currentRoute )
+		const emailPath = targetPath
+			? targetPath
 			: emailManagement( site.slug, domain.domain, currentRoute );
 
 		page( emailPath );

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -28,7 +28,10 @@ import {
 	createSiteFromDomainOnly,
 	domainTransferIn,
 } from 'calypso/my-sites/domains/paths';
-import { emailManagement } from 'calypso/my-sites/email/paths';
+import {
+	emailManagement,
+	emailManagementPurchaseNewEmailAccount,
+} from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './domain-row.scss';
@@ -301,17 +304,23 @@ class DomainRow extends PureComponent {
 		event.stopPropagation();
 
 		trackAddEmailClick( domain ); // analytics/tracks
-		this.goToEmailPage( event );
+		this.goToEmailPage( event, true );
 	};
 
-	goToEmailPage = ( event ) => {
+	goToEmailPage = ( event, isAddClick = false ) => {
 		const { currentRoute, disabled, domain, site } = this.props;
 		event.stopPropagation();
+		event.preventDefault();
 
 		if ( disabled ) {
 			return;
 		}
-		page( emailManagement( site.slug, domain.domain, currentRoute ) );
+
+		const emailPath = isAddClick
+			? emailManagementPurchaseNewEmailAccount( site.slug, domain.domain, currentRoute )
+			: emailManagement( site.slug, domain.domain, currentRoute );
+
+		page( emailPath );
 	};
 
 	renderEllipsisMenu() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change updates the click handling for the email link in the new domains table to redirect to the appropriate email page depending on whether the user already has email service, as well as ensuring that we don't append `#` to the URL.

#### Testing instructions

* Run this branch locally or via the Calypso live server
* Ensure that you have a domain without any email service, and a domain that has email service
   - If you don't have a domain with email service, test the no email logic first, and then add email forwarding to the domain
* Navigate to Upgrades -> Domains, where you should see your domains listed
* For a domain without email service, click on the "+ Add" button in the table
* Verify that you're taken to `/email/:domain/purchase/:site` and the URL doesn't include a trailing `#`
* Navigate to Upgrades -> Domains, where you should see your domains listed
* For a domain with existing email service, click on the "n mailbox(es)" link
* Verify that you're taken to `/email/:domain/manage/:site` and the URL doesn't include a trailing `#`