### PR TITLE
Guided Tours: fix type of the Step wait prop

### DIFF
--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -15,7 +15,10 @@ import {
 	targetForSlug,
 } from '../positioning';
 import { ArrowPosition, DialogPosition, Coordinate } from '../types';
+import type { CalypsoDispatch } from 'calypso/state/types';
 import type { TimestampMS } from 'calypso/types';
+import type { AnyAction } from 'redux';
+import type { ThunkAction } from 'redux-thunk';
 
 const debug = debugFactory( 'calypso:guided-tours' );
 
@@ -26,7 +29,7 @@ const anyFrom = ( obj: Record< string, string > ): string => {
 
 interface SectionContext {
 	sectionName?: string;
-	dispatch: < T >( x: Promise< T > ) => Promise< T >;
+	dispatch: CalypsoDispatch;
 	step: string;
 	shouldPause?: boolean;
 	branching: Record< string, { continue: string } >;
@@ -59,7 +62,7 @@ interface AcceptedProps {
 	shouldScrollTo?: boolean;
 	style?: CSSProperties;
 	target?: string;
-	wait?: ( props?: Props, context?: typeof contextTypes ) => Promise< void >;
+	wait?: () => ThunkAction< Promise< void >, unknown, void, AnyAction >;
 	waitForTarget?: boolean;
 	when?: ContextWhen;
 }


### PR DESCRIPTION
Fixes the TypeScript type of the `<Step wait>` prop. The old type was incorrect since #35340, and the `wait` prop is supposed to be an action creator that returns a thunk that returns a `Promise<void>`. That's a Redux jargon for saying that I can use it as:
```js
store.dispatch( props.wait() ).then( () => { ... } );
```

**How to test:**
The patch changes only types and runtime code shouldn't change at all. Verify that it fixes a TS error on `<Step wait={ waitForJetpackToggle } />` in the `jetpack-plugin-updates-tour` step.
