### PR TITLE
Fix domain settings breadcrumbs root level

### DIFF
--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -14,12 +14,11 @@ import './style.scss';
 
 const DnsDetails = ( {
 	dns,
-	isRequestingDomains,
 	selectedDomainName,
 	currentRoute,
 	selectedSite,
 }: DnsDetailsProps ): JSX.Element => {
-	const showPlaceholder = ! dns.hasLoadedFromServer || isRequestingDomains;
+	const showPlaceholder = ! dns.hasLoadedFromServer;
 	const translate = useTranslate();
 
 	// This could be moved to an utils file?

--- a/client/my-sites/domains/domain-management/settings/dns/types.ts
+++ b/client/my-sites/domains/domain-management/settings/dns/types.ts
@@ -3,7 +3,6 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 export type DnsDetailsProps = {
 	dns: DnsRequest;
-	isRequestingDomains: boolean;
 	selectedDomainName: string;
 	selectedSite: SiteData;
 	currentRoute: string;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -33,7 +33,6 @@ import {
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
-import { isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-info';
 import DomainSecurityDetails from './cards/domain-security-details';
@@ -54,7 +53,6 @@ const Settings = ( {
 	loadingNameserversError,
 	nameservers,
 	dns,
-	isRequestingDomains,
 	purchase,
 	requestWhois,
 	selectedDomainName,
@@ -208,7 +206,6 @@ const Settings = ( {
 			>
 				<DnsRecords
 					dns={ dns }
-					isRequestingDomains={ isRequestingDomains }
 					selectedDomainName={ selectedDomainName }
 					selectedSite={ selectedSite }
 					currentRoute={ currentRoute }
@@ -382,7 +379,6 @@ export default connect(
 				isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 			purchase: purchase && purchase.userId === currentUserId ? purchase : null,
 			dns: getDomainDns( state, ownProps.selectedDomainName ),
-			isRequestingDomains: isRequestingSiteDomains( state, ownProps.selectedSite.ID ),
 		};
 	},
 	{

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -20,7 +20,7 @@ import withDomainNameservers from 'calypso/my-sites/domains/domain-management/na
 import {
 	domainManagementList,
 	domainUseMyDomain,
-  isUnderDomainManagementAll
+	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -18,9 +18,9 @@ import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/co
 import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
 import {
-	domainManagementEdit,
 	domainManagementList,
 	domainUseMyDomain,
+  isUnderDomainManagementAll
 } from 'calypso/my-sites/domains/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -65,16 +65,14 @@ const Settings = ( {
 	const translate = useTranslate();
 
 	const renderBreadcrumbs = () => {
-		const previousPath = domainManagementEdit(
-			selectedSite?.slug,
-			selectedDomainName,
-			currentRoute
-		);
+		const previousPath = domainManagementList( selectedSite?.slug, currentRoute );
 
 		const items = [
 			{
-				label: translate( 'Domains' ),
-				href: domainManagementList( selectedSite?.slug, selectedDomainName ),
+				label: isUnderDomainManagementAll( currentRoute )
+					? translate( 'All Domains' )
+					: translate( 'Domains' ),
+				href: previousPath,
 			},
 			{ label: selectedDomainName },
 		];

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -35,7 +35,6 @@ export type SettingsPageConnectedProps = {
 	purchase: Purchase | null;
 	whoisData: WhoisData[];
 	dns: DnsRequest;
-	isRequestingDomains: boolean;
 };
 
 export type SettingsPageNameServerHocProps = {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes breadcrumbs root level on **Domain Settings** page: when domain detail page is reached from **All domains** list, the main level should display **All domains** and the root link should lead back to **All domains** listing (now the link leads back to Site domains listing).

![all-domains-desktop](https://user-images.githubusercontent.com/2797601/147918736-5345dbc6-4efc-4d8d-a99c-109baddfe3d8.png)

![all-domains-mobile](https://user-images.githubusercontent.com/2797601/147918743-08aef062-4b33-4ef0-baf0-72db92c91514.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "All Domains" listing (`/domains/manage` path)
- Select a domain
- Verify that root level on breadcrumbs displays "All domains" label and leads back to all domains listing
- Verify that `back` link on mobile leads back to all domains listing