### PR TITLE
Remove/woop flag from install workflow

### DIFF
--- a/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
+++ b/client/my-sites/woocommerce/dashboard/required-plugins-install-view.jsx
@@ -580,7 +580,7 @@ class RequiredPluginsInstallView extends Component {
 			return (
 				<>
 					<SetupNotices />
-					<WoopLandingPage siteId={ siteId } startSetup={ this.startSetup } />
+					<WoopLandingPage siteId={ siteId } />
 				</>
 			);
 		}

--- a/client/my-sites/woocommerce/index.js
+++ b/client/my-sites/woocommerce/index.js
@@ -28,12 +28,6 @@ function setup( context, next ) {
 	const site = getSelectedSiteWithFallback( state );
 	const siteId = site ? site.ID : null;
 
-	// Redirect unless the woop feature flag is enabled.
-	// todo: remove redirect and rely on plan eligibility checks in the landing page component
-	if ( ! isEnabled( 'woop' ) ) {
-		return page.redirect( `/home/${ site.slug }` );
-	}
-
 	// WooCommerce plugin is already installed, redirect to Woo.
 	// todo: replace with a plugin check that replaces the cta with a link to wc-admin
 	// instead of passive redirect.

--- a/client/my-sites/woocommerce/index.js
+++ b/client/my-sites/woocommerce/index.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { createElement } from 'react';
 import { makeLayout } from 'calypso/controller';

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -28,7 +28,7 @@ interface Props {
 
 const images = [ { src: Image01 }, { src: Image02 }, { src: Image03 }, { src: Image04 } ];
 
-const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId } ) => {
+const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	const { __ } = useI18n();
 	const navigationItems = [ { label: 'WooCommerce' } ];
 	const ctaRef = useRef( null );
@@ -38,16 +38,12 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { startSetup, siteId
 	);
 
 	function onCTAClickHandler() {
-		if ( isEnabled( 'woop' ) ) {
-			recordTracksEvent( 'calypso_woocommerce_dashboard_action_click', {
-				action: 'initial-setup',
-				feature: 'woop', // WooCommerce on Plans
-			} );
+		recordTracksEvent( 'calypso_woocommerce_dashboard_action_click', {
+			action: 'initial-setup',
+			feature: 'woop', // WooCommerce on Plans
+		} );
 
-			return page( `/start/woocommerce-install/?site=${ wpcomDomain }` );
-		}
-
-		return startSetup();
+		return page( `/start/woocommerce-install/?site=${ wpcomDomain }` );
 	}
 
 	function renderWarningNotice() {

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -101,7 +101,7 @@
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
 		"redirect-fallback-browsers": true,
-		"woop": true
+		"woop": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -108,7 +108,7 @@
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
 		"redirect-fallback-browsers": true,
-		"woop": true
+		"woop": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,7 +106,7 @@
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
 		"woocommerce/extension-referrers": false,
-		"woop": true,
+		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,7 +120,7 @@
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false,
 		"redirect-fallback-browsers": true,
-		"woop": true
+		"woop": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the woop flag checks from the install workflow

#### Testing instructions

Confirm the feature is working as usual. These changes should not change its functionality.

* go to landing page: `http://calypso.localhost:3000/start/woocommerce-install/confirm?site=<testing-site>`
* It should go to `confirm` step...
* and so on...

Related to:
* https://github.com/Automattic/wp-calypso/pull/59505
