### PR TITLE
Plugin Details: use sections.description for paid plugins

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -58,15 +58,17 @@ const PluginDetailsCTA = ( {
 	const isVip = useSelector( ( state ) => checkVipSite( state, selectedSite?.ID ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
-	const isFreePlan = isFreePlanProduct( selectedSite.plan );
+	const isFreePlan = selectedSite && isFreePlanProduct( selectedSite.plan );
 
-	const shouldUpgrade = ! (
-		isBusiness( selectedSite.plan ) ||
-		isEnterprise( selectedSite.plan ) ||
-		isEcommerce( selectedSite.plan ) ||
-		isJetpack ||
-		isVip
-	);
+	const shouldUpgrade =
+		selectedSite &&
+		! (
+			isBusiness( selectedSite.plan ) ||
+			isEnterprise( selectedSite.plan ) ||
+			isEcommerce( selectedSite.plan ) ||
+			isJetpack ||
+			isVip
+		);
 
 	// Eligibilities for Simple Sites.
 	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -279,7 +279,7 @@ function PluginDetails( props ) {
 
 						<div className="plugin-details__layout plugin-details__body">
 							<div className="plugin-details__layout-col-left">
-								{ fullPlugin.wporg ? (
+								{ fullPlugin.wporg || isMarketplaceProduct ? (
 									<PluginSections
 										className="plugin-details__plugins-sections"
 										plugin={ fullPlugin }

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -227,7 +227,7 @@ class PluginSections extends Component {
 		const contentClasses = classNames( 'plugin-sections__content', {
 			trimmed: ! this.props.removeReadMore && ! this.props.isWpcom && ! this.state.readMore,
 		} );
-		const banner = this.props.plugin.banners.high || this.props.plugin.banners.low;
+		const banner = this.props.plugin?.banners?.high || this.props.plugin?.banners?.low;
 
 		/*eslint-disable react/no-danger*/
 		if ( ! this.props.addBanner || ! banner || this.getSelected() !== 'description' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- After [this change](https://github.com/Automattic/wp-calypso/pull/59572/files), plugin details was using the `description` fetched from the site from the site for paid plugins when the plugin was installed. This PR unifies the implementation for both wporg and wpcom plugins to use `sections.description` which exists only in the wpcom and wporg APIs and not in the site plugin request.
- Also, while testing it in all sites view, I noticed some console errors of `selectedSite` being undefined.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1099" alt="SS 2021-12-30 at 10 36 53" src="https://user-images.githubusercontent.com/12430020/147735289-316d9d06-9fc8-4859-8347-a77fce84cfa6.png">|<img width="1149" alt="SS 2021-12-30 at 10 37 05" src="https://user-images.githubusercontent.com/12430020/147735301-7f0f2f4b-2ecd-4be0-9bf4-eb96ad464865.png">|

* Visit an already installed paid plugin
* Make sure that full description appears
* Visit a not installed paid plugin
* Check for regressions
* Visit the all sites view of a paid plugin
* Check for regressions

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
