### PR TITLE
Emails: Add feature logos to Google Workspace

### DIFF
--- a/client/my-sites/email/email-provider-features/list.js
+++ b/client/my-sites/email/email-provider-features/list.js
@@ -11,37 +11,38 @@ const getEmailForwardingFeatures = () => {
 };
 
 const getGoogleAppLogos = () => {
-	const options = { textOnly: true };
+	const translateOptions = { textOnly: true };
+
 	return [
 		{
 			image: gmailIcon,
-			imageAltText: translate( 'Gmail icon', options ),
-			title: translate( 'Gmail', options ),
+			imageAltText: translate( 'Gmail icon', translateOptions ),
+			title: translate( 'Gmail', translateOptions ),
 		},
 		{
 			image: googleCalendarIcon,
-			imageAltText: translate( 'Google Calendar icon', options ),
-			title: translate( 'Google Calendar', options ),
+			imageAltText: translate( 'Google Calendar icon', translateOptions ),
+			title: translate( 'Google Calendar', translateOptions ),
 		},
 		{
 			image: googleDriveIcon,
-			imageAltText: translate( 'Google Drive icon', options ),
-			title: translate( 'Google Drive', options ),
+			imageAltText: translate( 'Google Drive icon', translateOptions ),
+			title: translate( 'Google Drive', translateOptions ),
 		},
 		{
 			image: googleDocsIcon,
-			imageAltText: translate( 'Google Docs icon', options ),
-			title: translate( 'Google Docs', options ),
+			imageAltText: translate( 'Google Docs icon', translateOptions ),
+			title: translate( 'Google Docs', translateOptions ),
 		},
 		{
 			image: googleSheetsIcon,
-			imageAltText: translate( 'Google Sheets icon', options ),
-			title: translate( 'Google Sheets', options ),
+			imageAltText: translate( 'Google Sheets icon', translateOptions ),
+			title: translate( 'Google Sheets', translateOptions ),
 		},
 		{
 			image: googleSlidesIcon,
-			imageAltText: translate( 'Google Slides icon', options ),
-			title: translate( 'Google Slides', options ),
+			imageAltText: translate( 'Google Slides icon', translateOptions ),
+			title: translate( 'Google Slides', translateOptions ),
 		},
 	];
 };

--- a/client/my-sites/email/email-provider-features/list.js
+++ b/client/my-sites/email/email-provider-features/list.js
@@ -11,36 +11,37 @@ const getEmailForwardingFeatures = () => {
 };
 
 const getGoogleAppLogos = () => {
+	const options = { textOnly: true };
 	return [
 		{
 			image: gmailIcon,
-			imageAltText: translate( 'Gmail icon' ),
-			title: translate( 'Gmail' ),
+			imageAltText: translate( 'Gmail icon', options ),
+			title: translate( 'Gmail', options ),
 		},
 		{
 			image: googleCalendarIcon,
-			imageAltText: translate( 'Google Calendar icon' ),
-			title: translate( 'Google Calendar' ),
+			imageAltText: translate( 'Google Calendar icon', options ),
+			title: translate( 'Google Calendar', options ),
 		},
 		{
 			image: googleDriveIcon,
-			imageAltText: translate( 'Google Drive icon' ),
-			title: translate( 'Google Drive' ),
+			imageAltText: translate( 'Google Drive icon', options ),
+			title: translate( 'Google Drive', options ),
 		},
 		{
 			image: googleDocsIcon,
-			imageAltText: translate( 'Google Docs icon' ),
-			title: translate( 'Google Docs' ),
+			imageAltText: translate( 'Google Docs icon', options ),
+			title: translate( 'Google Docs', options ),
 		},
 		{
 			image: googleSheetsIcon,
-			imageAltText: translate( 'Google Sheets icon' ),
-			title: translate( 'Google Sheets' ),
+			imageAltText: translate( 'Google Sheets icon', options ),
+			title: translate( 'Google Sheets', options ),
 		},
 		{
 			image: googleSlidesIcon,
-			imageAltText: translate( 'Google Slides icon' ),
-			title: translate( 'Google Slides' ),
+			imageAltText: translate( 'Google Slides icon', options ),
+			title: translate( 'Google Slides', options ),
 		},
 	];
 };

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
@@ -31,12 +31,12 @@ export interface LogoFeature {
 
 export interface EmailProviderStackedFeaturesProps {
 	features: TranslateResult[];
-	logoFeatures: LogoFeature[];
+	appLogos: LogoFeature[];
 }
 
 export const EmailProviderStackedFeatures = ( {
 	features,
-	logoFeatures,
+	appLogos,
 }: EmailProviderStackedFeaturesProps ): ReactElement | null => {
 	const translate = useTranslate();
 
@@ -49,12 +49,14 @@ export const EmailProviderStackedFeatures = ( {
 			<span className={ 'email-provider-stacked-features__whats-included' }>
 				{ translate( "What's included:" ) }
 			</span>
+
 			{ features.map( ( feature, index ) => (
 				<EmailProviderStackedFeature key={ index } title={ feature } />
 			) ) }
-			{ logoFeatures && (
+
+			{ appLogos && (
 				<div className="email-provider-stacked-features__logos">
-					{ logoFeatures.map( ( { image, imageAltText, title }, index ) => (
+					{ appLogos.map( ( { image, imageAltText, title }, index ) => (
 						<img alt={ imageAltText } key={ index } src={ image } title={ title } />
 					) ) }
 				</div>

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
@@ -23,7 +23,7 @@ const EmailProviderStackedFeature = ( {
 	);
 };
 
-export interface LogoFeature {
+export interface AppLogo {
 	image: string;
 	imageAltText: string;
 	title: string;
@@ -31,7 +31,7 @@ export interface LogoFeature {
 
 export interface EmailProviderStackedFeaturesProps {
 	features: TranslateResult[];
-	appLogos: LogoFeature[];
+	appLogos: AppLogo[];
 }
 
 export const EmailProviderStackedFeatures = ( {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
@@ -23,12 +23,20 @@ const EmailProviderStackedFeature = ( {
 	);
 };
 
+export interface LogoFeature {
+	image: string;
+	imageAltText: string;
+	title: string;
+}
+
 export interface EmailProviderStackedFeaturesProps {
 	features: TranslateResult[];
+	logoFeatures: LogoFeature[];
 }
 
 export const EmailProviderStackedFeatures = ( {
 	features,
+	logoFeatures,
 }: EmailProviderStackedFeaturesProps ): ReactElement | null => {
 	const translate = useTranslate();
 
@@ -44,6 +52,13 @@ export const EmailProviderStackedFeatures = ( {
 			{ features.map( ( feature, index ) => (
 				<EmailProviderStackedFeature key={ index } title={ feature } />
 			) ) }
+			{ logoFeatures && (
+				<div className="email-provider-stacked-features__logos">
+					{ logoFeatures.map( ( { image, imageAltText, title }, index ) => (
+						<img alt={ imageAltText } key={ index } src={ image } title={ title } />
+					) ) }
+				</div>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -25,6 +25,7 @@ const EmailProvidersStackedCard = ( {
 	footerBadge,
 	formFields,
 	logo,
+	logoFeatures = [],
 	onExpandedChange = noop,
 	priceBadge = null,
 	productName,
@@ -92,7 +93,8 @@ const EmailProvidersStackedCard = ( {
 				<div className="email-provider-stacked-card__provider-right-panel">
 					{ ( ! showFeaturesToggleButton || areFeaturesExpanded ) && (
 						<>
-							<EmailProviderStackedFeatures features={ features } /> { footerBadge }
+							<EmailProviderStackedFeatures features={ features } logoFeatures={ logoFeatures } />
+							{ footerBadge }
 						</>
 					) }
 				</div>

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -25,7 +25,7 @@ const EmailProvidersStackedCard = ( {
 	footerBadge,
 	formFields,
 	logo,
-	logoFeatures = [],
+	appLogos = [],
 	onExpandedChange = noop,
 	priceBadge = null,
 	productName,
@@ -93,7 +93,7 @@ const EmailProvidersStackedCard = ( {
 				<div className="email-provider-stacked-card__provider-right-panel">
 					{ ( ! showFeaturesToggleButton || areFeaturesExpanded ) && (
 						<>
-							<EmailProviderStackedFeatures features={ features } logoFeatures={ logoFeatures } />
+							<EmailProviderStackedFeatures features={ features } appLogos={ appLogos } />
 							{ footerBadge }
 						</>
 					) }

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -295,15 +295,14 @@ $width-left-panel-card: 55%;
 }
 
 .email-provider-stacked-features__logos {
-	column-gap: 3px;
+	column-gap: 5px;
 	display: flex;
 	flex-wrap: wrap;
 	margin-left: 32px;
-	row-gap: 5px;
 
 	@include break-xlarge {
 		justify-content: space-between;
-		row-gap: 3px;
+		column-gap: 3px;
 	}
 
 	img {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -294,3 +294,20 @@ $width-left-panel-card: 55%;
 	}
 }
 
+.email-provider-stacked-features__logos {
+	column-gap: 3px;
+	display: flex;
+	flex-wrap: wrap;
+	margin-left: 30px;
+	margin-top: 0;
+	row-gap: 5px;
+	@include break-xlarge {
+		justify-content: space-between;
+		row-gap: 3px;
+	}
+
+	img {
+		width: 32px;
+	}
+}
+

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -298,9 +298,9 @@ $width-left-panel-card: 55%;
 	column-gap: 3px;
 	display: flex;
 	flex-wrap: wrap;
-	margin-left: 30px;
-	margin-top: 0;
+	margin-left: 32px;
 	row-gap: 5px;
+
 	@include break-xlarge {
 		justify-content: space-between;
 		row-gap: 3px;

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -22,6 +22,7 @@ import {
 } from 'calypso/lib/gsuite/new-users';
 import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { getGoogleAppLogos } from 'calypso/my-sites/email/email-provider-features/list';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
 import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison/price-with-interval';
@@ -73,6 +74,7 @@ const googleWorkspaceCardInformation: ProviderCard = {
 		'Professional email integrated with Google Meet and other productivity tools from Google.'
 	),
 	logo: { path: googleWorkspaceIcon, className: 'google-workspace-icon' },
+	logoFeatures: getGoogleAppLogos(),
 	productName: getGoogleMailServiceFamily(),
 	features: getGoogleFeatures(),
 };

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -74,7 +74,7 @@ const googleWorkspaceCardInformation: ProviderCard = {
 		'Professional email integrated with Google Meet and other productivity tools from Google.'
 	),
 	logo: { path: googleWorkspaceIcon, className: 'google-workspace-icon' },
-	logoFeatures: getGoogleAppLogos(),
+	appLogos: getGoogleAppLogos(),
 	productName: getGoogleMailServiceFamily(),
 	features: getGoogleFeatures(),
 };

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
-import type { LogoFeature } from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features';
+import type { AppLogo } from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features';
 import type { Site } from 'calypso/my-sites/scan/types';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -18,7 +18,7 @@ export interface ProviderCard {
 	footerBadge?: ReactElement | null;
 	formFields?: ReactElement;
 	logo?: ReactElement | { path: string; className?: string };
-	appLogos?: LogoFeature[];
+	appLogos?: AppLogo[];
 	onExpandedChange?: ( providerKey: string, expanded: boolean ) => void;
 	priceBadge?: ReactElement | TranslateResult | null;
 	productName: TranslateResult;

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -18,7 +18,7 @@ export interface ProviderCard {
 	footerBadge?: ReactElement | null;
 	formFields?: ReactElement;
 	logo?: ReactElement | { path: string; className?: string };
-	logoFeatures?: LogoFeature[];
+	appLogos?: LogoFeature[];
 	onExpandedChange?: ( providerKey: string, expanded: boolean ) => void;
 	priceBadge?: ReactElement | TranslateResult | null;
 	productName: TranslateResult;

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
+import type { LogoFeature } from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features';
 import type { Site } from 'calypso/my-sites/scan/types';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -17,6 +18,7 @@ export interface ProviderCard {
 	footerBadge?: ReactElement | null;
 	formFields?: ReactElement;
 	logo?: ReactElement | { path: string; className?: string };
+	logoFeatures?: LogoFeature[];
 	onExpandedChange?: ( providerKey: string, expanded: boolean ) => void;
 	priceBadge?: ReactElement | TranslateResult | null;
 	productName: TranslateResult;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes are adding the Google Workspace logos to the feature list shown in the new comparison card.

#### Remarks

I am unsure if the icons are fine to have a space between them when they are being showed in large displays. Please suggest what you think is better and we can test different layouts.

#### Testing instructions

1. Run `git checkout add/google-logos-to-stacked-comparison-card` and start your server, or access a live branch
2. Open the [`Emails` page](http://calypso.localhost:3000/email)
3. Click the `Add Email` button to access the `Email Comparison` page
4. Assert that you see the logos in the Google Workspace section
5. Assert that the Professional Email logo has the same size than the other main logos
6. Assert that the content of each section is aligned


![google logos](https://user-images.githubusercontent.com/5689927/149126027-f1cd77fa-acc9-4cf3-875d-affb895e05b5.gif)


Related to {1200182182542585-as-1201610800776461}
