### PR TITLE
Signup: Remove site-title-without-domains step

### DIFF
--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -41,7 +41,6 @@ const stepNameToModuleName = {
 	'site-picker': 'site-picker',
 	'site-style': 'site-style',
 	'site-title': 'site-title',
-	'site-title-without-domains': 'site-title',
 	'site-options': 'site-options',
 	'site-topic': 'site-topic',
 	'site-topic-with-theme': 'site-topic',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -585,17 +585,6 @@ export function generateSteps( {
 			fulfilledStepCallback: isSiteTopicFulfilled,
 		},
 
-		'site-title-without-domains': {
-			stepName: 'site-title-without-domains',
-			apiRequestFunction: createSiteWithCart,
-			delayApiRequestUntilComplete: true,
-			dependencies: [ 'themeSlugWithRepo' ],
-			providesDependencies: [ 'siteTitle', 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
-			props: {
-				showSiteMockups: true,
-			},
-		},
-
 		'site-style': {
 			stepName: 'site-style',
 			providesDependencies: [ 'siteStyle', 'themeSlugWithRepo' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As https://github.com/Automattic/wp-calypso/issues/56264 mentioned, `site-title-without-domains` step is no longer used. Hence, remove the step and related code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nope because the step is already abandoned

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56264
