### PR TITLE
Fix extra Professional Email mailbox purchases

### DIFF
--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -12,7 +12,7 @@ interface EmailSubscription {
 	status: string;
 }
 
-type EmailCost = {
+export type EmailCost = {
 	amount: number;
 	currency: string;
 	text: string;

--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -35,6 +35,7 @@ export type TitanEmailSubscription = EmailSubscription & {
 	maximumMailboxCount?: number;
 	numberOfMailboxes?: number;
 	orderId?: number;
+	productSlug?: string;
 	purchaseCostPerMailbox?: EmailCost | null;
 	renewalCostPerMailbox?: EmailCost | null;
 	subscriptionId?: number | null;

--- a/client/lib/titan/get-current-product-slug.ts
+++ b/client/lib/titan/get-current-product-slug.ts
@@ -1,0 +1,5 @@
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+export function getCurrentProductSlug( domain: ResponseDomain ): string | null {
+	return domain?.titanMailSubscription?.productSlug ?? null;
+}

--- a/client/lib/titan/get-titan-product-slug.ts
+++ b/client/lib/titan/get-titan-product-slug.ts
@@ -1,5 +1,5 @@
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-export function getCurrentProductSlug( domain: ResponseDomain ): string | null {
+export function getTitanProductSlug( domain: ResponseDomain ): string | null {
 	return domain?.titanMailSubscription?.productSlug ?? null;
 }

--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -11,3 +11,4 @@ export { getTitanSubscriptionId } from './get-titan-subscription-id';
 export { getTitanCalendarlUrl, getTitanContactsUrl, getTitanEmailUrl } from './get-titan-urls';
 export { hasTitanMailWithUs } from './has-titan-mail-with-us';
 export { isDomainEligibleForTitanFreeTrial } from './is-domain-eligible-for-titan-free-trial';
+export { isTitanMonthlyProduct } from './is-titan-monthly-product';

--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -1,5 +1,4 @@
 export { getConfiguredTitanMailboxCount } from './get-configured-titan-mailbox-count';
-export { getCurrentProductSlug } from './get-current-product-slug';
 export { getEligibleTitanDomain } from './get-eligible-titan-domain';
 export { getMaxTitanMailboxCount } from './get-max-titan-mailbox-count';
 export { getTitanExpiryDate } from './get-titan-expiry-date';
@@ -7,6 +6,7 @@ export { getTitanMailboxPurchaseCost } from './get-titan-mailbox-purchase-cost';
 export { getTitanMailboxRenewalCost } from './get-titan-mailbox-renewal-cost';
 export { getTitanMailOrderId } from './get-titan-mail-order-id';
 export { getTitanProductName } from './get-titan-product-name';
+export { getTitanProductSlug } from './get-titan-product-slug';
 export { getTitanSubscriptionId } from './get-titan-subscription-id';
 export { getTitanCalendarlUrl, getTitanContactsUrl, getTitanEmailUrl } from './get-titan-urls';
 export { hasTitanMailWithUs } from './has-titan-mail-with-us';

--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -1,4 +1,5 @@
 export { getConfiguredTitanMailboxCount } from './get-configured-titan-mailbox-count';
+export { getCurrentProductSlug } from './get-current-product-slug';
 export { getEligibleTitanDomain } from './get-eligible-titan-domain';
 export { getMaxTitanMailboxCount } from './get-max-titan-mailbox-count';
 export { getTitanExpiryDate } from './get-titan-expiry-date';

--- a/client/lib/titan/is-titan-monthly-product.ts
+++ b/client/lib/titan/is-titan-monthly-product.ts
@@ -1,0 +1,6 @@
+import { TITAN_MAIL_MONTHLY_SLUG } from '@automattic/calypso-products';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+export function isTitanMonthlyProduct( titanMailProduct: ProductListItem ): boolean {
+	return titanMailProduct?.product_slug === TITAN_MAIL_MONTHLY_SLUG;
+}

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -1,3 +1,4 @@
+import { TITAN_MAIL_MONTHLY_SLUG } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { localize } from 'i18n-calypso';
@@ -12,14 +13,15 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
+import { titanMailMonthly, titanMailYearly } from 'calypso/lib/cart-values/cart-items';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
+	getCurrentProductSlug,
 	getMaxTitanMailboxCount,
 	getTitanProductName,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
-import { TITAN_MAIL_MONTHLY_SLUG, TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
+import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import {
 	areAllMailboxesValid,
 	areAllMailboxesAvailable,
@@ -103,13 +105,18 @@ class TitanAddMailboxes extends Component {
 	};
 
 	getCartItem = () => {
-		const { maxTitanMailboxCount, selectedDomainName } = this.props;
+		const { maxTitanMailboxCount, selectedDomainName, titanMailProduct } = this.props;
 		const mailboxes = this.state.mailboxes;
 		const quantity = mailboxes.length + maxTitanMailboxCount;
 		const new_quantity = mailboxes.length;
 		const email_users = mailboxes.map( transformMailboxForCart );
 
-		return titanMailMonthly( {
+		const cartItemFunction =
+			titanMailProduct && titanMailProduct.product_slug === TITAN_MAIL_MONTHLY_SLUG
+				? titanMailMonthly
+				: titanMailYearly;
+
+		return cartItemFunction( {
 			domain: selectedDomainName,
 			quantity,
 			extra: {
@@ -196,9 +203,9 @@ class TitanAddMailboxes extends Component {
 	};
 
 	renderForm() {
-		const { isLoadingDomains, selectedDomainName, titanMonthlyProduct, translate } = this.props;
+		const { isLoadingDomains, selectedDomainName, titanMailProduct, translate } = this.props;
 
-		if ( isLoadingDomains || ! titanMonthlyProduct ) {
+		if ( isLoadingDomains || ! titanMailProduct ) {
 			return <AddEmailAddressesCardPlaceholder />;
 		}
 
@@ -239,7 +246,7 @@ class TitanAddMailboxes extends Component {
 			selectedDomain,
 			selectedDomainName,
 			selectedSite,
-			titanMonthlyProduct,
+			titanMailProduct,
 			translate,
 		} = this.props;
 
@@ -275,10 +282,10 @@ class TitanAddMailboxes extends Component {
 						/>
 					) }
 
-					{ selectedDomain && titanMonthlyProduct && (
+					{ selectedDomain && titanMailProduct && (
 						<TitanMailboxPricingNotice
 							domain={ selectedDomain }
-							titanMonthlyProduct={ titanMonthlyProduct }
+							titanMailProduct={ titanMailProduct }
 						/>
 					) }
 					{ this.renderForm() }
@@ -299,6 +306,9 @@ export default connect(
 			domains,
 			selectedDomainName: ownProps.selectedDomainName,
 		} );
+
+		const productSlug = getCurrentProductSlug( selectedDomain );
+
 		return {
 			selectedDomain,
 			selectedSite,
@@ -307,7 +317,7 @@ export default connect(
 			maxTitanMailboxCount: hasTitanMailWithUs( selectedDomain )
 				? getMaxTitanMailboxCount( selectedDomain )
 				: 0,
-			titanMonthlyProduct: getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG ),
+			titanMailProduct: productSlug ? getProductBySlug( state, productSlug ) : null,
 			isSelectedDomainNameValid: !! selectedDomain,
 		};
 	},

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -16,9 +16,9 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { titanMailMonthly, titanMailYearly } from 'calypso/lib/cart-values/cart-items';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
-	getCurrentProductSlug,
 	getMaxTitanMailboxCount,
 	getTitanProductName,
+	getTitanProductSlug,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
@@ -307,7 +307,7 @@ export default connect(
 			selectedDomainName: ownProps.selectedDomainName,
 		} );
 
-		const productSlug = getCurrentProductSlug( selectedDomain );
+		const productSlug = getTitanProductSlug( selectedDomain );
 
 		return {
 			selectedDomain,

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -1,4 +1,3 @@
-import { TITAN_MAIL_MONTHLY_SLUG } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { localize } from 'i18n-calypso';
@@ -20,6 +19,7 @@ import {
 	getTitanProductName,
 	getTitanProductSlug,
 	hasTitanMailWithUs,
+	isTitanMonthlyProduct,
 } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import {
@@ -111,10 +111,9 @@ class TitanAddMailboxes extends Component {
 		const new_quantity = mailboxes.length;
 		const email_users = mailboxes.map( transformMailboxForCart );
 
-		const cartItemFunction =
-			titanMailProduct && titanMailProduct.product_slug === TITAN_MAIL_MONTHLY_SLUG
-				? titanMailMonthly
-				: titanMailYearly;
+		const cartItemFunction = isTitanMonthlyProduct( titanMailProduct )
+			? titanMailMonthly
+			: titanMailYearly;
 
 		return cartItemFunction( {
 			domain: selectedDomainName,

--- a/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.tsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice.tsx
@@ -8,12 +8,15 @@ import {
 	hasTitanMailWithUs,
 	isTitanMonthlyProduct,
 } from 'calypso/lib/titan';
-import type { TranslateResult } from 'i18n-calypso';
-import type { ReactElement } from 'react';
 import type { EmailCost, ResponseDomain } from 'calypso/lib/domains/types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+import type { TranslateResult } from 'i18n-calypso';
+import type { ReactElement } from 'react';
 
-const doesAdditionalPriceMatchStandardPrice = ( domain: ResponseDomain, titanMailProduct: ProductListItem ): boolean => {
+const doesAdditionalPriceMatchStandardPrice = (
+	domain: ResponseDomain,
+	titanMailProduct: ProductListItem
+): boolean => {
 	if ( ! domain || ! hasTitanMailWithUs( domain ) ) {
 		return true;
 	}
@@ -28,8 +31,13 @@ const doesAdditionalPriceMatchStandardPrice = ( domain: ResponseDomain, titanMai
 	);
 };
 
-function getPriceMessage( { purchaseCost, translate }: { purchaseCost: EmailCost, translate: typeof originalTranslate } ): TranslateResult {
-
+function getPriceMessage( {
+	purchaseCost,
+	translate,
+}: {
+	purchaseCost: EmailCost;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
 	return purchaseCost.amount === 0
 		? translate( 'You can add new mailboxes for free until the end of your trial period.' )
 		: translate(
@@ -47,7 +55,17 @@ function getPriceMessage( { purchaseCost, translate }: { purchaseCost: EmailCost
 		  );
 }
 
-function getPriceMessageExplanation( { purchaseCost, renewalCost, titanMailProduct, translate }: { purchaseCost: EmailCost, renewalCost: EmailCost, titanMailProduct: ProductListItem, translate: typeof originalTranslate } ): TranslateResult {
+function getPriceMessageExplanation( {
+	purchaseCost,
+	renewalCost,
+	titanMailProduct,
+	translate,
+}: {
+	purchaseCost: EmailCost;
+	renewalCost: EmailCost;
+	titanMailProduct: ProductListItem;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
 	// We don't need any explanation of the price at this point, because we have already handled it previously.
 	if ( purchaseCost.amount === 0 ) {
 		return '';
@@ -56,23 +74,31 @@ function getPriceMessageExplanation( { purchaseCost, renewalCost, titanMailProdu
 	if ( purchaseCost.amount < renewalCost.amount ) {
 		return isTitanMonthlyProduct( titanMailProduct )
 			? translate(
-				'This is less than the regular price because you are only charged for the remainder of the current month.'
-			)
+					'This is less than the regular price because you are only charged for the remainder of the current month.'
+			  )
 			: translate(
-				'This is less than the regular price because you are only charged for the remainder of the current year.'
-			);
+					'This is less than the regular price because you are only charged for the remainder of the current year.'
+			  );
 	}
 
 	return isTitanMonthlyProduct( titanMailProduct )
 		? translate(
-			'This is more than the regular price because you are charged for the remainder of the current month plus any additional month until renewal.'
-		)
+				'This is more than the regular price because you are charged for the remainder of the current month plus any additional month until renewal.'
+		  )
 		: translate(
-			'This is more than the regular price because you are charged for the remainder of the current year plus any additional year until renewal.'
-		);
+				'This is more than the regular price because you are charged for the remainder of the current year plus any additional year until renewal.'
+		  );
 }
 
-function getPriceMessageRenewal( { expiryDate, renewalCost, translate }: { expiryDate: string, renewalCost: EmailCost, translate: typeof originalTranslate } ): TranslateResult {
+function getPriceMessageRenewal( {
+	expiryDate,
+	renewalCost,
+	translate,
+}: {
+	expiryDate: string;
+	renewalCost: EmailCost;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
 	return translate(
 		'All of your mailboxes are due to renew at the regular price of {{strong}}%(fullPrice)s{{/strong}} per mailbox when your subscription renews on {{strong}}%(expiryDate)s{{/strong}}.',
 		{
@@ -90,7 +116,13 @@ function getPriceMessageRenewal( { expiryDate, renewalCost, translate }: { expir
 	);
 }
 
-const TitanMailboxPricingNotice = ( { domain, titanMailProduct }: { domain: ResponseDomain, titanMailProduct: ProductListItem } ): ReactElement | null => {
+const TitanMailboxPricingNotice = ( {
+	domain,
+	titanMailProduct,
+}: {
+	domain: ResponseDomain;
+	titanMailProduct: ProductListItem;
+} ): ReactElement | null => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
@@ -116,12 +148,13 @@ const TitanMailboxPricingNotice = ( { domain, titanMailProduct }: { domain: Resp
 			<Notice icon="info-outline" showDismiss={ false } status="is-success">
 				{ isTitanMonthlyProduct( titanMailProduct )
 					? translate(
-						'You can purchase new mailboxes at the regular price of {{strong}}%(price)s{{/strong}} per mailbox per month.',
-						translateArgs
-					) : translate(
-						'You can purchase new mailboxes at the regular price of {{strong}}%(price)s{{/strong}} per mailbox per year.',
-						translateArgs
-					) }
+							'You can purchase new mailboxes at the regular price of {{strong}}%(price)s{{/strong}} per mailbox per month.',
+							translateArgs
+					  )
+					: translate(
+							'You can purchase new mailboxes at the regular price of {{strong}}%(price)s{{/strong}} per mailbox per year.',
+							translateArgs
+					  ) }
 			</Notice>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the Add New Mailboxes page for Professional Email to correctly support annual subscriptions, both in terms of adding them to the cart, and displaying accurate pricing information for proration, introductory offers, and renewals.
* The PR also depends on D72373-code to supply the product slug for the existing Professional Email subscription

#### Testing instructions

* Run this branch locally or via the Calypso live server
* Ensure that you have one domain with a monthly Professional Email subscription, and one domain with an annual Professional Email subscription (you can add these during testing if needed)
* For each of the above domains, navigate to **Upgrades** -> **Emails** and select the domain from the list
* Click on the "Add New Mailboxes" item when it becomes visible
* Verify that the pricing notice at the top of the page contains wording that reflects the subscription period (it should be "month" for monthly subscriptions and "year" for annual subscriptions)
* Fill out the form to create an additional mailbox, and submit the form
* Verify that you are redirected to checkout and the correct billing interval is displayed in checkout

It is also worth noting that there are three cases that need to be checked for both the monthly and annual products:
 * The subscription is still within the free trial period, so additional mailbox purchases are free during the trial
 * The subscription is out of the free trial (or has been renewed once), and the expiration date is less than a full billing period in the future, so additional mailbox purchases are prorated and cost less than normal (where a "billing period" is either a month or a year)
 * The subscription is out of the free trial (or has been renewed more than once), and the expiration date is more than a full billing period in the future, so additional mailbox purchases are prorated and cost more than normal (where a billing period is either a month or a year)

It may be easiest to mimic these by modifying the back end domains API to manually specify a value and text string that are more or less than normal - ping me for instructions if you'd like to handle things this way.

#### Screenshots

All of the screenshots below are the new translations for annual subscriptions, as these are all new strings.

##### Purchase within the free trial period
<img width="1090" alt="Screenshot 2022-01-03 at 13 46 32" src="https://user-images.githubusercontent.com/3376401/147928458-4ff8a61b-994e-4ede-bfdb-82eccc7b3635.png">

##### Purchase that is less than the standard price
<img width="1090" alt="Screenshot 2022-01-03 at 13 58 14" src="https://user-images.githubusercontent.com/3376401/147928466-71b167d2-e301-4400-a558-777903dc5838.png">

##### Purchase that is more than the standard price
<img width="1090" alt="Screenshot 2022-01-03 at 13 59 12" src="https://user-images.githubusercontent.com/3376401/147928463-5f279b0a-518c-45a8-8f90-f75a9e03729d.png">

##### Purchase at the standard price outside of the trial period
<img width="1090" alt="Screenshot 2022-01-03 at 14 10 05" src="https://user-images.githubusercontent.com/3376401/147928844-198b0126-2e3f-4b24-a14c-0cbdc9eb8353.png">