### PR TITLE
Launch Checklist: Update Edit Homepage title and button text when using Site Editor

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -54,6 +54,7 @@ export const getTask = (
 		taskUrls,
 		userEmail,
 		isBlogger,
+		isUsingSiteEditor,
 	} = {}
 ) => {
 	let taskData = {};
@@ -170,11 +171,13 @@ export const getTask = (
 		case CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED:
 			taskData = {
 				timing: 20,
-				title: translate( 'Update your homepage' ),
+				title: isUsingSiteEditor
+					? translate( "Update your site's design" )
+					: translate( 'Update your homepage' ),
 				description: translate(
 					"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
 				),
-				actionText: translate( 'Edit homepage' ),
+				actionText: isUsingSiteEditor ? translate( 'Edit Site' ) : translate( 'Edit homepage' ),
 				actionUrl: taskUrls?.front_page_updated,
 			};
 			break;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -54,7 +54,7 @@ export const getTask = (
 		taskUrls,
 		userEmail,
 		isBlogger,
-		isUsingSiteEditor,
+		isFSEActive,
 	} = {}
 ) => {
 	let taskData = {};
@@ -171,13 +171,13 @@ export const getTask = (
 		case CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED:
 			taskData = {
 				timing: 20,
-				title: isUsingSiteEditor
+				title: isFSEActive
 					? translate( "Update your site's design" )
 					: translate( 'Update your homepage' ),
 				description: translate(
 					"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
 				),
-				actionText: isUsingSiteEditor ? translate( 'Edit site' ) : translate( 'Edit homepage' ),
+				actionText: isFSEActive ? translate( 'Edit site' ) : translate( 'Edit homepage' ),
 				actionUrl: taskUrls?.front_page_updated,
 			};
 			break;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -177,7 +177,7 @@ export const getTask = (
 				description: translate(
 					"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
 				),
-				actionText: isUsingSiteEditor ? translate( 'Edit Site' ) : translate( 'Edit homepage' ),
+				actionText: isUsingSiteEditor ? translate( 'Edit site' ) : translate( 'Edit homepage' ),
 				actionUrl: taskUrls?.front_page_updated,
 			};
 			break;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -17,6 +17,7 @@ import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import getChecklistTaskUrls from 'calypso/state/selectors/get-checklist-task-urls';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
+import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { useSiteOption } from 'calypso/state/sites/hooks';
 import { getSiteOption, getSiteSlug, getCustomizerUrl } from 'calypso/state/sites/selectors';
@@ -107,6 +108,7 @@ const SiteSetupList = ( {
 	firstIncompleteTask,
 	isEmailUnverified,
 	isPodcastingSite,
+	isUsingSiteEditor,
 	menusUrl,
 	siteId,
 	siteSlug,
@@ -186,6 +188,7 @@ const SiteSetupList = ( {
 				taskUrls,
 				userEmail,
 				isBlogger,
+				isUsingSiteEditor,
 			} );
 			setCurrentTask( newCurrentTask );
 			trackTaskDisplay( dispatch, newCurrentTask, siteId, isPodcastingSite );
@@ -339,7 +342,7 @@ export default connect( ( state ) => {
 		siteSegment,
 		siteVerticals,
 	} );
-
+	const isUsingSiteEditor = isSiteUsingCoreSiteEditor( state, siteId );
 	// Existing usage didn't have a global selector, we can tidy this in a follow up.
 	const emailVerificationStatus = state?.currentUser?.emailVerification?.status;
 
@@ -348,6 +351,7 @@ export default connect( ( state ) => {
 		firstIncompleteTask: taskList.getFirstIncompleteTask(),
 		isEmailUnverified: ! isCurrentUserEmailVerified( state ),
 		isPodcastingSite: !! getSiteOption( state, siteId, 'anchor_podcast' ),
+		isUsingSiteEditor,
 		menusUrl: getCustomizerUrl( state, siteId, null, null, 'add-menu' ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import Spinner from 'calypso/components/spinner';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import { getTaskList } from 'calypso/lib/checklist';
 import { navigate } from 'calypso/lib/navigate';
@@ -17,7 +18,6 @@ import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import getChecklistTaskUrls from 'calypso/state/selectors/get-checklist-task-urls';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
-import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { useSiteOption } from 'calypso/state/sites/hooks';
 import { getSiteOption, getSiteSlug, getCustomizerUrl } from 'calypso/state/sites/selectors';
@@ -108,7 +108,7 @@ const SiteSetupList = ( {
 	firstIncompleteTask,
 	isEmailUnverified,
 	isPodcastingSite,
-	isUsingSiteEditor,
+	isFSEActive,
 	menusUrl,
 	siteId,
 	siteSlug,
@@ -188,7 +188,7 @@ const SiteSetupList = ( {
 				taskUrls,
 				userEmail,
 				isBlogger,
-				isUsingSiteEditor,
+				isFSEActive,
 			} );
 			setCurrentTask( newCurrentTask );
 			trackTaskDisplay( dispatch, newCurrentTask, siteId, isPodcastingSite );
@@ -326,7 +326,10 @@ const SiteSetupList = ( {
 	);
 };
 
-export default connect( ( state ) => {
+const ConnectedSiteSetupList = connect( ( state, props ) => {
+	const { blockEditorSettings } = props;
+
+	const isFSEActive = blockEditorSettings?.is_fse_active ?? false;
 	const siteId = getSelectedSiteId( state );
 	const user = getCurrentUser( state );
 	const designType = getSiteOption( state, siteId, 'design_type' );
@@ -342,7 +345,6 @@ export default connect( ( state ) => {
 		siteSegment,
 		siteVerticals,
 	} );
-	const isUsingSiteEditor = isSiteUsingCoreSiteEditor( state, siteId );
 	// Existing usage didn't have a global selector, we can tidy this in a follow up.
 	const emailVerificationStatus = state?.currentUser?.emailVerification?.status;
 
@@ -350,8 +352,8 @@ export default connect( ( state ) => {
 		emailVerificationStatus,
 		firstIncompleteTask: taskList.getFirstIncompleteTask(),
 		isEmailUnverified: ! isCurrentUserEmailVerified( state ),
+		isFSEActive,
 		isPodcastingSite: !! getSiteOption( state, siteId, 'anchor_podcast' ),
-		isUsingSiteEditor,
 		menusUrl: getCustomizerUrl( state, siteId, null, null, 'add-menu' ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
@@ -360,3 +362,5 @@ export default connect( ( state ) => {
 		userEmail: user?.email,
 	};
 } )( SiteSetupList );
+
+export default withBlockEditorSettings( ConnectedSiteSetupList );


### PR DESCRIPTION
### Changes proposed in this Pull Request

Change the CTA button and title copy of the Update your homepage launch checklist card when the site editor is enabled.

#### Before
<img width="1280" alt="Screen Shot 2022-01-04 at 5 10 24 PM" src="https://user-images.githubusercontent.com/5414230/148146170-7a030a66-0ecf-4cbf-84fa-fee17792fe85.png">

#### After
<img width="1280" alt="Screen Shot 2022-01-04 at 5 10 02 PM" src="https://user-images.githubusercontent.com/5414230/148146289-f3f9171a-6546-4177-b2b2-96b84cc41606.png">


### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up local calypso dev environment
* Apply this PR
* Visit the homepage for a site with core FSE enabled (we can create a core FSE enabled site by following [this onboarding flow](https://horizon.wordpress.com/new?flags=gutenboarding/site-editor))
* Verify that the Update your homepage launch checklist card title and action button are changed to `Update your site's design` and `Edit Site`
* Switch to a site without core FSE enabled
* Verify that the Update your homepage launch checklist card title and action button are changed to `Update your homepage` and `Edit Homepage`.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/59744
