### PR TITLE
Enable the backups date picker in all environments, remove date range picker from the backups date controls

### DIFF
--- a/client/my-sites/backup/backup-date-picker/index.tsx
+++ b/client/my-sites/backup/backup-date-picker/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -9,17 +8,15 @@ import { useDispatch, useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
-import DateRangeSelector from 'calypso/my-sites/activity/filterbar/date-range-selector';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useDatesWithNoSuccessfulBackups } from '../status/hooks';
 import DateButton from './date-button';
 import { useCanGoToDate, useFirstKnownBackupAttempt } from './hooks';
 
 import './style.scss';
 
-const SEARCH_LINK_CLICK = recordTracksEvent( 'calypso_jetpack_backup_search' );
 const PREV_DATE_CLICK = recordTracksEvent( 'calypso_jetpack_backup_date_previous' );
 const NEXT_DATE_CLICK = recordTracksEvent( 'calypso_jetpack_backup_date_next' );
 const CALENDAR_DATE_CLICK = recordTracksEvent( 'calypso_jetpack_backup_date_calendar_select_day' );
@@ -32,17 +29,10 @@ const onSpace = ( fn: () => void ) => ( { key }: { key?: string } ) => {
 
 const BackupDatePicker: React.FC< Props > = ( { selectedDate, onDateChange } ) => {
 	const dispatch = useDispatch();
-	const trackSearchLinkClick = () => dispatch( SEARCH_LINK_CLICK );
 
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
-	// Note: only one of these features should be enabled for a given environment.
-	const isUsingDateRangePicker = isEnabled( 'jetpack/backups-date-picker' );
-	const isUsingDateCalendarPicker = isEnabled( 'jetpack/backups-date-calendar' );
-
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const siteSlug = useSelector( getSelectedSiteSlug );
-
 	const today = useDateWithOffset( moment() ) as Moment;
 	const previousDate = moment( selectedDate ).subtract( 1, 'day' );
 	const nextDate = moment( selectedDate ).add( 1, 'day' );
@@ -156,17 +146,7 @@ const BackupDatePicker: React.FC< Props > = ( { selectedDate, onDateChange } ) =
 	return (
 		<div className="backup-date-picker">
 			<div className="backup-date-picker__select-date-container">
-				<div
-					className={
-						'backup-date-picker__select-date' +
-						( isUsingDateRangePicker
-							? ' backup-date-picker__select-date--with-date-range-picker'
-							: '' ) +
-						( isUsingDateCalendarPicker
-							? ' backup-date-picker__select-date--with-date-calendar-picker'
-							: '' )
-					}
-				>
+				<div className="backup-date-picker__select-date backup-date-picker__select-date--with-date-calendar-picker">
 					<div
 						className="backup-date-picker__select-date--previous"
 						role="button"
@@ -190,18 +170,9 @@ const BackupDatePicker: React.FC< Props > = ( { selectedDate, onDateChange } ) =
 						</span>
 					</div>
 
-					{ isUsingDateRangePicker && ! isUsingDateCalendarPicker && (
-						<DateRangeSelector
-							siteId={ siteId }
-							enabled={ true }
-							customLabel={ <Gridicon icon="calendar" /> }
-						/>
-					) }
-					{ ! isUsingDateRangePicker && isUsingDateCalendarPicker && (
-						<div className="backup-date-picker__current-date">
-							<b>{ selectedDisplayDate }</b>
-						</div>
-					) }
+					<div className="backup-date-picker__current-date">
+						<b>{ selectedDisplayDate }</b>
+					</div>
 
 					<div
 						className="backup-date-picker__select-date--next"
@@ -227,26 +198,15 @@ const BackupDatePicker: React.FC< Props > = ( { selectedDate, onDateChange } ) =
 							</Button>
 						</div>
 					</div>
-					{ isUsingDateRangePicker && ! isUsingDateCalendarPicker && (
-						<a
-							className="backup-date-picker__search-link"
-							href={ `/activity-log/${ siteSlug }` }
-							onClick={ trackSearchLinkClick }
-						>
-							<Gridicon icon="search" className="backup-date-picker__search-icon" />
-						</a>
-					) }
 				</div>
 			</div>
 
-			{ ! isUsingDateRangePicker && isUsingDateCalendarPicker && (
-				<DateButton
-					onDateSelected={ goToCalendarDate }
-					selectedDate={ selectedDate }
-					firstBackupDate={ firstVisibleBackupDate }
-					disabledDates={ datesWithNoBackups.dates }
-				/>
-			) }
+			<DateButton
+				onDateSelected={ goToCalendarDate }
+				selectedDate={ selectedDate }
+				firstBackupDate={ firstVisibleBackupDate }
+				disabledDates={ datesWithNoBackups.dates }
+			/>
 		</div>
 	);
 };

--- a/client/my-sites/backup/backup-date-picker/style.scss
+++ b/client/my-sites/backup/backup-date-picker/style.scss
@@ -42,15 +42,6 @@
 		justify-content: flex-start;
 	}
 
-	// Variant when the date range picker is used
-	&--with-date-range-picker {
-		.backup-date-picker__search-link {
-			@include breakpoint-deprecated( '>660px' ) {
-				margin-left: auto;
-			}
-		}
-	}
-
 	// Variant when the calendar date picker is used
 	&--with-date-calendar-picker {
 		.backup-date-picker__select-date--previous,
@@ -245,6 +236,11 @@
 	.DayPicker-Day.DayPicker-Day--is-selected.DayPicker-Day--today .date-picker__day,
 	.DayPicker-Day--is-selected .date-picker__day {
 		background-color: var( --studio-jetpack-green-50 );
+	}
+
+	// Style Sundays the same as the other days
+	.DayPicker-Day--sunday:not( .DayPicker-Day--today ):not( .DayPicker-Day--disabled ):not( .DayPicker-Day--outside ) .date-picker__day {
+		color: var( --color-neutral-70 );
 	}
 
 	// Show a small dot on the days that should have a backup available.

--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -258,23 +258,4 @@ describe( 'BackupDatePicker', () => {
 
 			picker.find( '.backup-date-picker__select-date--next' ).simulate( 'click' );
 		} ) );
-
-	test( 'Records a Tracks event when the search icon is clicked', () =>
-		new Promise( ( done ) => {
-			const checkSearchClickTracksEvent = ( event ) => {
-				const name = getTracksEventName( event );
-				expect( name ).toEqual( 'calypso_jetpack_backup_search' );
-				done();
-			};
-
-			// Enable the backup date picker feature for this test, since that is needed to show the search icon.
-			isEnabled.mockImplementation( ( flag ) => flag === 'jetpack/backups-date-picker' );
-			useDispatch.mockImplementation( () => checkSearchClickTracksEvent );
-
-			const picker = shallow(
-				<BackupDatePicker selectedDate={ moment() } onDateChange={ () => {} } />
-			);
-
-			picker.find( '.backup-date-picker__search-link' ).simulate( 'click' );
-		} ) );
 } );

--- a/config/development.json
+++ b/config/development.json
@@ -76,7 +76,6 @@
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
-		"jetpack/backups-date-calendar": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -37,7 +37,6 @@
 		"dev/preferences-helper": true,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
-		"jetpack/backups-date-calendar": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -31,7 +31,6 @@
 		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"jetpack-cloud": true,
-		"jetpack/backups-date-picker": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -34,7 +34,6 @@
 		"checkout/google-pay": false,
 		"i18n/community-translator": false,
 		"jetpack-cloud": true,
-		"jetpack/backups-date-picker": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -34,7 +34,6 @@
 		"checkout/google-pay": false,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
-		"jetpack/backups-date-calendar": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,7 +43,6 @@
 		"inline-help": true,
 		"i18n/empathy-mode": true,
 		"jetpack/api-cache": true,
-		"jetpack/backups-date-calendar": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the date picker control for Jetpack Backups in all environments
* It also removes the date-range control previously used on Jetpack Cloud from the backup date controls, in favor of the new date picker control.

#### Testing instructions

* Check out this PR in your Calypso test environment.
* Follow the test plan on #56367 to confirm that the date picker control works as intended with these changes.
* Test in both Calypso and Jetpack Cloud
* One additional small change, Sundays should now display the same color as other days in the date picker. Currently, dates that fall on a Sunday show as a slightly lighter grey than other days.

Unit tests should pass for:
`yarn run test-client client/my-sites/backup/backup-date-picker`
`yarn run test-client client/my-sites/backup/status`
