### PR TITLE
Plugins Browser: move billing switcher to plugins list title.

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,10 +1,8 @@
 import { Card } from '@automattic/components';
-import { withBreakpoint } from '@automattic/viewport-react';
+import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
@@ -13,96 +11,98 @@ import './style.scss';
 
 const DEFAULT_PLACEHOLDER_NUMBER = 6;
 
-class PluginsBrowserList extends Component {
-	static displayName = 'PluginsBrowserList';
+const PluginsBrowserList = ( {
+	plugins,
+	variant = PluginsBrowserListVariant.Fixed,
+	title,
+	subtitle,
+	extended,
+	billingPeriod,
+	setBillingPeriod,
+	showPlaceholders,
+	site,
+	currentSites,
+	listName,
+	size,
+} ) => {
+	const isWide = useBreakpoint( '>1280px' );
 
-	static propTypes = {
-		plugins: PropTypes.array.isRequired,
-		variant: PropTypes.oneOf( Object.values( PluginsBrowserListVariant ) ).isRequired,
-		extended: PropTypes.bool,
-		setBillingPeriod: PropTypes.oneOf( false, PropTypes.func ),
-	};
-
-	static defaultProps = {
-		variant: PluginsBrowserListVariant.Fixed,
-	};
-
-	renderPluginsViewList() {
-		const pluginsViewsList = this.props.plugins.map( ( plugin, n ) => {
+	const renderPluginsViewList = () => {
+		const pluginsViewsList = plugins.map( ( plugin, n ) => {
 			return (
 				<PluginBrowserItem
-					site={ this.props.site }
+					site={ site }
 					key={ plugin.slug + n }
 					plugin={ plugin }
-					currentSites={ this.props.currentSites }
-					listName={ this.props.listName }
+					currentSites={ currentSites }
+					listName={ listName }
 					variant={
-						this.props.extended
-							? PluginsBrowserElementVariant.Extended
-							: PluginsBrowserElementVariant.Compact
+						extended ? PluginsBrowserElementVariant.Extended : PluginsBrowserElementVariant.Compact
 					}
-					billingPeriod={ this.props.billingPeriod }
+					billingPeriod={ billingPeriod }
 				/>
 			);
 		} );
 
-		if ( this.props.size ) {
-			return pluginsViewsList.slice( 0, this.props.size );
+		if ( size ) {
+			return pluginsViewsList.slice( 0, size );
 		}
 
 		return pluginsViewsList;
-	}
+	};
 
-	renderPlaceholdersViews() {
-		return times( this.props.size || DEFAULT_PLACEHOLDER_NUMBER, ( i ) => (
+	const renderPlaceholdersViews = () => {
+		return times( size || DEFAULT_PLACEHOLDER_NUMBER, ( i ) => (
 			<PluginBrowserItem isPlaceholder key={ 'placeholder-plugin-' + i } />
 		) );
-	}
+	};
 
-	renderViews() {
-		const { plugins, showPlaceholders, variant } = this.props;
-
+	const renderViews = () => {
 		if ( ! plugins.length ) {
-			return this.renderPlaceholdersViews();
+			return renderPlaceholdersViews();
 		}
 
 		switch ( variant ) {
 			case PluginsBrowserListVariant.InfiniteScroll:
 				if ( showPlaceholders ) {
-					return this.renderPluginsViewList().concat( this.renderPlaceholdersViews() );
+					return renderPluginsViewList().concat( renderPlaceholdersViews() );
 				}
-				return this.renderPluginsViewList();
+				return renderPluginsViewList();
 			case PluginsBrowserListVariant.Paginated:
 				if ( showPlaceholders ) {
-					return this.renderPlaceholdersViews();
+					return renderPlaceholdersViews();
 				}
-				return this.renderPluginsViewList();
+				return renderPluginsViewList();
 			case PluginsBrowserListVariant.Fixed:
 			default:
-				return this.renderPluginsViewList();
+				return renderPluginsViewList();
 		}
-	}
+	};
 
-	render() {
-		return (
-			<div className="plugins-browser-list">
-				<div className="plugins-browser-list__header">
-					<div className={ classnames( 'plugins-browser-list__title', this.props.listName ) }>
-						{ this.props.title }
-						{ this.props.setBillingPeriod && (
-							<BillingIntervalSwitcher
-								billingPeriod={ this.props.billingPeriod }
-								onChange={ this.props.setBillingPeriod }
-								compact={ ! this.props.isBreakpointActive }
-							/>
-						) }
-					</div>
-					<div className="plugins-browser-list__subtitle">{ this.props.subtitle }</div>
+	return (
+		<div className="plugins-browser-list">
+			<div className="plugins-browser-list__header">
+				<div className={ classnames( 'plugins-browser-list__title', listName ) }>
+					{ title }
+					{ setBillingPeriod && (
+						<BillingIntervalSwitcher
+							billingPeriod={ billingPeriod }
+							onChange={ setBillingPeriod }
+							compact={ ! isWide }
+						/>
+					) }
 				</div>
-				<Card className="plugins-browser-list__elements">{ this.renderViews() }</Card>
+				<div className="plugins-browser-list__subtitle">{ subtitle }</div>
 			</div>
-		);
-	}
-}
+			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>
+		</div>
+	);
+};
 
-export default withBreakpoint( '>1280px' )( localize( PluginsBrowserList ) );
+PluginsBrowserList.propTypes = {
+	plugins: PropTypes.array.isRequired,
+	variant: PropTypes.oneOf( Object.values( PluginsBrowserListVariant ) ).isRequired,
+	extended: PropTypes.bool,
+};
+
+export default PluginsBrowserList;

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,9 +1,11 @@
 import { Card } from '@automattic/components';
+import { withBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
 import { PluginsBrowserListVariant } from './types';
@@ -18,6 +20,7 @@ class PluginsBrowserList extends Component {
 		plugins: PropTypes.array.isRequired,
 		variant: PropTypes.oneOf( Object.values( PluginsBrowserListVariant ) ).isRequired,
 		extended: PropTypes.bool,
+		setBillingPeriod: PropTypes.oneOf( false, PropTypes.func ),
 	};
 
 	static defaultProps = {
@@ -86,6 +89,13 @@ class PluginsBrowserList extends Component {
 				<div className="plugins-browser-list__header">
 					<div className={ classnames( 'plugins-browser-list__title', this.props.listName ) }>
 						{ this.props.title }
+						{ this.props.setBillingPeriod && (
+							<BillingIntervalSwitcher
+								billingPeriod={ this.props.billingPeriod }
+								onChange={ this.props.setBillingPeriod }
+								compact={ ! this.props.isBreakpointActive }
+							/>
+						) }
 					</div>
 					<div className="plugins-browser-list__subtitle">{ this.props.subtitle }</div>
 				</div>
@@ -95,4 +105,4 @@ class PluginsBrowserList extends Component {
 	}
 }
 
-export default localize( PluginsBrowserList );
+export default withBreakpoint( '>1280px' )( localize( PluginsBrowserList ) );

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -5,10 +5,6 @@
 		margin: 0;
 	}
 
-	.plugins-browser-list__header {
-		overflow: hidden; // lazy clearfix
-	}
-
 	.section-header {
 		background: none;
 		box-shadow: none;
@@ -36,6 +32,12 @@
 	.plugins-browser-list__title {
 		font-size: $font-title-small;
 		font-weight: 500;
+
+		&.paid {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+		}
 
 		&[class*='plugins-browser-list__search-for'] {
 			font-weight: 400;

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -10,7 +10,6 @@ import {
 import { Button } from '@automattic/components';
 import Search from '@automattic/search';
 import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
-import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -29,7 +28,6 @@ import { PaginationVariant } from 'calypso/components/pagination/constants';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import UrlSearch from 'calypso/lib/url-search';
-import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import NoResults from 'calypso/my-sites/no-results';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
@@ -80,7 +78,6 @@ const PluginsBrowser = ( {
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
 	// Billing period switcher.
-	const isWide = useBreakpoint( '>1280px' );
 	const [ billingPeriod, setBillingPeriod ] = useState( IntervalLength.MONTHLY );
 
 	const hasBusinessPlan =
@@ -239,15 +236,6 @@ const PluginsBrowser = ( {
 					className="plugins-browser__header"
 					navigationItems={ navigationItems }
 				>
-					{ isEnabled( 'marketplace-v1' ) && ! jetpackNonAtomic && (
-						<div className="plugins-browser__billling-interval-switcher">
-							<BillingIntervalSwitcher
-								billingPeriod={ billingPeriod }
-								onChange={ setBillingPeriod }
-								compact={ ! isWide }
-							/>
-						</div>
-					) }
 					<div className="plugins-browser__main-buttons">
 						<ManageButton
 							shouldShowManageButton={ shouldShowManageButton }
@@ -292,6 +280,7 @@ const PluginsBrowser = ( {
 				siteSlug={ siteSlug }
 				jetpackNonAtomic={ jetpackNonAtomic }
 				billingPeriod={ billingPeriod }
+				setBillingPeriod={ setBillingPeriod }
 			/>
 			<InfiniteScroll nextPageMethod={ fetchNextPagePlugins } />
 		</MainComponent>
@@ -459,6 +448,7 @@ const PluginSingleListView = ( {
 	siteSlug,
 	sites,
 	billingPeriod,
+	setBillingPeriod,
 } ) => {
 	const translate = useTranslate();
 
@@ -493,6 +483,7 @@ const PluginSingleListView = ( {
 			currentSites={ sites }
 			variant={ PluginsBrowserListVariant.Fixed }
 			billingPeriod={ billingPeriod }
+			setBillingPeriod={ category === 'paid' && setBillingPeriod }
 			extended
 		/>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Moves the billing switcher inline with the List title.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="557" alt="SS 2021-12-28 at 17 45 39" src="https://user-images.githubusercontent.com/12430020/147583183-b44e9fe8-eac7-442d-a5f7-b10803e2c26b.png">|<img width="410" alt="SS 2021-12-28 at 17 46 43" src="https://user-images.githubusercontent.com/12430020/147583263-5a0a5163-4493-4575-a0fe-2461c6590e20.png">|

* Visit `/plugins
* Verify that the billing switcher appears inline with the `Featured` title
* Initiate a search, it should not appear
* Switch to a Jetpack site, it should not appear

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59591
