### PR TITLE
ScanPage: Change withApplySiteOffset to create HOC without createHigherOrderComponent

### DIFF
--- a/client/components/site-offset/index.tsx
+++ b/client/components/site-offset/index.tsx
@@ -1,11 +1,16 @@
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { useContext } from 'react';
 import { SiteOffsetContext, contextTypeLoaded } from './context';
+import type { FC, ComponentType } from 'react';
 
-export const withApplySiteOffset = createHigherOrderComponent<
-	{ applySiteOffset: applySiteOffsetType | null },
-	unknown
->( ( WrappedComponent ) => {
+export type applySiteOffsetType = contextTypeLoaded;
+
+interface ApplySiteOffsetProps {
+	applySiteOffset: applySiteOffsetType | null;
+}
+
+export function withApplySiteOffset< ComponentProps >(
+	WrappedComponent: ComponentType< ComponentProps & ApplySiteOffsetProps >
+): FC< ComponentProps > {
 	return function WithApplySiteOffset( props ) {
 		return (
 			<SiteOffsetContext.Consumer>
@@ -15,10 +20,8 @@ export const withApplySiteOffset = createHigherOrderComponent<
 			</SiteOffsetContext.Consumer>
 		);
 	};
-}, 'WithApplySiteOffset' );
+}
 
 export const useApplySiteOffset = () => {
 	return useContext( SiteOffsetContext );
 };
-
-export type applySiteOffsetType = contextTypeLoaded;

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Button, ProgressBar, Gridicon, Card } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt';
@@ -423,4 +422,4 @@ export default connect(
 		dispatchRecordTracksEvent: recordTracksEvent,
 		dispatchScanRun: triggerScanRun,
 	}
-)( compose( withLocalizedMoment, withApplySiteOffset )( ScanPage ) );
+)( withLocalizedMoment( withApplySiteOffset( ScanPage ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the file `ScanPage` we have a TypeScript error having to do with `createHigherOrderComponent()`; the `ScanPage` component is passed as an argument to `withApplySiteOffset()`, which causes an error because for some reason that HOC is confused about what props its inner component should have. The generics passed to `createHigherOrderComponent()` are supposed to handle that situation, but I can't find a way to satisfy them in this case. Instead, this PR removes `createHigherOrderComponent` from `withApplySiteOffset` and creates the HOC manually.

It's likely that the actual error here stems from some issue in the definition of `createHigherOrderComponent` but since I couldn't figure it out, and because that is in an external package (`@wordpress/compose` outside of the monorepo), this seemed like a simpler fix. (This is being worked on in core at https://github.com/WordPress/gutenberg/pull/37795)

<img width="488" alt="Screen Shot 2022-01-10 at 12 45 35 PM" src="https://user-images.githubusercontent.com/2036909/148813407-cd25be1f-ba15-42a9-a6a3-3a4f2389fc3e.png">

<img width="504" alt="Screen_Shot_2022-01-08_at_2_06_05_PM" src="https://user-images.githubusercontent.com/2036909/148656716-00585bd4-22fc-4e6a-9420-6769b645fd9f.png">


#### Testing instructions

- Use a Jetpack site.
- Purchase a plan that includes Jetpack Scan or purchase Jetpack Scan itself.
- Visit `/scan/YOUR-SITE-HERE`.
- Press the "Scan now" button.
- When the scan completes, verify that you see a timestamp in the message; something like `The last Jetpack scan ran 10 minutes ago and everything looked great.`

I actually wasn't able to get the endpoint to return a timestamp for my sites, but that also happens in production. So another way to test this is to hard-code the data from the server with a diff like this:

```diff
diff --git a/client/my-sites/scan/main.tsx b/client/my-sites/scan/main.tsx
index 596a76c5c6..d01fc74d17 100644
--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -105,8 +105,8 @@ class ScanPage extends Component< Props > {
        renderScanOkay() {
                const { scanState, siteId, moment, dispatchScanRun, applySiteOffset } = this.props;

-               const lastScanStartTime = scanState?.mostRecent?.timestamp;
-               const lastScanDuration = scanState?.mostRecent?.duration;
+               const lastScanStartTime = '2022-01-10T17:39:39+00:00';
+               const lastScanDuration = 5;

                let lastScanFinishTime = '';
                if ( lastScanStartTime && applySiteOffset ) {
```