### PR TITLE
Woop: Sharpen up address step header

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -785,7 +785,7 @@ export function generateSteps( {
 		'store-address': {
 			stepName: 'store-address',
 			props: {
-				headerTitle: i18n.translate( 'Add an address so you can get paid' ),
+				headerTitle: i18n.translate( 'Add an address to accept payments' ),
 				headerDescription: i18n.translate(
 					'This will be used as your default business address. You can change it later if you need to.'
 				),


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/59505#discussion_r779184234

#### Changes proposed in this Pull Request

* Updates the header title for the address step in Woop onboarding.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* When testing outside of development: Activate the woop feature flag (`?flags=woop`).
* Navigate to /woocommerce-installation on a test site.
* Click "Set up my Store!".
* Verify the header title is correct.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
#### After

![accept-payment](https://user-images.githubusercontent.com/140841/148805366-b2236bf3-8cee-4031-bfcf-f1d495e7a440.png)
