### PR TITLE
Hide master bar on Jetpack Cloud Pricing page

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/pricing/header/style.scss
@@ -1,10 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-#header {
-	display: none;
-}
-
 .header {
 	text-align: center;
 }

--- a/client/jetpack-cloud/sections/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/pricing/header/style.scss
@@ -1,6 +1,10 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+#header {
+	display: none;
+}
+
 .header {
 	text-align: center;
 }

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -13,7 +13,9 @@
 	h2 {
 		line-height: inherit;
 	}
-
+	#header {
+		display: none;
+	}
 	.header {
 		margin-bottom: 24px;
 		padding: 0 5%;


### PR DESCRIPTION
Fixes `1164141197617539-as-1201622749500765`

#### Changes proposed in this Pull Request

* Hide master bar on Jetpack cloud pricing page using CSS instead of toggling its visibility via redux.
* This is to ensure that master bar is hidden on/before page load.

#### Testing instructions

* Checkout this branch and run `yarn start` before running `yarn start-jetpack-cloud-p`
* Goto http://jetpack.cloud.localhost:3001/pricing
* Throttle the connection in **Network** tab using **Slow 3G**
* Reload the page to ensure that you don't see the Calypso blue masterbar
* Goto http://jetpack.cloud.localhost:3001 again and select a site
* Goto Backup, Scan and Search sections
* Ensure that master bar at the top is not hidden.

### Testing instructions for devs
* Goto https://cloud.jetpack.com/pricing
* Open Dev Tools > Redux
* In filter input, enter `MASTERBAR_TOGGLE_VISIBILITY`
* Hover over to the action item below and click on **Jump**
* Click on the Forward and Backward buttons to toggle the visibility of the master bar
* Notice how the visibility of master bar at the top is toggled
* Now goto http://jetpack.cloud.localhost:3001/pricing
* Follow the same steps after opening Dev tools > Redux
* Notice how master bar is hidden regardless of its visibility state

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Before
<img width="900" alt="image" src="https://user-images.githubusercontent.com/18226415/148389653-3b9a41fc-71c9-437b-9168-fb755c1a4263.png">


After
![image](https://user-images.githubusercontent.com/18226415/148389722-4997cfd0-288c-4240-8988-c743e7eec6cb.png)