### PR TITLE
`QueryKeyringConnections`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-keyring-connections/index.jsx
+++ b/client/components/data/query-keyring-connections/index.jsx
@@ -15,8 +15,7 @@ class QueryKeyringConnections extends Component {
 		forceRefresh: false,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( ! this.props.isRequesting ) {
 			this.props.requestKeyringConnections( this.props.forceRefresh );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryKeyringConnections`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `stats/day/:site` or `marketing/connections/:site` and make sure you see a network request to `/keyrings`

Related to #58453 
