### PR TITLE
Emails: Simplify code in Professional Email Card

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -43,6 +43,7 @@ import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersStackedCardProps, ProviderCard } from './provider-card-props';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { ReactElement } from 'react';
 
 import './professional-email-card.scss';
@@ -92,7 +93,7 @@ const ProfessionalEmailCard = ( {
 	const domain = getSelectedDomain( {
 		domains,
 		selectedDomainName: selectedDomainName,
-	} ) as unknown;
+	} ) as ResponseDomain;
 
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
@@ -107,8 +108,7 @@ const ProfessionalEmailCard = ( {
 		getProductBySlug( state, TITAN_MAIL_YEARLY_SLUG )
 	);
 
-	const isEligibleForFreeTrial =
-		hasCartDomain || isDomainEligibleForTitanFreeTrial( domain as Record< string, unknown > );
+	const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
 
 	const titanMailProduct =
 		intervalLength === IntervalLength.MONTHLY ? titanMailMonthlyProduct : titanMailYearlyProduct;
@@ -124,8 +124,7 @@ const ProfessionalEmailCard = ( {
 		const validatedTitanMailboxes = validateTitanMailboxes( titanMailbox, optionalFields );
 
 		const mailboxesAreValid = areAllMailboxesValid( validatedTitanMailboxes, optionalFields );
-		const userCanAddEmail =
-			hasCartDomain || canCurrentUserAddEmail( domain as Record< string, unknown > );
+		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
 		const userCannotAddEmailReason = userCanAddEmail
 			? null
 			: getCurrentUserCannotAddEmailReason( domain );
@@ -184,7 +183,7 @@ const ProfessionalEmailCard = ( {
 	professionalEmail.onExpandedChange = onExpandedChange;
 	professionalEmail.priceBadge = (
 		<>
-			{ isDomainEligibleForTitanFreeTrial( domain as Record< string, unknown > ) && (
+			{ isDomainEligibleForTitanFreeTrial( domain ) && (
 				<div className="professional-email-card__discount badge badge--info-green">
 					{ translate( '3 months free' ) }
 				</div>

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -101,17 +101,12 @@ const ProfessionalEmailCard = ( {
 	const professionalEmail: ProviderCard = { ...professionalEmailCardInformation };
 	professionalEmail.detailsExpanded = detailsExpanded;
 
-	const titanMailMonthlyProduct = useSelector( ( state ) =>
-		getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG )
-	);
-	const titanMailYearlyProduct = useSelector( ( state ) =>
-		getProductBySlug( state, TITAN_MAIL_YEARLY_SLUG )
-	);
-
 	const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
 
-	const titanMailProduct =
-		intervalLength === IntervalLength.MONTHLY ? titanMailMonthlyProduct : titanMailYearlyProduct;
+	const titanMailSlug =
+		intervalLength === IntervalLength.MONTHLY ? TITAN_MAIL_MONTHLY_SLUG : TITAN_MAIL_YEARLY_SLUG;
+
+	const titanMailProduct = useSelector( ( state ) => getProductBySlug( state, titanMailSlug ) );
 
 	const [ titanMailbox, setTitanMailbox ] = useState( [
 		buildNewTitanMailbox( selectedDomainName, false ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This code is doing a clean up in the ProfessionalEmailCard component, to remove old way of fetching data with _connect_. The code is also aiming to do not include any new TypeScript error and therefore there might be strange "typings" in order to avoid TS warnings/errors. Please provide any input If the typing might be improved.

This code is aiming for the same thing as the [previous pull request](https://github.com/Automattic/wp-calypso/pull/59904)

#### Testing instructions

- Run this branch locally or via the Calypso live server
- For a site with only one domain and no email services, click on Upgrades -> Emails
- Verify that you see the new email comparison page
- Verify that you can add to cart a Professional Email Annual and Monthly subscription and you can check out too.

No need to add screenshot comparison, there is no visible change in the UI.

Related to {1200182182542585-as-1201636436682379}
