### PR TITLE
Fix bug where today's date was not selectable at times in the backups date picker

### DIFF
--- a/client/my-sites/backup/backup-date-picker/date-button.tsx
+++ b/client/my-sites/backup/backup-date-picker/date-button.tsx
@@ -51,6 +51,7 @@ const DateButton: React.FC< Props > = ( {
 					<DatePicker
 						calendarViewDate={ new Date( selectedDate.year(), selectedDate.month() ) } // sets the month when the calendar opens
 						moment={ moment }
+						timeReference={ selectedDate.clone() } // Use the current localized time of the selectedDate to adjust against when selecting a date
 						onSelectDay={ handleDatePicked }
 						selectedDay={
 							new Date( selectedDate.year(), selectedDate.month(), selectedDate.date() )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes a bug where, at some times, the current date could not be selected from the backups date picker component.

#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before applying this PR, try reproducing this bug for a site that has Jetpack backups.
* The bug is difficult to reproduce consistently. It seems to present if your current local time is before 12PM. You can temporarily alter your system clock to adjust your current time to satisfy this condition. 
* From the backups screen, click on the "Select Date" control to display the date picker. If today's date is currently selected, choose a different date in the past and then re-open the date picker and try clicking on today's date.
* The incorrect behavior is that the date picker would close, but the current selected date/ backup would not be updated. 
* Now apply this PR, confirm that you can always select the current day's date from the date picker calendar control on the backups screen.
