### PR TITLE
Enable emails/new-email-comparison feature flag in stage and production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -31,6 +31,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
+		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,6 +30,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
+		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the `emails/new-email-comparison` feature flag in stage and production. The flag was enabled through the wpcalypso environment in #59643.

#### Testing instructions

This one is tricky to test, as we'll only be able to verify the changes once the PR is deployed to the stage environment. Once that occurs, we can do the following:

* For a site with a domain that doesn't have email, navigate to **Upgrades** -> **Emails**
* Click on "Add Email" for a domain that doesn't have email
* Verify that you see the new email comparison UI on the next step -- this can be identified by the monthly/annual billing toggle at the top of the page.

Related to #59643