### PR TITLE
Hero Flow: Turn on video course as starting point

### DIFF
--- a/client/signup/steps/courses/index.tsx
+++ b/client/signup/steps/courses/index.tsx
@@ -41,6 +41,7 @@ export default function CoursesStep( props: Props ): React.ReactNode {
 			stepContent={
 				<VideosUi
 					courseSlug={ courseSlug }
+					areVideosTranslated={ false }
 					HeaderBar={ CoursesHeader }
 					FooterBar={ () => (
 						<CoursesFooter

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,7 +90,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/hero-flow-non-en": true,
-		"signup/starting-point-courses": false,
+		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"themes/premium": false,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -96,7 +96,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/hero-flow-non-en": true,
-		"signup/starting-point-courses": false,
+		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,
 		"themes/premium": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -98,7 +98,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/hero-flow-non-en": true,
-		"signup/starting-point-courses": false,
+		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"themes/premium": false,
 		"upgrades/redirect-payments": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://github.com/Automattic/wp-calypso/pull/58234 and pdtkmj-2r-p2 show that the video course works well. Also, https://github.com/Automattic/wp-calypso/issues/58206 is already shipped. So, we can turn on the config for production.
* Note that we should wait for the translation. See https://translate.wordpress.com/deliverables/overview/7074284/ 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?siteSlug=<your_site>`
* Select write intent
* Fill out the site options
* Select “Take the masterclass” as starting point
* Check the following things:
  * Video UI show correctly.
  * The “Back” button works correctly
  * “Draft your post” button works correctly
  * The footer shows after you complete the courses. Clicking the “start writing” button makes you complete the flow and land on the editor  
  * Ensure the tracks event works correctly

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58262