### PR TITLE
Experiment: Show the monthly plans tab by default in the plans step of signup flow

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -40,6 +40,7 @@ import JetpackCheckoutSitelessThankYouCompleted from './checkout-thank-you/jetpa
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import UpsellNudge, {
+	ANNUAL_PLAN_UPGRADE,
 	BUSINESS_PLAN_UPGRADE_UPSELL,
 	CONCIERGE_SUPPORT_SESSION,
 	CONCIERGE_QUICKSTART_SESSION,
@@ -265,6 +266,9 @@ export function upsellNudge( context, next ) {
 	} else if ( context.path.includes( 'offer-professional-email' ) ) {
 		upsellType = PROFESSIONAL_EMAIL_UPSELL;
 		upgradeItem = context.params.domain;
+	} else if ( context.path.includes( 'offer-annual-upgrade' ) ) {
+		upsellType = ANNUAL_PLAN_UPGRADE;
+		upgradeItem = context.params.upgradeItem;
 	}
 
 	setSectionMiddleware( { name: upsellType } )( context );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -271,5 +271,14 @@ export default function () {
 		clientRender
 	);
 
+	page(
+		'/checkout/:site/offer-annual-upgrade/:upgradeItem/:receiptId?',
+		redirectLoggedOut,
+		siteSelection,
+		upsellNudge,
+		makeLayout,
+		clientRender
+	);
+
 	page( '/checkout*', redirectLoggedOut );
 }

--- a/client/my-sites/checkout/upsell-nudge/annual-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/annual-plan-upgrade-upsell/index.jsx
@@ -116,11 +116,6 @@ export class AnnualPlanUpgradeUpsell extends PureComponent {
 								</li>
 							) }
 						</ul>
-						<p>
-							The good news is that you can upgrade your plan today and try the annual{ ' ' }
-							<span style={ { textTransform: 'capitalize' } }>{ annualPlanSlug } plan</span>{ ' ' }
-							risk-free thanks to our <b>14-day money-back guarantee</b>.
-						</p>
 						<p>Click below to upgrade your plan to an annual one and enjoy your benefits.</p>
 					</div>
 					<div className="annual-plan-upgrade-upsell__column-doodle">

--- a/client/my-sites/checkout/upsell-nudge/annual-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/annual-plan-upgrade-upsell/index.jsx
@@ -1,0 +1,159 @@
+import { CompactCard, Button, Gridicon } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { PureComponent } from 'react';
+import premiumThemesImage from 'calypso/assets/images/illustrations/themes.svg';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+import './style.scss';
+
+export class AnnualPlanUpgradeUpsell extends PureComponent {
+	render() {
+		const { receiptId, upgradeItem } = this.props;
+		const title = 'Checkout ‹ Annual Plan Upgrade';
+
+		return (
+			<>
+				<PageViewTracker
+					path="/checkout/:site/offer-annual-upgrade/:upgrade_item/:receipt_id"
+					title={ title }
+					properties={ { upgrade_item: upgradeItem } }
+				/>
+				<DocumentHead title={ title } />
+				{ receiptId ? (
+					<CompactCard className="annual-plan-upgrade-upsell__card-header">
+						{ this.header() }
+					</CompactCard>
+				) : (
+					''
+				) }
+				<CompactCard className="annual-plan-upgrade-upsell__card-body">{ this.body() }</CompactCard>
+				<CompactCard className="annual-plan-upgrade-upsell__card-footer">
+					{ this.footer() }
+				</CompactCard>
+			</>
+		);
+	}
+
+	header() {
+		return (
+			<header className="annual-plan-upgrade-upsell__small-header">
+				<h2 className="annual-plan-upgrade-upsell__title">
+					Hold tight, we're getting your site ready
+				</h2>
+			</header>
+		);
+	}
+
+	body() {
+		const {
+			pricePerMonthForAnnualPlan,
+			pricePerMonthForMonthlyPlan,
+			currencyCode,
+			annualPlanSlug,
+		} = this.props;
+		const discountRate = Math.ceil(
+			100 *
+				( ( pricePerMonthForMonthlyPlan - pricePerMonthForAnnualPlan ) /
+					pricePerMonthForMonthlyPlan )
+		);
+		const annualPlanSavings = Math.ceil(
+			( pricePerMonthForMonthlyPlan - pricePerMonthForAnnualPlan ) * 12
+		);
+		const formattedAnnualSavings = formatCurrency( annualPlanSavings, currencyCode, {
+			stripZeros: true,
+		} );
+		return (
+			<>
+				<h2 className="annual-plan-upgrade-upsell__header">
+					Upgrade to an annual plan to save { discountRate }% and get a free domain!
+				</h2>
+
+				<div className="annual-plan-upgrade-upsell__column-pane">
+					<div className="annual-plan-upgrade-upsell__column-content">
+						<p>
+							<b>An annual plan gets you these amazing benefits:</b>
+						</p>
+						<ul className="annual-plan-upgrade-upsell__checklist">
+							<li className="annual-plan-upgrade-upsell__checklist-item">
+								<Gridicon
+									icon="checkmark"
+									className="annual-plan-upgrade-upsell__checklist-item-icon"
+								/>
+								<span className="annual-plan-upgrade-upsell__checklist-item-text">
+									{ discountRate }% in savings: That is { formattedAnnualSavings } back in your
+									pocket.
+								</span>
+							</li>
+							<li className="annual-plan-upgrade-upsell__checklist-item">
+								<Gridicon
+									icon="checkmark"
+									className="annual-plan-upgrade-upsell__checklist-item-icon"
+								/>
+								<span className="annual-plan-upgrade-upsell__checklist-item-text">
+									A free custom domain for one year: any available domain you like, free for a year.
+								</span>
+							</li>
+							<li className="annual-plan-upgrade-upsell__checklist-item">
+								<Gridicon
+									icon="checkmark"
+									className="annual-plan-upgrade-upsell__checklist-item-icon"
+								/>
+								<span className="annual-plan-upgrade-upsell__checklist-item-text">
+									Your own personalized email address free for three months.
+								</span>
+							</li>
+							{ annualPlanSlug !== 'personal' && (
+								<li className="annual-plan-upgrade-upsell__checklist-item">
+									<Gridicon
+										icon="checkmark"
+										className="annual-plan-upgrade-upsell__checklist-item-icon"
+									/>
+									<span className="annual-plan-upgrade-upsell__checklist-item-text">
+										Live chat support: Get unlimited live chat support any time of the day with our
+										expert Happiness Engineers.
+									</span>
+								</li>
+							) }
+						</ul>
+						<p>
+							The good news is that you can upgrade your plan today and try the annual{ ' ' }
+							<span style={ { textTransform: 'capitalize' } }>{ annualPlanSlug } plan</span>{ ' ' }
+							risk-free thanks to our <b>14-day money-back guarantee</b>.
+						</p>
+						<p>Click below to upgrade your plan to an annual one and enjoy your benefits.</p>
+					</div>
+					<div className="annual-plan-upgrade-upsell__column-doodle">
+						<img
+							className="annual-plan-upgrade-upsell__doodle"
+							alt="Website expert offering a support session"
+							src={ premiumThemesImage }
+						/>
+					</div>
+				</div>
+			</>
+		);
+	}
+
+	footer() {
+		const { handleClickAccept, handleClickDecline } = this.props;
+		return (
+			<footer className="annual-plan-upgrade-upsell__footer">
+				<Button
+					data-e2e-button="decline"
+					className="annual-plan-upgrade-upsell__decline-offer-button"
+					onClick={ handleClickDecline }
+				>
+					No thanks
+				</Button>
+				<Button
+					primary
+					className="annual-plan-upgrade-upsell__accept-offer-button"
+					onClick={ () => handleClickAccept( 'accept' ) }
+				>
+					Upgrade and enjoy these benefits!
+				</Button>
+			</footer>
+		);
+	}
+}

--- a/client/my-sites/checkout/upsell-nudge/annual-plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/annual-plan-upgrade-upsell/style.scss
@@ -1,0 +1,159 @@
+main.annual-plan-upgrade-upsell.main {
+	margin: auto;
+}
+
+.annual-plan-upgrade-upsell {
+	display: flex;
+	flex-direction: column;
+
+	b {
+		font-weight: 700;
+	}
+
+	.card {
+		width: 100%;
+	}
+
+	&__placeholders {
+		display: flex;
+		flex-direction: column;
+
+		.is-placeholder {
+			animation: pulse-light 800ms ease-in-out infinite;
+			background: var( --color-neutral-10 );
+		}
+	}
+
+	&__placeholder-row {
+		height: 40px;
+		flex: 0 0 100%;
+		margin-bottom: 15px;
+	}
+
+	&__placeholder-button {
+		height: 50px;
+		width: 100%;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			width: 80px;
+			height: 40px;
+		}
+	}
+
+	&__placeholder-button-container {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	&__card-header,
+	&__card-footer {
+		width: 100%;
+	}
+
+	&__card-body {
+		overflow: auto;
+		flex: 1;
+	}
+
+	&__column-pane {
+		display: flex;
+		flex-flow: row;
+	}
+
+	&__column-content {
+		padding-right: 10px;
+		@include breakpoint-deprecated( '<480px' ) {
+			padding-right: 0;
+		}
+	}
+
+	&__column-doodle {
+		width: 120px;
+		flex-shrink: 0;
+		@include breakpoint-deprecated( '<480px' ) {
+			display: none;
+		}
+	}
+
+	&__doodle {
+		margin-top: 85px;
+	}
+
+	&__small-header {
+		font-style: italic;
+		text-align: center;
+	}
+
+	&__header {
+		font-size: $font-title-medium;
+		font-weight: 600;
+		text-align: center;
+		line-height: 1.4;
+		margin-top: 0.7em;
+		margin-bottom: 1em;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			font-size: $font-title-small;
+		}
+	}
+	&__sub-header {
+		font-size: $font-title-small;
+		font-weight: normal;
+		text-align: center;
+		line-height: 1.4;
+		margin-top: 5px;
+		margin-bottom: 1.6em;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			font-size: $font-body;
+		}
+	}
+
+	&__checklist {
+		margin: 0 0 0.75em;
+
+		&-item {
+			display: flex;
+			width: 100%;
+			align-items: flex-start;
+			margin-bottom: 1.2em;
+
+			@include breakpoint-deprecated( '<660px' ) {
+				align-items: flex-start;
+			}
+		}
+
+		&-item-icon {
+			width: 18px;
+			fill: var( --studio-jetpack-green-30 );
+			margin-right: 5px;
+		}
+
+		&-item-text {
+			flex: 1;
+		}
+	}
+
+	&__footer &__decline-offer-button {
+		color: var( --color-primary );
+
+		@include breakpoint-deprecated( '<480px' ) {
+			width: 100%;
+		}
+
+		@include breakpoint-deprecated( '>480px' ) {
+			float: left;
+		}
+	}
+
+	&__footer &__accept-offer-button {
+		@include breakpoint-deprecated( '<480px' ) {
+			width: 100%;
+			margin-top: 10px;
+		}
+
+		@include breakpoint-deprecated( '>480px' ) {
+			float: right;
+		}
+	}
+}

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -429,10 +429,12 @@ export class UpsellNudge extends Component {
 		// as we need to handle validation failures before redirecting to checkout.
 		if ( PROFESSIONAL_EMAIL_UPSELL === upsellType ) {
 			this.props.shoppingCartManager.replaceProductsInCart( [ productToAdd ] ).then( () => {
-				const { errors } = this.props?.cart?.messages;
-				if ( errors && errors.length ) {
-					// Stay on the page to show the relevant error(s)
-					return;
+				if ( this.props?.cart?.messages ) {
+					const { errors } = this.props.cart.messages;
+					if ( errors && errors.length ) {
+						// Stay on the page to show the relevant error(s)
+						return;
+					}
 				}
 				page( '/checkout/' + siteSlug );
 			} );

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -457,6 +457,7 @@ export class UpsellNudge extends Component {
 			BUSINESS_PLAN_UPGRADE_UPSELL,
 			CONCIERGE_QUICKSTART_SESSION,
 			PROFESSIONAL_EMAIL_UPSELL,
+			ANNUAL_PLAN_UPGRADE,
 		];
 		if ( 'accept' !== buttonAction || ! supportedUpsellTypes.includes( upsellType ) ) {
 			debug(
@@ -486,12 +487,23 @@ export class UpsellNudge extends Component {
 	};
 
 	renderPurchaseModal = () => {
+		const { pricePerMonthForMonthlyPlan, pricePerMonthForAnnualPlan, upsellType } = this.props;
 		const isCartUpdating = this.props.shoppingCartManager.isPendingUpdate;
 
 		const onCloseModal = () => {
 			this.props.shoppingCartManager.replaceProductsInCart( [] );
 			this.setState( { showPurchaseModal: false } );
 		};
+
+		let discountRateCopy;
+		if ( ANNUAL_PLAN_UPGRADE === upsellType ) {
+			const discountRate = Math.ceil(
+				100 *
+					( ( pricePerMonthForMonthlyPlan - pricePerMonthForAnnualPlan ) /
+						pricePerMonthForMonthlyPlan )
+			);
+			discountRateCopy = `You're saving ${ discountRate }% by paying annually`;
+		}
 
 		return (
 			<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration }>
@@ -501,6 +513,7 @@ export class UpsellNudge extends Component {
 					onClose={ onCloseModal }
 					siteSlug={ this.props.siteSlug }
 					isCartUpdating={ isCartUpdating }
+					discountRateCopy={ discountRateCopy }
 				/>
 			</StripeHookProvider>
 		);
@@ -524,6 +537,8 @@ const resolveProductSlug = ( upsellType, productAlias ) => {
 	switch ( upsellType ) {
 		case BUSINESS_PLAN_UPGRADE_UPSELL:
 			return getPlanByPathSlug( productAlias )?.getStoreSlug();
+		case ANNUAL_PLAN_UPGRADE:
+			return productAlias;
 		case PROFESSIONAL_EMAIL_UPSELL:
 			return TITAN_MAIL_MONTHLY_SLUG;
 		case CONCIERGE_QUICKSTART_SESSION:

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.jsx
@@ -19,8 +19,15 @@ function PurchaseModalStep( { children } ) {
 	);
 }
 
-function OrderStep( { siteSlug, product } ) {
+function OrderStep( { siteSlug, product, discountRateCopy } ) {
 	const translate = useTranslate();
+	const originalAmountDisplay = product.item_original_subtotal_display;
+	const originalAmountInteger = product.item_original_subtotal_integer;
+
+	const actualAmountDisplay = product.item_subtotal_display;
+	const isDiscounted = Boolean(
+		product.item_subtotal_integer < originalAmountInteger && originalAmountDisplay
+	);
 	return (
 		<PurchaseModalStep>
 			<div className="purchase-modal__step-title">{ translate( 'Your order' ) }</div>
@@ -28,8 +35,17 @@ function OrderStep( { siteSlug, product } ) {
 				<div>{ translate( 'Site: %(siteSlug)s', { args: { siteSlug } } ) }</div>
 				<div className="purchase-modal__product">
 					<span className="purchase-modal__product-name">{ product?.product_name }</span>
-					<span className="purchase-modal__cost">{ product?.product_cost_display }</span>
+					<span className="purchase-modal__cost">
+						{ isDiscounted && originalAmountDisplay ? (
+							<>
+								<s>{ originalAmountDisplay }</s> { actualAmountDisplay }
+							</>
+						) : (
+							actualAmountDisplay
+						) }
+					</span>
 				</div>
+				<div className="purchase-modal__annual-savings">{ discountRateCopy }</div>
 			</div>
 		</PurchaseModalStep>
 	);
@@ -104,6 +120,7 @@ export default function PurchaseModalContent( {
 	siteSlug,
 	step,
 	submitTransaction,
+	discountRateCopy,
 } ) {
 	const translate = useTranslate();
 
@@ -117,7 +134,11 @@ export default function PurchaseModalContent( {
 			>
 				<Gridicon icon="cross-small" />
 			</Button>
-			<OrderStep siteSlug={ siteSlug } product={ cart.products?.[ 0 ] } />
+			<OrderStep
+				siteSlug={ siteSlug }
+				product={ cart.products?.[ 0 ] }
+				discountRateCopy={ discountRateCopy }
+			/>
 			<PaymentMethodStep siteSlug={ siteSlug } card={ cards?.[ 0 ] } />
 			<CheckoutTerms cart={ cart } />
 			<hr />

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -26,6 +26,7 @@ type PurchaseModalProps = {
 	isCartUpdating: boolean;
 	onClose: () => void;
 	siteSlug: string;
+	discountRateCopy: string;
 };
 
 export function PurchaseModal( {
@@ -34,6 +35,7 @@ export function PurchaseModal( {
 	isCartUpdating,
 	onClose,
 	siteSlug,
+	discountRateCopy,
 }: PurchaseModalProps ): JSX.Element {
 	const [ step, setStep ] = useState( BEFORE_SUBMIT );
 	const submitTransaction = useSubmitTransaction( {
@@ -48,6 +50,7 @@ export function PurchaseModal( {
 		onClose,
 		siteSlug,
 		step,
+		discountRateCopy,
 		submitTransaction,
 	};
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -197,3 +197,9 @@ $left-margin: 36px;
 		height: 2rem;
 	}
 }
+
+.purchase-modal__annual-savings {
+	// stylelint-disable-next-line
+	font-size: 0.8rem;
+	color: #008a20;
+}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -4,6 +4,7 @@ import page from 'page';
 import { createElement } from 'react';
 import store from 'store';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
 import flows from 'calypso/signup/config/flows';
@@ -323,6 +324,11 @@ export default {
 			! isManageSiteFlow
 		) {
 			context.store.dispatch( setSelectedSiteId( null ) );
+		}
+
+		// Pre-fetching the experiment
+		if ( flowName === 'onboarding' ) {
+			await loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v1' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -327,7 +327,7 @@ export default {
 		}
 
 		// Pre-fetching the experiment
-		if ( flowName === 'onboarding' ) {
+		if ( flowName === 'onboarding' || flowName === 'launch-site' ) {
 			await loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v1' );
 		}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -265,6 +265,7 @@ export class PlansStep extends Component {
 		if ( ! this.state.experimentLoaded ) {
 			return null;
 		}
+
 		return (
 			<>
 				<StepWrapper

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -34,7 +34,7 @@ export class PlansStep extends Component {
 	};
 
 	componentWillMount() {
-		if ( this.props.flowName === 'onboarding' ) {
+		if ( this.props.flowName === 'onboarding' || this.props.flowName === 'launch-site' ) {
 			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v1' ).then(
 				( experiment ) => {
 					this.setState( { experiment, experimentLoaded: true } );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -127,7 +127,10 @@ export class PlansStep extends Component {
 			return intervalType;
 		}
 
-		if ( this.state.experiment?.variationName !== null ) {
+		if (
+			'calypso_signup_monthly_plans_default_202201_v1' === this.state.experiment?.experimentName &&
+			this.state.experiment?.variationName !== null
+		) {
 			return 'monthly';
 		}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -34,11 +34,15 @@ export class PlansStep extends Component {
 	};
 
 	componentWillMount() {
-		loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v1' ).then(
-			( experiment ) => {
-				this.setState( { experiment, experimentLoaded: true } );
-			}
-		);
+		if ( this.props.flowName === 'onboarding' ) {
+			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v1' ).then(
+				( experiment ) => {
+					this.setState( { experiment, experimentLoaded: true } );
+				}
+			);
+		} else {
+			this.setState( { experimentLoaded: true } );
+		}
 	}
 
 	componentDidMount() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -30,12 +30,15 @@ export class PlansStep extends Component {
 	state = {
 		isDesktop: isDesktop(),
 		experiment: null,
+		experimentLoaded: false,
 	};
 
 	componentWillMount() {
-		loadExperimentAssignment( 'disabled_monthly_personal_premium_v2' ).then( ( experimentName ) => {
-			this.setState( { experiment: experimentName } );
-		} );
+		loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v1' ).then(
+			( experiment ) => {
+				this.setState( { experiment, experimentLoaded: true } );
+			}
+		);
 	}
 
 	componentDidMount() {
@@ -120,6 +123,10 @@ export class PlansStep extends Component {
 			return intervalType;
 		}
 
+		if ( this.state.experiment?.variationName !== null ) {
+			return 'monthly';
+		}
+
 		// Default value
 		return 'yearly';
 	}
@@ -171,7 +178,7 @@ export class PlansStep extends Component {
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 					isReskinned={ isReskinned }
-					disableMonthlyExperiment={ this.state.experiment?.variationName !== null }
+					disableMonthlyExperiment={ false }
 				/>
 			</div>
 		);
@@ -255,6 +262,9 @@ export class PlansStep extends Component {
 			}
 		}
 
+		if ( ! this.state.experimentLoaded ) {
+			return null;
+		}
 		return (
 			<>
 				<StepWrapper


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR implements the experiment defined in pbxNRc-1aI-p2, which is to show the monthly plans by default in the plans step of the signup flow for India traffic.

![mnthlydef](https://user-images.githubusercontent.com/1269602/148386005-0b46fd07-bcaa-40a5-9cb5-f8f53e51ba8c.gif)

* Users who purchase a monthly plan will be shown an upsell to the annual plan:

<img width="727" alt="Screenshot 2022-01-13 at 3 07 33 PM" src="https://user-images.githubusercontent.com/1269602/149319211-1b035d46-c94b-4d10-b959-02f93afd268e.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to treatment using the bookmarklet for the experiment `calypso_signup_monthly_plans_default_202201_v1`
* Proxy through India and verify that in the plans step of the `onboarding` signup flow, the monthly plans are shown by default. Also verify that switching between the monthly and annual plans tab works well.
* Verify that monthly plans are shown by default in the launch site flow. 
* Verify that monthly plans are not shown by default in non-EN or through a non-India IP. 

**Test annual plans upsell has one-click enabled**

* Assign yourself to treatment, signup as a new user(proxied via India), and add any monthly plan to cart.
* In the checkout page, use an Indian credit. If you are store sandboxed, then you can use this dummy Stripe card `4000003560000008`.
* After checkout completes, you should see the annual plan upsell. Click on the "Yes ..." button and verify that you see a one-click upsell dialog:
<img width="741" alt="Screenshot 2022-01-11 at 5 23 05 PM" src="https://user-images.githubusercontent.com/1269602/148950702-c6e69005-52e5-42b1-965f-48d08a2ec049.png">

**Annual plan upsell with/without Personal plan**

* Assign yourself to `treatment` and go through the signup flow.
* If you purchase a monthly Personal plan, then the annual plan upsell should not mention the "Live chat feature":
<img width="745" alt="Screenshot 2022-01-11 at 5 20 15 PM" src="https://user-images.githubusercontent.com/1269602/148950946-9cd135c6-70a9-4252-8b75-c762a1baf24a.png">

* If you purchase any other monthly plan, then the upsell should have the "Live chat feature". Also verify that the plan name mentioned in the upsell copy is appropriate:

<img width="737" alt="Screenshot 2022-01-11 at 5 21 44 PM" src="https://user-images.githubusercontent.com/1269602/148951101-8ddc48d3-9b61-4c1c-a25c-b394b56a6a8c.png">


**Upsell variations for control/treatment**

1. After completing purchase of a Premium monthly, `control` group should show the Business plan upsell whereas `treatment` group should show the annual plan upsell. 


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

