### PR TITLE
Emails: Clean code for stacked comparison component

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -1,9 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { withShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
@@ -12,7 +11,6 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
-import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
@@ -26,31 +24,17 @@ import {
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
-import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 import type { ReactElement } from 'react';
 
 import './style.scss';
 
 type EmailProvidersStackedComparisonProps = {
-	cartDomainName?: string;
 	comparisonContext: string;
-	currencyCode?: string;
-	currentRoute?: string;
-	domain?: any;
-	domainName?: string;
-	domainsWithForwards?: string[];
-	gSuiteProduct?: string;
-	hasCartDomain?: boolean;
-	isGSuiteSupported?: boolean;
-	productsList?: string[];
-	requestingSiteDomains?: boolean;
 	selectedDomainName: string;
 	selectedEmailProviderSlug: string;
 	selectedIntervalLength: IntervalLength | undefined;
-	selectedSite?: SiteData | null;
-	shoppingCartManager?: any;
 	showEmailForwardLink?: boolean;
 	siteName: string;
 	source: string;
@@ -58,14 +42,9 @@ type EmailProvidersStackedComparisonProps = {
 
 const EmailProvidersStackedComparison = ( {
 	comparisonContext,
-	currentRoute,
-	domain,
-	domainsWithForwards,
-	isGSuiteSupported,
 	selectedDomainName,
 	selectedEmailProviderSlug,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
-	selectedSite,
 	showEmailForwardLink = true,
 	siteName,
 	source,
@@ -85,6 +64,28 @@ const EmailProvidersStackedComparison = ( {
 			google: false,
 		};
 	} );
+
+	const canPurchaseGoogleWorkspace = useSelector( canUserPurchaseGSuite );
+
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const selectedSite = useSelector( getSelectedSite );
+
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+	const domain = getSelectedDomain( {
+		domains,
+		selectedDomainName: selectedDomainName,
+	} );
+	const domainsWithForwards = useSelector( ( state ) => getDomainsWithForwards( state, domains ) );
+
+	const resolvedDomainName = domain ? domain.name : selectedDomainName;
+
+	if ( ! resolvedDomainName ) {
+		return <></>;
+	}
+
+	const isGSuiteSupported =
+		canPurchaseGoogleWorkspace && resolvedDomainName && hasGSuiteSupportedDomain( [ domain ] );
 
 	const changeExpandedState = ( providerKey: string, isCurrentlyExpanded: boolean ) => {
 		const expandedEntries = Object.entries( detailsExpanded ).map( ( entry ) => {
@@ -213,31 +214,4 @@ const EmailProvidersStackedComparison = ( {
 	);
 };
 
-export default connect( ( state, ownProps: EmailProvidersStackedComparisonProps ) => {
-	const selectedSite = getSelectedSite( state );
-	const domains = getDomainsBySiteId( state, selectedSite?.ID );
-	const domain = getSelectedDomain( {
-		domains,
-		selectedDomainName: ownProps.selectedDomainName,
-	} );
-
-	const hasCartDomain = Boolean( ownProps.cartDomainName );
-
-	const isGSuiteSupported =
-		canUserPurchaseGSuite( state ) &&
-		( hasCartDomain || ( domain && hasGSuiteSupportedDomain( [ domain ] ) ) );
-
-	return {
-		comparisonContext: ownProps.comparisonContext,
-		currentRoute: getCurrentRoute( state ),
-		domain,
-		domainsWithForwards: getDomainsWithForwards( state, domains ),
-		hasCartDomain,
-		isGSuiteSupported,
-		requestingSiteDomains: Boolean(
-			selectedSite && isRequestingSiteDomains( state, selectedSite.ID )
-		),
-		selectedSite,
-		source: ownProps.source,
-	};
-} )( withCartKey( withShoppingCart( EmailProvidersStackedComparison ) ) );
+export default EmailProvidersStackedComparison;

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -78,14 +78,11 @@ const EmailProvidersStackedComparison = ( {
 	} );
 	const domainsWithForwards = useSelector( ( state ) => getDomainsWithForwards( state, domains ) );
 
-	const resolvedDomainName = domain ? domain.name : selectedDomainName;
-
 	if ( ! domain ) {
 		return <></>;
 	}
 
-	const isGSuiteSupported =
-		canPurchaseGSuite && resolvedDomainName && hasGSuiteSupportedDomain( [ domain ] );
+	const isGSuiteSupported = canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] );
 
 	const changeExpandedState = ( providerKey: string, isCurrentlyExpanded: boolean ) => {
 		const expandedEntries = Object.entries( detailsExpanded ).map( ( entry ) => {

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -65,7 +65,7 @@ const EmailProvidersStackedComparison = ( {
 		};
 	} );
 
-	const canPurchaseGoogleWorkspace = useSelector( canUserPurchaseGSuite );
+	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
 	const currentRoute = useSelector( getCurrentRoute );
 
@@ -80,12 +80,12 @@ const EmailProvidersStackedComparison = ( {
 
 	const resolvedDomainName = domain ? domain.name : selectedDomainName;
 
-	if ( ! resolvedDomainName ) {
+	if ( ! domain ) {
 		return <></>;
 	}
 
 	const isGSuiteSupported =
-		canPurchaseGoogleWorkspace && resolvedDomainName && hasGSuiteSupportedDomain( [ domain ] );
+		canPurchaseGSuite && resolvedDomainName && hasGSuiteSupportedDomain( [ domain ] );
 
 	const changeExpandedState = ( providerKey: string, isCurrentlyExpanded: boolean ) => {
 		const expandedEntries = Object.entries( detailsExpanded ).map( ( entry ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This code is doing a clean up in the EmailProvidersStackedComparison component, to remove old way of fetching data with _connect_. The code is also aiming to do not include any new TypeScript error and therefore there might be strange "typings" in order to avoid TS warnings/errors. Please provide any input If the typing might be improved.

#### Testing instructions

- Run this branch locally or via the Calypso live server
- For a site with only one domain and no email services, click on Upgrades -> Emails
- Verify that you see the new email comparison page
- Verify that you can either add to cart a Professional Email/Google Workspace subscription and you can check out too.

No need to add screenshot comparison, there is no visible change in the UI.

Related to {1200182182542585-as-1201638650656825}
