### PR TITLE
Plugin Details: move plan upgrade required in a separate line.

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -13,6 +13,7 @@
 	min-height: 48px;
 	display: flex;
 	align-items: baseline;
+	flex-wrap: wrap;
 
 	&.align-right {
 		text-align: right;
@@ -26,7 +27,7 @@
 }
 
 .plugin-details-CTA__uprade-required {
-	margin-left: auto;
+	width: 100%;
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- moves plan upgrade required in a separate line.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="334" alt="SS 2021-12-30 at 12 49 17" src="https://user-images.githubusercontent.com/12430020/147745229-98091de0-0768-4ccb-98fe-5da566c5ce98.png">|<img width="373" alt="SS 2021-12-30 at 12 48 53" src="https://user-images.githubusercontent.com/12430020/147745210-27cb18b4-1400-4994-a0ab-43137bb307ff.png">|

- visit a paid plugin on a free site
- verify that "Plan upgrade required" wraps to the next line

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59628
