### PR TITLE
Marketplace: adjusts support and refund usps

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -69,7 +69,9 @@ const USPS: React.FC< Props > = ( {
 					{
 						id: 'refund',
 						image: <Gridicon icon="refund" size={ 16 } />,
-						text: translate( '30 day money-back guarantee' ),
+						text: translate( '%(days)d-day money-back guarantee', {
+							args: { days: billingPeriod === IntervalLength.ANNUALLY ? 14 : 7 },
+						} ),
 						eligibilities: [ 'marketplace' ],
 					},
 			  ]

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -47,6 +47,10 @@ const PluginDetailsSidebar = ( {
 		);
 	}
 	const supportLinks = [
+		{
+			href: 'https://wordpress.com/support/help-support-options/#live-chat-support',
+			label: translate( 'How to get help!' ),
+		},
 		{ href: 'https://automattic.com/privacy/', label: translate( 'See privacy policy' ) },
 	];
 	documentation_url &&
@@ -87,7 +91,7 @@ const PluginDetailsSidebar = ( {
 				id="support"
 				icon={ { src: support } }
 				title={ translate( 'Support' ) }
-				description={ translate( 'Handled by WooCommerce.' ) }
+				description={ translate( 'Live chat support 24x7.' ) }
 				links={ supportLinks }
 			/>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Replace `30 day money-back guarantee` with `7/14d-day money-back guarantee.` depending on billing interval
- Replace `Handled by WooCommerce.` with `Live chat support 24x7`
- Add a link `How to get help!` `https://wordpress.com/support/help-support-options/#live-chat-support` in Support section linking to live chat support paragraph

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![SS 2022-01-04 at 12 12 35](https://user-images.githubusercontent.com/12430020/148043611-aba20319-d906-48b1-af4a-9007ad74931c.png)


* Visit a not installed paid plugin
* Inspect the refund CTA in top right
* Inspect the support CTA on bottom right

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59655
