### PR TITLE
Checkout: fix free domain message

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -26,9 +26,9 @@ import styled from '@emotion/styled';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
+import { isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getPlanFeatures from '../lib/get-plan-features';
 import getRefundText from '../lib/get-refund-text';
@@ -201,7 +201,7 @@ function CheckoutSummaryFeaturesList( props: {
 						/>
 					);
 				} ) }
-			{ hasPlanInCart && <CheckoutSummaryPlanFeatures { ...props } /> }
+			{ hasPlanInCart && <CheckoutSummaryPlanFeatures /> }
 			<CheckoutSummaryFeaturesListItem>
 				<WPCheckoutCheckIcon id="features-list-support-text" />
 				<SupportText
@@ -289,7 +289,7 @@ function CheckoutSummaryFeaturesListDomainItem( {
 	);
 }
 
-function CheckoutSummaryPlanFeatures( { siteId }: { siteId: number | undefined } ) {
+function CheckoutSummaryPlanFeatures() {
 	const translate = useTranslate();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -300,15 +300,13 @@ function CheckoutSummaryPlanFeatures( { siteId }: { siteId: number | undefined }
 	const hasRenewalInCart = responseCart.products.some(
 		( product ) => product.extra.purchaseType === 'renewal'
 	);
-	const planHasDomainCredit = useSelector(
-		( state ) => siteId && hasDomainCredit( state, siteId )
-	);
+	const nextDomainIsFree = isNextDomainFree( responseCart );
 	const planFeatures = getPlanFeatures(
 		planInCart,
 		translate,
 		hasDomainsInCart,
 		hasRenewalInCart,
-		planHasDomainCredit
+		nextDomainIsFree
 	);
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -15,9 +15,9 @@ export default function getPlanFeatures(
 	translate: ReturnType< typeof useTranslate >,
 	hasDomainsInCart: boolean,
 	hasRenewalInCart: boolean,
-	planHasDomainCredit: boolean
+	nextDomainIsFree: boolean
 ): string[] {
-	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart && planHasDomainCredit;
+	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart && nextDomainIsFree;
 	const productSlug = plan?.product_slug;
 
 	if ( ! productSlug ) {


### PR DESCRIPTION
This PR updates the Checkout sidebar features list to use `isNextDomainFree` instead of `hasDomainCredit`.

In D64500-code, we updated the shopping cart endpoint to properly return `next_domain_is_free` when the next domain purchase will be free, however that logic isn't used in the Checkout feature sidebar. This was noticed in pcYYhz-uB-p2 by @delputnam for free sites that have an annual plan in their cart, but no domain. In that situation the `hasDomainCredit` selector (which checks for a domain credit from an existing purchase) returns false, however the purchase of the current plan in the cart will mean that the next domain purchase will fall under a credit.

I can't think of a reason we'd want to use the `hasDomainCredit` instead of `isNextDomainFree` here, since the endpoint has been patched.

**To test:**
- on a free site, add a monthly plan to your cart and visit Checkout
- verify that the sidebar feature list doesn't mention "Free domain for one year"
- use the variation picker to change to an annual plan
- verify that the sidebar feature list now shows "Free domain for one year"
- close Checkout (and leave the plan in the cart)
- add a domain to your cart and visit Checkout
- verify that the sidebar feature list doesn't mention "Free domain for one year" but does show a message for the current domain (e.g. "mydomainname.com - free for one year")