### PR TITLE
FSE Beta: increase exposure to 50%

### DIFF
--- a/client/landing/gutenboarding/hooks/use-fse-beta-eligibility.ts
+++ b/client/landing/gutenboarding/hooks/use-fse-beta-eligibility.ts
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { USER_STORE } from '../stores/user';
 
-const FSE_BETA_ROLLOUT_PERCENTAGE = 20;
+const FSE_BETA_ROLLOUT_PERCENTAGE = 50;
 
 export default function useFseBetaEligibility(): boolean {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Increase the percentage of existing users that get the FSE Beta opt-in during site creation to 50%.

#### Testing instructions

Same as #56585.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
