### PR TITLE
[ETK/error-reporting] Add filter to selectively enable the Error Reporting module, and disable it by default

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -16,14 +16,6 @@ namespace A8C\FSE\ErrorReporting;
  * @return bool True if current site is eligible for error reporting, false otherwise.
  */
 function is_site_eligible_for_error_reporting() {
-	// For now, Error Reporting is never activated in WoA. We would need to
-	// activate this feature using the filter below, but we still return `false`
-	// early if we detect we're in WoA, just in case. This will be removed
-	// once we decide to activate Error Reporting for AT sites.
-	if ( is_atomic() ) {
-		return false;
-	}
-
 	/**
 	 * Can be used to toggle the Error Reporting functionality.
 	 *
@@ -83,15 +75,6 @@ function user_in_sentry_test_segment( $user_id ) {
 	// segment the user is. i.e if current_segment is 10, then only ids that end in < 10
 	// will be considered part of the segment.
 	return $user_segment < $current_segment;
-}
-
-/**
- * Returns whether or not the site loading ETK is in the WoA env.
- *
- * @return bool
- */
-function is_atomic() {
-	return defined( 'IS_ATOMIC' ) && IS_ATOMIC;
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -8,6 +8,31 @@
 namespace A8C\FSE\ErrorReporting;
 
 /**
+ * Whether or not the site is eligible for Error Reporting, which is a feature that's
+ * specific to WPCOM.
+ *
+ * By default, sites should not be eligible.
+ *
+ * @return bool True if current site is eligible for error reporting, false otherwise.
+ */
+function is_site_eligible_for_error_reporting() {
+	// For now, Error Reporting is never activated in WoA. We would need to
+	// activate this feature using the filter below, but we still return `false`
+	// early if we detect we're in WoA, just in case. This will be removed
+	// once we decide to activate Error Reporting for AT sites.
+	if ( is_atomic() ) {
+		return false;
+	}
+
+	/**
+	 * Can be used to toggle the Error Reporting functionality.
+	 *
+	 * @param bool true if Error Reporting should be enabled, false otherwise.
+	 */
+	return apply_filters( 'a8c_enable_error_reporting', false );
+}
+
+/**
  * Inline  error handler that will capture errors before
  * the main handler has a chance to. Errors are pushed
  * to a global array called `_jsErr` which is then verified
@@ -127,8 +152,6 @@ function setup_error_reporting() {
 	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_script', 99 );
 }
 
-// We don't want to activate this module in AT just yet. See https://wp.me/p4TIVU-9DI#comment-10922.
-// @todo Remove once we have a version that works for WPCOM simple sites and WoA.
-if ( ! is_atomic() ) {
+if ( is_site_eligible_for_error_reporting() ) {
 	setup_error_reporting();
 }


### PR DESCRIPTION
It's been found out (thanks to a report by @rossanafmenezes and @vindl) that the Error Reporting module is causing a PHP error in non-WPCOM org sites (for the record: I had no idea ETK was even used outside of the WPCOM context! Lesson learned!). This happened because it's using a WPCOM-specific function (`is_automattician`). Slack thread: p1640801140226600-slack-C01DF571R5Y.

This led to a discussion about whether we want to even activate this module outside the WPCOM context, and the answer is clearly "no", as the Error Reporting is specific to WPCOM and not a general feature that can be tapped by org sites (yet!).

The verdict was to completely disable it by default and only selectively enable it in environments where it's needed, using a filter called `a8c_enable_error_reporting`. This filter is set to `false` by default and will be set to `true` in WPCOM simple (Thanks a bunch to @vindl for providing the help digging an example from FSE and for the suggestion about using a `mu-plugin` in WPCOM simple to set up the filter, this saved me a lot of research time!)

NOTE: This filter should still be set to `true` in WPCOM simple by using an `add_filter` call. Diff: D72337-code.

#### Changes proposed in this Pull Request

* Add filter to selectively enable the Error Reporting module, and disable it by default. 
* Keep a hard guard to disable it for WoA sites.

#### Testing instructions

* Sync this custom ETK build to your sandbox
* Follow the steps to test in t[his PR](https://github.com/Automattic/wp-calypso/pull/54257) (the main happy path should be enough) to see if the error reporting is being activated. Alternatively, you could add a `l()' call in the `setup_error_reporting()` body and verify that it's not being called (tail `/tmp/php-errors` for that). You can reload any WP-Admin page to test that, including the page that loads Gutenberg (new post or page)
* Apply D72337-code
* Reload the page and you should see the error reporting activated.

Related to https://github.com/Automattic/wp-calypso/pull/59509 and https://github.com/Automattic/wp-calypso/pull/54257.