### PR TITLE
Add Downgrades to Monthly within the refund period

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -204,6 +204,8 @@ class CancelPurchaseForm extends Component {
 			upsell: '',
 		};
 
+		const canRefund = !! parseFloat( this.getRefundAmount() );
+
 		if ( this.shouldUseBlankCanvasLayout() ) {
 			const { purchase } = this.props;
 			if ( value === 'couldNotInstall' && isWpComBusinessPlan( purchase.productSlug ) ) {
@@ -226,7 +228,7 @@ class CancelPurchaseForm extends Component {
 				newState.upsell = 'downgrade-personal';
 			}
 
-			if ( value === 'onlyNeedFree' && !! this.props.downgradeClick ) {
+			if ( value === 'onlyNeedFree' && !! this.props.downgradeClick && canRefund ) {
 				if ( isWpComPremiumPlan( purchase.productSlug ) ) {
 					newState.upsell = 'downgrade-personal';
 				} else if (
@@ -961,7 +963,7 @@ class CancelPurchaseForm extends Component {
 		const { refundOptions, currencyCode } = purchase;
 		const { precision } = getCurrencyDefaults( currencyCode );
 		const refundAmount =
-			isRefundable( purchase ) && refundOptions[ 0 ] && refundOptions[ 0 ].refund_amount
+			isRefundable( purchase ) && refundOptions?.[ 0 ]?.refund_amount
 				? refundOptions[ 0 ].refund_amount
 				: 0;
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -96,6 +96,8 @@ class CancelPurchaseForm extends Component {
 		flowType: PropTypes.string.isRequired,
 		showSurvey: PropTypes.bool.isRequired,
 		translate: PropTypes.func,
+		cancelBundledDomain: PropTypes.bool,
+		includedDomainPurchase: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -408,7 +410,14 @@ class CancelPurchaseForm extends Component {
 			return null;
 		}
 
-		const { downgradePlanPrice, purchase, site, translate } = this.props;
+		const {
+			downgradePlanPrice,
+			purchase,
+			site,
+			translate,
+			includedDomainPurchase,
+			cancelBundledDomain,
+		} = this.props;
 
 		const dismissUpsell = () => this.setState( { upsell: '' } );
 
@@ -476,6 +485,9 @@ class CancelPurchaseForm extends Component {
 							currencySymbol={ purchase.currencySymbol }
 							planCost={ planCost }
 							refundAmount={ this.getRefundAmount() }
+							upsell={ upsell }
+							cancelBundledDomain={ cancelBundledDomain }
+							includedDomainPurchase={ includedDomainPurchase }
 						/>
 					</Upsell>
 				);

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -80,7 +80,7 @@ export class DowngradeStep extends Component {
 				  );
 		}
 
-		if ( 'downgrade-monthly' === upsell ) {
+		if ( 'downgrade-monthly' === upsell && canRefund ) {
 			refundTitle = translate(
 				'Would you rather switch to the more affordable monthly subscription?'
 			);
@@ -104,15 +104,11 @@ export class DowngradeStep extends Component {
 				);
 			}
 
-			refundDetails = canRefund
-				? translate(
-						'You can downgrade and get a partial refund of %(amount)s or ' +
-							'continue to the next step and cancel the plan.',
-						{ args: { amount } }
-				  )
-				: translate( 'You can downgrade and the new plan will renew at only %(amount)s.', {
-						args: { amount },
-				  } );
+			refundDetails = translate(
+				'You can downgrade and get a partial refund of %(amount)s or ' +
+					'continue to the next step and cancel the plan.',
+				{ args: { amount } }
+			);
 		}
 
 		return (

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -89,7 +89,7 @@ export class DowngradeStep extends Component {
 				refundReason = (
 					<p>
 						{ translate(
-							'You will keep all features of your current plan including the domain %(domain)s but the plan period will be reduced.',
+							'You will keep most features of your current plan including the domain %(domain)s but the plan period will be reduced.',
 							{ args: { domain: includedDomainPurchase.meta } }
 						) }
 					</p>
@@ -98,7 +98,7 @@ export class DowngradeStep extends Component {
 				refundReason = (
 					<p>
 						{ translate(
-							'You will keep most of the features of your current plan but will not have a free domain.'
+							'You will keep most of the features of your current plan but will not have a free domain registration.'
 						) }
 					</p>
 				);

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -16,6 +16,8 @@ export class DowngradeStep extends Component {
 		refundAmount: PropTypes.string,
 		planCost: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+		cancelBundledDomain: PropTypes.bool,
+		includedDomainPurchase: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -27,7 +29,16 @@ export class DowngradeStep extends Component {
 	};
 
 	render() {
-		const { locale, translate, refundAmount, planCost, currencySymbol } = this.props;
+		const {
+			locale,
+			translate,
+			refundAmount,
+			planCost,
+			currencySymbol,
+			upsell,
+			cancelBundledDomain,
+			includedDomainPurchase,
+		} = this.props;
 		const canRefund = !! parseFloat( refundAmount );
 		const amount = currencySymbol + ( canRefund ? refundAmount : planCost );
 		const isEnglishLocale = [ 'en', 'en-gb' ].indexOf( locale ) >= 0;
@@ -68,6 +79,42 @@ export class DowngradeStep extends Component {
 						{ args: { amount } }
 				  );
 		}
+
+		if ( 'downgrade-monthly' === upsell ) {
+			refundTitle = translate(
+				'Would you rather switch to the more affordable monthly subscription?'
+			);
+
+			if ( cancelBundledDomain && includedDomainPurchase ) {
+				refundReason = (
+					<p>
+						{ translate(
+							'You will keep all features of your current plan including the domain %(domain)s but the plan period will be reduced.',
+							{ args: { domain: includedDomainPurchase.meta } }
+						) }
+					</p>
+				);
+			} else {
+				refundReason = (
+					<p>
+						{ translate(
+							'You will keep most of the features of your current plan but will not have a free domain.'
+						) }
+					</p>
+				);
+			}
+
+			refundDetails = canRefund
+				? translate(
+						'You can downgrade and get a partial refund of %(amount)s or ' +
+							'continue to the next step and cancel the plan.',
+						{ args: { amount } }
+				  )
+				: translate( 'You can downgrade and the new plan will renew at only %(amount)s.', {
+						args: { amount },
+				  } );
+		}
+
 		return (
 			<div>
 				<FormSectionHeading>{ refundTitle }</FormSectionHeading>

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -1,4 +1,8 @@
-import { isDomainRegistration } from '@automattic/calypso-products';
+import {
+	isDomainRegistration,
+	getMonthlyPlanByYearly,
+	getPlan,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { getCurrencyDefaults } from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
@@ -173,9 +177,13 @@ class CancelPurchaseButton extends Component {
 		);
 	};
 
-	downgradeClick = () => {
+	downgradeClick = ( upsell ) => {
 		const { purchase } = this.props;
-		const downgradePlan = getDowngradePlanFromPurchase( purchase );
+		let downgradePlan = getDowngradePlanFromPurchase( purchase );
+		if ( 'downgrade-monthly' === upsell ) {
+			const monthlyProductSlug = getMonthlyPlanByYearly( purchase.productSlug );
+			downgradePlan = getPlan( monthlyProductSlug );
+		}
 
 		this.setDisabled( true );
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -265,7 +265,7 @@ class CancelPurchaseButton extends Component {
 	};
 
 	render() {
-		const { purchase, translate } = this.props;
+		const { purchase, translate, cancelBundledDomain, includedDomainPurchase } = this.props;
 		let text;
 		let onClick;
 
@@ -318,6 +318,8 @@ class CancelPurchaseButton extends Component {
 					downgradeClick={ this.downgradeClick }
 					freeMonthOfferClick={ this.freeMonthOfferClick }
 					flowType={ this.getCancellationFlowType() }
+					cancelBundledDomain={ cancelBundledDomain }
+					includedDomainPurchase={ includedDomainPurchase }
 				/>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This will allow users to downgrade to monthly as a solution to the problem that the plan was too expensive.

We currently offer Downgrades from Premium to Personal. This will offer downgrades from 1-year and 2-year Personal, Business, and eCommerce to the monthly versions of the same plan.

#### Testing instructions

1. Apply D71002-code
2. Buy a non-Premium annual or 2-year plan
3. Cancel it and select that the plan was too expensive in the cancellation survey
4. You should see an option to downgrade to monthly. Click that
5. The plan should be downgraded to monthly

Repeat the steps with a plan that has a domain. 
6. Make sure that the domain is kept no matter if the user selected to keep it or not.
7. Go to Store Admin, scroll down to the Payments section and make sure a partial refund with the expected amount happened

https://user-images.githubusercontent.com/82778/149167507-3c5a206b-f9ce-45c4-9fc2-d6822e1d2822.mov

EDIT: this isn't supposed to be visible after the refund period is over.
8. Now hardcode is_refundable on the backend to return false. Make sure the upsell is not visible

EDIT: 
9. After downgrading the plan to a monthly plan, repeat the process and cancel again, selecting that the plan was too expensive. There should be no errors.