### PR TITLE
Theme Info Page: 'Contact Link' now appears on Atomic sites

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -45,6 +45,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isUserPaid } from 'calypso/state/purchases/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { hasFeature } from 'calypso/state/sites/plans/selectors';
@@ -95,6 +96,8 @@ class ThemeSheet extends Component {
 		isActive: PropTypes.bool,
 		isPurchased: PropTypes.bool,
 		isJetpack: PropTypes.bool,
+		isAtomic: PropTypes.bool,
+		isStandaloneJetpack: PropTypes.bool,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 		backPath: PropTypes.string,
@@ -499,7 +502,7 @@ class ThemeSheet extends Component {
 	renderSupportTab = () => {
 		const {
 			isCurrentUserPaid,
-			isJetpack,
+			isStandaloneJetpack,
 			forumUrl,
 			isWpcomTheme,
 			isLoggedIn,
@@ -511,7 +514,9 @@ class ThemeSheet extends Component {
 		if ( isLoggedIn ) {
 			renderedTab = (
 				<div>
-					{ isCurrentUserPaid && ! isJetpack && this.renderSupportContactUsCard( buttonCount++ ) }
+					{ isCurrentUserPaid &&
+						! isStandaloneJetpack &&
+						this.renderSupportContactUsCard( buttonCount++ ) }
 					{ forumUrl && this.renderSupportThemeForumCard( buttonCount++ ) }
 					{ isWpcomTheme && this.renderSupportCssCard( buttonCount++ ) }
 				</div>
@@ -867,6 +872,10 @@ export default connect(
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
 		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, id );
 
+		const isAtomic = isSiteAutomatedTransfer( state, siteId );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isStandaloneJetpack = isJetpack && ! isAtomic;
+
 		return {
 			...theme,
 			id,
@@ -879,7 +888,9 @@ export default connect(
 			isWpcomTheme,
 			isLoggedIn: isUserLoggedIn( state ),
 			isActive: isThemeActive( state, id, siteId ),
-			isJetpack: isJetpackSite( state, siteId ),
+			isJetpack,
+			isAtomic,
+			isStandaloneJetpack,
 			isVip: isVipSite( state, siteId ),
 			isPremium: isThemePremium( state, id ),
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),


### PR DESCRIPTION
The code that hid it on Jetpack sites was also hiding on Atomic sites.

#### Changes proposed in this Pull Request

* While viewing the Theme Info page on an Atomic site, the 'Contact Us' link in the support section will now display

![2022-01-12_10-16](https://user-images.githubusercontent.com/937354/149179096-5b3bba7f-2b1e-4152-9a57-289b602e3759.png)
![2022-01-12_10-18](https://user-images.githubusercontent.com/937354/149179111-e1b7f7fc-106b-4046-af0d-2bbb259930d5.png)

* This was meant to be hidden from Jetpack users (since they aren't eligible for support from WP.com), but it was also hidden for Atomic users. This change allows it to display for Atomic, but keeps it hidden on jetpack.

#### Testing instructions

* Change isomorphic attribute to false
```diff
diff --git a/client/sections.js b/client/sections.js
index 628832adfd..b1cceaf469 100644
--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
                module: 'calypso/my-sites/themes',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
        },
        {
@@ -219,7 +219,7 @@ const sections = [
                module: 'calypso/my-sites/theme',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
                trackLoadPerformance: true,
        },

```
* Visit the theme showcase
* Choose a premium theme and visit the support section
  * On simple sites, it should appear before and after the PR (no change)
  * On standalone jetpack sites (for example, JN sites), it should be hidden before and after the PR (no change)
  * For atomic sites, it should be hidden before the PR and be shown after the PR (change)

Related to #59989
