### PR TITLE
Videos UI: Correct display of the CTA description.

### DIFF
--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -29,6 +29,15 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 		return `${ course.cta.url }/${ selectedSite.domain }`;
 	};
 
+	const getCTADescription = () => {
+		if ( ! course?.cta?.description || course.cta.description === '' ) {
+			return translate(
+				"You did it! Now it's time to put your skills to work and draft your first post."
+			);
+		}
+		return course.cta.description;
+	};
+
 	return (
 		<div className="videos-ui__footer-bar">
 			<div
@@ -40,13 +49,7 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 					<Gridicon icon="chevron-left" size={ 24 } />
 					<span>{ translate( 'Back' ) }</span>
 				</a>
-				{ isCourseComplete && (
-					<p>
-						{ translate(
-							"You did it! Now it's time to put your skills to work and draft your first post."
-						) }
-					</p>
-				) }
+				{ isCourseComplete && <p>{ getCTADescription() }</p> }
 
 				{ isCourseComplete && (
 					<Button


### PR DESCRIPTION
We allow a course creator to add a custom message for the CTA prompt, but currently that prompt is hard-coded to "You did it! Now it's time to put your skills to work and draft your first post." This PR introduces the `cta.description` variable and uses it if it's not an empty string.

<img width="955" alt="Screen Shot 2022-01-12 at 12 06 26 PM" src="https://user-images.githubusercontent.com/349751/149213976-d7f29fb8-8be6-4b30-9dd7-130f4dcd1227.png">

#### Testing instructions

* In the course management site, set the CTA description to something different in `/wp-admin/post.php?post=89&action=edit`
* Click this PR's calypso.live link below.
* Open the videos UI, make sure all of the video are complete to display the CTA prompt.
* Verify the prompt is the custom prompt you set in the step above.
