### PR TITLE
More Informative Scan: Fix header overflow

### DIFF
--- a/client/components/jetpack/threat-dialog-new/index.tsx
+++ b/client/components/jetpack/threat-dialog-new/index.tsx
@@ -51,18 +51,6 @@ const ThreatDialog: React.FC< Props > = ( {
 		[ action ]
 	);
 
-	const getThreatSeverityText = ( threat: Threat ) => {
-		if ( threat.severity >= 5 ) {
-			return translate( 'critical' );
-		}
-
-		if ( threat.severity >= 3 ) {
-			return translate( 'high' );
-		}
-
-		return translate( 'low' );
-	};
-
 	return (
 		<ServerCredentialsWizardDialog
 			showDialog={ showDialog }
@@ -74,10 +62,7 @@ const ThreatDialog: React.FC< Props > = ( {
 		>
 			<>
 				<p>
-					{ action === 'fix' &&
-						translate( 'Jetpack will fix the %(severity)s threat:', {
-							args: { severity: getThreatSeverityText( threat ) },
-						} ) }
+					{ action === 'fix' && translate( 'Jetpack will fix the threat:' ) }
 
 					{ action === 'ignore' && translate( 'Jetpack will ignore the threat:' ) }
 				</p>

--- a/client/components/jetpack/threat-dialog-new/index.tsx
+++ b/client/components/jetpack/threat-dialog-new/index.tsx
@@ -82,7 +82,7 @@ const ThreatDialog: React.FC< Props > = ( {
 					{ action === 'ignore' && translate( 'Jetpack will ignore the threat:' ) }
 				</p>
 				<h3 className="threat-dialog-new__threat-title">
-					{ threat.fixable && <ThreatFixHeader threat={ threat } action={ action } /> }
+					{ <ThreatFixHeader threat={ threat } action={ action } /> }
 				</h3>
 				{ action === 'ignore' &&
 					translate(

--- a/client/components/jetpack/threat-fix-header/index.tsx
+++ b/client/components/jetpack/threat-fix-header/index.tsx
@@ -3,16 +3,16 @@ import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import { FixableThreat } from 'calypso/components/jetpack/threat-item-new/types';
+import { Threat } from 'calypso/components/jetpack/threat-item-new/types';
 import { getThreatFix, getThreatMessage } from 'calypso/components/jetpack/threat-item-new/utils';
 import ThreatSeverityBadge from 'calypso/components/jetpack/threat-severity-badge';
 
 import './style.scss';
 
 interface Props {
-	threat: FixableThreat;
+	threat: Threat;
 	fixAllDialog?: boolean;
-	onCheckFix?: ( checked: boolean, threat: FixableThreat ) => void;
+	onCheckFix?: ( checked: boolean, threat: Threat ) => void;
 	action: 'fix' | 'ignore';
 }
 
@@ -49,7 +49,7 @@ export default function ThreatFixHeader( {
 					) }
 				>
 					<Gridicon className="threat-fix-header__warning-icon" icon="info-outline" size={ 18 } />
-					{ action === 'fix' && getThreatFix( threat.fixable ) }
+					{ action === 'fix' && threat.fixable && getThreatFix( threat.fixable ) }
 					{ action === 'ignore' && translate( 'Jetpack will ignore the threat.' ) }
 				</span>
 			</div>

--- a/client/components/jetpack/threat-fix-header/style.scss
+++ b/client/components/jetpack/threat-fix-header/style.scss
@@ -63,7 +63,9 @@
     font-weight: 600;
     font-size: $font-body-large;
     line-height: 24px;
-    overflow: scroll;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__card-bottom {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Handle overflow for long filenames on the fix header
* Show threat header when ignoring a threat

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a JP site with Scan and add a few threats (You can use the threat tester plugin to add a few innocuous threats for testing).
* Open the links provided in this PR.
* Open the scan page, append the `?flags=+jetpack/more-informative-scan` query string to your URL to activate the feature flag.
* Verify that the layout handles long filenames properly.

