### PR TITLE
Make contact info card title translatable

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -234,13 +234,10 @@ const Settings = ( {
 			return null;
 		}
 
-		const getPlaceholderAccordion = () => (
-			<Accordion
-				title="Contact information"
-				subtitle="Contact information"
-				isPlaceholder
-			></Accordion>
-		);
+		const getPlaceholderAccordion = () => {
+			const label = translate( 'Contact information', { textOnly: true } );
+			return <Accordion title={ label } subtitle={ label } isPlaceholder></Accordion>;
+		};
 
 		if ( ! domain || ! domains ) return getPlaceholderAccordion();
 
@@ -255,13 +252,14 @@ const Settings = ( {
 		const contactInformation = findRegistrantWhois( whoisData );
 
 		const { privateDomain } = domain;
+		const titleLabel = translate( 'Contact information', { textOnly: true } );
 		const privacyProtectionLabel = privateDomain
 			? translate( 'Privacy protection on', { textOnly: true } )
 			: translate( 'Privacy protection off', { textOnly: true } );
 
 		if ( ! domain.currentUserCanManage ) {
 			return (
-				<Accordion title="Contact information" subtitle={ `${ privacyProtectionLabel }` }>
+				<Accordion title={ titleLabel } subtitle={ `${ privacyProtectionLabel }` }>
 					{ getContactsPrivacyInfo() }
 				</Accordion>
 			);
@@ -276,7 +274,7 @@ const Settings = ( {
 
 		return (
 			<Accordion
-				title="Contact information"
+				title={ titleLabel }
 				subtitle={ `${ contactInfoFullName }, ${ privacyProtectionLabel.toLowerCase() }` }
 			>
 				{ getContactsPrivacyInfo() }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR makes the title of the contact information card translatable (in domain settings page).

![contact](https://user-images.githubusercontent.com/2797601/147950806-be2c8ed8-61a4-4e20-8e78-5d199f242744.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Select a domain registered with WordPress.com and verify that the` Contact Information `card is still rendered correctly