### PR TITLE
Checkout: Remove sites from the checkout dropdown if they have already activated the purchased product

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -206,13 +206,13 @@ const LicensingActivationThankYou: FC< Props > = ( {
 			product && product.product_slug === productSlug;
 
 		return jetpackSites
-			.filter( ( site: JetpackSite ) => ! site.is_wpcom_atomic )
+			.filter( ( site ) => ! site.is_wpcom_atomic )
 			.filter(
-				( site: JetpackSite ) =>
+				( site ) =>
 					! site.products.some( isProductActivatedOnSite ) &&
 					! isProductActivatedOnSite( site.plan )
 			)
-			.map( ( site: JetpackSite ) => ( {
+			.map( ( site ) => ( {
 				value: site?.URL,
 				label: site.URL,
 				props: {

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -35,11 +35,14 @@ type JetpackSite = {
 	ID: number;
 	URL: string;
 	is_wpcom_atomic: boolean;
+	products: Product[];
+	plan: Product;
 };
 
 type Product = {
 	product_id: number;
 	product_name: string;
+	product_slug: string;
 };
 
 interface ProductsList {
@@ -199,8 +202,16 @@ const LicensingActivationThankYou: FC< Props > = ( {
 	] );
 
 	const siteSelectOptions = useMemo( () => {
+		const isProductActivatedOnSite = ( product: Product ) =>
+			product && product.product_slug === productSlug;
+
 		return jetpackSites
 			.filter( ( site: JetpackSite ) => ! site.is_wpcom_atomic )
+			.filter(
+				( site: JetpackSite ) =>
+					! site.products.some( isProductActivatedOnSite ) &&
+					! isProductActivatedOnSite( site.plan )
+			)
 			.map( ( site: JetpackSite ) => ( {
 				value: site?.URL,
 				label: site.URL,
@@ -213,7 +224,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 					},
 				},
 			} ) );
-	}, [ jetpackSites, selectedSite ] );
+	}, [ jetpackSites, selectedSite, productSlug ] );
 
 	const lastSelectOption = {
 		value: 'activate-license-manually',

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -11,13 +11,16 @@ export interface SiteData {
 	wpcom_url?: string;
 	jetpack?: boolean;
 	plan: SiteDataPlan;
+	products?: SiteDataPlan[];
 	capabilities?: Record< string, boolean >;
+	is_wpcom_atomic?: boolean;
 	// TODO: fill out the rest of this
 }
 
 export interface SiteDataPlan {
 	product_id: number;
 	product_slug: string;
+	product_name?: string;
 	product_name_short: string;
 	expired: boolean;
 	user_is_owner: boolean;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will remove your sites that already have the purchased product activated from the dropdown for choosing the site after purchasing.

#### Testing instructions

**Prerequisites**

- Site with Jetpack Complete (or other) plan activated.
- Site with Jetpack Backup (or other) product activated.
- Keep DevTools opened and look at your browser’s JavaScript console for any errors reported.

**Testing**

- Download this PR.
- Start Calypso with `yarn start`.
- Visit `https://cloud.jetpack.com/pricing`.

Testing with an already existing plan (e.g. Jetpack Complete)

- Select a Jetpack Complete plan.
- You will be redirected to the checkout page, replace `wordpress.com` with `calypso.localhost:3000` in the URL.
- Submit the checkout form and stop on the “Thank you for your purchase” screen.
- Verify that the dropdown doesn’t include your sites with already activated Jetpack Complete.

Testing with already existing products (e.g. Jetpack Backup)

- Select a Jetpack Backup product.
- You will be redirected to the checkout page, replace `wordpress.com` with `calypso.localhost:3000` in the URL.
- Submit the checkout form and stop on the “Thank you for your purchase” screen.
- Verify that the dropdown doesn’t include your sites with already activated Jetpack Backup.

Regression testing

- Make sure that you don’t have any sites removed that shouldn’t be missing, and also, you can try to purchase other product variations and make sure the purchase flow is working as expected.

Related to 1201509629272450-as-1201510024197557