### PR TITLE
Enable new email comparison page in more contexts

### DIFF
--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -20,6 +21,7 @@ import EmailListInactive from 'calypso/my-sites/email/email-management/home/emai
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
+import EmailProvidersComparisonStacked from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -82,7 +84,13 @@ class EmailManagementHome extends Component {
 			} );
 
 			if ( ! domainHasEmail( selectedDomain ) ) {
-				return (
+				return isEnabled( 'emails/new-email-comparison' ) ? (
+					<EmailProvidersComparisonStacked
+						comparisonContext="email-home-selected-domain"
+						selectedDomainName={ selectedDomainName }
+						source={ source }
+					/>
+				) : (
 					<EmailProvidersComparison
 						backPath={ domainManagementList( selectedSite.slug, null ) }
 						comparisonContext="email-home-selected-domain"
@@ -109,7 +117,13 @@ class EmailManagementHome extends Component {
 		const domainsWithNoEmail = nonWpcomDomains.filter( ( domain ) => ! domainHasEmail( domain ) );
 
 		if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
-			return (
+			return isEnabled( 'emails/new-email-comparison' ) ? (
+				<EmailProvidersComparisonStacked
+					comparisonContext="email-home-single-domain"
+					selectedDomainName={ domainsWithNoEmail[ 0 ].name }
+					source={ source }
+				/>
+			) : (
 				<EmailProvidersComparison
 					comparisonContext="email-home-single-domain"
 					selectedDomainName={ domainsWithNoEmail[ 0 ].name }

--- a/config/development.json
+++ b/config/development.json
@@ -53,6 +53,7 @@
 		"domains/premium-domain-purchases": true,
 		"domains/settings-page-redesign": true,
 		"email-accounts/enabled": true,
+		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -30,6 +30,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
+		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -35,6 +35,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
+		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the new email comparison page in more contexts using two approaches:
  - The PR enables the `emails/new-email-comparison` feature flag in the `development`, `horizon`, and `wpcalypso` environments
  - The PR enables the new component (behind the feature flag) to be displayed from the email home page when there is only one domain on the site without email, or when the user loads the `/email/:domain/manage/:siteSlug` URL and the domain doesn't have email service.

For now, the new component is _not_ used for the domain upsell flow, as we currently have a bit of a UX conflict with the way the existing flow looks.

#### Testing instructions

* Run this branch locally or via the Calypso live server
* For a site with only one domain and no email services, click on Upgrades -> Emails
* Verify that you see the new email comparison page
* For the same site, navigate to `/email/:domain/manage/:siteSlug`
* Verify that you see the new email comparison page