### PR TITLE
Thank You: remove price from ThankYouCard and PlanThankYouCard

### DIFF
--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -1,6 +1,5 @@
 import { getPlan, getPlanClass } from '@automattic/calypso-products';
 import { ProductIcon } from '@automattic/components';
-import formatCurrency from '@automattic/format-currency';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -33,15 +32,6 @@ class PlanThankYouCard extends Component {
 		return translate( '%(planName)s Plan', {
 			args: { planName: getPlan( plan.productSlug ).getTitle() },
 		} );
-	}
-
-	renderPlanPrice() {
-		const { plan } = this.props;
-		if ( ! plan || ! plan.rawPrice || ! plan.currencyCode ) {
-			return '';
-		}
-
-		return formatCurrency( plan.rawPrice, plan.currencyCode );
 	}
 
 	renderPlanIcon() {
@@ -109,7 +99,6 @@ class PlanThankYouCard extends Component {
 
 				<ThankYouCard
 					name={ this.renderPlanName() }
-					price={ this.renderPlanPrice() }
 					heading={ this.renderHeading() }
 					description={ 'string' === typeof description ? description : null }
 					descriptionWithHTML={ 'object' === typeof description ? description : null }

--- a/client/components/thank-you-card/index.jsx
+++ b/client/components/thank-you-card/index.jsx
@@ -13,7 +13,6 @@ const ThankYouCard = ( {
 	descriptionWithHTML,
 	buttonUrl,
 	buttonText,
-	price,
 	name,
 	icon,
 	action,
@@ -45,9 +44,6 @@ const ThankYouCard = ( {
 				<div className="thank-you-card__header-detail">
 					<div className={ classnames( 'thank-you-card__name', { 'is-placeholder': ! name } ) }>
 						{ name }
-					</div>
-					<div className={ classnames( 'thank-you-card__price', { 'is-placeholder': ! price } ) }>
-						{ price }
 					</div>
 				</div>
 
@@ -87,7 +83,6 @@ ThankYouCard.propTypes = {
 	descriptionWithHTML: PropTypes.object,
 	heading: PropTypes.string,
 	name: PropTypes.string,
-	price: PropTypes.string,
 	icon: PropTypes.node,
 	action: PropTypes.node,
 };

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -3,7 +3,7 @@
 	width: 100%;
 	max-width: 500px;
 	background-color: var( --color-success-40 );
-	border-radius: 8px 8px 6px 6px;
+	border-radius: 4px;
 	overflow: hidden;
 	margin: 12px auto 24px;
 	color: var( --color-text-inverted );
@@ -20,7 +20,7 @@
 	padding: 12px 0;
 	position: relative;
 	line-height: 1.2;
-	border-radius: 6px 6px 0 0;
+	border-radius: 4px 4px 0 0;
 	overflow: hidden;
 	z-index: z-index( 'root', '.thank-you-card__header' );
 
@@ -67,21 +67,6 @@
 		margin-left: auto;
 		margin-right: auto;
 		width: 35%;
-	}
-}
-
-.thank-you-card__price {
-	font-size: $font-body;
-	font-weight: 600;
-	color: var( --color-success-5 );
-
-	&.is-placeholder {
-		@include placeholder();
-
-		background-color: var( --color-success-5 );
-		margin-left: auto;
-		margin-right: auto;
-		width: 10%;
 	}
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -365,10 +365,6 @@
 		box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 );
 	}
 
-	.thank-you-card__price {
-		color: var( --color-neutral-60 );
-	}
-
 	.thank-you-card__description {
 		width: 340px;
 	}
@@ -830,7 +826,7 @@
 		.jetpack-checkout-siteless-thank-you__card-main {
 			max-width: 744px;
 		}
-		
+
 		.jetpack-checkout-siteless-thank-you__step {
 			display: flex;
 			align-items: flex-start;


### PR DESCRIPTION
The old `ThankYouCard` component is currently only used after Checkout for the Ecommerce plan (to handle the logic of verifying a user's address, waiting for the site to go Atomic, and then directing the user to Woo onboarding). As part of the original design, it displayed the plan's price but not the purchase price, causing issues if a user didn't pay full-price on the previous Checkout screen (pro-rated plan, coupon, credits, etc.). 

Since the component is barely used and none of our other Thank You messaging includes the transaction price, I've opted to remove it from the design entirely, instead of adding the complexity of querying for the site's most recent purchase.

Fixes: #59480

| Before | After |
| ----------- | ----------- |
| <img width="545" alt="Screen Shot 2021-12-29 at 1 31 31 PM" src="https://user-images.githubusercontent.com/942359/147692778-3885c198-9361-4dc4-8e86-4aaabbb40645.png"> | <img width="545" alt="Screen Shot 2021-12-29 at 1 30 59 PM" src="https://user-images.githubusercontent.com/942359/147692788-306878f4-f347-453d-a13e-be863e7a851c.png"> |

**To test:**
- visit http://calypso.localhost:3000/devdocs/blocks/plan-thank-you-card
- verify that everything looks okay