### PR TITLE
Home: Add width and height to Education Content illustrations

### DIFF
--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
@@ -31,6 +31,8 @@ const BloggingQuickStart = () => {
 			] }
 			illustration={ startLearningPrompt }
 			cardName={ EDUCATION_BLOGGING_QUICK_START }
+			width="371"
+			height="243"
 		/>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
@@ -31,8 +31,8 @@ const BloggingQuickStart = () => {
 			] }
 			illustration={ startLearningPrompt }
 			cardName={ EDUCATION_BLOGGING_QUICK_START }
-			width="371"
-			height="243"
+			width="183"
+			height="120"
 		/>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/earn/index.jsx
+++ b/client/my-sites/customer-home/cards/education/earn/index.jsx
@@ -24,6 +24,8 @@ const EducationEarn = ( { siteSlug } ) => {
 			] }
 			illustration={ earnCardPrompt }
 			cardName={ EDUCATION_EARN }
+			width="201"
+			height="114"
 		/>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -82,7 +82,7 @@ function EducationalContent( {
 						) ) }
 				</div>
 			</div>
-			{ isDesktop() && (
+			{ isDesktop() && illustration && (
 				<div className="educational-content__illustration">
 					<img src={ illustration } alt="" width={ width } height={ height } />
 				</div>
@@ -91,14 +91,29 @@ function EducationalContent( {
 	);
 }
 
+// Custom propType function that checks for illustration prop is set and returns an error in case it s not.
+function propTypeHasIllustration( props, propName, componentName ) {
+	let error;
+	if ( ! props.illustration ) {
+		return;
+	}
+
+	const prop = props[ propName ];
+	if ( typeof prop !== 'string' && typeof prop !== 'number' ) {
+		error = new Error(
+			`${ componentName } requires ${ propName } if an illustration is provided.`
+		);
+	}
+	return error;
+}
 EducationalContent.propTypes = {
-	title: PropTypes.string,
+	title: PropTypes.string.isRequired,
 	description: PropTypes.node.isRequired,
 	links: PropTypes.array,
 	modalLinks: PropTypes.array,
 	illustration: PropTypes.string,
 	cardName: PropTypes.string,
-	width: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
-	height: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
+	width: propTypeHasIllustration,
+	height: propTypeHasIllustration,
 };
 export default EducationalContent;

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
+import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -15,7 +16,7 @@ function trackNavigation( url, cardName ) {
 	);
 }
 
-export default function EducationalContent( {
+function EducationalContent( {
 	title,
 	description,
 	links,
@@ -89,3 +90,15 @@ export default function EducationalContent( {
 		</div>
 	);
 }
+
+EducationalContent.propTypes = {
+	title: PropTypes.string,
+	description: PropTypes.node.isRequired,
+	links: PropTypes.array,
+	modalLinks: PropTypes.array,
+	illustration: PropTypes.string,
+	cardName: PropTypes.string,
+	width: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
+	height: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
+};
+export default EducationalContent;

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -22,6 +22,8 @@ export default function EducationalContent( {
 	modalLinks,
 	illustration,
 	cardName,
+	width,
+	height,
 } ) {
 	const dispatch = useDispatch();
 
@@ -81,7 +83,7 @@ export default function EducationalContent( {
 			</div>
 			{ isDesktop() && (
 				<div className="educational-content__illustration">
-					<img src={ illustration } alt="" />
+					<img src={ illustration } alt="" width={ width } height={ height } />
 				</div>
 			) }
 		</div>

--- a/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
+++ b/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
@@ -22,6 +22,8 @@ const FreePhotoLibrary = () => {
 			] }
 			illustration={ freePhotoLibraryVideoPrompt }
 			cardName={ EDUCATION_FREE_PHOTO_LIBRARY }
+			height="115"
+			width="200"
 		/>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/wpcourses/index.jsx
+++ b/client/my-sites/customer-home/cards/education/wpcourses/index.jsx
@@ -25,6 +25,8 @@ const WpCourses = () => {
 			] }
 			illustration={ freePhotoLibraryVideoPrompt }
 			cardName={ EDUCATION_WPCOURSES }
+			width="418"
+			height="299"
 		/>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR intends to fix the illustrations sometimes being cut off in the browser. 
This happens because the dimensions of the illustrations are not set so the browser doesn't know how much space will take up. 

Before:
<img width="400" alt="Screen Shot 2021-12-30 at 10 12 39 AM" src="https://user-images.githubusercontent.com/115071/147779381-b0c4fc65-95eb-4ca5-ae79-2043aca52892.png">

After:

<img width="400" alt="Screen Shot 2021-12-30 at 10 12 48 AM" src="https://user-images.githubusercontent.com/115071/147779474-4e3dd620-4194-4aef-ad9f-0733968a0bac.png">

#### Testing instructions
* Load this PR. 
* Notice that the html now contains the donations of the illustration that is being included. 
* Notice that when you force refresh the page it.

