### PR TITLE
Plugin Details: minor cta copy update.

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -81,7 +81,7 @@ const USPS: React.FC< Props > = ( {
 					{
 						id: 'plan',
 						className: 'title',
-						text: translate( 'Included in the Business plan (%s)', {
+						text: translate( 'Included in the Business plan (%s):', {
 							args: [ planDisplayCost ],
 						} ),
 						eligibilities: [ 'needs-upgrade' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds `:` after the "Include in Business plan" copy so that it makes it more clear that the usps underneath are part of the Business plan.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I a free site load a paid plugin page.
* Inspect the usps under the CTA

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-2M-p2#comment-79