### PR TITLE
Jetpack Review Prompt: Fix type errors

### DIFF
--- a/client/state/jetpack-review-prompt/constants.ts
+++ b/client/state/jetpack-review-prompt/constants.ts
@@ -8,8 +8,12 @@ export interface SinglePreferenceType {
 }
 
 export interface PreferenceType {
-	scan?: SinglePreferenceType;
+	scan?: ScanPreferenceType;
 	restore?: SinglePreferenceType;
+}
+
+export interface ScanPreferenceType {
+	[ siteId: string ]: SinglePreferenceType;
 }
 
 export const emptyPreference: SinglePreferenceType = {

--- a/client/state/jetpack-review-prompt/selectors.ts
+++ b/client/state/jetpack-review-prompt/selectors.ts
@@ -16,11 +16,8 @@ const getExistingPreference = (
 ): SinglePreferenceType => {
 	const pref = ( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || {};
 	if ( type === 'scan' && pref?.scan ) {
-		return (
-			( pref?.scan[
-				state.ui.selectedSiteId as keyof ScanPreferenceType
-			] as SinglePreferenceType ) ?? emptyPreference
-		);
+		const scanKey = state.ui.selectedSiteId as keyof ScanPreferenceType;
+		return pref.scan[ scanKey ] ?? emptyPreference;
 	}
 	return pref.restore ?? emptyPreference;
 };

--- a/client/state/jetpack-review-prompt/selectors.ts
+++ b/client/state/jetpack-review-prompt/selectors.ts
@@ -6,6 +6,7 @@ import {
 	PreferenceType,
 	TIME_BETWEEN_PROMPTS,
 	SinglePreferenceType,
+	ScanPreferenceType,
 } from './constants';
 import type { AppState } from 'calypso/types';
 
@@ -14,12 +15,14 @@ const getExistingPreference = (
 	type: 'scan' | 'restore'
 ): SinglePreferenceType => {
 	const pref = ( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || {};
-	if ( type === 'scan' ) {
-		return pref.hasOwnProperty( 'scan' )
-			? pref.scan[ state.ui.selectedSiteId ] ?? emptyPreference
-			: emptyPreference;
+	if ( type === 'scan' && pref?.scan ) {
+		return (
+			( pref?.scan[
+				state.ui.selectedSiteId as keyof ScanPreferenceType
+			] as SinglePreferenceType ) ?? emptyPreference
+		);
 	}
-	return pref[ type ] ?? emptyPreference;
+	return pref.restore ?? emptyPreference;
 };
 
 const getIsDismissed = ( state: AppState, type: 'scan' | 'restore' ): boolean => {


### PR DESCRIPTION
Related to: p4TIVU-9U4-p2

#### Changes proposed in this Pull Request

TLDR; This PR fixes a type error that was originally introduced in #51749.

There were 2 review prompts (initially created as part of Project 5 Stars: pbtFFM-LF-p2) that prompt the user to leave a review of the Jetpack plugin- One for Jetpack Backup (After a successful restore process) and one for Jetpack Scan (after a successful threat-fix process). The review prompts state (to show and/or dimiss the review prompts) is persisted using Calypso [preferences](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/preferences/README.md). A typescript type error was occurring because the shape of the Scan review prompt preference is slightly different than the shape of the Backup(restore) review prompt.

#### Testing instructions

- git checkout this PR branch
- Open `client/state/jetpack-review-prompt/selectors.ts` in your editor and verify there are no longer any type errors.
- Run: `yarn test-client client/state/jetpack-review-prompt` - Verify all unit tests are passing.

I just to be sure, I personally did a full regression test on the Scan review prompt and everything is working fine as it did before.

If you also want to do a full regression test, follow these steps below:
- Create a new JN site and purchase Jetpack Scan with credits.
- Go to: https://cloud.jetpack.com/settings/:site (replace `:site` with the slug of your site).
- Enter your JN site SSH/SFTP credentials and server path and save. Confirm it's connected.
- Now SSH into your JN site. (using creds that JN sites provide in the dashboard)
- Go to `~/apps/user<somenumber>/public/wp-content/plugins/akismet`.
- Edit the `akismet.php` file. Somewhere in the file, add:
    - `$eicar = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";`
    - ( this will trigger a scan threat that Jetpack can auto-fix in the next steps)
- Now go to http://jetpack.cloud.localhost:3000/scan/:site (replace `:site` with the slug of your site).
- Click "Scan now" button to start a scan.
- When scan finishes (you should have 1 scan threat), click "Auto fix 1 threat", and confirm "Fix all threats" button. 
- When auto-fix finishes, you should see the review prompt at the bottom of the Scan card.
- Using Redux DevTools you can inspect `state.preferences.remoteValues.jetpack-review-prompt.scan[:siteId]`
- Click the dismiss (X) on the review prompt. verify the review prompt dissappears and in Redux DevTools you'll see values saved for `dismissCount` and `dismissedAt`.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
