### PR TITLE
Relaunching email-only registration test with cookies

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -115,8 +115,14 @@ export default function WPCheckoutOrderReview( {
 	}, [] );
 
 	function retrieveExperimentName() {
-		const cookies = cookie.parse( document.cookie );
-		return cookies.wpcom_signup_experiment_name;
+		let experiment = null;
+		try {
+			const cookies = cookie.parse( document.cookie );
+			experiment = cookies.wpcom_signup_experiment_name;
+		} catch ( error ) {
+			reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cookie_read_failed' ) );
+		}
+		return experiment;
 	}
 
 	const onRemoveProductCancel = useCallback( () => {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -103,8 +103,8 @@ export default function WPCheckoutOrderReview( {
 
 	useEffect( () => {
 		const experimentCheck = retrieveExperimentName();
-		let shouldCheck = experimentCheck?.length > 0;
-		loadExperimentAssignment( experimentCheck ).then( ( experimentObject ) => {
+		let shouldCheck = experimentCheck ? experimentCheck.length > 0 : false;
+		loadExperimentAssignment( experimentCheck ?? '' ).then( ( experimentObject ) => {
 			if ( shouldCheck ) {
 				setExperiment( experimentObject );
 			}
@@ -115,7 +115,7 @@ export default function WPCheckoutOrderReview( {
 	}, [] );
 
 	function retrieveExperimentName() {
-		let experiment = null;
+		let experiment = '';
 		try {
 			const cookies = cookie.parse( document.cookie );
 			experiment = cookies.wpcom_signup_experiment_name;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -7,7 +7,7 @@ import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { ExperimentAssignment } from '@automattic/explat-client';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
-import { useViewportMatch } from '@wordpress/compose';
+import cookie from 'cookie';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState, useEffect, useCallback } from 'react';
@@ -99,14 +99,11 @@ export default function WPCheckoutOrderReview( {
 	const cartKey = useCartKey();
 	const { responseCart, removeCoupon, couponStatus } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
-	const isDesktop = useViewportMatch( 'mobile', '>=' );
 	const reduxDispatch = useDispatch();
 
 	useEffect( () => {
-		const experimentCheck = isDesktop
-			? 'registration_email_only_desktop_random_usernames'
-			: 'registration_email_only_mobile_random_usernames';
-		let shouldCheck = true;
+		const experimentCheck = retrieveExperimentName();
+		let shouldCheck = experimentCheck?.length > 0;
 		loadExperimentAssignment( experimentCheck ).then( ( experimentObject ) => {
 			if ( shouldCheck ) {
 				setExperiment( experimentObject );
@@ -115,7 +112,12 @@ export default function WPCheckoutOrderReview( {
 		return () => {
 			shouldCheck = false;
 		};
-	}, [ isDesktop ] );
+	}, [] );
+
+	function retrieveExperimentName() {
+		const cookies = cookie.parse( document.cookie );
+		return cookies.wpcom_signup_experiment_name;
+	}
 
 	const onRemoveProductCancel = useCallback( () => {
 		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' ) );
@@ -159,7 +161,7 @@ export default function WPCheckoutOrderReview( {
 	};
 
 	const planIsP2Plus = hasP2PlusPlan( responseCart );
-	const shouldShowDomainNote = experiment?.variationName && domainUrl?.includes( 'wordpress.com' );
+	const shouldShowDomainNote = experiment?.variationName && domainUrl?.includes( '.wordpress.com' );
 	const isPwpoUser = useSelector(
 		( state ) =>
 			getCurrentUser( state ) && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { isDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
+import cookie from 'cookie';
 import { localize } from 'i18n-calypso';
 import { isEmpty, omit, get } from 'lodash';
 import PropTypes from 'prop-types';
@@ -144,14 +145,24 @@ export class UserStep extends Component {
 		];
 		if ( signupFlows.includes( this.props.flowName ) ) {
 			const experimentCheck = this.state.isDesktop
-				? 'registration_email_only_desktop_random_usernames'
-				: 'registration_email_only_mobile_random_usernames';
+				? 'registration_email_only_desktop_v3'
+				: 'registration_email_only_mobile_v3';
 
 			loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
 				this.setState( { experiment: experimentName } );
+				experimentName.variationName === 'treatment'
+					? this.persistExperimentName( experimentName.experimentName )
+					: null;
 			} );
 		}
 	}
+
+	persistExperimentName = ( experimentName ) => {
+		const DAY_IN_SECONDS = 3600 * 24;
+		const expirationDate = new Date( new Date().getTime() + DAY_IN_SECONDS * 1000 );
+		const options = { path: '/', expires: expirationDate, sameSite: 'strict' };
+		document.cookie = cookie.serialize( 'wpcom_signup_experiment_name', experimentName, options );
+	};
 
 	getSubHeaderText() {
 		const {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will launch the third iteration of the test to remove the username and password fields from the WordPress.com registration page. This first test is discussed at pbxNRc-144-p2 and the second test is discussed at pbxNRc-18X-p2.

The second test has data integrity issues reported by Explat for the desktop variation and I believe it is due to how I was [checking for test assignment in the prior variation](https://github.com/Automattic/wp-calypso/pull/59100/files#diff-7400f16bef0397fda9c7d5cabe2a75da337677000fcbc5897f97293d5b5e4018R110). In retrospect, I think both the method for checking viewport size and using `loadExperimentAssignment` again in checkout introduced the possibility for noise by assigning people to multiple or incorrect tests.

This PR addresses that by using a cookie to persist the test assignment name, and using that cookie to determine their experiment status on the checkout page.

It also changes the Explat experiment names to `registration_email_only_mobile_v3` and `registration_email_only_desktop_v3`


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api.wordpress.com
* Checkout this branch and start Calypso
* Add the Abacus bookmarklets for both tests listed above.
* Navigate to [LOCALCALYPSO]/start/new in an incognito browser
* Repeat the following steps in both mobile and desktop viewports:
* Assign yourself to the treatment variation for the relevant viewport (it may take a minute or two after clicking the bookmarklet for your variation assignment to propagate).
* Go through the control and treatment variations for each viewport.
* Test the flow through a non-onboarding signup flow (such as /start/personal)
* Check non-signup checkout flows and confirm that the user isn't assigned to either test, regardless of viewport. (This check is handled in Abacus).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58404 #59100
