### PR TITLE
Videos UI: enable language notification.

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -26,8 +26,7 @@ const VideosUi = ( {
 	const { updateUserCourseProgression } = useUpdateUserCourseProgressionMutation();
 
 	const [ shouldShowVideoTranslationNotice, setShouldShowVideoTranslationNotice ] = useState(
-		// @TODO remove the '&& false' as soon as notification text is translated
-		! isEnglish && ! areVideosTranslated && false
+		! isEnglish && ! areVideosTranslated
 	);
 
 	const [ selectedChapterIndex, setSelectedChapterIndex ] = useState( 0 );


### PR DESCRIPTION
This PR enables the language notification when the user lang is different than English.

#### Testing instructions
1. Go to the calypso.live link in the comments.
2. Make sure that the account that you're logged into has a language different than English.
3. Open the Video UI.
4. Verify you see the notification.
![image](https://user-images.githubusercontent.com/375980/147971627-595ad718-62cd-41e3-89fd-708377cc5237.png)

Closes https://github.com/Automattic/wp-calypso/issues/59675