### PR TITLE
Update eligibility warnings modal on plugin details

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -3,6 +3,7 @@ import {
 	FEATURE_PERFORMANCE,
 	FEATURE_UPLOAD_THEMES,
 	FEATURE_SFTP,
+	FEATURE_INSTALL_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -39,6 +40,7 @@ interface ExternalProps {
 	standaloneProceed: boolean;
 	className?: string;
 	eligibilityData?: EligibilityData;
+	currentContext?: string;
 }
 
 type Props = ExternalProps & ReturnType< typeof mergeProps > & LocalizeProps;
@@ -248,7 +250,11 @@ function mergeProps(
 	let context: string | null = null;
 	let feature = '';
 	let ctaName = '';
-	if ( includes( ownProps.backUrl, 'plugins' ) ) {
+	if ( ownProps.currentContext === 'plugin-details' ) {
+		context = ownProps.currentContext;
+		feature = FEATURE_INSTALL_PLUGINS;
+		ctaName = 'calypso-plugin-details-eligibility-upgrade-nudge';
+	} else if ( includes( ownProps.backUrl, 'plugins' ) ) {
 		context = 'plugins';
 		feature = FEATURE_UPLOAD_PLUGINS;
 		ctaName = 'calypso-plugin-eligibility-upgrade-nudge';

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,6 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
+import { Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import ExternalLink from 'calypso/components/external-link';
 import type { EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
@@ -26,8 +27,11 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 		{ map( warnings, ( { name, description, supportUrl }, index ) => (
 			<div className="eligibility-warnings__warning" key={ index }>
 				<div className="eligibility-warnings__message">
-					<span className="eligibility-warnings__message-title">{ name }</span>
-					:&nbsp;
+					{ context !== 'plugin-details' && (
+						<Fragment>
+							<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
+						</Fragment>
+					) }
 					<span className="eligibility-warnings__message-description">
 						{ description }{ ' ' }
 						{ supportUrl && (
@@ -42,10 +46,8 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 
 		<div className="eligibility-warnings__warning">
 			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
-				:&nbsp;
 				<span className="eligibility-warnings__message-description">
-					{ translate( '{{a}}Contact support{{/a}} for help.', {
+					{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
 						components: {
 							a: <ActionPanelLink href="/help/contact" />,
 						},
@@ -70,6 +72,7 @@ function getWarningDescription(
 		}
 	);
 	switch ( context ) {
+		case 'plugin-details':
 		case 'plugins':
 			return translate(
 				'By installing a plugin the following change will be made to the site:',

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -209,11 +209,14 @@ const CTAButton = ( {
 	return (
 		<>
 			<Dialog
+				additionalClassNames={ 'plugin-details-CTA__dialog-content' }
+				additionalOverlayClassNames={ 'plugin-details-CTA__modal-overlay' }
 				isVisible={ showEligibility }
 				title={ translate( 'Eligibility' ) }
 				onClose={ () => setShowEligibility( false ) }
 			>
 				<EligibilityWarnings
+					currentContext={ 'plugin-details' }
 					standaloneProceed
 					onProceed={ () =>
 						onClickInstallPlugin( {

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -5,6 +5,20 @@
 	padding-bottom: 0;
 }
 
+.plugin-details-CTA__modal-overlay.dialog__backdrop {
+	background-color: rgba( var( --color-neutral-100-rgb ), 0.7 );
+}
+
+.plugin-details-CTA__dialog-content {
+	.eligibility-warnings {
+		margin: 0;
+
+		.card {
+			box-shadow: none;
+		}
+	}
+}
+
 .plugin-details-CTA__price {
 	font-family: $brand-serif;
 	font-size: $font-title-large;

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -9,6 +9,7 @@ import './style.scss';
 
 type Props = {
 	additionalClassNames?: Parameters< typeof classnames >[ 0 ];
+	additionalOverlayClassNames?: Parameters< typeof classnames >[ 0 ];
 	baseClassName?: string;
 	buttons?: Button[];
 	className?: string;
@@ -24,6 +25,7 @@ type Props = {
 
 const Dialog = ( {
 	additionalClassNames,
+	additionalOverlayClassNames,
 	buttons,
 	baseClassName = 'dialog',
 	className,
@@ -51,7 +53,7 @@ const Dialog = ( {
 	// Previous implementation used a `<Card />`, styling still relies on the 'card' class being present
 	const dialogClassName = classnames( baseClassName, 'card', additionalClassNames );
 
-	const backdropClassName = classnames( baseClassName + '__backdrop', {
+	const backdropClassName = classnames( baseClassName + '__backdrop', additionalOverlayClassNames, {
 		'is-full-screen': isFullScreen,
 		'is-hidden': ! isBackdropVisible,
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added plugin-details context to EligibilityWarnings component.
* Added AdditionalOverlayClassNames prop to Dialog component to allow customizing the modal window.
* Removed eligibility warning name and text Questions.
* Removed border and padding from Eligibility Warnings cards.

#### Testing instructions

- From a free site Go to Plugins
- Click on any plugin to go to the details
- Click on Upgrade and activate.
- A modal window shows up

| Before | After |
|-------|------|
|<img width="1136" alt="SS 2021-11-25 at 14 19 10" src="https://user-images.githubusercontent.com/12430020/143440585-8887a088-2ce6-4509-82b2-1eb4ccd8cd89.png">|<img width="1707" alt="Screen Shot 2022-01-13 at 12 27 02 AM" src="https://user-images.githubusercontent.com/351784/149271130-fc88e775-1a1e-487b-9218-a7dc140aa872.png">|

Related to #58503
