### PR TITLE
Fix/videos UI size when video is loading

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -351,9 +351,11 @@
 		}
 
 		.videos-ui__body {
-			margin: 0 20px;
+			margin: 0 auto;
 			max-width: 1160px;
 			padding: 0 20px 80px;
+			align-self: center;
+			width: 100%;
 			h3 {
 				margin: 80px 0 20px;
 			}

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -354,7 +354,6 @@
 			margin: 0 auto;
 			max-width: 1160px;
 			padding: 0 20px 80px;
-			align-self: center;
 			width: 100%;
 			h3 {
 				margin: 80px 0 20px;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -351,7 +351,7 @@
 		}
 
 		.videos-ui__body {
-			margin: 0 auto;
+			margin: 0 20px;
 			max-width: 1160px;
 			padding: 0 20px 80px;
 			h3 {


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
| ![2022-01-06 16 07 38](https://user-images.githubusercontent.com/375980/148440897-733ecf49-1332-4d1a-844e-17d1417eb759.gif)  | ![2022-01-06 16 32 50](https://user-images.githubusercontent.com/375980/148440915-b1dcadb2-b332-44ee-bf56-d7348ba5462c.gif) |

#### Testing instructions


1. Apply this diff.
2. Open the Video UI in your local environment.
3. Disable internet connection via the chrome inspector.
4. Play a different video.
5. Verify the size of the video placeholder does not change.
6. Verify the behaviour on mobile.

Closes https://github.com/Automattic/wp-calypso/issues/59819