### PR TITLE
Jetpack Partner Portal: Fix reducer errors

### DIFF
--- a/client/components/eligibility-warnings/info-label/index.tsx
+++ b/client/components/eligibility-warnings/info-label/index.tsx
@@ -20,7 +20,7 @@ const Content = styled.div`
 	}
 `;
 
-const Label = styled.div`
+const Label = styled.div< { type: string } >`
 	font-size: 14px;
 	background-color: ${ ( props ) => ( props.type === 'info' ? '#b8e6bf' : '#eaeaea' ) };
 	height: 20px;

--- a/client/state/partner-portal/payment-methods/reducer.ts
+++ b/client/state/partner-portal/payment-methods/reducer.ts
@@ -18,12 +18,16 @@ interface FieldsStateValue {
 	isTouched: boolean;
 	errors: string[];
 }
-type FieldsState = Record< string, FieldsStateValue >;
+type FieldsState = Record< string, FieldsStateValue | undefined >;
+type FieldsAction =
+	| { type: 'FIELD_VALUE_SET'; payload: { key: string; value: string } }
+	| { type: 'FIELD_ERROR_SET'; payload: { key: string; message: string } }
+	| { type: 'TOUCH_ALL_FIELDS' };
 
-export const fields: Reducer< FieldsState, AnyAction > = (
-	state = initialState.fields,
-	action
-) => {
+export function fields(
+	state: FieldsState = initialState.fields,
+	action: FieldsAction
+): FieldsState {
 	switch ( action?.type ) {
 		case 'FIELD_VALUE_SET':
 			return {
@@ -42,7 +46,7 @@ export const fields: Reducer< FieldsState, AnyAction > = (
 			return {
 				...state,
 				[ action.payload.key ]: {
-					...state[ action.payload.key ],
+					...( state[ action.payload.key ] ?? { value: '', isTouched: true } ),
 					errors: [ action.payload.message ],
 				},
 			};
@@ -50,7 +54,7 @@ export const fields: Reducer< FieldsState, AnyAction > = (
 		case 'TOUCH_ALL_FIELDS': {
 			return Object.entries( state ).reduce( ( obj: FieldsState, [ key, value ] ) => {
 				obj[ key ] = {
-					...value,
+					...( value ?? { value: '', errors: [] } ),
 					isTouched: true, // mark whether the HTML input has been touched, so we only show errors if the input is touched and its value is not valid
 				};
 				return obj;
@@ -59,7 +63,7 @@ export const fields: Reducer< FieldsState, AnyAction > = (
 		default:
 			return state;
 	}
-};
+}
 
 export const cardDataComplete: Reducer< Record< string, boolean >, AnyAction > = (
 	state = initialState.cardDataComplete,

--- a/client/state/partner-portal/payment-methods/reducer.ts
+++ b/client/state/partner-portal/payment-methods/reducer.ts
@@ -13,7 +13,14 @@ const initialState = {
 	brand: {},
 };
 
-export const fields: Reducer< Record< string, unknown >, AnyAction > = (
+interface FieldsStateValue {
+	value: string;
+	isTouched: boolean;
+	errors: string[];
+}
+type FieldsState = Record< string, FieldsStateValue >;
+
+export const fields: Reducer< FieldsState, AnyAction > = (
 	state = initialState.fields,
 	action
 ) => {

--- a/client/state/partner-portal/payment-methods/reducer.ts
+++ b/client/state/partner-portal/payment-methods/reducer.ts
@@ -48,9 +48,9 @@ export const fields: Reducer< FieldsState, AnyAction > = (
 			};
 		}
 		case 'TOUCH_ALL_FIELDS': {
-			return Object.entries( state ).reduce( ( obj, [ key, value ] ) => {
+			return Object.entries( state ).reduce( ( obj: FieldsState, [ key, value ] ) => {
 				obj[ key ] = {
-					value: value.value,
+					...value,
 					isTouched: true, // mark whether the HTML input has been touched, so we only show errors if the input is touched and its value is not valid
 				};
 				return obj;

--- a/client/state/partner-portal/payment-methods/reducer.ts
+++ b/client/state/partner-portal/payment-methods/reducer.ts
@@ -29,7 +29,11 @@ export const fields: Reducer< FieldsState, AnyAction > = (
 			return {
 				...state,
 				[ action.payload.key ]: {
-					value: maskField( action.payload.key, state[ action.payload.key ], action.payload.value ),
+					value: maskField(
+						action.payload.key,
+						state[ action.payload.key ].value,
+						action.payload.value
+					),
 					isTouched: true, // mark whether the HTML input has been touched, so we only show errors if the input is touched and its value is not valid
 					errors: [],
 				},

--- a/client/state/partner-portal/payment-methods/reducer.ts
+++ b/client/state/partner-portal/payment-methods/reducer.ts
@@ -31,7 +31,7 @@ export const fields: Reducer< FieldsState, AnyAction > = (
 				[ action.payload.key ]: {
 					value: maskField(
 						action.payload.key,
-						state[ action.payload.key ].value,
+						state[ action.payload.key ]?.value ?? '',
 						action.payload.value
 					),
 					isTouched: true, // mark whether the HTML input has been touched, so we only show errors if the input is touched and its value is not valid


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `fields` reducer in the Jetpack partner portal payment methods code has a couple of small bugs which this fixes. The code was originally added in https://github.com/Automattic/wp-calypso/pull/54570. It has several TypeScript errors which revealed the bugs. Specifically:

1. When setting a value via the `FIELD_VALUE_SET` action, the code calls `maskField()` to set the `value` property of the field object but passes the whole object as the `previousValue`, when `maskField` expects a string. This PR changes the code to pass the `value` instead.
2. When calling the `TOUCH_ALL_FIELDS` action, the code erases the `errors` property. I believe this was accidental since the code comment implies that we touch fields in order for errors to become visible. This PR preserves the `errors` property in that action.

#### Testing instructions

None should be required since this code does not appear to be used by anything. The actions are imported only by tests and by `createStoredCreditCardPaymentMethodStore` which is never called.