### PR TITLE
Add warning for existing email forwards in new comparison page

### DIFF
--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -12,6 +12,7 @@ import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
 import EmailHeader from 'calypso/my-sites/email/email-header';
+import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
 import {
 	emailManagement,
 	emailManagementAddEmailForwards,

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -12,7 +12,6 @@ import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
 import EmailHeader from 'calypso/my-sites/email/email-header';
-import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
 import {
 	emailManagement,
 	emailManagementAddEmailForwards,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a warning to the new comparison page when a user has existing email forwards for the domain, and also hides the email forward footer when that is the case.
* In addition to the above, this PR tackles some other cleanup items:
  - Remove unused props from `connect()` and props type definition
  - Remove unused dispatch props (which were probably causing TS warnings or errors)
  - Removed domain name resolution from `connect()` as it was causing TS issues (and we should require the props to be supplied correctly)

_Note: this PR builds on #59616_

#### Testing instructions

* Run this branch locally or via the Calypso live server
* Ensure you have a domain without any email service, and a domain with email forwarding enabled (though you can start without email service, and then add email forwarding to the same domain if you want)
* Navigate to Upgrades -> Emails
* Click on "Add Email" next to your domain without any email services
* You should be on the `/email/:domain/purchase/:siteSlug` URL path
* Add `?flags=emails/new-email-comparison` to the URL
* Verify that you do not see the existing email forwards warning, and you do see the link to start with email forwarding in the footer.
* Navigate to Upgrades -> Emails
* Select your domain that has an existing email forward
* On the email management page, click on "Upgrade to a hosted email"
* If you are shown the old comparison page, add `?flags=emails/new-email-comparison` to the URL
* Verify that once the data loads, you see the warning for existing email forwards, and you do not see the footer link to start with email forwarding

##### Screenshot

<img width="1116" alt="Screenshot 2021-12-30 at 13 01 59" src="https://user-images.githubusercontent.com/3376401/147746184-dd4b9bae-44e2-4e10-8f82-7ee31a12d98c.png">

Related to #59616
