### PR TITLE
Add page to create new email forwards

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -1,6 +1,7 @@
 import { isEnabled as isConfigEnabled } from '@automattic/calypso-config';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailForwarding from 'calypso/my-sites/email/email-forwarding';
+import EmailForwardsAdd from 'calypso/my-sites/email/email-forwards-add';
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
 import TitanControlPanelRedirect from 'calypso/my-sites/email/email-management/titan-control-panel-redirect';
 import TitanManageMailboxes from 'calypso/my-sites/email/email-management/titan-manage-mailboxes';
@@ -15,6 +16,19 @@ import TitanSetUpMailbox from 'calypso/my-sites/email/titan-set-up-mailbox';
 import TitanSetUpThankYou from 'calypso/my-sites/email/titan-set-up-thank-you';
 
 export default {
+	emailManagementAddEmailForwards( pageContext, next ) {
+		pageContext.primary = (
+			<CalypsoShoppingCartProvider>
+				<EmailForwardsAdd
+					selectedDomainName={ pageContext.params.domain }
+					source={ pageContext.query.source }
+				/>
+			</CalypsoShoppingCartProvider>
+		);
+
+		next();
+	},
+
 	emailManagementAddGSuiteUsers( pageContext, next ) {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -1,0 +1,118 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import SectionHeader from 'calypso/components/section-header';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
+import EmailHeader from 'calypso/my-sites/email/email-header';
+import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
+import {
+	emailManagement,
+	emailManagementAddEmailForwards,
+	emailManagementPurchaseNewEmailAccount,
+} from 'calypso/my-sites/email/paths';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import {
+	hasLoadedSiteDomains,
+	isRequestingSiteDomains,
+} from 'calypso/state/sites/domains/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+type EmailForwardsAddProps = {
+	selectedDomainName: string;
+	source?: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {};
+
+const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps ): JSX.Element => {
+	const currentRoute = useSelector( getCurrentRoute );
+	const selectedSite = useSelector( getSelectedSite );
+
+	const hasLoadedDomains = useSelector( ( state ) =>
+		hasLoadedSiteDomains( state, selectedSite?.ID ?? null )
+	);
+	const requestingSiteDomains = useSelector( ( state ) =>
+		Boolean( selectedSite && isRequestingSiteDomains( state, selectedSite.ID ) )
+	);
+	const areDomainsLoading = requestingSiteDomains || ! hasLoadedDomains;
+
+	const translate = useTranslate();
+
+	const goToEmail = useCallback( (): void => {
+		if ( ! selectedSite ) {
+			return;
+		}
+
+		if ( source === 'purchase' ) {
+			page(
+				emailManagementPurchaseNewEmailAccount(
+					selectedSite.slug,
+					selectedDomainName,
+					currentRoute
+				)
+			);
+			return;
+		}
+
+		page( emailManagement( selectedSite.slug, selectedDomainName, currentRoute ) );
+	}, [ currentRoute, selectedDomainName, selectedSite, source ] );
+
+	const onAddEmailForwardSuccess = useCallback( () => {
+		if ( ! selectedSite ) {
+			return;
+		}
+
+		page( emailManagement( selectedSite.slug, selectedDomainName, currentRoute ) );
+	}, [ currentRoute, selectedDomainName, selectedSite ] );
+
+	const analyticsPath = emailManagementAddEmailForwards( ':site', ':domain', currentRoute );
+
+	return (
+		<div className="email-forwards-add">
+			<PageViewTracker path={ analyticsPath } title="Email Management > Add Email Forwards" />
+
+			<QueryProductsList />
+
+			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
+
+			<Main wideLayout={ true }>
+				<DocumentHead title={ translate( 'Add New Email Forwards' ) } />
+
+				<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
+
+				<HeaderCake onClick={ goToEmail }>
+					{ translate( 'Email Forwarding' ) + ': ' + selectedDomainName }
+				</HeaderCake>
+
+				{ areDomainsLoading && <AddEmailAddressesCardPlaceholder /> }
+
+				{ ! areDomainsLoading && (
+					<>
+						<SectionHeader label={ translate( 'Add New Email Forward' ) } />
+
+						<Card>
+							<EmailForwardingAddNewCompactList
+								onAddEmailForwardSuccess={ onAddEmailForwardSuccess }
+								onConfirmEmailForwarding={ noop }
+								selectedDomainName={ selectedDomainName }
+							/>
+						</Card>
+					</>
+				) }
+			</Main>
+		</div>
+	);
+};
+
+export default EmailForwardsAdd;

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -99,7 +99,7 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 
 				{ ! areDomainsLoading && (
 					<>
-						<SectionHeader label={ translate( 'Add New Email Forward' ) } />
+						<SectionHeader label={ translate( 'Add New Email Forwards' ) } />
 
 						<Card>
 							<EmailForwardingAddNewCompactList

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useCallback } from 'react';
@@ -12,7 +12,6 @@ import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
 import EmailHeader from 'calypso/my-sites/email/email-header';
-import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
 import {
 	emailManagement,
 	emailManagementAddEmailForwards,
@@ -95,21 +94,25 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 					{ translate( 'Email Forwarding' ) + ': ' + selectedDomainName }
 				</HeaderCake>
 
-				{ areDomainsLoading && <AddEmailAddressesCardPlaceholder /> }
+				<SectionHeader label={ translate( 'Add New Email Forwards' ) } />
 
-				{ ! areDomainsLoading && (
-					<>
-						<SectionHeader label={ translate( 'Add New Email Forwards' ) } />
+				<Card>
+					{ areDomainsLoading && (
+						<div className="email-forwards-add__placeholder">
+							<p>&nbsp;</p>
+							<p>&nbsp;</p>
+							<Button disabled>&nbsp;</Button>
+						</div>
+					) }
 
-						<Card>
-							<EmailForwardingAddNewCompactList
-								onAddEmailForwardSuccess={ onAddEmailForwardSuccess }
-								onConfirmEmailForwarding={ noop }
-								selectedDomainName={ selectedDomainName }
-							/>
-						</Card>
-					</>
-				) }
+					{ ! areDomainsLoading && (
+						<EmailForwardingAddNewCompactList
+							onAddEmailForwardSuccess={ onAddEmailForwardSuccess }
+							onConfirmEmailForwarding={ noop }
+							selectedDomainName={ selectedDomainName }
+						/>
+					) }
+				</Card>
 			</Main>
 		</div>
 	);

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -99,9 +99,9 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 				<Card>
 					{ areDomainsLoading && (
 						<div className="email-forwards-add__placeholder">
-							<p>&nbsp;</p>
-							<p>&nbsp;</p>
-							<Button disabled>&nbsp;</Button>
+							<p />
+							<p />
+							<Button disabled />
 						</div>
 					) }
 

--- a/client/my-sites/email/email-forwards-add/style.scss
+++ b/client/my-sites/email/email-forwards-add/style.scss
@@ -9,3 +9,26 @@
 		padding-top: 0;
 	}
 }
+
+.email-forwards-add__placeholder {
+	overflow: hidden;
+
+	> * {
+		@include placeholder();
+	}
+
+	button {
+		float: right;
+		margin-top: 1em;
+		min-width: 80px;
+	}
+
+	p {
+		line-height: 2.5em;
+		margin-top: 1.5em;
+	}
+
+	p + p {
+		margin-top: 3em;
+	}
+}

--- a/client/my-sites/email/email-forwards-add/style.scss
+++ b/client/my-sites/email/email-forwards-add/style.scss
@@ -1,0 +1,11 @@
+.email-forwards-add {
+	.email-forwarding__add-new-separator {
+		height: 0;
+		margin-bottom: 1em;
+	}
+
+	.email-forwarding__add-new .email-forwarding__form-content {
+		border-top: none;
+		padding-top: 0;
+	}
+}

--- a/client/my-sites/email/email-header/index.js
+++ b/client/my-sites/email/email-header/index.js
@@ -36,7 +36,7 @@ function EmailHeader( { currentRoute, selectedSite } ) {
 
 EmailHeader.propTypes = {
 	currentRoute: PropTypes.string,
-	selectedSite: PropTypes.object.isRequired,
+	selectedSite: PropTypes.object,
 };
 
 export default EmailHeader;

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -29,6 +29,7 @@ import {
 } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagement,
+	emailManagementAddEmailForwards,
 	emailManagementAddGSuiteUsers,
 	emailManagementForwarding,
 	emailManagementManageTitanAccount,
@@ -142,7 +143,7 @@ const EmailPlan = ( props ) => {
 		}
 
 		return {
-			path: emailManagementForwarding( selectedSite.slug, domain.name, currentRoute ),
+			path: emailManagementAddEmailForwards( selectedSite.slug, domain.name, currentRoute ),
 		};
 	}
 

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -159,7 +159,7 @@ const EmailProvidersStackedComparison: FunctionComponent< EmailProvidersStackedC
 				/>
 			) }
 
-			{ showEmailForwardLink && (
+			{ showEmailForwardLink && selectedSite && (
 				<div className="email-providers-stacked-comparison__email-forward-section">
 					{ translate( 'Looking for a free email solution?' ) }{ ' ' }
 					{ translate( 'Start with {{link}}Email Forwarding{{/link}}.', {
@@ -167,7 +167,7 @@ const EmailProvidersStackedComparison: FunctionComponent< EmailProvidersStackedC
 							link: (
 								<a
 									href={ emailManagementAddEmailForwards(
-										selectedSite?.slug,
+										selectedSite.slug,
 										selectedDomainName,
 										currentRoute,
 										'purchase'

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -17,11 +17,15 @@ import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-st
 import GoogleWorkspaceCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card';
 import ProfessionalEmailCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
-import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
+import {
+	emailManagementAddEmailForwards,
+	emailManagementInDepthComparison,
+} from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { NoticeOptions } from 'calypso/state/notices/types';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
@@ -47,6 +51,7 @@ type EmailProvidersStackedComparisonProps = {
 	shoppingCartManager?: any;
 	selectedSite?: SiteData | null;
 	selectedDomainName: string;
+	showEmailForwardLink?: boolean;
 	siteName: string;
 	source: string;
 	titanMailMonthlyProduct?: any;
@@ -58,9 +63,11 @@ const EmailProvidersStackedComparison: FunctionComponent< EmailProvidersStackedC
 ) => {
 	const {
 		comparisonContext,
+		currentRoute,
 		isGSuiteSupported,
 		selectedDomainName,
 		selectedSite,
+		showEmailForwardLink = true,
 		siteName,
 		source,
 	} = props;
@@ -114,7 +121,15 @@ const EmailProvidersStackedComparison: FunctionComponent< EmailProvidersStackedC
 			<div className="email-providers-stacked-comparison__how-they-compare">
 				{ translate( 'Not sure how to start? {{a}}See how they compare{{/a}}.', {
 					components: {
-						a: <a href={ emailManagementInDepthComparison( siteName, selectedDomainName ) } />,
+						a: (
+							<a
+								href={ emailManagementInDepthComparison(
+									siteName,
+									selectedDomainName,
+									currentRoute
+								) }
+							/>
+						),
 					},
 				} ) }
 			</div>
@@ -143,6 +158,26 @@ const EmailProvidersStackedComparison: FunctionComponent< EmailProvidersStackedC
 					onExpandedChange={ onExpandedStateChange }
 				/>
 			) }
+
+			{ showEmailForwardLink && (
+				<div className="email-providers-stacked-comparison__email-forward-section">
+					{ translate( 'Looking for a free email solution?' ) }{ ' ' }
+					{ translate( 'Start with {{link}}Email Forwarding{{/link}}.', {
+						components: {
+							link: (
+								<a
+									href={ emailManagementAddEmailForwards(
+										selectedSite?.slug,
+										selectedDomainName,
+										currentRoute,
+										'purchase'
+									) }
+								/>
+							),
+						},
+					} ) }
+				</div>
+			) }
 		</Main>
 	);
 };
@@ -166,12 +201,15 @@ export default connect(
 
 		return {
 			comparisonContext: ownProps.comparisonContext,
+			currentRoute: getCurrentRoute( state ),
 			domain,
 			domainsWithForwards: getDomainsWithForwards( state, domains ),
 			gSuiteAnnualProduct: getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY ),
 			hasCartDomain,
 			isGSuiteSupported,
-			requestingSiteDomains: isRequestingSiteDomains( state, domainName ),
+			requestingSiteDomains: Boolean(
+				selectedSite && isRequestingSiteDomains( state, selectedSite.ID )
+			),
 			selectedDomainName: domainName,
 			selectedSite,
 			source: ownProps.source,

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -18,3 +18,12 @@
 	display: none;
 	text-align: center;
 }
+
+.email-providers-stacked-comparison__email-forward-section {
+	margin-top: 1.5em;
+	text-align: center;
+
+	a {
+		text-decoration: underline;
+	}
+}

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -57,6 +57,23 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
+			paths.emailManagementAddEmailForwards(
+				':site',
+				':domain',
+				paths.emailManagementAllSitesPrefix
+			),
+			paths.emailManagementAddEmailForwards( ':site', ':domain' ),
+		],
+		handlers: [
+			...commonHandlers,
+			controller.emailManagementAddEmailForwards,
+			makeLayout,
+			clientRender,
+		],
+	} );
+
+	registerMultiPage( {
+		paths: [
 			paths.emailManagementAddGSuiteUsers(
 				':site',
 				':domain',

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -26,6 +26,26 @@ function resolveRootPath( relativeTo ) {
 }
 
 /**
+ * Retrieves the url of the Add New Mailboxes page for email forwarding:
+ *
+ *   https://wordpress.com/email/:domainName/forwarding/add/:siteName
+ *
+ * @param {string} siteSlug - slug of the current site
+ * @param {string} domainName - domain name to add forwarding for
+ * @param {string} relativeTo - optional path prefix
+ * @param {string} source - optional source
+ * @returns {string} the corresponding url
+ */
+export function emailManagementAddEmailForwards(
+	siteSlug,
+	domainName,
+	relativeTo = null,
+	source = null
+) {
+	return emailManagementEdit( siteSlug, domainName, 'forwarding/add', relativeTo, { source } );
+}
+
+/**
  * Retrieves the url of the Add New Mailboxes page either for G Suite or Google Workspace:
  *
  *   https://wordpress.com/email/:domainName/google-workspace/add-users/:siteName


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR creates a new page to add email forwards, with both the first and later email forward creation supported. The goal is to support adding email forwards from the existing email management page for email forwards, as well as from the new email comparison page that we're in the process of building.
* The page itself is very minimal at present, and reuses the `EmailForwardingAddNewCompactList` form component, which only supports adding one email forward at a time
* One notable feature is that the "Back" button returns the user to the purchase page for the case where the user starts adding an email forward from the new email comparison screen
* Another notable item is that when we add an email forward successfully, we redirect the user to the email management page for the relevant domain

#### Testing instructions

* Run this branch locally or via the Calypso live branch
* Ensure you have a domain that doesn't have any email service (which you can buy if needed)
* For that domain, navigate to Upgrades -> Emails, and then click on the "Add Email" button to the right of the domain name
* You should now be on the email purchase page with the URL of the form `/email/:domain/purchase/:site`
* Add `?flags=emails/new-email-comparison` to the URL
* Verify that you see the new email comparison page
* Next, verify that you see the following text at the bottom of the screen: "Looking for a free email solution? Start with Email Forwarding."
* Switch to monthly billing, and verify that the text is still present
* Click on the "Email Forwarding" link
* Verify that you're taken to the "Add New Email Forwards" page at `/email/:domain/forwarding/add/:site?source=purchase`
* Verify that the page looks OK and shows a relevant loading image
* Click on the "Back" link in the header
* Verify that you're taken back to the email purchase page
* Click on the "Email Forwarding" link at the bottom of the page to get back to the "Add New Email Forwards" page
* Try to add a new email forward (and feel free to test the validation, though that hasn't been touched in this PR) - the "Add" button should only be enabled when the form fields are valid
* When the new email forward submission succeeds, verify that you're redirected to the email management screen for the domain (though it may take a little while to load correctly)
* From the email management page, click on the "Add new email forwards" menu item
* Verify that you see the "Add New Email Forwards" page
* Try to add the same email forward as before
* Verify that you get an error message displayed on the same page
* Click on the "Back" link in the header
* Verify that you're taken back to the email management screen

#### Screenshots

##### New page

<img width="1116" alt="Screenshot 2021-12-29 at 20 51 58" src="https://user-images.githubusercontent.com/3376401/147695252-081431e1-489c-4461-8d2c-30a675742c79.png">

##### Footer link on new email comparison page

<img width="1074" alt="Screenshot 2021-12-29 at 20 48 06" src="https://user-images.githubusercontent.com/3376401/147695256-b131302f-e90c-4c6b-81ba-5bfcf2645c51.png">