### PR TITLE
`QuerySiteGuidedTransfer`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-site-guided-transfer/index.jsx
+++ b/client/components/data/query-site-guided-transfer/index.jsx
@@ -1,51 +1,29 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestGuidedTransferStatus } from 'calypso/state/sites/guided-transfer/actions';
 import { isRequestingGuidedTransferStatus } from 'calypso/state/sites/guided-transfer/selectors';
 
-class QuerySiteGuidedTransfer extends Component {
-	constructor( props ) {
-		super( props );
-		this.request = this.request.bind( this );
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( ! isRequestingGuidedTransferStatus( getState(), siteId ) ) {
+		dispatch( requestGuidedTransferStatus( siteId ) );
 	}
+};
 
-	request( props = this.props ) {
-		if ( ! props.isRequesting && props.siteId ) {
-			props.requestGuidedTransferStatus( props.siteId );
+function QuerySiteGuidedTransfer( { siteId } ) {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( siteId ) {
+			dispatch( request( siteId ) );
 		}
-	}
+	}, [ dispatch, siteId ] );
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.request();
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId !== nextProps.siteId ) {
-			this.request( nextProps );
-		}
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QuerySiteGuidedTransfer.propTypes = {
 	siteId: PropTypes.number,
-	isRequesting: PropTypes.bool,
 };
 
-QuerySiteGuidedTransfer.defaultProps = {
-	requestGuidedTransferStatus: () => {},
-};
-
-const mapStateToProps = ( state, ownProps ) => ( {
-	isRequesting: isRequestingGuidedTransferStatus( state, ownProps.siteId ),
-} );
-
-export default connect( mapStateToProps, { requestGuidedTransferStatus } )(
-	QuerySiteGuidedTransfer
-);
+export default QuerySiteGuidedTransfer;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QuerySiteGuidedTransfer`: refactor away from `UNSAFE_*`

#### Testing instructions

* For a simple site go to `/export/:site`
* Make sure you see a network request to `/transfer` (it also shows a card in the ui)

Please note this doesn't seem to be enabled on prod. As per p1tl8I-RM-p2 the project seems to be abandoned so we might as well remove all related code (cc @tyxla 😉)

Related to #58453 
