### PR TITLE
Try improving price alignment in theme showcase

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -157,7 +157,7 @@ export class Theme extends Component {
 		const showUpsell = hasPrice && upsellUrl;
 		const priceClass = classNames( 'theme__badge-price', {
 			'theme__badge-price-upgrade': ! hasPrice,
-			'theme__badge-price-test': showUpsell,
+			'theme__badge-price-upsell': showUpsell,
 		} );
 
 		const themeDescription = decodeEntities( description );

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -92,10 +92,6 @@ $theme-info-height: 54px;
 	font-weight: 600;
 }
 
-// .theme__badge-price-upsell {
-// 	padding: 18px 5px;
-// }
-
 .theme__upsell {
 	flex: 0 0 auto;
 	padding: 5px 10px 0 0;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -64,6 +64,7 @@ $theme-info-height: 54px;
 	height: $theme-info-height;
 	display: flex;
 	background: var( --color-surface );
+	align-items: center;
 }
 
 .theme__info-title {
@@ -85,19 +86,19 @@ $theme-info-height: 54px;
 
 .theme__badge-price {
 	flex: 0 0 auto;
-	padding: 18px 10px 0;
+	padding: 0 10px;
 	color: var( --color-success );
 	font-size: $font-body-small;
 	font-weight: 600;
 }
 
-.theme__badge-price-test {
-	padding: 18px 5px;
-}
+// .theme__badge-price-upsell {
+// 	padding: 18px 5px;
+// }
 
 .theme__upsell {
 	flex: 0 0 auto;
-	padding: 16px 10px 0 0;
+	padding: 5px 10px 0 0;
 	color: var( --color-neutral-light );
 }
 

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -285,3 +285,4 @@ $theme-info-height: 54px;
 .theme__ribbon {
 	text-transfrom: capitalize;
 }
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the visual alignment of prices in the theme showcase

![2022-01-12_15-08](https://user-images.githubusercontent.com/937354/149221663-bbc9667a-48d9-484e-89b3-9e557bdc2457.png)


I'm not sure what I'm doing here, but this might be an improvement?

#### Testing instructions

0. Turn off isomorphic attribute
```
diff --git a/client/sections.js b/client/sections.js
index 628832adfd..b1cceaf469 100644
--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
                module: 'calypso/my-sites/themes',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
        },
        {
@@ -219,7 +219,7 @@ const sections = [
                module: 'calypso/my-sites/theme',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
                trackLoadPerformance: true,
        },
```

1. Visit the Theme Showcase with a free simple site
2. Make sure the `?flags=themes/premium` flag is present in the URL
3. Visually inspect the price alignment

Related to #59993
