### PR TITLE
Update Transfer to Wordpress.com link in domain row popover

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import Badge from 'calypso/components/badge';
+import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import MaterialIcon from 'calypso/components/material-icon';
@@ -26,7 +27,7 @@ import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-tog
 import {
 	domainManagementList,
 	createSiteFromDomainOnly,
-	domainTransferIn,
+	domainUseMyDomain,
 } from 'calypso/my-sites/domains/paths';
 import {
 	emailManagement,
@@ -373,7 +374,13 @@ class DomainRow extends PureComponent {
 						</PopoverMenuItem>
 					) }
 					{ domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer && (
-						<PopoverMenuItem href={ domainTransferIn( site.slug, domain.name, true ) }>
+						<PopoverMenuItem
+							href={ domainUseMyDomain(
+								site.slug,
+								domain.name,
+								useMyDomainInputMode.transferDomain
+							) }
+						>
 							<Icon icon={ redo } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 							{ translate( 'Transfer to WordPress.com' ) }
 						</PopoverMenuItem>


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fix the "Transfer to WordPress.com" link in domain list popover menu, to use new Transfer In flow.

![transfer-popup](https://user-images.githubusercontent.com/2797601/148067564-1b22aeab-60d3-42e3-b6e9-10cf359f269a.png)

![new-flow](https://user-images.githubusercontent.com/2797601/148067735-3f855606-e912-418b-85c8-0363744b0f01.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades > Domains"
- Open the popover menu for a connected domain and select "Transfer to WordPress.com" menu item
- Ensure that the link leads to new Transfer In flow
