### PR TITLE
Fix race conditions in localized SSR

### DIFF
--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -1,13 +1,18 @@
 import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 import { defaultI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
-import i18n from 'i18n-calypso';
-import * as React from 'react';
+import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
+import type { I18N } from 'i18n-calypso';
+import type { FunctionComponent } from 'react';
 
-const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
-	const [ localeSlug, setLocaleSlug ] = React.useState( i18n.getLocaleSlug() );
+const CalypsoI18nProvider: FunctionComponent< { i18n: I18N } > = ( {
+	i18n = defaultCalypsoI18n,
+	children,
+} ) => {
+	const [ localeSlug, setLocaleSlug ] = useState( i18n.getLocaleSlug() );
 
-	React.useEffect( () => {
+	useEffect( () => {
 		const onChange = () => {
 			defaultI18n.setLocaleData( i18n.getLocale() );
 			setLocaleSlug( i18n.getLocaleSlug() );
@@ -18,16 +23,18 @@ const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 		return () => {
 			i18n.off( 'change', onChange );
 		};
-	}, [] );
+	}, [ i18n ] );
 
-	React.useEffect( () => {
+	useEffect( () => {
 		defaultI18n.resetLocaleData( i18n.getLocale() );
 	}, [ localeSlug ] );
 
 	return (
-		<LocaleProvider localeSlug={ localeSlug || i18nDefaultLocaleSlug }>
-			<I18nProvider i18n={ defaultI18n }>{ children }</I18nProvider>
-		</LocaleProvider>
+		<I18NContext.Provider value={ i18n }>
+			<LocaleProvider localeSlug={ localeSlug || i18nDefaultLocaleSlug }>
+				<I18nProvider i18n={ defaultI18n }>{ children }</I18nProvider>
+			</LocaleProvider>
+		</I18NContext.Provider>
 	);
 };
 

--- a/client/components/jetpack/log-item/index.tsx
+++ b/client/components/jetpack/log-item/index.tsx
@@ -2,13 +2,13 @@ import classnames from 'classnames';
 import { PureComponent, ReactNode } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import FoldableCard from 'calypso/components/foldable-card';
-
+import type { TranslateResult } from 'i18n-calypso';
 import './style.scss';
 
 export interface Props {
 	children?: ReactNode;
 	className?: string;
-	header: string | i18nCalypso.TranslateResult;
+	header: string | TranslateResult;
 	subheader?: string | ReactNode;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;

--- a/client/components/jetpack/server-credentials-wizard-dialog/index.tsx
+++ b/client/components/jetpack/server-credentials-wizard-dialog/index.tsx
@@ -7,6 +7,7 @@ import ExternalLink from 'calypso/components/external-link';
 import ServerCredentialsForm from 'calypso/components/jetpack/server-credentials-form';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement, ReactNode } from 'react';
 
 import './style.scss';
@@ -19,7 +20,7 @@ interface Props {
 	children: ReactNode;
 	buttons?: ReactElement[];
 	baseDialogClassName?: string;
-	title: i18nCalypso.TranslateResult;
+	title: TranslateResult;
 	titleClassName?: string;
 }
 

--- a/client/components/jetpack/threat-item-new/index.tsx
+++ b/client/components/jetpack/threat-item-new/index.tsx
@@ -11,6 +11,7 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import LogItem from '../log-item';
 import ThreatDescription from '../threat-description-new';
 import type { Threat } from 'calypso/components/jetpack/threat-item-new/types';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 interface Props {
@@ -68,7 +69,7 @@ const ThreatItem: React.FC< Props > = ( {
 		[ isFixing, onFixThreat, threat ]
 	);
 
-	const getFix = React.useCallback( (): i18nCalypso.TranslateResult | undefined => {
+	const getFix = React.useCallback( (): TranslateResult | undefined => {
 		if ( threat.status === 'fixed' ) {
 			return;
 		}

--- a/client/components/jetpack/threat-item-new/utils.ts
+++ b/client/components/jetpack/threat-item-new/utils.ts
@@ -1,9 +1,10 @@
 import { translate } from 'i18n-calypso';
 import { Threat, ThreatFix, ThreatType } from './types';
+import type { TranslateResult } from 'i18n-calypso';
 
 // This should be temporary since this data should be coming from the api
 // and not something that we should change to accommodate the results.
-export const getThreatMessage = ( threat: Threat ): string | i18nCalypso.TranslateResult => {
+export const getThreatMessage = ( threat: Threat ): string | TranslateResult => {
 	const { filename, extension = { slug: 'unknown', version: 'n/a' } } = threat;
 	const basename = filename ? filename.replace( /.*\//, '' ) : '';
 
@@ -84,7 +85,7 @@ export function getThreatType( threat: Threat ): ThreatType {
 	return 'none';
 }
 
-export const getThreatVulnerability = ( threat: Threat ): string | i18nCalypso.TranslateResult => {
+export const getThreatVulnerability = ( threat: Threat ): string | TranslateResult => {
 	switch ( getThreatType( threat ) ) {
 		case 'core':
 			return translate( 'Vulnerability found in WordPress' );
@@ -111,7 +112,7 @@ export const getThreatVulnerability = ( threat: Threat ): string | i18nCalypso.T
 	}
 };
 
-export const getThreatFix = ( fixable: ThreatFix ): i18nCalypso.TranslateResult => {
+export const getThreatFix = ( fixable: ThreatFix ): TranslateResult => {
 	switch ( fixable.fixer ) {
 		case 'replace':
 			return translate( 'Jetpack Scan will replace the affected file or directory.' );

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -12,8 +12,9 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import LogItem from '../log-item';
 import ThreatDescription from '../threat-description';
-
+import type { TranslateResult } from 'i18n-calypso';
 import './style.scss';
+
 interface Props {
 	threat: Threat;
 	isPlaceholder: boolean;
@@ -71,7 +72,7 @@ const ThreatItem: React.FC< Props > = ( {
 	);
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	const getFix = React.useCallback( (): i18nCalypso.TranslateResult | undefined => {
+	const getFix = React.useCallback( (): TranslateResult | undefined => {
 		if ( threat.status === 'fixed' ) {
 			return;
 		}

--- a/client/components/jetpack/threat-item/utils.ts
+++ b/client/components/jetpack/threat-item/utils.ts
@@ -1,5 +1,6 @@
 import { translate } from 'i18n-calypso';
 import { Threat, ThreatFix, ThreatType } from './types';
+import type { TranslateResult } from 'i18n-calypso';
 
 export function getThreatType( threat: Threat ): ThreatType {
 	// We can't use `hasOwnProperty` here to test these conditions because
@@ -29,7 +30,7 @@ export function getThreatType( threat: Threat ): ThreatType {
 	return 'none';
 }
 
-export const getThreatVulnerability = ( threat: Threat ): string | i18nCalypso.TranslateResult => {
+export const getThreatVulnerability = ( threat: Threat ): string | TranslateResult => {
 	switch ( getThreatType( threat ) ) {
 		case 'core':
 			return translate( 'Vulnerability found in WordPress' );
@@ -56,7 +57,7 @@ export const getThreatVulnerability = ( threat: Threat ): string | i18nCalypso.T
 	}
 };
 
-export const getThreatFix = ( fixable: ThreatFix | false ): i18nCalypso.TranslateResult => {
+export const getThreatFix = ( fixable: ThreatFix | false ): TranslateResult => {
 	if ( ! fixable ) {
 		return translate( 'Jetpack Scan will resolve the threat.' );
 	}

--- a/client/components/translatable/proptype.js
+++ b/client/components/translatable/proptype.js
@@ -15,7 +15,7 @@ function translatableStringChecker( props, propName, componentName ) {
 		// Translator Jumpstart after #21591
 		if (
 			'object' === typeof value &&
-			'function' === typeof value.type &&
+			[ 'object', 'function' ].includes( typeof value.type ) &&
 			( 'Translatable' === value.type.name ||
 				// Accept HOC wrappings (e.g. `localize( Translatable )`)
 				String( value.type.displayName ).match( /\(Translatable\)/ ) )

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -37,8 +37,9 @@ const ProviderWrappedLoggedOutLayout = ( {
 	primary,
 	secondary,
 	redirectUri,
+	i18n,
 } ) => (
-	<CalypsoI18nProvider>
+	<CalypsoI18nProvider i18n={ i18n }>
 		<RouteProvider
 			currentSection={ currentSection }
 			currentRoute={ currentRoute }

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -6,12 +6,13 @@ const noop = () => {};
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
-		const { store, queryClient, section, pathname, query, primary, secondary } = context;
+		const { i18n, store, queryClient, section, pathname, query, primary, secondary } = context;
 
 		// On server, only render LoggedOutLayout when logged-out.
 		if ( ! ( context.isServerSide && isUserLoggedIn( context.store.getState() ) ) ) {
 			context.layout = (
 				<LayoutComponent
+					i18n={ i18n }
 					store={ store }
 					queryClient={ queryClient }
 					currentSection={ section }

--- a/client/controller/ssr-setup-locale.js
+++ b/client/controller/ssr-setup-locale.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import { readFile } from 'fs/promises';
-import i18n from 'i18n-calypso';
+import { I18N } from 'i18n-calypso';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import config from 'calypso/server/config';
 import { LOCALE_SET } from 'calypso/state/action-types';
@@ -10,11 +10,13 @@ export function ssrSetupLocaleMiddleware() {
 
 	return function ssrSetupLocale( context, next ) {
 		function setLocaleData( localeData ) {
+			const i18n = new I18N();
 			i18n.setLocale( localeData );
 			const localeSlug = i18n.getLocaleSlug();
 			const localeVariant = i18n.getLocaleVariant();
 			context.store.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
 			context.lang = localeVariant || localeSlug;
+			context.i18n = i18n;
 			next();
 		}
 
@@ -31,7 +33,7 @@ export function ssrSetupLocaleMiddleware() {
 		}
 
 		const cachedTranslations = translationsCache[ lang ];
-		if ( typeof cachedTranslations !== 'undefined' ) {
+		if ( cachedTranslations ) {
 			setLocaleData( cachedTranslations );
 		} else {
 			readFile( getAssetFilePath( `languages/${ lang }-v1.1.json` ), 'utf-8' )

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -26,7 +26,7 @@ export function addLocaleQueryParam( params ) {
 	}
 
 	return Object.assign( params, {
-		query: stringify( Object.assign( query, localeQueryParam ) ),
+		query: stringify( Object.assign( localeQueryParam, query ) ),
 	} );
 }
 

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -21,13 +21,19 @@ describe( 'index', () => {
 		test( 'should include the locale query parameter for a non-default locale', () => {
 			i18n.setLocale( { '': { localeSlug: 'fr' } } );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
-			expect( params ).toEqual( { query: 'search=foo&locale=fr' } );
+			expect( params ).toEqual( { query: 'locale=fr&search=foo' } );
 		} );
 
 		test( 'should include the locale query parameter for a locale variant', () => {
 			i18n.setLocale( { '': { localeSlug: 'de', localeVariant: 'de_formal' } } );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
-			expect( params ).toEqual( { query: 'search=foo&locale=de_formal' } );
+			expect( params ).toEqual( { query: 'locale=de_formal&search=foo' } );
+		} );
+
+		test( 'should prioritize the locale specified on the request', () => {
+			i18n.setLocale( { '': { localeSlug: 'fr' } } );
+			const params = addLocaleQueryParam( { query: 'locale=cs' } );
+			expect( params ).toEqual( { query: 'locale=cs' } );
 		} );
 	} );
 
@@ -49,7 +55,7 @@ describe( 'index', () => {
 			i18n.setLocale( { '': { localeSlug: 'fr' } } );
 			const wpcom = {
 				async request( params ) {
-					expect( params.query ).toBe( 'search=foo&locale=fr' );
+					expect( params.query ).toBe( 'locale=fr&search=foo' );
 				},
 			};
 

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { isDomainTransfer, isConciergeSession } from '@automattic/calypso-products';
 import { CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import i18nCalypso, { localize, useTranslate } from 'i18n-calypso';
+import i18n, { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -31,7 +31,6 @@ import {
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
 import OwnerInfo from './owner-info';
-
 import 'calypso/me/purchases/style.scss';
 
 const eventProperties = ( warning ) => ( { warning, position: 'purchase-list' } );
@@ -115,7 +114,7 @@ class PurchaseItem extends Component {
 			if (
 				isRenewing( purchase ) &&
 				( locale === 'en' ||
-					i18nCalypso.hasTranslation(
+					i18n.hasTranslation(
 						'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s'
 					) )
 			) {
@@ -135,7 +134,7 @@ class PurchaseItem extends Component {
 
 			if (
 				locale === 'en' ||
-				i18nCalypso.hasTranslation( 'Free trial ends on {{span}}%(date)s{{/span}}' )
+				i18n.hasTranslation( 'Free trial ends on {{span}}%(date)s{{/span}}' )
 			) {
 				const expiryClass =
 					expiry < moment().add( 7, 'days' )

--- a/client/my-sites/backup/rewind-flow/rewind-flow-notice/check-your-email.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-flow-notice/check-your-email.tsx
@@ -1,9 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import Notice, { RewindFlowNoticeLevel } from './index';
+import type { TranslateResult } from 'i18n-calypso';
 
 interface Props {
-	message: i18nCalypso.TranslateResult;
+	message: TranslateResult;
 }
 
 const RewindFlowCheckYourEmail: FunctionComponent< Props > = ( { message } ) => {

--- a/client/my-sites/backup/rewind-flow/rewind-flow-notice/index.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-flow-notice/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
-import { FunctionComponent } from 'react';
+import type { TranslateResult } from 'i18n-calypso';
+import type { FunctionComponent } from 'react';
 
 enum RewindFlowNoticeLevel {
 	NOTICE,
@@ -10,8 +11,8 @@ enum RewindFlowNoticeLevel {
 interface Props {
 	gridicon: string;
 	link?: string;
-	message?: i18nCalypso.TranslateResult;
-	title: i18nCalypso.TranslateResult;
+	message?: TranslateResult;
+	title: TranslateResult;
 	type: RewindFlowNoticeLevel;
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { TermsOfServiceRecord, useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
-import i18nCalypso, { useTranslate, TranslateResult } from 'i18n-calypso';
+import i18n, { useTranslate, TranslateResult } from 'i18n-calypso';
 import moment from 'moment';
 import { useSelector } from 'react-redux';
 import { EDIT_PAYMENT_DETAILS } from 'calypso/lib/url/support';
@@ -67,7 +67,7 @@ function getMessageForTermsOfServiceRecord(
 			}
 			if (
 				( locale === 'en' ||
-					i18nCalypso.hasTranslation(
+					i18n.hasTranslation(
 						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription {{/manageSubscriptionLink}} at any time.'
 					) ) &&
 				args.subscription_start_date &&
@@ -77,7 +77,7 @@ function getMessageForTermsOfServiceRecord(
 				if (
 					args.is_renewal_price_prorated &&
 					( locale === 'en' ||
-						i18nCalypso.hasTranslation(
+						i18n.hasTranslation(
 							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
 						) )
 				) {
@@ -163,7 +163,7 @@ function getMessageForTermsOfServiceRecord(
 			}
 			if (
 				( locale === 'en' ||
-					i18nCalypso.hasTranslation(
+					i18n.hasTranslation(
 						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
 					) ) &&
 				args.subscription_start_date &&
@@ -173,7 +173,7 @@ function getMessageForTermsOfServiceRecord(
 				if (
 					args.is_renewal_price_prorated &&
 					( locale === 'en' ||
-						i18nCalypso.hasTranslation(
+						i18n.hasTranslation(
 							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
 						) )
 				) {

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,4 +1,4 @@
-import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { useDebouncedCallback } from 'use-debounce';
@@ -191,7 +191,7 @@ export const QuickLinks = ( {
 						label={
 							getLocaleSlug() === 'en' ||
 							getLocaleSlug() === 'en-gb' ||
-							i18nCalypso.hasTranslation( 'Create a logo with Fiverr' )
+							i18n.hasTranslation( 'Create a logo with Fiverr' )
 								? translate( 'Create a logo with Fiverr' )
 								: translate( 'Create a logo' )
 						}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -30,7 +30,7 @@ import type {
 	TransferDomainToOtherSiteProps,
 	TransferDomainToOtherSiteStateProps,
 } from './types';
-
+import type { TranslateResult } from 'i18n-calypso';
 import './style.scss';
 
 export class TransferDomainToOtherSite extends Component< TransferDomainToOtherSiteProps > {
@@ -110,7 +110,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		}
 	};
 
-	getMessage(): i18nCalypso.TranslateResult {
+	getMessage(): TranslateResult {
 		const { selectedDomainName: domainName, translate } = this.props;
 		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
 		return translate(

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -31,6 +31,7 @@ import isRequestingJetpackScan from 'calypso/state/selectors/is-requesting-jetpa
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ScanNavigation from './navigation';
+import type { TranslateResult } from 'i18n-calypso';
 import type { utc } from 'moment';
 
 import './style.scss';
@@ -73,7 +74,7 @@ class ScanPage extends Component< Props > {
 		);
 	}
 
-	renderHeader( text: i18nCalypso.TranslateResult ) {
+	renderHeader( text: TranslateResult ) {
 		return <h1 className="scan__header">{ text }</h1>;
 	}
 

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -78,7 +78,7 @@ export function fetchThemeFilters( context, next ) {
 			return next();
 		}
 	} );
-	store.dispatch( requestThemeFilters() );
+	store.dispatch( requestThemeFilters( context.lang ) );
 }
 
 // Legacy (Atlas-based Theme Showcase v4) route redirects

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -15,6 +15,7 @@ const fetchFilters = ( action ) =>
 			method: 'GET',
 			apiVersion: '1.2',
 			path: '/theme-filters',
+			query: action.locale ? { locale: action.locale } : {},
 		},
 		action
 	);

--- a/client/state/themes/actions/request-theme-filters.js
+++ b/client/state/themes/actions/request-theme-filters.js
@@ -8,8 +8,9 @@ import 'calypso/state/themes/init';
  *
  * @returns {object} A nested list of theme filters, keyed by filter slug
  */
-export function requestThemeFilters() {
+export function requestThemeFilters( locale = null ) {
 	return {
 		type: THEME_FILTERS_REQUEST,
+		locale,
 	};
 }

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1198,7 +1198,7 @@ describe( 'actions', () => {
 	describe( '#requestThemeFilters', () => {
 		test( 'should return THEME_FILTERS_REQUEST action', () => {
 			const action = requestThemeFilters();
-			expect( action ).to.deep.equal( { type: THEME_FILTERS_REQUEST } );
+			expect( action ).to.deep.equal( { type: THEME_FILTERS_REQUEST, locale: null } );
 		} );
 	} );
 

--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `i18n.getLocaleVariant()` method to get a nonstandard locale variant slug.
 - Bump `interpolate-components` (renamed to `@automattic/interpolate-components`) to 1.1.2 (for React 17 compat).
+- Add support for passing an `I18N` object in React context
 
 ## 5.0.0
 

--- a/packages/i18n-calypso/src/context.js
+++ b/packages/i18n-calypso/src/context.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import i18n from './default-i18n';
+
+export default createContext( i18n );

--- a/packages/i18n-calypso/src/default-i18n.js
+++ b/packages/i18n-calypso/src/default-i18n.js
@@ -1,0 +1,3 @@
+import I18N from './i18n';
+
+export default new I18N();

--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -1,13 +1,11 @@
+import I18NContext from './context';
+import i18n from './default-i18n';
 import I18N from './i18n';
-import localizeFactory from './localize';
-import rtlFactory from './rtl';
-import translateHookFactory from './use-translate';
+import localize from './localize';
+import { useRtl, withRtl } from './rtl';
+import useTranslate from './use-translate';
 
-// Export the `I18N` class
-export { I18N };
-
-// Create a default instance of `I18N` and make it the module default export
-const i18n = new I18N();
+export { I18N, I18NContext, localize, useRtl, withRtl, useTranslate };
 export default i18n;
 
 // Export the default instance's properties and bound methods for convenience
@@ -29,9 +27,3 @@ export const stateObserver = i18n.stateObserver;
 export const on = i18n.on.bind( i18n );
 export const off = i18n.off.bind( i18n );
 export const emit = i18n.emit.bind( i18n );
-
-// Export the React helpers bound to the default `i18n` instance
-export const localize = localizeFactory( i18n );
-export const useTranslate = translateHookFactory( i18n );
-const { useRtl, withRtl } = rtlFactory( i18n );
-export { useRtl, withRtl };

--- a/packages/i18n-calypso/src/localize.js
+++ b/packages/i18n-calypso/src/localize.js
@@ -1,47 +1,37 @@
-import { Component } from 'react';
+import { forwardRef, useContext, useEffect, useMemo, useState } from 'react';
+import I18NContext from './context';
+
+function bindI18nProps( i18n ) {
+	return {
+		numberFormat: i18n.numberFormat.bind( i18n ),
+		translate: i18n.translate.bind( i18n ),
+		locale: i18n.getLocaleSlug(),
+	};
+}
 
 /**
  * Localize a React component
  *
- * @param {object} i18n I18N instance to use for localization
- * @returns {Function} Component localization function
+ * @param  {import('react').Component} ComposedComponent React component to localize
+ * @returns {import('react').Component} The localized component
  */
-export default function ( i18n ) {
-	const i18nProps = {
-		numberFormat: i18n.numberFormat.bind( i18n ),
-		translate: i18n.translate.bind( i18n ),
-	};
+export default function localize( ComposedComponent ) {
+	const LocalizedComponent = forwardRef( ( props, ref ) => {
+		const i18n = useContext( I18NContext );
+		const [ counter, setCounter ] = useState( 0 );
+		useEffect( () => {
+			const onChange = () => setCounter( ( c ) => c + 1 );
+			i18n.on( 'change', onChange );
+			return () => i18n.off( 'change', onChange );
+		}, [ i18n ] );
 
-	/**
-	 * Localize a React component
-	 *
-	 * @param  {Component} ComposedComponent React component to localize
-	 * @returns {Component}                   The localized component
-	 */
-	return function ( ComposedComponent ) {
-		const componentName = ComposedComponent.displayName || ComposedComponent.name || '';
+		const i18nProps = useMemo( () => bindI18nProps( i18n, counter ), [ i18n, counter ] );
 
-		return class extends Component {
-			static displayName = 'Localized(' + componentName + ')';
+		return <ComposedComponent { ...props } { ...i18nProps } ref={ ref } />;
+	} );
 
-			boundForceUpdate = this.forceUpdate.bind( this );
+	const componentName = ComposedComponent.displayName || ComposedComponent.name || '';
+	LocalizedComponent.displayName = 'Localized(' + componentName + ')';
 
-			componentDidMount() {
-				i18n.on( 'change', this.boundForceUpdate );
-			}
-
-			componentWillUnmount() {
-				i18n.off( 'change', this.boundForceUpdate );
-			}
-
-			render() {
-				const props = {
-					locale: i18n.getLocaleSlug(),
-					...this.props,
-					...i18nProps,
-				};
-				return <ComposedComponent { ...props } />;
-			}
-		};
-	};
+	return LocalizedComponent;
 }

--- a/packages/i18n-calypso/src/rtl.js
+++ b/packages/i18n-calypso/src/rtl.js
@@ -1,31 +1,32 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { forwardRef } from 'react';
+import { forwardRef, useContext, useMemo } from 'react';
 import { useSubscription } from 'use-subscription';
+import I18NContext from './context';
 
-export default function rtlFactory( i18n ) {
+export function useRtl() {
+	const i18n = useContext( I18NContext );
 	// Subscription object (adapter) for the `useSubscription` hook
-	const RtlSubscription = {
-		getCurrentValue() {
-			return i18n.isRtl();
-		},
-		subscribe( callback ) {
-			i18n.on( 'change', callback );
-			return () => i18n.off( 'change', callback );
-		},
-	};
-
-	function useRtl() {
-		return useSubscription( RtlSubscription );
-	}
-
-	const withRtl = createHigherOrderComponent(
-		( WrappedComponent ) =>
-			forwardRef( ( props, ref ) => {
-				const isRtl = useRtl();
-				return <WrappedComponent { ...props } isRtl={ isRtl } ref={ ref } />;
-			} ),
-		'WithRTL'
+	const RtlSubscription = useMemo(
+		() => ( {
+			getCurrentValue() {
+				return i18n.isRtl();
+			},
+			subscribe( callback ) {
+				i18n.on( 'change', callback );
+				return () => i18n.off( 'change', callback );
+			},
+		} ),
+		[ i18n ]
 	);
 
-	return { useRtl, withRtl };
+	return useSubscription( RtlSubscription );
 }
+
+export const withRtl = createHigherOrderComponent(
+	( WrappedComponent ) =>
+		forwardRef( ( props, ref ) => {
+			const isRtl = useRtl();
+			return <WrappedComponent { ...props } isRtl={ isRtl } ref={ ref } />;
+		} ),
+	'WithRTL'
+);

--- a/packages/i18n-calypso/src/use-translate.js
+++ b/packages/i18n-calypso/src/use-translate.js
@@ -17,5 +17,5 @@ export default function useTranslate() {
 		return () => i18n.off( 'change', onChange );
 	}, [ i18n ] );
 
-	return useMemo( () => bindTranslate( i18n, counter ) );
+	return useMemo( () => bindTranslate( i18n, counter ), [ i18n, counter ] );
 }

--- a/packages/i18n-calypso/src/use-translate.js
+++ b/packages/i18n-calypso/src/use-translate.js
@@ -1,21 +1,21 @@
-import { useState, useEffect } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
+import I18NContext from './context';
 
-export default function ( i18n ) {
-	function bindTranslate() {
-		const translate = i18n.translate.bind( i18n );
-		Object.defineProperty( translate, 'localeSlug', { get: i18n.getLocaleSlug.bind( i18n ) } );
-		return translate;
-	}
+function bindTranslate( i18n ) {
+	const translate = i18n.translate.bind( i18n );
+	Object.defineProperty( translate, 'localeSlug', { get: i18n.getLocaleSlug.bind( i18n ) } );
+	return translate;
+}
 
-	return function useTranslate() {
-		const [ translate, setTranslate ] = useState( bindTranslate );
+export default function useTranslate() {
+	const i18n = useContext( I18NContext );
+	const [ counter, setCounter ] = useState( 0 );
 
-		useEffect( () => {
-			const onChange = () => setTranslate( bindTranslate );
-			i18n.on( 'change', onChange );
-			return () => i18n.off( 'change', onChange );
-		}, [] );
+	useEffect( () => {
+		const onChange = () => setCounter( ( c ) => c + 1 );
+		i18n.on( 'change', onChange );
+		return () => i18n.off( 'change', onChange );
+	}, [ i18n ] );
 
-		return translate;
-	};
+	return useMemo( () => bindTranslate( i18n, counter ) );
 }

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -145,3 +145,5 @@ export type LocalizedComponent< C > = React.ComponentClass<
 export function localize< C >( component: C ): LocalizedComponent< C >;
 export function useTranslate(): typeof translate & { localeSlug: string | undefined };
 export function useRtl(): boolean;
+
+export declare const I18NContext: React.Context< I18N >;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -3,138 +3,145 @@
 
 import * as React from 'react';
 
-declare namespace i18nCalypso {
-	type LocaleData = Record< string, any >;
-	type NormalizedTranslateArgs =
-		| ( TranslateOptions & { original: string } )
-		| ( TranslateOptions & {
-				original: string;
-				plural: string;
-				count: number;
-		  } );
+type LocaleData = Record< string, any >;
+type NormalizedTranslateArgs =
+	| ( TranslateOptions & { original: string } )
+	| ( TranslateOptions & {
+			original: string;
+			plural: string;
+			count: number;
+	  } );
 
-	export type Substitution = string | number | React.ReactFragment;
+export type Substitution = string | number | React.ReactFragment;
 
-	export type Substitutions =
-		| Substitution
-		| Substitution[]
-		| { [ placeholder: string ]: Substitution };
+export type Substitutions =
+	| Substitution
+	| Substitution[]
+	| { [ placeholder: string ]: Substitution };
 
-	export interface ComponentInterpolations {
-		[ placeholder: string ]: React.ReactElement;
-	}
-
-	export interface TranslateOptions {
-		/**
-		 * Arguments you would pass into sprintf to be run against the text for string substitution.
-		 */
-		args?: Substitutions;
-
-		/**
-		 * Comment that will be shown to the translator for anything that may need to be explained about the translation.
-		 */
-		comment?: string;
-
-		/**
-		 * Components to be interpolated in the translated string.
-		 */
-		components?: ComponentInterpolations;
-
-		/**
-		 * Provides the ability for the translator to provide a different translation for the same text in two locations (dependent on context). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
-		 */
-		context?: string;
-	}
-
-	// This deprecated signature is still supported
-	export interface DeprecatedTranslateOptions extends TranslateOptions {
-		original: string | { single: string; plural: string; count: number };
-	}
-
-	export type TranslateOptionsText = TranslateOptions & { textOnly: true };
-	export type TranslateOptionsPlural = TranslateOptions & { count: number };
-	export type TranslateOptionsPluralText = TranslateOptionsPlural & { textOnly: true };
-
-	// Translate hooks, like component interpolation or highlighting untranslated strings,
-	// force us to declare the return type as a generic React node, not as just string.
-	export type TranslateResult = React.ReactChild;
-
-	export function translate( options: DeprecatedTranslateOptions ): React.ReactChild;
-	export function translate( original: string ): React.ReactChild;
-	export function translate( original: string, options: TranslateOptions ): React.ReactChild;
-	export function translate( original: string, options: TranslateOptionsText ): string;
-	export function translate(
-		original: string,
-		plural: string,
-		options: TranslateOptionsPlural
-	): React.ReactChild;
-	export function translate(
-		original: string,
-		plural: string,
-		options: TranslateOptionsPluralText
-	): string;
-
-	export function setLocale( localeData: LocaleData ): void;
-	export function addTranslations( localeData: LocaleData ): void;
-	export function hasTranslation( original: string ): boolean;
-
-	export function configure( options: Record< string, any > ): void;
-
-	export interface NumberFormatOptions {
-		decimals?: number;
-		decPoint?: string;
-		thousandsSep?: string;
-	}
-
-	export function numberFormat( number: number, numberOfDecimalPlaces: number ): string;
-	export function numberFormat( number: number, options: NumberFormatOptions ): string;
-
-	export interface LocalizeProps {
-		locale: string;
-		translate: typeof translate;
-		numberFormat: typeof numberFormat;
-	}
-
-	// Infers prop type from component C
-	export type GetProps< C > = C extends React.ComponentType< infer P > ? P : never;
-
-	export type WithoutLocalizedProps< OrigProps > = Pick<
-		OrigProps,
-		Exclude< keyof OrigProps, keyof LocalizeProps >
-	>;
-
-	export type LocalizedComponent< C > = React.ComponentClass<
-		WithoutLocalizedProps< GetProps< C > >
-	>;
-
-	export function localize< C >( component: C ): LocalizedComponent< C >;
-
-	export function useTranslate(): typeof translate & { localeSlug: string | undefined };
-
-	export function reRenderTranslations(): void;
-
-	export type TranslateHook = (
-		translation: React.ReactChild,
-		options: NormalizedTranslateArgs
-	) => React.ReactChild;
-	export function registerTranslateHook( hook: TranslateHook ): void;
-
-	export type ComponentUpdateHook = ( ...args: any ) => any;
-	export function registerComponentUpdateHook( hook: ComponentUpdateHook ): void;
-
-	export function getLocale(): LocaleData;
-	export function getLocaleSlug(): string | null;
-	export function getLocaleVariant(): string | undefined;
-	export function isRtl(): boolean;
-	export const defaultLocaleSlug: string;
-
-	export type EventListener = ( ...payload: any ) => any;
-	export function on( eventName: string, listener: EventListener ): void;
-	export function off( eventName: string, listener: EventListener ): void;
-	export function emit( eventName: string, ...payload: any ): void;
-
-	export function useRtl(): boolean;
+export interface ComponentInterpolations {
+	[ placeholder: string ]: React.ReactElement;
 }
 
-export = i18nCalypso;
-export as namespace i18nCalypso;
+export interface TranslateOptions {
+	/**
+	 * Arguments you would pass into sprintf to be run against the text for string substitution.
+	 */
+	args?: Substitutions;
+
+	/**
+	 * Comment that will be shown to the translator for anything that may need to be explained about the translation.
+	 */
+	comment?: string;
+
+	/**
+	 * Components to be interpolated in the translated string.
+	 */
+	components?: ComponentInterpolations;
+
+	/**
+	 * Provides the ability for the translator to provide a different translation for the same text in two locations (dependent on context). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
+	 */
+	context?: string;
+}
+
+// This deprecated signature is still supported
+export interface DeprecatedTranslateOptions extends TranslateOptions {
+	original: string | { single: string; plural: string; count: number };
+}
+
+export type TranslateOptionsText = TranslateOptions & { textOnly: true };
+export type TranslateOptionsPlural = TranslateOptions & { count: number };
+export type TranslateOptionsPluralText = TranslateOptionsPlural & { textOnly: true };
+
+// Translate hooks, like component interpolation or highlighting untranslated strings,
+// force us to declare the return type as a generic React node, not as just string.
+export type TranslateResult = React.ReactChild;
+
+export interface NumberFormatOptions {
+	decimals?: number;
+	decPoint?: string;
+	thousandsSep?: string;
+}
+
+export type TranslateHook = (
+	translation: React.ReactChild,
+	options: NormalizedTranslateArgs
+) => React.ReactChild;
+
+export type ComponentUpdateHook = ( ...args: any ) => any;
+
+export type EventListener = ( ...payload: any ) => any;
+
+export interface I18N {
+	translate( options: DeprecatedTranslateOptions ): React.ReactChild;
+	translate( original: string ): React.ReactChild;
+	translate( original: string, options: TranslateOptions ): React.ReactChild;
+	translate( original: string, options: TranslateOptionsText ): string;
+	translate( original: string, plural: string, options: TranslateOptionsPlural ): React.ReactChild;
+	translate( original: string, plural: string, options: TranslateOptionsPluralText ): string;
+
+	numberFormat( number: number, numberOfDecimalPlaces: number ): string;
+	numberFormat( number: number, options: NumberFormatOptions ): string;
+
+	setLocale( localeData: LocaleData ): void;
+	addTranslations( localeData: LocaleData ): void;
+	hasTranslation( original: string ): boolean;
+
+	configure( options: Record< string, any > ): void;
+
+	getLocale(): LocaleData;
+	getLocaleSlug(): string | null;
+	getLocaleVariant(): string | undefined;
+	isRtl(): boolean;
+	defaultLocaleSlug: string;
+
+	reRenderTranslations(): void;
+
+	registerTranslateHook( hook: TranslateHook ): void;
+	registerComponentUpdateHook( hook: ComponentUpdateHook ): void;
+
+	on( eventName: string, listener: EventListener ): void;
+	off( eventName: string, listener: EventListener ): void;
+	emit( eventName: string, ...payload: any ): void;
+}
+
+declare const i18n: I18N;
+export default i18n;
+export declare const translate: typeof i18n.translate;
+export declare const numberFormat: typeof i18n.numberFormat;
+export declare const setLocale: typeof i18n.setLocale;
+export declare const addTranslations: typeof i18n.addTranslations;
+export declare const configure: typeof i18n.configure;
+export declare const getLocale: typeof i18n.getLocale;
+export declare const getLocaleSlug: typeof i18n.getLocaleSlug;
+export declare const getLocaleVariant: typeof i18n.getLocaleVariant;
+export declare const isRtl: typeof i18n.isRtl;
+export declare const defaultLocaleSlug: typeof i18n.defaultLocaleSlug;
+export declare const registerTranslateHook: typeof i18n.registerTranslateHook;
+export declare const registerComponentUpdateHook: typeof i18n.registerComponentUpdateHook;
+export declare const on: typeof i18n.on;
+export declare const off: typeof i18n.off;
+export declare const emit: typeof i18n.emit;
+
+export interface LocalizeProps {
+	locale: string;
+	translate: typeof translate;
+	numberFormat: typeof numberFormat;
+}
+
+// Infers prop type from component C
+export type GetProps< C > = C extends React.ComponentType< infer P > ? P : never;
+
+export type WithoutLocalizedProps< OrigProps > = Pick<
+	OrigProps,
+	Exclude< keyof OrigProps, keyof LocalizeProps >
+>;
+
+export type LocalizedComponent< C > = React.ComponentClass<
+	WithoutLocalizedProps< GetProps< C > >
+>;
+
+export function localize< C >( component: C ): LocalizedComponent< C >;
+export function useTranslate(): typeof translate & { localeSlug: string | undefined };
+export function useRtl(): boolean;


### PR DESCRIPTION
Fixes a serious bug in localized server-side rendering discovered by @sgomes when testing the `/log-in` routes. It's caused by the fact that there is one global singleton instance of the `i18n` object on the server and all requests from all users share it.

1. Locally, run `yarn build-languages` so that your `public/languages/` folder is populated with language files like `id-v.1.1.json`.
2. Then run local Calypso with `yarn start`.
3. Disable JavaScript in your browser devtools so that you are sure that you always see only the server-rendered markup and that the client-side JavaScript doesn't run.
4. Open the localized `/id/themes` page. You should see Calypso localized in Indonesian.
5. Now open the `/log-in` page. As it doesn't have any locale suffix (like `/log-in/id`) it should be in English. But it's in Indonesian, the language of the previously rendered Themes page!

<img width="503" alt="Screenshot 2022-01-10 at 12 24 15" src="https://user-images.githubusercontent.com/664258/148758598-0bb716a5-d95a-476b-bb11-073eb7e943d7.png">

The reason is that the `ssrSetupLocale` page.js handler, used on the `/:lang/themes` page, will set the global `i18n` instance to Indonesian locale. Then, when the `/log-in` page is rendered, it doesn't modify the `i18n` instance and uses it, assuming it's using the default `en` locale`. But it doesn't. It uses the somewhat random locale that the last `/themes` request happened to request.

The fix has several parts:
- first, I had to clean up `i18n-calypso` TS types so that they declare the `I18N` class. TypeScript files wouldn't compile otherwise.
- then I added support for React context to `i18n-calypso`. The `localize` HOC and the `useTranslate` hook no longer use the global `i18n` instance directly, but instead use the one provided by `I18NContext`. The default global `i18n` instance is the default value of that context, so that unless you mount a provider, the library behaves exactly the same way as it did before.
- another thing I had to modify is the `/theme-filters` REST request issued by the `/themes` SSR. There is a `wpcom` handler that adds the `locale` query parameter to it, reading the locale value from the global `i18n` instance. That's going to always be `en` now. But we need to pass the real locale, because the filters response contains localized labels. I achieved this by adding a custom `locale` parameter to the `requestThemeFilters` action that overrides the `locale` param.
- finally I modified the `ssrSetupLocale` handler and the rendering code to create a local `i18n` instance and pass it in context.

**How to test:**
Verify that the bug described above is indeed fixed: the `/log-in` page is always English, no matter what request you did before.

Also verify that the `/id/themes` page continues to be localized:

<img width="1070" alt="Screenshot 2022-01-10 at 11 28 36" src="https://user-images.githubusercontent.com/664258/148759680-1c802320-43ae-48d5-baec-46a13fc08b35.png">

The labels on the toolbar (Majalah, Bisnis) come from the `/theme-filters?locale=id` server response, not from local `translate` calls, so verify that both sources of localization work correctly.