### PR TITLE
`QueryJetpackPlugins`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-jetpack-plugins/index.jsx
+++ b/client/components/data/query-jetpack-plugins/index.jsx
@@ -14,19 +14,17 @@ class QueryJetpackPlugins extends Component {
 		fetchPlugins: PropTypes.func,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( this.props.siteIds && ! this.props.isRequestingForSites ) {
 			this.props.fetchPlugins( this.props.siteIds );
 		}
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( isEqual( nextProps.siteIds, this.props.siteIds ) ) {
+	componentDidUpdate( prevProps ) {
+		if ( isEqual( prevProps.siteIds, this.props.siteIds ) ) {
 			return;
 		}
-		this.refresh( nextProps.isRequestingForSites, nextProps.siteIds );
+		this.refresh( prevProps.isRequestingForSites, prevProps.siteIds );
 	}
 
 	refresh( isRequesting, siteIds ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryJetpackPlugins`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to e.g. `/activity-log/:site`
* Make sure you see a network request to `/sites/:siteId/plugins`
* Change your currently active site, then verify you see another request with updated `siteId`

Related to #58453 
