### PR TITLE
Add post-connection prompt for users who have available user licenses

### DIFF
--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -2,8 +2,6 @@ import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';
-import QueryJetpackUserLicensesCounts from 'calypso/components/data/query-jetpack-user-licenses-counts';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getUserLicenses, getUserLicensesCounts } from 'calypso/state/user-licensing/selectors';
 import type { License } from 'calypso/state/user-licensing/types';
@@ -60,8 +58,6 @@ function LicensingPromptDialog( { urlQueryArgs }: Props ) {
 
 	return (
 		<>
-			<QueryJetpackUserLicenses />
-			<QueryJetpackUserLicensesCounts />
 			<Dialog
 				additionalClassNames="licensing-prompt-dialog"
 				isVisible={ showLicensesDialog }

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -3,24 +3,24 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getUserLicenses, getUserLicensesCounts } from 'calypso/state/user-licensing/selectors';
 import type { License } from 'calypso/state/user-licensing/types';
 
 import './style.scss';
 
 interface Props {
-	urlQueryArgs: {
-		[ key: string ]: string;
-	};
+	siteId: number;
 }
 
-function LicensingPromptDialog( { urlQueryArgs }: Props ) {
-	const { redirect } = urlQueryArgs;
+function LicensingPromptDialog( { siteId }: Props ) {
 	const translate = useTranslate();
 	const [ showLicensesDialog, setShowLicensesDialog ] = useState< boolean >( false );
 	const [ detachedUserLicense, setDetachedUserLicense ] = useState< License | null >( null );
 	const userLicenses = useSelector( getUserLicenses );
 	const userLicensesCounts = useSelector( getUserLicensesCounts );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=jetpack#/my-plan';
 
 	const hasOneDetachedLicense = userLicensesCounts && userLicensesCounts[ 'detached' ] === 1;
 	const hasDetachedLicenses = userLicensesCounts && userLicensesCounts[ 'detached' ] !== 0;
@@ -34,10 +34,10 @@ function LicensingPromptDialog( { urlQueryArgs }: Props ) {
 	}, [ hasOneDetachedLicense, userLicenses ] );
 
 	useEffect( () => {
-		if ( hasDetachedLicenses ) {
+		if ( hasDetachedLicenses && siteAdminUrl ) {
 			setShowLicensesDialog( true );
 		}
-	}, [ hasDetachedLicenses ] );
+	}, [ hasDetachedLicenses, siteAdminUrl ] );
 
 	const title = useMemo( () => {
 		if ( hasOneDetachedLicense ) {
@@ -78,7 +78,7 @@ function LicensingPromptDialog( { urlQueryArgs }: Props ) {
 					) }
 				</p>
 				<div className="licensing-prompt-dialog__actions">
-					<Button className="licensing-prompt-dialog__btn" primary href={ redirect }>
+					<Button className="licensing-prompt-dialog__btn" primary href={ jetpackDashboardUrl }>
 						{ translate( 'Activate it now' ) }
 					</Button>
 					<Button className="licensing-prompt-dialog__btn" onClick={ closeDialog }>

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -1,20 +1,32 @@
-import { Dialog } from '@automattic/components';
-import { useEffect, useState } from 'react';
+import { Button, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';
 import QueryJetpackUserLicensesCounts from 'calypso/components/data/query-jetpack-user-licenses-counts';
+import { preventWidows } from 'calypso/lib/formatting';
 import {
 	getUserLicenses,
 	getUserLicensesCounts,
 	userHasDetachedLicenses,
 } from 'calypso/state/user-licensing/selectors';
 
-function LicensingPromptDialog() {
+import './style.scss';
+
+interface Props {
+	urlQueryArgs: {
+		[ key: string ]: string;
+	};
+}
+
+function LicensingPromptDialog( { urlQueryArgs }: Props ) {
+	const translate = useTranslate();
 	const hasDetachedLicenses = useSelector( userHasDetachedLicenses );
 	const userLicenses = useSelector( getUserLicenses );
 	const userLicensesCounts = useSelector( getUserLicensesCounts );
 	const [ showLicensesDialog, setShowLicensesDialog ] = useState< boolean >( false );
 
+	const { redirect } = urlQueryArgs;
 	const hasOneDetachedLicense = userLicensesCounts && userLicensesCounts[ 'detached' ] === 1;
 
 	const detachedUserLicense =
@@ -28,13 +40,54 @@ function LicensingPromptDialog() {
 		}
 	}, [ hasDetachedLicenses ] );
 
+	const title = useMemo( () => {
+		if ( hasOneDetachedLicense ) {
+			return preventWidows(
+				translate( 'Your %(productName)s is pending activation', {
+					args: {
+						productName: detachedUserLicense && detachedUserLicense.product,
+					},
+				} )
+			);
+		}
+		return preventWidows( translate( 'You have an available product license key' ) );
+	}, [ detachedUserLicense, hasOneDetachedLicense, translate ] );
+
+	const closeDialog = () => {
+		setShowLicensesDialog( false );
+	};
+
 	return (
 		<>
 			<QueryJetpackUserLicenses />
 			<QueryJetpackUserLicensesCounts />
-			<Dialog isVisible={ showLicensesDialog } onClose={ () => setShowLicensesDialog( false ) }>
-				<h1>Hey!</h1>
-				<pre>{ JSON.stringify( detachedUserLicense, null, 2 ) }</pre>
+			<Dialog
+				additionalClassNames="licensing-prompt-dialog"
+				isVisible={ showLicensesDialog }
+				onClose={ () => setShowLicensesDialog( false ) }
+				shouldCloseOnEsc
+			>
+				<h1 className="licensing-prompt-dialog__title">{ title }</h1>
+				<p>
+					{ preventWidows(
+						translate(
+							'{{strong}}Check your email{{/strong}} for your license key. You should have received it after making your purchase.',
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						)
+					) }
+				</p>
+				<div className="licensing-prompt-dialog__actions">
+					<Button className="licensing-prompt-dialog__btn" primary href={ redirect }>
+						{ translate( 'Activate it now' ) }
+					</Button>
+					<Button className="licensing-prompt-dialog__btn" onClick={ closeDialog }>
+						{ translate( 'Select another product' ) }
+					</Button>
+				</div>
 			</Dialog>
 		</>
 	);

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog } from '@automattic/components';
+import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -64,6 +64,12 @@ function LicensingPromptDialog( { siteId }: Props ) {
 			shouldCloseOnEsc
 		>
 			<h1 className="licensing-prompt-dialog__title">{ title }</h1>
+			<Gridicon
+				className="licensing-prompt-dialog__close"
+				icon="cross-small"
+				size={ 24 }
+				onClick={ closeDialog }
+			/>
 			<p className="licensing-prompt-dialog__instructions">
 				{ preventWidows(
 					translate(

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -65,7 +65,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 				shouldCloseOnEsc
 			>
 				<h1 className="licensing-prompt-dialog__title">{ title }</h1>
-				<p>
+				<p className="licensing-prompt-dialog__instructions">
 					{ preventWidows(
 						translate(
 							'{{strong}}Check your email{{/strong}} for your license key. You should have received it after making your purchase.',

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -57,36 +57,34 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	};
 
 	return (
-		<>
-			<Dialog
-				additionalClassNames="licensing-prompt-dialog"
-				isVisible={ showLicensesDialog }
-				onClose={ () => setShowLicensesDialog( false ) }
-				shouldCloseOnEsc
-			>
-				<h1 className="licensing-prompt-dialog__title">{ title }</h1>
-				<p className="licensing-prompt-dialog__instructions">
-					{ preventWidows(
-						translate(
-							'{{strong}}Check your email{{/strong}} for your license key. You should have received it after making your purchase.',
-							{
-								components: {
-									strong: <strong />,
-								},
-							}
-						)
-					) }
-				</p>
-				<div className="licensing-prompt-dialog__actions">
-					<Button className="licensing-prompt-dialog__btn" primary href={ jetpackDashboardUrl }>
-						{ translate( 'Activate it now' ) }
-					</Button>
-					<Button className="licensing-prompt-dialog__btn" onClick={ closeDialog }>
-						{ translate( 'Select another product' ) }
-					</Button>
-				</div>
-			</Dialog>
-		</>
+		<Dialog
+			additionalClassNames="licensing-prompt-dialog"
+			isVisible={ showLicensesDialog }
+			onClose={ () => setShowLicensesDialog( false ) }
+			shouldCloseOnEsc
+		>
+			<h1 className="licensing-prompt-dialog__title">{ title }</h1>
+			<p className="licensing-prompt-dialog__instructions">
+				{ preventWidows(
+					translate(
+						'{{strong}}Check your email{{/strong}} for your license key. You should have received it after making your purchase.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					)
+				) }
+			</p>
+			<div className="licensing-prompt-dialog__actions">
+				<Button className="licensing-prompt-dialog__btn" primary href={ jetpackDashboardUrl }>
+					{ translate( 'Activate it now' ) }
+				</Button>
+				<Button className="licensing-prompt-dialog__btn" onClick={ closeDialog }>
+					{ translate( 'Select another product' ) }
+				</Button>
+			</div>
+		</Dialog>
 	);
 }
 

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -1,0 +1,43 @@
+import { Dialog } from '@automattic/components';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';
+import QueryJetpackUserLicensesCounts from 'calypso/components/data/query-jetpack-user-licenses-counts';
+import {
+	getUserLicenses,
+	getUserLicensesCounts,
+	userHasDetachedLicenses,
+} from 'calypso/state/user-licensing/selectors';
+
+function LicensingPromptDialog() {
+	const hasDetachedLicenses = useSelector( userHasDetachedLicenses );
+	const userLicenses = useSelector( getUserLicenses );
+	const userLicensesCounts = useSelector( getUserLicensesCounts );
+	const [ showLicensesDialog, setShowLicensesDialog ] = useState< boolean >( false );
+
+	const hasOneDetachedLicense = userLicensesCounts && userLicensesCounts[ 'detached' ] === 1;
+
+	const detachedUserLicense =
+		userLicenses &&
+		hasOneDetachedLicense &&
+		Object.values( userLicenses.items ).filter( ( { attachedAt } ) => attachedAt === null )[ 0 ];
+
+	useEffect( () => {
+		if ( hasDetachedLicenses ) {
+			setShowLicensesDialog( true );
+		}
+	}, [ hasDetachedLicenses ] );
+
+	return (
+		<>
+			<QueryJetpackUserLicenses />
+			<QueryJetpackUserLicensesCounts />
+			<Dialog isVisible={ showLicensesDialog } onClose={ () => setShowLicensesDialog( false ) }>
+				<h1>Hey!</h1>
+				<pre>{ JSON.stringify( detachedUserLicense, null, 2 ) }</pre>
+			</Dialog>
+		</>
+	);
+}
+
+export default LicensingPromptDialog;

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -64,6 +64,11 @@ function LicensingPromptDialog( { siteId }: Props ) {
 
 	const selectAnotherProductClick = useCallback( () => {
 		setShowLicensesDialog( false );
+		dispatch( recordTracksEvent( 'calypso_user_license_modal_continue_click' ) );
+	}, [ dispatch ] );
+
+	const closeDialog = useCallback( () => {
+		setShowLicensesDialog( false );
 		dispatch( recordTracksEvent( 'calypso_user_license_modal_close_click' ) );
 	}, [ dispatch ] );
 
@@ -71,7 +76,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 		<Dialog
 			additionalClassNames="licensing-prompt-dialog"
 			isVisible={ showLicensesDialog }
-			onClose={ () => setShowLicensesDialog( false ) }
+			onClose={ closeDialog }
 			shouldCloseOnEsc
 		>
 			<h1 className="licensing-prompt-dialog__title">{ title }</h1>

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -5,11 +5,8 @@ import { useSelector } from 'react-redux';
 import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';
 import QueryJetpackUserLicensesCounts from 'calypso/components/data/query-jetpack-user-licenses-counts';
 import { preventWidows } from 'calypso/lib/formatting';
-import {
-	getUserLicenses,
-	getUserLicensesCounts,
-	userHasDetachedLicenses,
-} from 'calypso/state/user-licensing/selectors';
+import { getUserLicenses, getUserLicensesCounts } from 'calypso/state/user-licensing/selectors';
+import type { License } from 'calypso/state/user-licensing/types';
 
 import './style.scss';
 
@@ -20,19 +17,23 @@ interface Props {
 }
 
 function LicensingPromptDialog( { urlQueryArgs }: Props ) {
+	const { redirect } = urlQueryArgs;
 	const translate = useTranslate();
-	const hasDetachedLicenses = useSelector( userHasDetachedLicenses );
+	const [ showLicensesDialog, setShowLicensesDialog ] = useState< boolean >( false );
+	const [ detachedUserLicense, setDetachedUserLicense ] = useState< License | null >( null );
 	const userLicenses = useSelector( getUserLicenses );
 	const userLicensesCounts = useSelector( getUserLicensesCounts );
-	const [ showLicensesDialog, setShowLicensesDialog ] = useState< boolean >( false );
 
-	const { redirect } = urlQueryArgs;
 	const hasOneDetachedLicense = userLicensesCounts && userLicensesCounts[ 'detached' ] === 1;
+	const hasDetachedLicenses = userLicensesCounts && userLicensesCounts[ 'detached' ] !== 0;
 
-	const detachedUserLicense =
-		userLicenses &&
-		hasOneDetachedLicense &&
-		Object.values( userLicenses.items ).filter( ( { attachedAt } ) => attachedAt === null )[ 0 ];
+	useEffect( () => {
+		if ( userLicenses && hasOneDetachedLicense ) {
+			setDetachedUserLicense(
+				Object.values( userLicenses.items ).filter( ( { attachedAt } ) => attachedAt === null )[ 0 ]
+			);
+		}
+	}, [ hasOneDetachedLicense, userLicenses ] );
 
 	useEffect( () => {
 		if ( hasDetachedLicenses ) {

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -16,6 +16,10 @@
 	line-height: 40px;
 }
 
+.licensing-prompt-dialog .licensing-prompt-dialog__instructions {
+	font-size: $font-body;
+}
+
 .licensing-prompt-dialog__btn.is-primary {
 	margin-right: 16px;
 }

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -1,0 +1,25 @@
+@import 'jetpack-connect/colors.scss';
+
+.is-section-jetpack-connect .licensing-prompt-dialog {
+	@include jetpack-connect-colors();
+}
+
+// Adding some extra specificity to override defaults coming from the dialog class
+.licensing-prompt-dialog.dialog.card {
+	max-width: 650px;
+	padding: 24px;
+	border-radius: 4px;
+}
+
+.licensing-prompt-dialog .licensing-prompt-dialog__title {
+	font-size: $font-title-large;
+	line-height: 40px;
+}
+
+.licensing-prompt-dialog__btn.is-primary {
+	margin-right: 16px;
+}
+
+.licensing-prompt-dialog__btn {
+	border-radius: 4px;
+}

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 @import 'jetpack-connect/colors.scss';
 
 .is-section-jetpack-connect .licensing-prompt-dialog {
@@ -7,8 +10,11 @@
 // Adding some extra specificity to override defaults coming from the dialog class
 .licensing-prompt-dialog.dialog.card {
 	max-width: 650px;
-	padding: 24px;
 	border-radius: 4px;
+
+	@include break-mobile {
+		padding: 24px;
+	}
 }
 
 .licensing-prompt-dialog .licensing-prompt-dialog__title {
@@ -20,8 +26,19 @@
 	font-size: $font-body;
 }
 
+.licensing-prompt-dialog__actions {
+	display: flex;
+	flex-direction: column;
+
+	@include break-mobile {
+		flex-direction: row;
+	}
+}
+
 .licensing-prompt-dialog__btn.is-primary {
-	margin-right: 16px;
+	@include break-mobile {
+		margin-right: 16px;
+	}
 }
 
 .licensing-prompt-dialog__btn {

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -36,6 +36,8 @@
 	right: 8px;
 	top: 8px;
 
+	cursor: pointer;
+
 	@include break-mobile {
 		right: 24px;
 		top: 24px;

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -56,6 +56,9 @@
 }
 
 .licensing-prompt-dialog__btn.is-primary {
+	--color-accent: var( --studio-jetpack-green-40 );
+    --color-primary: var( --studio-jetpack-green-40 );
+
 	@include break-mobile {
 		margin-right: 16px;
 	}

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -9,6 +9,10 @@
 
 // Adding some extra specificity to override defaults coming from the dialog class
 .licensing-prompt-dialog.dialog.card {
+	position: relative;
+
+	padding: 12px 0;
+
 	max-width: 650px;
 	border-radius: 4px;
 
@@ -18,8 +22,24 @@
 }
 
 .licensing-prompt-dialog .licensing-prompt-dialog__title {
-	font-size: $font-title-large;
-	line-height: 40px;
+	font-size: $font-title-medium;
+	line-height: 30px;
+
+	@include break-mobile {
+		font-size: $font-title-large;
+		line-height: 40px;
+	}
+}
+
+.licensing-prompt-dialog__close {
+	position: absolute;
+	right: 8px;
+	top: 8px;
+
+	@include break-mobile {
+		right: 24px;
+		top: 24px;
+	}
 }
 
 .licensing-prompt-dialog .licensing-prompt-dialog__instructions {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -6,7 +6,6 @@ import { flowRight, get, includes, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import QueryJetpackUserLicensesCounts from 'calypso/components/data/query-jetpack-user-licenses-counts';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserConnection from 'calypso/components/data/query-user-connection';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -46,7 +45,6 @@ import getPartnerIdFromQuery from 'calypso/state/selectors/get-partner-id-from-q
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { isRequestingSite, isRequestingSites } from 'calypso/state/sites/selectors';
-import { userHasDetachedLicenses } from 'calypso/state/user-licensing/selectors';
 import AuthFormHeader from './auth-form-header';
 import {
 	ALREADY_CONNECTED,
@@ -109,7 +107,6 @@ export class JetpackAuthorize extends Component {
 		translate: PropTypes.func.isRequired,
 		user: PropTypes.object.isRequired,
 		userAlreadyConnected: PropTypes.bool.isRequired,
-		userHasDetachedLicenses: PropTypes.bool,
 	};
 
 	redirecting = false;
@@ -700,12 +697,7 @@ export class JetpackAuthorize extends Component {
 
 	getRedirectionTarget() {
 		const { clientId, homeUrl, redirectAfterAuth } = this.props.authQuery;
-		const {
-			partnerSlug,
-			selectedPlanSlug,
-			siteHasJetpackPaidProduct,
-			userHasUnattachedLicenses,
-		} = this.props;
+		const { partnerSlug, selectedPlanSlug, siteHasJetpackPaidProduct } = this.props;
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if ( 'pressable' === partnerSlug ) {
 			return `/start/pressable-nux?blogid=${ clientId }`;
@@ -722,9 +714,8 @@ export class JetpackAuthorize extends Component {
 			return `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`;
 		}
 
-		// If the site has a Jetpack paid product or the user has an available unattached product
-		// license key, send the user back to wp-admin rather than to the Plans page.
-		if ( siteHasJetpackPaidProduct || userHasUnattachedLicenses ) {
+		// If the site has a Jetpack paid product send the user back to wp-admin rather than to the Plans page.
+		if ( siteHasJetpackPaidProduct ) {
 			return redirectAfterAuth;
 		}
 
@@ -878,7 +869,6 @@ export class JetpackAuthorize extends Component {
 							siteId={ authSiteId }
 							siteIsOnSitesList={ this.props.isAlreadyOnSitesList }
 						/>
-						<QueryJetpackUserLicensesCounts />
 						<AuthFormHeader
 							authQuery={ this.props.authQuery }
 							isWoo={ this.isWooOnboarding() }
@@ -927,7 +917,6 @@ const connectComponent = connect(
 			siteHasJetpackPaidProduct: siteHasJetpackProductPurchase( state, authQuery.clientId ),
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
-			userHasUnattachedLicenses: userHasDetachedLicenses( state ),
 		};
 	},
 	{

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -26,7 +26,6 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         siteId={98765}
         siteIsOnSitesList={false}
       />
-      <QueryJetpackUserLicenses />
       <Connect(Localized(AuthFormHeader))
         authQuery={
           Object {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -337,7 +337,7 @@ describe( 'JetpackAuthorize', () => {
 			expect( target ).toBe( DEFAULT_PROPS.authQuery.redirectAfterAuth );
 		} );
 
-		test( 'should redirect to wp-admin when site has an unattached "user"(not partner) product license key', () => {
+		test( 'should redirect to /jetpack/connect/plans when user has an unattached "user"(not partner) license key', () => {
 			const renderableComponent = <JetpackAuthorize { ...DEFAULT_PROPS } />;
 			const component = shallow( renderableComponent );
 			component.setProps( {
@@ -345,7 +345,11 @@ describe( 'JetpackAuthorize', () => {
 			} );
 			const target = component.instance().getRedirectionTarget();
 
-			expect( target ).toBe( DEFAULT_PROPS.authQuery.redirectAfterAuth );
+			expect( target ).toBe(
+				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect=${ encodeURIComponent(
+					DEFAULT_PROPS.authQuery.redirectAfterAuth
+				) }`
+			);
 		} );
 
 		test( 'should redirect to redirect to the /jetpack/connect/plans page by default', () => {

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { TERM_MONTHLY, TERM_ANNUALLY } from '@automattic/calypso-products';
 import JetpackFreeWelcomePage from 'calypso/components/jetpack/jetpack-free-welcome';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSlugInTerm } from './convert-slug-terms';
@@ -58,6 +59,11 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 		: undefined;
 	const highlightedProducts = getHighlightedProduct( urlQueryArgs.plan ) || undefined;
 
+	const enableUserLicensesDialog = !! (
+		siteId &&
+		( isJetpackCloud() || context.path.startsWith( '/jetpack/connect/plans' ) )
+	);
+
 	context.primary = (
 		<SelectorPage
 			defaultDuration={ stringToDuration( durationParam ) || duration || TERM_ANNUALLY }
@@ -69,6 +75,7 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 			header={ context.header }
 			footer={ context.footer }
 			planRecommendation={ planRecommendation }
+			enableUserLicensesDialog={ enableUserLicensesDialog }
 		/>
 	);
 

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -8,6 +8,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QuerySites from 'calypso/components/data/query-sites';
+import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-dialog';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -179,6 +180,8 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		<>
 			<QueryJetpackSaleCoupon />
 			{ nav }
+
+			<LicensingPromptDialog urlQueryArgs={ urlQueryArgs } />
 
 			<Main className={ classNames( 'selector__main', iterationClassName ) } wideLayout>
 				<PageViewTracker

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -42,6 +42,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	footer,
 	planRecommendation,
 	highlightedProducts = [],
+	enableUserLicensesDialog = false,
 }: SelectorPageProps ) => {
 	const dispatch = useDispatch();
 
@@ -181,10 +182,10 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	return (
 		<>
 			<QueryJetpackSaleCoupon />
-			{ siteId && <QueryJetpackUserLicenses /> }
-			{ siteId && <QueryJetpackUserLicensesCounts /> }
+			{ siteId && enableUserLicensesDialog && <QueryJetpackUserLicenses /> }
+			{ siteId && enableUserLicensesDialog && <QueryJetpackUserLicensesCounts /> }
 
-			{ siteId && <LicensingPromptDialog siteId={ siteId } /> }
+			{ siteId && enableUserLicensesDialog && <LicensingPromptDialog siteId={ siteId } /> }
 
 			{ nav }
 

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from 'react';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
+import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';
+import QueryJetpackUserLicensesCounts from 'calypso/components/data/query-jetpack-user-licenses-counts';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -179,6 +181,9 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	return (
 		<>
 			<QueryJetpackSaleCoupon />
+			{ siteId && <QueryJetpackUserLicenses /> }
+			{ siteId && <QueryJetpackUserLicensesCounts /> }
+
 			{ nav }
 
 			<LicensingPromptDialog urlQueryArgs={ urlQueryArgs } />

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -184,9 +184,9 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 			{ siteId && <QueryJetpackUserLicenses /> }
 			{ siteId && <QueryJetpackUserLicensesCounts /> }
 
-			{ nav }
+			{ siteId && <LicensingPromptDialog siteId={ siteId } /> }
 
-			<LicensingPromptDialog urlQueryArgs={ urlQueryArgs } />
+			{ nav }
 
 			<Main className={ classNames( 'selector__main', iterationClassName ) } wideLayout>
 				<PageViewTracker

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -39,6 +39,7 @@ export interface SelectorPageProps extends BasePageProps {
 	siteSlug?: string;
 	planRecommendation?: PlanRecommendation;
 	highlightedProducts?: string[];
+	enableUserLicensesDialog?: boolean;
 }
 
 export interface ProductsGridProps {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implement a dialog/modal to be shown to users who just connected their site, or visited the pricing page from a site's WP Admin, and have at least one available license.

#### Testing instructions

**Things to keep in mind while reviewing**
* Try to test everything on both desktop and mobile.
* Compare the actual implementing to our Figma design: ceKxiVna5wfpmwFBsojrAx-fi-2804%3A32472

**Setup**
* Download this PR.
* Start both Calypsos with `yarn start` and `yarn start-jetpack-cloud-p` (run the last one after the first one is started).
* Go to `https://cloud.jetpack.com/pricing`.
* Purchase any Jetpack product other than Jetpack Search, and do not activate the product on any site.

**Post-connection flow**
* Create a JN site.
* Initiate the Jetpack setup process.
* Once you're on WordPress.com, replace `https://wordpress.com` with `http://calypso.localhost:3000`, and maintain the rest of the URL intact.
* Authorize the connection.
* Verify that after connecting your site, you're redirected to `http://calypso.localhost:3000/jetpack/connect/plans/:site`.
* Verify that you see a modal/dialog that tells you that you have an available license (if you have only one license available, you should see the name of the product; otherwise, no product name should be displayed. You can find your licenses in Store Admin).
![image](https://user-images.githubusercontent.com/3418513/148407223-2b15a987-1bf1-48ee-8a26-5a5dcb2a0c17.png)
* Open the Network tab, and enter `calypso_user_license_` in the search box.
* Verify that you see a request that tracks the `calypso_user_license_modal_view` event (you might need to refresh the page).
* Click on the `Select another product` button.
* Verify that the dialog is closed and an event with the name `calypso_user_license_modal_continue_click` is dispatched.
* Refresh the page.
* Click on the `Activate it now` button.
* Verify that you are redirected to the My Plan section in WP Admin.
* Verify that you see a request that tracks the `calypso_user_license_modal_activate_click` event.

**Plans tab flow**
* On WP Admin, click on the Plans tab.
* Verify that you are redirected to `https://cloud.jetpack.com/pricing/:site`.
* Replace `https://cloud.jetpack.com` with `http://jetpack.cloud.localhost:3001`.
* Verify that you see the modal/dialog again.
![image](https://user-images.githubusercontent.com/3418513/148410738-2ce8505b-4aad-44ae-850d-a8b43333ef8d.png)
* Open the Network tab, and enter `calypso_user_license_` in the search box.
* Verify that you see a request that tracks the `calypso_user_license_modal_view` event (you might need to refresh the page).
* Click on the `Select another product` button.
* Verify that the dialog is closed and an event with the name `calypso_user_license_modal_continue_click` is dispatched.
* Refresh the page.
* Click on the `Activate it now` button.
* Verify that you are redirected to the My Plan section in WP Admin.
* Verify that you see a request that tracks the `calypso_user_license_modal_activate_click` event.

**Verify no regression is introduced**
* Visit `http://jetpack.cloud.localhost:3001/pricing`.
* Verify that you don't see the modal/dialog.
* Visit `http://calypso.localhost:3000/plans/:site`.
* Verify that you don't see the modal/dialog.

Related to 1201509629272450-as-1201545797263874