### PR TITLE
Add "Requires a plan upgrade" For Free Plugins

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,3 +1,4 @@
+import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -13,6 +14,7 @@ import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
+import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserElementVariant } from './types';
@@ -92,6 +94,17 @@ const PluginsBrowserListElement = ( props ) => {
 		return version_compare( wpVersion, pluginTestedVersion, '>' );
 	} );
 
+	const isVip = useSelector( ( state ) => checkVipSite( state, selectedSite?.ID ) );
+	const shouldUpgrade =
+		selectedSite &&
+		! (
+			isBusiness( selectedSite.plan ) ||
+			isEnterprise( selectedSite.plan ) ||
+			isEcommerce( selectedSite.plan ) ||
+			isJetpack ||
+			isVip
+		);
+
 	if ( isPlaceholder ) {
 		return <Placeholder iconSize={ iconSize } />;
 	}
@@ -143,6 +156,7 @@ const PluginsBrowserListElement = ( props ) => {
 							isWpcomPreinstalled={ isWpcomPreinstalled }
 							plugin={ plugin }
 							billingPeriod={ billingPeriod }
+							shouldUpgrade={ shouldUpgrade }
 						/>
 					) }
 					<div className="plugins-browser-item__additional-info">
@@ -176,6 +190,7 @@ const InstalledInOrPricing = ( {
 	isWpcomPreinstalled,
 	plugin,
 	billingPeriod,
+	shouldUpgrade,
 } ) => {
 	const translate = useTranslate();
 
@@ -202,7 +217,14 @@ const InstalledInOrPricing = ( {
 									<span className="plugins-browser-item__period">{ period }</span>
 								</>
 							) : (
-								translate( 'Free' )
+								<>
+									{ translate( 'Free' ) }
+									{ shouldUpgrade && (
+										<span className="plugins-browser-item__requires-plan-upgrade">
+											{ translate( 'Requires a plan upgrade' ) }
+										</span>
+									) }
+								</>
 							) }
 						</>
 					)

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -159,7 +159,12 @@
 	justify-content: space-between;
 }
 
-.plugins-browser-item__period {
+.plugins-browser-item__period,
+.plugins-browser-item__requires-plan-upgrade {
 	color: var( --studio-gray-60 );
 	font-size: $font-body-extra-small;
+}
+
+.plugins-browser-item__requires-plan-upgrade {
+	margin-left: 5px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show "Requires a plan upgrade" for free plugins in the `InstalledInOrPricing` component. Before displaying the text a validation checks if the site is a free one.

#### Testing instructions

* Go to free site -> Plugins
* Free plugins should display the text "Requires a plan upgrade" next to "Free".
* The text is only displayed on free sites.

#### Before:
<img width="1078" alt="Screen Shot 2021-12-31 at 9 31 26 PM" src="https://user-images.githubusercontent.com/351784/147842838-68f44ff3-eecf-41a8-b023-b7f819bfa855.png">

#### After:
<img width="1064" alt="Screen Shot 2021-12-31 at 9 33 09 PM" src="https://user-images.githubusercontent.com/351784/147842847-33d8d07e-aef2-4783-a6b1-3eae6f039c59.png">

Related to #58499
