### PR TITLE
Remove Emojify component reference from i18n example

### DIFF
--- a/packages/i18n-calypso-cli/test/examples/i18n-test-examples.jsx
+++ b/packages/i18n-calypso-cli/test/examples/i18n-test-examples.jsx
@@ -93,7 +93,7 @@ corners.` );
 			},
 			components: {
 				href: <a href={ post.URL } target="_blank" rel="noopener noreferrer" />,
-				postTitle: <Emojify>{ postTitle }</Emojify>,
+				postTitle: <b>{ postTitle }</b>,
 			},
 			context:
 				'Stats: Sentence showing how much time has passed since the last post, and how the stats are',


### PR DESCRIPTION
A little followup to the `Emojify` removal in #56573: remove `Emojify` usage from a `i18n-calypso-cli` example file. Thanks @jblz for pointing it out :+1: