### PR TITLE
setLocaleMiddleware: add new path-slug param, remove unneeded user locale code

### DIFF
--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -1,6 +1,4 @@
-import config from '@automattic/calypso-config';
-import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
-import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setSection } from 'calypso/state/ui/actions';
 import { setLocale } from 'calypso/state/ui/language/actions';
 
@@ -40,23 +38,15 @@ export function setSectionMiddleware( section ) {
 	};
 }
 
-export function setLocaleMiddleware( context, next ) {
-	const currentUser = getCurrentUser( context.store.getState() );
-
-	if ( context.params.lang ) {
-		context.lang = context.params.lang;
-	} else if ( currentUser ) {
-		const shouldFallbackToDefaultLocale =
-			currentUser.use_fallback_for_incomplete_languages &&
-			isTranslatedIncompletely( currentUser.localeSlug );
-
-		context.lang = shouldFallbackToDefaultLocale
-			? config( 'i18n_default_locale_slug' )
-			: currentUser.localeSlug;
-	}
-
-	context.store.dispatch( setLocale( context.lang || config( 'i18n_default_locale_slug' ) ) );
-	next();
+export function setLocaleMiddleware( param = 'lang' ) {
+	return ( context, next ) => {
+		const paramsLocale = context.params[ param ];
+		if ( paramsLocale ) {
+			context.lang = paramsLocale;
+			context.store.dispatch( setLocale( paramsLocale ) );
+		}
+		next();
+	};
 }
 
 /**

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -16,7 +16,7 @@ export default ( router ) => {
 		// Only do the basics for layout on the server-side
 		router(
 			[ `/log-in/link/use/${ lang }`, `/log-in/link/jetpack/use/${ lang }` ],
-			setLocaleMiddleware,
+			setLocaleMiddleware(),
 			redirectLoggedIn,
 			makeLayout
 		);

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -58,7 +58,7 @@ export default ( router ) => {
 		router(
 			[ `/log-in/link/use/${ lang }`, `/log-in/jetpack/link/use/${ lang }` ],
 			redirectLoggedIn,
-			setLocaleMiddleware,
+			setLocaleMiddleware(),
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 			magicLoginUse,
 			makeLoggedOutLayout
@@ -67,7 +67,7 @@ export default ( router ) => {
 		router(
 			[ `/log-in/link/${ lang }`, `/log-in/jetpack/link/${ lang }`, `/log-in/new/link/${ lang }` ],
 			redirectLoggedIn,
-			setLocaleMiddleware,
+			setLocaleMiddleware(),
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 			magicLogin,
 			makeLoggedOutLayout
@@ -87,7 +87,7 @@ export default ( router ) => {
 		],
 		redirectJetpack,
 		redirectDefaultLocale,
-		setLocaleMiddleware,
+		setLocaleMiddleware(),
 		setHrefLangLinks,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		login,

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -14,6 +14,7 @@ import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { GUTENBOARDING_SECTION_DEFINITION } from 'calypso/landing/gutenboarding/section';
 import { filterLanguageRevisions } from 'calypso/lib/i18n-utils';
+import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
@@ -293,7 +294,13 @@ function setUpLoggedInRoute( req, res, next ) {
 				// Setting user in the state is safe as long as we don't cache it
 				req.context.store.dispatch( setCurrentUser( data ) );
 
-				if ( data.localeSlug ) {
+				if (
+					data.localeSlug &&
+					! (
+						data.use_fallback_for_incomplete_languages &&
+						isTranslatedIncompletely( data.localeVariant || data.localeSlug )
+					)
+				) {
 					req.context.lang = data.localeSlug;
 					req.context.store.dispatch( {
 						type: LOCALE_SET,


### PR DESCRIPTION
There is a page.js handler called `setLocaleMiddleware`, currently used only in `/log-in` routes, that looks at the `:lang` param in routes like `/log-in/:lang` and when it's like `/log-in/cs`, it switches the locale to `cs`.

This PR does two changes to that handler. First, it adds a `param` parameter to it, making it possible to customize the route param to look at. By default, `setLocaleMiddleware()` will look at `lang` param in `/log-in/:lang`, but it can also be used as `setLocaleMiddleware( 'locale' )` and look at the `locale` param in, e.g., `/jetpack/connect/authorize/:locale`. See also the [`getLanguageRouteParam`](https://github.com/Automattic/wp-calypso/blob/e3de69232da411c4d7167513e78def824c7dd32b/client/lib/i18n-utils/utils.js#L101) helper that has a similar convention. This change will help us use the `setLocaleMiddleware` handler at other places, like Signup or Jetpack Connect, in #58345.

Second, it removes the code that looks at the current user's locale and sets `context.lang` and Redux locale accordingly. That's because this code is redundant, as the current user's locale is already handled in handlers that are executed earlier:
- on server, there's the user bootstrapping code that looks at the user's locale (`setUpLoggedInRoute` in `client/server/pages`)
- on client, there's also code (`setupLocale` in `client/boot/locale`) that uses the current user as one of sources for determining the locale

Both these locale-setting handlers are called both in main Calypso entrypoint, and also in the separate login entrypoint.

There's a second commit in this PR that fixes a bug in `setUpLoggedInRoute`: it didn't honor the `use_fallback_for_incomplete_languages` flag and set the SSR locale even if it was incomplete.

**How to test:**
Verify that the `/log-in` page respects the logged-in user's locale, and when logged-out, it's `en` or determined from browser preferences. Also verify that a `/log-in/cs` or `/log-in/de` always uses the locale specified in the URL, both logged-in and logged-out.
