### PR TITLE
woop: adding feature flag check for onboarding steps

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -423,7 +423,9 @@ export function generateFlows( {
 		{
 			name: 'woocommerce-install',
 			pageTitle: translate( 'Add WooCommerce to your site' ),
-			steps: [ 'confirm', 'transfer' ],
+			steps: isEnabled( 'woop' )
+				? [ 'store-address', 'confirm', 'transfer' ]
+				: [ 'confirm', 'transfer' ],
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',
 			providesDependenciesInQuery: [ 'site' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Checking the woop feature flag to showcase the onboarding steps.

#### Testing instructions

* When https://github.com/Automattic/wp-calypso/pull/59505 is merged
* On a site without the woocommerce plugin installed navigate to http://calypso.localhost:3000/woocommerce-installation/
* Click on "Setup my Store"
* Should navigate to the address step.


Related to:
* https://github.com/Automattic/wp-calypso/pull/59505
* https://github.com/Automattic/wp-calypso/pull/59785
