### PR TITLE
Site Settings: Move unrelated countries list

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
@@ -2,7 +2,6 @@ import { uniqueBy } from '@automattic/js-utils';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchPaymentCountries } from 'calypso/state/countries/actions';
-import getCountries from 'calypso/state/selectors/get-countries';
 import {
 	requestSiteSettings,
 	saveSiteSettings,
@@ -35,8 +34,6 @@ export function useSiteSettings( siteId: number ) {
 	const dispatch = useDispatch();
 
 	const settings = useSelector( ( state ) => getSiteSettings( state, siteId ) );
-
-	const countriesList = useSelector( ( state ) => getCountries( state, 'payments' ) ) || [];
 
 	/*
 	 * Private settings store.
@@ -99,5 +96,5 @@ export function useSiteSettings( siteId: number ) {
 		setEditedSettings( [] );
 	}, [ dispatch, editedSettings, settings, siteId ] );
 
-	return { save, update, get, countriesList };
+	return { save, update, get };
 }

--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
@@ -1,7 +1,6 @@
 import { uniqueBy } from '@automattic/js-utils';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchPaymentCountries } from 'calypso/state/countries/actions';
 import {
 	requestSiteSettings,
 	saveSiteSettings,
@@ -48,7 +47,6 @@ export function useSiteSettings( siteId: number ) {
 		}
 
 		dispatch( requestSiteSettings( siteId ) );
-		dispatch( fetchPaymentCountries() );
 	}, [ dispatch, siteId ] );
 
 	// Simple getter helper.

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -1,10 +1,11 @@
 import { TextControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactElement } from 'react';
-import { useSelector } from 'react-redux';
+import { ReactElement, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import FormCountrySelect from 'calypso/components/forms/form-country-select';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { fetchPaymentCountries } from 'calypso/state/countries/actions';
 import getCountries from 'calypso/state/selectors/get-countries';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SupportCard from '../components/support-card';
@@ -25,6 +26,9 @@ import './style.scss';
 export default function StepStoreAddress( props: WooCommerceInstallProps ): ReactElement | null {
 	const { goToStep, isReskinned, headerTitle, headerDescription } = props;
 	const { __ } = useI18n();
+	const dispatch = useDispatch();
+
+	useEffect( () => dispatch( fetchPaymentCountries() ), [ dispatch ] );
 
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const countriesList = useSelector( ( state ) => getCountries( state, 'payments' ) ) || [];

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import FormCountrySelect from 'calypso/components/forms/form-country-select';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import getCountries from 'calypso/state/selectors/get-countries';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SupportCard from '../components/support-card';
 import { ActionSection, StyledNextButton } from '../confirm';
@@ -26,10 +27,11 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	const { __ } = useI18n();
 
 	const siteId = useSelector( getSelectedSiteId ) as number;
+	const countriesList = useSelector( ( state ) => getCountries( state, 'payments' ) ) || [];
 
 	const { wpcomDomain } = useWooCommerceOnPlansEligibility( siteId );
 
-	const { get, save, update, countriesList } = useSiteSettings( siteId );
+	const { get, save, update } = useSiteSettings( siteId );
 
 	const handleCountryChange: ChangeEventHandler< HTMLInputElement > = ( event ) => {
 		update( WOOCOMMERCE_DEFAULT_COUNTRY, event.target.value );

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -28,7 +28,9 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
-	useEffect( () => dispatch( fetchPaymentCountries() ), [ dispatch ] );
+	useEffect( () => {
+		dispatch( fetchPaymentCountries() );
+	}, [ dispatch ] );
 
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const countriesList = useSelector( ( state ) => getCountries( state, 'payments' ) ) || [];


### PR DESCRIPTION
The countries list has nothing to do with site settings and should be pulled separately.

#### Changes proposed in this Pull Request

* Moves fetching of country list out of useSiteSettings

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* When testing outside of development: Activate the `woop` feature flag.
* Navigate to `/woocommerce-installation` on a test site
* Click set up my Store!
* Verify the country dropdown is populated.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59505 
