### PR TITLE
Changes the email link on DIFM-L progress screen

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -30,6 +30,7 @@ import {
 	domainManagementRoot,
 	domainManagementDnsAddRecord,
 	domainManagementDnsEditRecord,
+	domainAddNew,
 } from 'calypso/my-sites/domains/paths';
 import {
 	emailManagement,
@@ -244,11 +245,13 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
  * @returns {boolean} true if the path is allowed, false otherwise
  */
 function isPathAllowedForDIFMInProgressSite( path, slug, primaryDomain, contextParams ) {
-	const domainAdditionPath = '/domains/add';
+	const DIFMLiteInProgressAllowedPaths = [ domainAddNew(), emailManagement( slug ) ];
 
 	return (
 		isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParams ) ||
-		path.startsWith( domainAdditionPath )
+		DIFMLiteInProgressAllowedPaths.some( ( DIFMLiteInProgressAllowedPath ) =>
+			path.startsWith( DIFMLiteInProgressAllowedPath )
+		)
 	);
 }
 

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -48,7 +48,11 @@ export function isUnderDomainManagementAll( path ) {
 }
 
 export function domainAddNew( siteName, searchTerm ) {
-	const path = `/domains/add/${ siteName }`;
+	let path = `/domains/add`;
+
+	if ( siteName ) {
+		path = `${ path }/${ siteName }`;
+	}
 
 	if ( searchTerm ) {
 		return `${ path }?suggestion=${ searchTerm }`;

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -70,7 +70,7 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactE
 					<Button
 						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 						className="empty-content__action button"
-						href={ emailManagement( slug, undefined ) }
+						href={ emailManagement( slug, null ) }
 						onClick={ recordEmailClick }
 					>
 						{ hasEmailWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -70,7 +70,7 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactE
 					<Button
 						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 						className="empty-content__action button"
-						href={ emailManagement( slug, domainName ) }
+						href={ emailManagement( slug, undefined ) }
 						onClick={ recordEmailClick }
 					>
 						{ hasEmailWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -163,7 +163,7 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 								warn: <span />,
 							},
 							args: {
-								siteAddress: siteId && siteDomain,
+								siteAddress: siteDomain,
 							},
 						}
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the "Add Email" button to redirect to the /email root page. This automatically checks if a custom domain is added to the site and prevents the user from seeing the email registration screen when they have a free subdomain. Context: pdh1Xd-ey-p2
* Refactors the `isPathAllowedForDIFMInProgressSite` to remove the hardcoded `/domains/add` path.
* Also included a small change from @tyxla's comment: https://github.com/Automattic/wp-calypso/pull/58951#pullrequestreview-843282217 (Thank you!)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in and switch to a site that has the `difm-lite-in-progress` sticker. (It can be toggled from the Blog RC) **Ensure that the site has any paid plan subscription but does not have a paid domain.**
* Click on the Add Email button.
* Confirm that you can see this screen:
![image](https://user-images.githubusercontent.com/5436027/148059649-1585dfa7-801b-4f2e-a367-3217900309ba.png)
* Confirm that you can add a domain to the site. (Skip the email setup)
* Confirm that after adding a domain, you can add an email inbox by clicking on the "Add Email" button on the DIFM Lite in progress screen.
* Confirm that you are able to access the domain and email management pages.

**Known Issue**: The Inbox link in the sidebar is not present.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1201454687238941-as-1201610698456652/f