### PR TITLE
Add whitelist messaging to backup failure and credentials verification screen

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -9,6 +9,7 @@ import { Interval, EVERY_SECOND } from 'calypso/lib/interval';
 import {
 	isSuccessfulDailyBackup,
 	isSuccessfulRealtimeBackup,
+	getBackupErrorCode,
 } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { useIsDateVisible } from 'calypso/my-sites/backup/hooks';
@@ -26,7 +27,13 @@ import VisibleDaysLimit from './status-card/visible-days-limit';
 
 import './style.scss';
 
-const DailyBackupStatus = ( { selectedDate, lastBackupDate, backup, deltas } ) => {
+const DailyBackupStatus = ( {
+	selectedDate,
+	lastBackupAttempt,
+	lastBackupDate,
+	backup,
+	deltas,
+} ) => {
 	const siteId = useSelector( getSelectedSiteId );
 
 	const moment = useLocalizedMoment();
@@ -117,6 +124,10 @@ const DailyBackupStatus = ( { selectedDate, lastBackupDate, backup, deltas } ) =
 		) : (
 			<NoBackupsOnSelectedDate selectedDate={ selectedDate } />
 		);
+	}
+
+	if ( getBackupErrorCode( lastBackupAttempt ) === 'NOT_ACCESSIBLE' ) {
+		return <BackupFailed backup={ lastBackupAttempt } />;
 	}
 
 	return <NoBackupsYet />;

--- a/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
@@ -37,7 +37,7 @@ const BackupFailed = ( { backup } ) => {
 			</div>
 			<div className="status-card__title">
 				{ mayBeBlockedByHost
-					? translate( `We'are having trouble backing up your site` )
+					? translate( `We're having trouble backing up your site` )
 					: getDisplayDate( backup.activityTs, false ) }
 			</div>
 			<div className="status-card__label">

--- a/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
+import { getBackupErrorCode } from 'calypso/lib/jetpack/backup-utils';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
@@ -26,7 +27,7 @@ const BackupFailed = ( { backup } ) => {
 	const displayDate = backupDate.format( 'L' );
 	const displayTime = backupDate.format( 'LT' );
 
-	const mayBeBlockedByHost = 'not_accessible' === backup.activityMeta.errorCode;
+	const mayBeBlockedByHost = getBackupErrorCode( backup ) === 'NOT_ACCESSIBLE';
 
 	return (
 		<>
@@ -40,7 +41,7 @@ const BackupFailed = ( { backup } ) => {
 					: getDisplayDate( backup.activityTs, false ) }
 			</div>
 			<div className="status-card__label">
-				<p>
+				<div>
 					{ mayBeBlockedByHost
 						? translate(
 								'Please {{b}}ask your hosting provider to allow connections{{/b}} from the IP addresses found on this page: {{a}}%(url)s{{/a}}',
@@ -65,7 +66,7 @@ const BackupFailed = ( { backup } ) => {
 									'able to be completed.',
 								{ args: { displayDate, displayTime } }
 						  ) }
-				</p>
+				</div>
 				{ ! mayBeBlockedByHost && (
 					<p>
 						{ translate(

--- a/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
@@ -26,38 +26,65 @@ const BackupFailed = ( { backup } ) => {
 	const displayDate = backupDate.format( 'L' );
 	const displayTime = backupDate.format( 'LT' );
 
+	const mayBeBlockedByHost = 'not_accessible' === backup.activityMeta.errorCode;
+
 	return (
 		<>
 			<div className="status-card__message-head">
 				<img src={ cloudErrorIcon } alt="" role="presentation" />
 				<div className="status-card__message-error">{ translate( 'Backup failed' ) }</div>
 			</div>
-			<div className="status-card__title">{ getDisplayDate( backup.activityTs, false ) }</div>
+			<div className="status-card__title">
+				{ mayBeBlockedByHost
+					? translate( `We'are having trouble backing up your site` )
+					: getDisplayDate( backup.activityTs, false ) }
+			</div>
 			<div className="status-card__label">
 				<p>
-					{ translate(
-						'A backup for your site was attempted on %(displayDate)s at %(displayTime)s and was not ' +
-							'able to be completed.',
-						{ args: { displayDate, displayTime } }
-					) }
+					{ mayBeBlockedByHost
+						? translate(
+								'Please {{b}}ask your hosting provider to allow connections{{/b}} from the IP addresses found on this page: {{a}}%(url)s{{/a}}',
+								{
+									components: {
+										a: (
+											<a
+												href="https://jetpack.com/support/how-to-add-jetpack-ips-allowlist/"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+										b: <b />,
+									},
+									args: {
+										url: 'https://jetpack.com/support/how-to-add-jetpack-ips-allowlist/',
+									},
+								}
+						  )
+						: translate(
+								'A backup for your site was attempted on %(displayDate)s at %(displayTime)s and was not ' +
+									'able to be completed.',
+								{ args: { displayDate, displayTime } }
+						  ) }
 				</p>
-				<p>
-					{ translate(
-						'Check out the {{a}}backups help guide{{/a}} or contact our support team to resolve the ' +
-							'issue.',
-						{
-							components: {
-								a: (
-									<a
-										href="https://jetpack.com/support/backup/"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
-				</p>
+				{ ! mayBeBlockedByHost && (
+					<p>
+						{ translate(
+							'Check out the {{a}}backups help guide{{/a}} or contact our support team to resolve the ' +
+								'issue.',
+							{
+								components: {
+									a: (
+										<a
+											href="https://jetpack.com/support/backup/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+				) }
 				<Button
 					className="status-card__support-button"
 					href={ contactSupportUrl( siteUrl ) }

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/verification/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/verification/index.tsx
@@ -18,6 +18,8 @@ interface Props {
 	onReview: () => void;
 }
 
+const ERROR_CODES_FOR_BLOCKED_REQUEST = [ 'service_unavailable', 'invalid_credentials' ];
+
 const UpdateErrorView: FunctionComponent< UpdateError > = ( {
 	wpcomError,
 	translatedError,
@@ -33,11 +35,32 @@ const UpdateErrorView: FunctionComponent< UpdateError > = ( {
 			<p>{ translatedError }</p>
 			<details>
 				<summary>{ translate( 'More details' ) }</summary>
-				<p>
-					{ wpcomMessage }{ ' ' }
-					<span>{ `[${ wpcomError?.code }, ${ JSON.stringify( wpcomError?.data ) }]` }</span>
-				</p>
-				{ showTransportMessage && <p>{ transportMessage }</p> }
+				{ ERROR_CODES_FOR_BLOCKED_REQUEST.includes( String( wpcomError?.code ) ) ? (
+					<ol>
+						<li>{ wpcomMessage }</li>
+						<li>
+							{ translate(
+								'Please {{b}}ask your hosting provider to allow connections{{/b}} from the IP addresses found on this page: %(url)s',
+								{
+									components: {
+										b: <b />,
+									},
+									args: {
+										url: 'https://jetpack.com/support/how-to-add-jetpack-ips-allowlist/',
+									},
+								}
+							) }
+						</li>
+					</ol>
+				) : (
+					<>
+						<p>
+							{ wpcomMessage }{ ' ' }
+							<span>{ `[${ wpcomError?.code }, ${ JSON.stringify( wpcomError?.data ) }]` }</span>
+						</p>
+						{ showTransportMessage && <p>{ transportMessage }</p> }
+					</>
+				) }
 			</details>
 		</div>
 	);

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -40,13 +40,17 @@ export const getDeltaActivitiesByType = ( logs ) => {
 	};
 };
 
-export const REWIND_ACTIVITIES = [
+export const SUCCESSFUL_BACKUP_ACTIVITIES = [
 	'rewind__backup_complete_full',
 	'rewind__backup_complete_initial',
-	'rewind__backup_error',
 	'rewind__backup_only_complete_full',
-	'rewind__backup_only_error',
 	'rewind__backup_only_complete_initial',
+];
+
+export const BACKUP_ATTEMPT_ACTIVITIES = [
+	...SUCCESSFUL_BACKUP_ACTIVITIES,
+	'rewind__backup_error',
+	'rewind__backup_only_error',
 ];
 
 /**
@@ -55,7 +59,18 @@ export const REWIND_ACTIVITIES = [
  * @param activity {object} Activity to check
  */
 export const isActivityBackup = ( activity ) => {
-	return REWIND_ACTIVITIES.includes( activity.activityName );
+	return BACKUP_ATTEMPT_ACTIVITIES.includes( activity.activityName );
+};
+
+/**
+ * Retrieve the backup error code from activity object.
+ *
+ * @typedef {import('calypso/state/data-layer/wpcom/sites/activity/from-api.js').processItem} ProcessItem
+ * @param {object} activity Activity to get the error code from.
+ * @returns {'BAD_CREDENTIALS'|'NOT_ACCESSIBLE'} The error code as set in @see {ProcessItem}
+ */
+export const getBackupErrorCode = ( activity ) => {
+	return activity?.activityMeta?.errorCode?.toUpperCase?.();
 };
 
 /**
@@ -64,12 +79,7 @@ export const isActivityBackup = ( activity ) => {
  * @param backup {object} Backup to check
  */
 export const isSuccessfulDailyBackup = ( backup ) => {
-	return (
-		'rewind__backup_complete_full' === backup.activityName ||
-		'rewind__backup_complete_initial' === backup.activityName ||
-		'rewind__backup_only_complete_full' === backup.activityName ||
-		'rewind__backup_only_complete_initial' === backup.activityName
-	);
+	return SUCCESSFUL_BACKUP_ACTIVITIES.includes( backup.activityName );
 };
 
 /**

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -40,19 +40,22 @@ export const getDeltaActivitiesByType = ( logs ) => {
 	};
 };
 
+export const REWIND_ACTIVITIES = [
+	'rewind__backup_complete_full',
+	'rewind__backup_complete_initial',
+	'rewind__backup_error',
+	'rewind__backup_only_complete_full',
+	'rewind__backup_only_error',
+	'rewind__backup_only_complete_initial',
+];
+
 /**
  * Check if the activity is the type of backup
  *
  * @param activity {object} Activity to check
  */
 export const isActivityBackup = ( activity ) => {
-	return (
-		'rewind__backup_complete_full' === activity.activityName ||
-		'rewind__backup_complete_initial' === activity.activityName ||
-		'rewind__backup_error' === activity.activityName ||
-		'rewind__backup_only_complete_full' === activity.activityName ||
-		'rewind__backup_only_complete_initial' === activity.activityName
-	);
+	return REWIND_ACTIVITIES.includes( activity.activityName );
 };
 
 /**

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -175,6 +175,9 @@ export const useRealtimeBackupStatus = ( siteId, selectedDate ) => {
 		successOnly: true,
 	} );
 
+	// This is the last attempt irrespective of date
+	const lastBackupAttempt = useLatestBackupAttempt( siteId );
+
 	const lastBackupBeforeDate = useLatestBackupAttempt( siteId, {
 		before: moment( selectedDate ).startOf( 'day' ),
 		successOnly: true,
@@ -217,6 +220,7 @@ export const useRealtimeBackupStatus = ( siteId, selectedDate ) => {
 			rawDeltas.isLoading,
 		mostRecentBackupEver: mostRecentBackupEver.backupAttempt,
 		lastBackupBeforeDate: lastBackupBeforeDate.backupAttempt,
+		lastBackupAttempt: lastBackupAttempt.backupAttempt,
 		lastBackupAttemptOnDate,
 		lastSuccessfulBackupOnDate,
 		backupAttemptsOnDate,

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -53,6 +53,7 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 	const {
 		isLoading,
 		lastBackupBeforeDate,
+		lastBackupAttempt,
 		lastBackupAttemptOnDate,
 		lastSuccessfulBackupOnDate,
 		backupAttemptsOnDate,
@@ -82,6 +83,7 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 					selectedDate,
 					lastBackupDate,
 					backup: lastSuccessfulBackupOnDate || lastBackupAttemptOnDate,
+					lastBackupAttempt,
 				} }
 			/>
 

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -184,7 +184,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 		case 'invalid_credentials':
 			dispatchFailure(
 				i18n.translate(
-					"We couldn't connect to your site. Please verify your credentials and give it another try."
+					"We couldn't connect to your site. Please verify that your credentials are correct and ensure that your host is not blocking the connection."
 				)
 			);
 			break;

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -35,6 +35,11 @@ export function processItem( item ) {
 				activityMeta.errorCode = 'bad_credentials';
 			}
 			break;
+		case 'rewind__backup_only_error':
+			if ( '3' === get( item.object, 'error_code', '' ) ) {
+				activityMeta.errorCode = 'not_accessible';
+			}
+			break;
 	}
 
 	return Object.assign(


### PR DESCRIPTION
Addresses 1164141197617539-as-1201487671935490

#### Changes proposed in this Pull Request

* Add appropriate messaging on the credentials verification screen to better guide the users.
* Add the similar messaging to Backup section to guide users about their host blocking Jetpack IPs.

#### Testing instructions

* Create a JN site and set up Jetpack Backup
* Goto Settings section on Jetpack Cloud - `jetpack.cloud.localhost:3001/settings/:site`
* Enter your SSH/SFTP credentials but enter a wrong port number (e.g. 100) to simulate a blocked request.
* Click on "Test and save credentials"
* Confirm that the credentials test fails with IP whitelist message under "More details"
* Now may be spin a new JN site and set up Jetpack Free
* Install WordFence plugin to the site and add [Jetpack IPs](https://jetpack.com/support/how-to-add-jetpack-ips-allowlist/) to block list
* Trigger a backup using Rewind Debugger and it should fail because of WordFence blocking.
* Goto Backup section on Jetpack Cloud - `jetpack.cloud.localhost:3001/backup/:site`
* Confirm that you see the backup failed messaging with a link to guide for whitelisting IPs

<img width="711" alt="Screenshot 2022-02-23 at 7 18 07 PM" src="https://user-images.githubusercontent.com/18226415/155332207-8d0842da-885b-455a-9491-6870558730a3.png">

<img width="749" alt="Screenshot 2022-02-23 at 6 31 00 PM" src="https://user-images.githubusercontent.com/18226415/155330340-e008f099-6176-4fa2-bed9-4d7739526e6d.png">
