### PR TITLE
Emails: Simplify code for Google Workspace Card (and make it TS compliant)

### DIFF
--- a/client/components/gsuite/docs/new-user-list.tsx
+++ b/client/components/gsuite/docs/new-user-list.tsx
@@ -9,12 +9,21 @@ import {
 	GSuiteNewUserField,
 	newUsers,
 } from 'calypso/lib/gsuite/new-users';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
 
-const domainOne = { name: 'example.blog' };
-const domainTwo = { name: 'test.blog' };
+const domainOne: SiteDomain = {
+	name: 'example.blog',
+	domain: 'example.blog',
+	supportsGdprConsentManagement: true,
+};
+const domainTwo: SiteDomain = {
+	name: 'test.blog',
+	domain: 'test.blog',
+	supportsGdprConsentManagement: true,
+};
 
 function GSuiteNewUserListExample(): JSX.Element {
-	const [ users, setUsers ] = useState( newUsers( domainOne.name ) );
+	const [ users, setUsers ] = useState( newUsers( domainOne.name ?? '' ) );
 	const [ domains, setDomains ] = useState( [ domainOne ] );
 	const [ useMultipleDomains, setUseMultipleDomains ] = useState( false );
 	const [ useExtraValidation, setUseExtraValidation ] = useState( false );
@@ -22,11 +31,11 @@ function GSuiteNewUserListExample(): JSX.Element {
 	const toggleUseMultipleDomains = () => {
 		if ( useMultipleDomains ) {
 			setDomains( [ domainOne ] );
-			setUsers( newUsers( domainOne.name ) );
+			setUsers( newUsers( domainOne.name ?? '' ) );
 			setUseMultipleDomains( false );
 		} else {
 			setDomains( [ domainOne, domainTwo ] );
-			setUsers( newUsers( domainOne.name ) );
+			setUsers( newUsers( domainOne.name ?? '' ) );
 			setUseMultipleDomains( true );
 		}
 	};
@@ -56,7 +65,7 @@ function GSuiteNewUserListExample(): JSX.Element {
 			<GSuiteNewUserList
 				domains={ domains }
 				extraValidation={ useExtraValidation ? extraValidation : ( user ) => user }
-				selectedDomainName={ domainOne.name }
+				selectedDomainName={ domainOne.name ?? '' }
 				onUsersChange={ ( changedUsers ) => setUsers( changedUsers ) }
 				users={ users }
 				onReturnKeyPress={ () => void 0 }

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -8,13 +8,14 @@ import {
 	validateUsers,
 } from 'calypso/lib/gsuite/new-users';
 import GSuiteNewUser from './new-user';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
 
 import './style.scss';
 
 interface Props {
 	autoFocus?: boolean;
 	children?: ReactNode;
-	domains?: { name: string }[];
+	domains?: SiteDomain[];
 	extraValidation: ( user: NewUser ) => NewUser;
 	selectedDomainName: string;
 	showAddAnotherMailboxButton?: boolean;
@@ -74,7 +75,9 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 				<Fragment key={ user.uuid }>
 					<GSuiteNewUser
 						autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
-						domains={ domains ? domains.map( ( domain ) => domain.name ) : [ selectedDomainName ] }
+						domains={
+							domains ? domains.map( ( domain ) => domain.name ?? '' ) : [ selectedDomainName ]
+						}
 						user={ user }
 						onUserValueChange={ onUserValueChange( user.uuid ) }
 						onUserRemove={ onUserRemove( user.uuid ) }

--- a/client/lib/domains/can-current-user-add-email.js
+++ b/client/lib/domains/can-current-user-add-email.js
@@ -1,12 +1,11 @@
 /**
- * @typedef { import("calypso/state/sites/domains/types").SiteDomain } SiteDomain domain object
  * @typedef { import("client/lib/domains/types").ResponseDomain } ResponseDomain domain object
  */
 /**
  * Determines if email can be added to the provided domain.
  * Additional checks are not performed for existing email subscriptions
  *
- * @param {SiteDomain|ResponseDomain|undefined} domain domain object
+ * @param {ResponseDomain|undefined} domain domain object
  * @returns {boolean} - whether email can be added to the domain
  */
 export function canCurrentUserAddEmail( domain ) {

--- a/client/lib/domains/can-current-user-add-email.js
+++ b/client/lib/domains/can-current-user-add-email.js
@@ -1,8 +1,12 @@
 /**
+ *
+ * @typedef { import("calypso/state/sites/domains/types").SiteDomain } SiteDomain domain object
+ */
+/**
  * Determines if email can be added to the provided domain.
  * Additional checks are not performed for existing email subscriptions
  *
- * @param {Object} domain domain object
+ * @param {SiteDomain|undefined} domain domain object
  * @returns {boolean} - whether email can be added to the domain
  */
 export function canCurrentUserAddEmail( domain ) {

--- a/client/lib/domains/can-current-user-add-email.js
+++ b/client/lib/domains/can-current-user-add-email.js
@@ -1,12 +1,12 @@
 /**
- *
  * @typedef { import("calypso/state/sites/domains/types").SiteDomain } SiteDomain domain object
+ * @typedef { import("client/lib/domains/types").ResponseDomain } ResponseDomain domain object
  */
 /**
  * Determines if email can be added to the provided domain.
  * Additional checks are not performed for existing email subscriptions
  *
- * @param {SiteDomain|undefined} domain domain object
+ * @param {SiteDomain|ResponseDomain|undefined} domain domain object
  * @returns {boolean} - whether email can be added to the domain
  */
 export function canCurrentUserAddEmail( domain ) {

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -9,6 +9,7 @@ import {
 	isGSuiteProductSlug,
 } from 'calypso/lib/gsuite';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
 
 // exporting these in the big export below causes trouble
 export interface GSuiteNewUserField {
@@ -352,7 +353,7 @@ const transformUserForCart = ( {
 } );
 
 const getItemsForCart = (
-	domains: { name: string; googleAppsSubscription?: { status?: string } }[],
+	domains: SiteDomain[],
 	productSlug: string,
 	users: GSuiteNewUser[]
 ): MinimalRequestCartProduct[] => {

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -101,15 +101,14 @@ const GoogleWorkspaceCard = ( {
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
 
-	const gSuiteProductYearly = useSelector( ( state ) =>
-		getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY )
+	const gSuiteProduct = useSelector( ( state ) =>
+		getProductBySlug(
+			state,
+			intervalLength === IntervalLength.MONTHLY
+				? GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
+				: GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+		)
 	);
-	const gSuiteProductMonthly = useSelector( ( state ) =>
-		getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY )
-	);
-
-	const gSuiteProduct =
-		intervalLength === IntervalLength.MONTHLY ? gSuiteProductMonthly : gSuiteProductYearly;
 
 	const productIsDiscounted = hasDiscount( gSuiteProduct );
 
@@ -177,9 +176,6 @@ const GoogleWorkspaceCard = ( {
 	const [ addingToCart, setAddingToCart ] = useState( false );
 
 	const onGoogleConfirmNewMailboxes = () => {
-		const gSuiteProduct =
-			intervalLength === IntervalLength.MONTHLY ? gSuiteProductMonthly : gSuiteProductYearly;
-
 		const usersAreValid = areAllUsersValid( googleUsers );
 		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -40,7 +40,6 @@ import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement } from 'react';
 
@@ -97,7 +96,7 @@ const GoogleWorkspaceCard = ( {
 	const domain = getSelectedDomain( {
 		domains,
 		selectedDomainName: selectedDomainName,
-	} ) as ResponseDomain;
+	} );
 
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
@@ -182,7 +181,7 @@ const GoogleWorkspaceCard = ( {
 			intervalLength === IntervalLength.MONTHLY ? gSuiteProductMonthly : gSuiteProductYearly;
 
 		const usersAreValid = areAllUsersValid( googleUsers );
-		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain as ResponseDomain );
+		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
 
 		recordTracksEventAddToCartClick(
 			comparisonContext,
@@ -199,10 +198,7 @@ const GoogleWorkspaceCard = ( {
 		}
 
 		setAddingToCart( true );
-		const domainsForCart = domains as {
-			name: string;
-			googleAppsSubscription?: { status?: string | undefined } | undefined;
-		}[];
+		const domainsForCart = domain ? [ domain ] : [];
 
 		const cartItems: MinimalRequestCartProduct[] = getItemsForCart(
 			domainsForCart,
@@ -227,7 +223,7 @@ const GoogleWorkspaceCard = ( {
 		<FormFieldset className="google-workspace-card__form-fieldset">
 			<GSuiteNewUserList
 				extraValidation={ identityMap }
-				domains={ domainList as ResponseDomain[] }
+				domains={ domainList }
 				onUsersChange={ setGoogleUsers }
 				selectedDomainName={ selectedDomainName }
 				users={ googleUsers }

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -22,6 +22,7 @@ export interface ProductListItem {
 		start_date?: string;
 		expires?: string;
 	};
+	sale_cost?: number;
 }
 
 export function getProductsList( state: AppState ): Record< string, ProductListItem > {

--- a/client/state/sites/domains/types.ts
+++ b/client/state/sites/domains/types.ts
@@ -3,6 +3,7 @@ export interface SiteDomain {
 	autoRenewing?: boolean;
 	blogId?: number;
 	canSetAsPrimary?: boolean;
+	currentUserCanAddEmail?: boolean;
 	currentUserCanManage?: boolean;
 	domain: string;
 	expired?: boolean;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This code is doing a clean up in the GoogleWorkspaceCard component, to remove old way of fetching data with _connect_. The code is also aiming to do not include any new TypeScript error and therefore there might be strange "typings" in order to avoid TS warnings/errors. Please provide any input If the typing might be improved.

#### Testing instructions

- Run this branch locally or via the Calypso live server
- For a site with only one domain and no email services, click on Upgrades -> Emails
- Verify that you see the new email comparison page
- Verify that you can add to cart a Google Workspace Annual subscription and you can check out too.

No need to add screenshot comparison, there is no visible change in the UI.

Related to {1200182182542585-as-1201636436682375}
