### PR TITLE
P2 signup: fix confirm email screen styling issues

### DIFF
--- a/client/signup/steps/p2-confirm-email/style.scss
+++ b/client/signup/steps/p2-confirm-email/style.scss
@@ -24,8 +24,10 @@
 		padding: 8px;
 	}
 
-	button.p2-confirm-email__resend-email ,
-	button.p2-confirm-email__change-email {
+	/* TODO Revisit specificity when p2-new signup flow becomes main flow
+	and p2-new styles for p2-step-wrapper can have their specificity reduced */
+	.p2-step-wrapper button.p2-confirm-email__resend-email ,
+	.p2-step-wrapper button.p2-confirm-email__change-email {
 		background: none;
 		color: var( --p2-color-link );
 		text-decoration: underline;
@@ -47,13 +49,13 @@
 	}
 
 	button.p2-confirm-email__continue {
-		margin-top: 2.5em;
 		max-width: 228px;
 	}
 }
 
 .p2-confirm-email__message {
 	text-align: center;
+	margin-bottom: 3em;
 }
 
 .p2-confirm-email__actions {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There are some CSS issues that weren't apparent when testing with `calypso.localhost:3000`. This PR fixes them.

* Fixes the "Resend verification email" button background color (should be none)
* Fixes whitespace between text and "Continue" button 

<img width="800" alt="Screen Shot 2021-12-30 at 7 40 17 PM" src="https://user-images.githubusercontent.com/730823/147748891-3fa1710a-106a-4b2f-a82a-dd03a579396d.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live link to verify that the above CSS issues have been fixed
* Go to `<calypso.live link>/start/p2-new` and sign up for an account (or manually toggle your test account to unverified via the instructions in D72286-code)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
