### PR TITLE
Home: Fix the on focus help search on iPhone

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -169,9 +169,14 @@ $min_results_height: 180px;
 			border-radius: 2px;
 
 			.search__input {
-				padding: 11px 0;
-				font-size: $font-body-small;
+				padding: 6px 0;
+				font-size: $font-body;
 				color: var( --color-text );
+
+				@include break-mobile {
+					padding: 11px 0;
+					font-size: $font-body-small;
+				}
 			}
 
 			.search__input::placeholder {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently when you load the /home/example.com page on iPhone the field once focused zoomed in.

Before: 

https://user-images.githubusercontent.com/115071/147709524-deaf056f-a9c3-472b-9cc9-3afb984ad2d6.mp4

After:

https://user-images.githubusercontent.com/115071/147709529-54415908-e6ae-462a-9484-92f3c6b56176.mp4

#### Testing instructions
* Load the PR in an iPhone simulator browser. 
* Load the /home/example.com focus on the search element in the help section. 
* Notice that it doesn't zoom into anymore? 

Fixes https://github.com/Automattic/wp-calypso/issues/59624
