### PR TITLE
Modify Cart Order Review Step To Always Show Product Variant Selector

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -300,18 +300,19 @@ export default function WPCheckout( {
 					onError={ onReviewError }
 					className="wp-checkout__review-order-step"
 					stepId="review-order-step"
-					isStepActive={ isOrderReviewActive }
+					// isStepActive={ isOrderReviewActive }
+					isStepActive={ false }
 					isStepComplete={ true }
-					goToThisStep={ () => setIsOrderReviewActive( ! isOrderReviewActive ) }
-					goToNextStep={ () => {
-						setIsOrderReviewActive( ! isOrderReviewActive );
-						reduxDispatch(
-							recordTracksEvent( 'calypso_checkout_composite_step_complete', {
-								step: 0,
-								step_name: 'review-order-step',
-							} )
-						);
-					} }
+					// goToThisStep={ () => setIsOrderReviewActive( ! isOrderReviewActive ) }
+					// goToNextStep={ () => {
+					// 	setIsOrderReviewActive( ! isOrderReviewActive );
+					// 	reduxDispatch(
+					// 		recordTracksEvent( 'calypso_checkout_composite_step_complete', {
+					// 			step: 0,
+					// 			step_name: 'review-order-step',
+					// 		} )
+					// 	);
+					// } }
 					activeStepContent={
 						<WPCheckoutOrderReview
 							removeProductFromCart={ removeProductFromCart }
@@ -325,16 +326,19 @@ export default function WPCheckout( {
 					titleContent={ <OrderReviewTitle /> }
 					completeStepContent={
 						<WPCheckoutOrderReview
-							isSummary
+							// isSummary
 							removeProductFromCart={ removeProductFromCart }
 							couponFieldStateProps={ couponFieldStateProps }
+							onChangePlanLength={ changePlanLength }
 							siteUrl={ siteUrl }
+							siteId={ siteId }
+							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						/>
 					}
-					editButtonText={ String( translate( 'Edit' ) ) }
-					editButtonAriaLabel={ String( translate( 'Edit your order' ) ) }
-					nextStepButtonText={ String( translate( 'Save order' ) ) }
-					nextStepButtonAriaLabel={ String( translate( 'Save your order' ) ) }
+					// editButtonText={ String( translate( 'Edit' ) ) }
+					// editButtonAriaLabel={ String( translate( 'Edit your order' ) ) }
+					// nextStepButtonText={ String( translate( 'Save order' ) ) }
+					// nextStepButtonAriaLabel={ String( translate( 'Save your order' ) ) }
 					validatingButtonText={ validatingButtonText }
 					validatingButtonAriaLabel={ validatingButtonText }
 					formStatus={ formStatus }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -18,7 +18,6 @@ import {
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
-import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
@@ -49,8 +48,6 @@ import type { OnChangeItemVariant } from '../components/item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
-
-const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -177,26 +174,6 @@ export default function WPCheckout( {
 	// always visible. It is not a step and its visibility is managed manually.
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
 
-	// The "Order review" step is not managed by Composite Checkout and is shown/hidden manually.
-	// If the page includes a 'order-review=true' query string, then start with
-	// the order review step visible.
-	const [ isOrderReviewActive, setIsOrderReviewActive ] = useState( () => {
-		try {
-			const shouldInitOrderReviewStepActive =
-				window?.location?.search.includes( 'order-review=true' ) ?? false;
-			if ( shouldInitOrderReviewStepActive ) {
-				return true;
-			}
-		} catch ( error ) {
-			// If there's a problem loading the query string, just default to false.
-			debug(
-				'Error loading query string to determine if we should see the order review step at load',
-				error
-			);
-		}
-		return false;
-	} );
-
 	const { formStatus } = useFormStatus();
 
 	const arePostalCodesSupported = getCountryPostalCodeSupport(
@@ -293,40 +270,17 @@ export default function WPCheckout( {
 			<CheckoutStepArea
 				submitButtonHeader={ <SubmitButtonHeader /> }
 				submitButtonFooter={ <SubmitButtonFooter /> }
-				disableSubmitButton={ isOrderReviewActive }
 			>
 				{ infoMessage }
 				<CheckoutStepBody
 					onError={ onReviewError }
 					className="wp-checkout__review-order-step"
 					stepId="review-order-step"
-					// isStepActive={ isOrderReviewActive }
 					isStepActive={ false }
 					isStepComplete={ true }
-					// goToThisStep={ () => setIsOrderReviewActive( ! isOrderReviewActive ) }
-					// goToNextStep={ () => {
-					// 	setIsOrderReviewActive( ! isOrderReviewActive );
-					// 	reduxDispatch(
-					// 		recordTracksEvent( 'calypso_checkout_composite_step_complete', {
-					// 			step: 0,
-					// 			step_name: 'review-order-step',
-					// 		} )
-					// 	);
-					// } }
-					activeStepContent={
-						<WPCheckoutOrderReview
-							removeProductFromCart={ removeProductFromCart }
-							couponFieldStateProps={ couponFieldStateProps }
-							onChangePlanLength={ changePlanLength }
-							siteUrl={ siteUrl }
-							siteId={ siteId }
-							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-						/>
-					}
 					titleContent={ <OrderReviewTitle /> }
 					completeStepContent={
 						<WPCheckoutOrderReview
-							// isSummary
 							removeProductFromCart={ removeProductFromCart }
 							couponFieldStateProps={ couponFieldStateProps }
 							onChangePlanLength={ changePlanLength }
@@ -335,15 +289,11 @@ export default function WPCheckout( {
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						/>
 					}
-					// editButtonText={ String( translate( 'Edit' ) ) }
-					// editButtonAriaLabel={ String( translate( 'Edit your order' ) ) }
-					// nextStepButtonText={ String( translate( 'Save order' ) ) }
-					// nextStepButtonAriaLabel={ String( translate( 'Save your order' ) ) }
 					validatingButtonText={ validatingButtonText }
 					validatingButtonAriaLabel={ validatingButtonText }
 					formStatus={ formStatus }
 				/>
-				<CheckoutSteps areStepsActive={ ! isOrderReviewActive }>
+				<CheckoutSteps>
 					{ contactDetailsType !== 'none' && (
 						<CheckoutStep
 							stepId={ 'contact-form' }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -3,7 +3,7 @@
  */
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
@@ -146,9 +146,11 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			expect(
-				screen.getByText( getVariantItemTextForInterval( expectedVariant ) )
-			).toBeInTheDocument();
+			const getVariantItemText = await screen.findByText(
+				getVariantItemTextForInterval( expectedVariant )
+			);
+
+			expect( getVariantItemText ).toBeInTheDocument();
 		}
 	);
 
@@ -167,9 +169,10 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			expect(
+			const renderedVariant = await waitFor( () =>
 				screen.queryByText( getVariantItemTextForInterval( expectedVariant ) )
-			).not.toBeInTheDocument();
+			);
+			expect( renderedVariant ).not.toBeInTheDocument();
 		}
 	);
 
@@ -185,9 +188,9 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const variantItem = screen
-				.getByText( getVariantItemTextForInterval( expectedVariant ) )
-				.closest( 'label' );
+			const variantItem = (
+				await screen.findByText( getVariantItemTextForInterval( expectedVariant ) )
+			 ).closest( 'label' );
 			const lowestVariantItem = variantItem.closest( 'ul' ).querySelector( 'label:first-of-type' );
 			const lowestVariantSlug = lowestVariantItem.closest( 'div' ).querySelector( 'input' ).value;
 			const variantSlug = variantItem.closest( 'div' ).querySelector( 'input' ).value;
@@ -221,14 +224,14 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const variantItem = screen
-				.getByText( getVariantItemTextForInterval( expectedVariant ) )
-				.closest( 'label' );
+			const variantItem = (
+				await screen.findByText( getVariantItemTextForInterval( expectedVariant ) )
+			 ).closest( 'label' );
 			expect( within( variantItem ).queryByText( /Save \d+%/ ) ).not.toBeInTheDocument();
 		}
 	);
 
-	it( 'does not render the variant picker if there are no variants after clicking into edit mode', async () => {
+	it( 'does not render the variant picker if there are no variants', async () => {
 		const cartChanges = { products: [ domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -3,7 +3,7 @@
  */
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { render, fireEvent, screen, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
@@ -145,8 +145,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			} ) );
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
-			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-			fireEvent.click( editOrderButton );
 
 			expect(
 				screen.getByText( getVariantItemTextForInterval( expectedVariant ) )
@@ -168,8 +166,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
-			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-			fireEvent.click( editOrderButton );
 
 			expect(
 				screen.queryByText( getVariantItemTextForInterval( expectedVariant ) )
@@ -188,8 +184,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			} ) );
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
-			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-			fireEvent.click( editOrderButton );
 
 			const variantItem = screen
 				.getByText( getVariantItemTextForInterval( expectedVariant ) )
@@ -226,8 +220,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			} ) );
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
-			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-			fireEvent.click( editOrderButton );
 
 			const variantItem = screen
 				.getByText( getVariantItemTextForInterval( expectedVariant ) )
@@ -239,8 +231,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 	it( 'does not render the variant picker if there are no variants after clicking into edit mode', async () => {
 		const cartChanges = { products: [ domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-		fireEvent.click( editOrderButton );
 
 		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
@@ -258,8 +248,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			} ) );
 			const cartChanges = { products: [ getPersonalPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
-			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-			fireEvent.click( editOrderButton );
 
 			expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
 			expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
@@ -271,8 +259,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 		const currentPlanRenewal = { ...planWithoutDomain, extra: { purchaseType: 'renewal' } };
 		const cartChanges = { products: [ currentPlanRenewal ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-		fireEvent.click( editOrderButton );
 
 		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -593,7 +593,8 @@ describe( 'CompositeCheckout', () => {
 			'Remove WordPress.com Personal from cart'
 		);
 		fireEvent.click( removeProductButton );
-		const confirmButton = await screen.findByText( 'Continue' );
+		const confirmModal = await screen.findByRole( 'dialog' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		fireEvent.click( confirmButton );
 		await waitFor( () => {
 			expect( navigate ).toHaveBeenCalledWith( '/plans/foo.com' );
@@ -608,7 +609,8 @@ describe( 'CompositeCheckout', () => {
 			'Remove foo.cash from cart'
 		);
 		fireEvent.click( removeProductButton );
-		const confirmButton = await screen.findByText( 'Continue' );
+		const confirmModal = await screen.findByRole( 'dialog' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		fireEvent.click( confirmButton );
 		await waitFor( async () => {
 			expect( navigate ).not.toHaveBeenCalledWith( '/plans/foo.com' );
@@ -767,7 +769,7 @@ describe( 'CompositeCheckout', () => {
 			screen
 				.getAllByLabelText( 'WordPress.com Personal' )
 				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
-			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
 			screen
 				.getAllByLabelText( 'bar.com' )
 				.map( ( element ) => expect( element ).toHaveTextContent( 'R$0' ) );
@@ -796,8 +798,8 @@ describe( 'CompositeCheckout', () => {
 			container
 		);
 		await waitFor( async () => {
-			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
-			expect( screen.getAllByText( 'foo.cash' ) ).toHaveLength( 3 );
+			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
+			expect( screen.getAllByText( 'foo.cash' ) ).toHaveLength( 2 );
 		} );
 	} );
 
@@ -809,8 +811,8 @@ describe( 'CompositeCheckout', () => {
 			container
 		);
 		await waitFor( async () => {
-			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 3 );
+			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 2 );
 		} );
 	} );
 
@@ -825,9 +827,9 @@ describe( 'CompositeCheckout', () => {
 			container
 		);
 		await waitFor( () => {
-			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
-			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 6 );
+			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
+			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 4 );
 		} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -568,36 +568,19 @@ describe( 'CompositeCheckout', () => {
 		} );
 	} );
 
-	it( 'removes a product from the cart after clicking to remove it in edit mode', async () => {
+	it( 'removes a product from the cart after clicking to remove', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
 		);
-		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 2 );
+		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 1 );
 		fireEvent.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
 		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		fireEvent.click( confirmButton );
 		await waitFor( () => {
-			expect( screen.queryAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 0 );
-		} );
-	} );
-
-	it( 'removes a product from the cart after clicking to remove it outside of edit mode', async () => {
-		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
-		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
-		const removeProductButton = await within( activeSection ).findByLabelText(
-			'Remove WordPress.com Personal from cart'
-		);
-		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 2 );
-		fireEvent.click( removeProductButton );
-		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
-		fireEvent.click( confirmButton );
-		await waitFor( async () => {
 			expect( screen.queryAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 0 );
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -571,8 +571,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'removes a product from the cart after clicking to remove it in edit mode', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
-		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-		fireEvent.click( editOrderButton );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
@@ -607,8 +605,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'redirects to the plans page if the cart is empty after removing the last product', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
-		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-		fireEvent.click( editOrderButton );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
@@ -624,8 +620,6 @@ describe( 'CompositeCheckout', () => {
 	it( 'does not redirect to the plans page if the cart is empty after removing a product when it is not the last', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
-		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-		fireEvent.click( editOrderButton );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove foo.cash from cart'

--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -52,7 +52,7 @@ function useShowStaleCartNotice() {
 				infoNotice( translate( 'Your cart is awaiting payment.' ), {
 					id: staleCartItemNoticeId,
 					button: translate( 'View your cart' ),
-					href: `/checkout/${ selectedSiteSlug }?order-review=true`, // Redirect to the order-review step
+					href: `/checkout/${ selectedSiteSlug }`,
 					onClick: () => {
 						reduxDispatch( recordTracksEvent( 'calypso_cart_abandonment_notice_click' ) );
 					},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove step controls for the WordPress.com cart "order review"
  * This will effectively lock the step in the same "complete" state
* Modify the complete step of the order review step to always show product variant selectors
* Remove related code that is made unnecessary by the changes above.

##### Screenshots

| Before | Before ( with Edit ) |  After |
|--------|--------------------| ------|
| <img width="568" alt="Screen Shot 2022-01-07 at 11 55 14" src="https://user-images.githubusercontent.com/2810519/148599821-64e1835b-34b9-440e-aaed-e52f904c0d2c.png"> | <img width="568" alt="Screen Shot 2022-01-07 at 11 55 17" src="https://user-images.githubusercontent.com/2810519/148599824-c232b727-39c2-4b1f-ad97-525f3d0e883b.png"> |<img width="568" alt="Screen Shot 2022-01-07 at 11 55 46" src="https://user-images.githubusercontent.com/2810519/148599812-36cfbcc1-709d-478a-ad7d-c2234c3de4db.png"> |

##### Mobile Screenshots

| Before | Before ( with Edit ) |  After |
|--------|--------------------| ------|
| ![Screen Shot 2022-01-07 at 11 57 37](https://user-images.githubusercontent.com/2810519/148599996-f0ef4865-3cb7-4109-bb60-2bd32fa69656.png) | ![Screen Shot 2022-01-07 at 11 57 34](https://user-images.githubusercontent.com/2810519/148600002-02f7b5ee-abc3-4c10-94d4-a6d7fb2f7d48.png) | ![Screen Shot 2022-01-07 at 11 57 40](https://user-images.githubusercontent.com/2810519/148599989-54f2c5bb-7710-4c39-99a8-10ed48b3299a.png) | 

#### Testing instructions

Testing should cover as many cases in the cart as possible:

- A single two variant product, such as any Jetpack plan or product.
- A single three variant product, such as a WordPress.com plan.
- Combinations of the above ( 2 Jetpack plans, 2 WordPress.com plans and a Jetpack plan, etc )

With your casrt test:
1. Changing a variant with the exposed variant selector changes which variant is in the cart.
2. Check that the total is correctly updated
3. Check that other products in the card ( if any ) variants are not changed.

Related to 1201295898168937-as-1201295899380971