### PR TITLE
Update customer home for paid plugins

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -51,6 +51,7 @@ export const QuickLinks = ( {
 	trackAnchorPodcastAction,
 	trackAddEmailAction,
 	trackAddDomainAction,
+	trackExplorePluginsAction,
 	isExpanded,
 	updateHomeQuickLinksToggleStatus,
 	isUnifiedNavEnabled,
@@ -176,6 +177,13 @@ export const QuickLinks = ( {
 			) }
 			{ canManageSite && (
 				<>
+					<ActionBox
+						href={ `/plugins/${ siteSlug }` }
+						hideLinkIndicator
+						onClick={ trackExplorePluginsAction }
+						label={ translate( 'Explore Plugins' ) }
+						gridicon="plugins"
+					/>
 					<ActionBox
 						href="https://wp.me/logo-maker/?utm_campaign=my_home"
 						onClick={ trackDesignLogoAction }
@@ -331,6 +339,17 @@ const trackAddEmailAction = ( isStaticHomePage ) => ( dispatch ) => {
 	);
 };
 
+const trackExplorePluginsAction = ( isStaticHomePage ) => ( dispatch ) => {
+	dispatch(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_customer_home_my_site_explore_plugins_click', {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', 'my_site_explore_plugins' )
+		)
+	);
+};
+
 const trackAddDomainAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
@@ -398,6 +417,7 @@ const mapDispatchToProps = {
 	trackAnchorPodcastAction,
 	trackAddEmailAction,
 	trackAddDomainAction,
+	trackExplorePluginsAction,
 	updateHomeQuickLinksToggleStatus: ( status ) =>
 		savePreference( 'homeQuickLinksToggleStatus', status ),
 };
@@ -418,6 +438,7 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		trackAnchorPodcastAction: () => dispatchProps.trackAnchorPodcastAction( isStaticHomePage ),
 		trackAddEmailAction: () => dispatchProps.trackAddEmailAction( isStaticHomePage ),
 		trackAddDomainAction: () => dispatchProps.trackAddDomainAction( isStaticHomePage ),
+		trackExplorePluginsAction: () => dispatchProps.trackExplorePluginsAction( isStaticHomePage ),
 		...ownProps,
 	};
 };

--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -21,6 +21,7 @@ export const TASK_EARN_FEATURES = 'home-task-earn-features';
 export const TASK_FIND_DOMAIN = 'home-task-find-domain';
 export const TASK_GO_MOBILE_ANDROID = 'home-task-go-mobile-android';
 export const TASK_GO_MOBILE_IOS = 'home-task-go-mobile-ios';
+export const TASK_MARKETPLACE = 'home-task-marketplace';
 export const TASK_PODCASTING = 'home-task-podcasting';
 export const TASK_RENEW_EXPIRED_PLAN = 'home-task-renew-expired-plan';
 export const TASK_RENEW_EXPIRING_PLAN = 'home-task-renew-expiring-plan';

--- a/client/my-sites/customer-home/cards/tasks/marketplace/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/marketplace/index.jsx
@@ -1,0 +1,26 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import announcementImage from 'calypso/assets/images/marketplace/diamond.svg';
+import { TASK_MARKETPLACE } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const Marketplace = () => {
+	const translate = useTranslate();
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+
+	return (
+		<Task
+			title={ translate( 'Buy the best plugins' ) }
+			description={ translate(
+				"Now you can purchase plugins right on WordPress.com to extend your website's capabilities."
+			) }
+			actionText={ translate( "Let's explore!" ) }
+			actionUrl={ `/plugins/${ siteSlug }` }
+			illustration={ announcementImage }
+			taskId={ TASK_MARKETPLACE }
+		/>
+	);
+};
+
+export default Marketplace;

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -15,6 +15,7 @@ import {
 	TASK_GO_MOBILE_ANDROID,
 	TASK_GO_MOBILE_IOS,
 	TASK_PODCASTING,
+	TASK_MARKETPLACE,
 	TASK_RENEW_EXPIRED_PLAN,
 	TASK_RENEW_EXPIRING_PLAN,
 	TASK_SITE_SETUP_CHECKLIST,
@@ -32,6 +33,7 @@ import ConnectAccounts from 'calypso/my-sites/customer-home/cards/tasks/connect-
 import EarnFeatures from 'calypso/my-sites/customer-home/cards/tasks/earn-features';
 import FindDomain from 'calypso/my-sites/customer-home/cards/tasks/find-domain';
 import GoMobile from 'calypso/my-sites/customer-home/cards/tasks/go-mobile';
+import Marketplace from 'calypso/my-sites/customer-home/cards/tasks/marketplace';
 import Podcasting from 'calypso/my-sites/customer-home/cards/tasks/podcasting';
 import Renew from 'calypso/my-sites/customer-home/cards/tasks/renew';
 import SiteSetupList from 'calypso/my-sites/customer-home/cards/tasks/site-setup-list';
@@ -52,6 +54,7 @@ const cardComponents = {
 	[ TASK_FIND_DOMAIN ]: FindDomain,
 	[ TASK_GO_MOBILE_ANDROID ]: GoMobile,
 	[ TASK_GO_MOBILE_IOS ]: GoMobile,
+	[ TASK_MARKETPLACE ]: Marketplace,
 	[ TASK_PODCASTING ]: Podcasting,
 	[ TASK_RENEW_EXPIRED_PLAN ]: Renew,
 	[ TASK_RENEW_EXPIRING_PLAN ]: Renew,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds Explore Plugins quicklink.
* adds a marketplace ad in primary home banners.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D72692-code
* Load `/home` with admin rights
* See how the "Plugins banner" and "Explore Plugins link" display
* repeat with a user without admin rights
* banner and link should not display

Note: the banner position is random on every reload

![SS 2022-01-07 at 17 43 54](https://user-images.githubusercontent.com/12430020/148568465-6472bd68-de47-4367-b03a-125ebf360ff9.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59657