### PR TITLE
Add form validation to the woo installer address step

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
@@ -16,7 +16,7 @@ export const WOOCOMMERCE_DEFAULT_COUNTRY = 'woocommerce_default_country';
 export const WOOCOMMERCE_STORE_POSTCODE = 'woocommerce_store_postcode';
 export const WOOCOMMERCE_ONBOARDING_PROFILE = 'woocommerce_onboarding_profile';
 
-type optionNameType =
+export type optionNameType =
 	| 'blog_public'
 	| typeof WOOCOMMERCE_STORE_ADDRESS_1
 	| typeof WOOCOMMERCE_STORE_ADDRESS_2

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -220,22 +220,22 @@ function useAddressFormValidation( siteId: number ) {
 
 	const validate = () => {
 		errors[ WOOCOMMERCE_STORE_ADDRESS_1 ] = ! get( WOOCOMMERCE_STORE_ADDRESS_1 )
-			? __( 'Address line is required.' )
+			? __( 'Please add an address' )
 			: '';
 		errors[ WOOCOMMERCE_STORE_ADDRESS_2 ] = ''; // Optional field
 		errors[ WOOCOMMERCE_DEFAULT_COUNTRY ] = ! get( WOOCOMMERCE_DEFAULT_COUNTRY )
-			? __( 'Country / Region is required.' )
+			? __( 'Please select a country / region' )
 			: '';
 		errors[ WOOCOMMERCE_STORE_CITY ] = ! get( WOOCOMMERCE_STORE_CITY )
-			? __( 'City is required.' )
+			? __( 'Please add a city' )
 			: '';
 		errors[ WOOCOMMERCE_STORE_POSTCODE ] = ! get( WOOCOMMERCE_STORE_POSTCODE )
-			? __( 'Postcode is required.' )
+			? __( 'Please add a postcode' )
 			: '';
-		errors[ WOOCOMMERCE_ONBOARDING_PROFILE ] = ! get( WOOCOMMERCE_ONBOARDING_PROFILE )[
+		errors[ WOOCOMMERCE_ONBOARDING_PROFILE ] = ! get( WOOCOMMERCE_ONBOARDING_PROFILE )?.[
 			'store_email'
 		]
-			? __( 'Email address is required.' )
+			? __( 'A valid email address is required' )
 			: '';
 
 		setErrors( errors );

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -114,17 +114,6 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 					/>
 					<ControlError error={ address2Error } />
 
-					<ComboboxControl
-						label={ __( 'Country / Region' ) }
-						value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) }
-						onChange={ ( value: string | null ) => {
-							update( WOOCOMMERCE_DEFAULT_COUNTRY, value || '' );
-							clearError( WOOCOMMERCE_DEFAULT_COUNTRY );
-						} }
-						options={ countriesAsOptions }
-					/>
-					<ControlError error={ countryError } />
-
 					<CityZipRow>
 						<div>
 							<TextControl
@@ -150,6 +139,17 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 							<ControlError error={ postcodeError } />
 						</div>
 					</CityZipRow>
+
+					<ComboboxControl
+						label={ __( 'Country / Region' ) }
+						value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) }
+						onChange={ ( value: string | null ) => {
+							update( WOOCOMMERCE_DEFAULT_COUNTRY, value || '' );
+							clearError( WOOCOMMERCE_DEFAULT_COUNTRY );
+						} }
+						options={ countriesAsOptions }
+					/>
+					<ControlError error={ countryError } />
 
 					<TextControl
 						label={ __( 'Email address' ) }

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -82,9 +82,11 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	const cityError = getError( WOOCOMMERCE_STORE_CITY );
 	const postcodeError = getError( WOOCOMMERCE_STORE_POSTCODE );
 	const emailError = getError( WOOCOMMERCE_ONBOARDING_PROFILE );
+
+	const [ submitted, setSubmitted ] = useState( 0 );
 	useEffect( () => {
 		return;
-	}, [ address1Error, address2Error, countryError, cityError, postcodeError, emailError ] );
+	}, [ submitted ] );
 
 	function getContent() {
 		return (
@@ -163,6 +165,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 						<SupportCard />
 						<StyledNextButton
 							onClick={ () => {
+								setSubmitted( submitted + 1 );
 								if ( validate() ) {
 									save();
 									goToStep( 'confirm' );

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -116,7 +116,6 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 					<ComboboxControl
 						label={ __( 'Country / Region' ) }
 						value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) }
-						allowReset={ false }
 						onChange={ ( value: string | null ) => {
 							update( WOOCOMMERCE_DEFAULT_COUNTRY, value || '' );
 							clearError( WOOCOMMERCE_DEFAULT_COUNTRY );

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -238,7 +238,7 @@ function useAddressFormValidation( siteId: number ) {
 		errors[ WOOCOMMERCE_ONBOARDING_PROFILE ] = ! emailValidator.validate(
 			get( WOOCOMMERCE_ONBOARDING_PROFILE )?.[ 'store_email' ]
 		)
-			? __( 'A valid email address is required' )
+			? __( 'Please add a store email' )
 			: '';
 
 		setErrors( errors );

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -75,6 +75,16 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 		return onboardingProfile[ 'store_email' ] || '';
 	}
 
+	// Form validation.
+	const address1Error = getError( WOOCOMMERCE_STORE_ADDRESS_1 );
+	const address2Error = getError( WOOCOMMERCE_STORE_ADDRESS_2 );
+	const countryError = getError( WOOCOMMERCE_DEFAULT_COUNTRY );
+	const cityError = getError( WOOCOMMERCE_STORE_CITY );
+	const postcodeError = getError( WOOCOMMERCE_STORE_POSTCODE );
+	useEffect( () => {
+		return;
+	}, [ address1Error, address2Error, countryError, cityError, postcodeError ] );
+
 	function getContent() {
 		return (
 			<>
@@ -88,7 +98,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 							clearError( WOOCOMMERCE_STORE_ADDRESS_1 );
 						} }
 					/>
-					<ControlError error={ getError( WOOCOMMERCE_STORE_ADDRESS_1 ) } />
+					<ControlError error={ address1Error } />
 
 					<TextControl
 						label={ __( 'Address line 2' ) }
@@ -98,7 +108,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 							clearError( WOOCOMMERCE_STORE_ADDRESS_2 );
 						} }
 					/>
-					<ControlError error={ getError( WOOCOMMERCE_STORE_ADDRESS_2 ) } />
+					<ControlError error={ address2Error } />
 
 					<ComboboxControl
 						label={ __( 'Country / Region' ) }
@@ -110,7 +120,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 						} }
 						options={ countriesAsOptions }
 					/>
-					<ControlError error={ getError( WOOCOMMERCE_DEFAULT_COUNTRY ) } />
+					<ControlError error={ countryError } />
 
 					<CityZipRow>
 						<div>
@@ -122,7 +132,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 									clearError( WOOCOMMERCE_STORE_CITY );
 								} }
 							/>
-							<ControlError error={ getError( WOOCOMMERCE_STORE_CITY ) } />
+							<ControlError error={ cityError } />
 						</div>
 
 						<div>
@@ -134,7 +144,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 									clearError( WOOCOMMERCE_STORE_POSTCODE );
 								} }
 							/>
-							<ControlError error={ getError( WOOCOMMERCE_STORE_POSTCODE ) } />
+							<ControlError error={ postcodeError } />
 						</div>
 					</CityZipRow>
 

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -141,7 +141,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 					</CityZipRow>
 
 					<ComboboxControl
-						label={ __( 'Country / Region' ) }
+						label={ __( 'Country / State' ) }
 						value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) }
 						onChange={ ( value: string | null ) => {
 							update( WOOCOMMERCE_DEFAULT_COUNTRY, value || '' );

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { TextControl, ComboboxControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import emailValidator from 'email-validator';
 import { ReactElement, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
@@ -234,9 +235,9 @@ function useAddressFormValidation( siteId: number ) {
 		errors[ WOOCOMMERCE_STORE_POSTCODE ] = ! get( WOOCOMMERCE_STORE_POSTCODE )
 			? __( 'Please add a postcode' )
 			: '';
-		errors[ WOOCOMMERCE_ONBOARDING_PROFILE ] = ! get( WOOCOMMERCE_ONBOARDING_PROFILE )?.[
-			'store_email'
-		]
+		errors[ WOOCOMMERCE_ONBOARDING_PROFILE ] = ! emailValidator.validate(
+			get( WOOCOMMERCE_ONBOARDING_PROFILE )?.[ 'store_email' ]
+		)
 			? __( 'A valid email address is required' )
 			: '';
 

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -81,9 +81,10 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	const countryError = getError( WOOCOMMERCE_DEFAULT_COUNTRY );
 	const cityError = getError( WOOCOMMERCE_STORE_CITY );
 	const postcodeError = getError( WOOCOMMERCE_STORE_POSTCODE );
+	const emailError = getError( WOOCOMMERCE_ONBOARDING_PROFILE );
 	useEffect( () => {
 		return;
-	}, [ address1Error, address2Error, countryError, cityError, postcodeError ] );
+	}, [ address1Error, address2Error, countryError, cityError, postcodeError, emailError ] );
 
 	function getContent() {
 		return (
@@ -151,12 +152,12 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 					<TextControl
 						label={ __( 'Email address' ) }
 						value={ getProfileEmail() }
-						onChange={ () => {
-							updateProfileEmail;
+						onChange={ ( value ) => {
+							updateProfileEmail( value );
 							clearError( WOOCOMMERCE_ONBOARDING_PROFILE );
 						} }
-						required={ true }
 					/>
+					<ControlError error={ emailError } />
 
 					<ActionSection>
 						<SupportCard />
@@ -230,6 +231,11 @@ function useAddressFormValidation( siteId: number ) {
 			: '';
 		errors[ WOOCOMMERCE_STORE_POSTCODE ] = ! get( WOOCOMMERCE_STORE_POSTCODE )
 			? __( 'Postcode is required.' )
+			: '';
+		errors[ WOOCOMMERCE_ONBOARDING_PROFILE ] = ! get( WOOCOMMERCE_ONBOARDING_PROFILE )[
+			'store_email'
+		]
+			? __( 'Email address is required.' )
 			: '';
 
 		setErrors( errors );

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 import { TextControl, ComboboxControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactElement, useEffect } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { fetchWooCommerceCountries } from 'calypso/state/countries/actions';
@@ -18,6 +19,7 @@ import {
 	WOOCOMMERCE_DEFAULT_COUNTRY,
 	WOOCOMMERCE_STORE_POSTCODE,
 	WOOCOMMERCE_ONBOARDING_PROFILE,
+	optionNameType,
 } from '../hooks/use-site-settings';
 import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '..';
@@ -43,19 +45,17 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	}, [ dispatch ] );
 
 	const siteId = useSelector( getSelectedSiteId ) as number;
+
 	const countriesList = useSelector( ( state ) => getCountries( state, 'woocommerce' ) ) || [];
-
-	const { wpcomDomain } = useWooCommerceOnPlansEligibility( siteId );
-
-	const { get, save, update } = useSiteSettings( siteId );
-
 	const countriesAsOptions = Object.entries( countriesList ).map( ( [ key, value ] ) => {
 		return { value: key, label: value };
 	} );
 
-	const handleCountryChange = ( value: string | null ) => {
-		update( WOOCOMMERCE_DEFAULT_COUNTRY, value || '' );
-	};
+	const { get, save, update } = useSiteSettings( siteId );
+
+	const { wpcomDomain } = useWooCommerceOnPlansEligibility( siteId );
+
+	const { validate, clearError, getError } = useAddressFormValidation( siteId );
 
 	// @todo: Add a general hook to get and update multi-option data like the profile.
 	function updateProfileEmail( email: string ) {
@@ -80,62 +80,87 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 			<>
 				<div className="step-store-address__info-section" />
 				<div className="step-store-address__instructions-container">
-					<form
-						onSubmit={ () => {
-							save();
-							goToStep( 'confirm' );
+					<TextControl
+						label={ __( 'Address line 1' ) }
+						value={ get( WOOCOMMERCE_STORE_ADDRESS_1 ) }
+						onChange={ ( value ) => {
+							update( WOOCOMMERCE_STORE_ADDRESS_1, value );
+							clearError( WOOCOMMERCE_STORE_ADDRESS_1 );
 						} }
-					>
-						<TextControl
-							label={ __( 'Address line 1' ) }
-							value={ get( WOOCOMMERCE_STORE_ADDRESS_1 ) }
-							onChange={ ( value ) => update( WOOCOMMERCE_STORE_ADDRESS_1, value ) }
-							required={ true }
-						/>
+					/>
+					<ControlError error={ getError( WOOCOMMERCE_STORE_ADDRESS_1 ) } />
 
-						<TextControl
-							label={ __( 'Address line 2' ) }
-							value={ get( WOOCOMMERCE_STORE_ADDRESS_2 ) }
-							onChange={ ( value ) => update( WOOCOMMERCE_STORE_ADDRESS_2, value ) }
-						/>
+					<TextControl
+						label={ __( 'Address line 2' ) }
+						value={ get( WOOCOMMERCE_STORE_ADDRESS_2 ) }
+						onChange={ ( value ) => {
+							update( WOOCOMMERCE_STORE_ADDRESS_2, value );
+							clearError( WOOCOMMERCE_STORE_ADDRESS_2 );
+						} }
+					/>
+					<ControlError error={ getError( WOOCOMMERCE_STORE_ADDRESS_2 ) } />
 
-						<ComboboxControl
-							label={ __( 'Country / Region' ) }
-							value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) as string }
-							onChange={ handleCountryChange }
-							options={ countriesAsOptions }
-							allowReset={ false }
-							required={ true }
-						/>
+					<ComboboxControl
+						label={ __( 'Country / Region' ) }
+						value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) }
+						allowReset={ false }
+						onChange={ ( value: string | null ) => {
+							update( WOOCOMMERCE_DEFAULT_COUNTRY, value || '' );
+							clearError( WOOCOMMERCE_DEFAULT_COUNTRY );
+						} }
+						options={ countriesAsOptions }
+					/>
+					<ControlError error={ getError( WOOCOMMERCE_DEFAULT_COUNTRY ) } />
 
-						<CityZipRow>
+					<CityZipRow>
+						<div>
 							<TextControl
 								label={ __( 'City' ) }
 								value={ get( WOOCOMMERCE_STORE_CITY ) }
-								onChange={ ( value ) => update( WOOCOMMERCE_STORE_CITY, value ) }
-								required={ true }
+								onChange={ ( value ) => {
+									update( WOOCOMMERCE_STORE_CITY, value );
+									clearError( WOOCOMMERCE_STORE_CITY );
+								} }
 							/>
+							<ControlError error={ getError( WOOCOMMERCE_STORE_CITY ) } />
+						</div>
 
+						<div>
 							<TextControl
 								label={ __( 'Postcode' ) }
 								value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
-								onChange={ ( value ) => update( WOOCOMMERCE_STORE_POSTCODE, value ) }
-								required={ true }
+								onChange={ ( value ) => {
+									update( WOOCOMMERCE_STORE_POSTCODE, value );
+									clearError( WOOCOMMERCE_STORE_POSTCODE );
+								} }
 							/>
-						</CityZipRow>
+							<ControlError error={ getError( WOOCOMMERCE_STORE_POSTCODE ) } />
+						</div>
+					</CityZipRow>
 
-						<TextControl
-							label={ __( 'Email address' ) }
-							value={ getProfileEmail() }
-							onChange={ updateProfileEmail }
-							required={ true }
-						/>
+					<TextControl
+						label={ __( 'Email address' ) }
+						value={ getProfileEmail() }
+						onChange={ () => {
+							updateProfileEmail;
+							clearError( WOOCOMMERCE_ONBOARDING_PROFILE );
+						} }
+						required={ true }
+					/>
 
-						<ActionSection>
-							<SupportCard />
-							<StyledNextButton type="submit">{ __( 'Continue' ) }</StyledNextButton>
-						</ActionSection>
-					</form>
+					<ActionSection>
+						<SupportCard />
+						<StyledNextButton
+							onClick={ () => {
+								if ( validate() ) {
+									save();
+									goToStep( 'confirm' );
+								}
+							} }
+						>
+							{ __( 'Continue' ) }
+						</StyledNextButton>
+					</ActionSection>
 				</div>
 			</>
 		);
@@ -166,4 +191,52 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 			{ ...props }
 		/>
 	);
+}
+
+function ControlError( props: { error: string } ): ReactElement | null {
+	const { error } = props;
+	if ( error ) {
+		return <FormInputValidation isError={ true } isValid={ false } text={ error } />;
+	}
+	return null;
+}
+
+function useAddressFormValidation( siteId: number ) {
+	const { get } = useSiteSettings( siteId );
+	const { __ } = useI18n();
+
+	const [ errors, setErrors ] = useState( {} as Record< optionNameType, string > );
+
+	const validate = () => {
+		errors[ WOOCOMMERCE_STORE_ADDRESS_1 ] = ! get( WOOCOMMERCE_STORE_ADDRESS_1 )
+			? __( 'Address line is required.' )
+			: '';
+		errors[ WOOCOMMERCE_STORE_ADDRESS_2 ] = ''; // Optional field
+		errors[ WOOCOMMERCE_DEFAULT_COUNTRY ] = ! get( WOOCOMMERCE_DEFAULT_COUNTRY )
+			? __( 'Country / Region is required.' )
+			: '';
+		errors[ WOOCOMMERCE_STORE_CITY ] = ! get( WOOCOMMERCE_STORE_CITY )
+			? __( 'City is required.' )
+			: '';
+		errors[ WOOCOMMERCE_STORE_POSTCODE ] = ! get( WOOCOMMERCE_STORE_POSTCODE )
+			? __( 'Postcode is required.' )
+			: '';
+
+		setErrors( errors );
+
+		return Object.values( errors ).filter( Boolean ).length === 0;
+	};
+
+	const clearError = ( field: optionNameType ) => {
+		errors[ field ] = '';
+		setErrors( errors );
+	};
+
+	const getError = ( field: optionNameType ) => errors[ field ] || '';
+
+	return {
+		validate,
+		clearError,
+		getError,
+	};
 }

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -101,6 +101,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 							update( WOOCOMMERCE_STORE_ADDRESS_1, value );
 							clearError( WOOCOMMERCE_STORE_ADDRESS_1 );
 						} }
+						className={ address1Error ? 'is-error' : '' }
 					/>
 					<ControlError error={ address1Error } />
 
@@ -111,6 +112,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 							update( WOOCOMMERCE_STORE_ADDRESS_2, value );
 							clearError( WOOCOMMERCE_STORE_ADDRESS_2 );
 						} }
+						className={ address2Error ? 'is-error' : '' }
 					/>
 					<ControlError error={ address2Error } />
 
@@ -123,6 +125,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 									update( WOOCOMMERCE_STORE_CITY, value );
 									clearError( WOOCOMMERCE_STORE_CITY );
 								} }
+								className={ cityError ? 'is-error' : '' }
 							/>
 							<ControlError error={ cityError } />
 						</div>
@@ -135,6 +138,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 									update( WOOCOMMERCE_STORE_POSTCODE, value );
 									clearError( WOOCOMMERCE_STORE_POSTCODE );
 								} }
+								className={ postcodeError ? 'is-error' : '' }
 							/>
 							<ControlError error={ postcodeError } />
 						</div>
@@ -148,6 +152,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 							clearError( WOOCOMMERCE_DEFAULT_COUNTRY );
 						} }
 						options={ countriesAsOptions }
+						className={ countryError ? 'is-error' : '' }
 					/>
 					<ControlError error={ countryError } />
 
@@ -158,6 +163,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 							updateProfileEmail( value );
 							clearError( WOOCOMMERCE_ONBOARDING_PROFILE );
 						} }
+						className={ emailError ? 'is-error' : '' }
 					/>
 					<ControlError error={ emailError } />
 

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -80,57 +80,62 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 			<>
 				<div className="step-store-address__info-section" />
 				<div className="step-store-address__instructions-container">
-					<TextControl
-						label={ __( 'Address line 1' ) }
-						value={ get( WOOCOMMERCE_STORE_ADDRESS_1 ) }
-						onChange={ ( value ) => update( WOOCOMMERCE_STORE_ADDRESS_1, value ) }
-					/>
-
-					<TextControl
-						label={ __( 'Address line 2' ) }
-						value={ get( WOOCOMMERCE_STORE_ADDRESS_2 ) }
-						onChange={ ( value ) => update( WOOCOMMERCE_STORE_ADDRESS_2, value ) }
-					/>
-
-					<ComboboxControl
-						label={ __( 'Country / Region' ) }
-						value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) as string }
-						onChange={ handleCountryChange }
-						options={ countriesAsOptions }
-						allowReset={ false }
-					/>
-
-					<CityZipRow>
+					<form
+						onSubmit={ () => {
+							save();
+							goToStep( 'confirm' );
+						} }
+					>
 						<TextControl
-							label={ __( 'City' ) }
-							value={ get( WOOCOMMERCE_STORE_CITY ) }
-							onChange={ ( value ) => update( WOOCOMMERCE_STORE_CITY, value ) }
+							label={ __( 'Address line 1' ) }
+							value={ get( WOOCOMMERCE_STORE_ADDRESS_1 ) }
+							onChange={ ( value ) => update( WOOCOMMERCE_STORE_ADDRESS_1, value ) }
+							required={ true }
 						/>
 
 						<TextControl
-							label={ __( 'Postcode' ) }
-							value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
-							onChange={ ( value ) => update( WOOCOMMERCE_STORE_POSTCODE, value ) }
+							label={ __( 'Address line 2' ) }
+							value={ get( WOOCOMMERCE_STORE_ADDRESS_2 ) }
+							onChange={ ( value ) => update( WOOCOMMERCE_STORE_ADDRESS_2, value ) }
 						/>
-					</CityZipRow>
 
-					<TextControl
-						label={ __( 'Email address' ) }
-						value={ getProfileEmail() }
-						onChange={ updateProfileEmail }
-					/>
+						<ComboboxControl
+							label={ __( 'Country / Region' ) }
+							value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) as string }
+							onChange={ handleCountryChange }
+							options={ countriesAsOptions }
+							allowReset={ false }
+							required={ true }
+						/>
 
-					<ActionSection>
-						<SupportCard />
-						<StyledNextButton
-							onClick={ () => {
-								save();
-								goToStep( 'confirm' );
-							} }
-						>
-							{ __( 'Continue' ) }
-						</StyledNextButton>
-					</ActionSection>
+						<CityZipRow>
+							<TextControl
+								label={ __( 'City' ) }
+								value={ get( WOOCOMMERCE_STORE_CITY ) }
+								onChange={ ( value ) => update( WOOCOMMERCE_STORE_CITY, value ) }
+								required={ true }
+							/>
+
+							<TextControl
+								label={ __( 'Postcode' ) }
+								value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
+								onChange={ ( value ) => update( WOOCOMMERCE_STORE_POSTCODE, value ) }
+								required={ true }
+							/>
+						</CityZipRow>
+
+						<TextControl
+							label={ __( 'Email address' ) }
+							value={ getProfileEmail() }
+							onChange={ updateProfileEmail }
+							required={ true }
+						/>
+
+						<ActionSection>
+							<SupportCard />
+							<StyledNextButton type="submit">{ __( 'Continue' ) }</StyledNextButton>
+						</ActionSection>
+					</form>
 				</div>
 			</>
 		);

--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -5,8 +5,16 @@
 .components-combobox-control__suggestions-container {
 	// Remove `width: 100%;` https://github.com/WordPress/gutenberg/blob/0135921bcb72ceec629fa8f9e755891afab747b9/packages/components/src/combobox-control/style.scss#L32
 	width: unset;
+
+	// Remove margin from component to match text controls
+	margin-bottom: unset;
 }
 
 .components-form-token-field__suggestions-list {
 	width: min-content;
+}
+
+.components-combobox-control__reset.components-button {
+	// Height of 22 ensures combobox input matches height of text controls
+	height: 22px;
 }

--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -2,19 +2,25 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.components-combobox-control__suggestions-container {
-	// Remove `width: 100%;` https://github.com/WordPress/gutenberg/blob/0135921bcb72ceec629fa8f9e755891afab747b9/packages/components/src/combobox-control/style.scss#L32
-	width: unset;
+.step-store-address__instructions-container {
+	.components-combobox-control__suggestions-container {
+		// Remove `width: 100%;` https://github.com/WordPress/gutenberg/blob/0135921bcb72ceec629fa8f9e755891afab747b9/packages/components/src/combobox-control/style.scss#L32
+		width: unset;
 
-	// Remove margin from component to match text controls
-	margin-bottom: unset;
-}
+		// Remove margin from component to match text controls
+		margin-bottom: unset;
+	}
 
-.components-form-token-field__suggestions-list {
-	width: min-content;
-}
+	.components-form-token-field__suggestions-list {
+		width: min-content;
+	}
 
-.components-combobox-control__reset.components-button {
-	// Height of 22 ensures combobox input matches height of text controls
-	height: 22px;
+	.components-combobox-control__reset.components-button {
+		// Height of 22 ensures combobox input matches height of text controls
+		height: 22px;
+	}
+
+	.form-input-validation.is-error {
+		line-height: 1.4rem;
+	}
 }

--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -23,4 +23,21 @@
 	.form-input-validation.is-error {
 		line-height: 1.4rem;
 	}
+
+	// On error, color the border of inputs red & remove the blue box shadow
+	// We have to remove the box shadow here because we can't apply box shadow
+	// to the suggestion dropdown conditionally like we can with the text control.
+	.components-base-control.is-error {
+		.components-text-control__input {
+			border-color: var( --color-error );
+			&:focus {
+				box-shadow: 0 0 0 0 var( --color-error );
+			}
+		}
+
+		.components-combobox-control__suggestions-container {
+			border-color: var( --color-error );
+			box-shadow: 0 0 0 0 var( --color-error );
+		}
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add form validation to the woo installer's address step.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/woocommerce-installation/?flags=woop
* Choose a non atomic site (atomic won't work until JP updates with new country endpoint data)
* Click set up my store
* You should be taken to the address step (when the woop flag is active)
* Clicking the continue button should fail with validation errors until the form is completed correctly.
* Once completing the install and transfer flow you'll land on Woo's original setup profile, your address should be prepopulated using atomic data - though I noticed a timing issue with fetching country info (the form errored)

Before
![Screenshot 2022-01-13 at 13-21-47 Add WooCommerce to your site — WordPress com](https://user-images.githubusercontent.com/811776/149254460-9960f9e7-0d1e-4eb9-b863-5f6773ab40e0.png)

After
![Screenshot 2022-01-13 at 13-58-06 Add WooCommerce to your site — WordPress com](https://user-images.githubusercontent.com/811776/149257937-6800a1a6-f128-4c7b-9931-da1a668b465d.png)

Fixes #59857
