### PR TITLE
Shopping Cart: Move canItemBeRemovedFromCart to wpcom-checkout package

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,6 +1,7 @@
-import { isPremium, isBusiness } from '@automattic/calypso-products';
+import { isPremium } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import {
+	canItemBeRemovedFromCart,
 	getCouponLineItemFromCart,
 	getCreditsLineItemFromCart,
 	isWpComProductRenewal,
@@ -11,9 +12,7 @@ import {
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { useSelector } from 'react-redux';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
-import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
@@ -79,11 +78,6 @@ export function WPOrderReviewLineItems( {
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
-	const hasMarketplaceProduct = useSelector( ( state ) =>
-		responseCart.products.some( ( product: ResponseCartProduct ) =>
-			isMarketplaceProduct( state, product.product_slug )
-		)
-	);
 
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
@@ -97,7 +91,7 @@ export function WPOrderReviewLineItems( {
 					<WPOrderReviewListItem key={ product.uuid }>
 						<LineItem
 							product={ product }
-							hasDeleteButton={ canItemBeDeleted( product, responseCart, hasMarketplaceProduct ) }
+							hasDeleteButton={ canItemBeRemovedFromCart( product, responseCart ) }
 							removeProductFromCart={ removeProductFromCart }
 							isSummary={ isSummary }
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -159,26 +153,4 @@ WPOrderReviewLineItems.propTypes = {
  */
 function isPremiumPlanWithDIFMInTheCart( item: ResponseCartProduct, responseCart: ResponseCart ) {
 	return isPremium( item ) && hasDIFMProduct( responseCart );
-}
-
-function canItemBeDeleted(
-	item: ResponseCartProduct,
-	responseCart: ResponseCart,
-	hasMarketplaceProduct: boolean
-): boolean {
-	const itemTypesThatCannotBeDeleted = [ 'domain_redemption' ];
-	if ( itemTypesThatCannotBeDeleted.includes( item.product_slug ) ) {
-		return false;
-	}
-
-	// The Premium plan cannot be removed from the cart when in combination with the DIFM lite product
-	if ( isPremiumPlanWithDIFMInTheCart( item, responseCart ) ) {
-		return false;
-	}
-
-	// The Business plan cannot be removed from the cart when in combination with a marketplace product
-	if ( isBusiness( item ) && hasMarketplaceProduct ) {
-		return false;
-	}
-	return true;
 }

--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -3,13 +3,13 @@ import {
 	getCreditsLineItemFromCart,
 	NonProductLineItem,
 	LineItem,
+	canItemBeRemovedFromCart,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import type { Theme } from '@automattic/composite-checkout';
 import type {
 	ResponseCart,
 	RemoveProductFromCart,
-	ResponseCartProduct,
 	RemoveCouponFromCart,
 } from '@automattic/shopping-cart';
 
@@ -48,7 +48,7 @@ export function MiniCartLineItems( {
 					<MiniCartLineItemWrapper key={ product.uuid }>
 						<LineItem
 							product={ product }
-							hasDeleteButton={ canItemBeDeleted( product ) }
+							hasDeleteButton={ canItemBeRemovedFromCart( product, responseCart ) }
 							removeProductFromCart={ removeProductFromCart }
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 							responseCart={ responseCart }
@@ -70,9 +70,4 @@ export function MiniCartLineItems( {
 			) }
 		</MiniCartLineItemsWrapper>
 	);
-}
-
-function canItemBeDeleted( item: ResponseCartProduct ): boolean {
-	const itemTypesThatCannotBeDeleted = [ 'domain_redemption' ];
-	return ! itemTypesThatCannotBeDeleted.includes( item.product_slug );
 }

--- a/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
+++ b/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
@@ -1,0 +1,45 @@
+import { isPremium, isDIFMProduct } from '@automattic/calypso-products';
+import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Determine whether there is a DIFM (Do it for me) product in the shopping cart.
+ */
+function hasDIFMProduct( cart: ResponseCart ): boolean {
+	return cart.products.some( isDIFMProduct );
+}
+
+/**
+ * Check if the given item is the premium plan product and the DIFM product exists in the provided shopping cart object
+ */
+function isPremiumPlanWithDIFMInTheCart( item: ResponseCartProduct, responseCart: ResponseCart ) {
+	return isPremium( item ) && hasDIFMProduct( responseCart );
+}
+
+/**
+ * Check if a cart item can be removed from the cart.
+ *
+ * If this returns false, there will be no option to remove the specified
+ * product from the cart.
+ *
+ * Please use this sparingly; it's often better to add guards inside the
+ * shopping-cart endpoint on the backend rather than here. Not being shown any
+ * way to remove an item from the cart can be very confusing for users. If you
+ * add a guard in the shopping-cart endpoint instead, it can return an error
+ * message to explain why.
+ */
+export function canItemBeRemovedFromCart(
+	item: ResponseCartProduct,
+	responseCart: ResponseCart
+): boolean {
+	const itemTypesThatCannotBeDeleted = [ 'domain_redemption' ];
+	if ( itemTypesThatCannotBeDeleted.includes( item.product_slug ) ) {
+		return false;
+	}
+
+	// The Premium plan cannot be removed from the cart when in combination with the DIFM lite product
+	if ( isPremiumPlanWithDIFMInTheCart( item, responseCart ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -26,3 +26,4 @@ export * from './get-introductory-offer-interval-display';
 export * from './join-classes';
 export * from './checkout-line-items';
 export * from './get-country-postal-code-support';
+export * from './can-item-be-removed-from-cart';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This moves the logic that determines if we should show a "Remove from cart" button in the shopping cart to the `@automattic/wpcom-checkout` package. By doing this, we deduplicate the logic and use the same decisions for both the mini-cart and the checkout version of the cart (see the discussion https://github.com/Automattic/wp-calypso/pull/59732#issuecomment-1005607732).

In order to do this, we have to remove one of the guards: we can no longer check for marketplace products in the cart (added in https://github.com/Automattic/wp-calypso/pull/59065) because doing so requires access to the calypso redux state tree that we cannot access in other packages. To mitigate this, @cpapazoglou and I are working to move that guard into the shopping-cart endpoint instead in D72599-code. 

**Do not merge this until that guard is in place!**

#### Testing instructions

First, add a plan to your cart and verify that you can safely remove it from your cart again.

Second, you'll need to modify the `canItemBeRemovedFromCart` to return `false`, and then verify that you can no longer remove products from your cart.