### PR TITLE
Janitorial: replace hardcoded check with a call to `isJetpackTemporarySitePurchase`

### DIFF
--- a/client/me/purchases/purchases-site/index.tsx
+++ b/client/me/purchases/purchases-site/index.tsx
@@ -11,6 +11,7 @@ import QuerySites from 'calypso/components/data/query-sites';
 import { getSite } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
 import PurchaseItem from '../purchase-item';
+import { isJetpackTemporarySitePurchase } from '../utils';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
 
@@ -75,7 +76,7 @@ export default function PurchasesSite(
 						isDisconnectedSite={ ! site }
 						purchase={ purchase }
 						isJetpack={ isJetpackPlan( purchase ) || isJetpackProduct( purchase ) }
-						isJetpackTemporarySite={ purchase.domain === 'siteless.jetpack.com' }
+						isJetpackTemporarySite={ isJetpackTemporarySitePurchase( purchase.domain ) }
 						site={ site }
 						showSite={ showSite }
 						name={ name }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `purchase.domain === 'siteless.jetpack.com'` with a call to `isJetpackTemporarySitePurchase`.

Note: this is a small refactor. Nothing should change in terms of appearance or behavior.

#### Testing instructions

* Download this PR.
* Start Calypso with `yarn start`.
* Visit `https://cloud.jetpack.com/pricing`.
* Purchase any Jetpack product other than Jetpack Search.
* Do not activate the license key on any site.
* Visit `http://calypso.localhost:3000/me/purchases`.
* Verify that you see an entry for the product you just purchased with `Pending activation` status.
* Visit `https://wordpress.com/me/purchases`.
* Verify that everything looks the same as in your local development environment.

Related to 1164141197617539-as-1201624154131992

#### Demo
![image](https://user-images.githubusercontent.com/3418513/148610033-5d124e26-13c2-4fd1-8641-9f113722dcdd.png)

