### PR TITLE
Shopping Cart: update removal modal copy for Marketplace products

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -367,6 +367,7 @@ export interface ResponseCartProductExtra {
 	privacy?: boolean;
 	afterPurchaseUrl?: string;
 	isJetpackCheckout?: boolean;
+	is_marketplace_product?: boolean;
 }
 
 export interface RequestCartProductExtra extends ResponseCartProductExtra {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -317,28 +317,24 @@ function returnModalCopyForProduct(
 	const productType = getProductTypeForModalCopy(
 		product,
 		hasBundledDomainInCart,
-		hasMarketplaceProductsInCart
+		hasMarketplaceProductsInCart,
+		isPwpoUser
 	);
 	const isRenewal = isWpComProductRenewal( product );
-	return returnModalCopy(
-		productType,
-		translate,
-		createUserAndSiteBeforeTransaction,
-		isPwpoUser,
-		isRenewal
-	);
+	return returnModalCopy( productType, translate, createUserAndSiteBeforeTransaction, isRenewal );
 }
 
 function getProductTypeForModalCopy(
 	product: ResponseCartProduct,
 	hasBundledDomainInCart: boolean,
-	hasMarketplaceProductsInCart: boolean
+	hasMarketplaceProductsInCart: boolean,
+	isPwpoUser: boolean
 ): string {
 	if ( isWpComPlan( product.product_slug ) ) {
 		if ( hasMarketplaceProductsInCart ) {
 			return 'plan with marketplace dependencies';
 		}
-		if ( hasBundledDomainInCart ) {
+		if ( hasBundledDomainInCart && ! isPwpoUser ) {
 			return 'plan with domain dependencies';
 		}
 		return 'plan';
@@ -355,7 +351,6 @@ function returnModalCopy(
 	productType: string,
 	translate: ReturnType< typeof useTranslate >,
 	createUserAndSiteBeforeTransaction: boolean,
-	isPwpoUser: boolean,
 	isRenewal = false
 ): ModalCopy {
 	switch ( productType ) {
@@ -401,13 +396,9 @@ function returnModalCopy(
 				);
 			} else {
 				description = String(
-					isPwpoUser
-						? translate(
-								'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan.'
-						  )
-						: translate(
-								'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
-						  )
+					translate(
+						'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
+					)
 				);
 			}
 			return { title, description };
@@ -418,7 +409,7 @@ function returnModalCopy(
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
 					description: String(
 						translate(
-							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date. We will then take you back to your site.'
+							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date.'
 						)
 					),
 				};
@@ -430,7 +421,7 @@ function returnModalCopy(
 					createUserAndSiteBeforeTransaction
 						? translate( 'When you press Continue, we will remove your plan from the cart.' )
 						: translate(
-								'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. We will then take you back to your site.'
+								'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan.'
 						  )
 				),
 			};

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -309,14 +309,14 @@ interface ModalCopy {
 function returnModalCopyForProduct(
 	product: ResponseCartProduct,
 	translate: ReturnType< typeof useTranslate >,
-	hasDomainsInCart: boolean,
+	hasBundledDomainInCart: boolean,
 	hasMarketplaceProductsInCart: boolean,
 	createUserAndSiteBeforeTransaction: boolean,
 	isPwpoUser: boolean
 ): ModalCopy {
 	const productType = getProductTypeForModalCopy(
 		product,
-		hasDomainsInCart,
+		hasBundledDomainInCart,
 		hasMarketplaceProductsInCart
 	);
 	const isRenewal = isWpComProductRenewal( product );
@@ -331,15 +331,15 @@ function returnModalCopyForProduct(
 
 function getProductTypeForModalCopy(
 	product: ResponseCartProduct,
-	hasDomainsInCart: boolean,
+	hasBundledDomainInCart: boolean,
 	hasMarketplaceProductsInCart: boolean
 ): string {
 	if ( isWpComPlan( product.product_slug ) ) {
 		if ( hasMarketplaceProductsInCart ) {
 			return 'plan with marketplace dependencies';
 		}
-		if ( hasDomainsInCart ) {
-			return 'plan with dependencies';
+		if ( hasBundledDomainInCart ) {
+			return 'plan with domain dependencies';
 		}
 		return 'plan';
 	}
@@ -365,7 +365,7 @@ function returnModalCopy(
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
 					description: String(
 						translate(
-							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date. If any of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
+							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date. Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
 						)
 					),
 				};
@@ -375,11 +375,11 @@ function returnModalCopy(
 				title: String( translate( 'You are about to remove your plan from the cart' ) ),
 				description: String(
 					translate(
-						'When you press Continue, we will remove your plan from the cart. If any of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
+						'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
 					)
 				),
 			};
-		case 'plan with dependencies': {
+		case 'plan with domain dependencies': {
 			if ( isRenewal ) {
 				return {
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
@@ -797,8 +797,10 @@ function WPLineItem( {
 } ): JSX.Element {
 	const id = product.uuid;
 	const translate = useTranslate();
-	const hasDomainsInCart = responseCart.products.some(
-		( product ) => product.is_domain_registration || product.product_slug === 'domain_transfer'
+	const hasBundledDomainsInCart = responseCart.products.some(
+		( product ) =>
+			( product.is_domain_registration || product.product_slug === 'domain_transfer' ) &&
+			product.is_bundled
 	);
 	const hasMarketplaceProductsInCart = responseCart.products.some(
 		( product ) => product.extra.is_marketplace_product === true
@@ -809,7 +811,7 @@ function WPLineItem( {
 	const modalCopy = returnModalCopyForProduct(
 		product,
 		translate,
-		hasDomainsInCart,
+		hasBundledDomainsInCart,
 		hasMarketplaceProductsInCart,
 		createUserAndSiteBeforeTransaction || false,
 		isPwpoUser || false

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -360,7 +360,7 @@ function returnModalCopy(
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
 					description: String(
 						translate(
-							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date. Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
+							"Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, we'll remove them along with your plan in the cart, and your plan will keep its current expiry date."
 						)
 					),
 				};
@@ -370,7 +370,7 @@ function returnModalCopy(
 				title: String( translate( 'You are about to remove your plan from the cart' ) ),
 				description: String(
 					translate(
-						'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
+						"Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, we'll remove them along with your new plan in the cart, and your site will continue to run its current plan."
 					)
 				),
 			};
@@ -397,7 +397,7 @@ function returnModalCopy(
 			} else {
 				description = String(
 					translate(
-						'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart.'
+						"Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, we'll remove them along with your new plan in the cart, and your site will continue to run its current plan."
 					)
 				);
 			}


### PR DESCRIPTION
This updates the `returnModalCopy` when a user removes the required Business plan when making a Marketplace purchase to include copy about the dependency. While I was in there, I cleaned up some other strings (which will need re-translation).

<img width="461" alt="Screen Shot 2022-01-12 at 5 08 06 PM" src="https://user-images.githubusercontent.com/942359/149231847-0f271add-d546-4247-919c-e970e5858598.png">

**To Test:**
- ~requires D72910-code~
- visit `/checkout/{yoursite.wordpress.com}/business-bundle-monthly,woocommerce_subscriptions_monthly`
- click "remove from cart" for the Business plan
- verify that the modal mentions that items that require the plan will also be removed from the cart
- click cancel
- click "remove from cart" for the Marketplace product
- verify that the modal doesn't mention dependencies