### PR TITLE
Fix the url of purchase-has-extended endpoint

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1214,7 +1214,7 @@ class CancelPurchaseForm extends Component {
 
 		try {
 			const res = await wpcom.req.get( {
-				path: `/purchases/${ purchaseId }/has-extendedd`,
+				path: `/purchases/${ purchaseId }/has-extended`,
 				apiNamespace: 'wpcom/v2',
 			} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR is a follow-up fix that removes a typo from the wrong url of `purhcase/has-extended` endpoint that is used by #59575 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See #59575

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
