### PR TITLE
Add domain transfer in card for mapped domains

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -284,11 +284,26 @@ const Settings = ( {
 		);
 	};
 
+	const renderTranferInMappedDomainSection = () => {
+		if ( ! ( domain?.isEligibleForInboundTransfer && domain?.type === domainTypes.MAPPED ) )
+			return null;
+
+		return (
+			<Accordion
+				title={ translate( 'Transfer your domain to WordPress.com', { textOnly: true } ) }
+				subtitle={ translate( 'Manage your site and domain all in one place', { textOnly: true } ) }
+			>
+				Placeholder
+			</Accordion>
+		);
+	};
+
 	const renderMainContent = () => {
 		// TODO: If it's a registered domain or transfer and the domain's registrar is in maintenance, show maintenance card
 		return (
 			<>
 				{ renderDetailsSection() }
+				{ renderTranferInMappedDomainSection() }
 				{ renderSetAsPrimaryDomainSection() }
 				{ renderNameServersSection() }
 				{ renderDnsRecords() }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Accordion from 'calypso/components/domains/accordion';
+import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -19,7 +20,7 @@ import withDomainNameservers from 'calypso/my-sites/domains/domain-management/na
 import {
 	domainManagementEdit,
 	domainManagementList,
-	domainTransferIn,
+	domainUseMyDomain,
 } from 'calypso/my-sites/domains/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -309,7 +310,11 @@ const Settings = ( {
 			>
 				<Button
 					onClick={ handleTransferDomainClick }
-					href={ domainTransferIn( selectedSite.slug, domain.name, true ) }
+					href={ domainUseMyDomain(
+						selectedSite.slug,
+						domain.name,
+						useMyDomainInputMode.transferDomain
+					) }
 					primary={ true }
 				>
 					{ translate( 'Transfer' ) }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -15,7 +16,12 @@ import DomainTransferInfoCard from 'calypso/my-sites/domains/domain-management/c
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
-import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainTransferIn,
+} from 'calypso/my-sites/domains/paths';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import { requestWhois } from 'calypso/state/domains/management/actions';
@@ -284,6 +290,14 @@ const Settings = ( {
 		);
 	};
 
+	const handleTransferDomainClick = () => {
+		if ( ! domain ) return;
+		recordTracksEvent( 'calypso_domain_management_mapped_transfer_click', {
+			section: domain.type,
+			domain: domain.name,
+		} );
+	};
+
 	const renderTranferInMappedDomainSection = () => {
 		if ( ! ( domain?.isEligibleForInboundTransfer && domain?.type === domainTypes.MAPPED ) )
 			return null;
@@ -293,7 +307,13 @@ const Settings = ( {
 				title={ translate( 'Transfer your domain to WordPress.com', { textOnly: true } ) }
 				subtitle={ translate( 'Manage your site and domain all in one place', { textOnly: true } ) }
 			>
-				Placeholder
+				<Button
+					onClick={ handleTransferDomainClick }
+					href={ domainTransferIn( selectedSite.slug, domain.name, true ) }
+					primary={ true }
+				>
+					{ translate( 'Transfer' ) }
+				</Button>
 			</Accordion>
 		);
 	};
@@ -364,5 +384,6 @@ export default connect(
 	},
 	{
 		requestWhois,
+		recordTracksEvent,
 	}
 )( withDomainNameservers( Settings ) );

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { DnsRequest, ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
@@ -46,6 +47,7 @@ export type SettingsPageNameServerHocProps = {
 
 export type SettingsPageConnectedDispatchProps = {
 	requestWhois: ( domain: string ) => void;
+	recordTracksEvent: typeof recordTracksEvent;
 };
 
 export type SettingsHeaderProps = {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR add a new `Transfer In` card in domain settings page, when a domain is `isEligibleForInboundTransfer` and the type is `MAPPED`.

![transfer-card](https://user-images.githubusercontent.com/2797601/147942407-18dacfbb-1507-48da-a426-8e42f6e8e6ec.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Select a `MAPPED` domain and verify that the transfer card is displayed and the button leads to `Transfer In` page
- Verify also that for other domains type (`REGISTERED`/`TRANSFER`/... ) the card isn't displayed.