### PR TITLE
i18n: Wrap domains list filter button for translation

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -548,26 +548,26 @@ class AllDomains extends Component {
 	}
 
 	renderDomainTableFilterButton() {
-		const { context } = this.props;
+		const { context, translate } = this.props;
 
 		const selectedFilter = context?.query?.filter;
 		const nonWpcomDomains = this.mergeFilteredDomainsWithDomainsDetails();
 
 		const filterOptions = [
 			{
-				label: 'All domains',
+				label: translate( 'All domains' ),
 				value: '',
 				path: domainManagementRoot(),
 				count: nonWpcomDomains?.length,
 			},
 			{
-				label: 'Owned by me',
+				label: translate( 'Owned by me' ),
 				value: 'owned-by-me',
 				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-me' } ),
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-me' )?.length,
 			},
 			{
-				label: 'Owned by others',
+				label: translate( 'Owned by others' ),
 				value: 'owned-by-others',
 				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-others' } ),
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-others' )?.length,

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -217,27 +217,27 @@ export class SiteDomains extends Component {
 	}
 
 	renderDomainTableFilterButton() {
-		const { selectedSite, domains, context } = this.props;
+		const { selectedSite, domains, context, translate } = this.props;
 
 		const selectedFilter = context?.query?.filter;
 		const nonWpcomDomains = filterOutWpcomDomains( domains );
 
 		const filterOptions = [
 			{
-				label: 'Site domains',
+				label: translate( 'Site domains' ),
 				value: '',
 				path: domainManagementList( selectedSite?.slug ),
 				count: nonWpcomDomains?.length,
 			},
 			{
-				label: 'Owned by me',
+				label: translate( 'Owned by me' ),
 				value: 'owned-by-me',
 				path:
 					domainManagementList( selectedSite?.slug ) + '?' + stringify( { filter: 'owned-by-me' } ),
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-me' )?.length,
 			},
 			{
-				label: 'Owned by others',
+				label: translate( 'Owned by others' ),
 				value: 'owned-by-others',
 				path:
 					domainManagementList( selectedSite?.slug ) +
@@ -247,7 +247,7 @@ export class SiteDomains extends Component {
 			},
 			null,
 			{
-				label: 'All my domains',
+				label: translate( 'All my domains' ),
 				value: 'all-my-domains',
 				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-me' } ),
 				count: null,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wraps the option labels of the domains list filter button in `translate` calls.

**Before & after on `/domains/manage`**
<img src="https://user-images.githubusercontent.com/75777864/147769470-55ce0cf2-aec7-4058-8caa-ce1e988c9092.png" width="400" /> <img src="https://user-images.githubusercontent.com/75777864/147769503-8d2363bf-9c4c-480e-96d4-e0fc77479bef.png" width="400" />


**Before & after on `/domains/manage/[mysite]`**
<img src="https://user-images.githubusercontent.com/75777864/147769603-63b9f6aa-3586-498c-85ef-05cb5265d519.png" width="400" /> <img src="https://user-images.githubusercontent.com/75777864/147769627-745d1268-248a-4c5a-910b-bd788ad5155b.png" width="400" />


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open http://calypso.localhost:3000/ and change your interface language to Dutch (because those translations are complete).
2. Open http://calypso.localhost:3000/domains/manage and verify that the options in the filter button are translated, matching the first "after" screenshot above.
3. Use the site switcher at the top left to switch to a site, navigate to Upgrades > Domeinen if you're not already there, and verify that the options in the filter button are translated, matching the second "after" screenshot above.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 362-gh-Automattic/i18n-issues
