### PR TITLE
Add ToS Acceptance Tracking to login, signup and checkout

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -18,6 +18,7 @@ import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
 import { isValidLandingPageVertical } from 'calypso/lib/signup/verticals';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wpcom from 'calypso/lib/wp';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import flows from 'calypso/signup/config/flows';
@@ -761,6 +762,7 @@ export function createAccount(
 				client_id: config( 'wpcom_signup_id' ),
 				client_secret: config( 'wpcom_signup_key' ),
 				...userData,
+				tos: getToSAcceptancePayload(),
 			},
 			responseHandler( SIGNUP_TYPE_SOCIAL )
 		);
@@ -780,6 +782,7 @@ export function createAccount(
 					locale: getLocaleSlug(),
 					client_id: config( 'wpcom_signup_id' ),
 					client_secret: config( 'wpcom_signup_key' ),
+					tos: getToSAcceptancePayload(),
 				},
 				oauth2Signup
 					? {

--- a/client/lib/tos-acceptance-tracking/README.md
+++ b/client/lib/tos-acceptance-tracking/README.md
@@ -1,0 +1,5 @@
+# tos-acceptance-tracking
+
+This generates the payload needed to track users actions relating to ToS acceptances.
+Whenever a user completes an action (such as a successful login) by clicking a CTA, we want to be able track meta information associated with this action.
+

--- a/client/lib/tos-acceptance-tracking/index.js
+++ b/client/lib/tos-acceptance-tracking/index.js
@@ -1,0 +1,11 @@
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+
+export default function () {
+	const width = window.document.documentElement.clientWidth;
+	const height = window.document.documentElement.clientHeight;
+	return {
+		path: window.location.pathname,
+		locale: getLocaleSlug(),
+		viewport: `${ width }x${ height }`,
+	};
+}

--- a/client/lib/tos-acceptance-tracking/index.js
+++ b/client/lib/tos-acceptance-tracking/index.js
@@ -1,11 +1,19 @@
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 
 export default function () {
-	const width = window.document.documentElement.clientWidth;
-	const height = window.document.documentElement.clientHeight;
+	let viewportWidth = 0;
+	let viewportHeight = 0;
+	let path = '/';
+
+	if ( 'undefined' !== typeof window ) {
+		viewportWidth = window.document.documentElement.clientWidth;
+		viewportHeight = window.document.documentElement.clientHeight;
+		path = window.location.pathname;
+	}
+
 	return {
-		path: window.location.pathname,
+		path,
 		locale: getLocaleSlug(),
-		viewport: `${ width }x${ height }`,
+		viewport: `${ viewportWidth }x${ viewportHeight }`,
 	};
 }

--- a/client/lib/tos-acceptance-tracking/index.js
+++ b/client/lib/tos-acceptance-tracking/index.js
@@ -1,6 +1,6 @@
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 
-export default function () {
+export default function getToSAcceptancePayload() {
 	let viewportWidth = 0;
 	let viewportHeight = 0;
 	let path = '/';

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -2,6 +2,7 @@ import { makeRedirectResponse, makeErrorResponse } from '@automattic/composite-c
 import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
 import { tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
@@ -130,5 +131,6 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		country,
 		postalCode: postalCode ? tryToGuessPostalCodeFormat( postalCode.toUpperCase(), country ) : '',
 		domainDetails,
+		tos: getToSAcceptancePayload(),
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -1,4 +1,5 @@
 import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { createWpcomAccountBeforeTransaction } from './create-wpcom-account-before-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
@@ -32,5 +33,14 @@ export default async function submitWpcomTransaction(
 		payload.cart = await createWpcomAccountBeforeTransaction( payload.cart, transactionOptions );
 	}
 
-	return wp.req.post( '/me/transactions', mapRecordKeysRecursively( payload, camelToSnakeCase ) );
+	return wp.req.post(
+		'/me/transactions',
+		mapRecordKeysRecursively(
+			{
+				...payload,
+				tos: getToSAcceptancePayload(),
+			},
+			camelToSnakeCase
+		)
+	);
 }

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -1,5 +1,4 @@
 import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
-import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { createWpcomAccountBeforeTransaction } from './create-wpcom-account-before-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
@@ -33,14 +32,5 @@ export default async function submitWpcomTransaction(
 		payload.cart = await createWpcomAccountBeforeTransaction( payload.cart, transactionOptions );
 	}
 
-	return wp.req.post(
-		'/me/transactions',
-		mapRecordKeysRecursively(
-			{
-				...payload,
-				tos: getToSAcceptancePayload(),
-			},
-			camelToSnakeCase
-		)
-	);
+	return wp.req.post( '/me/transactions', mapRecordKeysRecursively( payload, camelToSnakeCase ) );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -9,6 +9,7 @@ import {
 	isValueTruthy,
 	getLabel,
 } from '@automattic/wpcom-checkout';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import {
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
@@ -219,5 +220,6 @@ export function createTransactionEndpointRequestPayload( {
 			useForAllSubscriptions,
 			eventSource,
 		},
+		tos: getToSAcceptancePayload(),
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.ts
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.ts
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import i18n from 'i18n-calypso';
 import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { stringifyBody } from 'calypso/state/login/utils';
 
@@ -95,6 +96,7 @@ export async function createAccount( {
 			locale: getLocaleSlug(),
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
+			tos: getToSAcceptancePayload(),
 		} );
 
 		if ( ! isCreateAccountResponse( response ) || ! response.success ) {

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -74,6 +74,11 @@ describe( 'existingCardProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
 	};
 
 	it( 'throws an error if there is no storedDetailsId passed', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
@@ -65,6 +65,11 @@ describe( 'freePurchaseProcessor', () => {
 			tef_bank: undefined,
 			zip: '',
 		},
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/full-credits-processor.ts
@@ -65,6 +65,11 @@ describe( 'fullCreditsProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -66,6 +66,11 @@ describe( 'genericRedirectProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -157,6 +157,11 @@ describe( 'multiPartnerCardProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
 	};
 
 	const basicExpectedEbanxRequest = {

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -276,6 +276,11 @@ describe( 'payPalExpressProcessor', () => {
 				coupon: '',
 				create_new_blog: true,
 			},
+			tos: {
+				locale: 'en',
+				path: '/checkout/no-site',
+				viewport: '0x0',
+			},
 		} );
 	} );
 
@@ -303,6 +308,11 @@ describe( 'payPalExpressProcessor', () => {
 				cart_key: 'no-site',
 				coupon: '',
 				create_new_blog: true,
+			},
+			tos: {
+				locale: 'en',
+				path: '/checkout/no-site',
+				viewport: '0x0',
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -53,6 +53,11 @@ describe( 'payPalExpressProcessor', () => {
 		domain_details: null,
 		postal_code: '',
 		success_url: 'https://example.com/thank-you',
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
 	};
 
 	beforeEach( () => {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -889,6 +889,11 @@ export const expectedCreateAccountRequest = {
 	locale: 'en',
 	client_id: config( 'wpcom_signup_id' ),
 	client_secret: config( 'wpcom_signup_key' ),
+	tos: {
+		locale: 'en',
+		path: '/',
+		viewport: '0x0',
+	},
 };
 
 export function mockCachedContactDetailsEndpoint( data ): void {

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -70,6 +70,11 @@ describe( 'weChatProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
 	};
 
 	const redirect_url = 'https://test-redirect-url';

--- a/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
@@ -68,6 +68,11 @@ describe( 'webPayProcessor', () => {
 			tef_bank: undefined,
 			zip: '10001',
 		},
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
 	};
 
 	it( 'throws an error if there is no stripe object', async () => {

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import {
 	LOGIN_EMAIL_SEND,
 	MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH,
@@ -68,6 +69,7 @@ export const sendLoginEmail = ( action ) => {
 					...( redirect_to && { redirect_to } ),
 					...( flow && { flow } ),
 					create_account: createAccount,
+					tos: getToSAcceptancePayload(),
 				},
 			},
 			{ ...action, infoNoticeId: noticeAction ? noticeAction.notice.noticeId : null }

--- a/client/state/login/actions/login-social-user.js
+++ b/client/state/login/actions/login-social-user.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { get } from 'lodash';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import {
 	SOCIAL_LOGIN_REQUEST,
 	SOCIAL_LOGIN_REQUEST_FAILURE,
@@ -33,6 +34,7 @@ export const loginSocialUser = ( socialInfo, redirectTo ) => ( dispatch ) => {
 		redirect_to: redirectTo,
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
+		tos: JSON.stringify( getToSAcceptancePayload() ),
 	} )
 		.then( ( response ) => {
 			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {

--- a/client/state/login/actions/login-user.js
+++ b/client/state/login/actions/login-user.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { get } from 'lodash';
+import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import {
 	LOGIN_REQUEST,
 	LOGIN_REQUEST_FAILURE,
@@ -37,6 +38,7 @@ export const loginUser = ( usernameOrEmail, password, redirectTo, domain ) => ( 
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
 		domain: domain,
+		tos: JSON.stringify( getToSAcceptancePayload() ),
 	} )
 		.then( ( response ) => {
 			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -92,6 +92,13 @@ export type WPCOMTransactionEndpointRequestPayload = {
 	cart: WPCOMTransactionEndpointCart;
 	payment: WPCOMTransactionEndpointPaymentDetails;
 	domainDetails?: DomainContactDetails;
+	tos?: ToSAcceptanceTrackingDetails;
+};
+
+export type ToSAcceptanceTrackingDetails = {
+	path: string;
+	locale: string;
+	viewport: string;
 };
 
 export type WPCOMTransactionEndpointPaymentDetails = {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -202,6 +202,7 @@ export type PayPalExpressEndpointRequestPayload = {
 	domainDetails: DomainContactDetails | null;
 	country: string;
 	postalCode: string;
+	tos?: ToSAcceptanceTrackingDetails;
 };
 
 export type PayPalExpressEndpointResponse = unknown;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More info: pau2Xa-3my-p2

This adds sends the ToS Acceptance payload in the follow scenarios:
- log-in
- sign-up
- checkout

The payload is included under the `tos` key and contains:
- `path` - the route where the ToS was accepted
- `locale` - selected locale code
- `viewport` - width and height of the viewport

#### Testing instructions

* Sandbox `public-api.wordpress.com`
* Apply the patches from D72596-code and D72595-code so that the ToS payload gets processed
* Open the Network tab with Preserve Logs enabled
* Go through the following scenarios:
  * Log In
    * go to `/log-in`
    * log in with username and password
    * make sure the request to `wp-login.php?action=login-endpoint` contains the `tos` property
  * Log In email link
    * go to `/log-in/link`
    * enter email
    * make sure the request to `/auth/send-login-emai` contains the `tos` property   
  * Social Log In
    * for this, you'll need to configure your calypso to run behind `wordpress.com`
    * go to `/log-in`
    * log in with Google or Apple
    * make sure the request to `wp-login.php?action=social-login-endpoint` contains the `tos` property
  * Sign Up
    * go to `/start`
    * enter email, username, and password
    * make sure the request to `/users/new` contains the `tos` property
  * Social Up
    * go to `/start`
    * register with a new Google or Apple account
    * make sure the request to `/users/social/new` contains the `tos` property
  * Social Sign Up with existing account
    * for this, you'll need to configure your calypso to run behind `wordpress.com`
    * go to `/start`
    * register with an already used Google or Apple account
    * make sure the request to `/users/social/new` contains the `tos` property
  * Checkout
    * proceed to the checkout page 
    * fill in the details
    * click on Pay
    * make sure the request to `/me/transactions` contains the `tos` property
  * Checkout PayPal
    * proceed to the checkout page 
    * fill in the details
    * choose PayPal as Payment Method and submit
    * make sure the request to `/me/paypal-express-url` contains the `tos` property