### PR TITLE
Hide premium themes on standalone Jetpack sites

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Popover, Gridicon } from '@automattic/components';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
@@ -12,9 +11,11 @@ import KeyedSuggestions from 'calypso/components/keyed-suggestions';
 import Search from 'calypso/components/search';
 import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import StickyPanel from 'calypso/components/sticky-panel';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getThemeFilters, getThemeFilterToTermTable } from 'calypso/state/themes/selectors';
+import {
+	arePremiumThemesEnabled,
+	getThemeFilters,
+	getThemeFilterToTermTable,
+} from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MagicSearchWelcome from './welcome';
 
@@ -281,9 +282,8 @@ class ThemesMagicSearchCard extends Component {
 	};
 
 	render() {
-		const { translate, filters, showTierThemesControl, isStandaloneJetpack } = this.props;
+		const { translate, filters, showTierThemesControl, premiumThemesEnabled } = this.props;
 		const { isPopoverVisible } = this.state;
-		const isPremiumThemesEnabled = ! isStandaloneJetpack && config.isEnabled( 'themes/premium' );
 
 		const tiers = [
 			{ value: 'all', label: translate( 'All' ) },
@@ -383,7 +383,7 @@ class ThemesMagicSearchCard extends Component {
 						onClick={ this.handleClickInside }
 					>
 						{ searchField }
-						{ isPremiumThemesEnabled && showTierThemesControl && (
+						{ premiumThemesEnabled && showTierThemesControl && (
 							<SimplifiedSegmentedControl
 								key={ this.props.tier }
 								initialSelected={ this.props.tier || 'all' }
@@ -407,11 +407,8 @@ const allowSomeAllValidFilters = ( filtersKeys ) =>
 export default compose(
 	connect( ( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
-		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		return {
-			isStandaloneJetpack: isJetpack && ! isAtomic,
-			isJetpack: isJetpackSite( state, siteId ),
+			premiumThemesEnabled: arePremiumThemesEnabled( state, siteId ),
 			filters: allowSomeThemeFilters( getThemeFilters( state ) ),
 			allValidFilters: allowSomeAllValidFilters(
 				Object.keys( getThemeFilterToTermTable( state ) )

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -8,6 +8,7 @@ import QueryThemes from 'calypso/components/data/query-themes';
 import ThemesList from 'calypso/components/themes-list';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
@@ -203,6 +204,11 @@ export const ConnectedThemesSelection = connect(
 		}
 	) => {
 		const isJetpack = isJetpackSite( state, siteId );
+		const isAtomic = isSiteAutomatedTransfer( state, siteId );
+		const isStandaloneJetpack = isJetpack && ! isAtomic;
+		// Jetpack doesn't support premium themes
+		const isSupportPremiumThemes = ! isStandaloneJetpack && config.isEnabled( 'themes/premium' );
+
 		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {
 			sourceSiteId = source;
@@ -218,7 +224,7 @@ export const ConnectedThemesSelection = connect(
 		const query = {
 			search,
 			page,
-			tier: config.isEnabled( 'themes/premium' ) ? tier : 'free',
+			tier: isSupportPremiumThemes ? tier : 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number,
 		};

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { compact, isEqual, property, snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -8,10 +7,10 @@ import QueryThemes from 'calypso/components/data/query-themes';
 import ThemesList from 'calypso/components/themes-list';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
+	arePremiumThemesEnabled,
 	getPremiumThemePrice,
 	getThemesForQueryIgnoringPage,
 	getThemesFoundForQuery,
@@ -204,10 +203,7 @@ export const ConnectedThemesSelection = connect(
 		}
 	) => {
 		const isJetpack = isJetpackSite( state, siteId );
-		const isAtomic = isSiteAutomatedTransfer( state, siteId );
-		const isStandaloneJetpack = isJetpack && ! isAtomic;
-		// Jetpack doesn't support premium themes
-		const isSupportPremiumThemes = ! isStandaloneJetpack && config.isEnabled( 'themes/premium' );
+		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
 
 		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {
@@ -224,7 +220,7 @@ export const ConnectedThemesSelection = connect(
 		const query = {
 			search,
 			page,
-			tier: isSupportPremiumThemes ? tier : 'free',
+			tier: premiumThemesEnabled ? tier : 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number,
 		};

--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
-		// isomorphic: true,
+		isomorphic: true,
 		title: 'Themes',
 	},
 	{
@@ -219,7 +219,7 @@ const sections = [
 		module: 'calypso/my-sites/theme',
 		enableLoggedOut: true,
 		group: 'sites',
-		// isomorphic: true,
+		isomorphic: true,
 		title: 'Themes',
 		trackLoadPerformance: true,
 	},

--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: true,
+		// isomorphic: true,
 		title: 'Themes',
 	},
 	{
@@ -219,7 +219,7 @@ const sections = [
 		module: 'calypso/my-sites/theme',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: true,
+		// isomorphic: true,
 		title: 'Themes',
 		trackLoadPerformance: true,
 	},

--- a/client/state/themes/selectors/are-premium-themes-enabled.js
+++ b/client/state/themes/selectors/are-premium-themes-enabled.js
@@ -1,0 +1,22 @@
+import { isEnabled } from '@automattic/calypso-config';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Whether a site can see premium themes at all.
+ *
+ * @param  {object}  state   Global state tree
+ * @param  {number}  siteId  Site ID, optional
+ * @returns {boolean}        True if the site should see premium themes in the showcase
+ */
+export function arePremiumThemesEnabled( state, siteId ) {
+	if ( ! siteId ) {
+		return isEnabled( 'themes/premium' );
+	}
+	const isJetpack = isJetpackSite( state, siteId );
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const isStandaloneJetpack = isJetpack && ! isAtomic;
+	return isEnabled( 'themes/premium' ) && ! isStandaloneJetpack;
+}

--- a/client/state/themes/selectors/get-recommended-themes.js
+++ b/client/state/themes/selectors/get-recommended-themes.js
@@ -15,7 +15,7 @@ export function getRecommendedThemes( state, filter ) {
 	let themes = state.themes.recommendedThemes[ filter ]?.themes || emptyList;
 
 	// Remove premium themes if not supported
-	const siteId = getSelectedSiteId( state );
+	const siteId = state.ui ? getSelectedSiteId( state ) : false;
 	const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
 	if ( ! premiumThemesEnabled ) {
 		themes = themes.filter( ( t ) => ! t?.stylesheet?.startsWith( 'premium/' ) );

--- a/client/state/themes/selectors/get-recommended-themes.js
+++ b/client/state/themes/selectors/get-recommended-themes.js
@@ -1,4 +1,6 @@
 import 'calypso/state/themes/init';
+import { arePremiumThemesEnabled } from 'calypso/state/themes/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const emptyList = [];
 
@@ -7,9 +9,17 @@ const emptyList = [];
  *
  * @param {object} state Global state tree
  * @param {string} filter A filter string for a theme query
- *
  * @returns {Array} the list of recommended themes
  */
 export function getRecommendedThemes( state, filter ) {
-	return state.themes.recommendedThemes[ filter ]?.themes || emptyList;
+	let themes = state.themes.recommendedThemes[ filter ]?.themes || emptyList;
+
+	// Remove premium themes if not supported
+	const siteId = getSelectedSiteId( state );
+	const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
+	if ( ! premiumThemesEnabled ) {
+		themes = themes.filter( ( t ) => ! t?.stylesheet?.startsWith( 'premium/' ) );
+	}
+
+	return themes;
 }

--- a/client/state/themes/selectors/get-trending-themes.js
+++ b/client/state/themes/selectors/get-trending-themes.js
@@ -1,4 +1,6 @@
 import 'calypso/state/themes/init';
+import { arePremiumThemesEnabled } from 'calypso/state/themes/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const emptyList = [];
 
@@ -6,17 +8,25 @@ const emptyList = [];
  * Gets the list of trending themes.
  *
  * @param {object} state Global state tree
- *
  * @returns {Array} the list of trending themes
  */
 export function getTrendingThemes( state ) {
 	if ( ! state.themes.trendingThemes?.themes ) {
 		return emptyList;
 	}
-	const themes = Object.values( state.themes.trendingThemes?.themes );
+	let themes = Object.values( state.themes.trendingThemes?.themes );
 	// Only return themes which do not have the "Block Templates" feature.
 	// @TODO remove this check when it is valid to do so.
-	return themes.filter( ( t ) =>
+	themes = themes.filter( ( t ) =>
 		t?.taxonomies?.features.every( ( f ) => f.slug !== 'block-templates' )
 	);
+
+	// Remove premium themes if not supported
+	const siteId = getSelectedSiteId( state );
+	const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
+	if ( ! premiumThemesEnabled ) {
+		themes = themes.filter( ( t ) => ! t?.stylesheet?.startsWith( 'premium/' ) );
+	}
+
+	return themes;
 }

--- a/client/state/themes/selectors/get-trending-themes.js
+++ b/client/state/themes/selectors/get-trending-themes.js
@@ -22,7 +22,7 @@ export function getTrendingThemes( state ) {
 	);
 
 	// Remove premium themes if not supported
-	const siteId = getSelectedSiteId( state );
+	const siteId = state.ui ? getSelectedSiteId( state ) : false;
 	const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
 	if ( ! premiumThemesEnabled ) {
 		themes = themes.filter( ( t ) => ! t?.stylesheet?.startsWith( 'premium/' ) );

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -1,3 +1,4 @@
+export { arePremiumThemesEnabled } from 'calypso/state/themes/selectors/are-premium-themes-enabled';
 export { areRecommendedThemesLoading } from 'calypso/state/themes/selectors/are-recommended-themes-loading';
 export { areTrendingThemesLoading } from 'calypso/state/themes/selectors/are-trending-themes-loading';
 export { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On non-atomic jetpack sites, do not allow premium themes to display in the theme showcase
* They're currently not supported
* When they do display, they can prompt the user to 'Upgrade to Activate' and to buy an expensive Jetpack plan. Even if they bought the plan, they would not be able to use calypso to install the theme
* By hiding the theme, we stop the user from going down a path of paying for something they cannot use

Example of free Jetpack site before change prompting to upgrade:
![2022-01-10_14-53](https://user-images.githubusercontent.com/937354/148843681-16375b54-cab2-4d4f-8c02-a348a5eb3ca6.png)

After change, no premium selector available even when the flag is on
![2022-01-10_15-43](https://user-images.githubusercontent.com/937354/148843949-489001c6-b574-4dda-9cc1-191358bb21c9.png)


#### Testing instructions

* Use JN or Docker to make a jetpack site connected to calypso
* Visit `calypso.localhost:3000/themes/<SITE>?flags=themes/premium` for simple, atomic and standalone jetpack sites
* You should be able to see premium themes on simple and atomic, but not on standalone jetpack

