### PR TITLE
Update Jetpack Cloud revoke license dialog warning message and appearance

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -59,18 +59,6 @@ export default function RevokeLicenseDialog( {
 		</Button>,
 	];
 
-	buttons.unshift(
-		<a
-			href="https://github.com/Automattic/jetpack-licensing-api/tree/master/integration-docs#glossary"
-			target="_blank"
-			rel="noreferrer noopener"
-		>
-			{ translate( 'Learn more about revoking licenses' ) }
-			&nbsp;
-			<Gridicon icon="external" size={ 18 } />
-		</a>
-	);
-
 	return (
 		<Dialog
 			isVisible={ true }
@@ -82,13 +70,22 @@ export default function RevokeLicenseDialog( {
 			<h2 className="revoke-license-dialog__heading">
 				{ translate( 'Are you sure you want to revoke this license?' ) }
 			</h2>
-
 			<p>
 				{ translate(
 					'A revoked license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
 				) }
+				&nbsp;
+				<a
+					className="revoke-license-dialog__learn-more"
+					href="https://github.com/Automattic/jetpack-licensing-api/tree/master/integration-docs#glossary"
+					target="_blank"
+					rel="noreferrer noopener"
+				>
+					{ translate( 'More about revoking licenses' ) }
+					&nbsp;
+					<Gridicon icon="external" size={ 18 } />
+				</a>
 			</p>
-
 			<ul>
 				{ siteUrl && (
 					<li>
@@ -102,13 +99,10 @@ export default function RevokeLicenseDialog( {
 					<strong>{ translate( 'License:' ) }</strong> <code>{ licenseKey }</code>
 				</li>
 			</ul>
-
 			<p className="revoke-license-dialog__warning">
 				<Gridicon icon="info-outline" size={ 18 } />
 
-				{ translate(
-					'Please note once this license is revoked from this site it cannot be reappiled to this site. You can however add a new or different licenses to this site.'
-				) }
+				{ translate( 'Please note this action cannot be undone.' ) }
 			</p>
 		</Dialog>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -81,7 +81,7 @@ export default function RevokeLicenseDialog( {
 					target="_blank"
 					rel="noreferrer noopener"
 				>
-					{ translate( 'More about revoking licenses' ) }
+					{ translate( 'Learn more about revoking licenses' ) }
 					&nbsp;
 					<Gridicon icon="external" size={ 18 } />
 				</a>

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -106,7 +106,9 @@ export default function RevokeLicenseDialog( {
 			<p className="revoke-license-dialog__warning">
 				<Gridicon icon="info-outline" size={ 18 } />
 
-				{ translate( 'Please note this action cannot be undone.' ) }
+				{ translate(
+					'Please note once this license is revoked from this site it cannot be reappiled to this site. You can however add a new or different licenses to this site.'
+				) }
 			</p>
 		</Dialog>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
@@ -30,7 +30,7 @@
 		font-size: 1.125rem; /* stylelint-disable */
 		font-weight: 600;
 		line-height: 20px;
-		color: var( --studio-gray-60 );
+		color: var( --studio-red-60 );
 		border-bottom: 1px solid var( --studio-gray-5 );
 
 		@include break-mobile() {
@@ -49,6 +49,10 @@
 			top: 2px;
 			margin-right: 7px;
 		}
+	}
+
+	&__learn-more {
+		text-decoration: underline;
 	}
 
 	ul {

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
@@ -27,10 +27,10 @@
 	&__heading {
 		margin: -16px -16px 16px;
 		padding: 9px 16px;
-		font-size: 1.25rem;
+		font-size: 1.125rem; /* stylelint-disable */
 		font-weight: 600;
 		line-height: 20px;
-		color: var( --studio-red-60 );
+		color: var( --studio-gray-60 );
 		border-bottom: 1px solid var( --studio-gray-5 );
 
 		@include break-mobile() {
@@ -41,7 +41,7 @@
 	}
 
 	&__warning {
-		font-weight: 600;
+		font-weight: 500;
 		color: var( --studio-red-60 );
 
 		.gridicon {


### PR DESCRIPTION
Completes 1201265858818161-as-1201265858818196/f

#### Changes proposed in this Pull Request

* Revoke license dialog copy was feeling too "scary", this PR updates the copy and some of the styles in order to set a better tone for the message.
* Match the appearance of the revoke license dialog 👉🏻  MJgOP8OS9ZVG6EQ6L4sPCC-fi-1772%3A15331 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Setup a JN website
* Make sure to have a Partner Account 👉🏻  PCYsg-zPi-p2
* Then go to [Jetpack Cloud Licensing Portal](https://cloud.jetpack.com/partner-portal/)
* Under the "Licenses" section, generate a license and then click to revoke the license you just created.
* You should see text as in 👉🏻 MJgOP8OS9ZVG6EQ6L4sPCC-fi-1772%3A15331 


### Screenshots
<img width="678" alt="Screen Shot 2022-01-10 at 15 55 53" src="https://user-images.githubusercontent.com/5550190/148823052-ec606319-e51b-4ecf-969c-514c0a3cf3e9.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->