### PR TITLE
Videos UI - Remove chapter accordion animations until data is fully loaded

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -30,6 +30,7 @@ const VideosUi = ( {
 	);
 
 	const [ selectedChapterIndex, setSelectedChapterIndex ] = useState( 0 );
+	const [ isPreloadAnimationState, setisPreloadAnimationState ] = useState( true );
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
 	const currentVideo = course?.videos?.[ currentVideoKey || 0 ];
@@ -59,6 +60,7 @@ const VideosUi = ( {
 
 		setCurrentVideoKey( initialVideoSlug );
 		setSelectedChapterIndex( videoSlugs.indexOf( initialVideoSlug ) );
+		setisPreloadAnimationState( false );
 	}, [ course, videoSlugs, completedVideoSlugs, currentVideoKey ] );
 
 	const isChapterSelected = ( idx ) => {
@@ -158,7 +160,10 @@ const VideosUi = ( {
 								return (
 									<div
 										key={ i }
-										className={ `${ isChapterSelected( i ) ? 'selected ' : '' }videos-ui__chapter` }
+										className={ classNames( 'videos-ui__chapter', {
+											selected: isChapterSelected( i ),
+											preload: isPreloadAnimationState,
+										} ) }
 									>
 										<button
 											type="button"

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -197,7 +197,7 @@
 					padding: 13px 20px;
 				}
 
-				.videos-ui__active-video-content {
+				&:not( .preload ) .videos-ui__active-video-content {
 					overflow: hidden;
 					max-height: 0;
 					transition: max-height 0.2s ease-out;
@@ -212,7 +212,7 @@
 					}
 				}
 
-				&.selected .videos-ui__active-video-content {
+				&.selected:not( .preload ) .videos-ui__active-video-content {
 					max-height: 250px;
 				}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR addresses concerns in https://github.com/Automattic/wp-calypso/issues/59729, which noted that the chapter accordion animations in the Videos UI struggled during the period when the UI is first loading. 
* In this PR, I add a `preload` state to the UI's classes which is removed once the `useEffect` which manages data loading runs to completion.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this diff to local Calypso.
* Load the Videos UI, both with no videos watched and some videos watched, and verify that the loading animations no longer jump around the screen during the loading process.

Before:

![accordion-animation-before](https://user-images.githubusercontent.com/13437011/148998023-4be573ed-c786-4f30-83d2-7de1cc37b008.gif)

After:

![accordion-animation-after](https://user-images.githubusercontent.com/13437011/148998920-6b757dfc-cb0e-46bd-b689-0750fac32725.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59729
