### PR TITLE
Marketplace: make sure site is AT before allowing redirects to wp-admin

### DIFF
--- a/client/state/atomic/transfers/selectors.ts
+++ b/client/state/atomic/transfers/selectors.ts
@@ -3,8 +3,10 @@ import type { AppState } from 'calypso/types';
 
 import 'calypso/state/atomic/init';
 
+const emptyData = {};
+
 export const getLatestAtomicTransfer = (
 	state: AppState,
-	siteId: number
+	siteId: number | null
 ): { transfer?: AtomicTransfer; error?: AtomicTransferError } =>
-	state?.atomicTransfers?.[ siteId ] || {};
+	siteId ? state?.atomicTransfers?.[ siteId ] ?? emptyData : emptyData;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- allows `null` `siteId` in `getLatestAtomicTransfer`
- requests AT status until site gets transferred

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* on a non Atomic site go and buy a paid plugin
* after paying and being redirected to the Thank You page, click "Manage Plugins" as soon as it is available
* you should be redirected to WP Admin without any errors
* repeat for an already Atomic site

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59695
