### PR TITLE
Domains: Hide domain transfer options for non-owners

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -1,5 +1,6 @@
 import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { isDomainInGracePeriod } from 'calypso/lib/domains';
 import { type as domainType } from 'calypso/lib/domains/constants';
 import { domainManagementTransfer } from 'calypso/my-sites/domains/paths';
 import DomainInfoCard from '..';
@@ -11,7 +12,13 @@ const DomainTransferInfoCard = ( {
 }: DomainInfoCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
 
-	if ( domain.type === domainType.TRANSFER ) return null;
+	if (
+		! domain.currentUserIsOwner ||
+		( domain.expired && ! isDomainInGracePeriod( domain ) ) ||
+		domain.type === domainType.TRANSFER
+	) {
+		return null;
+	}
 
 	const getDescription = () => {
 		switch ( domain.type ) {

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -200,9 +200,9 @@ class DomainManagementNavigationEnhanced extends Component {
 
 	getTransferDomain() {
 		const { moment, selectedSite, translate, domain, currentRoute } = this.props;
-		const { expired, isLocked, transferAwayEligibleAt } = domain;
+		const { currentUserIsOwner, expired, isLocked, transferAwayEligibleAt } = domain;
 
-		if ( ! domain.currentUserIsOwner || ( expired && ! isDomainInGracePeriod( domain ) ) ) {
+		if ( ! currentUserIsOwner || ( expired && ! isDomainInGracePeriod( domain ) ) ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -202,7 +202,7 @@ class DomainManagementNavigationEnhanced extends Component {
 		const { moment, selectedSite, translate, domain, currentRoute } = this.props;
 		const { expired, isLocked, transferAwayEligibleAt } = domain;
 
-		if ( expired && ! isDomainInGracePeriod( domain ) ) {
+		if ( ! domain.currentUserIsOwner || ( expired && ! isDomainInGracePeriod( domain ) ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

As reported in p2MSmN-91m-p2, users who were not the owners of a domain were able to see transfer options for it. This PR hides these options if the current user is not the owner of the domain. Both the old domain settings page and the redesigned one were updated.

#### Screenshots

- Current domain settings page:

![Markup on 2022-01-11 at 12:24:57](https://user-images.githubusercontent.com/5324818/148975239-1846e3c2-70c8-4323-9b11-7ed7b82cf5fe.png)

- Redesigned domain settings page:

![Markup on 2022-01-11 at 12:26:59](https://user-images.githubusercontent.com/5324818/148975268-eef79195-8ca9-45b7-be45-d9e17a87b9ee.png)

- With this PR, these pages should look like this:

<img width="754" alt="Screen Shot 2022-01-11 at 12 25 42" src="https://user-images.githubusercontent.com/5324818/148975400-0203e115-aadc-4916-ade7-bc59c21e63eb.png">

<img width="1079" alt="Screen Shot 2022-01-11 at 12 27 26" src="https://user-images.githubusercontent.com/5324818/148975422-8a136908-bcbe-4d13-9047-f90a9a995d71.png">

### Testing instructions

- Build this branch locally or open the live Calypso link
- Select a site where you have a domain which you're not an owner of
- Go to "Upgrades > Domains"
- Select the domain that you do not own
- Ensure the transfer options card is not shown
- Please test both the current and redesigned settings pages by applying or disabling the `domains/settings-page-redesign` flag as appropriate - append `?flags=domains/settings-page-redesign` (enable flag) or `?flags=-domains/settings-page-redesign` (disable flag) to the URL
