### PR TITLE
Provide CTA button for thank you pages without directives

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -307,6 +307,15 @@ export class CheckoutThankYouHeader extends PureComponent {
 			}
 		);
 	}
+	visitMyHome = ( event ) => {
+		event.preventDefault();
+
+		const { selectedSite } = this.props;
+
+		//TODO add tracks event for this error
+
+		page( `/home/${ selectedSite.slug }` );
+	};
 
 	visitDomain = ( event ) => {
 		event.preventDefault();
@@ -486,6 +495,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 	getButtons() {
 		const {
 			hasFailedPurchases,
+			isDataLoaded,
 			jetpackSearchCustomizeUrl,
 			translate,
 			primaryPurchase,
@@ -499,6 +509,18 @@ export class CheckoutThankYouHeader extends PureComponent {
 		const isTrafficGuidePurchase = 'traffic-guide' === displayMode;
 		const isSearch = purchases?.length > 0 && purchases[ 0 ].productType === 'search';
 
+		if (
+			isDataLoaded &&
+			( ! primaryPurchase || ! selectedSite || ( selectedSite.jetpack && ! isAtomic ) )
+		) {
+			return (
+				<div className="checkout-thank-you__header-button">
+					<Button className={ headerButtonClassName } primary onClick={ this.visitMyHome }>
+						{ translate( 'Go to Site Home' ) }
+					</Button>
+				</div>
+			);
+		}
 		if ( isSearch ) {
 			return (
 				<div className="checkout-thank-you__header-button">

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -312,7 +312,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		const { selectedSite } = this.props;
 
-		//TODO add tracks event for this error
+		this.props.recordTracksEvent( 'calypso_thank_you_no_site_receipt_error' );
 
 		page( `/home/${ selectedSite.slug }` );
 	};
@@ -516,7 +516,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			return (
 				<div className="checkout-thank-you__header-button">
 					<Button className={ headerButtonClassName } primary onClick={ this.visitMyHome }>
-						{ translate( 'Go to Site Home' ) }
+						{ translate( 'Go to My Home' ) }
 					</Button>
 				</div>
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Thank you pages tend to have a call to action button (or series of buttons/actions), for instance a new plan will have a thank you page that directs the customer to begin using their new features.

In some cases, the Thank You page may appear directionless as noted in this issue https://github.com/Automattic/wp-calypso/issues/45078

When this happens we should offer a generic Thank You page that directs the customer back to their site _My Home_ section, this at least gives them a general place to go and navigate from there.

#### Testing instructions

- Go to http://calypso.localhost:3000/checkout/thank-you/$site_url
- You should see a very generic thank you page with a button to `Go to My Home`

![image](https://user-images.githubusercontent.com/16580129/149843338-e03f8a45-133e-41fa-903a-cbf71cfff59a.png)


Related to https://github.com/Automattic/wp-calypso/issues/45078
