### PR TITLE
Add explicit dependency for react-router v5

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -171,6 +171,7 @@
 		"react-modal": "^3.14.3",
 		"react-query": "^3.32.1",
 		"react-redux": "^7.2.6",
+		"react-router": "^5.1.2",
 		"react-router-dom": "^5.1.2",
 		"react-transition-group": "^4.3.0",
 		"reakit": "^1.2.3",

--- a/client/package.json
+++ b/client/package.json
@@ -171,7 +171,6 @@
 		"react-modal": "^3.14.3",
 		"react-query": "^3.32.1",
 		"react-redux": "^7.2.6",
-		"react-router": "^5.1.2",
 		"react-router-dom": "^5.1.2",
 		"react-transition-group": "^4.3.0",
 		"reakit": "^1.2.3",
@@ -219,6 +218,7 @@
 		"html-loader": "^0.5.5",
 		"ignore-loader": "^0.1.2",
 		"pkg-dir": "^5.0.0",
+		"react-router": "^5.1.2",
 		"react-test-renderer": "^17.0.2",
 		"redux-mock-store": "^1.5.4"
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,7 +3102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.0, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.0, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.16.7
   resolution: "@babel/runtime@npm:7.16.7"
   dependencies:
@@ -12472,6 +12472,7 @@ __metadata:
     react-modal: ^3.14.3
     react-query: ^3.32.1
     react-redux: ^7.2.6
+    react-router: ^5.1.2
     react-router-dom: ^5.1.2
     react-test-renderer: ^17.0.2
     react-transition-group: ^4.3.0
@@ -30651,6 +30652,26 @@ fsevents@~2.1.2:
   peerDependencies:
     react: ">=16.8"
   checksum: 60f9b079c03b6d213740cda937ba7265c2b6ce31d3e9cd9155fa64fb5b62fa5b15cfa9a487fb272809d935e4238697833d5910bb9aaed89b948c0071e3e5c399
+  languageName: node
+  linkType: hard
+
+"react-router@npm:^5.1.2":
+  version: 5.2.1
+  resolution: "react-router@npm:5.2.1"
+  dependencies:
+    "@babel/runtime": ^7.12.13
+    history: ^4.9.0
+    hoist-non-react-statics: ^3.1.0
+    loose-envify: ^1.3.1
+    mini-create-react-context: ^0.4.0
+    path-to-regexp: ^1.7.0
+    prop-types: ^15.6.2
+    react-is: ^16.6.0
+    tiny-invariant: ^1.0.2
+    tiny-warning: ^1.0.0
+  peerDependencies:
+    react: ">=15"
+  checksum: cd4e8632b129bedc2a1d850591709a4361903584e147de4ff67af6cd19139bde731f5690cc637d606fccdacb4d7211ab3aa53afbb90ab2aeeeb9492194706a3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds `react-router` version 5.1.2 to the `client` dev-dependencies list.

Even though we don't use this package directly, we use it by proxy with `react-router-dom`. Since the type definitions for that latter package simply re-export the type definitions from `react-router`, we need to make sure that the types provided by that package are using the correct version.

This will fix type errors in two places which use the v5 API but were throwing type errors because the definitions were for the v6 API:

- https://github.com/Automattic/wp-calypso/blob/3a43eac69ebda8790ce75f8b0ed6aec2018f8a56/client/landing/gutenboarding/index.tsx#L64
- https://github.com/Automattic/wp-calypso/blob/3a43eac69ebda8790ce75f8b0ed6aec2018f8a56/client/landing/gutenboarding/onboarding-block/edit.tsx#L217

#### Testing instructions

Verify that this doesn't change anything.