### PR TITLE
`QueryPostStats`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -8,60 +8,39 @@ import { isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 class QueryPostStats extends Component {
 	static defaultProps = {
 		requestPostStats: () => {},
-		heartbeat: 0,
 	};
 
 	static propTypes = {
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 		fields: PropTypes.array,
+		// connected props
 		requestingPostStats: PropTypes.bool,
 		requestPostStats: PropTypes.func,
-		heartbeat: PropTypes.number,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		const { requestingPostStats, siteId, postId } = this.props;
-		if ( ! requestingPostStats && siteId && typeof postId !== 'undefined' ) {
-			this.requestPostStats( this.props );
-		}
+	componentDidMount() {
+		this.requestPostStats();
 	}
 
-	componentWillUnmount() {
-		this.clearInterval();
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { siteId, postId, fields, heartbeat } = this.props;
+	componentDidUpdate( prevProps ) {
+		const { siteId, postId, fields } = this.props;
 		if (
-			! ( siteId && typeof postId !== 'undefined' ) ||
-			( siteId === nextProps.siteId &&
-				postId === nextProps.postId &&
-				isEqual( fields, nextProps.fields ) &&
-				heartbeat === nextProps.heartbeat )
+			siteId === prevProps.siteId &&
+			postId === prevProps.postId &&
+			isEqual( fields, prevProps.fields )
 		) {
 			return;
 		}
 
-		this.requestPostStats( nextProps );
+		this.requestPostStats();
 	}
 
-	requestPostStats( props ) {
-		const { siteId, postId, fields, heartbeat } = props;
-		props.requestPostStats( siteId, postId, fields );
-		this.clearInterval();
-		if ( heartbeat ) {
-			this.interval = setInterval( () => {
-				props.requestPostStats( siteId, postId, fields );
-			}, heartbeat );
-		}
-	}
+	requestPostStats() {
+		const { siteId, postId, fields, requestingPostStats } = this.props;
 
-	clearInterval() {
-		if ( this.interval ) {
-			clearInterval( this.interval );
+		if ( ! requestingPostStats && siteId && typeof postId !== 'undefined' ) {
+			this.props.requestPostStats( siteId, postId, fields );
 		}
 	}
 

--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -6,10 +6,9 @@ import { isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 
 function useMemoizedFields( fields ) {
 	const memoizedFields = useRef();
-	const joinedArray = fields.join();
 
-	if ( joinedArray !== memoizedFields.current ) {
-		memoizedFields.current = joinedArray;
+	if ( fields.join() !== memoizedFields.current?.join() ) {
+		memoizedFields.current = fields;
 	}
 
 	return memoizedFields.current;
@@ -27,7 +26,7 @@ function QueryPostStats( { siteId, postId, fields } ) {
 
 	useEffect( () => {
 		if ( siteId && postId ) {
-			dispatch( request( siteId, postId, memoizedFields.split( ',' ) ) );
+			dispatch( request( siteId, postId, memoizedFields ) );
 		}
 	}, [ dispatch, siteId, postId, memoizedFields ] );
 

--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -7,7 +7,7 @@ import { isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 function useMemoizedFields( fields ) {
 	const memoizedFields = useRef();
 
-	if ( fields.join() !== memoizedFields.current?.join() ) {
+	if ( fields?.join() !== memoizedFields.current?.join() ) {
 		memoizedFields.current = fields;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryPostStats`: refactor away from `UNSAFE_*`
* Remove `heartbeat` implementation (it's not used anywhere)

#### Testing instructions

* Go to `/stats/insights/:site`
* Make sure you see a request to `/sites/:siteId/stats/post/:postId`
* If you switch your currently active site or change the `postId` (e.g. via devtools) there should be another request with adjusted params

Related to #58453 
