### PR TITLE
Activity Log, Pricing: Fix several type errors

### DIFF
--- a/client/components/activity-card-list/visible-days-limit-upsell/index.tsx
+++ b/client/components/activity-card-list/visible-days-limit-upsell/index.tsx
@@ -10,23 +10,30 @@ import ActivityLogItem from 'calypso/my-sites/activity/activity-log-item';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useTrackUpsellView, useTrackUpgradeClick } from './hooks';
+import type { Activity } from 'calypso/components/activity-card/types';
 
 import './style.scss';
 
-const PLACEHOLDER_ACTIVITY = {
+const PLACEHOLDER_ACTIVITY: Activity = {
 	actorName: 'Jetpack',
-	actorRemoteId: 0,
-	actorWpcomId: 0,
 	actorRole: '',
 	actorType: 'Application',
-	activityDate: '2021-01-01T00:00:00.000+00:00',
+	activityId: -1,
+	activityName: '',
+	activityMedia: {
+		available: false,
+		medium_url: '',
+		name: '',
+		thumbnail_url: '',
+		type: '',
+		url: '',
+	},
 	activityTs: 1609459200000,
-	activityGroup: 'rewind',
 	activityIcon: 'cloud',
+	activityIsRewindable: false,
 	activityStatus: 'success',
-	activityType: 'Backup',
 	activityTitle: '',
-	activityDescription: [],
+	activityDescription: [ {} ],
 };
 
 type OwnProps = {

--- a/client/components/activity-card/types.ts
+++ b/client/components/activity-card/types.ts
@@ -30,6 +30,7 @@ export interface Activity {
 	actorRole?: string;
 	actorType?: string;
 
+	activityIsRewindable: boolean;
 	rewindId?: string;
 	streams?: Activity[];
 }

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -37,7 +37,11 @@ import './style.scss';
 
 class ActivityLogItem extends Component {
 	static propTypes = {
+		className: PropTypes.string,
+
 		siteId: PropTypes.number.isRequired,
+
+		activity: PropTypes.object.isRequired,
 
 		// Connected props
 		siteSlug: PropTypes.string.isRequired,
@@ -410,11 +414,12 @@ class ActivityLogItem extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { activity, siteId } ) => {
+const mapStateToProps = ( state, { className, activity, siteId } ) => {
 	const rewindState = getRewindState( state, siteId );
 	const site = getSite( state, siteId );
 
 	return {
+		className,
 		activity,
 		gmtOffset: getSiteGmtOffset( state, siteId ),
 		mightBackup: activity && activity.activityId === getRequestedBackup( state, siteId ),

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
@@ -1,15 +1,17 @@
+import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useMemo } from 'react';
 import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
+import { ITEM_TYPE_PLAN } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import useJetpackFreeButtonProps from './use-jetpack-free-button-props';
-import type { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
+import type { QueryArgs, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 type OwnProps = {
 	siteId: number | null;
 	urlQueryArgs: QueryArgs;
 };
 
-const useFreeItem = () => {
+const useFreeItem = (): SelectorProduct => {
 	const translate = useTranslate();
 
 	return useMemo(
@@ -19,11 +21,17 @@ const useFreeItem = () => {
 			displayName: translate( 'Jetpack Free' ),
 			features: {
 				items: [
-					{ text: translate( 'Brute force attack protection' ) },
-					{ text: translate( 'Site stats' ) },
-					{ text: translate( 'Content Delivery Network' ) },
+					{ slug: 'not used', text: translate( 'Brute force attack protection' ) },
+					{ slug: 'not used', text: translate( 'Site stats' ) },
+					{ slug: 'not used', text: translate( 'Content Delivery Network' ) },
 				],
 			},
+			type: ITEM_TYPE_PLAN, // not used
+			term: TERM_ANNUALLY, // not used
+			iconSlug: 'not used',
+			shortName: 'not used',
+			tagline: 'not used',
+			description: 'not used',
 		} ),
 		[ translate ]
 	);

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -102,6 +102,11 @@ function itemToSelectorProduct(
 			yearlyProductSlug = PRODUCTS_LIST[ item.product_slug as JetpackProductSlug ].type;
 		}
 
+		// We do not support TERM_BIENNIALLY for Jetpack plans
+		if ( item.term === TERM_BIENNIALLY ) {
+			return null;
+		}
+
 		const iconSlug = `${ yearlyProductSlug || item.product_slug }_v2_dark`;
 
 		return {

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -29,7 +29,7 @@ import {
 	ITEM_TYPE_PRODUCT,
 	ITEM_TYPE_PLAN,
 } from './constants';
-import { getForCurrentCROIteration, Iterations } from './iterations';
+import { getForCurrentCROIteration } from './iterations';
 import objectIsPlan from './object-is-plan';
 import { SelectorProduct } from './types';
 
@@ -45,7 +45,7 @@ function slugIsJetpackPlanSlug( slug: string ): slug is JetpackPlanSlug {
 }
 
 function objectIsSelectorProduct(
-	item: Record< string, unknown > | SelectorProduct
+	item: Plan | Product | SelectorProduct | Record< string, unknown >
 ): item is SelectorProduct {
 	const requiredKeys = [
 		'productSlug',
@@ -60,14 +60,17 @@ function objectIsSelectorProduct(
 
 function slugToItem( slug: string ): Plan | Product | SelectorProduct | null | undefined {
 	if ( EXTERNAL_PRODUCTS_LIST.includes( slug ) ) {
-		return getForCurrentCROIteration( ( variation: Iterations ) =>
-			EXTERNAL_PRODUCTS_SLUG_MAP[ slug ]( variation )
-		);
-	} else if ( slugIsJetpackProductSlug( slug ) ) {
+		return EXTERNAL_PRODUCTS_SLUG_MAP[ slug ]();
+	}
+
+	if ( slugIsJetpackProductSlug( slug ) ) {
 		return ( JETPACK_SITE_PRODUCTS_WITH_FEATURES as Record< string, Product > )[ slug ];
-	} else if ( slugIsJetpackPlanSlug( slug ) ) {
+	}
+
+	if ( slugIsJetpackPlanSlug( slug ) ) {
 		return getPlan( slug ) as Plan;
 	}
+
 	return null;
 }
 
@@ -82,7 +85,9 @@ function itemToSelectorProduct(
 ): SelectorProduct | null {
 	if ( objectIsSelectorProduct( item ) ) {
 		return item;
-	} else if ( objectIsProduct( item ) ) {
+	}
+
+	if ( objectIsProduct( item ) ) {
 		let monthlyProductSlug;
 		let yearlyProductSlug;
 		if (
@@ -119,7 +124,9 @@ function itemToSelectorProduct(
 				items: buildCardFeaturesFromItem( item ),
 			},
 		};
-	} else if ( objectIsPlan( item ) ) {
+	}
+
+	if ( objectIsPlan( item ) ) {
 		const productSlug = item.getStoreSlug();
 		let monthlyProductSlug;
 		let yearlyProductSlug;
@@ -147,6 +154,7 @@ function itemToSelectorProduct(
 			legacy: ! isResetPlan,
 		};
 	}
+
 	return null;
 }
 
@@ -161,5 +169,6 @@ export default function slugToSelectorProduct( slug: string ): SelectorProduct |
 	if ( ! item ) {
 		return null;
 	}
+
 	return itemToSelectorProduct( item );
 }


### PR DESCRIPTION
Relates to `p4TIVU-9U4-p2`.

#### Changes proposed in this Pull Request

* Update properties for `PLACEHOLDER_ACTIVITY` on the component that loads the Activity Log "visibility limit" upsell, so that it complies with the `Activity` type.
* Add an `activityIsRewindable` property to the `Activity` type, since it's referenced in several places, and all activities have this property from the API anyway.
* Add missing `className` property to the PropTypes for `ActivityLogItem`.
* Add missing -- albeit unused -- properties to the product object constructed for `JetpackFreeCard`, so it complies with the `SelectorProduct` type.
* Update `slugToItem` to remove unneeded references to `getForCurrentCROIteration`.
* Convert one if-else tree to if/early-returns.

#### Testing instructions

* On the Activity Log for a Jetpack site with Free or a history-limited plan (e.g., Backup (10 GB)), verify the upsell still appears when you reach the end of your site's history and behaves as it does in production. For more info, check out #54900.
* On the Pricing page for Jetpack products:
  * Verify all paid products still appear and behave as they do in production. All buttons should work correctly, and all formatting should remain the same.
  * Verify the Free card still appears and behaves as it does in production. All buttons should work correctly, and all formatting should remain the same.