### PR TITLE
`QueryTheme`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-theme/index.jsx
+++ b/client/components/data/query-theme/index.jsx
@@ -1,45 +1,31 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestTheme } from 'calypso/state/themes/actions';
 import { isRequestingTheme } from 'calypso/state/themes/selectors';
 
-class QueryTheme extends Component {
-	static propTypes = {
-		siteId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] )
-			.isRequired,
-		themeId: PropTypes.string.isRequired,
-		// Connected props
-		isRequesting: PropTypes.bool.isRequired,
-		requestTheme: PropTypes.func.isRequired,
-	};
-
-	componentDidMount() {
-		this.request( this.props );
+const request = ( siteId, themeId ) => ( dispatch, getState ) => {
+	if ( ! isRequestingTheme( getState(), siteId, themeId ) ) {
+		dispatch( requestTheme( themeId, siteId ) );
 	}
+};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId && this.props.themeId === nextProps.themeId ) {
-			return;
+function QueryTheme( { siteId, themeId } ) {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( siteId && themeId ) {
+			dispatch( request( siteId, themeId ) );
 		}
-		this.request( nextProps );
-	}
+	}, [ dispatch, siteId, themeId ] );
 
-	request( props ) {
-		if ( ! props.isRequesting ) {
-			props.requestTheme( props.themeId, props.siteId );
-		}
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, { siteId, themeId } ) => ( {
-		isRequesting: isRequestingTheme( state, siteId, themeId ),
-	} ),
-	{ requestTheme }
-)( QueryTheme );
+QueryTheme.propTypes = {
+	siteId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] )
+		.isRequired,
+	themeId: PropTypes.string.isRequired,
+};
+
+export default QueryTheme;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryTheme`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/themes/:site`
* You should see a request to `/themes/:currently-active-theme`
* Open React DevTools and look for the `QueryTheme` component, change any of the props and make sure you see another request with just changed params

Related to #58453 
