### PR TITLE
Add a separate transfer mode for pending transfers

### DIFF
--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -80,6 +80,7 @@ export const useMyDomainInputMode = {
 	transferOrConnect: 'transfer-or-connect',
 	ownershipVerification: 'ownership-verification',
 	transferDomain: 'transfer-domain',
+	startPendingTransfer: 'start-pending-transfer',
 } as const;
 
 export const transferDomainError = {

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -299,6 +299,7 @@ function UseMyDomain( props ) {
 			case inputMode.ownershipVerification:
 				return renderOwnershipVerificationFlow();
 			case inputMode.transferDomain:
+			case inputMode.startPendingTransfer:
 				return renderTransferDomainFlow();
 		}
 	};

--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -82,7 +82,7 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 			}
 		};
 
-		if ( inputMode.transferDomain === mode ) {
+		if ( inputMode.startPendingTransfer === mode ) {
 			await startInboundTransferAndReload();
 		} else {
 			await addTransferToCartAndCheckout();

--- a/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
@@ -27,7 +27,7 @@ class TransferInDomainType extends Component {
 	goToInboundTransferPage() {
 		const { domain, selectedSite } = this.props;
 		page(
-			domainUseMyDomain( selectedSite.slug, domain.name, useMyDomainInputMode.transferDomain )
+			domainUseMyDomain( selectedSite.slug, domain.name, useMyDomainInputMode.startPendingTransfer )
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We need to have a separate mode for pending transfers and transfers for connected domains.

#### Testing instructions

Attempt transfers for the following three scenarios and make sure each works correctly:

- Adding a new transfer when creating a new site.
- Make sure that you correctly get to the code that should attempt to start the transfer when going through the "Start Transfer" flow.

- Add a new transfer to an existing site through the "Use a domain I own" flow.
- Make sure that the transfer gets added to the cart correctly.

- Attempt to transfer a currently connected domain.
- Make sure that the transfer gets added to the cart correctly.

In the last two cases, you can hack the back-end to avoid actually starting the transfer when you go through the actual checkout process.