### PR TITLE
DIFM Lite: Adds button to skip design selection

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -770,14 +770,15 @@ export function generateSteps( {
 			apiRequestFunction: setDesignIfNewSite,
 			delayApiRequestUntilComplete: true,
 			dependencies: [ 'siteSlug', 'newOrExistingSiteChoice' ],
-			providesDependencies: [ 'selectedDesign', 'selectedSiteCategory' ],
-			optionalDependencies: [ 'selectedDesign' ],
+			providesDependencies: [ 'selectedDesign', 'selectedSiteCategory', 'isLetUsChooseSelected' ],
+			optionalDependencies: [ 'selectedDesign', 'isLetUsChooseSelected' ],
 			props: {
 				hideSkip: true,
 				hideExternalPreview: true,
 				useDIFMThemes: true,
 				showDesignPickerCategories: true,
 				showDesignPickerCategoriesAllFilter: false,
+				showLetUsChoose: true,
 			},
 		},
 		'site-info-collection': {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -23,11 +23,19 @@ import { getStepUrl } from 'calypso/signup/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import DIFMThemes from '../difm-design-picker/themes';
+import LetUsChoose from './let-us-choose';
 import PreviewToolbar from './preview-toolbar';
 import './style.scss';
 
 export default function DesignPickerStep( props ) {
-	const { flowName, stepName, isReskinned, queryParams, showDesignPickerCategories } = props;
+	const {
+		flowName,
+		stepName,
+		isReskinned,
+		queryParams,
+		showDesignPickerCategories,
+		showLetUsChoose,
+	} = props;
 
 	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
 	const useFeaturedPicksButtons =
@@ -92,7 +100,7 @@ export default function DesignPickerStep( props ) {
 		sort: sortBlogToTop,
 	} );
 
-	function pickDesign( _selectedDesign ) {
+	function pickDesign( _selectedDesign, additionalDependencies = {} ) {
 		// Design picker preview will submit the defaultDependencies via next button,
 		// So only do this when the user picks the design directly
 		dispatch(
@@ -103,6 +111,7 @@ export default function DesignPickerStep( props ) {
 				{
 					selectedDesign: _selectedDesign,
 					selectedSiteCategory: categorization.selection,
+					...additionalDependencies,
 				}
 			)
 		);
@@ -156,12 +165,19 @@ export default function DesignPickerStep( props ) {
 						align="left"
 					/>
 				}
-				categoriesFooter={
-					useFeaturedPicksButtons && (
-						<FeaturedPicksButtons designs={ featuredPicksDesigns } onSelect={ pickDesign } />
-					)
-				}
+				categoriesFooter={ renderCategoriesFooter() }
 			/>
+		);
+	}
+
+	function renderCategoriesFooter() {
+		return (
+			<div>
+				{ useFeaturedPicksButtons && (
+					<FeaturedPicksButtons designs={ featuredPicksDesigns } onSelect={ pickDesign } />
+				) }
+				{ showLetUsChoose && <LetUsChoose designs={ designs } onSelect={ pickDesign } /> }
+			</div>
 		);
 	}
 

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -172,14 +172,14 @@ export default function DesignPickerStep( props ) {
 
 	function renderCategoriesFooter() {
 		return (
-			<div>
+			<>
 				{ useFeaturedPicksButtons && (
 					<FeaturedPicksButtons designs={ featuredPicksDesigns } onSelect={ pickDesign } />
 				) }
 				{ showLetUsChoose && (
 					<LetUsChoose flowName={ props.flowName } designs={ designs } onSelect={ pickDesign } />
 				) }
-			</div>
+			</>
 		);
 	}
 

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -176,7 +176,9 @@ export default function DesignPickerStep( props ) {
 				{ useFeaturedPicksButtons && (
 					<FeaturedPicksButtons designs={ featuredPicksDesigns } onSelect={ pickDesign } />
 				) }
-				{ showLetUsChoose && <LetUsChoose designs={ designs } onSelect={ pickDesign } /> }
+				{ showLetUsChoose && (
+					<LetUsChoose flowName={ props.flowName } designs={ designs } onSelect={ pickDesign } />
+				) }
 			</div>
 		);
 	}

--- a/client/signup/steps/design-picker/let-us-choose.tsx
+++ b/client/signup/steps/design-picker/let-us-choose.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import type { Design } from '@automattic/design-picker';
+
+interface Props {
+	designs: Design[];
+	onSelect: ( design: Design ) => void;
+}
+
+const LetUsChooseContainer = styled.div`
+	color: var( --color-neutral-70 );
+	font-size: 14px;
+	margin-bottom: 40px;
+
+	@media ( min-width: 600px ) {
+		margin-top: 40px;
+	}
+`;
+
+const LetUsChooseButton = styled( Button )`
+	border-radius: 4px;
+	height: 40px;
+	font-weight: 500;
+	margin-top: 20px;
+	text-align: center;
+`;
+
+const LetUsChoose = ( { designs, onSelect }: Props ) => {
+	const translate = useTranslate();
+
+	const defaultDesign = designs.find( ( design ) =>
+		design.features.includes( 'difm-lite-default' )
+	);
+
+	if ( ! defaultDesign ) {
+		return null;
+	}
+
+	function onClick() {
+		// @ts-expect-error: TS complains that defaultDesign could
+		// be undefined. But we already return early if it is so.
+		onSelect( defaultDesign, {
+			isLetUsChooseSelected: true,
+		} );
+	}
+
+	return (
+		<LetUsChooseContainer>
+			<div>
+				{ translate(
+					"Can't decide? " + 'No problem, our experts can choose the perfect design for your site!'
+				) }
+			</div>
+			<LetUsChooseButton isSecondary onClick={ onClick }>
+				{ translate( 'Let us choose' ) }
+			</LetUsChooseButton>
+		</LetUsChooseContainer>
+	);
+};
+
+export default LetUsChoose;

--- a/client/signup/steps/design-picker/let-us-choose.tsx
+++ b/client/signup/steps/design-picker/let-us-choose.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Design } from '@automattic/design-picker';
 
 interface Props {
+	flowName: string;
 	designs: Design[];
 	onSelect: ( design: Design ) => void;
 }
@@ -26,7 +28,7 @@ const LetUsChooseButton = styled( Button )`
 	text-align: center;
 `;
 
-const LetUsChoose = ( { designs, onSelect }: Props ) => {
+const LetUsChoose = ( { flowName, designs, onSelect }: Props ) => {
 	const translate = useTranslate();
 
 	const defaultDesign = designs.find( ( design ) =>
@@ -38,6 +40,9 @@ const LetUsChoose = ( { designs, onSelect }: Props ) => {
 	}
 
 	function onClick() {
+		recordTracksEvent( 'calypso_signup_let_us_choose_click', {
+			flow: flowName,
+		} );
 		// @ts-expect-error: TS complains that defaultDesign could
 		// be undefined. But we already return early if it is so.
 		onSelect( defaultDesign, {

--- a/client/signup/steps/design-picker/let-us-choose.tsx
+++ b/client/signup/steps/design-picker/let-us-choose.tsx
@@ -54,7 +54,7 @@ const LetUsChoose = ( { flowName, designs, onSelect }: Props ) => {
 		<LetUsChooseContainer>
 			<div>
 				{ translate(
-					"Can't decide? " + 'No problem, our experts can choose the perfect design for your site!'
+					"Can't decide? No problem, our experts can choose the perfect design for your site!"
 				) }
 			</div>
 			<LetUsChooseButton isSecondary onClick={ onClick }>

--- a/client/signup/steps/difm-design-picker/themes.tsx
+++ b/client/signup/steps/difm-design-picker/themes.tsx
@@ -12,7 +12,7 @@ const difmThemes: Design[] = [
 				slug: 'blog',
 			},
 		],
-		features: [],
+		features: [ 'difm-lite-default' ],
 		is_premium: false,
 		slug: 'russell',
 		template: 'russell',

--- a/client/signup/steps/site-info-collection/index.jsx
+++ b/client/signup/steps/site-info-collection/index.jsx
@@ -35,6 +35,7 @@ function SiteInformationCollection( {
 		selectedSiteCategory,
 		selectedDesign,
 		newOrExistingSiteChoice,
+		isLetUsChooseSelected,
 	} = useSelector( getSignupDependencyStore );
 	const dispatch = useDispatch();
 	const loggedInUsername = useSelector( getCurrentUserName );
@@ -48,6 +49,7 @@ function SiteInformationCollection( {
 			difm_lite_site_category: selectedSiteCategory,
 			difm_lite_typeform_response_id: typeformSubmissionId,
 			difm_lite_new_or_existing_site_choice: newOrExistingSiteChoice,
+			difm_lite_let_us_choose_selected: !! isLetUsChooseSelected,
 		};
 		const cartItem = { product_slug: WPCOM_DIFM_LITE, extra };
 		const step = {

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -13,7 +13,7 @@ export interface Category {
 	name: string;
 }
 
-export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'
+export type DesignFeatures = 'anchorfm' | 'difm-lite-default'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'
 
 export interface Design {
 	categories: Array< Category >;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pdh1Xd-gN-p2

* Adds a "Let us choose" button to allow users to skip the design picker screen.
* Adds `difm-lite-default` as a feature to the Russel theme. If the user clicks on the "Let Us Choose" button, the first theme with the `difm-lite-default` feature will be set on the site. (Currently, the list of themes is on the client-side, but it will be powered from the API in the future).
* Also adds a `difm_lite_let_us_choose_selected` option which will be displayed in the Blog RC. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Optional - Apply D72586-code
* Start the flow at `/start/do-it-for-me`.
* Choose "New Site" on the first step.
* On the design picker step, confirm that you see the "Let us choose" button:
![image](https://user-images.githubusercontent.com/5436027/148342862-78c18321-7968-4cf5-b6ca-9e989012f01d.png)
* Click the "Let Us Choose" button.
* Go through the rest of the flow and complete the purchase.
* Confirm that the theme has been changed to Russel. You can do this by checking the Blog RC.

**Testing for regressions in the design picker**
* Navigate to `/start/setup-site/intent?siteSlug=<any site slug>`
* Click on "Start Building".
* On the design picker step, confirm that you are not able to see the "Let us choose" button.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->