### PR TITLE
Happychat: Remove Lodash from chat reducer

### DIFF
--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,4 +1,4 @@
-import { findIndex, map, get, sortBy } from 'lodash';
+import { map, get, sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC,
@@ -113,7 +113,7 @@ const timelineReducer = ( state = [], action ) => {
 			const event = timelineEvent( {}, action );
 
 			// If the message already exists in the timeline, replace it
-			const idx = findIndex( state, ( { id } ) => event.id === id );
+			const idx = state.findIndex( ( { id } ) => event.id === id );
 			if ( idx >= 0 ) {
 				return [ ...state.slice( 0, idx ), event, ...state.slice( idx + 1 ) ];
 			}
@@ -122,7 +122,7 @@ const timelineReducer = ( state = [], action ) => {
 			return state.concat( [ event ] );
 		}
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE_UPDATE: {
-			const index = findIndex( state, ( { id } ) => action.message.id === id );
+			const index = state.findIndex( ( { id } ) => action.message.id === id );
 			return index === -1
 				? state
 				: [ ...state.slice( 0, index ), timelineEvent( {}, action ), ...state.slice( index + 1 ) ];

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,4 +1,4 @@
-import { map, get, sortBy } from 'lodash';
+import { get, sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC,
@@ -146,7 +146,7 @@ const timelineReducer = ( state = [], action ) => {
 				} ) ?? [];
 			return sortTimeline(
 				state.concat(
-					map( messages, ( message ) => ( {
+					messages.map( ( message ) => ( {
 						id: message.id,
 						source: message.source,
 						message: message.text,

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -52,7 +52,6 @@ export const lastActivityTimestamp = withSchemaValidation(
  * @param  {object} state  Current state
  * @param  {object} action Action payload
  * @returns {object}        Updated state
- *
  */
 export const status = ( state = HAPPYCHAT_CHAT_STATUS_DEFAULT, action ) => {
 	switch ( action.type ) {
@@ -68,7 +67,6 @@ export const status = ( state = HAPPYCHAT_CHAT_STATUS_DEFAULT, action ) => {
  * @param  {object} state  Current state
  * @param  {object} action Action payload
  * @returns {object}        Updated state
- *
  */
 const timelineEvent = ( state = {}, action ) => {
 	switch ( action.type ) {
@@ -103,7 +101,6 @@ const sortTimeline = ( timeline ) =>
  * @param  {object} state  Current state
  * @param  {object} action Action payload
  * @returns {object}        Updated state
- *
  */
 const timelineReducer = ( state = [], action ) => {
 	switch ( action.type ) {

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,4 +1,4 @@
-import { get, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC,
@@ -84,8 +84,8 @@ const timelineEvent = ( state = {}, action ) => {
 				files: message.files,
 				timestamp: maybeUpscaleTimePrecision( message.timestamp ),
 				user_id: message.user.id,
-				type: get( message, 'type', 'message' ),
-				links: get( message, 'meta.links' ),
+				type: message.type ?? 'message',
+				links: message.meta?.links,
 			};
 		}
 	}
@@ -107,7 +107,7 @@ const timelineReducer = ( state = [], action ) => {
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE:
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC: {
 			// if meta.forOperator is set, skip so won't show to user
-			if ( get( action, 'message.meta.forOperator', false ) ) {
+			if ( action.message.meta?.forOperator ?? false ) {
 				return state;
 			}
 			const event = timelineEvent( {}, action );
@@ -138,7 +138,7 @@ const timelineReducer = ( state = [], action ) => {
 					}
 
 					// if meta.forOperator is set, skip so won't show to user
-					if ( get( message, 'meta.forOperator', false ) ) {
+					if ( message.meta?.forOperator ?? false ) {
 						return false;
 					}
 
@@ -156,8 +156,8 @@ const timelineReducer = ( state = [], action ) => {
 						files: message.files,
 						timestamp: maybeUpscaleTimePrecision( message.timestamp ),
 						user_id: message.user.id,
-						type: get( message, 'type', 'message' ),
-						links: get( message, 'meta.links' ),
+						type: message.type ?? 'message',
+						links: message.meta?.links,
 					} ) )
 				)
 			);

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -142,7 +142,7 @@ const timelineReducer = ( state = [], action ) => {
 						return false;
 					}
 
-					return ! state.some( { id: message.id } );
+					return ! state.some( ( event ) => event.id === message.id );
 				} ) ?? [];
 			return sortTimeline(
 				state.concat(

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-case-declarations */
-
-import { concat, filter, find, findIndex, map, get, sortBy } from 'lodash';
+import { filter, find, findIndex, map, get, sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC,
@@ -123,7 +122,7 @@ const timelineReducer = ( state = [], action ) => {
 			}
 
 			// This is a new message — append it!
-			return concat( state, [ event ] );
+			return state.concat( [ event ] );
 
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE_UPDATE:
 			const index = findIndex( state, ( { id } ) => action.message.id === id );

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,4 +1,4 @@
-import { find, findIndex, map, get, sortBy } from 'lodash';
+import { findIndex, map, get, sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC,
@@ -142,7 +142,7 @@ const timelineReducer = ( state = [], action ) => {
 						return false;
 					}
 
-					return ! find( state, { id: message.id } );
+					return ! state.some( { id: message.id } );
 				} ) ?? [];
 			return sortTimeline(
 				state.concat(

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-case-declarations */
 import { filter, find, findIndex, map, get, sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
@@ -72,7 +71,7 @@ const timelineEvent = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE:
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC:
-		case HAPPYCHAT_IO_RECEIVE_MESSAGE_UPDATE:
+		case HAPPYCHAT_IO_RECEIVE_MESSAGE_UPDATE: {
 			const { message } = action;
 			return {
 				id: message.id,
@@ -88,6 +87,7 @@ const timelineEvent = ( state = {}, action ) => {
 				type: get( message, 'type', 'message' ),
 				links: get( message, 'meta.links' ),
 			};
+		}
 	}
 	return state;
 };
@@ -105,7 +105,7 @@ const sortTimeline = ( timeline ) =>
 const timelineReducer = ( state = [], action ) => {
 	switch ( action.type ) {
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE:
-		case HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC:
+		case HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC: {
 			// if meta.forOperator is set, skip so won't show to user
 			if ( get( action, 'message.meta.forOperator', false ) ) {
 				return state;
@@ -120,15 +120,17 @@ const timelineReducer = ( state = [], action ) => {
 
 			// This is a new message — append it!
 			return state.concat( [ event ] );
-
-		case HAPPYCHAT_IO_RECEIVE_MESSAGE_UPDATE:
+		}
+		case HAPPYCHAT_IO_RECEIVE_MESSAGE_UPDATE: {
 			const index = findIndex( state, ( { id } ) => action.message.id === id );
 			return index === -1
 				? state
 				: [ ...state.slice( 0, index ), timelineEvent( {}, action ), ...state.slice( index + 1 ) ];
-		case HAPPYCHAT_IO_REQUEST_TRANSCRIPT_TIMEOUT:
+		}
+		case HAPPYCHAT_IO_REQUEST_TRANSCRIPT_TIMEOUT: {
 			return state;
-		case HAPPYCHAT_IO_REQUEST_TRANSCRIPT_RECEIVE:
+		}
+		case HAPPYCHAT_IO_REQUEST_TRANSCRIPT_RECEIVE: {
 			const messages = filter( action.messages, ( message ) => {
 				if ( ! message.id ) {
 					return false;
@@ -158,6 +160,7 @@ const timelineReducer = ( state = [], action ) => {
 					} ) )
 				)
 			);
+		}
 	}
 	return state;
 };

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,4 +1,4 @@
-import { filter, find, findIndex, map, get, sortBy } from 'lodash';
+import { find, findIndex, map, get, sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC,
@@ -131,18 +131,19 @@ const timelineReducer = ( state = [], action ) => {
 			return state;
 		}
 		case HAPPYCHAT_IO_REQUEST_TRANSCRIPT_RECEIVE: {
-			const messages = filter( action.messages, ( message ) => {
-				if ( ! message.id ) {
-					return false;
-				}
+			const messages =
+				action.messages?.filter( ( message ) => {
+					if ( ! message.id ) {
+						return false;
+					}
 
-				// if meta.forOperator is set, skip so won't show to user
-				if ( get( message, 'meta.forOperator', false ) ) {
-					return false;
-				}
+					// if meta.forOperator is set, skip so won't show to user
+					if ( get( message, 'meta.forOperator', false ) ) {
+						return false;
+					}
 
-				return ! find( state, { id: message.id } );
-			} );
+					return ! find( state, { id: message.id } );
+				} ) ?? [];
 			return sortTimeline(
 				state.concat(
 					map( messages, ( message ) => ( {

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,4 +1,3 @@
-import { sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC,
@@ -92,8 +91,9 @@ const timelineEvent = ( state = {}, action ) => {
 	return state;
 };
 
-const sortTimeline = ( timeline ) =>
-	sortBy( timeline, ( event ) => parseInt( event.timestamp, 10 ) );
+const getEventTimestamp = ( event ) => parseInt( event.timestamp, 10 );
+const timelineSortCmp = ( a, b ) => getEventTimestamp( a ) - getEventTimestamp( b );
+const sortTimeline = ( timeline ) => timeline.concat().sort( timelineSortCmp );
 
 /**
  * Adds timeline events for happychat

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -93,7 +93,7 @@ const timelineEvent = ( state = {}, action ) => {
 
 const getEventTimestamp = ( event ) => parseInt( event.timestamp, 10 );
 const timelineSortCmp = ( a, b ) => getEventTimestamp( a ) - getEventTimestamp( b );
-const sortTimeline = ( timeline ) => timeline.concat().sort( timelineSortCmp );
+const sortTimeline = ( timeline ) => timeline.slice().sort( timelineSortCmp );
 
 /**
  * Adds timeline events for happychat
@@ -107,7 +107,7 @@ const timelineReducer = ( state = [], action ) => {
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE:
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE_OPTIMISTIC: {
 			// if meta.forOperator is set, skip so won't show to user
-			if ( action.message.meta?.forOperator ?? false ) {
+			if ( action.message.meta?.forOperator ) {
 				return state;
 			}
 			const event = timelineEvent( {}, action );
@@ -138,7 +138,7 @@ const timelineReducer = ( state = [], action ) => {
 					}
 
 					// if meta.forOperator is set, skip so won't show to user
-					if ( message.meta?.forOperator ?? false ) {
+					if ( message.meta?.forOperator ) {
 						return false;
 					}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the Lodash usage from the Happychat chat reducer, in favor of using native JavaScript.

This makes progress on 2 projects we're working on with @Automattic/team-calypso-frameworks: migration away from Lodash and reducing the bundle size when extracting inline help to a separate widget (ideally, we'll yield the best results when we remove all Lodash from inline help).

We also use the chance to fix some pre-existing suppressed ESLint errors and warnings.

#### Testing instructions

* Enable yourself as an agent with available chat slots in the Happychat staging HUD.
* Open the chat in Calypso.
* Test sending and receiving messages.
* Reload and verify the chat session persists.
* Smoke test happychat and verify everything still works well.
* Keep an eye in the console for errors
* Verify tests still pass (admittedly, they're a bit limited).