### PR TITLE
Site Editor e2e - fix element click intercepted false failure in mobile browsersize.

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -986,6 +986,10 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 		} );
 
 		it( 'Tracks "wpcom_block_editor_convert_to_template_part"', async function () {
+			// Reload editor to start from consistent clean slate for tests.
+			await this.driver.navigate().refresh();
+			await driverHelper.acceptAlertIfPresent( this.driver );
+
 			const editor = await SiteEditorComponent.Expect( this.driver );
 
 			const threeColumnsEqualSplitVariationLocator = By.css(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Lately there has been a consistent false failure on this test for mobile due to an element click intercept. Reloading the editor to get rid of content added by previous tests seems to get rid of the issue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run this test suite on mobile and confirm that it no longer fails on this test with 'element click intercepted'.  However, at this point it will still fail later in this test due to other assertions being fixed in https://github.com/Automattic/wp-calypso/pull/59680

* Run the tests on the 'mobile' brosersize and confirm they no longer fail on 'element click intercepted'.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  https://github.com/Automattic/wp-calypso/pull/59680
