### PR TITLE
Playwright: use locator when interacting with SEO preview button.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -52,7 +52,8 @@ export class MarketingPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async openSEOPreview(): Promise< void > {
-		await this.page.click( selectors.seoPreviewButton );
+		const locator = this.page.locator( selectors.seoPreviewButton );
+		await locator.click();
 		await this.page.waitForSelector( selectors.seoPreviewPane );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR switches to use `locator.click` when interacting with the SEO preview button. 

Background:

This test (SEO: Preview) has been flakey due to the preview button shifting after text has been entered in the SEO preview textbox.

By using the `locator` API, the goal is to force the Playwright engine to re-evaluate the location of the Preview button immediately prior to the click action being performed.

#### Testing instructions

- [ ] Ensure that:
  - [ ] SEO: Preview spec runs to completion.


Closes #59918
