### PR TITLE
Editor: Fix the user cannot edit post/page without content

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -18,7 +18,13 @@ import { filter, forEach, get, map } from 'lodash';
 import { Component, useEffect, useState } from 'react';
 import tinymce from 'tinymce/tinymce';
 import { STORE_KEY as NAV_SIDEBAR_STORE_KEY } from '../../../../editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants';
-import { inIframe, isEditorReadyWithBlocks, sendMessage, getPages } from '../../utils';
+import {
+	inIframe,
+	isEditorReady,
+	isEditorReadyWithBlocks,
+	sendMessage,
+	getPages,
+} from '../../utils';
 import FeedbackForm from './fse-beta/feedback-form';
 /**
  * Conditional dependency.  We cannot use the standard 'import' since this package is
@@ -963,7 +969,7 @@ function getCalypsoUrlInfo( calypsoPort ) {
 }
 
 async function handleEditorLoaded( calypsoPort ) {
-	await isEditorReadyWithBlocks();
+	await isEditorReady();
 	const isNew = select( 'core/editor' ).isCleanNewPost();
 	const blocks = select( 'core/block-editor' ).getBlocks();
 

--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -29,9 +29,32 @@ export function sendMessage( message ) {
 }
 
 /**
- * Indicates if the block editor has been initialized with blocks.
+ * Indicates if the block editor has been initialized.
  *
  * @returns {Promise} Promise that resolves when the editor has been initialized.
+ */
+export const isEditorReady = async () =>
+	new Promise( ( resolve ) => {
+		const unsubscribe = subscribe( () => {
+			// Calypso sends the message as soon as the iframe is loaded, so we
+			// need to be sure that the editor is initialized and the core blocks
+			// registered. There is an unstable selector for that, so we use
+			// `isCleanNewPost` otherwise which is triggered when everything is
+			// initialized if the post is new.
+			const editorIsReady = select( 'core/editor' ).__unstableIsEditorReady
+				? select( 'core/editor' ).__unstableIsEditorReady()
+				: select( 'core/editor' ).isCleanNewPost();
+			if ( editorIsReady ) {
+				unsubscribe();
+				resolve();
+			}
+		} );
+	} );
+
+/**
+ * Indicates if the block editor has been initialized with blocks.
+ *
+ * @returns {Promise} Promise that resolves when the editor has been initialized with blocks.
  */
 export const isEditorReadyWithBlocks = async () =>
 	new Promise( ( resolve ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://github.com/Automattic/wp-calypso/pull/59525 checks the editor is loaded or not, but it requires the post/page with blocks so that the post/page without content keeps loading and the user is unable to edit it

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open another terminal and run `cd apps/wpcom-block-editor && yarn dev --sync`. Also, make sure `widgets.wp.com` points to your sandbox
* Add new Page/Post
* Insert a title
* Save as draft or publish page
* Refresh page and the page should load successfully

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/59805
