### PR TITLE
Remove http-data from login entrypoint

### DIFF
--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -2,17 +2,12 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import analyticsMiddleware from 'calypso/state/analytics/middleware';
 import currentUser from 'calypso/state/current-user/reducer';
-import {
-	reducer as httpData,
-	enhancer as httpDataEnhancer,
-} from 'calypso/state/data-layer/http-data';
 import wpcomApiMiddleware from 'calypso/state/data-layer/wpcom-api-middleware';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
 
 // Legacy reducers
 // The reducers in this list are not modularized, and are always loaded on boot.
 const rootReducer = combineReducers( {
-	httpData,
 	currentUser,
 } );
 
@@ -23,7 +18,6 @@ export default () =>
 		rootReducer,
 		composeEnhancers(
 			addReducerEnhancer,
-			httpDataEnhancer,
 			applyMiddleware( thunkMiddleware, wpcomApiMiddleware, analyticsMiddleware )
 		)
 	);

--- a/client/state/data-layer/http-data.ts
+++ b/client/state/data-layer/http-data.ts
@@ -1,5 +1,6 @@
 import { Reducer, AnyAction, Dispatch, Action, StoreEnhancerStoreCreator } from 'redux';
 import { HTTP_DATA_REQUEST, HTTP_DATA_TICK } from 'calypso/state/action-types';
+import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { Lazy, TimestampMS, TimerHandle } from 'calypso/types';
 
@@ -131,7 +132,7 @@ const onSuccess = ( action: HttpDataAction, apiData: unknown ) => {
 	}
 };
 
-export default {
+registerHandlers( 'declarative resource loader', {
 	[ HTTP_DATA_REQUEST ]: [
 		dispatchRequest( {
 			fetch,
@@ -139,7 +140,7 @@ export default {
 			onError,
 		} ),
 	],
-};
+} );
 
 export const reducer: Reducer< number, Action< typeof HTTP_DATA_TICK > > = (
 	state = 0,

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -1,9 +1,7 @@
 import { getHandlers, registerHandlers } from 'calypso/state/data-layer/handler-registry';
-import httpData from './http-data';
 import { bypassDataLayer } from './utils';
 import wpcomHttpHandlers from './wpcom-http';
 
-registerHandlers( 'declarative resource loader', httpData );
 registerHandlers( 'WordPress API request loader', wpcomHttpHandlers );
 
 const shouldNext = ( action ) => {


### PR DESCRIPTION
The login entrypoint doesn't use any `http-data` getters, so it doesn't need to register the associated Redux reducer and enhancer. This PR removes these from the login Redux store.

The PR also moves the import and registration of the `http-data` data-layer handlers from the `wpcom-api-middleware` (common base for all data layer handlers) module to the `http-data` one. Any module that wants to use the `http-data` framework must import this module.

It would be nice to remove the entire data layer from login, and for that we need to migrate away the following handlers:
- `state/data-layer/wpcom/locale-guess`
- `state/data-layer/wpcom/auth/send-login-email`
- `state/data-layer/wpcom/users/auth-options`
- `state/data-layer/wpcom/i18n/language-names`

**How to test:**
Verify that nothing in the login entrypoint imports the `http-data` module. I verified this by loading the `/log-in` page in development mode and checking in devtools that the `http-data` module is no longer present in the bundle.