### PR TITLE
Design Picker: Refactor styles into base package

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -192,6 +192,7 @@ const Designs: React.FunctionComponent = () => {
 						/>
 					)
 				}
+				highResThumbnails
 			/>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/designs/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/designs/style.scss
@@ -58,7 +58,7 @@
 			flex-direction: column-reverse;
 			align-items: flex-start;
 			margin-top: 0;
-			margin-bottom: 40px;
+			margin-bottom: 48px;
 		}
 
 		.designs__heading-title {

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -1,4 +1,5 @@
 import { useSelect, useDispatch } from '@wordpress/data';
+import classnames from 'classnames';
 import * as React from 'react';
 import { Redirect, Switch, Route, useLocation } from 'react-router-dom';
 import { isE2ETest } from 'calypso/lib/e2e';
@@ -32,6 +33,8 @@ import type { BlockEditProps } from '@wordpress/blocks';
 
 import './colors.scss';
 import './style.scss';
+
+const WIDE_LAYOUT_STEPS: StepType[] = [ Step.DesignSelection ];
 
 const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = () => {
 	const {
@@ -206,7 +209,11 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	}
 
 	return (
-		<div className="onboarding-block">
+		<div
+			className={ classnames( 'onboarding-block', {
+				'onboarding-block--is-wide': WIDE_LAYOUT_STEPS.includes( step ),
+			} ) }
+		>
 			{ isCreatingSite && (
 				<Redirect
 					push={ shouldTriggerCreate ? undefined : true }

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -3,6 +3,10 @@
 
 .onboarding-block {
 	@include onboarding-block-margin;
+
+	&--is-wide {
+		@include onboarding-block-margin-wide;
+	}
 }
 
 .gutenboarding-page {

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -49,29 +49,7 @@
 		}
 	}
 
-	.design-picker__grid {
-		grid-template-columns: 1fr;
-
-		@include break-medium {
-			grid-template-columns: 1fr 1fr;
-			column-gap: 49px;
-			row-gap: 39px;
-		}
-	}
-
 	.design-picker__has-categories {
-		.design-picker__grid {
-			@include break-medium {
-				grid-template-columns: 1fr;
-				column-gap: 24px;
-				row-gap: 36px;
-			}
-
-			@include break-large {
-				grid-template-columns: 1fr 1fr;
-			}
-		}
-
 		.formatted-header__subtitle {
 			// Overrides some very specific selectors in /client/signup/style.scss
 			margin: 12px 0 48px !important;

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -223,6 +223,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	categoriesFooter,
 	categorization,
 } ) => {
+	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
 		const result = categorization?.selection
 			? filterDesignsByCategory( designs, categorization.selection )
@@ -233,8 +234,12 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	}, [ designs, categorization?.selection ] );
 
 	return (
-		<div className={ classnames( 'design-picker', `design-picker--theme-${ theme }`, className ) }>
-			{ !! categorization?.categories.length && (
+		<div
+			className={ classnames( 'design-picker', `design-picker--theme-${ theme }`, className, {
+				'design-picker--has-categories': hasCategories,
+			} ) }
+		>
+			{ categorization && hasCategories && (
 				<DesignPickerCategoryFilter
 					categories={ categorization.categories }
 					selectedCategory={ categorization.selection }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -169,12 +169,20 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	const isBlankCanvas = isBlankCanvasDesign( props.design );
 
 	if ( ! onPreview ) {
-		return <DesignButton { ...props } />;
+		return (
+			<div className="design-button-container">
+				<DesignButton { ...props } />
+			</div>
+		);
 	}
 
 	// Show the preview directly when selecting the design if the device is not desktop
 	if ( ! isDesktop ) {
-		return <DesignButton { ...props } onSelect={ onPreview } />;
+		return (
+			<div className="design-button-container">
+				<DesignButton { ...props } onSelect={ onPreview } />
+			</div>
+		);
 	}
 
 	// We don't need preview for blank canvas

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -35,10 +35,7 @@
 		margin: 0 -12px 30px;
 	}
 
-	.design-button-container,
-	.design-picker__design-option {
-		cursor: pointer;
-		font-family: inherit;
+	.design-button-container {
 		width: calc( 100% - 24px );
 		margin: 0 12px 24px; // only applies in IE
 
@@ -46,6 +43,11 @@
 			width: calc( 50% - 24px );
 			margin-bottom: 40px;
 		}
+	}
+
+	.design-picker__design-option {
+		cursor: pointer;
+		font-family: inherit;
 	}
 
 	.design-picker__design-option-header {
@@ -101,8 +103,7 @@
 			}
 		}
 
-		.design-button-container,
-		.design-picker__design-option {
+		.design-button-container {
 			width: auto;
 			margin: 0;
 
@@ -295,8 +296,6 @@
 
 	.design-picker__design-option {
 		flex: 1;
-		width: auto;
-		margin: 0;
 	}
 
 	.design-button-cover {
@@ -372,8 +371,7 @@
 	}
 
 	@supports not ( display: grid ) {
-		.design-button-container,
-		.design-picker__design-option {
+		.design-button-container {
 			@include break-medium {
 				width: calc( 100% - 24px );
 			}

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -42,16 +42,8 @@
 		width: 100%;
 		margin: 24px; // only applies in IE
 
-		@include break-mobile {
+		@include break-medium {
 			width: calc( 50% - 24px );
-		}
-
-		@include break-xlarge {
-			width: calc( 33.33% - 32px );
-		}
-
-		@include onboarding-break-gigantic {
-			width: calc( 25% - 32px );
 		}
 	}
 
@@ -81,16 +73,13 @@
 		.design-picker__grid {
 			display: grid;
 			grid-template-columns: 1fr;
-			row-gap: 48px;
+			row-gap: 24px;
 			margin: 0 0 30px;
 
-			@include break-mobile {
-				grid-template-columns: repeat( auto-fill, minmax( 295px, auto ) );
+			@include break-medium {
+				grid-template-columns: 1fr 1fr;
 				column-gap: 24px;
-			}
-
-			@include onboarding-break-gigantic {
-				column-gap: 32px;
+				row-gap: 40px;
 			}
 		}
 
@@ -100,7 +89,7 @@
 			row-gap: 48px;
 			margin: 0 0 30px;
 
-			@include break-mobile {
+			@include break-medium {
 				grid-template-columns: 1fr 1fr;
 				column-gap: 24px;
 			}
@@ -116,10 +105,6 @@
 			margin: 0;
 
 			@include break-xlarge {
-				width: auto;
-			}
-
-			@include onboarding-break-gigantic {
 				width: auto;
 			}
 		}
@@ -362,6 +347,35 @@
 	&:focus-within {
 		.design-button-cover {
 			opacity: 1;
+		}
+	}
+}
+
+// layout with categories
+.design-picker--has-categories {
+	@supports ( display: grid ) {
+		.design-picker__grid {
+			@include break-medium {
+				grid-template-columns: 1fr;
+				column-gap: 24px;
+				row-gap: 36px;
+			}
+
+			@include break-large {
+				grid-template-columns: 1fr 1fr;
+			}
+		}
+	}
+
+	@supports not ( display: grid ) {
+		.design-picker__design-option {
+			@include break-medium {
+				width: auto;
+			}
+
+			@include break-large {
+				width: calc( 50% - 24px );
+			}
 		}
 	}
 }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -28,22 +28,23 @@
 	}
 
 	.design-picker__grid {
-		margin: 0 -24px 30px;
+		margin: 0 -12px 30px;
 	}
 
 	.design-picker__grid-minimal {
-		margin: 0 -24px 30px;
+		margin: 0 -12px 30px;
 	}
 
+	.design-button-container,
 	.design-picker__design-option {
 		cursor: pointer;
 		font-family: inherit;
-		float: left;
-		width: 100%;
-		margin: 24px; // only applies in IE
+		width: calc( 100% - 24px );
+		margin: 0 12px 24px; // only applies in IE
 
 		@include break-medium {
 			width: calc( 50% - 24px );
+			margin-bottom: 40px;
 		}
 	}
 
@@ -100,6 +101,7 @@
 			}
 		}
 
+		.design-button-container,
 		.design-picker__design-option {
 			width: auto;
 			margin: 0;
@@ -293,6 +295,8 @@
 
 	.design-picker__design-option {
 		flex: 1;
+		width: auto;
+		margin: 0;
 	}
 
 	.design-button-cover {
@@ -358,7 +362,7 @@
 			@include break-medium {
 				grid-template-columns: 1fr;
 				column-gap: 24px;
-				row-gap: 36px;
+				row-gap: 40px;
 			}
 
 			@include break-large {
@@ -368,9 +372,10 @@
 	}
 
 	@supports not ( display: grid ) {
+		.design-button-container,
 		.design-picker__design-option {
 			@include break-medium {
-				width: auto;
+				width: calc( 100% - 24px );
 			}
 
 			@include break-large {

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -73,6 +73,13 @@
 	}
 }
 
+@mixin onboarding-block-margin-wide {
+	@include break-medium {
+		margin-left: $onboarding-block-margin-small;
+		margin-right: $onboarding-block-margin-small;
+	}
+}
+
 @mixin onboarding-heading-padding {
 	margin: $onboarding-heading-margin-mobile;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following https://github.com/Automattic/wp-calypso/pull/58622#pullrequestreview-823479835 to roll the style overrides we do in both `client/signup/steps/design-picker/style.scss` and `client/landing/gutenboarding/onboarding-block/designs/style.scss`  into the base @automattic/design-picker package. So anyone using the picker would get the 2-column of thumbnails by default.
* Also, use the `highResThumbnails` prop for <DesignPicker> since the thumbnails will be larger.


| Hero Flow | Gutenboarding |
| - | - |
| <video src="https://user-images.githubusercontent.com/13596067/148194338-3bd108dc-9e77-4e3d-9045-87b964aaa476.mov" /> | <video src="https://user-images.githubusercontent.com/13596067/148194307-e50d4b83-21b9-4e7f-9ac8-9ce24990b7b1.mov" /> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the design picker at the following places look good under different viewport
  * `/new/design`
  * `/start/setup-site?siteSlug=<your_site>` and go to the design step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/58879
