### PR TITLE
Marketplace: Fix paid plugins ratings

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -137,7 +137,6 @@ function PluginDetails( props ) {
 		const wpcomPlugin = {
 			...wpComPluginData,
 			fetched: isWpComPluginFetched,
-			rating: ( wpComPluginData?.rating / 5 ) * 100,
 		};
 
 		return {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -14,6 +14,7 @@ import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
+import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserElementVariant } from './types';
@@ -42,6 +43,9 @@ const PluginsBrowserListElement = ( props ) => {
 		isJetpack && currentSites
 			? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), plugin.slug )
 			: []
+	);
+	const isMarketplaceProduct = useSelector( ( state ) =>
+		isMarketplaceProductSelector( state, plugin.slug || '' )
 	);
 
 	const dateFromNow = useMemo(
@@ -150,7 +154,7 @@ const PluginsBrowserListElement = ( props ) => {
 						/>
 					) }
 					<div className="plugins-browser-item__additional-info">
-						{ !! plugin.rating && (
+						{ !! plugin.rating && ! isMarketplaceProduct && (
 							<div className="plugins-browser-item__ratings">
 								<PluginRatings
 									rating={ plugin.rating }

--- a/client/state/products-list/selectors/is-marketplace-product.js
+++ b/client/state/products-list/selectors/is-marketplace-product.js
@@ -4,5 +4,5 @@ import { getProductsList } from '../selectors/get-products-list';
 
 export const isMarketplaceProduct = ( state, productSlug ) => {
 	const productsList = getProductsList( state );
-	return hasMarketplaceProduct( productsList, productSlug );
+	return productsList ? hasMarketplaceProduct( productsList, productSlug ) : false;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* removes paid plugins ratings from list.
* fix ratings for paid plugins to use wporg format.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before List | After List|
|-------|------|
|<img width="1082" alt="SS 2022-01-12 at 16 03 56" src="https://user-images.githubusercontent.com/12430020/149154975-cfe9c346-6382-4e35-9b24-2341b07099e9.png">|<img width="1148" alt="SS 2022-01-12 at 16 04 06" src="https://user-images.githubusercontent.com/12430020/149155001-cf783118-7aeb-400a-8c12-b95cad6e7d06.png">|

|Before Details | After Details|
|-------|------|
|<img width="1103" alt="SS 2022-01-12 at 16 05 19" src="https://user-images.githubusercontent.com/12430020/149155196-6a7bfb0f-d2fb-4144-911f-97948620ab0f.png">|<img width="1098" alt="SS 2022-01-12 at 16 05 38" src="https://user-images.githubusercontent.com/12430020/149155257-1927addb-d001-4b33-a62e-292bdf9f5a5c.png">|

* apply D72901-code
* Delete the `query-state` indexed db row
* Go to `/plugins`
* Inspect that ratings don't appear for paid plugins but still appear for wporg
* Go to a paid plugin details page, inspect that ratings are correctly appearing in a decimal format

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59752