### PR TITLE
More Informative Scan: Fix Modal Message

### DIFF
--- a/client/components/jetpack/fix-all-threats-dialog-new/index.tsx
+++ b/client/components/jetpack/fix-all-threats-dialog-new/index.tsx
@@ -70,6 +70,7 @@ const FixAllThreatsDialog = ( { onConfirmation, onCloseDialog, showDialog, threa
 								threat={ threat }
 								fixAllDialog={ true }
 								onCheckFix={ onSelectCheckbox }
+								action="fix"
 							/>
 						</div>
 					) ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the message for the fix all threats modal

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a JP site with Scan and add a few threats (You can use the threat tester plugin to add a few innocuous threats for testing).
* Open the links provided in this PR.
* Open the scan page, append the `?flags=+jetpack/more-informative-scan` query string to your URL to activate the feature flag.
* Open the fix all modal and verify that the messaging appears correctly.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Before
<img width="717" alt="Screen Shot 2022-01-05 at 10 51 06" src="https://user-images.githubusercontent.com/12788275/148228628-f7137333-44df-40aa-8518-5695c1510cd4.png">


#### After
<img width="715" alt="Screen Shot 2022-01-05 at 10 51 16" src="https://user-images.githubusercontent.com/12788275/148228643-86c2fe54-9bab-47fe-bb0c-530e833d540e.png">

