### PR TITLE
Address Step: Align city and zip fields

### DIFF
--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { TextControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement } from 'react';
@@ -20,6 +21,16 @@ import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '..';
 import type { ChangeEventHandler } from 'react';
 import './style.scss';
+
+const CityZipRow = styled.div`
+	display: -ms-grid;
+	display: grid;
+	width: 100%;
+	-ms-grid-columns: 48% 4% 48%;
+	grid-template-columns: 48% 48%;
+	grid-column-gap: 4%;
+	justify-items: stretch;
+`;
 
 export default function StepStoreAddress( props: WooCommerceInstallProps ): ReactElement | null {
 	const { goToStep, isReskinned, headerTitle, headerDescription } = props;
@@ -59,17 +70,19 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 						countriesList={ countriesList }
 					/>
 
-					<TextControl
-						label={ __( 'City', 'woocommerce-admin' ) }
-						value={ get( WOOCOMMERCE_STORE_CITY ) }
-						onChange={ ( value ) => update( WOOCOMMERCE_STORE_CITY, value ) }
-					/>
+					<CityZipRow>
+						<TextControl
+							label={ __( 'City', 'woocommerce-admin' ) }
+							value={ get( WOOCOMMERCE_STORE_CITY ) }
+							onChange={ ( value ) => update( WOOCOMMERCE_STORE_CITY, value ) }
+						/>
 
-					<TextControl
-						label={ __( 'Postcode', 'woocommerce-admin' ) }
-						value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
-						onChange={ ( value ) => update( WOOCOMMERCE_STORE_POSTCODE, value ) }
-					/>
+						<TextControl
+							label={ __( 'Postcode', 'woocommerce-admin' ) }
+							value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
+							onChange={ ( value ) => update( WOOCOMMERCE_STORE_POSTCODE, value ) }
+						/>
+					</CityZipRow>
 
 					<ActionSection>
 						<SupportCard />


### PR DESCRIPTION
The figma shows city and zip input fields on one line, this PR makes it so.

#### Changes proposed in this Pull Request

* Introduces a styled component that displays the city and zip text controls in a grid.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* When testing outside of development: Activate the woop feature flag (`?flags=woop`).
* Navigate to /woocommerce-installation on a test site.
* Click "Set up my Store!".
* Check that city and zip fields are on one line.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.

-->

#### Before
<img width="1391" alt="Screen Shot 2022-01-10 at 10 48 21 AM" src="https://user-images.githubusercontent.com/1398304/148821892-54b4364e-4241-488b-a350-7b7055fd93f7.png">

#### After

<img width="1391" alt="Screen Shot 2022-01-10 at 10 45 00 AM" src="https://user-images.githubusercontent.com/1398304/148821913-4e9c8560-0502-415b-8cc9-64bdb320ce14.png">
