### PR TITLE
HelpResults: show footer only if it has a non-empty label

### DIFF
--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -1,38 +1,41 @@
 import { CompactCard } from '@automattic/components';
-import { PureComponent } from 'react';
 import HelpResult from './item';
 
 import './style.scss';
 
-export default class extends PureComponent {
-	static displayName = 'HelpResults';
-
-	render() {
-		if ( ! this.props.helpLinks.length ) {
-			return null;
-		}
-
-		return (
-			<>
-				{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
-				<h2 className="help__section-title">{ this.props.header }</h2>
-				<div className="help-results">
-					{ this.props.helpLinks.map( ( helpLink ) => (
-						<HelpResult
-							key={ helpLink.link }
-							helpLink={ helpLink }
-							iconTypeDescription={ this.props.iconTypeDescription }
-							onClick={ this.props.onClick }
-							compact={ this.props.compact }
-						/>
-					) ) }
-					<a href={ this.props.searchLink } target="__blank">
-						<CompactCard className="help-results__footer">
-							<span className="help-results__footer-text">{ this.props.footer }</span>
-						</CompactCard>
-					</a>
-				</div>
-			</>
-		);
+export default function HelpResults( {
+	compact,
+	footer,
+	helpLinks,
+	header,
+	iconTypeDescription,
+	onClick,
+	searchLink,
+} ) {
+	if ( ! helpLinks.length ) {
+		return null;
 	}
+
+	return (
+		<>
+			{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
+			<h2 className="help__section-title">{ header }</h2>
+			<div className="help-results">
+				{ helpLinks.map( ( helpLink ) => (
+					<HelpResult
+						key={ helpLink.link }
+						helpLink={ helpLink }
+						iconTypeDescription={ iconTypeDescription }
+						onClick={ onClick }
+						compact={ compact }
+					/>
+				) ) }
+				<a href={ searchLink } target="__blank">
+					<CompactCard className="help-results__footer">
+						<span className="help-results__footer-text">{ footer }</span>
+					</CompactCard>
+				</a>
+			</div>
+		</>
+	);
 }

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -30,11 +30,13 @@ export default function HelpResults( {
 						compact={ compact }
 					/>
 				) ) }
-				<a href={ searchLink } target="__blank">
-					<CompactCard className="help-results__footer">
-						<span className="help-results__footer-text">{ footer }</span>
-					</CompactCard>
-				</a>
+				{ footer && (
+					<a href={ searchLink } target="__blank">
+						<CompactCard className="help-results__footer">
+							<span className="help-results__footer-text">{ footer }</span>
+						</CompactCard>
+					</a>
+				) }
 			</div>
 		</>
 	);

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -1,30 +1,28 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { CompactCard, Gridicon } from '@automattic/components';
-import { PureComponent } from 'react';
+import { Component } from 'react';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
-export default class extends PureComponent {
-	static displayName = 'HelpResult';
-
+export default class HelpResult extends Component {
 	onClick = ( event ) => {
 		if ( this.props.helpLink.disabled ) {
 			return event.preventDefault();
 		}
 
-		this.props.onClick && this.props.onClick( event, this.props.helpLink );
+		this.props.onClick?.( event, this.props.helpLink );
 	};
 
-	getResultImage = () => {
+	getResultImage() {
 		if ( ! this.props.helpLink.image ) {
 			return;
 		}
 
 		return <img src={ this.props.helpLink.image } alt="" />;
-	};
+	}
 
-	getResultIcon = () => {
+	getResultIcon() {
 		//If we've assigned an image, don't show the icon
 		if ( this.props.helpLink.image ) {
 			return;
@@ -48,7 +46,7 @@ export default class extends PureComponent {
 			);
 		}
 		return <Gridicon className={ iconClass } icon={ iconTypeDescription } size={ iconSize } />;
-	};
+	}
 
 	render() {
 		const { compact, helpLink } = this.props;


### PR DESCRIPTION
The `HelpResults` component always renders a footer element, even if the `footer` prop is not there, and it leads to an empty box rendered at the bottom. See this screenshot from the `/help/contact` page after you start typing into the message box:

<img width="728" alt="Screenshot 2022-01-03 at 13 41 49" src="https://user-images.githubusercontent.com/664258/147933736-20288b11-1a95-4b1f-a330-635fe3f3fe53.png">

This PR fixes that by rendering the footer optionally:

<img width="699" alt="Screenshot 2022-01-03 at 13 45 52" src="https://user-images.githubusercontent.com/664258/147933764-e4961a67-6a67-43d9-bda3-3a5eb56422d5.png">

The first commit does some React modernization (no `PureComponent`, functional components), best reviewed separately.

**How to test:**
Test the help search on `/me/contact` where it's triggered by typing into the message box, and also the "main" help search on `/help`.