### PR TITLE
Make certain that locationState is an object in useStepNavigation

### DIFF
--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -72,8 +72,16 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 
 	// Transfer anchor podcast ID, episode ID from the query string to the location state, if needed
 	const locationResult = useLocation();
-	const locationState =
-		'state' in locationResult ? ( locationResult.state as Record< string, string > ) : {};
+	const getLocationState = (): Record< string, string > => {
+		if ( ! locationResult ) {
+			return {};
+		}
+		if ( ! locationResult.state ) {
+			return {};
+		}
+		return locationResult.state as Record< string, string >;
+	};
+	const locationState = getLocationState();
 	if ( anchorFmPodcastId ) {
 		locationState.anchorFmPodcastId = anchorFmPodcastId;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This may fix https://github.com/Automattic/wp-calypso/issues/59738

#### Testing instructions

See https://wordpress.com/support/audio/podcasting/#create-a-site-from-your-anchor-podcast

- Use a logged-out session or an incognito window.
- Visit `/new?anchor_podcast=22b6608` and verify that there are no JS errors in the console.