### PR TITLE
Avoid removing plan with active marketplace subscriptions

### DIFF
--- a/client/components/forms/form-section-heading/index.jsx
+++ b/client/components/forms/form-section-heading/index.jsx
@@ -1,7 +1,16 @@
 import classnames from 'classnames';
+import { ReactChild, ReactElement } from 'react';
 
 import './style.scss';
-
+/**
+ * Render a form section heading
+ *
+ * @param {Object} props Component props
+ * @param {string=} props.className optional extra CSS class(es) to be added to the component
+ * @param {ReactChild=} props.children react element props that must contain some children
+ * @param {Object=} props.otherProps react element props that must contain some children
+ * @returns {ReactElement} React component
+ */
 const FormSectionHeading = ( { className, children, ...otherProps } ) => (
 	<h3 { ...otherProps } className={ classnames( className, 'form-section-heading' ) }>
 		{ children }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -731,15 +731,13 @@ class ManagePurchase extends Component {
 	}
 
 	getActiveMarketplaceSubscriptions() {
-		const { purchase, purchases, productsList, siteId } = this.props;
+		const { purchase, purchases, productsList } = this.props;
 
 		if ( ! isPlan( purchase ) ) return [];
 
 		return purchases.filter(
 			( _purchase ) =>
-				_purchase.siteId === siteId &&
-				_purchase.active &&
-				hasMarketplaceProduct( productsList, _purchase.productSlug )
+				_purchase.active && hasMarketplaceProduct( productsList, _purchase.productSlug )
 		);
 	}
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -942,7 +942,7 @@ export default connect( ( state, props ) => {
 			: null;
 	const selectedSiteId = getSelectedSiteId( state );
 	const siteId = selectedSiteId || ( purchase ? purchase.siteId : null );
-	const purchases = getSitePurchases( state, siteId );
+	const purchases = purchase && getSitePurchases( state, purchase.siteId );
 	const userId = getCurrentUserId( state );
 	const isProductOwner = purchase && purchase.userId === userId;
 	const renewableSitePurchases = getRenewableSitePurchases( state, siteId );

--- a/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
+++ b/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
@@ -53,7 +53,7 @@ export const MarketPlaceSubscriptionsDialog = ( {
 				</FormSectionHeading>
 				<p>
 					{ translate(
-						'When you downgrade your plan, the following subscription will remain active:',
+						'The following subscriptions depend on your plan:',
 						'When you downgrade your plan, the following subscriptions will remain active:',
 						{ count: activeSubscriptions.length }
 					) }

--- a/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
+++ b/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
@@ -1,15 +1,7 @@
-import { Button, Dialog } from '@automattic/components';
+import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, ReactChild, useState } from 'react';
+import { Fragment } from 'react';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
-
-interface ButtonProps {
-	action: string;
-	label: ReactChild;
-	onClick: () => void;
-	isPrimary?: boolean;
-	busy?: boolean;
-}
 
 interface MarketPlaceSubscriptionsDialogProps {
 	planName: string;
@@ -18,7 +10,6 @@ interface MarketPlaceSubscriptionsDialogProps {
 	isDialogVisible: boolean;
 	isRemoving: boolean;
 	activeSubscriptions: Array< { id: number; productName: string } >;
-	removeAllSubscriptions: () => void;
 }
 
 export const MarketPlaceSubscriptionsDialog = ( {
@@ -26,53 +17,30 @@ export const MarketPlaceSubscriptionsDialog = ( {
 	closeDialog,
 	removePlan,
 	isDialogVisible,
-	isRemoving,
 	activeSubscriptions,
-	removeAllSubscriptions,
 }: MarketPlaceSubscriptionsDialogProps ): JSX.Element => {
 	const translate = useTranslate();
 
-	const [ removeAction, setRemoveAction ] = useState( '' );
-
-	const buttons: ButtonProps[] = [
+	const buttons = [
 		{
 			action: 'cancel',
 			label: translate( 'Cancel' ),
 			onClick: closeDialog,
 		},
 		{
-			action: 'removePlan',
-			label: translate( 'Remove Plan' ),
-			onClick: removePlan,
-		},
-		{
 			isPrimary: true,
-			action: 'removeAllSubscriptions',
-			label: translate( 'Remove All Subscriptions' ),
-			onClick: removeAllSubscriptions,
-			busy: true,
+			action: 'removePlanAndAllSubscriptions',
+			label: translate( 'Remove Plan & All Subscriptions', {
+				comment:
+					'This button removes the active plan and all active Marketplace subscriptions on the site',
+			} ),
+			onClick: removePlan,
 		},
 	];
 
-	const renderButton = ( { action, label, onClick, isPrimary }: ButtonProps ) => (
-		<Button
-			disabled={ isRemoving && removeAction !== action }
-			busy={ isRemoving && removeAction === action }
-			onClick={ () => {
-				onClick();
-				setRemoveAction( action );
-			} }
-			primary={ isPrimary }
-			data-e2e-button={ action }
-			data-tip-target={ `dialog-base-action-${ action }` }
-		>
-			{ label }
-		</Button>
-	);
-
 	return (
 		<Dialog
-			buttons={ buttons.map( ( b ) => renderButton( b ) ) }
+			buttons={ buttons }
 			className="marketplace-subscriptions-dialog"
 			isVisible={ isDialogVisible }
 			onClose={ closeDialog }
@@ -85,8 +53,8 @@ export const MarketPlaceSubscriptionsDialog = ( {
 				</FormSectionHeading>
 				<p>
 					{ translate(
-						'When you downgrade your plan, the following active subscription will remain active:',
-						'When you downgrade your plan, the following active subscriptions will remain active:',
+						'When you downgrade your plan, the following subscription will remain active:',
+						'When you downgrade your plan, the following subscriptions will remain active:',
 						{ count: activeSubscriptions.length }
 					) }
 				</p>
@@ -97,8 +65,8 @@ export const MarketPlaceSubscriptionsDialog = ( {
 				</ul>
 				<p>
 					{ translate(
-						'You should remove this subscription before downgrading your plan. Would you still like to downgrade your plan?',
-						'You should remove these subscriptions before downgrading your plan. Would you still like to downgrade your plan?',
+						'You should remove this subscription before downgrading your plan. Would you like to remove this subscription and downgrade your plan?',
+						'You should remove these subscriptions before downgrading your plan. Would you like to remove all subscriptions and downgrade your plan?',
 						{ count: activeSubscriptions.length }
 					) }
 				</p>

--- a/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
+++ b/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
@@ -1,19 +1,40 @@
-import { Dialog } from '@automattic/components';
+import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment } from 'react';
+import { Fragment, ReactChild, useState } from 'react';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+
+interface ButtonProps {
+	action: string;
+	label: ReactChild;
+	onClick: () => void;
+	isPrimary?: boolean;
+	busy?: boolean;
+}
+
+interface MarketPlaceSubscriptionsDialogProps {
+	planName: string;
+	closeDialog: () => void;
+	removePlan: () => void;
+	isDialogVisible: boolean;
+	isRemoving: boolean;
+	activeSubscriptions: Array< { id: number; productName: string } >;
+	removeAllSubscriptions: () => void;
+}
 
 export const MarketPlaceSubscriptionsDialog = ( {
 	planName,
 	closeDialog,
 	removePlan,
 	isDialogVisible,
+	isRemoving,
 	activeSubscriptions,
 	removeAllSubscriptions,
-} ) => {
+}: MarketPlaceSubscriptionsDialogProps ): JSX.Element => {
 	const translate = useTranslate();
 
-	const buttons = [
+	const [ removeAction, setRemoveAction ] = useState( '' );
+
+	const buttons: ButtonProps[] = [
 		{
 			action: 'cancel',
 			label: translate( 'Cancel' ),
@@ -26,14 +47,32 @@ export const MarketPlaceSubscriptionsDialog = ( {
 		},
 		{
 			isPrimary: true,
-			action: 'removePlan',
+			action: 'removeAllSubscriptions',
 			label: translate( 'Remove All Subscriptions' ),
 			onClick: removeAllSubscriptions,
+			busy: true,
 		},
 	];
+
+	const renderButton = ( { action, label, onClick, isPrimary }: ButtonProps ) => (
+		<Button
+			disabled={ isRemoving && removeAction !== action }
+			busy={ isRemoving && removeAction === action }
+			onClick={ () => {
+				onClick();
+				setRemoveAction( action );
+			} }
+			primary={ isPrimary }
+			data-e2e-button={ action }
+			data-tip-target={ `dialog-base-action-${ action }` }
+		>
+			{ label }
+		</Button>
+	);
+
 	return (
 		<Dialog
-			buttons={ buttons }
+			buttons={ buttons.map( ( b ) => renderButton( b ) ) }
 			className="marketplace-subscriptions-dialog"
 			isVisible={ isDialogVisible }
 			onClose={ closeDialog }

--- a/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
+++ b/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
@@ -1,0 +1,69 @@
+import { Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { Fragment } from 'react';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+
+export const MarketPlaceSubscriptionsDialog = ( {
+	planName,
+	closeDialog,
+	removePlan,
+	isDialogVisible,
+	activeSubscriptions,
+	removeAllSubscriptions,
+} ) => {
+	const translate = useTranslate();
+
+	const buttons = [
+		{
+			action: 'cancel',
+			label: translate( 'Cancel' ),
+			onClick: closeDialog,
+		},
+		{
+			action: 'removePlan',
+			label: translate( 'Remove Plan' ),
+			onClick: removePlan,
+		},
+		{
+			isPrimary: true,
+			action: 'removePlan',
+			label: translate( 'Remove All Subscriptions' ),
+			onClick: removeAllSubscriptions,
+		},
+	];
+	return (
+		<Dialog
+			buttons={ buttons }
+			className="marketplace-subscriptions-dialog"
+			isVisible={ isDialogVisible }
+			onClose={ closeDialog }
+		>
+			<Fragment>
+				<FormSectionHeading>
+					{ translate( 'Remove %(plan)s', {
+						args: { plan: planName },
+					} ) }
+				</FormSectionHeading>
+				<p>
+					{ translate(
+						'When you downgrade your plan, the following active subscription will remain active:',
+						'When you downgrade your plan, the following active subscriptions will remain active:',
+						{ count: activeSubscriptions.length }
+					) }
+				</p>
+				<ul>
+					{ activeSubscriptions.map( ( subscription ) => {
+						return <li key={ subscription.id }>{ subscription.productName }</li>;
+					} ) }
+				</ul>
+				<p>
+					{ translate(
+						'You should remove this subscription before downgrading your plan. Would you still like to downgrade your plan?',
+						'You should remove these subscriptions before downgrading your plan. Would you still like to downgrade your plan?',
+						{ count: activeSubscriptions.length }
+					) }
+				</p>
+			</Fragment>
+		</Dialog>
+	);
+};

--- a/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
+++ b/client/me/purchases/marketplace-subscriptions-dialog/index.tsx
@@ -53,8 +53,8 @@ export const MarketPlaceSubscriptionsDialog = ( {
 				</FormSectionHeading>
 				<p>
 					{ translate(
+						'The following subscription depends on your plan:',
 						'The following subscriptions depend on your plan:',
-						'When you downgrade your plan, the following subscriptions will remain active:',
 						{ count: activeSubscriptions.length }
 					) }
 				</p>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -319,6 +319,7 @@ class RemovePurchase extends Component {
 		return (
 			<MarketPlaceSubscriptionsDialog
 				isDialogVisible={ this.state.isDialogVisible }
+				isRemoving={ this.state.isRemoving }
 				closeDialog={ this.closeDialog }
 				removePlan={ this.removePurchase }
 				planName={ getName( purchase ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a new modal for removing plans that have active Marketplace subscriptions
* The modal has a "Remove Plan & All Subscriptions" button, that lets the user remove all active subscriptions and then the selected plan with one click:

![image](https://user-images.githubusercontent.com/11555574/149156886-64d2f4a1-fe99-4209-981a-eeacb417dcf8.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Plan without Marketplace subscriptions
* Purchase a plan
* Navigate to `/me/purchases` and click on the plan
* Click on the `Remove <plan name>` button
* Verify that the new modal is not shown 

#### Remove all subscriptions ([video](https://d.pr/v/IMTRcf))
* Purchase a plan and one or more subscriptions
* Navigate to `/me/purchases` and click on the plan
* Click on the `Remove <plan name>` button
* Verify that the modal is shown, and the correct subscriptions are listed on it
* Click on the `Remove Plan & All Subscriptions` button on the modal
* Fill out the feedback form and click on `Remove Plan` button
* Verify that all Marketplace subscriptions and the plan are removed, and you're redirected back to the `/me/purchases` page

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59661
