### PR TITLE
Update: Remove scinos from E2E codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,7 +118,7 @@
 /packages/languages @Automattic/i18n
 
 # E2E specs
-/test/e2e @WunderBart @scinos @Automattic/quality-squad
+/test/e2e @WunderBart @Automattic/quality-squad
 /packages/calypso-e2e @Automattic/quality-squad
 
 # Node updates


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove scinos as codeowner for E2E tests.

