### PR TITLE
Add display logic for general introductory offer terms

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -68,7 +68,7 @@ function getMessageForTermsOfServiceRecord(
 			if (
 				( locale === 'en' ||
 					i18nCalypso.hasTranslation(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.'
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription {{/manageSubscriptionLink}} at any time.'
 					) ) &&
 				args.subscription_start_date &&
 				args.subscription_expiry_date &&
@@ -78,11 +78,11 @@ function getMessageForTermsOfServiceRecord(
 					args.is_renewal_price_prorated &&
 					( locale === 'en' ||
 						i18nCalypso.hasTranslation(
-							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.'
+							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
 						) )
 				) {
 					return translate(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.',
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 						{
 							args: {
 								startDate: moment( args.subscription_start_date ).format( 'll' ),
@@ -97,7 +97,7 @@ function getMessageForTermsOfServiceRecord(
 								updatePaymentMethodLink: (
 									<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
 								),
-								manageSubscriptionlink: (
+								manageSubscriptionLink: (
 									<a
 										href={ `/purchases/subscriptions/${ siteSlug }` }
 										target="_blank"
@@ -109,7 +109,7 @@ function getMessageForTermsOfServiceRecord(
 					);
 				}
 				return translate(
-					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 					{
 						args: {
 							startDate: moment( args.subscription_start_date ).format( 'll' ),
@@ -123,7 +123,7 @@ function getMessageForTermsOfServiceRecord(
 							updatePaymentMethodLink: (
 								<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
 							),
-							manageSubscriptionlink: (
+							manageSubscriptionLink: (
 								<a
 									href={ `/purchases/subscriptions/${ siteSlug }` }
 									target="_blank"
@@ -164,7 +164,7 @@ function getMessageForTermsOfServiceRecord(
 			if (
 				( locale === 'en' ||
 					i18nCalypso.hasTranslation(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.'
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
 					) ) &&
 				args.subscription_start_date &&
 				args.subscription_expiry_date &&
@@ -174,11 +174,11 @@ function getMessageForTermsOfServiceRecord(
 					args.is_renewal_price_prorated &&
 					( locale === 'en' ||
 						i18nCalypso.hasTranslation(
-							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.'
+							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
 						) )
 				) {
 					return translate(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.',
+						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 						{
 							args: {
 								startDate: moment( args.subscription_start_date ).format( 'll' ),
@@ -194,7 +194,7 @@ function getMessageForTermsOfServiceRecord(
 								updatePaymentMethodLink: (
 									<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
 								),
-								manageSubscriptionlink: (
+								manageSubscriptionLink: (
 									<a
 										href={ `/purchases/subscriptions/${ siteSlug }` }
 										target="_blank"
@@ -206,7 +206,7 @@ function getMessageForTermsOfServiceRecord(
 					);
 				}
 				return translate(
-					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription {{/manageSubscriptionLink}} at any time.',
 					{
 						args: {
 							startDate: moment( args.subscription_start_date ).format( 'll' ),
@@ -221,7 +221,7 @@ function getMessageForTermsOfServiceRecord(
 							updatePaymentMethodLink: (
 								<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
 							),
-							manageSubscriptionlink: (
+							manageSubscriptionLink: (
 								<a
 									href={ `/purchases/subscriptions/${ siteSlug }` }
 									target="_blank"
@@ -270,7 +270,7 @@ function getMessageForTermsOfServiceRecord(
 							startDate: moment( args.subscription_start_date ).format( 'll' ),
 						},
 						components: {
-							manageSubscriptionlink: (
+							manageSubscriptionLink: (
 								<a
 									href={ `/purchases/subscriptions/${ siteSlug }` }
 									target="_blank"
@@ -285,7 +285,7 @@ function getMessageForTermsOfServiceRecord(
 
 					if ( args.product_meta && args.product_meta !== '' ) {
 						return translate(
-							'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.',
+							'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 							{
 								args: {
 									...proratedRenewalArgs.args,
@@ -299,7 +299,7 @@ function getMessageForTermsOfServiceRecord(
 					}
 
 					return translate(
-						'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.',
+						'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 						proratedRenewalArgs
 					);
 				}
@@ -314,7 +314,7 @@ function getMessageForTermsOfServiceRecord(
 						startDate: moment( args.subscription_start_date ).format( 'll' ),
 					},
 					components: {
-						manageSubscriptionlink: (
+						manageSubscriptionLink: (
 							<a
 								href={ `/purchases/subscriptions/${ siteSlug }` }
 								target="_blank"
@@ -329,7 +329,7 @@ function getMessageForTermsOfServiceRecord(
 
 				if ( args.product_meta && args.product_meta !== '' ) {
 					return translate(
-						'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+						'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 						{
 							args: {
 								...standardRenewalArgs.args,
@@ -343,7 +343,7 @@ function getMessageForTermsOfServiceRecord(
 				}
 
 				return translate(
-					'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+					'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 					standardRenewalArgs
 				);
 			}
@@ -366,10 +366,11 @@ function getMessageForTermsOfServiceRecord(
 
 			if ( args.product_meta && args.product_meta !== '' ) {
 				return translate(
-					'At the end of the promotional period your %(productName)s subscription for %(domainName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}',
+					'At the end of the promotional period your %(productName)s subscription for %(domainName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 					{
 						args: {
 							...defaultRenewalArgs.args,
+							domainName: args.product_meta,
 						},
 						components: {
 							...defaultRenewalArgs.components,
@@ -379,7 +380,7 @@ function getMessageForTermsOfServiceRecord(
 			}
 
 			return translate(
-				'At the end of the promotional period your %(productName)s subscription will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}',
+				'At the end of the promotional period your %(productName)s subscription will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 				defaultRenewalArgs
 			);
 		}

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -252,6 +252,137 @@ function getMessageForTermsOfServiceRecord(
 					},
 				}
 			);
+		case 'terms_for_bundled_trial_unknown_payment_method': {
+			if (
+				args.subscription_start_date &&
+				args.subscription_expiry_date &&
+				args.subscription_auto_renew_date
+			) {
+				if ( args.is_renewal_price_prorated ) {
+					const proratedRenewalArgs = {
+						args: {
+							endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+							numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+							productName: args.product_name,
+							regularPrice: args.regular_renewal_price,
+							renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+							renewalPrice: args.renewal_price,
+							startDate: moment( args.subscription_start_date ).format( 'll' ),
+						},
+						components: {
+							manageSubscriptionlink: (
+								<a
+									href={ `/purchases/subscriptions/${ siteSlug }` }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							updatePaymentMethodLink: (
+								<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
+							),
+						},
+					};
+
+					if ( args.product_meta && args.product_meta !== '' ) {
+						return translate(
+							'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.',
+							{
+								args: {
+									...proratedRenewalArgs.args,
+									domainName: args.product_meta,
+								},
+								components: {
+									...proratedRenewalArgs.components,
+								},
+							}
+						);
+					}
+
+					return translate(
+						'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription{{/manageSubscriptionlink}} at any time.',
+						proratedRenewalArgs
+					);
+				}
+
+				const standardRenewalArgs = {
+					args: {
+						endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+						numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+						productName: args.product_name,
+						renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+						renewalPrice: args.renewal_price,
+						startDate: moment( args.subscription_start_date ).format( 'll' ),
+					},
+					components: {
+						manageSubscriptionlink: (
+							<a
+								href={ `/purchases/subscriptions/${ siteSlug }` }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						updatePaymentMethodLink: (
+							<a href={ EDIT_PAYMENT_DETAILS } target="_blank" rel="noopener noreferrer" />
+						),
+					},
+				};
+
+				if ( args.product_meta && args.product_meta !== '' ) {
+					return translate(
+						'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+						{
+							args: {
+								...standardRenewalArgs.args,
+								domainName: args.product_meta,
+							},
+							components: {
+								...standardRenewalArgs.components,
+							},
+						}
+					);
+				}
+
+				return translate(
+					'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionlink}}manage your subscription {{/manageSubscriptionlink}} at any time.',
+					standardRenewalArgs
+				);
+			}
+
+			const defaultRenewalArgs = {
+				args: {
+					productName: args.product_name,
+					renewalPrice: args.renewal_price,
+				},
+				components: {
+					link: (
+						<a
+							href={ `/purchases/subscriptions/${ siteSlug }` }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			};
+
+			if ( args.product_meta && args.product_meta !== '' ) {
+				return translate(
+					'At the end of the promotional period your %(productName)s subscription for %(domainName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}',
+					{
+						args: {
+							...defaultRenewalArgs.args,
+						},
+						components: {
+							...defaultRenewalArgs.components,
+						},
+					}
+				);
+			}
+
+			return translate(
+				'At the end of the promotional period your %(productName)s subscription will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}',
+				defaultRenewalArgs
+			);
+		}
 		default:
 			debug(
 				`Unknown terms of service code: ${ termsOfServiceRecord.code }`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR depends on D72681-code, which adds the new `terms_for_bundled_trial_unknown_payment_method` code for terms
* The joint goal of the back end change and this PR is to ensure that we show reasonably complete details for introductory offers in checkout, primarily when we don't yet know what payment method will be used
* The key change is that we now support a new `terms_for_bundled_trial_unknown_payment_method` type of terms, which are applied for introductory offers where we are not able to identify the correct payment method. In particular, we use language to describe the dates we will _try_ to charge the user, and what amounts we expect to charge on those dates.
* For now, this PR does not update the existing messages to incorporate the `args.product_meta` value being returned from the server.

#### Testing instructions

* Ensure that you're running against a back end that has D72681-code applied.
* Run this branch locally or via the Calypso live server.
* Navigate to **Upgrades** -> **Domains**
* Click on the "Add a domain" button, and then on the "Search for a domain" option
* Search for and select a domain on the domain search screen
* On the email upsell page, fill out the form to add at least one Professional Email mailbox, and click on the "Add" button
* Verify that you're redirected to checkout and that you see additional terms displayed for the Professional Email subscription (which should mention both the product and domain name)
* Remove both products from your cart
* Navigate to **Upgrades** -> **Domains**
* Click on the "Add a domain" button, and then on the "Search for a domain" option
* Search for and select a domain
* Hit one of the "Skip" buttons on the email upsell page
* Purchase the domain using credits (as we don't want a payment method linked to the domain)
* After completing the purchase, navigate to **Upgrades** -> **Emails**
* Click on the "Add Email" button next to the domain you just purchased
* You should be presented with an email purchase screen where the Professional Email form/card only contains two fields and the page includes a toggle for "Pay monthly" and "Pay annually" -- if you're seeing 4 fields and no billing interval toggle, add `?flags=emails/new-email-comparison` to the URL, and verify you see the toggle and the two fields
* Ensure you are on the "Pay annually" view, then fill out the fields for Professional Email and hit the "Add" button
* Verify that you're taken to checkout, and that the checkout terms include the introductory offer period, the reduced initial renewal, and the standard price for subsequent renewals

#### Screenshot

<img width="578" alt="Screenshot 2022-01-07 at 14 44 13" src="https://user-images.githubusercontent.com/3376401/148552314-787acc54-852d-4506-b8a8-6b10a0f0d9d0.png">
This screenshot includes the updated terms for an monthly Professional Email subscription bought against a domain previously purchased with credits (`email-example.com`), and an annual Professional Email subscription being purchased alongside a domain registration (`testupsell.com`).