### PR TITLE
Jetpack Connect: remove _.flowRight and _.concat calls

### DIFF
--- a/client/jetpack-connect/main-header.jsx
+++ b/client/jetpack-connect/main-header.jsx
@@ -7,7 +7,6 @@ import {
 	PRODUCTS_LIST,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
-import { concat } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -15,7 +14,7 @@ import { FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
 
 class JetpackConnectMainHeader extends Component {
 	static propTypes = {
-		type: PropTypes.oneOf( concat( FLOW_TYPES, false ) ),
+		type: PropTypes.oneOf( [ ...FLOW_TYPES, false ] ),
 	};
 
 	getTexts() {

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { concat, flowRight, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -22,7 +21,7 @@ export class JetpackConnectMain extends Component {
 	static propTypes = {
 		locale: PropTypes.string,
 		path: PropTypes.string,
-		type: PropTypes.oneOf( concat( FLOW_TYPES, false ) ),
+		type: PropTypes.oneOf( [ ...FLOW_TYPES, false ] ),
 		url: PropTypes.string,
 		processJpSite: PropTypes.func,
 	};
@@ -92,7 +91,7 @@ export class JetpackConnectMain extends Component {
 	handleOnClickTos = () => this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
 
 	isInstall() {
-		return includes( FLOW_TYPES, this.props.type );
+		return FLOW_TYPES.includes( this.props.type );
 	}
 
 	renderSiteInput( status ) {
@@ -137,18 +136,13 @@ export class JetpackConnectMain extends Component {
 }
 
 const connectComponent = connect(
-	( state ) => {
-		return {
-			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-			getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
-			isLoggedIn: isUserLoggedIn( state ),
-			isRequestingSites: isRequestingSites( state ),
-		};
-	},
-	{
-		checkUrl,
-		recordTracksEvent,
-	}
+	( state ) => ( {
+		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+		getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
+		isLoggedIn: isUserLoggedIn( state ),
+		isRequestingSites: isRequestingSites( state ),
+	} ),
+	{ checkUrl, recordTracksEvent }
 );
 
-export default flowRight( jetpackConnection, connectComponent, localize )( JetpackConnectMain );
+export default jetpackConnection( connectComponent( localize( JetpackConnectMain ) ) );

--- a/client/jetpack-connect/search.jsx
+++ b/client/jetpack-connect/search.jsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { concat, flowRight } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -27,7 +26,7 @@ import { cleanUrl } from './utils';
 
 export class SearchPurchase extends Component {
 	static propTypes = {
-		type: PropTypes.oneOf( concat( FLOW_TYPES, false ) ),
+		type: PropTypes.oneOf( [ ...FLOW_TYPES, false ] ),
 		url: PropTypes.string,
 		processJpSite: PropTypes.func,
 	};
@@ -219,9 +218,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	jetpackConnection,
-	connectComponent,
-	searchSites,
-	localize
-)( SearchPurchase );
+export default jetpackConnection( connectComponent( searchSites( localize( SearchPurchase ) ) ) );

--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { concat, flowRight } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -27,7 +26,7 @@ import { cleanUrl } from '../../jetpack-connect/utils';
 
 export class SearchPurchase extends Component {
 	static propTypes = {
-		type: PropTypes.oneOf( concat( FLOW_TYPES, false ) ),
+		type: PropTypes.oneOf( [ ...FLOW_TYPES, false ] ),
 		url: PropTypes.string,
 		processJpSite: PropTypes.func,
 	};
@@ -217,9 +216,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	jetpackConnection,
-	connectComponent,
-	searchSites,
-	localize
-)( SearchPurchase );
+export default jetpackConnection( connectComponent( searchSites( localize( SearchPurchase ) ) ) );


### PR DESCRIPTION
Removes `flowRight`, `concat` and `includes` from a few Jetpack Connect React components. A spinoff from locale setup refactor in #58345.