### PR TITLE
Do not call loadExperimentAssignment with an empty string

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -103,18 +103,19 @@ export default function WPCheckoutOrderReview( {
 
 	useEffect( () => {
 		const experimentCheck = retrieveExperimentName();
-		let shouldCheck = experimentCheck ? experimentCheck.length > 0 : false;
-		loadExperimentAssignment( experimentCheck ?? '' ).then( ( experimentObject ) => {
-			if ( shouldCheck ) {
-				setExperiment( experimentObject );
-			}
-		} );
+		let shouldCheck = true;
+		experimentCheck &&
+			loadExperimentAssignment( experimentCheck ).then( ( experimentObject ) => {
+				if ( shouldCheck ) {
+					setExperiment( experimentObject );
+				}
+			} );
 		return () => {
 			shouldCheck = false;
 		};
 	}, [] );
 
-	function retrieveExperimentName() {
+	function retrieveExperimentName(): string {
 		let experiment = '';
 		try {
 			const cookies = cookie.parse( document.cookie );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -102,6 +102,17 @@ export default function WPCheckoutOrderReview( {
 	const reduxDispatch = useDispatch();
 
 	useEffect( () => {
+		function retrieveExperimentName(): string {
+			let experiment = '';
+			try {
+				const cookies = cookie.parse( document.cookie );
+				experiment = cookies.wpcom_signup_experiment_name;
+			} catch ( error ) {
+				reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cookie_read_failed' ) );
+			}
+			return experiment;
+		}
+
 		const experimentCheck = retrieveExperimentName();
 		let shouldCheck = true;
 		experimentCheck &&
@@ -113,18 +124,7 @@ export default function WPCheckoutOrderReview( {
 		return () => {
 			shouldCheck = false;
 		};
-	}, [] );
-
-	function retrieveExperimentName(): string {
-		let experiment = '';
-		try {
-			const cookies = cookie.parse( document.cookie );
-			experiment = cookies.wpcom_signup_experiment_name;
-		} catch ( error ) {
-			reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cookie_read_failed' ) );
-		}
-		return experiment;
-	}
+	}, [ reduxDispatch ] );
 
 	const onRemoveProductCancel = useCallback( () => {
 		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a small bug introduced by https://github.com/Automattic/wp-calypso/pull/59715 where `loadExperimentAssignment()` could be called with an empty string, resulting in an error log.

#### Testing instructions

None