### PR TITLE
Checkout: Move pre-transaction account creation to own function

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -34,8 +34,8 @@ export async function createWpcomAccountBeforeTransaction(
 		const siteId = siteIdFromResponse || transactionOptions.siteId;
 		return {
 			...transactionCart,
-			blog_id: String( siteId ) || '0',
-			cart_key: String( siteId ) || 'no-site',
+			blog_id: siteId ? String( siteId ) : '0',
+			cart_key: siteId ? String( siteId ) : 'no-site',
 			create_new_blog: siteId ? false : true,
 		};
 	} );

--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -1,0 +1,42 @@
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { createAccount } from '../payment-method-helpers';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { WPCOMTransactionEndpointCart } from '@automattic/wpcom-checkout';
+
+export async function createWpcomAccountBeforeTransaction(
+	transactionCart: WPCOMTransactionEndpointCart,
+	transactionOptions: PaymentProcessorOptions
+): Promise< WPCOMTransactionEndpointCart > {
+	const isJetpackUserLessCheckout = transactionCart.is_jetpack_checkout;
+
+	return createAccount( {
+		signupFlowName: isJetpackUserLessCheckout
+			? 'jetpack-userless-checkout'
+			: 'onboarding-registrationless',
+		email: transactionOptions.contactDetails?.email?.value,
+		siteId: transactionOptions.siteId,
+		recaptchaClientId: transactionOptions.recaptchaClientId,
+	} ).then( ( response ) => {
+		const siteIdFromResponse = response?.blog_details?.blogid;
+
+		// We need to store the created site ID so that if the transaction fails,
+		// we can retry safely. createUserAndSiteBeforeTransaction will still be
+		// set and createAccount is idempotent for site site creation so long as
+		// siteId is set (although it will update the email address if that
+		// changes).
+		if ( siteIdFromResponse ) {
+			transactionOptions.reduxDispatch( setSelectedSiteId( Number( siteIdFromResponse ) ) );
+		}
+
+		// If the account is already created (as happens when we are reprocessing
+		// after a transaction error), then the create account response will not
+		// have a site ID, so we fetch from state.
+		const siteId = siteIdFromResponse || transactionOptions.siteId;
+		return {
+			...transactionCart,
+			blog_id: String( siteId ) || '0',
+			cart_key: String( siteId ) || 'no-site',
+			create_new_blog: siteId ? false : true,
+		};
+	} );
+}

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -65,6 +65,21 @@ export default async function payPalProcessor(
 		.catch( ( error ) => makeErrorResponse( error.message ) );
 }
 
+/**
+ * Submit a transaction to the WPCOM PayPal transactions endpoint.
+ *
+ * This is one of two transactions endpoint functions; also see
+ * `submitWpcomTransaction`.
+ *
+ * Note that the payload property is (mostly) in camelCase but the actual
+ * submitted data will be converted (mostly) to snake_case.
+ *
+ * Please do not alter payload inside this function if possible to retain type
+ * safety. Instead, alter
+ * `createPayPalExpressEndpointRequestPayloadFromLineItems` or add a new type
+ * safe function that works similarly (see
+ * `createWpcomAccountBeforeTransaction`).
+ */
 async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -3,11 +3,10 @@ import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils
 import { tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import wp from 'calypso/lib/wp';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
 import { createTransactionEndpointCartFromResponseCart } from '../lib/translate-cart';
-import { createAccount } from '../payment-method-helpers';
+import { createWpcomAccountBeforeTransaction } from './create-wpcom-account-before-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { ResponseCart, DomainContactDetails } from '@automattic/shopping-cart';
@@ -70,53 +69,16 @@ async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions
 ) {
-	const path = '/me/paypal-express-url';
-	const apiVersion = '1.2';
-
 	const isJetpackUserLessCheckout =
 		payload.cart.is_jetpack_checkout && payload.cart.cart_key === 'no-user';
 
 	if ( transactionOptions.createUserAndSiteBeforeTransaction || isJetpackUserLessCheckout ) {
-		return createAccount( {
-			signupFlowName: isJetpackUserLessCheckout
-				? 'jetpack-userless-checkout'
-				: 'onboarding-registrationless',
-			email: transactionOptions.contactDetails?.email?.value,
-			siteId: transactionOptions.siteId,
-			recaptchaClientId: transactionOptions.recaptchaClientId,
-		} ).then( ( response ) => {
-			const siteIdFromResponse = response?.blog_details?.blogid;
-
-			// We need to store the created site ID so that if the transaction fails,
-			// we can retry safely. createUserAndSiteBeforeTransaction will still be
-			// set and createAccount is idempotent for site site creation so long as
-			// siteId is set (although it will update the email address if that
-			// changes).
-			if ( siteIdFromResponse ) {
-				transactionOptions.reduxDispatch( setSelectedSiteId( Number( siteIdFromResponse ) ) );
-			}
-
-			// If the account is already created (as happens when we are reprocessing
-			// after a transaction error), then the create account response will not
-			// have a site ID, so we fetch from state.
-			const siteId = siteIdFromResponse || transactionOptions.siteId;
-			const newPayload = {
-				...payload,
-				siteId,
-				cart: {
-					...payload.cart,
-					blog_id: siteId || '0',
-					cart_key: siteId || 'no-site',
-					create_new_blog: siteId ? false : true,
-				},
-			};
-
-			const body = mapRecordKeysRecursively( newPayload, camelToSnakeCase );
-			return wp.req.post( { path }, { apiVersion }, body );
-		} );
+		payload.cart = await createWpcomAccountBeforeTransaction( payload.cart, transactionOptions );
 	}
 
 	const body = mapRecordKeysRecursively( payload, camelToSnakeCase );
+	const path = '/me/paypal-express-url';
+	const apiVersion = '1.2';
 	return wp.req.post( { path }, { apiVersion }, body );
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -1,13 +1,23 @@
 import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
 import wp from 'calypso/lib/wp';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { createAccount } from '../payment-method-helpers';
+import { createWpcomAccountBeforeTransaction } from './create-wpcom-account-before-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
 	WPCOMTransactionEndpointRequestPayload,
 	WPCOMTransactionEndpointResponse,
 } from '@automattic/wpcom-checkout';
 
+/**
+ * Submit a transaction to the WPCOM transactions endpoint.
+ *
+ * Note that the payload property is (mostly) in camelCase but the actual
+ * submitted data will be converted (mostly) to snake_case.
+ *
+ * Please do not alter payload inside this function if possible to retain type
+ * safety. Instead, alter `createTransactionEndpointRequestPayload` or add a
+ * new type safe function that works similarly (see
+ * `createWpcomAccountBeforeTransaction`).
+ */
 export default async function submitWpcomTransaction(
 	payload: WPCOMTransactionEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions
@@ -16,45 +26,7 @@ export default async function submitWpcomTransaction(
 		payload.cart.is_jetpack_checkout && payload.cart.cart_key === 'no-user';
 
 	if ( transactionOptions.createUserAndSiteBeforeTransaction || isJetpackUserLessCheckout ) {
-		const isJetpackUserLessCheckout = payload.cart.is_jetpack_checkout;
-
-		return createAccount( {
-			signupFlowName: isJetpackUserLessCheckout
-				? 'jetpack-userless-checkout'
-				: 'onboarding-registrationless',
-			email: transactionOptions.contactDetails?.email?.value,
-			siteId: transactionOptions.siteId,
-			recaptchaClientId: transactionOptions.recaptchaClientId,
-		} ).then( ( response ) => {
-			const siteIdFromResponse = response?.blog_details?.blogid;
-
-			// We need to store the created site ID so that if the transaction fails,
-			// we can retry safely. createUserAndSiteBeforeTransaction will still be
-			// set and createAccount is idempotent for site site creation so long as
-			// siteId is set (although it will update the email address if that
-			// changes).
-			if ( siteIdFromResponse ) {
-				transactionOptions.reduxDispatch( setSelectedSiteId( Number( siteIdFromResponse ) ) );
-			}
-
-			// If the account is already created (as happens when we are reprocessing
-			// after a transaction error), then the create account response will not
-			// have a site ID, so we fetch from state.
-			const siteId = siteIdFromResponse || transactionOptions.siteId;
-			const newPayload = {
-				...payload,
-				cart: {
-					...payload.cart,
-					blog_id: siteId || '0',
-					cart_key: siteId || 'no-site',
-					create_new_blog: siteId ? false : true,
-				},
-			};
-			return wp.req.post(
-				'/me/transactions',
-				mapRecordKeysRecursively( newPayload, camelToSnakeCase )
-			);
-		} );
+		payload.cart = await createWpcomAccountBeforeTransaction( payload.cart, transactionOptions );
 	}
 
 	return wp.req.post( '/me/transactions', mapRecordKeysRecursively( payload, camelToSnakeCase ) );

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -10,6 +10,9 @@ import type {
 /**
  * Submit a transaction to the WPCOM transactions endpoint.
  *
+ * This is one of two transactions endpoint functions; also see
+ * `wpcomPayPalExpress`.
+ *
  * Note that the payload property is (mostly) in camelCase but the actual
  * submitted data will be converted (mostly) to snake_case.
  *

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -347,8 +347,8 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedStripeRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: 1234567,
-					cart_key: 1234567,
+					blog_id: '1234567',
+					cart_key: '1234567',
 					coupon: '',
 					create_new_blog: false,
 				},
@@ -416,8 +416,8 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedStripeRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: 1234567,
-					cart_key: 1234567,
+					blog_id: '1234567',
+					cart_key: '1234567',
 					coupon: '',
 					create_new_blog: false,
 				},

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -203,8 +203,8 @@ describe( 'payPalExpressProcessor', () => {
 			cancel_url: 'https://example.com/?cart=no-user',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: 1234567,
-				cart_key: 1234567,
+				blog_id: '1234567',
+				cart_key: '1234567',
 				coupon: '',
 				create_new_blog: false,
 			},
@@ -270,8 +270,8 @@ describe( 'payPalExpressProcessor', () => {
 			site_id: 1234567,
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: 1234567,
-				cart_key: 1234567,
+				blog_id: '1234567',
+				cart_key: '1234567',
 				coupon: '',
 				create_new_blog: false,
 			},

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -199,7 +199,6 @@ describe( 'payPalExpressProcessor', () => {
 		expect( createAccountEndpoint ).toHaveBeenCalledWith( expectedCreateAccountRequest );
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
-			site_id: 1234567,
 			cancel_url: 'https://example.com/?cart=no-user',
 			cart: {
 				...basicExpectedRequest.cart,
@@ -267,7 +266,6 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			cancel_url: 'https://example.com/?cart=no-user',
-			site_id: 1234567,
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '1234567',


### PR DESCRIPTION
#### Background

There are two endpoints that wpcom checkout uses for its roughly 13 payment processors: `/me/transactions` and `/me/paypal-express-url`, currently handled by the functions `submitWpcomTransaction` and `wpcomPayPalExpress`, respectively.

Since checkout can be used when logged-out, both functions must handle the case where a wpcom account must be created before the transaction is submitted. Currently the code to perform this operation is duplicated in both functions. This is not ideal since it would be easy to accidentally alter one of those operations without altering the other.

In addition, the rather large extra block of code obfuscates the simple utility nature of both functions; they are intended to be the last step to submitting data to the endpoints and use TypeScript types to verify the data being submitted. It would also be easy to accidentally mutate the data just before the submission and the mutation would never signal a type error.

#### Changes proposed in this Pull Request

To resolve both of these potential issues, this PR moves the account creation code into its own function and calls it in both submission functions. This will simplify both functions to hopefully make it more clear that they should remain simple, and DRY the account creation process to protect it against diverging.

**NOTE**: There was already one difference between the two account creation blocks; the PayPal block also added a `site_id` property to the request submitted to the `/me/paypal-express-url` with the newly created site ID when an account had been created. This PR removes that property because it does not appear to be used anywhere inside the endpoint that I can find, and I can't even imagine what that property would do since it's only sent on new site creation and by that point the account and site have already been created and the site ID will be included in the cart data.

#### Testing instructions

Automated tests should cover both of these changes but you can manually test account creation as well by going through signup using a siteless checkout flow (eg: domain-only checkout available at `/start/domain/domain-only`). Remember that there are two flows this changes: PayPal, and everything else.