### PR TITLE
Remove FEATURE_BUSINESS_ONBOARDING feature

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -33,7 +33,6 @@ import {
 	FEATURE_BASIC_DESIGN,
 	FEATURE_BLANK,
 	FEATURE_BLOG_DOMAIN,
-	FEATURE_BUSINESS_ONBOARDING,
 	FEATURE_CLOUDFLARE_ANALYTICS,
 	FEATURE_COLLECT_PAYMENTS_V2,
 	FEATURE_COMMUNITY_SUPPORT,
@@ -603,15 +602,6 @@ export const FEATURES_LIST = {
 				"Keep the focus on your site's brand by removing the WordPress.com footer branding."
 			),
 		getStoreSlug: () => 'no-adverts/no-adverts.php',
-	},
-
-	[ FEATURE_BUSINESS_ONBOARDING ]: {
-		getSlug: () => FEATURE_BUSINESS_ONBOARDING,
-		getTitle: () => i18n.translate( 'Get personalized help' ),
-		getDescription: () =>
-			i18n.translate(
-				"Meet one-on-one with a WordPress.com expert who'll help you set up your site exactly as you need it."
-			),
 	},
 
 	[ FEATURE_ADVANCED_SEO ]: {

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -4,7 +4,7 @@ import {
 	PLAN_BUSINESS,
 	FEATURE_AUDIO_UPLOADS,
 	FEATURE_ADVANCED_DESIGN,
-	FEATURE_BUSINESS_ONBOARDING,
+	FEATURE_UPLOAD_PLUGINS,
 } from '@automattic/calypso-products';
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
@@ -793,7 +793,7 @@ describe( 'selectors', () => {
 						},
 					},
 					2916284,
-					FEATURE_BUSINESS_ONBOARDING
+					FEATURE_UPLOAD_PLUGINS
 				)
 			).to.be.false;
 		} );

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -56,7 +56,6 @@ export const FEATURE_AUDIO_UPLOADS = 'audio-upload';
 export const FEATURE_WORDADS_INSTANT = 'wordads-instant';
 export const FEATURE_NO_BRANDING = 'no-wp-branding';
 export const FEATURE_ADVANCED_SEO = 'advanced-seo';
-export const FEATURE_BUSINESS_ONBOARDING = 'business-onboarding';
 export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
 export const FEATURE_INSTALL_PLUGINS = 'install-plugins';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the remaining uses of `FEATURE_BUSINESS_ONBOARDING`, which serves as a follow-on to #58485, which removed the feature from being listed in the UI.

#### Testing instructions

I am honestly not sure if there is any way to visibly test this given the work that was done in #58485, as confirmed in [this comment](https://github.com/Automattic/wp-calypso/pull/59704#issuecomment-1005579661).

Related to #58485