### PR TITLE
Remove use of lodash from client/lib/gsuite/new-users.ts

### DIFF
--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -177,10 +177,12 @@ const validateNewUserMailboxIsUnique = (
  * Adds a duplicate error to each mailBox with a duplicate mailbox
  */
 const validateNewUsersAreUnique = ( users: GSuiteNewUser[] ): GSuiteNewUser[] => {
-	const mailboxesByCount = users.reduce( ( workingCount: Record< string, number >, user ) => {
-		const mailboxName = user.mailBox.value;
-		workingCount[ mailboxName ] = 1 + ( workingCount[ mailboxName ] ?? 0 );
-		return workingCount;
+	const mailBoxesByCount = users.reduce( ( result: Record< string, number >, user ) => {
+		const mailBoxName = user.mailBox.value;
+
+		result[ mailBoxName ] = 1 + ( result[ mailBoxName ] ?? 0 );
+
+		return result;
 	}, {} );
 
 	return users.map( ( { uuid, domain, mailBox, firstName, lastName, password } ) => ( {
@@ -188,7 +190,7 @@ const validateNewUsersAreUnique = ( users: GSuiteNewUser[] ): GSuiteNewUser[] =>
 		firstName,
 		lastName,
 		domain,
-		mailBox: validateNewUserMailboxIsUnique( mailBox, mailboxesByCount ),
+		mailBox: validateNewUserMailboxIsUnique( mailBox, mailBoxesByCount ),
 		password,
 	} ) );
 };
@@ -355,13 +357,14 @@ const getItemsForCart = (
 	users: GSuiteNewUser[]
 ): MinimalRequestCartProduct[] => {
 	const usersGroupedByDomain = users.reduce(
-		( usersByDomain: Record< string, GSuiteProductUser[] >, user: GSuiteNewUser ) => {
-			if ( ! usersByDomain[ user.domain.value ] ) {
-				usersByDomain[ user.domain.value ] = [];
+		( result: Record< string, GSuiteProductUser[] >, user: GSuiteNewUser ) => {
+			if ( ! result[ user.domain.value ] ) {
+				result[ user.domain.value ] = [];
 			}
-			usersByDomain[ user.domain.value ].push( transformUserForCart( user ) );
 
-			return usersByDomain;
+			result[ user.domain.value ].push( transformUserForCart( user ) );
+
+			return result;
 		},
 		{}
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR refactors the code in `client/lib/gsuite/new-users.ts` to use vanilla JS functions instead of lodash

#### Testing instructions

* Run this branch locally or via the Calypso live server
* Ensure that you have an existing G Suite or Google Workspace subscription with at least one existing mailbox
* Go to Upgrades -> Email and select the domain for your existing Google subscription
* Click on the "Add new mailboxes" menu item
* Fill out the form for a new mailbox
* Click on the "Add another mailbox"
* Fill out the second mailbox form and use the same mailbox name as above
* Verify that you get the following error message for the mailbox name field: `Please use a unique mailbox for each user.`
* Change the mailbox name to match your existing mailbox
* Verify that you get the following error message for the mailbox name field: `You already have this email address.`
* Ensure that your developer console is open to the network tab
* Update both mailboxes in the form to be valid
* Click on the "Continue" button to go to checkout
* Find the response from the `/rest/v1.1/me/shopping-cart/:siteId` end point
* Verify that `body.products` includes an entry for your subscription, and expand that product
* Verify that the product includes `extra.google_apps_users`, and that each of the users includes the `email`, `firstname`, `lastname`, and `hash` properties