### PR TITLE
Plans step: Do not hide the annual savings tooltip on scrolling down

### DIFF
--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -328,7 +328,7 @@ const StyledPopover = styled( Popover )`
 
 		.rtl &.is-left {
 			.popover__arrow {
-				right: 40px;
+				right: 20px;
 				border-left-color: var( --color-neutral-100 );
 				&::before {
 					border-left-color: var( --color-neutral-100 );
@@ -336,7 +336,7 @@ const StyledPopover = styled( Popover )`
 			}
 
 			.popover__inner {
-				left: -50px;
+				right: 30px;
 			}
 		}
 

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -93,7 +93,12 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 		<>
 			{ [ 'right', 'bottom' ].map( ( pos ) => (
 				<CSSTransition key={ pos } in={ inProp } timeout={ timeout } classNames="popover">
-					<StyledPopover position={ pos } context={ context } isVisible={ true }>
+					<StyledPopover
+						position={ pos }
+						context={ context }
+						isVisible={ true }
+						autoPosition={ false }
+					>
 						{ children }
 					</StyledPopover>
 				</CSSTransition>
@@ -149,17 +154,15 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 					path={ generatePath( props, { intervalType: 'yearly' } ) }
 				>
 					<span ref={ ( ref ) => ref && setSpanRef( ref ) }>{ translate( 'Pay annually' ) }</span>
-					{ popupIsVisible && (
-						<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
-							{ translate(
-								'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
-								{
-									args: { maxDiscount },
-									comment: 'Will be like "Save up to 30% by paying annually..."',
-								}
-							) }
-						</PopupMessages>
-					) }
+					<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
+						{ translate(
+							'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
+							{
+								args: { maxDiscount },
+								comment: 'Will be like "Save up to 30% by paying annually..."',
+							}
+						) }
+					</PopupMessages>
 				</SegmentedControl.Item>
 			</SegmentedControl>
 		</IntervalTypeToggleWrapper>
@@ -304,8 +307,20 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 const StyledPopover = styled( Popover )`
 	&.popover {
 		display: none;
-		transition-property: transform;
+		opacity: 0;
+		transition-property: opacity, transform;
 		transition-timing-function: ease-in;
+
+		&.popover-enter-active {
+			opacity: 1;
+			transition-duration: 0.3s;
+		}
+
+		&.popover-exit,
+		&.popover-enter-done {
+			opacity: 1;
+			transition-duration: 0.01s;
+		}
 
 		&.is-right,
 		.rtl &.is-left {
@@ -313,22 +328,26 @@ const StyledPopover = styled( Popover )`
 				display: block;
 			}
 
+			&.popover-enter {
+				transform: translate( 30px, 0 );
+			}
+
+			&.popover-enter-active,
+			&.popover-enter-done {
+				transform: translate( 20px, 0 );
+			}
+
 			.popover__arrow {
 				border-right-color: var( --color-neutral-100 );
 				&::before {
 					border-right-color: var( --color-neutral-100 );
 				}
-				left: 20px;
-			}
-
-			.popover__inner {
-				left: 30px;
 			}
 		}
 
 		.rtl &.is-left {
 			.popover__arrow {
-				right: 20px;
+				right: 40px;
 				border-left-color: var( --color-neutral-100 );
 				&::before {
 					border-left-color: var( --color-neutral-100 );
@@ -336,7 +355,7 @@ const StyledPopover = styled( Popover )`
 			}
 
 			.popover__inner {
-				right: 30px;
+				left: -50px;
 			}
 		}
 
@@ -365,20 +384,6 @@ const StyledPopover = styled( Popover )`
 		.rtl &.is-bottom {
 			.popover__arrow {
 				border-right-color: transparent;
-			}
-		}
-
-		&.is-bottom-right,
-		.rtl &.is-bottom-left {
-			@media ( min-width: 960px ) {
-				display: block;
-			}
-
-			.popover__arrow {
-				border-bottom-color: var( --color-neutral-100 );
-				&::before {
-					border-bottom-color: var( --color-neutral-100 );
-				}
 			}
 		}
 

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -93,12 +93,7 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 		<>
 			{ [ 'right', 'bottom' ].map( ( pos ) => (
 				<CSSTransition key={ pos } in={ inProp } timeout={ timeout } classNames="popover">
-					<StyledPopover
-						position={ pos }
-						context={ context }
-						isVisible={ true }
-						autoposition={ false }
-					>
+					<StyledPopover position={ pos } context={ context } isVisible={ true }>
 						{ children }
 					</StyledPopover>
 				</CSSTransition>

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -93,7 +93,12 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 		<>
 			{ [ 'right', 'bottom' ].map( ( pos ) => (
 				<CSSTransition key={ pos } in={ inProp } timeout={ timeout } classNames="popover">
-					<StyledPopover position={ pos } context={ context } isVisible={ true }>
+					<StyledPopover
+						position={ pos }
+						context={ context }
+						isVisible={ true }
+						autoposition={ false }
+					>
 						{ children }
 					</StyledPopover>
 				</CSSTransition>
@@ -149,15 +154,17 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 					path={ generatePath( props, { intervalType: 'yearly' } ) }
 				>
 					<span ref={ ( ref ) => ref && setSpanRef( ref ) }>{ translate( 'Pay annually' ) }</span>
-					<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
-						{ translate(
-							'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
-							{
-								args: { maxDiscount },
-								comment: 'Will be like "Save up to 30% by paying annually..."',
-							}
-						) }
-					</PopupMessages>
+					{ popupIsVisible && (
+						<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
+							{ translate(
+								'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
+								{
+									args: { maxDiscount },
+									comment: 'Will be like "Save up to 30% by paying annually..."',
+								}
+							) }
+						</PopupMessages>
+					) }
 				</SegmentedControl.Item>
 			</SegmentedControl>
 		</IntervalTypeToggleWrapper>
@@ -302,20 +309,8 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 const StyledPopover = styled( Popover )`
 	&.popover {
 		display: none;
-		opacity: 0;
-		transition-property: opacity, transform;
+		transition-property: transform;
 		transition-timing-function: ease-in;
-
-		&.popover-enter-active {
-			opacity: 1;
-			transition-duration: 0.3s;
-		}
-
-		&.popover-exit,
-		&.popover-enter-done {
-			opacity: 1;
-			transition-duration: 0.01s;
-		}
 
 		&.is-right,
 		.rtl &.is-left {
@@ -323,20 +318,16 @@ const StyledPopover = styled( Popover )`
 				display: block;
 			}
 
-			&.popover-enter {
-				transform: translate( 30px, 0 );
-			}
-
-			&.popover-enter-active,
-			&.popover-enter-done {
-				transform: translate( 20px, 0 );
-			}
-
 			.popover__arrow {
 				border-right-color: var( --color-neutral-100 );
 				&::before {
 					border-right-color: var( --color-neutral-100 );
 				}
+				left: 20px;
+			}
+
+			.popover__inner {
+				left: 30px;
 			}
 		}
 
@@ -379,6 +370,20 @@ const StyledPopover = styled( Popover )`
 		.rtl &.is-bottom {
 			.popover__arrow {
 				border-right-color: transparent;
+			}
+		}
+
+		&.is-bottom-right,
+		.rtl &.is-bottom-left {
+			@media ( min-width: 960px ) {
+				display: block;
+			}
+
+			.popover__arrow {
+				border-bottom-color: var( --color-neutral-100 );
+				&::before {
+					border-bottom-color: var( --color-neutral-100 );
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the signup flow plans step, the tooltip next to "Pay annually" disappears when scrolling down and doesn't come back again. Check below. This PR fixes the issue.

**BEFORE**

![mnthlydef](https://user-images.githubusercontent.com/1269602/148540430-9d8fe606-fcb2-406c-b9ef-73dd89eb4b82.gif)

**AFTER**

![mnthlydef](https://user-images.githubusercontent.com/1269602/148541820-7e777e99-f6d6-4e2d-9b51-44e13bd59ed2.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the issue described is fixed.
* In mobile view, when on the monthly plans tab in the plans step, verify that after scrolling down and scrolling back up, the annual savings tooltip is visible.
* Verify the tooltip looks fine in an RTL locale.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


