### PR TITLE
Emails: Add header and feature flag to In-Depth Comparison page

### DIFF
--- a/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/index.tsx
@@ -15,7 +15,7 @@ type ComparisonTableProps = {
 };
 
 const ComparisonTable: FunctionComponent< ComparisonTableProps > = () => {
-	return <p> New component </p>;
+	return null;
 };
 
 export default ComparisonTable;

--- a/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
@@ -1,9 +1,12 @@
+import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import ComparisonTable from 'calypso/my-sites/email/email-providers-in-depth-comparison/comparison-table';
 import {
 	professionalEmailFeatures,
 	googleWorkspaceFeatures,
 } from 'calypso/my-sites/email/email-providers-in-depth-comparison/data';
+
+import './style.scss';
 
 type EmailProvidersInDepthComparisonProps = {
 	comparisonContext: string;
@@ -13,8 +16,16 @@ type EmailProvidersInDepthComparisonProps = {
 };
 
 const EmailProvidersInDepthComparison: FunctionComponent< EmailProvidersInDepthComparisonProps > = () => {
+	const translate = useTranslate();
+
 	return (
-		<ComparisonTable emailProviders={ [ professionalEmailFeatures, googleWorkspaceFeatures ] } />
+		<>
+			<h1 className="email-providers-in-depth-comparison__header wp-brand-font">
+				{ translate( 'See how they compare' ) }
+			</h1>
+
+			<ComparisonTable emailProviders={ [ professionalEmailFeatures, googleWorkspaceFeatures ] } />
+		</>
 	);
 };
 

--- a/client/my-sites/email/email-providers-in-depth-comparison/style.scss
+++ b/client/my-sites/email/email-providers-in-depth-comparison/style.scss
@@ -1,5 +1,7 @@
+@import '@automattic/typography/styles/variables';
+
 .email-providers-in-depth-comparison__header {
-	font-size: xxx-large;
+	font-size: $font-title-large;
 	margin-bottom: 64px;
 	text-align: center;
 }

--- a/client/my-sites/email/email-providers-in-depth-comparison/style.scss
+++ b/client/my-sites/email/email-providers-in-depth-comparison/style.scss
@@ -1,0 +1,5 @@
+.email-providers-in-depth-comparison__header {
+	font-size: xxx-large;
+	margin-bottom: 64px;
+	text-align: center;
+}

--- a/client/my-sites/email/email-providers-stacked-comparison/billing-interval-toggle/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/billing-interval-toggle/style.scss
@@ -2,7 +2,7 @@
 	align-content: space-between;
 
 	> .segmented-control.is-compact {
-		margin: 8px auto 16px;
+		margin: 25px auto;
 		max-width: 480px;
 
 		.segmented-control__link {

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -115,21 +116,23 @@ const EmailProvidersStackedComparison: FunctionComponent< EmailProvidersStackedC
 				{ translate( 'Pick an email solution' ) }
 			</h1>
 
-			<div className="email-providers-stacked-comparison__how-they-compare">
-				{ translate( 'Not sure how to start? {{a}}See how they compare{{/a}}.', {
-					components: {
-						a: (
-							<a
-								href={ emailManagementInDepthComparison(
-									siteName,
-									selectedDomainName,
-									currentRoute
-								) }
-							/>
-						),
-					},
-				} ) }
-			</div>
+			{ isEnabled( 'emails/in-depth-comparison' ) && (
+				<div className="email-providers-stacked-comparison__sub-header">
+					{ translate( 'Not sure how to start? {{a}}See how they compare{{/a}}.', {
+						components: {
+							a: (
+								<a
+									href={ emailManagementInDepthComparison(
+										siteName,
+										selectedDomainName,
+										currentRoute
+									) }
+								/>
+							),
+						},
+					} ) }
+				</div>
+			) }
 
 			<BillingIntervalToggle
 				onIntervalChange={ setIntervalLength }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -44,9 +44,9 @@ type EmailProvidersStackedComparisonProps = {
 	isGSuiteSupported?: boolean;
 	productsList?: string[];
 	requestingSiteDomains?: boolean;
-	shoppingCartManager?: any;
-	selectedSite?: SiteData | null;
 	selectedDomainName: string;
+	selectedSite?: SiteData | null;
+	shoppingCartManager?: any;
 	showEmailForwardLink?: boolean;
 	siteName: string;
 	source: string;

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -118,7 +118,7 @@ const EmailProvidersStackedComparison: FunctionComponent< EmailProvidersStackedC
 
 			{ isEnabled( 'emails/in-depth-comparison' ) && (
 				<div className="email-providers-stacked-comparison__sub-header">
-					{ translate( 'Not sure how to start? {{a}}See how they compare{{/a}}.', {
+					{ translate( 'Not sure where to start? {{a}}See how they compare{{/a}}.', {
 						components: {
 							a: (
 								<a

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -48,15 +48,3 @@ export type EmailProvidersStackedCardProps = {
 	titanMailYearlyProduct?: any;
 	onExpandedChange?: ( providerKey: string, expand: boolean ) => void;
 };
-
-type ValueError = {
-	value: string;
-	error: string;
-};
-
-export type Mailbox = {
-	uuid: string;
-	domain: ValueError;
-	mailbox: ValueError;
-	password: ValueError;
-};

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -11,9 +11,9 @@ export interface ProviderCard {
 	description: TranslateResult;
 	detailsExpanded?: boolean;
 	discount?: ReactElement | null;
-	footerBadge?: ReactElement | null;
 	expandButtonLabel: TranslateResult;
 	features: TranslateResult[];
+	footerBadge?: ReactElement | null;
 	formFields?: ReactElement;
 	logo?: ReactElement | { path: string; className?: string };
 	onExpandedChange?: ( providerKey: string, expanded: boolean ) => void;
@@ -24,10 +24,9 @@ export interface ProviderCard {
 }
 
 export type EmailProvidersStackedCardProps = {
-	comparisonContext: string;
 	cart?: any;
 	cartDomainName?: string;
-	selectedSite?: Site | null;
+	comparisonContext: string;
 	currencyCode?: string | null;
 	currentRoute?: string;
 	detailsExpanded: boolean;
@@ -37,14 +36,15 @@ export type EmailProvidersStackedCardProps = {
 	gSuiteProductMonthly?: any;
 	gSuiteProductYearly?: any;
 	hasCartDomain?: boolean;
+	intervalLength: IntervalLength;
 	isGSuiteSupported?: boolean;
+	onExpandedChange?: ( providerKey: string, expand: boolean ) => void;
 	productsList?: string[];
 	requestingSiteDomains?: boolean;
 	selectedDomainName: string;
+	selectedSite?: Site | null;
 	shoppingCartManager?: any;
 	source: string;
-	intervalLength: IntervalLength;
 	titanMailMonthlyProduct?: any;
 	titanMailYearlyProduct?: any;
-	onExpandedChange?: ( providerKey: string, expand: boolean ) => void;
 };

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -16,6 +16,7 @@
 }
 
 .email-providers-stacked-comparison__sub-header {
+	font-size: $font-body-small;
 	text-align: center;
 }
 

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
+@import '@automattic/typography/styles/variables';
 
 .email-providers-stacked-comparison__main {
 	padding: 0 20px 20px;
@@ -10,7 +11,7 @@
 }
 
 .email-providers-stacked-comparison__header {
-	font-size: 2rem;
+	font-size: $font-title-large;
 	text-align: center;
 }
 

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -1,11 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.email-providers-stacked-comparison__header {
-	font-size: 2rem;
-	text-align: center;
-}
-
 .email-providers-stacked-comparison__main {
 	padding: 0 20px 20px;
 
@@ -14,8 +9,12 @@
 	}
 }
 
-.email-providers-stacked-comparison__how-they-compare {
-	display: none;
+.email-providers-stacked-comparison__header {
+	font-size: 2rem;
+	text-align: center;
+}
+
+.email-providers-stacked-comparison__sub-header {
 	text-align: center;
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -52,6 +52,7 @@
 		"domains/premium-domain-purchases": true,
 		"domains/settings-page-redesign": true,
 		"email-accounts/enabled": true,
+		"emails/in-depth-comparison": true,
 		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
This pull request updates the `Email Comparison` page to show a link to the `In-Depth Comparison` page according to a new feature flag. This will make it easier to test this new page in development. Finally, it also:

* Adds a header to the `In-Depth Comparison` page
* Adds a stylesheet for that page
* Removes types no longer used, and reorder some others

`Email Comparison` | `In-Depth Comparison`
------ | -----
<img width="623" alt="01" src="https://user-images.githubusercontent.com/594356/148084411-35751a3f-8089-49cc-a2ce-63bf5d7ab4ff.png"> | <img width="623" alt="02" src="https://user-images.githubusercontent.com/594356/148084436-d0a55527-25aa-4b3e-bd99-d4650660fecf.png">


#### Testing instructions

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout update/in-depth-comparison-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/59714#issuecomment-1004915691)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Click the `See how they compare` link to access the `In-Depth Comparison` page
6. Assert that the page looks like in the screenshot above