### PR TITLE
Sibyl: correctly route atomic sites requests 

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -216,9 +216,11 @@ export class HelpContactForm extends PureComponent {
 			newIDs.sort();
 			return existingIDs.toString() === newIDs.toString();
 		};
-		const site = this.props.helpSite.jetpack
-			? config( 'jetpack_support_blog' )
-			: config( 'wpcom_support_blog' );
+
+		const site =
+			! this.props.helpSite.jetpack || this.props.helpSite.is_wpcom_atomic
+				? config( 'wpcom_support_blog' )
+				: config( 'jetpack_support_blog' );
 
 		wpcom.req
 			.get( '/help/qanda', { query, site } )

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -177,7 +177,7 @@ export class HelpContactForm extends PureComponent {
 			// The API would reject something like "https://wp.com/slug".
 			// It'd need to either be "http(s)://wp.com" or "wp.com".
 			const url = this.state.userDeclaredUrl;
-			const query = url.includes( '://' )
+			const queryUrl = url.includes( '://' )
 				? new URL( this.state.userDeclaredUrl ).hostname
 				: new URL( 'http://' + this.state.userDeclaredUrl ).hostname;
 
@@ -195,7 +195,7 @@ export class HelpContactForm extends PureComponent {
 						this.setState( { errorData: error.error, siteData: null, hasRetriedRequest: false } );
 					} );
 
-			return request( query );
+			return request( queryUrl );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When selecting the site in the support contact form, make sure Atomic sites get QandA results from the WordPress.com support site.

#### Testing instructions
Test the suggested QandA results in the contact form (`/help/contact`) for
- Wpcom simple site
- Jetpack connected site (not atomic)
- Atomic site

Make sure to update the "How can we help?" text between tests to make sure the QandA results are reloaded. 

See #pdm0RZ-1v-p2