### PR TITLE
Tour Kit: Refactor Popper clipDimensions/styles checks

### DIFF
--- a/packages/tour-kit/src/components/tour-kit-spotlight.tsx
+++ b/packages/tour-kit/src/components/tour-kit-spotlight.tsx
@@ -67,9 +67,9 @@ const TourKitSpotlight: React.FunctionComponent< Props > = ( { referenceElement,
 	const clipRepositionProps = referenceElement
 		? {
 				style: {
-					...( clipDimensions && clipDimensions ),
+					...clipDimensions,
 					...popperStyles?.popper,
-					...( styles && styles ),
+					...styles,
 				},
 				...popperAttributes?.popper,
 		  }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Cleanup the tour-kit code by removing unnecessary checks: `clipDimensions &&` and `styles &&` in `tour-kit-spotlight`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout branch, then `yarn dev --sync` from the `apps/editing-toolkit` folder to sync the welcome tour to the sandbox
- Append `?welcome-tour-next` to the URL while in the editor, as spotlight is visible only in this way for now.
- Check that everything is working as usual: 
-- Slide 1 has no spotlight effect, hence `clipDimensions` is null. It shouldn't throw any error! 
-- Slide 3 has a spotlight effect, so it should also work as before

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59981
