### PR TITLE
Enable signup/hero-flow-non-en in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,6 +90,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
+		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": false,
 		"site-indicator": true,
 		"support-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -94,6 +94,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
+		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": false,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,6 +96,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
+		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": false,
 		"site-indicator": true,
 		"support-user": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change will enable the Hero Flow for non-English users.

* Enable the existing `signup/hero-flow-non-en` flag in production environments

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This won't really be testable until it lands on staging. Once on staging I'll test the signup flow using English and non-English users before deploying to produciton.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58859
