### PR TITLE
Offer annual Professional Email subscriptions in domain upsell flow

### DIFF
--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -1,3 +1,4 @@
+import { TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
@@ -36,6 +37,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 				} ) }
 				selectedDomainName={ domain }
 				skipButtonLabel={ translate( 'Skip' ) }
+				titanProductSlug={ TITAN_MAIL_YEARLY_SLUG }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/email/email-provider-features/list.js
+++ b/client/my-sites/email/email-provider-features/list.js
@@ -56,9 +56,9 @@ const getGoogleFeatures = () => {
 	];
 };
 
-const getTitanFeatures = () => {
+const getTitanFeatures = ( isMonthlyProduct = true ) => {
 	return [
-		translate( 'Monthly billing' ),
+		isMonthlyProduct ? translate( 'Monthly billing' ) : translate( 'Annual billing' ),
 		translate( 'Send and receive from your custom domain' ),
 		translate( '30GB storage' ),
 		translate( 'Email, calendars, and contacts' ),

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -557,7 +557,33 @@ class EmailProvidersComparison extends Component {
 			? translate( '{{price/}} /mailbox /month (billed monthly)', priceComponents )
 			: translate( '{{price/}} /mailbox /month (billed annually)', priceComponents );
 
-		const discount = isEligibleForFreeTrial ? translate( '3 months free' ) : null;
+		const discount = ! isEligibleForFreeTrial ? null : (
+			<>
+				{ translate( '3 months free' ) }
+				{ ! titanIsMonthly && (
+					<span className="email-providers-comparison__discount-with-renewal">
+						<span>
+							{ ' ' }
+							{ translate(
+								'%(firstRenewalPrice)s/mailbox billed in 3 months, renews at %(standardPrice)s/mailbox',
+								{
+									args: {
+										firstRenewalPrice: formatCurrency(
+											( titanMailProduct?.cost ?? 0 ) * 0.75,
+											currencyCode
+										),
+										standardPrice: formatCurrency( titanMailProduct?.cost ?? 0, currencyCode ),
+									},
+									comment:
+										"%(firstRenewalPrice)s is a formatted, reduced price that the user will pay in three months (e.g. '$3'), " +
+										"%(standardPrice)s is a formatted price (e.g. '$5')",
+								}
+							) }
+						</span>
+					</span>
+				) }
+			</>
+		);
 
 		const logo = (
 			<Gridicon

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -659,7 +659,7 @@ class EmailProvidersComparison extends Component {
 				formFields={ formFields }
 				showExpandButton={ this.isDomainEligibleForEmail( domain ) }
 				expandButtonLabel={ expandButtonLabel }
-				features={ getTitanFeatures() }
+				features={ getTitanFeatures( titanIsMonthly ) }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -563,7 +563,6 @@ class EmailProvidersComparison extends Component {
 				{ ! titanIsMonthly && (
 					<span className="email-providers-comparison__discount-with-renewal">
 						<span>
-							{ ' ' }
 							{ translate(
 								'%(firstRenewalPrice)s/mailbox billed in 3 months, renews at %(standardPrice)s/mailbox',
 								{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the component used in the domain upsell flow to support both monthly and annual subscriptions for Professional Email, with the caller deciding which of the two should be offered.
* The second piece of the PR is to specify the annual product for the email upsell page in the in-Calypso domain purchase flow

#### Testing instructions

* Run this branch locally or via the [Calypso live server](https://github.com/Automattic/wp-calypso/pull/59842#issuecomment-1007214769)
* Navigate to **Upgrades** -> **Domains**
* Click on the "Add a domain" button, and then on the "Search for a domain" option
* Search for a domain, and click on the "Select" button for a domain name
* Verify that you see the domain upsell page, and that the Professional Email card shows you a "billed annually" price, and a price that is less than the normal monthly price by about 1/6th
* Fill out the form to add a mailbox, and click on the "Add" button
* Verify that checkout displays the annual product (it should say "billed annually")
* Complete checkout and verify that the purchase goes through correctly
* Now navigate to **Upgrades** -> **Emails**
* For a domain where you don't have an email solution, click on "Add Email"
* Verify that you see the new email comparison page
* Add `?flags=-emails/new-email-comparison` to the URL
* Verify that you now see the old email comparison page
* Verify that the monthly price is displayed for Professional Email, and the price includes "billed monthly"
* Add one or more mailboxes and click on the "Add" button
* Verify that you're taken to checkout and that the product shows "billed monthly"
* Complete checkout and verify that the purchase completes and has the correct billing interval

#### Screenshots

##### Domain upsell showing annual product

<img width="1065" alt="Screenshot 2022-01-07 at 10 53 26" src="https://user-images.githubusercontent.com/3376401/148518344-705c32cc-37fa-4ac3-95c0-022e7267b764.png">

##### Checkout showing annual product with new domain

<img width="589" alt="Screenshot 2022-01-07 at 09 53 37" src="https://user-images.githubusercontent.com/3376401/148512238-b2db5b9a-d622-4d65-b558-b4a12b8f1c72.png">