### PR TITLE
P2 pre-approved domains: add role to setting

### DIFF
--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -16,6 +16,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import TokenField from 'calypso/components/token-field';
 import wpcom from 'calypso/lib/wp';
+import RoleSelect from 'calypso/my-sites/people/role-select';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -32,6 +33,7 @@ const P2PreapprovedDomainsForm = ( {
 	updateFields,
 } ) => {
 	const SETTING_KEY_PREAPPROVED_DOMAINS = 'p2_preapproved_domains';
+	const DEFAULT_ROLE = 'author';
 
 	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
 	const isP2Hub = useSelector( ( state ) => isSiteP2Hub( state, siteId ) );
@@ -40,6 +42,7 @@ const P2PreapprovedDomainsForm = ( {
 	const [ isValidating, setIsValidating ] = useState( false );
 	const [ validTokens, setValidTokens ] = useState( [] );
 	const [ invalidTokens, setInvalidTokens ] = useState( {} );
+	const [ selectedRole, setSelectedRole ] = useState( DEFAULT_ROLE );
 	const [ error, setError ] = useState( {} );
 
 	useEffect( () => {
@@ -49,8 +52,9 @@ const P2PreapprovedDomainsForm = ( {
 
 		// Domains should always be toggled on if text field is not empty.
 		// The reverse is not true -- it can be toggled on while empty.
-		if ( fields.p2_preapproved_domains.length > 0 ) {
+		if ( fields.p2_preapproved_domains?.domains?.[ 0 ] ) {
 			setIsToggledOn( true );
+			setSelectedRole( fields.p2_preapproved_domains?.role );
 		}
 	}, [ fields ] );
 
@@ -58,24 +62,41 @@ const P2PreapprovedDomainsForm = ( {
 		return null;
 	}
 
-	const getFormField = () => {
-		return fields?.p2_preapproved_domains || [];
+	const getFormFieldValue = () => {
+		return fields?.p2_preapproved_domains;
 	};
 
-	const setFormField = ( domains ) => {
-		updateFields( { [ SETTING_KEY_PREAPPROVED_DOMAINS ]: domains } );
+	const setFormFieldValue = ( role, domains ) => {
+		const value = {
+			role,
+			domains,
+		};
+		updateFields( { [ SETTING_KEY_PREAPPROVED_DOMAINS ]: value } );
 	};
 
 	const handleSubmitButtonClick = ( event ) => {
-		if ( ! isValidating ) {
-			handleSubmitForm( event );
+		if ( isValidating ) {
+			return;
 		}
+
+		// Bail if there are no domains provided.
+		const formFieldValue = getFormFieldValue();
+		if ( ! formFieldValue?.domains?.[ 0 ] ) {
+			return;
+		}
+
+		// Bail if there are invalid domains.
+		if ( invalidTokens.length > 0 ) {
+			return;
+		}
+
+		handleSubmitForm( event );
 	};
 
 	const handleDomainsToggle = () => {
 		// Clear field if toggling off. If toggling on, it should have
 		// been empty to start with.
-		setFormField( [] );
+		setFormFieldValue( DEFAULT_ROLE, [] );
 
 		setIsToggledOn( ! isToggledOn );
 	};
@@ -141,12 +162,16 @@ const P2PreapprovedDomainsForm = ( {
 
 	const onTokensChange = ( rawTokens ) => {
 		const tokens = normalizeTokens( rawTokens );
-		setFormField( tokens );
+		setFormFieldValue( selectedRole, tokens );
 		validateTokens( tokens );
 	};
 
+	const getTokens = () => {
+		return fields?.p2_preapproved_domains?.domains || [];
+	};
+
 	const getTokensWithStatus = () => {
-		const rawTokens = getFormField();
+		const rawTokens = getTokens();
 
 		const tokens = rawTokens.map( ( token ) => {
 			if ( invalidTokens && invalidTokens[ token ] ) {
@@ -169,6 +194,12 @@ const P2PreapprovedDomainsForm = ( {
 		} );
 
 		return tokens;
+	};
+
+	const onRoleChange = ( event ) => {
+		const role = event.target.value || DEFAULT_ROLE;
+		setSelectedRole( role );
+		setFormFieldValue( role, getTokens() );
 	};
 
 	return (
@@ -202,6 +233,15 @@ const P2PreapprovedDomainsForm = ( {
 							></ToggleControl>
 							{ isToggledOn && (
 								<>
+									<RoleSelect
+										id="role"
+										name="role"
+										includeFollower={ false }
+										siteId={ siteId }
+										onChange={ onRoleChange }
+										value={ selectedRole }
+										disabled={ isRequestingSettings }
+									/>
 									<FormLabel htmlFor="blogname">{ translate( 'Approved domains' ) }</FormLabel>
 									<TokenField
 										name="p2_preapproved_domains"

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -62,26 +62,22 @@ const P2PreapprovedDomainsForm = ( {
 		return null;
 	}
 
-	const getFormFieldValue = () => {
-		return fields?.p2_preapproved_domains;
-	};
-
 	const setFormFieldValue = ( role, domains ) => {
 		const value = {
 			role,
 			domains,
 		};
+
+		if ( ! domains?.[ 0 ] ) {
+			updateFields( { [ SETTING_KEY_PREAPPROVED_DOMAINS ]: '' } );
+			return;
+		}
+
 		updateFields( { [ SETTING_KEY_PREAPPROVED_DOMAINS ]: value } );
 	};
 
 	const handleSubmitButtonClick = ( event ) => {
 		if ( isValidating ) {
-			return;
-		}
-
-		// Bail if there are no domains provided.
-		const formFieldValue = getFormFieldValue();
-		if ( ! formFieldValue?.domains?.[ 0 ] ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of the P2 revised signup flow project

* Frontend side of changes required to add the user role to `p2_preapproved_domains` setting. This setting was introduced in a previous PR, but was only limited to the list of domains that are pre-approved.
* Background: workspaces can list email domains that are pre-approved to join. Users with those email domains can join on their own, and will get assigned the role specified in the setting.
 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D72538-code to get the API side of changes
* Visit the General Settings section of a P2 hub, e.g. `calypso.localhost:3000/settings/general/<site-slug>`
* Verify that you can select roles and domains, and persist these settings.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screens
<img width="737" alt="Screen Shot 2022-01-05 at 11 29 28 PM" src="https://user-images.githubusercontent.com/730823/148244062-9ff8b941-3323-4f67-a880-c0fbc6d3f26f.png">

