### PR TITLE
Hide expiration date for mapped domain on domains list

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -148,9 +148,10 @@ class DomainRow extends PureComponent {
 	}
 
 	renderExpiryDate( expiryDate ) {
+		const { domain } = this.props;
 		return (
 			<div className="domain-row__registered-until-cell">
-				{ expiryDate ? expiryDate.format( 'LL' ) : '-' }
+				{ expiryDate && domain.type !== 'MAPPED' ? expiryDate.format( 'LL' ) : '-' }
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -151,7 +151,7 @@ class DomainRow extends PureComponent {
 		const { domain } = this.props;
 		return (
 			<div className="domain-row__registered-until-cell">
-				{ expiryDate && domain.type !== 'MAPPED' ? expiryDate.format( 'LL' ) : '-' }
+				{ expiryDate && domain.type !== domainTypes.MAPPED ? expiryDate.format( 'LL' ) : '-' }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently we display the domain connection subscription expiration date under the "Registered until" date for connected domains in the domain lists. This isn't correct since the subscription expiry is most likely not the actual registration expiry. 

This PR replace the date with a simple dash.

![before](https://user-images.githubusercontent.com/2797601/149311935-16557caf-95cf-4054-88bc-10ad81c0233d.png)

![after](https://user-images.githubusercontent.com/2797601/149311946-39dde5b3-90d4-4567-9022-e10f6ede1e83.png)

#### Testing instructions

- Open the live Calypso link or build this branch locally
- Go to the all domains page (`/domains/manage`) or to the site domains for a site you own (`/domains/manage/[SITE]`)
- Ensure that for mapped domains, the cell displaying the expiration date shows a simple "-"