### PR TITLE
Address step validation follow up

### DIFF
--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -244,7 +244,7 @@ function useAddressFormValidation( siteId: number ) {
 		errors[ WOOCOMMERCE_ONBOARDING_PROFILE ] = ! emailValidator.validate(
 			get( WOOCOMMERCE_ONBOARDING_PROFILE )?.[ 'store_email' ]
 		)
-			? __( 'Please add a store email' )
+			? __( 'Please add a valid email address' )
 			: '';
 
 		setErrors( errors );

--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -39,5 +39,10 @@
 			border-color: var( --color-error );
 			box-shadow: 0 0 0 0 var( --color-error );
 		}
+
+		.components-base-control__field {
+			// Remove margin-bottom on error so errors are positioned closer to the corresponding field
+			margin-bottom: unset;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Address step validation tweaks follow up on #59974
* Fix wording of email error
* Fix error placement

#### Testing instructions

* Go to http://calypso.localhost:3000/woocommerce-installation/?flags=woop
* Choose a non atomic site (atomic won't work until JP updates with new country endpoint data)
* Click set up my store
* You should be taken to the address step (when the woop flag is active)
* Clicking the continue button should fail with validation errors until the form is completed correctly.

Before
![Screenshot 2022-01-13 at 13-58-06 Add WooCommerce to your site — WordPress com](https://user-images.githubusercontent.com/811776/149257937-6800a1a6-f128-4c7b-9931-da1a668b465d.png)

After
![Screenshot 2022-01-13 at 16-54-22 Add WooCommerce to your site — WordPress com](https://user-images.githubusercontent.com/811776/149273710-aa170911-af6d-490b-aa67-58ee5e593fda.png)

Related to #
