### PR TITLE
State: Change SerializableReducer type to an interface

### DIFF
--- a/client/state/utils/serialize.ts
+++ b/client/state/utils/serialize.ts
@@ -1,13 +1,11 @@
 import { getInitialState } from '@automattic/state-utils';
 import type { Reducer, AnyAction, Action } from 'redux';
 
-export type SerializableReducer< TState = any, TAction extends AnyAction = Action > = Reducer<
-	TState,
-	TAction
-> & {
+export interface SerializableReducer< TState = any, TAction extends AnyAction = Action >
+	extends Reducer< TState, TAction > {
 	serialize?: ( state: TState ) => any;
 	deserialize?: ( persisted: any ) => TState;
-};
+}
 
 export function serialize< TState >( reducer: SerializableReducer< TState >, state: TState ): any {
 	if ( ! reducer.serialize ) {


### PR DESCRIPTION
Here we modify the `SerializableReducer` type used in `client/state/utils` to change it from a `type` to an `interface`. This helps TS correctly understand that it's still a function with additional properties.

This fixes [TS errors in keyed-reducer](https://github.com/Automattic/wp-calypso/blob/38702807941db4bbd14258ece52b8cb42197369c/client/state/utils/keyed-reducer.ts#L80-L86).

Co-authored-by: @dmsnell <dennis.snell@automattic.com>

#### Testing instructions

This only changes types so it should not require testing.