### PR TITLE
Woop: Collect and save store email in site settings

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/Readme.md
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/Readme.md
@@ -4,8 +4,28 @@ Simple React custom hook to handle site options.
 
 ## API
 
+The hook must be called passing the site ID, returning an object with different properties and helpers
+
+### Example
+
 ```es6
-const { get, save, update } = useSiteSettings( <site-id> );
+import useSiteSettings from './use-site-settings';
+
+function StoreAddressFrom() {
+	const { get, save, update } = useSiteSettings( 'site-id' );
+
+	return (
+		<div>
+			<TextControl
+				label={ __( 'Store address' ) }
+				value={ get( 'woocommerce_store_address' ) }
+				onChange={ ( newAddress ) => update( { woocommerce_store_address: newAddress } ) }
+			/>
+
+			<Button onClick={ save }>Save</Button>
+		</div>
+	);
+}
 ```
 
 ### countriesList
@@ -22,20 +42,31 @@ Helper to 'update' site options in the redux store.
 
 Helper to 'save' site options permanently on the server-side.
 
+### multipleOptionHandler
+
+Use this helper when the option contains multiple values. It returns get and update methods for this particular option.
+
 ## Example
 
 ```es6
 import useSiteSettings from './use-site-settings';
 
 function StoreAddressFrom() {
-	const { get, save, update } = useSiteSettings( 'site-id' );
+	const { multipleOptionHandler, save } = useSiteSettings( 'site-id' );
+	const { get, update } = multipleOptionHandler( 'woocommerce_onboarding_profile' );
 
 	return (
 		<div>
 			<TextControl
-				label={ __( 'Store address' ) }
-				value={ get( 'woocommerce_store_address' ) }
-				onChange={ ( newAddress ) => update( { woocommerce_store_address: newAddress } ) }
+				label={ __( 'Email address', 'woocommerce-admin' ) }
+				value={ get( 'store_email' ) }
+				onChange={ ( value ) => update( 'store_email', value ) }
+			/>
+
+			<CheckboxControl
+				label={ __( 'Agreed marketing', 'woocommerce-admin' ) }
+				checked={ get( 'is_agree_marketing' ) }
+				onChange={ ( value ) => update( 'is_agree_marketing', value ) }
 			/>
 
 			<Button onClick={ save }>Save</Button>

--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/Readme.md
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/Readme.md
@@ -51,7 +51,7 @@ Use this helper when the option contains multiple values. It returns get and upd
 ```es6
 import useSiteSettings from './use-site-settings';
 
-function StoreAddressFrom() {
+function StoreOnboardingData() {
 	const { multipleOptionHandler, save } = useSiteSettings( 'site-id' );
 	const { get, update } = multipleOptionHandler( 'woocommerce_onboarding_profile' );
 

--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
@@ -16,6 +16,7 @@ export const WOOCOMMERCE_STORE_ADDRESS_2 = 'woocommerce_store_address_2';
 export const WOOCOMMERCE_STORE_CITY = 'woocommerce_store_city';
 export const WOOCOMMERCE_DEFAULT_COUNTRY = 'woocommerce_default_country';
 export const WOOCOMMERCE_STORE_POSTCODE = 'woocommerce_store_postcode';
+export const WOOCOMMERCE_ONBOARDING_PROFILE = 'woocommerce_onboarding_profile';
 
 type optionNameType =
 	| 'blog_public'
@@ -23,7 +24,8 @@ type optionNameType =
 	| typeof WOOCOMMERCE_STORE_ADDRESS_2
 	| typeof WOOCOMMERCE_STORE_CITY
 	| typeof WOOCOMMERCE_DEFAULT_COUNTRY
-	| typeof WOOCOMMERCE_STORE_POSTCODE;
+	| typeof WOOCOMMERCE_STORE_POSTCODE
+	| typeof WOOCOMMERCE_ONBOARDING_PROFILE;
 
 /**
  * Simple react custom hook to deal with site settings.

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -15,6 +15,7 @@ import {
 	WOOCOMMERCE_STORE_CITY,
 	WOOCOMMERCE_DEFAULT_COUNTRY,
 	WOOCOMMERCE_STORE_POSTCODE,
+	WOOCOMMERCE_ONBOARDING_PROFILE,
 } from '../hooks/use-site-settings';
 import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '..';
@@ -29,7 +30,11 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 
 	const { wpcomDomain } = useWooCommerceOnPlansEligibility( siteId );
 
-	const { get, save, update, countriesList } = useSiteSettings( siteId );
+	const { get, save, update, countriesList, multipleOptionHandler } = useSiteSettings( siteId );
+	const {
+		get: getOnboardingProfileOption,
+		update: updateOnboardingProfileOption,
+	} = multipleOptionHandler( WOOCOMMERCE_ONBOARDING_PROFILE );
 
 	const handleCountryChange: ChangeEventHandler< HTMLInputElement > = ( event ) => {
 		update( WOOCOMMERCE_DEFAULT_COUNTRY, event.target.value );
@@ -69,6 +74,12 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 						label={ __( 'Postcode', 'woocommerce-admin' ) }
 						value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
 						onChange={ ( value ) => update( WOOCOMMERCE_STORE_POSTCODE, value ) }
+					/>
+
+					<TextControl
+						label={ __( 'Email address', 'woocommerce-admin' ) }
+						value={ getOnboardingProfileOption( 'store_email' ) }
+						onChange={ ( value ) => updateOnboardingProfileOption( 'store_email', value ) }
 					/>
 
 					<ActionSection>

--- a/client/state/site-settings/selectors.js
+++ b/client/state/site-settings/selectors.js
@@ -43,6 +43,7 @@ export function getSiteSettingsSaveRequestStatus( state, siteId ) {
  woocommerce_store_city?: string;
  woocommerce_store_postcode?: string;
  woocommerce_default_country?: string;
+ woocommerce_onboarding_profile?: string;
  }} SiteSettingsItem
  */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the store email field to the store address step, collect its value to finally save it in the server-side

### Custom hook API changes

In order to deal with options that support multiple values (object shape), the custom hook exposes the new `multipleOptionHadler` function. It allows handling the option data kinda easily:

```es6
```es6
import useSiteSettings from './use-site-settings';

function StoreOnboardingData() {
  const { multipleOptionHandler, save } = useSiteSettings( 'site-id' );
  const { get, update } = multipleOptionHandler( 'woocommerce_onboarding_profile' );

  return (
    <div>
      <TextControl
        label={ __( 'Email address', 'woocommerce-admin' ) }
        value={ get( 'store_email' ) }
        onChange={ ( value ) => update( 'store_email', value ) }
      />

      <Button onClick={ save }>Save</Button>
    </div>
  );
}
```

In the example above, the `store_email` stores into the `woocommerce_onboarding_profile` option, which has an object shape. Once the `save` function calls, it performs a POST request passing the `woocommerce_onboarding_profile` field properly:

Payload:
<img src="https://user-images.githubusercontent.com/77539/148560663-52e77e22-7808-41a7-baa0-d441c92c6e66.png" width="400px" />

Response
<img src="https://user-images.githubusercontent.com/77539/148560737-eba258ba-0476-4581-8078-9c949dd87a3a.png" width="400px" />

Checking the data
<img src="https://user-images.githubusercontent.com/77539/148560922-62d7e04e-a1b0-43ec-8b61-35143f25f97c.png" width="400px" />


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with a simple site
* Apply testing patch D72639-code
* Set store email value. Confirm it's properly saved. Confirm it's persistent (hard-refresh)


https://user-images.githubusercontent.com/77539/148563009-ad93e6dc-e16d-435b-b2f7-da8284d42be3.mov


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
