### PR TITLE
Signup: Remove onboarding-with-preview flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -86,21 +86,6 @@ export function generateFlows( {
 			lastModified: '2019-06-20',
 		},
 		{
-			name: 'onboarding-with-preview',
-			steps: [
-				'user',
-				'site-type',
-				'site-topic-with-preview',
-				'site-title-with-preview',
-				'domains-with-preview',
-				'plans',
-			],
-			destination: getSignupDestination,
-			description: 'The improved onboarding flow.',
-			lastModified: '2020-03-03',
-			showRecaptcha: true,
-		},
-		{
 			name: 'onboarding',
 			steps: isEnabled( 'signup/professional-email-step' )
 				? [ 'user', 'domains', 'emails', 'plans' ]

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -43,7 +43,6 @@ const stepNameToModuleName = {
 	'site-options': 'site-options',
 	'site-topic': 'site-topic',
 	'site-topic-with-theme': 'site-topic',
-	'site-type': 'site-type',
 	'site-type-with-theme': 'site-type',
 	'starting-point': 'starting-point',
 	survey: 'survey',
@@ -58,10 +57,6 @@ const stepNameToModuleName = {
 	'oauth2-name': 'user',
 	displayname: 'user',
 	'reader-landing': 'reader-landing',
-	// Steps with preview
-	'site-topic-with-preview': 'site-topic',
-	'domains-with-preview': 'domains',
-	'site-title-with-preview': 'site-title',
 	passwordless: 'passwordless',
 	'p2-details': 'p2-details',
 	'p2-site': 'p2-site',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -559,13 +559,6 @@ export function generateSteps( {
 			providesDependencies: [],
 		},
 
-		/* Improved Onboarding */
-		'site-type': {
-			stepName: 'site-type',
-			providesDependencies: [ 'siteType', 'themeSlugWithRepo' ],
-			fulfilledStepCallback: isSiteTypeFulfilled,
-		},
-
 		'site-type-with-theme': {
 			stepName: 'site-type',
 			providesDependencies: [ 'siteType' ],
@@ -583,45 +576,6 @@ export function generateSteps( {
 			stepName: 'site-topic',
 			providesDependencies: [ 'siteTopic' ],
 			fulfilledStepCallback: isSiteTopicFulfilled,
-		},
-
-		// Steps with preview
-		// These can be removed once we make the preview the default
-		'site-topic-with-preview': {
-			stepName: 'site-topic-with-preview',
-			providesDependencies: [ 'siteTopic', 'themeSlugWithRepo' ],
-			optionalDependencies: [ 'themeSlugWithRepo' ],
-			fulfilledStepCallback: isSiteTopicFulfilled,
-			props: {
-				showSiteMockups: true,
-			},
-		},
-
-		'domains-with-preview': {
-			stepName: 'domains-with-preview',
-			apiRequestFunction: createSiteWithCart,
-			providesDependencies: [
-				'siteId',
-				'siteSlug',
-				'domainItem',
-				'themeItem',
-				'shouldHideFreePlan',
-			],
-			optionalDependencies: [ 'shouldHideFreePlan' ],
-			props: {
-				showSiteMockups: true,
-				isDomainOnly: false,
-			},
-			dependencies: [ 'themeSlugWithRepo' ],
-			delayApiRequestUntilComplete: true,
-		},
-
-		'site-title-with-preview': {
-			stepName: 'site-title-with-preview',
-			providesDependencies: [ 'siteTitle' ],
-			props: {
-				showSiteMockups: true,
-			},
 		},
 
 		launch: {

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -184,7 +184,7 @@ class SiteMockups extends Component {
 }
 
 export default connect(
-	( state, ownProps ) => {
+	( state ) => {
 		const siteType = getSiteType( state );
 		const themeSlug = getSiteTypePropertyValue( 'slug', siteType, 'theme' );
 		const titleFallback = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupTitleFallback' );
@@ -199,9 +199,6 @@ export default connect(
 			verticalPreviewStyles: getSiteVerticalPreviewStyles( state ),
 			siteVerticalName: getSiteVerticalName( state ),
 			verticalSlug: getSiteVerticalSlug( state ),
-			shouldShowHelpTip:
-				'site-topic-with-preview' === ownProps.stepName ||
-				'site-title-with-preview' === ownProps.stepName,
 			themeSlug: themeSlug,
 			fontUrl: defaultFontUri,
 			shouldFetchVerticalData,

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -154,7 +154,7 @@ class AboutStep extends Component {
 
 	handleSubmit = ( event ) => {
 		event.preventDefault();
-		const { goToNextStep, stepName, flowName, shouldHideSiteTitle, previousFlowName } = this.props;
+		const { goToNextStep, stepName, flowName, previousFlowName } = this.props;
 
 		//Defaults
 		let themeRepo = 'pub/radcliffe-2';
@@ -167,15 +167,13 @@ class AboutStep extends Component {
 		const siteTopicInput = formState.getFieldValue( this.state.form, 'siteTopic' );
 		const eventAttributes = {};
 
-		if ( ! shouldHideSiteTitle ) {
-			//Site Title
-			const siteTitleInput = formState.getFieldValue( this.state.form, 'siteTitle' );
-			if ( siteTitleInput !== '' ) {
-				siteTitleValue = siteTitleInput;
-				this.props.setSiteTitle( siteTitleValue );
-			}
-			eventAttributes.site_title = siteTitleInput || 'N/A';
+		//Site Title
+		const siteTitleInput = formState.getFieldValue( this.state.form, 'siteTitle' );
+		if ( siteTitleInput !== '' ) {
+			siteTitleValue = siteTitleInput;
+			this.props.setSiteTitle( siteTitleValue );
 		}
+		eventAttributes.site_title = siteTitleInput || 'N/A';
 
 		// Set Site Topic value for tracking/marketing
 		eventAttributes.site_topic = this.state.hasPrepopulatedVertical
@@ -409,7 +407,7 @@ class AboutStep extends Component {
 	}
 
 	renderContent() {
-		const { translate, siteTitle, shouldHideSiteTitle } = this.props;
+		const { translate, siteTitle } = this.props;
 
 		const { siteTopicValue } = this.state;
 
@@ -418,28 +416,24 @@ class AboutStep extends Component {
 				<div className="about__form-wrapper">
 					<form onSubmit={ this.handleSubmit }>
 						<Card>
-							{ ! shouldHideSiteTitle && (
-								<FormFieldset>
-									<FormLabel htmlFor="siteTitle">
-										{ translate( 'What would you like to name your site?' ) }
-										<InfoPopover className="about__info-popover" position="top">
-											{ translate(
-												"We'll use this as your site title. " +
-													"Don't worry, you can change this later."
-											) }
-										</InfoPopover>
-									</FormLabel>
-									<FormTextInput
-										id="siteTitle"
-										name="siteTitle"
-										placeholder={ translate(
-											"E.g., Mel's Diner, Stevie’s Blog, Vail Renovations"
+							<FormFieldset>
+								<FormLabel htmlFor="siteTitle">
+									{ translate( 'What would you like to name your site?' ) }
+									<InfoPopover className="about__info-popover" position="top">
+										{ translate(
+											"We'll use this as your site title. " +
+												"Don't worry, you can change this later."
 										) }
-										defaultValue={ siteTitle }
-										onChange={ this.handleChangeEvent }
-									/>
-								</FormFieldset>
-							) }
+									</InfoPopover>
+								</FormLabel>
+								<FormTextInput
+									id="siteTitle"
+									name="siteTitle"
+									placeholder={ translate( "E.g., Mel's Diner, Stevie’s Blog, Vail Renovations" ) }
+									defaultValue={ siteTitle }
+									onChange={ this.handleChangeEvent }
+								/>
+							</FormFieldset>
 
 							{ this.shouldShowSiteTopicField() && (
 								<FormFieldset>
@@ -509,7 +503,7 @@ class AboutStep extends Component {
 }
 
 export default connect(
-	( state, ownProps ) => ( {
+	( state ) => ( {
 		siteTitle: getSiteTitle( state ),
 		siteGoals: getSiteGoals( state ),
 		siteTopic: getSurveyVertical( state ),
@@ -517,10 +511,6 @@ export default connect(
 		isLoggedIn: isUserLoggedIn( state ),
 		verticalId: getSiteVerticalId( state ),
 		verticalParentId: getSiteVerticalParentId( state ),
-		shouldHideSiteTitle:
-			'onboarding' === ownProps.flowName && includes( ownProps.steps, 'site-title' ),
-		shouldSkipAboutStep:
-			includes( ownProps.steps, 'site-topic' ) && includes( ownProps.steps, 'site-title' ),
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
 	{

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -543,14 +543,10 @@ export default connect(
 		isLoggedIn: isUserLoggedIn( state ),
 		verticalId: getSiteVerticalId( state ),
 		verticalParentId: getSiteVerticalParentId( state ),
-		shouldHideSiteGoals:
-			'onboarding' === ownProps.flowName && includes( ownProps.steps, 'site-type' ),
 		shouldHideSiteTitle:
 			'onboarding' === ownProps.flowName && includes( ownProps.steps, 'site-title' ),
 		shouldSkipAboutStep:
-			includes( ownProps.steps, 'site-type' ) &&
-			includes( ownProps.steps, 'site-topic' ) &&
-			includes( ownProps.steps, 'site-title' ),
+			includes( ownProps.steps, 'site-topic' ) && includes( ownProps.steps, 'site-title' ),
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
 	{

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -12,7 +12,6 @@ import InfoPopover from 'calypso/components/info-popover';
 import SegmentedControl from 'calypso/components/segmented-control';
 import SiteVerticalsSuggestionSearch from 'calypso/components/site-verticals-suggestion-search';
 import formState from 'calypso/lib/form-state';
-import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { isValidLandingPageVertical } from 'calypso/lib/signup/verticals';
 import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -26,7 +25,6 @@ import { setSiteGoals } from 'calypso/state/signup/steps/site-goals/actions';
 import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
 import { setSiteTitle } from 'calypso/state/signup/steps/site-title/actions';
 import { getSiteTitle } from 'calypso/state/signup/steps/site-title/selectors';
-import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { setSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
 import {
 	getSiteVerticalId,
@@ -156,15 +154,7 @@ class AboutStep extends Component {
 
 	handleSubmit = ( event ) => {
 		event.preventDefault();
-		const {
-			goToNextStep,
-			stepName,
-			flowName,
-			shouldHideSiteTitle,
-			shouldHideSiteGoals,
-			previousFlowName,
-			siteType,
-		} = this.props;
+		const { goToNextStep, stepName, flowName, shouldHideSiteTitle, previousFlowName } = this.props;
 
 		//Defaults
 		let themeRepo = 'pub/radcliffe-2';
@@ -213,41 +203,28 @@ class AboutStep extends Component {
 		} );
 
 		//Site Goals
-		if ( shouldHideSiteGoals ) {
-			themeRepo =
-				getSiteTypePropertyValue( 'slug', siteType, 'theme' ) || 'pub/independent-publisher-2';
+		const siteGoalsInput = formState.getFieldValue( this.state.form, 'siteGoals' );
+		const siteGoalsArray = siteGoalsInput.split( ',' );
+		const siteGoalsGroup = siteGoalsArray.sort().join();
 
-			if ( 'ecommerce' === flowName ) {
-				designType = 'page';
-			} else {
-				designType = getSiteTypePropertyValue( 'slug', siteType, 'designType' ) || 'blog';
-			}
+		this.props.setSiteGoals( siteGoalsInput );
+		themeRepo = this.state.hasPrepopulatedVertical
+			? 'pub/radcliffe-2'
+			: getThemeForSiteGoals( siteGoalsInput );
+		designType = getDesignTypeForSiteGoals( siteGoalsInput, flowName );
 
-			eventAttributes.site_type = siteType;
-		} else {
-			const siteGoalsInput = formState.getFieldValue( this.state.form, 'siteGoals' );
-			const siteGoalsArray = siteGoalsInput.split( ',' );
-			const siteGoalsGroup = siteGoalsArray.sort().join();
+		for ( let i = 0; i < siteGoalsArray.length; i++ ) {
+			eventAttributes[ `site_goal_${ siteGoalsArray[ i ] }` ] = true;
+		}
 
-			this.props.setSiteGoals( siteGoalsInput );
-			themeRepo = this.state.hasPrepopulatedVertical
-				? 'pub/radcliffe-2'
-				: getThemeForSiteGoals( siteGoalsInput );
-			designType = getDesignTypeForSiteGoals( siteGoalsInput, flowName );
+		eventAttributes.site_goal_selections = siteGoalsGroup;
 
-			for ( let i = 0; i < siteGoalsArray.length; i++ ) {
-				eventAttributes[ `site_goal_${ siteGoalsArray[ i ] }` ] = true;
-			}
-
-			eventAttributes.site_goal_selections = siteGoalsGroup;
-
-			//Store
-			if ( designType === DESIGN_TYPE_STORE ) {
-				nextFlowName =
-					siteGoalsArray.indexOf( 'sell' ) === -1 && previousFlowName
-						? previousFlowName
-						: 'ecommerce';
-			}
+		//Store
+		if ( designType === DESIGN_TYPE_STORE ) {
+			nextFlowName =
+				siteGoalsArray.indexOf( 'sell' ) === -1 && previousFlowName
+					? previousFlowName
+					: 'ecommerce';
 		}
 
 		//SET DESIGN TYPE
@@ -432,7 +409,7 @@ class AboutStep extends Component {
 	}
 
 	renderContent() {
-		const { translate, siteTitle, shouldHideSiteTitle, shouldHideSiteGoals } = this.props;
+		const { translate, siteTitle, shouldHideSiteTitle } = this.props;
 
 		const { siteTopicValue } = this.state;
 
@@ -479,14 +456,12 @@ class AboutStep extends Component {
 								</FormFieldset>
 							) }
 
-							{ ! shouldHideSiteGoals && (
-								<FormFieldset>
-									<FormLegend>
-										{ translate( 'What’s the primary goal you have for your site?' ) }
-									</FormLegend>
-									{ this.renderGoalCheckboxes() }
-								</FormFieldset>
-							) }
+							<FormFieldset>
+								<FormLegend>
+									{ translate( 'What’s the primary goal you have for your site?' ) }
+								</FormLegend>
+								{ this.renderGoalCheckboxes() }
+							</FormFieldset>
 
 							{ this.renderExperienceOptions() }
 
@@ -539,7 +514,6 @@ export default connect(
 		siteGoals: getSiteGoals( state ),
 		siteTopic: getSurveyVertical( state ),
 		userExperience: getUserExperience( state ),
-		siteType: getSiteType( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		verticalId: getSiteVerticalId( state ),
 		verticalParentId: getSiteVerticalParentId( state ),

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -131,7 +131,6 @@ export default withSchemaValidation( schema, ( state = {}, action ) => {
 		case SIGNUP_PROGRESS_SUBMIT_STEP:
 			return submitStep( state, action );
 		case SIGNUP_STEPS_SITE_TYPE_SET:
-			delete state[ 'domains-with-preview' ];
 			return state;
 		case SIGNUP_PROGRESS_REMOVE_STEP:
 			return removeStep( state, action );

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -8,7 +8,6 @@ import {
 	SIGNUP_PROGRESS_PROCESS_STEP,
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
-	SIGNUP_STEPS_SITE_TYPE_SET,
 	SIGNUP_PROGRESS_REMOVE_STEP,
 	SIGNUP_PROGRESS_ADD_STEP,
 } from 'calypso/state/action-types';
@@ -130,8 +129,6 @@ export default withSchemaValidation( schema, ( state = {}, action ) => {
 			return saveStep( state, action );
 		case SIGNUP_PROGRESS_SUBMIT_STEP:
 			return submitStep( state, action );
-		case SIGNUP_STEPS_SITE_TYPE_SET:
-			return state;
 		case SIGNUP_PROGRESS_REMOVE_STEP:
 			return removeStep( state, action );
 	}

--- a/client/state/signup/steps/site-type/actions.js
+++ b/client/state/signup/steps/site-type/actions.js
@@ -1,4 +1,3 @@
-import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { SIGNUP_STEPS_SITE_TYPE_SET } from 'calypso/state/action-types';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 
@@ -11,21 +10,9 @@ export function setSiteType( siteType ) {
 	};
 }
 
-export function submitSiteType( siteType, stepName = 'site-type' ) {
+export function submitSiteType( siteType, stepName ) {
 	return ( dispatch ) => {
 		dispatch( setSiteType( siteType ) );
-
-		let themeSlugWithRepo = undefined;
-		if ( 'site-type-with-theme' !== stepName ) {
-			themeSlugWithRepo =
-				getSiteTypePropertyValue( 'slug', siteType, 'theme' ) || 'pub/independent-publisher-2';
-		}
-
-		dispatch(
-			submitSignupStep(
-				{ stepName },
-				{ siteType, ...( themeSlugWithRepo && { themeSlugWithRepo } ) }
-			)
-		);
+		dispatch( submitSignupStep( { stepName }, { siteType } ) );
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As pbAok1-2hj-p2#comment-4634 mentioned, `onboarding-with-preview` is no longer used, remove the flow to keep codebase simple

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nope because the flow is already abandoned

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56264