### PR TITLE
 Emails: Update components to use ReactElement type instead of FunctionComponent

### DIFF
--- a/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/index.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { FunctionComponent } from 'react';
 import type {
 	ComparisonTableProps,
 	EmailProviderFeatures,
 } from 'calypso/my-sites/email/email-providers-in-depth-comparison/types';
+import type { ReactElement } from 'react';
 
-const ComparisonTable: FunctionComponent< ComparisonTableProps > = ( { emailProviders } ) => {
+const ComparisonTable: ReactElement< ComparisonTableProps > | null = ( { emailProviders } ) => {
 	return (
 		<div className="email-providers-in-depth-comparison-table">
 			{ emailProviders.map( ( emailProviderFeatures: EmailProviderFeatures, index: number ) => {

--- a/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/comparison-table/index.tsx
@@ -6,7 +6,7 @@ import type {
 } from 'calypso/my-sites/email/email-providers-in-depth-comparison/types';
 import type { ReactElement } from 'react';
 
-const ComparisonTable: ReactElement< ComparisonTableProps > | null = ( { emailProviders } ) => {
+const ComparisonTable = ( { emailProviders }: ComparisonTableProps ): ReactElement => {
 	return (
 		<div className="email-providers-in-depth-comparison-table">
 			{ emailProviders.map( ( emailProviderFeatures: EmailProviderFeatures, index: number ) => {

--- a/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
@@ -4,12 +4,11 @@ import {
 	professionalEmailFeatures,
 	googleWorkspaceFeatures,
 } from 'calypso/my-sites/email/email-providers-in-depth-comparison/data';
-import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-in-depth-comparison/types';
 import type { ReactElement } from 'react';
 
 import './style.scss';
 
-const EmailProvidersInDepthComparison: ReactElement< EmailProvidersInDepthComparisonProps > | null = () => {
+const EmailProvidersInDepthComparison = (): ReactElement => {
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
@@ -8,6 +8,8 @@ import type { ReactElement } from 'react';
 
 import './style.scss';
 
+// This component should accept props with type EmailProvidersInDepthComparisonProps,
+// but that's not possible until we actually use the props in the component.
 const EmailProvidersInDepthComparison = (): ReactElement => {
 	const translate = useTranslate();
 

--- a/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-in-depth-comparison/index.tsx
@@ -1,15 +1,15 @@
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
 import ComparisonTable from 'calypso/my-sites/email/email-providers-in-depth-comparison/comparison-table';
 import {
 	professionalEmailFeatures,
 	googleWorkspaceFeatures,
 } from 'calypso/my-sites/email/email-providers-in-depth-comparison/data';
 import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-in-depth-comparison/types';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
-const EmailProvidersInDepthComparison: FunctionComponent< EmailProvidersInDepthComparisonProps > = () => {
+const EmailProvidersInDepthComparison: ReactElement< EmailProvidersInDepthComparisonProps > | null = () => {
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/email/email-providers-stacked-comparison/billing-interval-toggle/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/billing-interval-toggle/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { ReactElement } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -13,11 +13,10 @@ interface BillingIntervalToggleProps {
 	onIntervalChange: ( intervalLength: IntervalLength ) => void;
 }
 
-export const BillingIntervalToggle: ReactElement< BillingIntervalToggleProps > | null = (
-	props
-) => {
-	const { onIntervalChange = noop, intervalLength } = props;
-
+export const BillingIntervalToggle = ( {
+	intervalLength,
+	onIntervalChange = noop,
+}: BillingIntervalToggleProps ): ReactElement => {
 	const translate = useTranslate();
 
 	const onIntervalClick = ( intervalLength: IntervalLength ) => {

--- a/client/my-sites/email/email-providers-stacked-comparison/billing-interval-toggle/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/billing-interval-toggle/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { FunctionComponent } from 'react';
+import React, { ReactElement } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
 
@@ -13,7 +13,9 @@ interface BillingIntervalToggleProps {
 	onIntervalChange: ( intervalLength: IntervalLength ) => void;
 }
 
-export const BillingIntervalToggle: FunctionComponent< BillingIntervalToggleProps > = ( props ) => {
+export const BillingIntervalToggle: ReactElement< BillingIntervalToggleProps > | null = (
+	props
+) => {
 	const { onIntervalChange = noop, intervalLength } = props;
 
 	const translate = useTranslate();

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { preventWidows } from 'calypso/lib/formatting';
 import type { TranslateResult } from 'i18n-calypso';
-import type { FunctionComponent, MouseEventHandler } from 'react';
+import type { ReactElement, MouseEventHandler } from 'react';
 
 import './style.scss';
 
@@ -10,7 +10,7 @@ export interface EmailProviderStackedFeatureProps {
 	title: TranslateResult;
 }
 
-const EmailProviderStackedFeature: FunctionComponent< EmailProviderStackedFeatureProps > = (
+const EmailProviderStackedFeature: ReactElement< EmailProviderStackedFeatureProps > | null = (
 	props
 ) => {
 	const { title } = props;
@@ -28,7 +28,7 @@ export interface EmailProviderStackedFeaturesProps {
 	features: TranslateResult[];
 }
 
-export const EmailProviderStackedFeatures: FunctionComponent< EmailProviderStackedFeaturesProps > = (
+export const EmailProviderStackedFeatures: ReactElement< EmailProviderStackedFeaturesProps > | null = (
 	props
 ) => {
 	const { features } = props;
@@ -55,7 +55,7 @@ interface EmailProviderStackedFeaturesToggleButtonProps {
 	isRelatedContentExpanded: boolean;
 }
 
-export const EmailProviderStackedFeaturesToggleButton: FunctionComponent< EmailProviderStackedFeaturesToggleButtonProps > = ( {
+export const EmailProviderStackedFeaturesToggleButton: ReactElement< EmailProviderStackedFeaturesToggleButtonProps > | null = ( {
 	handleClick,
 	isRelatedContentExpanded,
 } ) => {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { preventWidows } from 'calypso/lib/formatting';
 import type { TranslateResult } from 'i18n-calypso';
-import type { ReactElement, MouseEventHandler } from 'react';
+import type { MouseEventHandler, ReactElement } from 'react';
 
 import './style.scss';
 
@@ -10,10 +10,9 @@ export interface EmailProviderStackedFeatureProps {
 	title: TranslateResult;
 }
 
-const EmailProviderStackedFeature: ReactElement< EmailProviderStackedFeatureProps > | null = (
-	props
-) => {
-	const { title } = props;
+const EmailProviderStackedFeature = ( {
+	title,
+}: EmailProviderStackedFeatureProps ): ReactElement => {
 	const size = 18;
 	return (
 		<div className="email-provider-stacked-features__feature">
@@ -28,10 +27,9 @@ export interface EmailProviderStackedFeaturesProps {
 	features: TranslateResult[];
 }
 
-export const EmailProviderStackedFeatures: ReactElement< EmailProviderStackedFeaturesProps > | null = (
-	props
-) => {
-	const { features } = props;
+export const EmailProviderStackedFeatures = ( {
+	features,
+}: EmailProviderStackedFeaturesProps ): ReactElement | null => {
 	const translate = useTranslate();
 
 	if ( ! features ) {
@@ -55,10 +53,10 @@ interface EmailProviderStackedFeaturesToggleButtonProps {
 	isRelatedContentExpanded: boolean;
 }
 
-export const EmailProviderStackedFeaturesToggleButton: ReactElement< EmailProviderStackedFeaturesToggleButtonProps > | null = ( {
+export const EmailProviderStackedFeaturesToggleButton = ( {
 	handleClick,
 	isRelatedContentExpanded,
-} ) => {
+}: EmailProviderStackedFeaturesToggleButtonProps ): ReactElement => {
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -8,14 +8,14 @@ import {
 	EmailProviderStackedFeaturesToggleButton,
 } from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features';
 import type { ProviderCard } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props';
-import type { FunctionComponent } from 'react';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-const EmailProvidersStackedCard: FunctionComponent< ProviderCard > = ( props ) => {
+const EmailProvidersStackedCard: ReactElement< ProviderCard > | null = ( props ) => {
 	const {
 		children,
 		className,

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -8,38 +8,36 @@ import {
 	EmailProviderStackedFeaturesToggleButton,
 } from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features';
 import type { ProviderCard } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props';
-import type { ReactElement } from 'react';
+import type { MouseEvent, ReactElement } from 'react';
 
 import './style.scss';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-const EmailProvidersStackedCard: ReactElement< ProviderCard > | null = ( props ) => {
-	const {
-		children,
-		className,
-		description,
-		detailsExpanded,
-		expandButtonLabel,
-		features,
-		footerBadge,
-		formFields,
-		logo,
-		onExpandedChange = noop,
-		priceBadge = null,
-		productName,
-		providerKey,
-		showExpandButton = true,
-	} = props;
-
+const EmailProvidersStackedCard = ( {
+	children,
+	className,
+	description,
+	detailsExpanded,
+	expandButtonLabel,
+	features,
+	footerBadge,
+	formFields,
+	logo,
+	onExpandedChange = noop,
+	priceBadge = null,
+	productName,
+	providerKey,
+	showExpandButton = true,
+}: ProviderCard ): ReactElement => {
 	const [ areFeaturesExpanded, setFeaturesExpanded ] = useState( false );
 
 	const isViewportSizeLowerThan660px = useBreakpoint( '<660px' );
 
 	const showFeaturesToggleButton = detailsExpanded && isViewportSizeLowerThan660px;
 
-	const toggleVisibility = ( event: React.MouseEvent ): void => {
+	const toggleVisibility = ( event: MouseEvent ): void => {
 		event.preventDefault();
 
 		onExpandedChange( providerKey, ! detailsExpanded );

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -27,7 +27,7 @@ import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwar
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
-import type { FunctionComponent } from 'react';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -52,7 +52,7 @@ type EmailProvidersStackedComparisonProps = {
 	source: string;
 };
 
-const EmailProvidersStackedComparison: FunctionComponent< EmailProvidersStackedComparisonProps > = (
+const EmailProvidersStackedComparison: ReactElement< EmailProvidersStackedComparisonProps > | null = (
 	props
 ) => {
 	const {

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -52,22 +52,18 @@ type EmailProvidersStackedComparisonProps = {
 	source: string;
 };
 
-const EmailProvidersStackedComparison: ReactElement< EmailProvidersStackedComparisonProps > | null = (
-	props
-) => {
-	const {
-		comparisonContext,
-		currentRoute,
-		domain,
-		domainsWithForwards,
-		isGSuiteSupported,
-		selectedDomainName,
-		selectedSite,
-		showEmailForwardLink = true,
-		siteName,
-		source,
-	} = props;
-
+const EmailProvidersStackedComparison = ( {
+	comparisonContext,
+	currentRoute,
+	domain,
+	domainsWithForwards,
+	isGSuiteSupported,
+	selectedDomainName,
+	selectedSite,
+	showEmailForwardLink = true,
+	siteName,
+	source,
+}: EmailProvidersStackedComparisonProps ): ReactElement => {
 	const translate = useTranslate();
 
 	const [ intervalLength, setIntervalLengthPure ] = useState( IntervalLength.ANNUALLY );

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -36,6 +36,7 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { addToCartAndCheckout, recordTracksEventAddToCartClick, IntervalLength } from './utils';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement } from 'react';
 
 import './google-workspace-card.scss';
@@ -47,7 +48,7 @@ function identityMap< T >( item: T ): T {
 	return item;
 }
 
-const getGoogleFeatures = () => {
+const getGoogleFeatures = (): TranslateResult[] => {
 	return [
 		translate( 'Send and receive from your custom domain' ),
 		translate( '30GB storage' ),
@@ -72,17 +73,21 @@ const googleWorkspaceCardInformation: ProviderCard = {
 	features: getGoogleFeatures(),
 };
 
-const GoogleWorkspaceCard: ReactElement< EmailProvidersStackedCardProps > | null = ( props ) => {
-	const {
-		currencyCode = '',
-		detailsExpanded,
-		domain,
-		gSuiteProductMonthly,
-		gSuiteProductYearly,
-		onExpandedChange,
-		selectedDomainName,
-		intervalLength,
-	} = props;
+const GoogleWorkspaceCard = ( {
+	comparisonContext,
+	currencyCode = '',
+	detailsExpanded,
+	domain,
+	gSuiteProductMonthly,
+	gSuiteProductYearly,
+	hasCartDomain,
+	intervalLength,
+	onExpandedChange,
+	selectedDomainName,
+	selectedSite,
+	shoppingCartManager,
+	source,
+}: EmailProvidersStackedCardProps ): ReactElement => {
 	const googleWorkspace: ProviderCard = { ...googleWorkspaceCardInformation };
 	googleWorkspace.detailsExpanded = detailsExpanded;
 
@@ -93,10 +98,10 @@ const GoogleWorkspaceCard: ReactElement< EmailProvidersStackedCardProps > | null
 
 	const priceWithInterval = (
 		<PriceWithInterval
-			intervalLength={ intervalLength }
 			cost={ gSuiteProduct?.cost ?? 0 }
 			currencyCode={ currencyCode ?? '' }
 			hasDiscount={ productIsDiscounted }
+			intervalLength={ intervalLength }
 			sale={ gSuiteProduct?.sale_cost ?? null }
 		/>
 	);
@@ -149,17 +154,6 @@ const GoogleWorkspaceCard: ReactElement< EmailProvidersStackedCardProps > | null
 	const [ addingToCart, setAddingToCart ] = useState( false );
 
 	const onGoogleConfirmNewMailboxes = () => {
-		const {
-			comparisonContext,
-			domain,
-			gSuiteProductMonthly,
-			gSuiteProductYearly,
-			hasCartDomain,
-			selectedSite,
-			shoppingCartManager,
-			source,
-		} = props;
-
 		const gSuiteProduct =
 			intervalLength === IntervalLength.MONTHLY ? gSuiteProductMonthly : gSuiteProductYearly;
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -4,7 +4,7 @@ import {
 } from '@automattic/calypso-products';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { translate } from 'i18n-calypso';
-import { FunctionComponent, useState } from 'react';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -36,6 +36,7 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { addToCartAndCheckout, recordTracksEventAddToCartClick, IntervalLength } from './utils';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { ReactElement } from 'react';
 
 import './google-workspace-card.scss';
 
@@ -71,7 +72,7 @@ const googleWorkspaceCardInformation: ProviderCard = {
 	features: getGoogleFeatures(),
 };
 
-const GoogleWorkspaceCard: FunctionComponent< EmailProvidersStackedCardProps > = ( props ) => {
+const GoogleWorkspaceCard: ReactElement< EmailProvidersStackedCardProps > | null = ( props ) => {
 	const {
 		currencyCode = '',
 		detailsExpanded,

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-badge.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-badge.tsx
@@ -6,9 +6,10 @@ type PriceBadgeProps = {
 	priceComponent: ReactElement;
 };
 
-const PriceBadge: ReactElement< PriceBadgeProps > | null = ( props ) => {
-	const { additionalPriceInformationComponent, priceComponent } = props;
-
+const PriceBadge = ( {
+	additionalPriceInformationComponent,
+	priceComponent,
+}: PriceBadgeProps ): ReactElement => {
 	return (
 		<div className="provider-cards__price-badge">
 			<PromoCardPrice

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-badge.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-badge.tsx
@@ -1,12 +1,12 @@
 import PromoCardPrice from 'calypso/components/promo-section/promo-card/price';
-import type { FunctionComponent, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 type PriceBadgeProps = {
 	additionalPriceInformationComponent?: ReactElement | null;
 	priceComponent: ReactElement;
 };
 
-const PriceBadge: FunctionComponent< PriceBadgeProps > = ( props ) => {
+const PriceBadge: ReactElement< PriceBadgeProps > | null = ( props ) => {
 	const { additionalPriceInformationComponent, priceComponent } = props;
 
 	return (

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-with-interval.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-with-interval.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
 import type { TranslateResult } from 'i18n-calypso';
-import type { FunctionComponent } from 'react';
+import type { ReactElement } from 'react';
 
 type PriceWithIntervalProps = {
 	cost: number;
@@ -13,7 +13,7 @@ type PriceWithIntervalProps = {
 	sale?: number | null;
 };
 
-const PriceWithInterval: FunctionComponent< PriceWithIntervalProps > = ( props ) => {
+const PriceWithInterval: ReactElement< PriceWithIntervalProps > | null = ( props ) => {
 	const { cost, currencyCode, hasDiscount, sale, intervalLength } = props;
 
 	const showSale = sale && sale !== 0;

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-with-interval.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/price-with-interval.tsx
@@ -13,9 +13,13 @@ type PriceWithIntervalProps = {
 	sale?: number | null;
 };
 
-const PriceWithInterval: ReactElement< PriceWithIntervalProps > | null = ( props ) => {
-	const { cost, currencyCode, hasDiscount, sale, intervalLength } = props;
-
+const PriceWithInterval = ( {
+	cost,
+	currencyCode,
+	hasDiscount,
+	intervalLength,
+	sale,
+}: PriceWithIntervalProps ): ReactElement => {
 	const showSale = sale && sale !== 0;
 
 	const priceClassName = classNames( 'provider-cards__price-with-interval-price', {

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -72,22 +72,21 @@ const professionalEmailCardInformation: ProviderCard = {
 	features: getTitanFeatures(),
 };
 
-const ProfessionalEmailCard: ReactElement< EmailProvidersStackedCardProps > | null = ( props ) => {
-	const {
-		currencyCode = '',
-		hasCartDomain,
-		detailsExpanded,
-		domain,
-		onExpandedChange,
-		selectedDomainName,
-		intervalLength,
-		titanMailMonthlyProduct,
-		titanMailYearlyProduct,
-		comparisonContext,
-		shoppingCartManager,
-		selectedSite,
-		source,
-	} = props;
+const ProfessionalEmailCard = ( {
+	currencyCode = '',
+	hasCartDomain,
+	detailsExpanded,
+	domain,
+	onExpandedChange,
+	selectedDomainName,
+	intervalLength,
+	titanMailMonthlyProduct,
+	titanMailYearlyProduct,
+	comparisonContext,
+	shoppingCartManager,
+	selectedSite,
+	source,
+}: EmailProvidersStackedCardProps ): ReactElement => {
 	const professionalEmail: ProviderCard = { ...professionalEmailCardInformation };
 	professionalEmail.detailsExpanded = detailsExpanded;
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -2,7 +2,7 @@ import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from '@automattic/cal
 import { Gridicon } from '@automattic/components';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { translate } from 'i18n-calypso';
-import { FunctionComponent, useState } from 'react';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
 import {
@@ -39,6 +39,7 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { addToCartAndCheckout, IntervalLength, recordTracksEventAddToCartClick } from './utils';
 import type { EmailProvidersStackedCardProps, ProviderCard } from './provider-card-props';
+import type { ReactElement } from 'react';
 
 import './professional-email-card.scss';
 
@@ -71,7 +72,7 @@ const professionalEmailCardInformation: ProviderCard = {
 	features: getTitanFeatures(),
 };
 
-const ProfessionalEmailCard: FunctionComponent< EmailProvidersStackedCardProps > = ( props ) => {
+const ProfessionalEmailCard: ReactElement< EmailProvidersStackedCardProps > | null = ( props ) => {
 	const {
 		currencyCode = '',
 		hasCartDomain,

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -7,6 +7,7 @@ export interface ProviderCard {
 	additionalPriceInformation?: TranslateResult;
 	badge?: ReactElement;
 	billingPeriod?: TranslateResult;
+	children?: any;
 	className?: string;
 	description: TranslateResult;
 	detailsExpanded?: boolean;
@@ -17,7 +18,7 @@ export interface ProviderCard {
 	formFields?: ReactElement;
 	logo?: ReactElement | { path: string; className?: string };
 	onExpandedChange?: ( providerKey: string, expanded: boolean ) => void;
-	priceBadge?: ReactElement | TranslateResult;
+	priceBadge?: ReactElement | TranslateResult | null;
 	productName: TranslateResult;
 	providerKey: string;
 	showExpandButton?: boolean;

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -23,7 +23,7 @@ type GoogleSaleBannerProps = {
 	domains: Array< ResponseDomain >;
 };
 
-const GoogleSaleBanner: ReactElement< GoogleSaleBannerProps > | null = ( { domains } ) => {
+const GoogleSaleBanner = ( { domains }: GoogleSaleBannerProps ): ReactElement => {
 	const translate = useTranslate();
 
 	const canCurrentUserPurchaseGSuite = useSelector( canUserPurchaseGSuite );

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -23,7 +23,7 @@ type GoogleSaleBannerProps = {
 	domains: Array< ResponseDomain >;
 };
 
-const GoogleSaleBanner = ( { domains }: GoogleSaleBannerProps ): ReactElement => {
+const GoogleSaleBanner = ( { domains }: GoogleSaleBannerProps ): ReactElement | null => {
 	const translate = useTranslate();
 
 	const canCurrentUserPurchaseGSuite = useSelector( canUserPurchaseGSuite );

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -1,7 +1,6 @@
 import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import { Banner } from 'calypso/components/banner';
@@ -16,6 +15,7 @@ import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -23,7 +23,7 @@ type GoogleSaleBannerProps = {
 	domains: Array< ResponseDomain >;
 };
 
-const GoogleSaleBanner: FunctionComponent< GoogleSaleBannerProps > = ( { domains } ) => {
+const GoogleSaleBanner: ReactElement< GoogleSaleBannerProps > | null = ( { domains } ) => {
 	const translate = useTranslate();
 
 	const canCurrentUserPurchaseGSuite = useSelector( canUserPurchaseGSuite );


### PR DESCRIPTION
This pull request addresses [this comment](https://github.com/Automattic/wp-calypso/pull/59714/files#r778290020) about defining the type of components with `ReactElement` instead of `FunctionComponent`. Per facebook/create-react-app#8177, the latter is indeed no longer recommended.

#### Testing instructions

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout update/email-components-type` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/59775#issuecomment-1005976449)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Assert that everything works as before
6. Click the `See how they compare` link to access the `In-Depth Comparison` page
7. Assert that the page displays correctly
