### PR TITLE
Fix domain settings page for inbound transfers

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -111,11 +111,15 @@ export default {
 	},
 
 	domainManagementTransferIn( pageContext, next ) {
+		let component = DomainManagement.TransferIn;
+		if ( config.isEnabled( 'domains/settings-page-redesign' ) ) {
+			component = DomainManagement.Settings;
+		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransferIn( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Edit"
-				component={ DomainManagement.TransferIn }
+				component={ component }
 				context={ pageContext }
 				needsContactDetails
 				needsDomains


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fix a small a bug for inbound transfer domains.  At the moment, selecting a domain of type `TRANSFER` from domains list, leads to the old domain setting.

 
![list](https://user-images.githubusercontent.com/2797601/148410389-29a9aab0-fcfa-4640-8f05-5aec7bea4b14.png)

![old page](https://user-images.githubusercontent.com/2797601/148410398-ace231c7-4e2f-4308-a415-3efa917fbac1.png)

![new page](https://user-images.githubusercontent.com/2797601/148410414-d88454f0-d37f-4540-8c0c-b40a43a10685.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades -> Domains"
- Click on a domain currently with pending transfer status and verify that the detail page is the new one
