### PR TITLE
Jetpack: Make Activation CTA on pricing page redirect to the activation screen

### DIFF
--- a/client/components/jetpack/licensing-activation-banner/index.tsx
+++ b/client/components/jetpack/licensing-activation-banner/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 function LicensingActivationBanner( { siteId }: Props ) {
 	const translate = useTranslate();
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=jetpack#/my-plan';
+	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=jetpack#/license/activation';
 	const userLicensesCounts = useSelector( getUserLicensesCounts );
 	const hasDetachedLicenses = userLicensesCounts && userLicensesCounts[ 'detached' ] !== 0;
 

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -22,7 +22,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	const userLicenses = useSelector( getUserLicenses );
 	const userLicensesCounts = useSelector( getUserLicensesCounts );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=jetpack#/my-plan';
+	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=jetpack#/license/activation';
 
 	const hasOneDetachedLicense = userLicensesCounts && userLicensesCounts[ 'detached' ] === 1;
 	const hasDetachedLicenses = userLicensesCounts && userLicensesCounts[ 'detached' ] !== 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, the activation CTA points to the My Plan section, and this PR changes it to make it point to the license activation flow.

#### Testing instructions

* Download this PR.
* Go to https://cloud.jetpack.com/pricing. (if you already have an available user license, skip this and the next two steps)
* Purchase any Jetpack product other than Jetpack Search.
* Do not activate the product in any site.
* Start Calypso with `yarn start`.
* Create a JN.
* Start the Jetpack setup process.
* Once you're on wordpress.com, replace it with `calypso.localhost:3000` (keep the rest of the URL intact).
* Continue the connection process.
* On the plans page, verify that the user license prompt points to the activation flow and not to the My plan section.
* On the plans page, verify that the user license banner points to the activation flow and not to the My plan section.

Related to 1201509629272450-as-1201653224938699

#### Demo

**Prompt**
![image](https://user-images.githubusercontent.com/3418513/149193702-3ca08941-f483-478b-9d01-e0a20b402609.png)

**Banner**
![image](https://user-images.githubusercontent.com/3418513/149193754-c2d3af94-41db-499d-905f-d10939f4a486.png)
