### PR TITLE
Design Picker: Expose Quadrat variations

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -122,6 +122,101 @@
 			"features": []
 		},
 		{
+			"title": "Quadrat Black",
+			"slug": "quadrat-black",
+			"template": "quadrat",
+			"theme": "quadrat-black",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Quadrat Black",
+			"slug": "quadrat-black",
+			"template": "quadrat",
+			"theme": "quadrat-black",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
+			"title": "Quadrat Green",
+			"slug": "quadrat-green",
+			"template": "quadrat",
+			"theme": "quadrat-green",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Quadrat Green",
+			"slug": "quadrat-green",
+			"template": "quadrat",
+			"theme": "quadrat-green",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
+			"title": "Quadrat Red",
+			"slug": "quadrat-red",
+			"template": "quadrat",
+			"theme": "quadrat-red",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Quadrat Red",
+			"slug": "quadrat-red",
+			"template": "quadrat",
+			"theme": "quadrat-red",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
+			"title": "Quadrat White",
+			"slug": "quadrat-white",
+			"template": "quadrat",
+			"theme": "quadrat-white",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Quadrat White",
+			"slug": "quadrat-white",
+			"template": "quadrat",
+			"theme": "quadrat-white",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
+			"title": "Quadrat Yellow",
+			"slug": "quadrat-yellow",
+			"template": "quadrat",
+			"theme": "quadrat-yellow",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Quadrat Yellow",
+			"slug": "quadrat-yellow",
+			"template": "quadrat",
+			"theme": "quadrat-yellow",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
 			"title": "Geologist",
 			"slug": "geologist",
 			"template": "geologist",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Quadrat color variation themes are now network activated in the themes showcase. We want to make them selectable themes in the onboarding design picker as well.

To do so, we add Quadrat color variants metadata to the `available-designs-config.json` file

![2022-01-11 13 08 05](https://user-images.githubusercontent.com/5414230/149021832-abd11a2c-72fb-4ba8-b51d-bfbdd9872e25.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Spin up a local dev environment for calypso
* Create a new site and enroll in the FSE beta
* Walk through each step until you arrive at the design picker
* Verify that Quadrat Black, Green, White, Yellow, and Red are selectable themes
* Create a new site with a Quadrat variant and verify that the styling, front page, and editor content match the look of the selected variant
* Create another new site and **do not** enroll in the FSE beta
* Walk through each step until you arrive at the design picker
* Verify that Quadrat Black, Green, White, Yellow, and Red are selectable themes
* Create a new site with a Quadrat variant and verify that the styling, front page, and editor content match the look of the selected variant

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to (Will create related issue in a bit)
