### PR TITLE
Server document render: stop setting context.isRTL, calculate just-in-time from context.lang

### DIFF
--- a/client/controller/ssr-setup-locale.js
+++ b/client/controller/ssr-setup-locale.js
@@ -2,7 +2,6 @@
 import { readFile } from 'fs/promises';
 import i18n from 'i18n-calypso';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
-import { getLanguage } from 'calypso/lib/i18n-utils';
 import config from 'calypso/server/config';
 import { LOCALE_SET } from 'calypso/state/action-types';
 
@@ -16,7 +15,6 @@ export function ssrSetupLocaleMiddleware() {
 			const localeVariant = i18n.getLocaleVariant();
 			context.store.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
 			context.lang = localeVariant || localeSlug;
-			context.isRTL = getLanguage( context.lang )?.rtl ?? false;
 			next();
 		}
 

--- a/client/document/domains-landing.jsx
+++ b/client/document/domains-landing.jsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import Head from 'calypso/components/head';
+import { isLocaleRtl } from 'calypso/lib/i18n-utils';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
 import { chunkCssLinks } from './utils';
 
@@ -12,10 +13,10 @@ function DomainsLanding( {
 	entrypoint,
 	head,
 	i18nLocaleScript,
-	isRTL,
 	lang,
 	manifests,
 } ) {
+	const isRTL = isLocaleRtl( lang );
 	return (
 		<html lang={ lang } dir={ isRTL ? 'rtl' : 'ltr' }>
 			<Head title={ head.title } branchName={ branchName } inlineScriptNonce={ inlineScriptNonce }>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -13,6 +13,7 @@ import Head from 'calypso/components/head';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import { isLocaleRtl } from 'calypso/lib/i18n-utils';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
 import { isBilmurEnabled, getBilmurUrl } from './utils/bilmur';
 import { chunkCssLinks } from './utils/chunk';
@@ -28,7 +29,6 @@ class Document extends Component {
 			head,
 			i18nLocaleScript,
 			initialReduxState,
-			isRTL,
 			entrypoint,
 			manifests,
 			lang,
@@ -84,6 +84,8 @@ class Document extends Component {
 		const theme = config( 'theme' );
 
 		const LoadingLogo = chooseLoadingLogo( this.props );
+
+		const isRTL = isLocaleRtl( lang );
 
 		return (
 			<html

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -123,7 +123,6 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		user: false,
 		env: calypsoEnv,
 		sanitize: sanitize,
-		isRTL: false,
 		requestFrom: request.query.from,
 		isWCComConnect,
 		isWooDna: wooDnaConfig( request.query ).isWooDnaFlow(),

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -427,11 +427,6 @@ const assertDefaultContext = ( { url, entry } ) => {
 		expect( request.context.sanitize ).toEqual( app.getMocks().sanitize );
 	} );
 
-	it( 'sets the RTL', async () => {
-		const { request } = await app.run();
-		expect( request.context.isRTL ).toEqual( false );
-	} );
-
 	it( 'sets requestFrom', async () => {
 		const { request } = await app.run( { request: { query: { from: 'from' } } } );
 		expect( request.context.requestFrom ).toEqual( 'from' );

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -7,7 +7,7 @@ import Lru from 'lru';
 import { createElement } from 'react';
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
-import { isDefaultLocale, isLocaleRtl, isTranslatedIncompletely } from 'calypso/lib/i18n-utils';
+import { isDefaultLocale, isTranslatedIncompletely } from 'calypso/lib/i18n-utils';
 import {
 	getLanguageFileUrl,
 	getLanguageManifestFileUrl,
@@ -189,9 +189,6 @@ export function attachI18n( context ) {
 
 	if ( context.store ) {
 		context.lang = getCurrentLocaleSlug( context.store.getState() ) || localeSlug;
-
-		const isLocaleRTL = isLocaleRtl( localeSlug );
-		context.isRTL = isLocaleRTL !== null ? isLocaleRTL : context.isRTL;
 	}
 }
 

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -19,9 +19,6 @@ function setUpLocale( context, next ) {
 	const language = getLanguage( context.params.lang );
 	if ( language ) {
 		context.lang = context.params.lang;
-		if ( language.rtl ) {
-			context.isRTL = true;
-		}
 	}
 
 	next();


### PR DESCRIPTION
A little simplification of our i18n setup code, extracted from #58345. Whenever we set `context.lang`, we were setting `context.isRTL`, too:
```js
context.lang = locale;
context.isRTL = getLanguage( locale ).rtl;
```
After this patch, all we're ever setting is `context.lang`, and the `isRTL` is determined from `context.lang` at the place that needs it -- when setting the `<html dir>` attribute.

**How to test:**
Verify that after this patch we're indeed not setting `context.isRTL` anywhere, and that, except the two `client/document` modules, it wasn't read anywhere else.