### PR TITLE
Use matticbot instead of Sergio's SSH key

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -317,7 +317,7 @@ object WpCalypso : GitVcsRoot({
 	branchSpec = "+:refs/heads/*"
 	useTagsAsBranches = true
 	authMethod = uploadedKey {
-		uploadedKey = "Sergio TeamCity"
+		uploadedKey = "matticbot"
 	}
 })
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Use the existing `matticbot` key instead of sergio's SSH key. See pMz3w-epx-p2 for more info.

### Testing instructions
- CI is green, and uses settings from VCS instead of the server.