### PR TITLE
Change the privacy protection notice text so it's accurate when privacy protection is not toggleable

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -53,7 +53,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ): JSX.Element => {
 			privacyProtectionNote = (
 				<p className="contact-information__toggle-item">
 					{ translate(
-						"Privacy protection can't be toggled due to the registry’s policies. {{a}}Learn more{{/a}}",
+						'Privacy protection is not available due to the registry’s policies. {{a}}Learn more{{/a}}',
 						{
 							components: {
 								a: <a href={ PRIVACY_PROTECTION } target="blank" />,
@@ -62,6 +62,20 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ): JSX.Element => {
 					) }
 				</p>
 			);
+			if ( privateDomain ) {
+				privacyProtectionNote = (
+					<p className="contact-information__toggle-item">
+						{ translate(
+							"Privacy protection must be enabled due to the registry's policies. {{a}}Learn more{{/a}}",
+							{
+								components: {
+									a: <a href={ PRIVACY_PROTECTION } target="blank" />,
+								},
+							}
+						) }
+					</p>
+				);
+			}
 		}
 		const additionalProps = { disabled: isUpdatingPrivacy || ! privacyAvailable };
 		return (

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -53,7 +53,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ): JSX.Element => {
 			privacyProtectionNote = (
 				<p className="contact-information__toggle-item">
 					{ translate(
-						'Privacy protection is not available due to the registry’s policies. {{a}}Learn more{{/a}}',
+						"Privacy protection can't be toggled due to the registry’s policies. {{a}}Learn more{{/a}}",
 						{
 							components: {
 								a: <a href={ PRIVACY_PROTECTION } target="blank" />,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Change the message we show when privacy protection is not available for a domain so it's more accurate when privacy is both on and off. For certain domains privacy protection is not available so the original message works but for some domains privacy protection is enabled by defauld and can't be disabled so in those cases the original message didn't make sense.

Before:
<img width="677" alt="Screenshot 2021-12-29 at 16 31 45" src="https://user-images.githubusercontent.com/1355045/147672732-44829f76-d12c-4f87-be91-cd457eb7f9b7.png">
<img width="668" alt="Screenshot 2021-12-29 at 16 31 59" src="https://user-images.githubusercontent.com/1355045/147672733-38bae6e1-661c-4879-9846-81923fc1b151.png">


After:

<img width="667" alt="Screen Shot 2022-01-03 at 2 50 31 PM" src="https://user-images.githubusercontent.com/1379730/147973891-2eaf14a0-a3af-4bc8-b8f1-26fe9cd05a10.png">
<img width="667" alt="Screen Shot 2022-01-03 at 2 50 52 PM" src="https://user-images.githubusercontent.com/1379730/147973906-34030f85-8123-42d6-87d9-9d3b3097d332.png">


#### Testing instructions

* Run the branch and check a domain that doesn't support privacy protection (.jp) or one that doesn't support disabling privacy (.app). Make sure you're looking at the new design if you're using the calypso.live version with `flags=domains/settings-page-redesign`
