### PR TITLE
Add Transfer details to the domain settings page for incoming transfers

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -43,7 +43,7 @@
 			@include placeholder();
 		}
 
-		& .button {
+		& .button:not( .is-primary ) {
 			color: var( --studio-gray-80 );
 		}
 		& .button:not( :first-child ) {

--- a/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
@@ -24,6 +24,7 @@ const TransferredDomainDetails = ( {
 
 		return (
 			<Button
+				primary
 				href={ domainUseMyDomain(
 					selectedSite.slug,
 					domain.name,

--- a/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
@@ -42,12 +42,15 @@ const TransferredDomainDetails = ( {
 		if ( transferStatus.PENDING_START === domain.transferStatus ) {
 			return currentUserIsOwner
 				? translate(
-						'We need you to complete a couple of steps before we can transfer %(domain)s from your ' +
+						'We need you to complete a couple of steps before we can transfer {{strong}}%(domain)s{{/strong}} from your ' +
 							'current domain provider to WordPress.com. Your domain will stay at your current provider ' +
 							'until the transfer is completed.',
 						{
 							args: {
 								domain: name,
+							},
+							components: {
+								strong: <strong />,
 							},
 						}
 				  )

--- a/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
@@ -18,7 +18,7 @@ const TransferredDomainDetails = ( {
 	const translate = useTranslate();
 
 	const renderStartTransferButton = () => {
-		if ( ! domain.currentUserIsOwner ) {
+		if ( ! domain.currentUserIsOwner || transferStatus.PENDING_START !== domain.transferStatus ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
@@ -1,0 +1,114 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
+import { transferStatus } from 'calypso/lib/domains/constants';
+import { INCOMING_DOMAIN_TRANSFER_STATUSES } from 'calypso/lib/url/support';
+import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import type { DetailsCardProps } from './types';
+
+import './style.scss';
+
+const TransferredDomainDetails = ( {
+	domain,
+	isLoadingPurchase,
+	selectedSite,
+}: DetailsCardProps ): JSX.Element => {
+	const translate = useTranslate();
+
+	const renderStartTransferButton = () => {
+		if ( ! domain.currentUserIsOwner ) {
+			return null;
+		}
+
+		return (
+			<Button
+				href={ domainUseMyDomain(
+					selectedSite.slug,
+					domain.name,
+					useMyDomainInputMode.startPendingTransfer
+				) }
+				disabled={ isLoadingPurchase }
+			>
+				{ translate( 'Start transfer' ) }
+			</Button>
+		);
+	};
+
+	const getDescriptionText = () => {
+		const { currentUserIsOwner, name, owner } = domain;
+		if ( transferStatus.PENDING_START === domain.transferStatus ) {
+			return currentUserIsOwner
+				? translate(
+						'We need you to complete a couple of steps before we can transfer %(domain)s from your ' +
+							'current domain provider to WordPress.com. Your domain will stay at your current provider ' +
+							'until the transfer is completed.',
+						{
+							args: {
+								domain: name,
+							},
+						}
+				  )
+				: translate(
+						'This domain transfer is waiting to be initiated. Please contact the domain owner, {{strong}}%(owner)s{{/strong}}, to start it.',
+						{
+							args: {
+								owner,
+							},
+							components: {
+								strong: <strong />,
+							},
+						}
+				  );
+		} else if ( transferStatus.CANCELLED === domain.transferStatus ) {
+			return currentUserIsOwner
+				? translate(
+						'We were unable to complete the transfer of {{strong}}%(domain)s{{/strong}}. ' +
+							'You can remove the transfer from your account or try to start the transfer again. ' +
+							'{{a}}Learn more{{/a}}',
+						{
+							args: {
+								domain: name,
+							},
+							components: {
+								strong: <strong />,
+								a: (
+									<a
+										href={ INCOMING_DOMAIN_TRANSFER_STATUSES }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+				  )
+				: translate(
+						'The domain transfer failed to complete. Please contact the domain owner, {{strong}}%(owner)s{{/strong}}, to restart it.',
+						{
+							args: {
+								owner,
+							},
+							components: {
+								strong: <strong />,
+							},
+						}
+				  );
+		}
+
+		return translate(
+			'Your transfer has been started and is waiting for authorization from your current ' +
+				'domain provider. This process can take up to 7 days. If you need to cancel or expedite the ' +
+				'transfer please contact them for assistance.'
+		);
+	};
+
+	return (
+		<div className="details-card">
+			<div className="details-card__section">{ getDescriptionText() }</div>
+			<div className="details-card__section">{ renderStartTransferButton() }</div>
+		</div>
+	);
+};
+
+export default TransferredDomainDetails;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -38,6 +38,7 @@ import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-in
 import DomainSecurityDetails from './cards/domain-security-details';
 import NameServersCard from './cards/name-servers-card';
 import RegisteredDomainDetails from './cards/registered-domain-details';
+import TransferredDomainDetails from './cards/transferred-domain-details';
 import DnsRecords from './dns';
 import { getSslReadableStatus, isSecuredWithUs } from './helpers';
 import SetAsPrimary from './set-as-primary';
@@ -135,6 +136,22 @@ const Settings = ( {
 					expanded
 				>
 					<ConnectedDomainDetails
+						domain={ domain }
+						selectedSite={ selectedSite }
+						purchase={ purchase }
+						isLoadingPurchase={ isLoadingPurchase }
+					/>
+				</Accordion>
+			);
+		} else if ( domain.type === domainTypes.TRANSFER ) {
+			return (
+				<Accordion
+					title={ translate( 'Action required', { textOnly: true } ) }
+					subtitle={ translate( 'Start transfer', { textOnly: true } ) }
+					key="main"
+					expanded
+				>
+					<TransferredDomainDetails
 						domain={ domain }
 						selectedSite={ selectedSite }
 						purchase={ purchase }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -146,8 +146,8 @@ const Settings = ( {
 		} else if ( domain.type === domainTypes.TRANSFER ) {
 			return (
 				<Accordion
-					title={ translate( 'Action required', { textOnly: true } ) }
-					subtitle={ translate( 'Start transfer', { textOnly: true } ) }
+					title={ translate( 'Details', { textOnly: true } ) }
+					subtitle={ translate( 'Transfer details', { textOnly: true } ) }
 					key="main"
 					expanded
 				>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds the transfer current details for an incoming transfer - also enabling the user to start a transfer.
This is part of the domain settings pages redesign project detailed in pcYYhz-m2-p2.

#### Preview

##### Pending start - not owner
<img src="https://user-images.githubusercontent.com/18705930/149018932-c4737fae-76be-4ae1-b7fc-e1b9aa8e170a.png" width=400/>

##### Pending start - owner
<img src="https://user-images.githubusercontent.com/18705930/149018969-88904401-bc76-4bcc-97ea-95e47a3a97df.png" width=400/>

##### In progress
<img src="https://user-images.githubusercontent.com/18705930/149019045-622bef6c-0d13-454b-9cd5-0edfc8b06008.png" width=400/>

##### Failed - not owner
<img src="https://user-images.githubusercontent.com/18705930/149019101-c6b5424d-bebd-4ab5-b95f-2de6e4e2cfce.png" width=400/>

##### Failed - owner
<img src="https://user-images.githubusercontent.com/18705930/149019130-f217f9d4-c294-4800-8253-8e312372c407.png" width=400/>

#### Testing instructions
- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag;
- Go to "Upgrades > Domains";
- Select any domain transfer not yet completed (inbound);
- Confirm that:
  - If the transfer is pending start:
    - If you are the domain owner, you should see the "Start Transfer" button as in the screenshot.
    - If you're not the owner, then you should only see a message referring to the domain's owner.
  - If the transfer was canceled: 
    - If you are the domain owner, you should see the message describing the possible steps.
    - If you're not the owner, then you should only see a message referring to the domain's owner.
  - If the transfer is ongoing, then you should see the same message as in the screenshot.