### PR TITLE
Remove Jetpack Monthly Pricing Toggle and add New Intro Banner

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -85,6 +85,7 @@
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,

--- a/config/development.json
+++ b/config/development.json
@@ -84,7 +84,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -50,7 +50,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -51,6 +51,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -41,7 +41,7 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -42,6 +42,7 @@
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -35,7 +35,7 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -36,6 +36,7 @@
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -38,6 +38,7 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -37,7 +37,7 @@
 		"jetpack/backups-date-picker": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -39,6 +39,7 @@
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -38,7 +38,7 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -52,7 +52,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,

--- a/config/production.json
+++ b/config/production.json
@@ -53,6 +53,7 @@
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -52,6 +52,7 @@
 		"jetpack/magic-link-signup": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,

--- a/config/test.json
+++ b/config/test.json
@@ -47,6 +47,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": false,

--- a/config/test.json
+++ b/config/test.json
@@ -46,7 +46,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/more-informative-scan": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,6 +60,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
 		"jitms": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -59,7 +59,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/more-informative-scan": true,
-		"jetpack/pricing-page-annual-only": false,
+		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
 		"jitms": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* enable `jetpack/pricing-page-annual-only` in all environments

#### Testing instructions

( these instructions are identical to  #59088 without checking the flag on/flag off states

1. Boot branch with Calypso Green
2. Navigate to `/pricing`
3. Verify there is no monthly toggle on the page and all prices are annual with 50% discount
4. Boot branch with Calypso Blue
5. Navigate to `/plans/:siteSlug` for a Jetpack site
6. Verify there is no monthly toggle on the page and all prices are annual with 50% discount

Related to 1201295898168937-as-1201639481320058
