### PR TITLE
E2E: discontinue `Editor: Basic Post Flow` from running as part of calypso-pr and calypso-release groups.

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__post-basic-flow-spec.ts
@@ -1,6 +1,4 @@
 /**
- * @group calypso-pr
- * @group calypso-release
  * @group gutenberg
  */
 
@@ -72,7 +70,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Patterns', function () {
-		const patternName = 'About Me';
+		const patternName = 'Heading';
 
 		it( `Add ${ patternName }`, async function () {
 			await gutenbergEditorPage.addPattern( patternName );
@@ -119,7 +117,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			}
 		} );
 
-		it.skip( 'Close preview', async function () {
+		skipItIf(targetDevice === 'desktop')( 'Close preview', async function () {
 			// Mobile path.
 			if ( previewPage ) {
 				await previewPage.close();

--- a/test/e2e/specs/specs-wpcom/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__post-basic-flow-spec.ts
@@ -117,7 +117,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			}
 		} );
 
-		skipItIf(targetDevice === 'desktop')( 'Close preview', async function () {
+		skipItIf( targetDevice === 'desktop' )( 'Close preview', async function () {
 			// Mobile path.
 			if ( previewPage ) {
 				await previewPage.close();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR discontinues `Editor: Basic Post Flow` from running as part of the `calypso-pr` and `pre-release` groups.
The aforementioned groups are focused on Calypso behavior, not Gutenberg.

For more information, see discussion at p1641930193090800/1641546921.046300-slack-C02DQP0FP.

Key changes:
- remove `calypso-pr` and `calypso-release` groups from `Editor: Basic Post Flow`.
- use `Heading` post pattern instead of `About Me`.
- use conditional skip, as Preview step should not be skipped for mobile devices.
- move the spec file under `specs/specs-wpcom`.

#### Testing instructions

Ensure that:

- [x] Calypso E2E does not register this spec as having been run.
- [x] WPCOM Gutenberg E2E continues to run this spec.
