### PR TITLE
Update @wordpress/components type definitions to 14.0.9

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -136,7 +136,7 @@ packageExtensions:
   '@types/wordpress__blocks@6.4.12':
     peerDependencies:
       react: '*'
-  '@types/wordpress__components@14.0.5':
+  '@types/wordpress__components@14.0.9':
     peerDependencies:
       react: '*'
   '@types/wordpress__editor@10.0.1':

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -42,7 +42,7 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 						autoCorrect="off"
 					/>
 					<div className="nux-launch-step__input-hint">
-						<Tip size={ 18 } />
+						<Tip />
 						{ /* translators: The "it" here refers to the site title. */ }
 						<span>{ __( "Don't worry, you can change it later.", 'full-site-editing' ) }</span>
 					</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/wp-components-types.d.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/wp-components-types.d.ts
@@ -1,5 +1,0 @@
-declare module '@wordpress/components' {
-	const Tip: React.ComponentType< any >;
-}
-
-export {};

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
 		"@types/wordpress__api-fetch": "^3.2.4",
 		"@types/wordpress__block-editor": "^6.0.4",
 		"@types/wordpress__block-library": "^2.6.1",
-		"@types/wordpress__components": "^14.0.5",
+		"@types/wordpress__components": "^14.0.9",
 		"@types/wordpress__compose": "^4.0.1",
 		"@types/wordpress__data": "^4.6.10",
 		"@types/wordpress__data-controls": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7333,23 +7333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/wordpress__components@npm:*":
-  version: 14.0.5
-  resolution: "@types/wordpress__components@npm:14.0.5"
-  dependencies:
-    "@types/react": "*"
-    "@types/tinycolor2": "*"
-    "@types/wordpress__components": "*"
-    "@types/wordpress__notices": "*"
-    "@types/wordpress__rich-text": "*"
-    "@wordpress/element": ^3.0.0
-    downshift: ^6.0.15
-    re-resizable: ^6.4.0
-  checksum: e3f9e81acb372af796a45fd28454e5813d6e38dbd31c5c71520692f8a37a4b2ca8a4fa99e39619250f19bbd8bd8927065a016ad123c315bab9aff0d808eb5520
-  languageName: node
-  linkType: hard
-
-"@types/wordpress__components@npm:^14.0.9":
+"@types/wordpress__components@npm:*, @types/wordpress__components@npm:^14.0.9":
   version: 14.0.9
   resolution: "@types/wordpress__components@npm:14.0.9"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7333,7 +7333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/wordpress__components@npm:*, @types/wordpress__components@npm:^14.0.5":
+"@types/wordpress__components@npm:*":
   version: 14.0.5
   resolution: "@types/wordpress__components@npm:14.0.5"
   dependencies:
@@ -7346,6 +7346,22 @@ __metadata:
     downshift: ^6.0.15
     re-resizable: ^6.4.0
   checksum: e3f9e81acb372af796a45fd28454e5813d6e38dbd31c5c71520692f8a37a4b2ca8a4fa99e39619250f19bbd8bd8927065a016ad123c315bab9aff0d808eb5520
+  languageName: node
+  linkType: hard
+
+"@types/wordpress__components@npm:^14.0.9":
+  version: 14.0.9
+  resolution: "@types/wordpress__components@npm:14.0.9"
+  dependencies:
+    "@types/react": "*"
+    "@types/tinycolor2": "*"
+    "@types/wordpress__components": "*"
+    "@types/wordpress__notices": "*"
+    "@types/wordpress__rich-text": "*"
+    "@wordpress/element": ^3.0.0
+    downshift: ^6.0.15
+    re-resizable: ^6.4.0
+  checksum: 47035d37811ee3d3e2c4d7b3029c39040670a176802320c154fd18967a6e755738785816fb6cbe6804d83a6e332be705e5faecf86dd681e94f0730c574b296bf
   languageName: node
   linkType: hard
 
@@ -38047,7 +38063,7 @@ testarmada-magellan@11.0.10:
     "@types/wordpress__api-fetch": ^3.2.4
     "@types/wordpress__block-editor": ^6.0.4
     "@types/wordpress__block-library": ^2.6.1
-    "@types/wordpress__components": ^14.0.5
+    "@types/wordpress__components": ^14.0.9
     "@types/wordpress__compose": ^4.0.1
     "@types/wordpress__data": ^4.6.10
     "@types/wordpress__data-controls": ^2.2.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates our dependency on the `@wordpress/components` **type definitions** (this is actually `@types/wordpress__components` since it uses [DefinitelyTyped](https://definitelytyped.org/), not the package itself) to 14.0.9 which includes the types for `ComboboxControl`, `ToolbarGroup`, `Guide`, `Tip` and `VisuallyHidden` thanks to the following PRs:

- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58058
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58077
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58080
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58106

Since we use all of the above components in calypso, this will fix our remaining TypeScript errors.

**Note**: the `editing-toolkit` app uses the `Tip` component, which works in TypeScript because that package adds its own type definition. Because this PR also adds a (more correct) type definition, it creates a type error in that package. It also creates an additional type error because that package is using `Tip` with a `size` prop that doesn't exist in the component's definition. Therefore, this PR removes both the override and the use of `size`.

#### Testing instructions

Verify that this doesn't change any behavior and affects only types.