### PR TITLE
Fix: Update link to new BuiltByWP.com domain

### DIFF
--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -26,7 +26,12 @@ class UpworkBanner extends PureComponent {
 				forceDisplay //Upwork banner has its own logic for showing/hiding
 				className="upwork-banner__troubleshooting"
 				showIcon
-				onClick={ () => window.open( 'https://wordpress.com/built-by-wordpress-com/', '_blank' ) }
+				onClick={ () =>
+					window.open(
+						'https://builtbywp.com/?utm_medium=automattic_referred&utm_source=WordPresscom&utm_campaign=design-picker-cta',
+						'_blank'
+					)
+				}
 				callToAction={ translate( 'Find your expert' ) }
 				dismissPreferenceName={ 'upwork-dismissible-banner' }
 				tracksClickName={ 'calypso_upwork_banner_start_now_button_click' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the link from the "Find Your Expert" button from wordpress.com to builtbywp.com. Ref p1641995133042200-slack-martech.

#### Testing instructions

* Go to the theme page, click the "Find Your Expert" button above the theme list. Ensure it goes to the new domain with the correct UTM tags (https://builtbywp.com/?utm_medium=automattic_referred&utm_source=WordPresscom&utm_campaign=design-picker-cta)

Related to #
