### PR TITLE
HappychatButton: move floating styles from layout to the component

### DIFF
--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -13,6 +13,7 @@ import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat
 import isHappychatConnectionUninitialized from 'calypso/state/happychat/selectors/is-happychat-connection-uninitialized';
 import { openChat } from 'calypso/state/happychat/ui/actions';
 import { getHappychatAuth } from 'calypso/state/happychat/utils';
+import './button.scss';
 
 const noop = () => {};
 
@@ -21,6 +22,8 @@ export class HappychatButton extends Component {
 		allowMobileRedirect: PropTypes.bool,
 		borderless: PropTypes.bool,
 		primary: PropTypes.bool,
+		floating: PropTypes.bool,
+		offset: PropTypes.bool,
 		getAuth: PropTypes.func,
 		initConnection: PropTypes.func,
 		isChatActive: PropTypes.bool,
@@ -34,6 +37,9 @@ export class HappychatButton extends Component {
 	static defaultProps = {
 		allowMobileRedirect: false,
 		borderless: true,
+		primary: false,
+		floating: false,
+		offset: false,
 		getAuth: noop,
 		initConnection: noop,
 		isChatActive: false,
@@ -68,12 +74,16 @@ export class HappychatButton extends Component {
 			className,
 			primary,
 			borderless,
+			floating,
+			offset,
 			hasUnread,
 			isChatAvailable,
 			isChatActive,
 		} = this.props;
 		const showButton = isChatAvailable || isChatActive;
 		const classes = classnames( 'happychat__button', className, {
+			'is-floating': floating,
+			'is-offset': offset,
 			'has-unread': hasUnread,
 		} );
 

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -23,7 +23,7 @@ export class HappychatButton extends Component {
 		borderless: PropTypes.bool,
 		primary: PropTypes.bool,
 		floating: PropTypes.bool,
-		offset: PropTypes.bool,
+		withOffset: PropTypes.bool,
 		getAuth: PropTypes.func,
 		initConnection: PropTypes.func,
 		isChatActive: PropTypes.bool,
@@ -39,7 +39,7 @@ export class HappychatButton extends Component {
 		borderless: true,
 		primary: false,
 		floating: false,
-		offset: false,
+		withOffset: false,
 		getAuth: noop,
 		initConnection: noop,
 		isChatActive: false,
@@ -75,7 +75,7 @@ export class HappychatButton extends Component {
 			primary,
 			borderless,
 			floating,
-			offset,
+			withOffset,
 			hasUnread,
 			isChatAvailable,
 			isChatActive,
@@ -83,7 +83,7 @@ export class HappychatButton extends Component {
 		const showButton = isChatAvailable || isChatActive;
 		const classes = classnames( 'happychat__button', className, {
 			'is-floating': floating,
-			'is-offset': offset,
+			'with-offset': withOffset,
 			'has-unread': hasUnread,
 		} );
 

--- a/client/components/happychat/button.scss
+++ b/client/components/happychat/button.scss
@@ -1,0 +1,36 @@
+.happychat__button.is-floating {
+	position: fixed;
+	right: 24px;
+	bottom: 24px;
+	z-index: z-index( 'root', '.floating-help' );
+	line-height: 0;
+	padding: 1px;
+	border-radius: 100%; /* stylelint-disable-line */
+	background: var( --color-primary );
+	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
+
+	.gridicon {
+		fill: var( --color-text-inverted );
+		margin: 2px;
+		top: 0;
+		height: 24px;
+		width: 24px;
+	}
+
+	&.is-active {
+		background: var( --color-primary );
+		border-color: var( --color-primary-40 );
+	}
+
+	&.has-unread {
+		background-color: var( --color-accent );
+		border-color: var( --color-accent );
+	}
+
+	// Make happychat button appear above the FAB icon
+	// when the latter is already shown.
+	&.is-offset {
+		bottom: calc( 24px + 60px );
+		right: calc( 24px + 5px );
+	}
+}

--- a/client/components/happychat/button.scss
+++ b/client/components/happychat/button.scss
@@ -29,7 +29,7 @@
 
 	// Make happychat button appear above the FAB icon
 	// when the latter is already shown.
-	&.is-offset {
+	&.with-offset {
 		bottom: calc( 24px + 60px );
 		right: calc( 24px + 5px );
 	}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -316,10 +316,8 @@ class Layout extends Component {
 						placeholder={ null }
 						allowMobileRedirect
 						borderless={ false }
-						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-						className={ classnames( 'floating-happychat-button', {
-							offset: loadInlineHelp,
-						} ) }
+						floating
+						offset={ loadInlineHelp }
 					/>
 				) }
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -317,7 +317,7 @@ class Layout extends Component {
 						allowMobileRedirect
 						borderless={ false }
 						floating
-						offset={ loadInlineHelp }
+						withOffset={ loadInlineHelp }
 					/>
 				) }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -334,43 +334,6 @@
 	}
 }
 
-.floating-happychat-button {
-	position: fixed;
-	right: 24px;
-	bottom: 24px;
-	z-index: z-index( 'root', '.floating-help' );
-	line-height: 0;
-	padding: 1px;
-	border-radius: 100%; /* stylelint-disable-line */
-	background: var( --color-primary );
-	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
-
-	.gridicon {
-		fill: var( --color-text-inverted );
-		margin: 2px;
-		top: 0;
-		height: 24px;
-		width: 24px;
-	}
-
-	&.is-active {
-		background: var( --color-primary );
-		border-color: var( --color-primary-40 );
-	}
-
-	&.has-unread {
-		background-color: var( --color-accent );
-		border-color: var( --color-accent );
-	}
-
-	// Make happychat button appear above the FAB icon
-	// when the latter is already is already shown.
-	&.offset {
-		bottom: calc( 24px + 60px );
-		right: calc( 24px + 5px );
-	}
-}
-
 // layout adjustments for docked Happychat window
 @include breakpoint-deprecated( '>1040px' ) {
 	.layout.has-docked-chat {


### PR DESCRIPTION
In the global `client/layout/style.scss` stylesheet, there is a `.floating-happychat-button` class that provides styling for the floating HappyChat button (the one above the Help button):

<img width="389" alt="Screenshot 2022-01-03 at 13 03 30" src="https://user-images.githubusercontent.com/664258/147929223-3213f681-0d08-41da-8a1e-b600a06f0ec7.png">

This floating button is then rendered as `<HappychatButton className="floating-happychat-button"/>` markup.

Such a global styling, however, is not good if you want to extract the `HappychatButton` to a package and use it indepedently.

That's why this PR moves the styling inside the `HappychatButton` component, and exposes boolean `floating` and `offset` props that can be used to turn the styling on.

The `offset` prop is used to move the button up a few pixels so that it doesn't overlap with the Help button.

Part of the Inline Help extraction in #55189.

**How to test:**
Run Calypso in dev mode and open `https://hud-staging.happychat.io` in a separate tab. Then start a testing chat with yourself. Minimize the chat window. Verify that the button has the floating design as in the screenshot above. In devtools, try to enable and disable the `is-offset` class and notice what it does.