### PR TITLE
Fix wrong success message for p2 connections

### DIFF
--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -14,7 +14,11 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice, warningNotice } from 'calypso/state/notices/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import getRemovableConnections from 'calypso/state/selectors/get-removable-connections';
-import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
+import {
+	requestKeyringConnections,
+	requestP2KeyringConnections,
+} from 'calypso/state/sharing/keyring/actions';
 import {
 	getKeyringConnectionsByName,
 	getRefreshableKeyringConnections,
@@ -72,6 +76,7 @@ export class SharingService extends Component {
 		translate: PropTypes.func,
 		updateSiteConnection: PropTypes.func,
 		warningNotice: PropTypes.func,
+		isP2HubSite: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -91,6 +96,7 @@ export class SharingService extends Component {
 		siteUserConnections: [],
 		updateSiteConnection: () => {},
 		warningNotice: () => {},
+		isP2HubSite: false,
 	};
 
 	/**
@@ -166,9 +172,13 @@ export class SharingService extends Component {
 				// Attempt to create a new connection. If a Keyring connection ID
 				// is not provided, the user will need to authorize the app
 				requestExternalAccess( service.connect_URL, ( { keyring_id: newKeyringId } ) => {
-					// When the user has finished authorizing the connection
-					// (or otherwise closed the window), force a refresh
-					this.props.requestKeyringConnections();
+					if ( this.props.isP2HubSite ) {
+						this.props.requestP2KeyringConnections( this.props.siteId );
+					} else {
+						// When the user has finished authorizing the connection
+						// (or otherwise closed the window), force a refresh
+						this.props.requestKeyringConnections();
+					}
 
 					// In the case that a Keyring connection doesn't exist, wait for app
 					// authorization to occur, then display with the available connections
@@ -640,6 +650,7 @@ export function connectFor( sharingService, mapStateToProps, mapDispatchToProps 
 				siteUserConnections: getSiteUserConnectionsForService( state, siteId, userId, service.ID ),
 				userId,
 				isExpanded: isServiceExpanded( state, service ),
+				isP2HubSite: isSiteP2Hub( state, siteId ),
 			};
 			return typeof mapStateToProps === 'function' ? mapStateToProps( state, props ) : props;
 		},
@@ -652,6 +663,7 @@ export function connectFor( sharingService, mapStateToProps, mapDispatchToProps 
 			fetchConnection,
 			recordGoogleEvent,
 			recordTracksEvent,
+			requestP2KeyringConnections,
 			requestKeyringConnections,
 			updateSiteConnection,
 			warningNotice,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix not expected success message when closing a Github connection window without actually connecting, context 4187-gh-Automattic/p2

#### Testing instructions
- Github connections can be accessed on wordpress.com/marketing/connections/<hub-url> only by a12s
- Make sure there is also a Slack connection on that hub
- Click on the Github connect button
- Close the github connection modal -> There should be no success message

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #