### PR TITLE
Fix layout issue in Jetpack SSO approval UI in Calypso Blue

### DIFF
--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -411,7 +411,7 @@ class JetpackSsoForm extends Component {
 						noticeText={ translate( 'You must verify your email to sign in with WordPress.com.' ) }
 						noticeStatus="is-info"
 					>
-						<Card>
+						<Card className="jetpack-connect__logged-in-card">
 							{ currentUser.email_verified && this.maybeRenderErrorNotice() }
 							<div className="jetpack-connect__sso-user-profile">
 								<Gravatar user={ currentUser } size={ 120 } imgSize={ 400 } />


### PR DESCRIPTION
Fixes 1164141197617539-as-1201622882352462

#### Changes proposed in this Pull Request

* Add `className="jetpack-connect__logged-in-card"` to `Card` component inside `JetpackSsoForm` in order to unify styling.

#### Testing instructions

* Create a JN site
* Sign in to a secondary wp.com account and connect Jetpack
* Enable **WordPress.com login** in Jetpack settings from wp-admin
* Now login to the primary wp.com
* Goto `/wp-admin` of the site and use  **Log in with WordPress.com**
* On the SSO screen, see the fixed layout
* Check for any regression

Before and After
<img width="344" alt="image" src="https://user-images.githubusercontent.com/18226415/148514667-03221ac3-adbf-4b91-80e7-211cf5dc5c3d.png">...<img width="328" alt="image" src="https://user-images.githubusercontent.com/18226415/148514687-2cba0105-77a9-4c25-b66e-56876dbcb846.png">
