### PR TITLE
Playwright: miscellaneous bugfixes to the framework.

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -96,7 +96,7 @@ export async function reloadAndRetry(
 ): Promise< void > {
 	for ( let retries = 3; retries > 0; retries -= 1 ) {
 		try {
-			await func( page );
+			return await func( page );
 		} catch ( err ) {
 			// Throw the error if final retry failed.
 			if ( retries === 1 ) {

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -451,7 +451,7 @@ export class GutenbergEditorPage {
 		const frame = await this.getEditorFrame();
 
 		await Promise.all( [
-			this.page.waitForNavigation( { url } ),
+			this.page.waitForNavigation( { url: url, waitUntil: 'domcontentloaded' } ),
 			frame.click( selectors.viewButton ),
 		] );
 

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -470,7 +470,7 @@ export class GutenbergEditorPage {
 		 * @param page
 		 */
 		async function confirmPostShown( page: Page ): Promise< void > {
-			await page.waitForSelector( '.entry-content', { timeout: 5 * 1000 } );
+			await page.waitForSelector( '.entry-content', { timeout: 15 * 1000 } );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR incorporates fixes for two permanently failing tests on WPCOM Gutenberg - #59927 and #59929.

Key changes:
- when visiting published page, only wait for `domcontentloaded`.
- in `ElementHelper`, change the statement within try block to `return await` in order to execute only once if successful.
- extend timeout for `confirmPostShown` closure.
- adjust element state for inserted block to `attached`to support behavior change of Cover block.

#### Testing instructions

Ensure that following suites do not produce failures for `mobile` and `desktop` variants respectively:
- [x] Cover styles
- [x] Gutter controls

One remaining failure for Block Widgets is addressed in a separate PR https://github.com/Automattic/wp-calypso/pull/59959.

Related to https://github.com/Automattic/wp-calypso/pull/59959.
Closes #59927, #59929.