### PR TITLE
Signup: Fix TS errors in SignupFlowController

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -423,19 +423,13 @@ export default class SignupFlowController {
 		);
 	}
 
-	_findDependencies(
-		stepName: string,
-		dependencyKey: keyof StepDependendencies = 'dependencies'
-	): Record< string, unknown > {
+	_findDependencies( stepName: string, dependencyKey: keyof StepDependendencies = 'dependencies' ) {
 		const dependencyStore: Record< string, unknown > = getSignupDependencyStore(
 			this._reduxStore.getState()
 		);
 		const stepConfig = steps[ stepName ];
-		if ( ! stepConfig || ! stepConfig[ dependencyKey ] ) {
-			return {};
-		}
-		const keysToSelect = stepConfig[ dependencyKey ] ?? [];
-		return pick( dependencyStore, keysToSelect );
+		const keysToSelect = stepConfig ? stepConfig[ dependencyKey ] : undefined;
+		return pick( dependencyStore, keysToSelect ?? [] );
 	}
 
 	_destination( dependencies: Dependencies ): string {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -41,18 +41,21 @@ import type { Flow, Dependencies } from '../../signup/types';
 
 const debug = debugModule( 'calypso:signup' );
 
-interface Step {
-	apiRequestFunction?: (
-		callback: ( errors: Record< string, string >[], providedDependencies: Dependencies ) => void,
-		dependenciesFound: Dependencies,
-		step: Step,
-		reduxStore: Store
-	) => void;
-	delayApiRequestUntilComplete?: boolean;
+interface StepDependendencies {
 	dependencies?: string[];
 	providedDependencies?: string[];
 	providesDependencies?: string[];
 	optionalDependencies?: string[];
+}
+
+interface Step extends StepDependendencies {
+	apiRequestFunction?: (
+		callback: ( errors: Record< string, string >[], providedDependencies: Dependencies ) => void,
+		dependenciesFound: Record< string, unknown >,
+		step: Step,
+		reduxStore: Store
+	) => void;
+	delayApiRequestUntilComplete?: boolean;
 	providesToken?: boolean;
 	stepName: string;
 	allowUnauthenticated?: boolean;
@@ -420,14 +423,19 @@ export default class SignupFlowController {
 		);
 	}
 
-	_findDependencies( stepName: string, dependencyKey = 'dependencies' ): Record< string, unknown > {
-		const dependencyStore = getSignupDependencyStore( this._reduxStore.getState() );
+	_findDependencies(
+		stepName: string,
+		dependencyKey: keyof StepDependendencies = 'dependencies'
+	): Record< string, unknown > {
+		const dependencyStore: Record< string, unknown > = getSignupDependencyStore(
+			this._reduxStore.getState()
+		);
 		const stepConfig = steps[ stepName ];
 		if ( ! stepConfig || ! stepConfig[ dependencyKey ] ) {
 			return {};
 		}
-
-		return pick( dependencyStore, stepConfig[ dependencyKey ] );
+		const keysToSelect = stepConfig[ dependencyKey ] ?? [];
+		return pick( dependencyStore, keysToSelect );
 	}
 
 	_destination( dependencies: Dependencies ): string {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes TypeScript errors introduced in https://github.com/Automattic/wp-calypso/pull/54743, specifically in the `_findDependencies()` function. The changes are as follows:

- The `_findDependencies` function can in theory query any key of a `Step`, but in fact it only will work for keys that have a value of `string[]` (because the second argument of `lodash.pick` must be a string or an array of strings). This PR adds types to narrow the `dependencyKey` argument to those keys.
- The `apiRequestFunction` property of a `Step` accepts the results of calling `_findDependencies`, which is an object of arbitrary data returned from the signup dependency store, as its second argument. However, the `Dependencies` type that was used represents the dependency _keys_ as an object whose values are an array of dependency key strings. This PR changes the type to `Record< string, unknown >` to match how it is being used.

#### Testing instructions

Verify that these changes are to types only and do not modify any behavior.