### PR TITLE
Redirect even fewer assets

### DIFF
--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -55,7 +55,9 @@ function allowPath( path ) {
 		? path.replace( new RegExp( `^/${ prefixedLocale }` ), '' )
 		: path;
 
-	const allowedPaths = [ '/browsehappy', '/themes', '/theme', '/calypso/evergreen' ];
+	// '/calypso' is the static assets path, and should never be redirected. (Can
+	// cause CDN caching issues if an asset gets cached with a redirect.)
+	const allowedPaths = [ '/browsehappy', '/themes', '/theme', '/calypso' ];
 	// For example, match either exactly "/themes" or "/themes/*"
 	return allowedPaths.some( ( p ) => parsedPath === p || parsedPath.startsWith( p + '/' ) );
 }


### PR DESCRIPTION
Don't redirect anything in `/calypso`, which is the static assets path. 