### PR TITLE
Fix general tracking tests - list view select

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -345,6 +345,15 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		return await driverHelper.clickWhenClickable( this.driver, backButtonLocator );
 	}
 
+	async scrollListViewToEnd() {
+		const listViewContainerSelector = '.edit-site-editor__list-view-panel-content';
+		// const listViewContainer = await this.driver.findElement( listViewContainerSelector );
+		// return await listViewContainer.scrollTo( 0, 100000 );
+		return await this.driver.executeScript(
+			`document.querySelector( '${ listViewContainerSelector }' ).scrollTo(0,1000000);`
+		);
+	}
+
 	/**
 	 * Alias for `toggleNavigationSidebar`. We need to have the same function
 	 * name in both this and gutenberg editor component to make sure general

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -347,8 +347,6 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 
 	async scrollListViewToEnd() {
 		const listViewContainerSelector = '.edit-site-editor__list-view-panel-content';
-		// const listViewContainer = await this.driver.findElement( listViewContainerSelector );
-		// return await listViewContainer.scrollTo( 0, 100000 );
 		return await this.driver.executeScript(
 			`document.querySelector( '${ listViewContainerSelector }' ).scrollTo(0,1000000);`
 		);

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -690,4 +690,11 @@ export default class GutenbergEditorComponent extends AbstractEditorComponent {
 		await Promise.all( notices.map( ( notice ) => notice.click() ) );
 		await driverHelper.waitUntilElementNotLocated( this.driver, locator );
 	}
+
+	async scrollListViewToEnd() {
+		const listViewContainerSelector = '.edit-post-editor__list-view-panel-content';
+		return await this.driver.executeScript(
+			`document.querySelector( '${ listViewContainerSelector }' ).scrollTo(0,1000000);`
+		);
+	}
 }

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -146,11 +146,16 @@ export function createGeneralTests( { it, editorType, postType, baseContext = un
 		await editor.toggleListView();
 
 		const secondLastItemLocator = By.css(
-			'[aria-label="Block navigation structure"] [role="row"]:nth-last-child(2) button'
+			'[aria-label="Block navigation structure"] [role="row"]:nth-last-child(2) a'
 		);
 		const lastItemLocator = By.css(
-			'[aria-label="Block navigation structure"] [role="row"]:nth-last-child(1) button'
+			'[aria-label="Block navigation structure"] [role="row"]:nth-last-child(1) a'
 		);
+
+		// Scroll to the bottom of the list view container before attempting to click the items. For
+		// whatever reason, the above nth-child selectors stopped working (return null) when the
+		// elements have not first been scrolled into view.
+		await editor.scrollListViewToEnd();
 		await driverHelper.clickWhenClickable( this.driver, secondLastItemLocator );
 		await driverHelper.clickWhenClickable( this.driver, lastItemLocator );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to https://github.com/Automattic/wp-calypso/pull/59423 - the list view select button was recently updated to an anchor. While the linked PR fixed the tracking system to account for this, our tests were still selecting by 'button'.

This PR updates the tests to appropriately select by the 'a' tag. However, the tests still failed to pick up the selectors after this change. After investigating, it seems these nth-last query selectors seem to return `null` unless we have previously scrolled the bottom elements into view. Im not sure why this issue is surfacing now (maybe Gutenberg changed the nested list view items to be expanded instead of collapsed by default causing the bottom items to not be in view?), but either way injecting a script to scroll the list view content container to the bottom seems to resolve the issue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the general test for the list view select tracking event passes when running the following test suites:
* `wp-calypso-gutenberg-site-editor-tracking-spec.js`
* `wp-calypso-gutenberg-page-editor-tracking-spec.js`
* `wp-calypso-gutenberg-post-editor-tracking-spec.js`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
