### PR TITLE
Remove _.includes from isCurrentUserMaybeInGdprZone

### DIFF
--- a/client/lib/analytics/utils/is-current-user-maybe-in-gdpr-zone.js
+++ b/client/lib/analytics/utils/is-current-user-maybe-in-gdpr-zone.js
@@ -1,5 +1,41 @@
 import cookie from 'cookie';
-import { includes } from 'lodash';
+
+const GDPR_COUNTRIES = [
+	// European Member countries
+	'AT', // Austria
+	'BE', // Belgium
+	'BG', // Bulgaria
+	'CY', // Cyprus
+	'CZ', // Czech Republic
+	'DE', // Germany
+	'DK', // Denmark
+	'EE', // Estonia
+	'ES', // Spain
+	'FI', // Finland
+	'FR', // France
+	'GR', // Greece
+	'HR', // Croatia
+	'HU', // Hungary
+	'IE', // Ireland
+	'IT', // Italy
+	'LT', // Lithuania
+	'LU', // Luxembourg
+	'LV', // Latvia
+	'MT', // Malta
+	'NL', // Netherlands
+	'PL', // Poland
+	'PT', // Portugal
+	'RO', // Romania
+	'SE', // Sweden
+	'SI', // Slovenia
+	'SK', // Slovakia
+	'GB', // United Kingdom
+	// Single Market Countries that GDPR applies to
+	'CH', // Switzerland
+	'IS', // Iceland
+	'LI', // Liechtenstein
+	'NO', // Norway
+];
 
 /**
  * Returns a boolean telling whether the current user could be in the GDPR zone.
@@ -10,46 +46,5 @@ export default function isCurrentUserMaybeInGdprZone() {
 	const cookies = cookie.parse( document.cookie );
 	const countryCode = cookies.country_code;
 
-	if ( ! countryCode || 'unknown' === countryCode ) {
-		return true;
-	}
-
-	const gdprCountries = [
-		// European Member countries
-		'AT', // Austria
-		'BE', // Belgium
-		'BG', // Bulgaria
-		'CY', // Cyprus
-		'CZ', // Czech Republic
-		'DE', // Germany
-		'DK', // Denmark
-		'EE', // Estonia
-		'ES', // Spain
-		'FI', // Finland
-		'FR', // France
-		'GR', // Greece
-		'HR', // Croatia
-		'HU', // Hungary
-		'IE', // Ireland
-		'IT', // Italy
-		'LT', // Lithuania
-		'LU', // Luxembourg
-		'LV', // Latvia
-		'MT', // Malta
-		'NL', // Netherlands
-		'PL', // Poland
-		'PT', // Portugal
-		'RO', // Romania
-		'SE', // Sweden
-		'SI', // Slovenia
-		'SK', // Slovakia
-		'GB', // United Kingdom
-		// Single Market Countries that GDPR applies to
-		'CH', // Switzerland
-		'IS', // Iceland
-		'LI', // Liechtenstein
-		'NO', // Norway
-	];
-
-	return includes( gdprCountries, countryCode );
+	return ! countryCode || 'unknown' === countryCode || GDPR_COUNTRIES.includes( countryCode );
 }

--- a/client/lib/analytics/utils/is-current-user-maybe-in-gdpr-zone.ts
+++ b/client/lib/analytics/utils/is-current-user-maybe-in-gdpr-zone.ts
@@ -42,7 +42,7 @@ const GDPR_COUNTRIES = [
  *
  * @returns {boolean} Whether the current user could be in the GDPR zone
  */
-export default function isCurrentUserMaybeInGdprZone() {
+export default function isCurrentUserMaybeInGdprZone(): boolean {
 	const cookies = cookie.parse( document.cookie );
 	const countryCode = cookies.country_code;
 


### PR DESCRIPTION
A little Lodash removal I did while reviewing the cookie banner changes in #59848. Removes `_.includes` use.