### PR TITLE
Add tests for the unsupported browser redirect

### DIFF
--- a/client/server/lib/is-unsupported-browser.js
+++ b/client/server/lib/is-unsupported-browser.js
@@ -1,0 +1,41 @@
+import { matchesUA } from 'browserslist-useragent';
+
+/**
+ * This is a list of browsers which DEFINITELY do not work on WordPress.com.
+ *
+ * I created this list by finding the oldest version of Chrome which supports the
+ * log-in page, and then finding which language feature was added in that release.
+ *
+ * In this case, the feature was optional chaining, which we use in our bundle,
+ * but is not supported by these browsers. As a result, these browsers do not
+ * work with the WordPress.com login page. See https://caniuse.com/?search=optional%20chaining.
+ *
+ * In other words, if you use Chrome v79, you won't be able to log in. But if you
+ * use v80, the form works.
+ *
+ * For browsers not listed, we have not tested whether they work.
+ *
+ * Importantly, browsers are only completely supported if they fall within the range
+ * listed in package.json. This list only serves as a way to assist users who are
+ * using a browser which is definitely broken. It is not a guarantee that things
+ * will work flawlessly on newer versions.
+ */
+const UNSUPPORTED_BROWSERS = [
+	'ie <= 11',
+	'edge <= 79',
+	'firefox <= 73',
+	'chrome <= 79',
+	'safari <= 13', // Note: 13.1 IS supported. Browserslist considers Safari point releases as new versions.
+	'opera <= 66',
+	'ios <= 13.3',
+];
+
+export default function isUnsupportedBrowser( req ) {
+	// The desktop app sends a UserAgent including WordPress, Electron and Chrome.
+	// We need to check if the chrome portion is supported, but the UA library
+	// will select WordPress and Electron before Chrome, giving a result not
+	// based on the chrome version.
+	const userAgentString = req.useragent.source;
+	const sanitizedUA = userAgentString.replace( / (WordPressDesktop|Electron)\/[.\d]+/g, '' );
+	return matchesUA( sanitizedUA, { ignoreMinor: true, browsers: UNSUPPORTED_BROWSERS } );
+}

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -1,47 +1,7 @@
 import config from '@automattic/calypso-config';
-import { matchesUA } from 'browserslist-useragent';
 import { addQueryArgs } from 'calypso/lib/url';
 import analytics from 'calypso/server/lib/analytics';
-
-/**
- * This is a list of browsers which DEFINITELY do not work on WordPress.com.
- *
- * I created this list by finding the oldest version of Chrome which supports the
- * log-in page, and then finding which language feature was added in that release.
- *
- * In this case, the feature was optional chaining, which we use in our bundle,
- * but is not supported by these browsers. As a result, these browsers do not
- * work with the WordPress.com login page. See https://caniuse.com/?search=optional%20chaining.
- *
- * In other words, if you use Chrome v79, you won't be able to log in. But if you
- * use v80, the form works.
- *
- * For browsers not listed, we have not tested whether they work.
- *
- * Importantly, browsers are only completely supported if they fall within the range
- * listed in package.json. This list only serves as a way to assist users who are
- * using a browser which is definitely broken. It is not a guarantee that things
- * will work flawlessly on newer versions.
- */
-const UNSUPPORTED_BROWSERS = [
-	'ie <= 11',
-	'edge <= 79',
-	'firefox <= 73',
-	'chrome <= 79',
-	'safari <= 13', // Note: 13.1 IS supported. Browserslist considers Safari point releases as new versions.
-	'opera <= 66',
-	'ios <= 13.3',
-];
-
-function isUnsupportedBrowser( req ) {
-	// The desktop app sends a UserAgent including WordPress, Electron and Chrome.
-	// We need to check if the chrome portion is supported, but the UA library
-	// will select WordPress and Electron before Chrome, giving a result not
-	// based on the chrome version.
-	const userAgentString = req.useragent.source;
-	const sanitizedUA = userAgentString.replace( / (WordPressDesktop|Electron)\/[.\d]+/g, '' );
-	return matchesUA( sanitizedUA, { ignoreMinor: true, browsers: UNSUPPORTED_BROWSERS } );
-}
+import isUnsupportedBrowser from 'calypso/server/lib/is-unsupported-browser';
 
 /**
  * These public pages work even in unsupported browsers, so we do not redirect them.

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1272,14 +1272,15 @@ describe( 'main app', () => {
 		} );
 
 		afterEach( () => {
-			jest.clearAllMocks();
+			customApp.reset();
 		} );
 
 		afterAll( () => {
 			// Without this, recordEvent() calls will throw errors for the rest
-			// of the test suite.
+			// of the test suite. Unsure why it's not being cleared otherwise.
 			app.getMocks().analytics.tracks.recordEvent.mockReset();
 		} );
+
 		it( 'records the event when there is a report', async () => {
 			const { response, request } = await app.run( {
 				request: {


### PR DESCRIPTION
### Changes proposed in this Pull Request
Add several unit tests for the unsupported browser redirect:
- tests that the redirect happens
- that static assets are never redirected
- that information is logged

I also made two changes in the test suite. Previously, `withEvergreenBrowser` mocked `matchesUA`. Since our implementation of how that works changes, this mock doesn't really make sense any more. I've decided to instead split out the `isUnsupportedBrowser` function, and then mock that. (We could also parse in user agents, but if we do, we'll have to maintain the "supported" user agent.) Additionally, one mocked function was never unmocked.
 
### Testing instructions
TeamCity, also double check the redirect itself in browserstack
