### PR TITLE
Add notices under domain settings header

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -372,7 +372,7 @@ const Settings = ( {
 			{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
-			<SettingsHeader domain={ domain } />
+			<SettingsHeader domain={ domain } purchase={ purchase } site={ selectedSite } />
 			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />
 		</Main>
 	);

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -372,7 +372,7 @@ const Settings = ( {
 			{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
-			<SettingsHeader domain={ domain } purchase={ purchase } site={ selectedSite } />
+			<SettingsHeader domain={ domain } site={ selectedSite } />
 			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />
 		</Main>
 	);

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -107,12 +107,12 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 	};
 
 	const renderNotices = () => {
-		const { domain, purchase, site } = props;
-		const { noticeText, statusClass } = resolveDomainStatus( domain, purchase, {
+		const { domain, site } = props;
+		const { noticeText, statusClass } = resolveDomainStatus( domain, null, {
 			siteSlug: site?.slug,
 			getMappingErrors: true,
 			email: null,
-		} );
+		} as any );
 
 		if ( noticeText && statusClass )
 			return (

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -1,6 +1,7 @@
 import { Circle, SVG } from '@wordpress/components';
 import { home, Icon, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import Badge from 'calypso/components/badge';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { resolveDomainStatus } from 'calypso/lib/domains';
@@ -105,6 +106,36 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 		return <div className="settings-header__container-badges">{ badges }</div>;
 	};
 
+	const renderNotices = () => {
+		const { domain, purchase, site } = props;
+		const { noticeText, statusClass } = resolveDomainStatus( domain, purchase, {
+			siteSlug: site?.slug,
+			getMappingErrors: true,
+			email: null,
+		} );
+
+		if ( noticeText && statusClass )
+			return (
+				<div className="settings-header__domain-notice">
+					<Icon
+						icon={ info }
+						size={ 18 }
+						className={ classnames( 'settings-header__domain-notice-icon gridicon', {
+							'gridicon--error settings-header__domain-notice-icon--rotated': [
+								'status-error',
+								'status-warning',
+								'status-alert',
+							].includes( statusClass ),
+						} ) }
+						viewBox="2 2 20 20"
+					/>
+					<div className="settings-header__domain-notice-message">{ noticeText }</div>
+				</div>
+			);
+
+		return null;
+	};
+
 	return (
 		<div className="settings-header__container">
 			<div className="settings-header__container-title">
@@ -117,6 +148,7 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 				/>
 				{ renderBadges() }
 			</div>
+			{ renderNotices() }
 		</div>
 	);
 };

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -117,6 +117,49 @@
 			}
 		}
 	}
+	&__domain-notice {
+		flex-basis: 100%;
+		background-color: var( --studio-gray-0 );
+		display: flex;
+		align-items: center;
+		padding: 5px;
+		margin: 12px 0 24px;
+		gap: 8px;
+		border-radius: 2px;
+	}
+
+	&__domain-notice-icon.gridicon {
+		align-self: flex-start;
+		min-width: 18px;
+		position: relative;
+		top: 2px;
+		fill: var( --studio-green-50 );
+
+		&--error {
+			fill: var( --studio-orange-40 );
+		}
+	}
+
+	&__domain-notice-icon--rotated {
+		transform: rotate( 180deg );
+	}
+
+	&__domain-notice-message {
+		font-weight: 400;
+		font-size: $font-body-small;
+		color: var( --studio-gray-80 );
+
+		button.button-plain {
+			cursor: pointer;
+			color: var( --color-link );
+
+			&:hover,
+			&:focus,
+			&:active {
+				color: var( --color-link-dark );
+			}
+		}
+	}
 }
 
 .domain-settings-page {

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -52,7 +52,6 @@ export type SettingsPageConnectedDispatchProps = {
 export type SettingsHeaderProps = {
 	domain: ResponseDomain;
 	site: SiteData;
-	purchase: Purchase | null;
 };
 
 export type SettingsPageProps = SettingsPagePassedProps &

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -51,6 +51,8 @@ export type SettingsPageConnectedDispatchProps = {
 
 export type SettingsHeaderProps = {
 	domain: ResponseDomain;
+	site: SiteData;
+	purchase: Purchase | null;
 };
 
 export type SettingsPageProps = SettingsPagePassedProps &


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR add domain notices on the header of domain setting page, according to new Figma design (hlVh2q24ad6MCwlwNnE9PQ-fi)

![Markup on 2022-01-07 at 12:20:16](https://user-images.githubusercontent.com/2797601/148536947-88e367e7-8a93-4fbe-b1ae-688004f1a27a.png)

## Testing instructions

To test different cases it could be useful apply this patch on the sandbox (2b3dd-pb/)

- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades -> Domains"
- Select different domains and verify that for each case the notice is show according the [Domain messages file](https://docs.google.com/spreadsheets/d/1311HcXoEvPNyMy_FvrzWO0z2nrT5mflPV-_7qdo0Smo/edit#gid=1768180225)