### PR TITLE
Importing: Address some RTL bugs in the importer signup flow

### DIFF
--- a/client/signup/steps/import/capture/index.tsx
+++ b/client/signup/steps/import/capture/index.tsx
@@ -122,6 +122,7 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 								placeholder={ __( 'Enter your site address' ) }
 								onChange={ onInputChange }
 								value={ urlValue }
+								dir="ltr"
 							/>
 							{ showSubmitButton && (
 								<NextButton type={ 'submit' }>

--- a/client/signup/steps/import/capture/index.tsx
+++ b/client/signup/steps/import/capture/index.tsx
@@ -1,5 +1,5 @@
 import { NextButton } from '@automattic/onboarding';
-import { Icon, chevronRight } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React, { useEffect, useState } from 'react';
@@ -38,7 +38,7 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 	analyzerError,
 	recordTracksEvent,
 } ) => {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 
 	/**
 	 ↓ Fields
@@ -125,7 +125,7 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 							/>
 							{ showSubmitButton && (
 								<NextButton type={ 'submit' }>
-									<Icon icon={ chevronRight } />
+									<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 								</NextButton>
 							) }
 							{ ( ! isValid && showError ) ||

--- a/client/signup/steps/import/ready/preview.tsx
+++ b/client/signup/steps/import/ready/preview.tsx
@@ -71,7 +71,7 @@ const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
 						<div role="presentation" className="import__preview-bar-dot" />
 						{ websiteMatch && (
 							<div className="import__preview-url-field">
-								<div>
+								<div dir="ltr">
 									<span>{ websiteMatch?.groups?.protocol }</span>
 									{ websiteMatch?.groups?.address }
 								</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're working on making the Hero Flow available to all languages (#58859), and since the Importer flow is exposed in the Hero Flow, it means other languages will start to see it. This PR address a few issues I saw in some simple smoke testing.

FYI @vishnugopal 

* **Flip icon in RTL lanauges**
  <img width="1325" alt="Screenshot 2022-01-12 at 2 19 15 PM" src="https://user-images.githubusercontent.com/1500769/149055964-51ce107a-8754-43c9-a0aa-242b200e4751.png">
  The icon on the blue "next" button should point to the left for RTL languages like Hebrew. Notice how the "back" button icon is pointing to the right in the screenshot rather than to the left as it does in English.
  The a8c specific `<GridIcon>` component usually the flipping automatically, however this flow is using the `@wordpress/icons` package. In an effort to stick with GB components (and since I seem to remember we're moving away from gridicons) I'm switching icons based on the `isRTL()` function. This is the pattern I observed when searching the GB codebase.

* **Make it easier to enter domain names in RTL languages**
  Typing in the site address field feels weird and janky in RTL languages. By telling the DOM that the input field will only be used to enter LTR style values (domains are always LTR) it fixes the experience. We an example of prior art, the same `dir="ltr"` attribute is used in the domain search field in the main signup flow.

* **Fix trailing slash in import preview in RTL languages**
  <img width="1251" alt="Screenshot 2022-01-12 at 4 16 28 PM" src="https://user-images.githubusercontent.com/1500769/149057831-4cff760c-57cb-4835-ac72-ccd983595826.png">
  The trailing slash that usually appears at the end of the URL in the faux-browser of the preview step, appears at the beginning of the URL in RTL languages. Using the same `dir="ltr"` attribute here informs the browser to lay things out in the correct way for URLs.
  Another fix would be to perhaps remove the trailing slash? I see the step uses a regex to pull apart and assemble this URL for presenting in the faux-browser address bar. Using the built-in `URL` class we could parse the individual components of the URL and not show any "path" component.

* ~~Switch the domain capture input's placeholder to use an existing translation~~
  A previous version of this PR also changed the placeholder text for the domain input field, however the translation has since been fixed so we don't need to change it anymore. p1642000891051800/1641952802.043500-slack-CRWCHQGUB

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using `localhost.calypso:3000` so that Hero Flow will be enabled for non-en
* To enter the import flow, click the link at the bottom of the intent step of the Hero Flow
* Test the features described above

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58859