### PR TITLE
SiteSettingsSeoFrom: refactor away from `UNSAFE_cWRP`

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -24,8 +24,8 @@ import './style.scss';
 
 const SiteSettingsTraffic = ( {
 	fields,
-	handleAutosavingToggle,
 	handleAutosavingRadio,
+	handleAutosavingToggle,
 	handleSubmitForm,
 	isAdmin,
 	isJetpack,
@@ -33,6 +33,7 @@ const SiteSettingsTraffic = ( {
 	isRequestingSettings,
 	isSavingSettings,
 	setFieldValue,
+	siteId,
 	translate,
 } ) => (
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -48,7 +49,11 @@ const SiteSettingsTraffic = ( {
 
 		{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
 		{ isAdmin && (
-			<AsyncLoad require="calypso/my-sites/site-settings/seo-settings/form" placeholder={ null } />
+			<AsyncLoad
+				key={ siteId }
+				require="calypso/my-sites/site-settings/seo-settings/form"
+				placeholder={ null }
+			/>
 		) }
 		{ isAdmin && (
 			<RelatedPosts
@@ -101,6 +106,7 @@ const connectComponent = connect( ( state ) => {
 	const isJetpackAdmin = isJetpack && isAdmin;
 
 	return {
+		siteId,
 		isAdmin,
 		isJetpack,
 		isJetpackAdmin,

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -5,10 +5,11 @@ import {
 	findFirstSimilarPlanKey,
 } from '@automattic/calypso-products';
 import { Card, Button } from '@automattic/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
-import { get, isEqual, mapValues, omit, pickBy } from 'lodash';
+import { get, isEqual, mapValues, pickBy } from 'lodash';
 import { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import pageTitleImage from 'calypso/assets/images/illustrations/seo-page-title.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -42,6 +43,8 @@ import { requestSiteSettings, saveSiteSettings } from 'calypso/state/site-settin
 import {
 	isSiteSettingsSaveSuccessful,
 	getSiteSettingsSaveError,
+	isRequestingSiteSettings,
+	isSavingSiteSettings,
 } from 'calypso/state/site-settings/selectors';
 import { requestSite } from 'calypso/state/sites/actions';
 import { hasFeature } from 'calypso/state/sites/plans/selectors';
@@ -62,91 +65,61 @@ function getGeneralTabUrl( slug ) {
 	return `/settings/general/${ slug }`;
 }
 
-function stateForSite( site ) {
-	return {
-		frontPageMetaDescription: get( site, 'options.advanced_seo_front_page_description', '' ),
-		isFetchingSettings: get( site, 'fetchingSettings', false ),
-	};
-}
-
 export class SeoForm extends Component {
 	static displayName = 'SiteSettingsFormSEO';
 
+	_mounted = false;
+
 	state = {
-		...stateForSite( this.props.selectedSite ),
-		seoTitleFormats: this.props.storedTitleFormats,
-		// dirtyFields is used to prevent prop updates
-		// from overwriting local stateful edits that
-		// are in progress and haven't yet been saved
-		// to the server
 		dirtyFields: new Set(),
 	};
 
-	componentDidMount() {
-		this.refreshCustomTitles();
+	static getDerivedStateFromProps( props, state ) {
+		const { dirtyFields } = state;
+		const nextState = {};
+
+		if (
+			! dirtyFields.has( 'seoTitleFormats' ) &&
+			! isEqual( props.storedTitleFormats, state.seoTitleFormats )
+		) {
+			nextState.seoTitleFormats = props.storedTitleFormats;
+		}
+
+		if (
+			! dirtyFields.has( 'frontPageMetaDescription' ) &&
+			! isEqual(
+				props.selectedSite.options?.advanced_seo_front_page_description,
+				state.frontPageMetaDescription
+			)
+		) {
+			nextState.frontPageMetaDescription =
+				props.selectedSite.options?.advanced_seo_front_page_description;
+		}
+
+		if ( Object.keys( nextState ).length > 0 ) {
+			return nextState;
+		}
+
+		return null;
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { selectedSite: prevSite, isFetchingSite, translate } = this.props;
-		const { selectedSite: nextSite } = nextProps;
-		const { dirtyFields } = this.state;
+	componentDidMount() {
+		this.refreshCustomTitles();
+		this._mounted = true;
+	}
 
-		// save success
-		if ( this.state.isSubmittingForm && nextProps.isSaveSuccess ) {
-			this.props.markSaved();
-			this.props.requestSiteSettings( nextProps.siteId );
-			this.refreshCustomTitles();
-			this.setState( { isSubmittingForm: false } );
+	componentWillUnmount() {
+		this._mounted = false;
+	}
+
+	handleSubmitSuccess() {
+		this.props.markSaved();
+		this.props.requestSiteSettings( this.props.siteId );
+		this.refreshCustomTitles();
+
+		if ( this._mounted ) {
+			this.setState( { dirtyFields: new Set() } );
 		}
-
-		// save error
-		if ( this.state.isSubmittingForm && nextProps.saveError ) {
-			this.setState( { isSubmittingForm: false } );
-			this.props.errorNotice(
-				translate( 'There was a problem saving your changes. Please, try again.' ),
-				{
-					id: 'seo-settings-form-error',
-				}
-			);
-		}
-
-		// if we are changing sites, everything goes
-		if ( prevSite.ID !== nextSite.ID ) {
-			return this.setState(
-				{
-					...stateForSite( nextSite ),
-					seoTitleFormats: nextProps.storedTitleFormats,
-					dirtyFields: new Set(),
-				},
-				this.refreshCustomTitles
-			);
-		}
-
-		let nextState = {
-			...stateForSite( nextProps.selectedSite ),
-			seoTitleFormats: nextProps.storedTitleFormats,
-		};
-
-		if ( ! isFetchingSite ) {
-			const nextDirtyFields = new Set( dirtyFields );
-			nextDirtyFields.delete( 'seoTitleFormats' );
-
-			nextState = {
-				...nextState,
-				seoTitleFormats: nextProps.storedTitleFormats,
-				dirtyFields: nextDirtyFields,
-			};
-		}
-
-		if ( dirtyFields.has( 'seoTitleFormats' ) ) {
-			nextState = omit( nextState, [ 'seoTitleFormats' ] );
-		}
-
-		// Don't update state for fields the user has edited
-		nextState = omit( nextState, Array.from( dirtyFields ) );
-
-		this.setState( nextState );
 	}
 
 	handleMetaChange = ( { target: { value: frontPageMetaDescription } } ) => {
@@ -183,10 +156,6 @@ export class SeoForm extends Component {
 
 		this.props.removeNotice( 'seo-settings-form-error' );
 
-		this.setState( {
-			isSubmittingForm: true,
-		} );
-
 		// We need to be careful here and only
 		// send _changes_ to the API instead of
 		// sending all of the title formats.
@@ -214,7 +183,11 @@ export class SeoForm extends Component {
 			( format ) => ( Array.isArray( format ) && 0 === format.length ? '' : format )
 		);
 
-		this.props.saveSiteSettings( siteId, updatedOptions );
+		this.props.saveSiteSettings( siteId, updatedOptions ).then( ( res ) => {
+			if ( res.updated ) {
+				this.handleSubmitSuccess();
+			}
+		} );
 
 		this.trackSubmission();
 	};
@@ -268,12 +241,12 @@ export class SeoForm extends Component {
 			isSitePrivate,
 			isSiteHidden,
 			translate,
+			isFetchingSettings,
+			isSavingSettings,
 		} = this.props;
 		const { slug = '', URL: siteUrl = '' } = selectedSite;
 
 		const {
-			isSubmittingForm,
-			isFetchingSettings,
 			frontPageMetaDescription,
 			showPasteError = false,
 			hasHtmlTagError = false,
@@ -281,10 +254,10 @@ export class SeoForm extends Component {
 			showPreview = false,
 		} = this.state;
 
-		const isDisabled = isSubmittingForm || isFetchingSettings;
+		const isDisabled = isSavingSettings || isFetchingSettings;
 		const isSeoDisabled = isDisabled || isSeoToolsActive === false;
 		const isSaveDisabled =
-			isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
+			isDisabled || isSavingSettings || ( ! showPasteError && invalidCodes.length > 0 );
 
 		const generalTabUrl = getGeneralTabUrl( slug );
 
@@ -367,7 +340,7 @@ export class SeoForm extends Component {
 						<div>
 							<SettingsSectionHeader
 								disabled={ isSaveDisabled || isSeoDisabled }
-								isSaving={ isSubmittingForm }
+								isSaving={ isSavingSettings }
 								onButtonClick={ this.submitSeoForm }
 								showButton
 								title={ translate( 'Page Title Structure' ) }
@@ -401,7 +374,7 @@ export class SeoForm extends Component {
 							<div>
 								<SettingsSectionHeader
 									disabled={ isSaveDisabled || isSeoDisabled }
-									isSaving={ isSubmittingForm }
+									isSaving={ isSavingSettings }
 									onButtonClick={ this.submitSeoForm }
 									showButton
 									title={ translate( 'Website Meta' ) }
@@ -495,6 +468,8 @@ const mapStateToProps = ( state ) => {
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
 		saveError: getSiteSettingsSaveError( state, siteId ),
 		path: getCurrentRouteParameterized( state, siteId ),
+		isFetchingSettings: isRequestingSiteSettings( state, siteId ),
+		isSavingSettings: isSavingSiteSettings( state, siteId ),
 	};
 };
 
@@ -512,4 +487,14 @@ const mapDispatchToProps = {
 		recordTracksEvent( 'calypso_seo_tools_front_page_meta_updated', properties ),
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( protectForm( localize( SeoForm ) ) );
+const withCurrentSiteKey = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const siteId = useSelector( getSelectedSiteId );
+		return <Wrapped { ...props } key={ siteId } />;
+	},
+	'WithCurrentSiteKey'
+);
+
+export default withCurrentSiteKey(
+	connect( mapStateToProps, mapDispatchToProps )( protectForm( localize( SeoForm ) ) )
+);

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -8,7 +8,7 @@ import { Card, Button } from '@automattic/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
 import { get, isEqual, mapValues, pickBy } from 'lodash';
-import { Component } from 'react';
+import { Component, createRef } from 'react';
 import { connect, useSelector } from 'react-redux';
 import pageTitleImage from 'calypso/assets/images/illustrations/seo-page-title.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -66,7 +66,7 @@ function getGeneralTabUrl( slug ) {
 }
 
 export class SiteSettingsFormSEO extends Component {
-	_mounted = false;
+	_mounted = createRef();
 
 	state = {
 		dirtyFields: new Set(),
@@ -103,11 +103,6 @@ export class SiteSettingsFormSEO extends Component {
 
 	componentDidMount() {
 		this.refreshCustomTitles();
-		this._mounted = true;
-	}
-
-	componentWillUnmount() {
-		this._mounted = false;
 	}
 
 	handleSubmitSuccess() {
@@ -282,7 +277,7 @@ export class SiteSettingsFormSEO extends Component {
 		const isPublicComingSoon = ! isSitePrivate && siteIsComingSoon;
 
 		return (
-			<div>
+			<div ref={ this._mounted }>
 				<QuerySiteSettings siteId={ siteId } />
 				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -65,9 +65,7 @@ function getGeneralTabUrl( slug ) {
 	return `/settings/general/${ slug }`;
 }
 
-export class SeoForm extends Component {
-	static displayName = 'SiteSettingsFormSEO';
-
+export class SiteSettingsFormSEO extends Component {
 	_mounted = false;
 
 	state = {
@@ -496,5 +494,5 @@ const withCurrentSiteKey = createHigherOrderComponent(
 );
 
 export default withCurrentSiteKey(
-	connect( mapStateToProps, mapDispatchToProps )( protectForm( localize( SeoForm ) ) )
+	connect( mapStateToProps, mapDispatchToProps )( protectForm( localize( SiteSettingsFormSEO ) ) )
 );

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -5,11 +5,10 @@ import {
 	findFirstSimilarPlanKey,
 } from '@automattic/calypso-products';
 import { Card, Button } from '@automattic/components';
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
 import { get, isEqual, mapValues, pickBy } from 'lodash';
 import { Component, createRef } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 import pageTitleImage from 'calypso/assets/images/illustrations/seo-page-title.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -480,14 +479,7 @@ const mapDispatchToProps = {
 		recordTracksEvent( 'calypso_seo_tools_front_page_meta_updated', properties ),
 };
 
-const withCurrentSiteKey = createHigherOrderComponent(
-	( Wrapped ) => ( props ) => {
-		const siteId = useSelector( getSelectedSiteId );
-		return <Wrapped { ...props } key={ siteId } />;
-	},
-	'WithCurrentSiteKey'
-);
-
-export default withCurrentSiteKey(
-	connect( mapStateToProps, mapDispatchToProps )( protectForm( localize( SiteSettingsFormSEO ) ) )
-);
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( protectForm( localize( SiteSettingsFormSEO ) ) );

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -19,7 +19,7 @@ import {
 	PLAN_JETPACK_SECURITY_DAILY,
 } from '@automattic/calypso-products';
 import { shallow } from 'enzyme';
-import { SeoForm } from '../form';
+import { SiteSettingsFormSEO as SeoForm } from '../form';
 
 const props = {
 	refreshSiteData: ( x ) => x,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `SiteSettingsFormSEO`: refactor away from `UNSAFE_cWRP`

#### Testing instructions

* Open `/marketing/traffic/:site` for a site with a business plan
* Make sure _Enable SEO Tools_ is checked
* For _Page Title Structure_ and _Website Meta_ change settings and save them
* Make sure they're persisted and everything behaves as on prod
* Also try the error case by blocking network requests to `/sites/:siteId/settings`

Related to #58453
