### PR TITLE
Woo installer: Add email field to address step

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
@@ -25,9 +25,7 @@ type optionNameType =
 	| typeof WOOCOMMERCE_STORE_POSTCODE
 	| typeof WOOCOMMERCE_ONBOARDING_PROFILE;
 
-type OptionObjectType = Record< string, unknown >;
-
-type OptionValueType = string | number | Array< string | number > | OptionObjectType | undefined;
+type OptionValueType = Record< string, unknown > | string;
 
 /**
  * Simple react custom hook to deal with site settings.
@@ -56,12 +54,12 @@ export function useSiteSettings( siteId: number ) {
 	}, [ dispatch, siteId ] );
 
 	// Simple getter helper.
-	function get( option: optionNameType ): OptionValueType {
+	function get( option: optionNameType ) {
 		if ( ! settings || Object.keys( settings ).length === 0 ) {
 			return '';
 		}
 
-		return settings[ option ];
+		return settings[ option ] || '';
 	}
 
 	/*

--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
@@ -25,6 +25,10 @@ type optionNameType =
 	| typeof WOOCOMMERCE_STORE_POSTCODE
 	| typeof WOOCOMMERCE_ONBOARDING_PROFILE;
 
+type OptionObjectType = Record< string, unknown >;
+
+type OptionValueType = string | number | Array< string | number > | OptionObjectType | undefined;
+
 /**
  * Simple react custom hook to deal with site settings.
  *
@@ -52,12 +56,12 @@ export function useSiteSettings( siteId: number ) {
 	}, [ dispatch, siteId ] );
 
 	// Simple getter helper.
-	function get( option: optionNameType ) {
+	function get( option: optionNameType ): OptionValueType {
 		if ( ! settings || Object.keys( settings ).length === 0 ) {
 			return '';
 		}
 
-		return settings[ option ] || '';
+		return settings[ option ];
 	}
 
 	/*
@@ -65,7 +69,7 @@ export function useSiteSettings( siteId: number ) {
 	 * Changes are applied to the Redux store.
 	 */
 	const update = useCallback(
-		( option: optionNameType, value: string ) => {
+		( option: optionNameType, value: OptionValueType ) => {
 			setEditedSettings( ( state ) => uniqueBy( [ ...state, option ] ) );
 
 			// Store the edited option in the private store.

--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
@@ -14,6 +14,7 @@ export const WOOCOMMERCE_STORE_ADDRESS_2 = 'woocommerce_store_address_2';
 export const WOOCOMMERCE_STORE_CITY = 'woocommerce_store_city';
 export const WOOCOMMERCE_DEFAULT_COUNTRY = 'woocommerce_default_country';
 export const WOOCOMMERCE_STORE_POSTCODE = 'woocommerce_store_postcode';
+export const WOOCOMMERCE_ONBOARDING_PROFILE = 'woocommerce_onboarding_profile';
 
 type optionNameType =
 	| 'blog_public'
@@ -21,7 +22,8 @@ type optionNameType =
 	| typeof WOOCOMMERCE_STORE_ADDRESS_2
 	| typeof WOOCOMMERCE_STORE_CITY
 	| typeof WOOCOMMERCE_DEFAULT_COUNTRY
-	| typeof WOOCOMMERCE_STORE_POSTCODE;
+	| typeof WOOCOMMERCE_STORE_POSTCODE
+	| typeof WOOCOMMERCE_ONBOARDING_PROFILE;
 
 /**
  * Simple react custom hook to deal with site settings.

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -57,17 +57,20 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 
 	// @todo: Add a general hook to get and update multi-option data like the profile.
 	function updateProfileEmail( email: string ) {
-		const profile_data = get( WOOCOMMERCE_ONBOARDING_PROFILE ) || {};
+		const onboardingProfile = get( WOOCOMMERCE_ONBOARDING_PROFILE ) || {};
 
-		profile_data[ 'store_email' ] = email;
+		const updatedOnboardingProfile = {
+			...onboardingProfile,
+			store_email: email,
+		};
 
-		update( WOOCOMMERCE_ONBOARDING_PROFILE, profile_data );
+		update( WOOCOMMERCE_ONBOARDING_PROFILE, updatedOnboardingProfile );
 	}
 
 	function getProfileEmail() {
-		const profile_data = get( WOOCOMMERCE_ONBOARDING_PROFILE ) || {};
+		const onboardingProfile = get( WOOCOMMERCE_ONBOARDING_PROFILE );
 
-		return profile_data[ 'store_email' ] || '';
+		return onboardingProfile[ 'store_email' ] || '';
 	}
 
 	function getContent() {

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -67,7 +67,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	function getProfileEmail() {
 		const profile_data = get( WOOCOMMERCE_ONBOARDING_PROFILE ) || {};
 
-		return profile_data['store_email'] || '';
+		return profile_data[ 'store_email' ] || '';
 	}
 
 	function getContent() {
@@ -109,7 +109,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 					</CityZipRow>
 
 					<TextControl
-						label={ __( 'Email address', 'woocommerce-admin' ) }
+						label={ __( 'Email address' ) }
 						value={ getProfileEmail() }
 						onChange={ updateProfileEmail }
 					/>

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -67,9 +67,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	function getProfileEmail() {
 		const profile_data = get( WOOCOMMERCE_ONBOARDING_PROFILE ) || {};
 
-		const storeEmail = profile_data[ 'store_email' ];
-
-		return storeEmail || '';
+		return profile_data['store_email'] || '';
 	}
 
 	function getContent() {

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -111,7 +111,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 					<TextControl
 						label={ __( 'Email address', 'woocommerce-admin' ) }
 						value={ getProfileEmail() }
-						onChange={ ( value ) => updateProfileEmail( value ) }
+						onChange={ updateProfileEmail }
 					/>
 
 					<ActionSection>

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -18,6 +18,7 @@ import {
 	WOOCOMMERCE_STORE_CITY,
 	WOOCOMMERCE_DEFAULT_COUNTRY,
 	WOOCOMMERCE_STORE_POSTCODE,
+	WOOCOMMERCE_ONBOARDING_PROFILE,
 } from '../hooks/use-site-settings';
 import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '..';
@@ -53,6 +54,23 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	const handleCountryChange: ChangeEventHandler< HTMLInputElement > = ( event ) => {
 		update( WOOCOMMERCE_DEFAULT_COUNTRY, event.target.value );
 	};
+
+	// @todo: Add a general hook to get and update multi-option data like the profile.
+	function updateProfileEmail( email: string ) {
+		const profile_data = get( WOOCOMMERCE_ONBOARDING_PROFILE ) || {};
+
+		profile_data[ 'store_email' ] = email;
+
+		update( WOOCOMMERCE_ONBOARDING_PROFILE, profile_data );
+	}
+
+	function getProfileEmail() {
+		const profile_data = get( WOOCOMMERCE_ONBOARDING_PROFILE ) || {};
+
+		const storeEmail = profile_data[ 'store_email' ];
+
+		return storeEmail || '';
+	}
 
 	function getContent() {
 		return (
@@ -91,6 +109,12 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 							onChange={ ( value ) => update( WOOCOMMERCE_STORE_POSTCODE, value ) }
 						/>
 					</CityZipRow>
+
+					<TextControl
+						label={ __( 'Email address', 'woocommerce-admin' ) }
+						value={ getProfileEmail() }
+						onChange={ ( value ) => updateProfileEmail( value ) }
+					/>
 
 					<ActionSection>
 						<SupportCard />

--- a/client/state/site-settings/selectors.js
+++ b/client/state/site-settings/selectors.js
@@ -43,6 +43,7 @@ export function getSiteSettingsSaveRequestStatus( state, siteId ) {
  woocommerce_store_city?: string;
  woocommerce_store_postcode?: string;
  woocommerce_default_country?: string;
+ woocommerce_onboarding_profile?: string;
  }} SiteSettingsItem
  */
 

--- a/client/state/site-settings/selectors.js
+++ b/client/state/site-settings/selectors.js
@@ -43,7 +43,7 @@ export function getSiteSettingsSaveRequestStatus( state, siteId ) {
  woocommerce_store_city?: string;
  woocommerce_store_postcode?: string;
  woocommerce_default_country?: string;
- woocommerce_onboarding_profile?: string;
+ woocommerce_onboarding_profile?: array;
  }} SiteSettingsItem
  */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an email address field and pre-fill and update it.

<img width="473" alt="Screen Shot 2022-01-11 at 5 24 24 PM" src="https://user-images.githubusercontent.com/1689238/149031416-a3501133-a347-4111-b8a1-b3ec84195a03.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply https://href.li/?D72639-code and sandbox the API.
* Go to the address step: `http://calypso.localhost:3000/start/woocommerce-install/store-address?site=<siteId>`
* Your customer email address should be pre-filled.
* Enter an email address.
* Click continue and check that the network request to the `settings` API includes the email in the update to settings.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/57423