### PR TITLE
Theme Showcase: Remove g flag from redirect regular expression.

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -119,8 +119,8 @@ export function redirectTiers( { res, originalUrl, params: { tier } }, next ) {
 		return next();
 	}
 
-	const typeTierRegex = new RegExp( `/type/${ tier }$`, 'g' );
-	const inlineOrPostfixTierRegex = new RegExp( `(?<=/)${ tier }/|/${ tier }$`, 'g' );
+	const typeTierRegex = new RegExp( `/type/${ tier }$` );
+	const inlineOrPostfixTierRegex = new RegExp( `(?<=/)${ tier }/|/${ tier }$` );
 
 	const redirectUrl = originalUrl
 		.replace( typeTierRegex, '' )


### PR DESCRIPTION
This PR is a follow up for [this comment](https://github.com/Automattic/wp-calypso/pull/58973#discussion_r777344309) by @jsnajdr. It removes the `g` flag since the pattern we are looking for happens at most 1 time.

### Testing
1. Verify the tests pass correctly.
2. If being extra careful check that no regression is introduced. See [this PR](https://github.com/Automattic/wp-calypso/pull/58973) and [this one](https://github.com/Automattic/wp-calypso/pull/56430) to check the testing URLs.