### PR TITLE
Jetpack plans: Fix TS errors on CRM free card and iterations

### DIFF
--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -5,7 +5,9 @@ import { getUrlParts } from '@automattic/calypso-url';
  */
 
 // No iterations, currently
-export enum Iterations {}
+export enum Iterations {
+	_ = '', // Needed to convince TS that this is not a numeric enum.
+}
 
 const iterationNames: string[] = Object.values( Iterations );
 

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/index.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
+	TERM_ANNUALLY,
 	PRODUCT_JETPACK_CRM_FREE,
 	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 	TERM_MONTHLY,
@@ -11,12 +12,13 @@ import { useDispatch } from 'react-redux';
 import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
 import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
+import { ITEM_TYPE_PLAN } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import type { Duration, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 const CRM_FREE_URL =
 	'https://jetpackcrm.com/pricing?utm_source=jetpack&utm_medium=web&utm_campaign=pricing_i4&utm_content=pricing';
 
-const useCrmFreeItem = ( duration: Duration ) => {
+const useCrmFreeItem = ( duration: Duration ): SelectorProduct => {
 	const translate = useTranslate();
 
 	return useMemo(
@@ -27,11 +29,17 @@ const useCrmFreeItem = ( duration: Duration ) => {
 			displayName: translate( 'Jetpack CRM' ),
 			features: {
 				items: [
-					{ text: translate( 'Unlimited contacts' ) },
-					{ text: translate( 'Manage billing and create invoices' ) },
-					{ text: translate( 'CRM fully integrated with WordPress' ) },
+					{ slug: 'not used', text: translate( 'Unlimited contacts' ) },
+					{ slug: 'not used', text: translate( 'Manage billing and create invoices' ) },
+					{ slug: 'not used', text: translate( 'CRM fully integrated with WordPress' ) },
 				],
 			},
+			type: ITEM_TYPE_PLAN, // not used
+			term: TERM_ANNUALLY, // not used
+			iconSlug: 'not used',
+			shortName: 'not used',
+			tagline: 'not used',
+			description: 'not used',
 		} ),
 		[ duration, translate ]
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/59870 which fixed several TS errors in the Jetpack plans code. This fixes the remaining errors in the same way, by filling in the required properties for a plan on the free plan object.

#### Testing instructions

Verify that this does not have any effect on the behavior of this code.