### PR TITLE
Emails: Show price according to billing interval on In-Depth Comparison page

### DIFF
--- a/client/lib/gsuite/get-google-mail-service-family.js
+++ b/client/lib/gsuite/get-google-mail-service-family.js
@@ -6,6 +6,10 @@ import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 } from 'calypso/lib/gsuite/constants';
 
+/**
+ * @param {string|null} productSlug - optional product slug
+ * @returns {string}
+ */
 export function getGoogleMailServiceFamily( productSlug = null ) {
 	if ( productSlug ) {
 		switch ( productSlug ) {

--- a/client/lib/titan/is-domain-eligible-for-titan-free-trial.js
+++ b/client/lib/titan/is-domain-eligible-for-titan-free-trial.js
@@ -1,7 +1,11 @@
 /**
+ * @typedef { import("client/lib/domains/types").ResponseDomain } ResponseDomain domain object
+ */
+
+/**
  * Determines if the specified domain is eligible for the Titan 3-month free trial.
  *
- * @param {object} domain - domain object
+ * @param {ResponseDomain|undefined} domain - domain object
  * @returns {boolean} whether the domain is eligible or not
  */
 export function isDomainEligibleForTitanFreeTrial( domain ) {

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -4,14 +4,31 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
+import { getSelectedDomain } from 'calypso/lib/domains';
+import GoogleWorkspacePrice from 'calypso/my-sites/email/email-providers-comparison/price/google-workspace';
+import ProfessionalEmailPrice from 'calypso/my-sites/email/email-providers-comparison/price/professional-email';
 import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type {
 	ComparisonTableProps,
+	ComparisonTablePriceProps,
 	EmailProviderFeatures,
 } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 import type { ReactElement } from 'react';
+
+const ComparisonTablePrice = ( {
+	domain,
+	emailProviderSlug,
+	intervalLength,
+}: ComparisonTablePriceProps ): ReactElement => {
+	if ( emailProviderSlug === 'google-workspace' ) {
+		return <GoogleWorkspacePrice intervalLength={ intervalLength } />;
+	}
+
+	return <ProfessionalEmailPrice domain={ domain } intervalLength={ intervalLength } />;
+};
 
 const ComparisonTable = ( {
 	emailProviders,
@@ -20,17 +37,23 @@ const ComparisonTable = ( {
 }: ComparisonTableProps ): ReactElement => {
 	const translate = useTranslate();
 
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const selectedSite = useSelector( getSelectedSite );
 	const currentRoute = useSelector( getCurrentRoute );
 
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+	const domain = getSelectedDomain( {
+		domains,
+		selectedDomainName: selectedDomainName,
+	} );
+
 	const selectEmailProvider = ( emailProviderSlug: string ) => {
-		if ( selectedSiteSlug === null ) {
+		if ( selectedSite === null ) {
 			return;
 		}
 
 		page(
 			emailManagementPurchaseNewEmailAccount(
-				selectedSiteSlug,
+				selectedSite.slug,
 				selectedDomainName,
 				currentRoute,
 				null,
@@ -50,6 +73,12 @@ const ComparisonTable = ( {
 
 							<h2>{ emailProviderFeatures.name }</h2>
 						</div>
+
+						<ComparisonTablePrice
+							domain={ domain }
+							emailProviderSlug={ emailProviderFeatures.slug }
+							intervalLength={ intervalLength }
+						/>
 
 						<Button onClick={ () => selectEmailProvider( emailProviderFeatures.slug ) } primary>
 							{ translate( 'Select' ) }

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -3,6 +3,7 @@
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import ComparisonTable from 'calypso/my-sites/email/email-providers-comparison/in-depth/comparison-table';
 import {
@@ -45,6 +46,8 @@ const EmailProvidersInDepthComparison = ( {
 
 	return (
 		<>
+			<QueryProductsList />
+
 			<h1 className="email-providers-in-depth-comparison__header">
 				{ translate( 'Choose the right plan for you' ) }
 			</h1>

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -1,4 +1,5 @@
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactNode } from 'react';
 
@@ -6,6 +7,12 @@ export type ComparisonTableProps = {
 	emailProviders: EmailProviderFeatures[];
 	intervalLength: IntervalLength;
 	selectedDomainName: string;
+};
+
+export type ComparisonTablePriceProps = {
+	domain: SiteDomain | undefined;
+	emailProviderSlug: string;
+	intervalLength: IntervalLength;
 };
 
 export type EmailProviderFeatures = {

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -1,0 +1,95 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
+} from '@automattic/calypso-products';
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
+import InfoPopover from 'calypso/components/info-popover';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
+import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
+import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
+import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison/price-with-interval';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+const getGoogleWorkspaceProductSlug = ( intervalLength: IntervalLength ): string => {
+	return intervalLength === IntervalLength.MONTHLY
+		? GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
+		: GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+};
+
+type GoogleWorkspacePriceProps = {
+	intervalLength: IntervalLength;
+};
+
+const GoogleWorkspacePrice = ( { intervalLength }: GoogleWorkspacePriceProps ): ReactElement => {
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+
+	const productSlug = getGoogleWorkspaceProductSlug( intervalLength );
+	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+
+	const productIsDiscounted = hasDiscount( product );
+
+	const standardPriceForIntervalLength = formatPrice( product?.cost ?? 0, currencyCode ?? '' );
+	const salePriceForIntervalLength = formatPrice( product?.sale_cost ?? 0, currencyCode ?? '' );
+
+	const discount = productIsDiscounted ? (
+		<div className="google-workspace-price__discount">
+			{ translate(
+				'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
+				{
+					args: {
+						discount: product?.sale_coupon?.discount,
+						discountedPrice: salePriceForIntervalLength,
+						standardPrice: standardPriceForIntervalLength,
+					},
+					comment:
+						"%(discount)d is a numeric percentage discount (e.g. '50'), " +
+						"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
+						"%(standardPrice)s is a formatted price (e.g. '$5')",
+					components: {
+						span: <span />,
+					},
+				}
+			) }
+
+			<InfoPopover position="right" showOnHover>
+				{ translate(
+					'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
+					{
+						args: {
+							googleMailService: getGoogleMailServiceFamily( productSlug ),
+						},
+						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+					}
+				) }
+			</InfoPopover>
+		</div>
+	) : null;
+
+	const priceWithInterval = (
+		<PriceWithInterval
+			cost={ product?.cost ?? 0 }
+			currencyCode={ currencyCode ?? '' }
+			hasDiscount={ productIsDiscounted }
+			intervalLength={ intervalLength }
+			sale={ product?.sale_cost ?? null }
+		/>
+	);
+
+	return (
+		<PriceBadge
+			additionalPriceInformationComponent={ discount }
+			priceComponent={ priceWithInterval }
+		/>
+	);
+};
+
+export default GoogleWorkspacePrice;

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { isDomainEligibleForTitanFreeTrial } from 'calypso/lib/titan';
+import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
+import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
+import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison/price-with-interval';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+const getTitanProductSlug = ( intervalLength: IntervalLength ): string => {
+	return intervalLength === IntervalLength.MONTHLY
+		? TITAN_MAIL_MONTHLY_SLUG
+		: TITAN_MAIL_YEARLY_SLUG;
+};
+
+type ProfessionalEmailPriceProps = {
+	domain: SiteDomain | undefined;
+	intervalLength: IntervalLength;
+};
+
+const ProfessionalEmailPrice = ( {
+	domain,
+	intervalLength,
+}: ProfessionalEmailPriceProps ): ReactElement => {
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+
+	const productSlug = getTitanProductSlug( intervalLength );
+	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+
+	const isEligibleForFreeTrial = isDomainEligibleForTitanFreeTrial( domain );
+
+	const priceWithInterval = (
+		<PriceWithInterval
+			cost={ product?.cost ?? 0 }
+			currencyCode={ currencyCode ?? '' }
+			hasDiscount={ isEligibleForFreeTrial }
+			intervalLength={ intervalLength }
+		/>
+	);
+
+	return (
+		<>
+			{ isEligibleForFreeTrial && (
+				<div className="professional-email-price__discount badge badge--info-green">
+					{ translate( '3 months free' ) }
+				</div>
+			) }
+
+			<PriceBadge priceComponent={ priceWithInterval } />
+		</>
+	);
+};
+
+export default ProfessionalEmailPrice;

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -1,0 +1,3 @@
+professional-email-price__discount.badge {
+	margin-bottom: 12px;
+}

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -1,3 +1,7 @@
+google-workspace-price__discount {
+	margin-bottom: 12px;
+}
+
 professional-email-price__discount.badge {
 	margin-bottom: 12px;
 }

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -1,7 +1,7 @@
-google-workspace-price__discount {
+.google-workspace-price__discount {
 	margin-bottom: 12px;
 }
 
-professional-email-price__discount.badge {
+.professional-email-price__discount {
 	margin-bottom: 12px;
 }

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -9,8 +9,6 @@ import { useSelector } from 'react-redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
-import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
-import InfoPopover from 'calypso/components/info-popover';
 import { canCurrentUserAddEmail, getSelectedDomain } from 'calypso/lib/domains';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
@@ -20,11 +18,9 @@ import {
 	GSuiteNewUser,
 	newUsers,
 } from 'calypso/lib/gsuite/new-users';
-import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
-import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
-import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison/price-with-interval';
+import GoogleWorkspacePrice from 'calypso/my-sites/email/email-providers-comparison/price/google-workspace';
 import EmailProvidersStackedCard from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card';
 import {
 	EmailProvidersStackedCardProps,
@@ -35,7 +31,6 @@ import {
 	recordTracksEventAddToCartClick,
 } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -90,7 +85,6 @@ const GoogleWorkspaceCard = ( {
 	googleWorkspace.detailsExpanded = detailsExpanded;
 
 	const hasCartDomain = Boolean( cartDomainName );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const selectedSite = useSelector( getSelectedSite );
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const domain = getSelectedDomain( {
@@ -110,67 +104,7 @@ const GoogleWorkspaceCard = ( {
 		)
 	);
 
-	const productIsDiscounted = hasDiscount( gSuiteProduct );
-
-	const priceWithInterval = (
-		<PriceWithInterval
-			cost={ gSuiteProduct?.cost ?? 0 }
-			currencyCode={ currencyCode ?? '' }
-			hasDiscount={ productIsDiscounted }
-			intervalLength={ intervalLength }
-			sale={ gSuiteProduct?.sale_cost ?? null }
-		/>
-	);
-
-	const standardPriceForIntervalLength = formatPrice(
-		gSuiteProduct?.cost ?? 0,
-		currencyCode ?? ''
-	);
-	const salePriceForIntervalLength = formatPrice(
-		gSuiteProduct?.sale_cost ?? 0,
-		currencyCode ?? ''
-	);
-
-	const discount = productIsDiscounted ? (
-		<div className="google-workspace-card__discount-with-renewal">
-			{ translate(
-				'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
-				{
-					args: {
-						discount: gSuiteProduct?.sale_coupon?.discount,
-						discountedPrice: salePriceForIntervalLength,
-						standardPrice: standardPriceForIntervalLength,
-					},
-					comment:
-						"%(discount)d is a numeric percentage discount (e.g. '50'), " +
-						"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
-						"%(standardPrice)s is a formatted price (e.g. '$5')",
-					components: {
-						span: <span />,
-					},
-				}
-			) }
-
-			<InfoPopover position="right" showOnHover>
-				{ translate(
-					'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
-					{
-						args: {
-							googleMailService: googleWorkspace.productName,
-						},
-						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-					}
-				) }
-			</InfoPopover>
-		</div>
-	) : null;
-
-	googleWorkspace.priceBadge = (
-		<PriceBadge
-			additionalPriceInformationComponent={ discount }
-			priceComponent={ priceWithInterval }
-		/>
-	);
+	googleWorkspace.priceBadge = <GoogleWorkspacePrice intervalLength={ intervalLength } />;
 
 	const [ googleUsers, setGoogleUsers ] = useState( newUsers( selectedDomainName ) );
 	const [ addingToCart, setAddingToCart ] = useState( false );

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
@@ -11,7 +11,3 @@
 		padding-right: 12px;
 	}
 }
-
-.professional-email-card__discount.badge {
-	margin-bottom: 12px;
-}

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -1,4 +1,3 @@
-import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { translate } from 'i18n-calypso';
@@ -15,7 +14,7 @@ import {
 	canCurrentUserAddEmail,
 	getCurrentUserCannotAddEmailReason,
 } from 'calypso/lib/domains';
-import { getTitanProductName, isDomainEligibleForTitanFreeTrial } from 'calypso/lib/titan';
+import { getTitanProductName } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import {
 	areAllMailboxesValid,
@@ -25,8 +24,7 @@ import {
 } from 'calypso/lib/titan/new-mailbox';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
-import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
-import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison/price-with-interval';
+import ProfessionalEmailPrice from 'calypso/my-sites/email/email-providers-comparison/price/professional-email';
 import EmailProvidersStackedCard from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card';
 import {
 	addToCartAndCheckout,
@@ -38,12 +36,9 @@ import {
 } from 'calypso/my-sites/email/titan-new-mailbox';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersStackedCardProps, ProviderCard } from './provider-card-props';
-import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { ReactElement } from 'react';
 
 import './professional-email-card.scss';
@@ -55,6 +50,7 @@ const logo = <Gridicon className="professional-email-card__logo" icon="my-sites"
 const badge = (
 	<img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan', { textOnly: true } ) } />
 );
+
 const getTitanFeatures = () => {
 	return [
 		translate( 'Inbox, calendars, and contacts' ),
@@ -87,26 +83,18 @@ const ProfessionalEmailCard = ( {
 	source,
 }: EmailProvidersStackedCardProps ): ReactElement => {
 	const hasCartDomain = Boolean( cartDomainName );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const selectedSite = useSelector( getSelectedSite );
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const domain = getSelectedDomain( {
 		domains,
 		selectedDomainName: selectedDomainName,
-	} ) as ResponseDomain;
+	} );
 
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
 
 	const professionalEmail: ProviderCard = { ...professionalEmailCardInformation };
 	professionalEmail.detailsExpanded = detailsExpanded;
-
-	const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
-
-	const titanMailSlug =
-		intervalLength === IntervalLength.MONTHLY ? TITAN_MAIL_MONTHLY_SLUG : TITAN_MAIL_YEARLY_SLUG;
-
-	const titanMailProduct = useSelector( ( state ) => getProductBySlug( state, titanMailSlug ) );
 
 	const [ titanMailbox, setTitanMailbox ] = useState( [
 		buildNewTitanMailbox( selectedDomainName, false ),
@@ -166,25 +154,9 @@ const ProfessionalEmailCard = ( {
 
 	const onTitanFormReturnKeyPress = noop;
 
-	const priceWithInterval = (
-		<PriceWithInterval
-			intervalLength={ intervalLength }
-			cost={ titanMailProduct?.cost ?? 0 }
-			currencyCode={ currencyCode ?? '' }
-			hasDiscount={ isEligibleForFreeTrial }
-		/>
-	);
-
 	professionalEmail.onExpandedChange = onExpandedChange;
 	professionalEmail.priceBadge = (
-		<>
-			{ isDomainEligibleForTitanFreeTrial( domain ) && (
-				<div className="professional-email-card__discount badge badge--info-green">
-					{ translate( '3 months free' ) }
-				</div>
-			) }
-			<PriceBadge priceComponent={ priceWithInterval } />
-		</>
+		<ProfessionalEmailPrice domain={ domain } intervalLength={ intervalLength } />
 	);
 
 	professionalEmail.formFields = (


### PR DESCRIPTION
This pull request adds monthly and yearly prices to the `In-Depth Comparison` page:

Monthly | Annually
------ | -----
<img width="623" alt="01" src="https://user-images.githubusercontent.com/594356/148992258-dc25fc5f-5ffb-46e6-b90e-bc4a34c568f4.png"> | <img width="623" alt="02" src="https://user-images.githubusercontent.com/594356/148992276-c6ac1ba4-c948-4583-8994-31ca9a3c9408.png">

This change is a follow-up of #59916, and involved extracting price components that are used by the `Email Comparison` page to a new place. I've also tweaked two specific parts of the code that I've mentioned as inline comments. The following are out-of-scope:

* Using an `Enum` for the email provider slugs
* Handling Google Workspace properly when monthly billing is selected
* Displaying things nicely 😉

#### Testing instructions

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout update/in-depth-comparison-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/59954#issuecomment-1010190882)
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Click the `See how they compare` link to access the `In-Depth Comparison` page
6. Assert that the page shows the right prices
7. Change the billing interval
8. Assert that the page shows the new prices
9. Reload the page
10. Assert that the page shows the right prices

You may also want to test with a sale coupon for Google Workspace.