### PR TITLE
Marketplace: add interval switcher for free plugins on elligible plans.

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -1,5 +1,4 @@
 // File used only for development and testing.
-import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
 import { Button, Card, CompactCard } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -21,14 +20,13 @@ import {
 	requestEligibility,
 } from 'calypso/state/automated-transfer/actions';
 import { getAutomatedTransfer, getEligibility } from 'calypso/state/automated-transfer/selectors';
+import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import {
 	getPluginOnSite,
 	getPlugins,
 	isRequestingForSites,
 } from 'calypso/state/plugins/installed/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -56,9 +54,7 @@ export default function MarketplaceTest() {
 	const pluginDetails = useSelector( ( state ) => getPlugins( state, [ selectedSiteId ] ) );
 	const { data = [], isFetching } = useWPCOMPlugins( 'all' );
 
-	// Site type
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
-	const isVip = useSelector( ( state ) => checkVipSite( state, selectedSite?.ID ) );
+	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
 
 	const isRequestingForSite = useSelector( ( state ) =>
 		isRequestingForSites( state, [ selectedSiteId ] )
@@ -76,14 +72,6 @@ export default function MarketplaceTest() {
 	const dispatch = useDispatch();
 	const transferDetails = useSelector( ( state ) => getAutomatedTransfer( state, selectedSiteId ) );
 	const eligibilityDetails = useSelector( ( state ) => getEligibility( state, selectedSiteId ) );
-
-	const shouldUpgrade = ! (
-		isBusiness( selectedSite?.plan ) ||
-		isEnterprise( selectedSite?.plan ) ||
-		isEcommerce( selectedSite?.plan ) ||
-		isJetpack ||
-		isVip
-	);
 
 	const marketplacePages = [
 		{

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -286,10 +286,12 @@ function onClickInstallPlugin( {
 		if ( upgradeAndInstall ) {
 			// We also need to add a business plan to the cart.
 			return page(
-				`/checkout/${ selectedSite.slug }/${ product_slug },${ businessPlanToAdd(
+				`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
 					selectedSite?.plan,
 					billingPeriod
-				) }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2`
+				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
+					selectedSite.slug
+				}#step2`
 			);
 		}
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -304,7 +304,8 @@ function onClickInstallPlugin( {
 		// We also need to add a business plan to the cart.
 		return page(
 			`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
-				selectedSite?.plan
+				selectedSite?.plan,
+				billingPeriod
 			) }?redirect_to=${ installPluginURL }#step2`
 		);
 	}
@@ -314,7 +315,7 @@ function onClickInstallPlugin( {
 }
 
 // Return the correct business plan slug depending on current plan and pluginBillingPeriod
-function businessPlanToAdd( currentPlan, pluginBillingPeriod = null ) {
+function businessPlanToAdd( currentPlan, pluginBillingPeriod ) {
 	switch ( currentPlan.product_slug ) {
 		case PLAN_PERSONAL_2_YEARS:
 		case PLAN_PREMIUM_2_YEARS:

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,7 +1,4 @@
 import {
-	isBusiness,
-	isEcommerce,
-	isEnterprise,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
 	PLAN_PREMIUM,
@@ -28,10 +25,10 @@ import {
 	isEligibleForAutomatedTransfer,
 } from 'calypso/state/automated-transfer/selectors';
 import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
+import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { PluginPrice, getPeriodVariationValue } from '../plugin-price';
 import USPS from './usps';
@@ -55,20 +52,11 @@ const PluginDetailsCTA = ( {
 
 	// Site type
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
-	const isVip = useSelector( ( state ) => checkVipSite( state, selectedSite?.ID ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 	const isFreePlan = selectedSite && isFreePlanProduct( selectedSite.plan );
 
-	const shouldUpgrade =
-		selectedSite &&
-		! (
-			isBusiness( selectedSite.plan ) ||
-			isEnterprise( selectedSite.plan ) ||
-			isEcommerce( selectedSite.plan ) ||
-			isJetpack ||
-			isVip
-		);
+	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
 
 	// Eligibilities for Simple Sites.
 	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -27,6 +27,7 @@ import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import {
 	getPluginOnSite,
 	getPluginOnSites,
@@ -96,6 +97,7 @@ function PluginDetails( props ) {
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isWpcom = selectedSite && ! isJetpack;
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
+	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
 
 	// Header Navigation and billing period switcher.
 	const isWide = useBreakpoint( '>1280px' );
@@ -221,7 +223,7 @@ function PluginDetails( props ) {
 				compactBreadcrumb={ ! isWide }
 			>
 				{ isEnabled( 'marketplace-v1' ) &&
-					isMarketplaceProduct &&
+					( isMarketplaceProduct || shouldUpgrade ) &&
 					! requestingPluginsForSites &&
 					! isPluginInstalledOnsite && (
 						<BillingIntervalSwitcher

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,4 +1,3 @@
-import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -13,8 +12,8 @@ import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
-import { default as checkVipSite } from 'calypso/state/selectors/is-vip-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserElementVariant } from './types';
@@ -94,16 +93,7 @@ const PluginsBrowserListElement = ( props ) => {
 		return version_compare( wpVersion, pluginTestedVersion, '>' );
 	} );
 
-	const isVip = useSelector( ( state ) => checkVipSite( state, selectedSite?.ID ) );
-	const shouldUpgrade =
-		selectedSite &&
-		! (
-			isBusiness( selectedSite.plan ) ||
-			isEnterprise( selectedSite.plan ) ||
-			isEcommerce( selectedSite.plan ) ||
-			isJetpack ||
-			isVip
-		);
+	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
 
 	if ( isPlaceholder ) {
 		return <Placeholder iconSize={ iconSize } />;

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -8,13 +8,15 @@ const shouldUpgradeCheck = (
 	state: IAppState,
 	selectedSite: { ID: number; plan: WithSnakeCaseSlug | WithCamelCaseSlug }
 ) => {
-	return ! (
-		isBusiness( selectedSite?.plan ) ||
-		isEnterprise( selectedSite?.plan ) ||
-		isEcommerce( selectedSite?.plan ) ||
-		isJetpackSite( state, selectedSite?.ID ) ||
-		isVipSite( state, selectedSite?.ID )
-	);
+	return selectedSite
+		? ! (
+				isBusiness( selectedSite?.plan ) ||
+				isEnterprise( selectedSite?.plan ) ||
+				isEcommerce( selectedSite?.plan ) ||
+				isJetpackSite( state, selectedSite?.ID ) ||
+				isVipSite( state, selectedSite?.ID )
+		  )
+		: null;
 };
 
 export default shouldUpgradeCheck;

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -1,0 +1,20 @@
+import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
+import { default as isVipSite } from 'calypso/state/selectors/is-vip-site';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { IAppState } from 'calypso/state/types';
+import type { WithCamelCaseSlug, WithSnakeCaseSlug } from '@automattic/calypso-products';
+
+const shouldUpgradeCheck = (
+	state: IAppState,
+	selectedSite: { ID: number; plan: WithSnakeCaseSlug | WithCamelCaseSlug }
+) => {
+	return ! (
+		isBusiness( selectedSite?.plan ) ||
+		isEnterprise( selectedSite?.plan ) ||
+		isEcommerce( selectedSite?.plan ) ||
+		isJetpackSite( state, selectedSite?.ID ) ||
+		isVipSite( state, selectedSite?.ID )
+	);
+};
+
+export default shouldUpgradeCheck;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* extracts shouldUpgrade to a selector.
* uses new shouldUpgradeCheck selector.
* adds billing switcher to free plugins for `shouldUpgrade` plans
* on cta click, add plan depending on interval selector even for free plugins

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1088" alt="SS 2022-01-07 at 14 45 38" src="https://user-images.githubusercontent.com/12430020/148545960-ad2790c9-c414-443a-aeeb-f078ad31637f.png">|<img width="1085" alt="SS 2022-01-07 at 14 45 13" src="https://user-images.githubusercontent.com/12430020/148545917-2a3c22e3-12bb-413d-89af-1a517f624c7f.png">|

**Regressions**
* Check that there are no regressions regarding sites that `shouldUpgrade`
* in Plugin Details the CTA should read "Upgrade and activate"
* in Plugin Browser Item you should see "Requires a plan upgrade" for free plugins

**New changes**
* on a free site go to `plugins/contact-form-7/[DOMAIN]`
* clicking either `monthly` or `annually` should add the correct business plan in cart

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59696
