### PR TITLE
composite-checkout: Simplify and split up CheckoutProvider

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -1,7 +1,7 @@
 import { isYearly, isJetpackPurchasableItem, isMonthlyProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
-	Checkout,
+	CheckoutStepsProvider,
 	CheckoutStep,
 	CheckoutStepArea,
 	CheckoutSteps,
@@ -287,7 +287,7 @@ export default function WPCheckout( {
 	);
 
 	return (
-		<Checkout onStepChanged={ handleStepChanged }>
+		<CheckoutStepsProvider onStepChanged={ handleStepChanged }>
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
 				<CheckoutErrorBoundary
 					errorMessage={ translate( 'Sorry, there was an error loading this information.' ) }
@@ -458,7 +458,7 @@ export default function WPCheckout( {
 					/>
 				</CheckoutSteps>
 			</CheckoutStepArea>
-		</Checkout>
+		</CheckoutStepsProvider>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -567,33 +567,6 @@ export default function CompositeCheckout( {
 		checkoutFlow,
 	} );
 
-	const handleStepChanged = useCallback(
-		( {
-			stepNumber,
-			previousStepNumber,
-			paymentMethodId,
-		}: {
-			stepNumber: number | null;
-			previousStepNumber: number;
-			paymentMethodId: string;
-		} ) => {
-			if ( stepNumber === 2 && previousStepNumber === 1 ) {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_first_step_complete', {
-						payment_method:
-							translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
-					} )
-				);
-			}
-			reduxDispatch(
-				recordTracksEvent( 'calypso_checkout_composite_step_changed', {
-					step: stepNumber,
-				} )
-			);
-		},
-		[ reduxDispatch ]
-	);
-
 	const handlePaymentMethodChanged = useCallback(
 		( method: string ) => {
 			logStashEvent( 'payment_method_select', {
@@ -725,7 +698,6 @@ export default function CompositeCheckout( {
 				onPaymentError={ handlePaymentError }
 				onPaymentRedirect={ handlePaymentRedirect }
 				onPageLoadError={ onPageLoadError }
-				onStepChanged={ handleStepChanged }
 				onPaymentMethodChanged={ handlePaymentMethodChanged }
 				paymentMethods={ paymentMethods }
 				paymentProcessors={ paymentProcessors }

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -40,7 +40,7 @@ Any component which is a child of `CheckoutProvider` gets access to the followin
 - [usePaymentMethodId](#usePaymentMethodId)
 - [useTotal](#useTotal)
 
-The [Checkout](#checkout) component creates a wrapper for Checkout. Within the component you can render any children to create the checkout experience, but a few components are provided to make this easier:
+The [CheckoutStepsProvider](#CheckoutStepsProvider) component creates a wrapper for Checkout. Within the component you can render any children to create the checkout experience, but a few components are provided to make this easier:
 
 - [CheckoutSummaryArea](#CheckoutSummaryArea) (optional) can be used to render an invisible area that, by default, floats beside the checkout steps on larger screens and collapses behind a toggle at the top of smaller screens.
 - [CheckoutSummaryCard](#CheckoutSummaryCard) (optional) can be used inside CheckoutSummaryArea to render a bordered area.
@@ -198,7 +198,7 @@ This component's props are:
 
 ## CheckoutStepArea
 
-Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects. Should be a direct child of [Checkout](#Checkout).
+Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects. Should be a direct child of [CheckoutStepsProvider](#CheckoutStepsProvider).
 
 This component's props are:
 
@@ -240,7 +240,7 @@ This component's props are:
 
 ## CheckoutSteps
 
-A wrapper for [CheckoutStep](#CheckoutStep) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout). It has the following props.
+A wrapper for [CheckoutStep](#CheckoutStep) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [CheckoutStepsProvider](#CheckoutStepsProvider). It has the following props.
 
 - `areStepsActive?: boolean`. Whether or not the set of steps is active and able to be edited. Defaults to `true`.
 
@@ -276,7 +276,7 @@ An enum that holds the values of the [form status](#useFormStatus).
 
 ## MainContentWrapper
 
-A styled div, controlled by the [theme](#checkoutTheme), that's used as the inner wrapper for the [Checkout](#Checkout) component. You shouldn't need to use this manually.
+A styled div, controlled by the [theme](#checkoutTheme), that's used as the inner wrapper for the [CheckoutStepsProvider](#CheckoutStepsProvider) component. You shouldn't need to use this manually.
 
 ### OrderReviewLineItems
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -127,6 +127,7 @@ A generic button component that is used internally for almost all buttons (like 
 The main wrapper component for Checkout. It has the following props.
 
 - `className?: string`. The className for the component.
+- `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 
 ### CheckoutCheckIcon
 
@@ -154,7 +155,6 @@ It has the following props.
 - `onPaymentRedirect?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for redirect payment methods when payment begins to redirect. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentError?: ({paymentMethodId: string | null, transactionError: string | null }) => null`. A function to call for payment methods when payment is not successful.
 - `onPageLoadError?: ( errorType: string, errorMessage: string, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
-- `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 - `onPaymentMethodChanged?: (method: string) => void`. A function to call when the active payment method is changed. The argument will be the method's id.
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -122,7 +122,7 @@ A generic button component that is used internally for almost all buttons (like 
 - `fullWidth?: bool`. The button width defaults to 'auto', but if this is set it will be '100%'.
 - `isBusy?: bool`. If true, the button will be displayed as a loading spinner.
 
-### Checkout
+### CheckoutStepsProvider
 
 The main wrapper component for Checkout. It has the following props.
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import {
-	Checkout,
+	CheckoutStepsProvider,
 	CheckoutStepArea,
 	CheckoutStep,
 	CheckoutStepBody,
@@ -182,7 +182,7 @@ function MyCheckoutBody() {
 	const country = getCountry();
 
 	return (
-		<Checkout>
+		<CheckoutStepsProvider>
 			<CheckoutSummaryArea className={ orderSummary.className }>
 				{ orderSummary.summaryContent }
 			</CheckoutSummaryArea>
@@ -229,7 +229,7 @@ function MyCheckoutBody() {
 					/>
 				</CheckoutSteps>
 			</CheckoutStepArea>
-		</Checkout>
+		</CheckoutStepsProvider>
 	);
 }
 

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import { useFormStatusManager } from '../lib/form-status';
 import { LineItemsProvider } from '../lib/line-items';
+import { PaymentProcessorProvider } from '../lib/payment-processors';
 import defaultTheme from '../lib/theme';
 import { useTransactionStatusManager } from '../lib/transaction-status';
 import {
@@ -115,7 +116,6 @@ export function CheckoutProvider( {
 			formStatus,
 			setFormStatus,
 			transactionStatusManager,
-			paymentProcessors,
 			onPageLoadError,
 			onStepChanged,
 			onPaymentMethodChanged,
@@ -126,7 +126,6 @@ export function CheckoutProvider( {
 			paymentMethods,
 			setFormStatus,
 			transactionStatusManager,
-			paymentProcessors,
 			onPageLoadError,
 			onStepChanged,
 			onPaymentMethodChanged,
@@ -146,10 +145,12 @@ export function CheckoutProvider( {
 			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
 			<ThemeProvider theme={ theme || defaultTheme }>
 				<LineItemsProvider items={ items } total={ total }>
-					<CheckoutContext.Provider value={ value }>
-						<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
-						{ children }
-					</CheckoutContext.Provider>
+					<PaymentProcessorProvider paymentProcessors={ paymentProcessors }>
+						<CheckoutContext.Provider value={ value }>
+							<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
+							{ children }
+						</CheckoutContext.Provider>
+					</PaymentProcessorProvider>
 				</LineItemsProvider>
 			</ThemeProvider>
 		</CheckoutErrorBoundary>

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -45,7 +45,6 @@ export function CheckoutProvider( {
 	onPaymentRedirect,
 	onPaymentError,
 	onPageLoadError,
-	onStepChanged,
 	onPaymentMethodChanged,
 	redirectToUrl,
 	theme,
@@ -117,7 +116,6 @@ export function CheckoutProvider( {
 			setFormStatus,
 			transactionStatusManager,
 			onPageLoadError,
-			onStepChanged,
 			onPaymentMethodChanged,
 		} ),
 		[
@@ -127,7 +125,6 @@ export function CheckoutProvider( {
 			setFormStatus,
 			transactionStatusManager,
 			onPageLoadError,
-			onStepChanged,
 			onPaymentMethodChanged,
 		]
 	);

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -209,7 +209,7 @@ interface CheckoutStepsProps {
 	areStepsActive?: boolean;
 }
 
-export function Checkout( {
+export function CheckoutStepsProvider( {
 	children,
 	className,
 	onStepChanged,

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -28,7 +28,7 @@ import {
 	getDefaultPaymentMethodStep,
 	usePaymentMethod,
 } from '../public-api';
-import { FormStatus, CheckoutStepProps } from '../types';
+import { FormStatus } from '../types';
 import Button from './button';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import CheckoutNextStepButton from './checkout-next-step-button';
@@ -36,6 +36,7 @@ import CheckoutSubmitButton from './checkout-submit-button';
 import LoadingContent from './loading-content';
 import { CheckIcon } from './shared-icons';
 import type { Theme } from '../lib/theme';
+import type { CheckoutStepProps, StepChangedCallback } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 
@@ -50,6 +51,7 @@ interface CheckoutStepDataContext {
 	setActiveStepNumber: ( stepNumber: number ) => void;
 	setStepCompleteStatus: Dispatch< SetStateAction< StepCompleteStatus > >;
 	setTotalSteps: ( totalSteps: number ) => void;
+	onStepChanged?: StepChangedCallback;
 }
 
 interface CheckoutSingleStepDataContext {
@@ -210,9 +212,11 @@ interface CheckoutStepsProps {
 export function Checkout( {
 	children,
 	className,
+	onStepChanged,
 }: {
 	children: ReactNode;
 	className?: string;
+	onStepChanged?: StepChangedCallback;
 } ): JSX.Element {
 	const { isRTL } = useI18n();
 	const { formStatus } = useFormStatus();
@@ -257,6 +261,7 @@ export function Checkout( {
 						setActiveStepNumber,
 						setStepCompleteStatus,
 						setTotalSteps,
+						onStepChanged,
 					} }
 				>
 					{ children || getDefaultCheckoutSteps() }
@@ -281,13 +286,16 @@ export const CheckoutStep = ( {
 	validatingButtonAriaLabel,
 }: CheckoutStepProps ): JSX.Element => {
 	const { __ } = useI18n();
-	const { setActiveStepNumber, setStepCompleteStatus, stepCompleteStatus } = useContext(
-		CheckoutStepDataContext
-	);
+	const {
+		setActiveStepNumber,
+		setStepCompleteStatus,
+		stepCompleteStatus,
+		onStepChanged,
+	} = useContext( CheckoutStepDataContext );
 	const { stepNumber, nextStepNumber, isStepActive, isStepComplete, areStepsActive } = useContext(
 		CheckoutSingleStepDataContext
 	);
-	const { onPageLoadError, onStepChanged } = useContext( CheckoutContext );
+	const { onPageLoadError } = useContext( CheckoutContext );
 	const { formStatus, setFormValidating, setFormReady } = useFormStatus();
 	const setThisStepCompleteStatus = ( newStatus: boolean ) =>
 		setStepCompleteStatus( { ...stepCompleteStatus, [ stepNumber ]: newStatus } );

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -1,6 +1,5 @@
 import { createContext } from 'react';
 import {
-	StepChangedCallback,
 	CheckoutPageErrorCallback,
 	FormStatus,
 	PaymentMethod,
@@ -16,7 +15,6 @@ interface CheckoutContext {
 	setFormStatus: ( newStatus: FormStatus ) => void;
 	transactionStatusManager: TransactionStatusManager | null;
 	onPageLoadError?: CheckoutPageErrorCallback;
-	onStepChanged?: StepChangedCallback;
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 }
 

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -4,7 +4,6 @@ import {
 	CheckoutPageErrorCallback,
 	FormStatus,
 	PaymentMethod,
-	PaymentProcessorProp,
 	TransactionStatusManager,
 	PaymentMethodChangedCallback,
 } from '../types';
@@ -16,7 +15,6 @@ interface CheckoutContext {
 	formStatus: FormStatus;
 	setFormStatus: ( newStatus: FormStatus ) => void;
 	transactionStatusManager: TransactionStatusManager | null;
-	paymentProcessors: PaymentProcessorProp;
 	onPageLoadError?: CheckoutPageErrorCallback;
 	onStepChanged?: StepChangedCallback;
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
@@ -29,7 +27,6 @@ const defaultCheckoutContext: CheckoutContext = {
 	formStatus: FormStatus.LOADING,
 	setFormStatus: noop,
 	transactionStatusManager: null,
-	paymentProcessors: {},
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/composite-checkout/src/lib/payment-processors.tsx
+++ b/packages/composite-checkout/src/lib/payment-processors.tsx
@@ -1,6 +1,6 @@
-import { useContext } from 'react';
-import CheckoutContext from '../lib/checkout-context';
+import { useContext, createContext, useMemo } from 'react';
 import {
+	PaymentProcessorProp,
 	PaymentProcessorFunction,
 	PaymentProcessorResponseData,
 	PaymentProcessorSuccess,
@@ -9,9 +9,10 @@ import {
 	PaymentProcessorError,
 	PaymentProcessorResponseType,
 } from '../types';
+import type { ReactNode } from 'react';
 
 export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
-	const { paymentProcessors } = useContext( CheckoutContext );
+	const { paymentProcessors } = useContext( PaymentProcessorContext );
 	if ( ! paymentProcessors[ key ] ) {
 		throw new Error( `No payment processor found with key: ${ key }` );
 	}
@@ -19,7 +20,7 @@ export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
 }
 
 export function usePaymentProcessors(): Record< string, PaymentProcessorFunction > {
-	const { paymentProcessors } = useContext( CheckoutContext );
+	const { paymentProcessors } = useContext( PaymentProcessorContext );
 	return paymentProcessors;
 }
 
@@ -39,4 +40,29 @@ export function makeRedirectResponse( url: string ): PaymentProcessorRedirect {
 
 export function makeManualResponse( payload: unknown ): PaymentProcessorManual {
 	return { type: PaymentProcessorResponseType.MANUAL, payload };
+}
+
+interface PaymentProcessorContext {
+	paymentProcessors: PaymentProcessorProp;
+}
+
+const defaultPaymentProcessorContext: PaymentProcessorContext = {
+	paymentProcessors: {},
+};
+
+export const PaymentProcessorContext = createContext( defaultPaymentProcessorContext );
+
+export function PaymentProcessorProvider( {
+	paymentProcessors,
+	children,
+}: {
+	paymentProcessors: PaymentProcessorProp;
+	children: ReactNode;
+} ): JSX.Element {
+	const value = useMemo( () => ( { paymentProcessors } ), [ paymentProcessors ] );
+	return (
+		<PaymentProcessorContext.Provider value={ value }>
+			{ children }
+		</PaymentProcessorContext.Provider>
+	);
 }

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -7,21 +7,7 @@ import CheckoutOrderSummaryStep, {
 } from './components/checkout-order-summary';
 import CheckoutPaymentMethods from './components/checkout-payment-methods';
 import { CheckoutProvider } from './components/checkout-provider';
-import {
-	Checkout,
-	CheckoutStep,
-	CheckoutStepArea,
-	CheckoutStepBody,
-	CheckoutSteps,
-	CheckoutSummaryArea,
-	CheckoutSummaryCard,
-	useIsStepActive,
-	useIsStepComplete,
-	useSetStepComplete,
-	MainContentWrapper,
-	CheckoutStepAreaWrapper,
-	SubmitButtonWrapper,
-} from './components/checkout-steps';
+export * from './components/checkout-steps';
 import CheckoutSubmitButton from './components/checkout-submit-button';
 import {
 	getDefaultOrderSummary,
@@ -59,7 +45,6 @@ export type { Theme } from './lib/theme';
 // Re-export the public API
 export {
 	Button,
-	Checkout,
 	CheckoutCheckIcon,
 	CheckoutErrorBoundary,
 	CheckoutModal,
@@ -68,22 +53,13 @@ export {
 	CheckoutOrderSummaryStepTitle,
 	CheckoutPaymentMethods,
 	CheckoutProvider,
-	CheckoutStep,
-	CheckoutStepArea,
-	CheckoutStepAreaWrapper,
-	CheckoutStepBody,
-	CheckoutSteps,
 	CheckoutSubmitButton,
-	CheckoutSummaryArea,
-	CheckoutSummaryCard,
 	InvalidPaymentProcessorResponseError,
-	MainContentWrapper,
 	OrderReviewLineItems,
 	OrderReviewSection,
 	OrderReviewTotal,
 	PaymentLogo,
 	RadioButton,
-	SubmitButtonWrapper,
 	checkoutTheme,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummary,
@@ -95,8 +71,6 @@ export {
 	makeSuccessResponse,
 	useAllPaymentMethods,
 	useFormStatus,
-	useIsStepActive,
-	useIsStepComplete,
 	useLineItems,
 	useLineItemsOfType,
 	usePaymentMethod,
@@ -104,7 +78,6 @@ export {
 	usePaymentProcessor,
 	usePaymentProcessors,
 	useProcessPayment,
-	useSetStepComplete,
 	useTotal,
 	useTransactionStatus,
 };

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -108,7 +108,6 @@ export interface CheckoutProviderProps {
 	onPaymentRedirect?: PaymentEventCallback;
 	onPaymentError?: PaymentErrorCallback;
 	onPageLoadError?: CheckoutPageErrorCallback;
-	onStepChanged?: StepChangedCallback;
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 	isLoading?: boolean;
 	redirectToUrl?: ( url: string ) => void;

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -9,7 +9,7 @@ import {
 import { createContext, Fragment, useState, useContext } from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import {
-	Checkout,
+	CheckoutStepsProvider,
 	CheckoutProvider,
 	CheckoutStep,
 	CheckoutStepArea,
@@ -23,7 +23,7 @@ import {
 const myContext = createContext();
 const usePaymentData = () => useContext( myContext );
 
-describe( 'Checkout', () => {
+describe( 'CheckoutStepsProvider', () => {
 	describe( 'using the default steps', function () {
 		describe( 'using other defaults', function () {
 			let MyCheckout;
@@ -39,7 +39,7 @@ describe( 'Checkout', () => {
 						paymentProcessors={ getMockPaymentProcessors() }
 						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
-						<Checkout />
+						<CheckoutStepsProvider />
 					</CheckoutProvider>
 				);
 			} );
@@ -100,7 +100,7 @@ describe( 'Checkout', () => {
 						paymentProcessors={ getMockPaymentProcessors() }
 						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
-						<Checkout />
+						<CheckoutStepsProvider />
 					</CheckoutProvider>
 				);
 				const renderResult = render( <MyCheckout /> );
@@ -141,7 +141,7 @@ describe( 'Checkout', () => {
 						paymentProcessors={ getMockPaymentProcessors() }
 						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
-						<Checkout />
+						<CheckoutStepsProvider />
 					</CheckoutProvider>
 				);
 				const renderResult = render( <MyCheckout /> );
@@ -184,9 +184,9 @@ describe( 'Checkout', () => {
 							paymentProcessors={ getMockPaymentProcessors() }
 							initiallySelectedPaymentMethodId={ mockMethod.id }
 						>
-							<Checkout>
+							<CheckoutStepsProvider>
 								{ createStepsFromStepObjects( props.steps || steps, paymentData ) }
-							</Checkout>
+							</CheckoutStepsProvider>
 						</CheckoutProvider>
 					</myContext.Provider>
 				);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `CheckoutProvider` component in the `@automattic/composite-checkout` package is a sort of "god component" which holds the context for all aspects of the package's various functionality. Since its inception, the number of possible configurations of the package's pieces has increased quite a lot, and it is now being used for many things not specifically related to the checkout page (eg: payment method selection, custom checkout modals, themed dialogs). In all these cases it's not ideal to require the full `CheckoutProvider` when much of it may not be used.

This PR attempts to break the functionality of `CheckoutProvider` into smaller independent pieces and add those pieces to the public API of the package. `CheckoutProvider` will remain as a trivial convenience wrapper for all this functionality, but this way consumers may instead choose to implement only part of the system for their own use cases.

#### Testing instructions

Existing automated tests should cover all changes being made here.