### PR TITLE
Add banner video to the plugin details page

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -84,6 +84,7 @@ export function getAllowedPluginData( plugin ) {
 		'network',
 		'num_ratings',
 		'plugin_url',
+		'product_video',
 		'rating',
 		'ratings',
 		'sections',
@@ -210,6 +211,9 @@ export function normalizePluginData( plugin, pluginData ) {
 				break;
 			case 'compatibility':
 				returnData[ key ] = normalizeCompatibilityList( item );
+				break;
+			case 'product_video':
+				returnData.banner_video_src = item;
 				break;
 			default:
 				returnData[ key ] = item;

--- a/client/my-sites/plugins/plugin-featured-video/index.tsx
+++ b/client/my-sites/plugins/plugin-featured-video/index.tsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+
+interface PluginFeaturedVideoVideoProps {
+	id: string;
+	src: string;
+	productName: string;
+}
+
+export const PluginFeaturedVideo = ( { id, src, productName }: PluginFeaturedVideoVideoProps ) => {
+	const translate = useTranslate();
+
+	const getIframeTitle = () =>
+		translate( '%s Product Video', { args: [ productName ], textOnly: true } );
+
+	return (
+		<iframe
+			className="plugin-featured-video__iframe"
+			id={ id }
+			src={ src }
+			title={ getIframeTitle() }
+			loading="lazy"
+		/>
+	);
+};

--- a/client/my-sites/plugins/plugin-featured-video/style.scss
+++ b/client/my-sites/plugins/plugin-featured-video/style.scss
@@ -1,0 +1,4 @@
+.plugin-featured-video__iframe {
+	width: 100%;
+	min-height: 300px;
+}

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -10,6 +10,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
+import { PluginFeaturedVideo } from '../plugin-featured-video';
 
 import './style.scss';
 
@@ -228,9 +229,14 @@ class PluginSections extends Component {
 			trimmed: ! this.props.removeReadMore && ! this.props.isWpcom && ! this.state.readMore,
 		} );
 		const banner = this.props.plugin?.banners?.high || this.props.plugin?.banners?.low;
+		const videoUrl = this.props.plugin?.banner_video_src;
 
 		/*eslint-disable react/no-danger*/
-		if ( ! this.props.addBanner || ! banner || this.getSelected() !== 'description' ) {
+		if (
+			! this.props.addBanner ||
+			( ! banner && ! videoUrl ) ||
+			this.getSelected() !== 'description'
+		) {
 			return (
 				<div
 					ref={ this.descriptionContent }
@@ -240,6 +246,26 @@ class PluginSections extends Component {
 						__html: this.props.plugin.sections[ this.getSelected() ],
 					} }
 				/>
+			);
+		}
+
+		if ( videoUrl ) {
+			return (
+				<div ref={ this.descriptionContent } className={ contentClasses }>
+					<div className="plugin-sections__banner">
+						<PluginFeaturedVideo
+							id="product-video-iframe"
+							src={ videoUrl }
+							productName={ this.props.plugin.name }
+						/>
+					</div>
+					<div
+						// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
+						dangerouslySetInnerHTML={ {
+							__html: this.props.plugin.sections[ this.getSelected() ],
+						} }
+					/>
+				</div>
 			);
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the plugin has a banner video, it is now rendered on the plugin page

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

__Setup__ 
* patch D72459-code
* sandbox public-api
* Verify that when navigating to the product page, the `product_video` field is returned in the response: 
<img width="1499" alt="api response" src="https://user-images.githubusercontent.com/11555574/148230232-5246563a-c03c-414b-acf2-bebcee8b61c8.png">


__Product with product video__
* Go to a plugin page which has banner video (eg. `/plugins/woocommerce-subscriptions`)  
* Verify that the plugin page renders the video, and it is interactive:

| | Before | After |
| --- | --- | --- |
| Desktop | ![wordpress com_plugins_woocommerce-subscriptions_gcsecseyfree wordpress com (3)](https://user-images.githubusercontent.com/11555574/148229850-85cc5366-e3a5-445f-9ef2-6542d1ce5ddc.png) | ![calypso localhost_3000_plugins_gcsecseyfree wordpress com (1)](https://user-images.githubusercontent.com/11555574/148229783-e5616b6f-7d29-4076-865e-14ab938d8b8f.png) |
| Mobile | ![wordpress com_plugins_woocommerce-subscriptions_gcsecseyfree wordpress com(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/11555574/148229918-91975048-9826-41d8-baf5-17278afa9106.png) |  ![calypso localhost_3000_plugins_gcsecseyfree wordpress com(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/11555574/148229979-d757d598-6db8-40cc-baa7-f1b46f42bafa.png)|

Desktop video: https://d.pr/v/hFwt3i
Mobile video: https://d.pr/v/L5yzkv

__Product page without product video__
* Go to a plugin page which has banner video (eg. `/plugins/woocommerce-xero`)  
* Verify that there are no regressions

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59406