### PR TITLE
i18n: Localize Google Analytics Support Document Link

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -38,7 +38,7 @@ const GoogleAnalyticsSimpleForm = ( {
 	site,
 	translate,
 } ) => {
-	const analyticsSupportUrl = 'https://wordpress.com/support/google-analytics/';
+	const analyticsSupportUrl = localizeUrl( 'https://wordpress.com/support/google-analytics/' );
 	const nudgeTitle = translate(
 		'Connect your site to Google Analytics in seconds with the Premium plan'
 	);
@@ -161,11 +161,7 @@ const GoogleAnalyticsSimpleForm = ( {
 									{
 										components: {
 											a: (
-												<a
-													href={ localizeUrl( analyticsSupportUrl ) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
+												<a href={ analyticsSupportUrl } target="_blank" rel="noopener noreferrer" />
 											),
 										},
 									}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Localize Google Analytics Support Document link on `/marketing/traffic/{site}`.

![CleanShot 2022-01-11 at 11 19 09](https://user-images.githubusercontent.com/2722412/148915274-09ae7770-43bb-4e86-803e-72b0e50b07a4.png)


#### Testing instructions

* Change UI to Mag-16 language.
* Go to `/marketing/traffic/{site}`, where `{site}` is a simple site (Jetpack sites link to Jetpack Support Document, which isn't translated at this point).
* Confirm the "Learn more" link points to the localized support document.

Related to 367-gh-Automattic/i18n-issues
