### PR TITLE
Remove link to premium themes forum

### DIFF
--- a/client/state/themes/selectors/get-theme-forum-url.js
+++ b/client/state/themes/selectors/get-theme-forum-url.js
@@ -1,4 +1,3 @@
-import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 import { isWpcomTheme } from 'calypso/state/themes/selectors/is-wpcom-theme';
 import { isWporgTheme } from 'calypso/state/themes/selectors/is-wporg-theme';
 
@@ -13,9 +12,6 @@ import 'calypso/state/themes/init';
  * @returns {?string}         Theme forum URL
  */
 export function getThemeForumUrl( state, themeId ) {
-	if ( isThemePremium( state, themeId ) ) {
-		return '//premium-themes.forums.wordpress.com/forum/' + themeId;
-	}
 	if ( isWpcomTheme( state, themeId ) ) {
 		return '//en.forums.wordpress.com/forum/themes';
 	}

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1570,7 +1570,7 @@ describe( 'themes selectors', () => {
 				expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
 			} );
 
-			test( 'given a premium theme, should return the specific theme forum URL', () => {
+			test( 'given a premium theme, should return the general themes forum URL', () => {
 				const forumUrl = getThemeForumUrl(
 					{
 						sites: {
@@ -1587,7 +1587,7 @@ describe( 'themes selectors', () => {
 					'mood'
 				);
 
-				expect( forumUrl ).to.equal( '//premium-themes.forums.wordpress.com/forum/mood' );
+				expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
 			} );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Premium themes will no longer have forum links pointing to `'//premium-themes.forums.wordpress.com/forum/' + themeId`, they will be sent to the general forums instead

![2022-01-12_10-44_1](https://user-images.githubusercontent.com/937354/149184325-79a692cd-58b8-440a-a962-1f565cfd7444.png)

Before PR: Links to Premium themes forum
![2022-01-12_10-43](https://user-images.githubusercontent.com/937354/149184357-29e3374c-55ac-4d52-9b40-5cd8ad76c90d.png)

After PR: Links to general forum
![2022-01-12_10-44](https://user-images.githubusercontent.com/937354/149184365-164e4d28-5947-4bc7-97ed-8d6d0efd4287.png)


#### Testing instructions

* Change isomorphic attribute to false
```diff
diff --git a/client/sections.js b/client/sections.js
index 628832adfd..b1cceaf469 100644
--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
                module: 'calypso/my-sites/themes',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
        },
        {
@@ -219,7 +219,7 @@ const sections = [
                module: 'calypso/my-sites/theme',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
                trackLoadPerformance: true,
        },

```
* Visit the theme showcase
* Choose a premium theme and visit the support section
* The forum link for premium themes should no longer point to ``'//premium-themes.forums.wordpress.com/forum/'` after this change

Related to #59988
