### PR TITLE
Site Editor tracking - remove old global styles entity handling.

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -604,24 +604,6 @@ const trackEditEntityRecord = ( kind, type, id, updates ) => {
 		return;
 	}
 
-	if ( kind === 'postType' && type === 'wp_global_styles' ) {
-		const editedEntity = select( 'core' ).getEditedEntityRecord( kind, type, id );
-		const entityContent = JSON.parse( editedEntity?.content );
-		const updatedContent = JSON.parse( updates?.content );
-
-		// Sometimes a second update is triggered corresponding to no changes since the last update.
-		// Therefore we must check if there is a change to avoid debouncing a valid update to a changeless update.
-		if ( ! isEqual( updatedContent, entityContent ) ) {
-			buildGlobalStylesContentEvents(
-				updatedContent,
-				entityContent,
-				'wpcom_block_editor_global_styles_update'
-			);
-		}
-	}
-
-	// Gutenberg v11.9 has changed the global styles object to this format.
-	// Once this is stable we can remove the old postType format above.
 	if ( kind === 'root' && type === 'globalStyles' ) {
 		const editedEntity = select( 'core' ).getEditedEntityRecord( kind, type, id );
 		const entityContent = { settings: editedEntity.settings, styles: editedEntity.styles };
@@ -650,39 +632,24 @@ const trackSaveEditedEntityRecord = ( kind, type, id ) => {
 	const savedEntity = select( 'core' ).getEntityRecord( kind, type, id );
 	const editedEntity = select( 'core' ).getEditedEntityRecord( kind, type, id );
 
-	if ( kind === 'postType' && type === 'wp_global_styles' ) {
-		const entityContent = JSON.parse( savedEntity?.content?.raw );
-		const updatedContent = JSON.parse( editedEntity?.content );
+	// If the item saved is a template part, make note of the area variation.
+	const templatePartArea = type === 'wp_template_part' ? savedEntity?.area : undefined;
+	// If the template parts area variation changed, add the new area classification as well.
+	const newTemplatePartArea =
+		type === 'wp_template_part' && savedEntity?.area !== editedEntity?.area
+			? editedEntity.area
+			: undefined;
 
-		buildGlobalStylesContentEvents(
-			updatedContent,
-			entityContent,
-			'wpcom_block_editor_global_styles_save'
-		);
-	} else {
-		// If the item saved is a template part, make note of the area variation.
-		const templatePartArea = type === 'wp_template_part' ? savedEntity?.area : undefined;
-		// If the template parts area variation changed, add the new area classification as well.
-		const newTemplatePartArea =
-			type === 'wp_template_part' && savedEntity?.area !== editedEntity?.area
-				? editedEntity.area
-				: undefined;
+	tracksRecordEvent( 'wpcom_block_editor_edited_entity_saved', {
+		entity_kind: kind,
+		entity_type: type,
+		entity_id: id,
+		saving_source: findSavingSource(),
+		template_part_area: templatePartArea,
+		new_template_part_area: newTemplatePartArea,
+	} );
 
-		tracksRecordEvent( 'wpcom_block_editor_edited_entity_saved', {
-			entity_kind: kind,
-			entity_type: type,
-			entity_id: id,
-			saving_source: findSavingSource(),
-			template_part_area: templatePartArea,
-			new_template_part_area: newTemplatePartArea,
-		} );
-	}
-
-	// Gutenberg v11.9 has changed the global styles object to this format.
-	// Once this is stable we can remove the old postType format above.
 	if ( kind === 'root' && type === 'globalStyles' ) {
-		const savedEntity = select( 'core' ).getEntityRecord( kind, type, id );
-		const editedEntity = select( 'core' ).getEditedEntityRecord( kind, type, id );
 		const entityContent = { settings: savedEntity.settings, styles: savedEntity.styles };
 		const updatedContent = { settings: editedEntity.settings, styles: editedEntity.styles };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In Gv11.9 the Global Styles object was moved from a postType entity to a root type entity. While tracking was updated to handle this, now that we are stable beyond 11.9 this PR cleans up the handling for the outdated entity that is no longer in use.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
There should be no observable changes at this point. Events should continue to fire as expected. Editing and saving global styles should continue to send the appropriate update and save events.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
