### PR TITLE
Marketplace: Add business plan price in usp

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -179,6 +179,7 @@ const PluginDetailsCTA = ( {
 					shouldUpgrade={ shouldUpgrade }
 					isFreePlan={ isFreePlan }
 					isMarketplaceProduct={ isMarketplaceProduct }
+					billingPeriod={ billingPeriod }
 				/>
 			) }
 		</div>

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,6 +1,10 @@
+import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 
 const StyledUl = styled.ul`
 	margin-top: 20px;
@@ -31,10 +35,23 @@ interface Props {
 	shouldUpgrade: boolean;
 	isFreePlan: boolean;
 	isMarketplaceProduct: boolean;
+	billingPeriod: IntervalLength;
 }
 
-const USPS: React.FC< Props > = ( { shouldUpgrade, isFreePlan, isMarketplaceProduct } ) => {
+const USPS: React.FC< Props > = ( {
+	shouldUpgrade,
+	isFreePlan,
+	isMarketplaceProduct,
+	billingPeriod,
+} ) => {
 	const translate = useTranslate();
+
+	const planDisplayCost = useSelector( ( state ) =>
+		getProductDisplayCost(
+			state,
+			billingPeriod === IntervalLength.ANNUALLY ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY
+		)
+	);
 
 	const filteredUSPS = [
 		...( isMarketplaceProduct
@@ -62,7 +79,9 @@ const USPS: React.FC< Props > = ( { shouldUpgrade, isFreePlan, isMarketplaceProd
 					{
 						id: 'plan',
 						className: 'title',
-						text: translate( 'Included in the Business plan' ),
+						text: translate( 'Included in the Business plan (%s)', {
+							args: [ planDisplayCost ],
+						} ),
 						eligibilities: [ 'needs-upgrade' ],
 					},
 			  ]


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added the plan price to the USP

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a Marketplace prouct page
* Verify that the USP now contain the Business product price for the selected billing period:
  | Annual | Monthly | 
  | --- | --- | 
  |  ![image](https://user-images.githubusercontent.com/11555574/147956757-5e7d3142-5bab-422e-9697-24400174fbfd.png) | ![image](https://user-images.githubusercontent.com/11555574/147956791-d1425ae3-5aba-4e1c-920a-e8093715fe13.png) |


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59656 