### PR TITLE
Design Picker: Expose Geologist variations

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -141,6 +141,82 @@
 			"features": []
 		},
 		{
+			"title": "Geologist Blue",
+			"slug": "geologist-blue",
+			"template": "geologist",
+			"theme": "geologist-blue",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Geologist Blue",
+			"slug": "geologist-blue",
+			"template": "geologist",
+			"theme": "geologist-blue",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
+			"title": "Geologist Cream",
+			"slug": "geologist-cream",
+			"template": "geologist",
+			"theme": "geologist-cream",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Geologist Cream",
+			"slug": "geologist-cream",
+			"template": "geologist",
+			"theme": "geologist-cream",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
+			"title": "Geologist Slate",
+			"slug": "geologist-slate",
+			"template": "geologist",
+			"theme": "geologist-slate",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Geologist Slate",
+			"slug": "geologist-slate",
+			"template": "geologist",
+			"theme": "geologist-slate",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
+			"title": "Geologist Yellow",
+			"slug": "geologist-yellow",
+			"template": "geologist",
+			"theme": "geologist-yellow",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Geologist Yellow",
+			"slug": "geologist-yellow",
+			"template": "geologist",
+			"theme": "geologist-yellow",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"features": []
+		},
+		{
 			"title": "Zoologist",
 			"slug": "zoologist",
 			"template": "zoologist",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Geologist color variation themes are now network activated in the themes showcase. We want to make them selectable themes in the onboarding design picker as well.

To do so, we add Geologist color variants metadata to the `available-designs-config.json` file

![2022-01-11 13 45 38](https://user-images.githubusercontent.com/5414230/149026758-eded7116-111b-4c25-ba41-c47b20423b73.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Spin up a local dev environment for calypso
* Create a new site and enroll in the FSE beta
* Walk through each step until you arrive at the design picker
* Verify that Geologist Blue, Cream, Slate, and Yellow are selectable themes
* Create a new site with a Geologist variant and verify that the styling, front page, and editor content match the look of the selected variant
* Create another new site and **do not** enroll in the FSE beta
* Walk through each step until you arrive at the design picker
* Verify that Geologist Blue, Cream, Slate, and Yellow are selectable themes
* Create a new site with a Geologist variant and verify that the styling, front page, and editor content match the look of the selected variant

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to (Will create related issue in a bit)
