### PR TITLE
Remove lodash from email library code

### DIFF
--- a/client/lib/gsuite/get-eligible-gsuite-domain.js
+++ b/client/lib/gsuite/get-eligible-gsuite-domain.js
@@ -1,4 +1,3 @@
-import { get, sortBy } from 'lodash';
 import { canDomainAddGSuite } from './can-domain-add-gsuite';
 import { getGSuiteSupportedDomains } from './gsuite-supported-domain';
 
@@ -19,10 +18,13 @@ export function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 	}
 
 	// Orders domains with the primary domain in first position, if any
-	const supportedDomains = sortBy(
-		getGSuiteSupportedDomains( domains ),
-		( domain ) => ! domain.isPrimary
+	const supportedDomains = getGSuiteSupportedDomains( domains ).sort(
+		( domainA, domainB ) => domainB.isPrimary - domainA.isPrimary
 	);
 
-	return get( supportedDomains, '[0].name', '' );
+	if ( ! supportedDomains.length ) {
+		return '';
+	}
+
+	return supportedDomains[ 0 ].name;
 }

--- a/client/lib/gsuite/get-eligible-gsuite-domain.js
+++ b/client/lib/gsuite/get-eligible-gsuite-domain.js
@@ -19,7 +19,7 @@ export function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 
 	// Orders domains with the primary domain in first position, if any
 	const supportedDomains = getGSuiteSupportedDomains( domains ).sort(
-		( domainA, domainB ) => domainB.isPrimary - domainA.isPrimary
+		( domainA, domainB ) => ( domainB.isPrimary ?? false ) - ( domainA.isPrimary ?? false )
 	);
 
 	if ( ! supportedDomains.length ) {

--- a/client/lib/gsuite/get-gsuite-mailbox-count.js
+++ b/client/lib/gsuite/get-gsuite-mailbox-count.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 export function getGSuiteMailboxCount( domain ) {
-	return get( domain, 'googleAppsSubscription.totalUserCount', 0 );
+	return domain?.googleAppsSubscription?.totalUserCount ?? 0;
 }

--- a/client/lib/gsuite/has-pending-gsuite-users.js
+++ b/client/lib/gsuite/has-pending-gsuite-users.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 /**
  * Does a domain have pending G Suite Users
  *
@@ -7,5 +5,5 @@ import { get } from 'lodash';
  * @returns {boolean} - Does domain have pending G Suite users
  */
 export function hasPendingGSuiteUsers( domain ) {
-	return get( domain, 'googleAppsSubscription.pendingUsers.length', 0 ) !== 0;
+	return 0 !== ( domain?.googleAppsSubscription?.pendingUsers?.length ?? 0 );
 }

--- a/client/lib/titan/has-titan-mail-with-us.js
+++ b/client/lib/titan/has-titan-mail-with-us.js
@@ -1,6 +1,5 @@
-import { get } from 'lodash';
-
 export function hasTitanMailWithUs( domain ) {
-	const subscriptionStatus = get( domain, 'titanMailSubscription.status', '' );
+	const subscriptionStatus = domain?.titanMailSubscription?.status ?? '';
+
 	return subscriptionStatus === 'active' || subscriptionStatus === 'suspended';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes some simple usages of lodash from `client/lib/gsuite/` and `client/lib/titan/`

#### Testing instructions

* Code inspection should be sufficient for this change, especially the minor `get()` refactors
* I am not sure if the code path for the `getEligibleGSuiteDomain()` code is even triggered anywhere!