### PR TITLE
Happychat selectors: remove usages of createSelector

### DIFF
--- a/client/state/happychat/selectors/has-active-happychat-session.js
+++ b/client/state/happychat/selectors/has-active-happychat-session.js
@@ -1,5 +1,3 @@
-import { createSelector } from '@automattic/state-utils';
-import { includes } from 'lodash';
 import {
 	HAPPYCHAT_CHAT_STATUS_BLOCKED,
 	HAPPYCHAT_CHAT_STATUS_CLOSED,
@@ -9,6 +7,13 @@ import {
 
 import 'calypso/state/happychat/init';
 
+const INACTIVE_CHAT_STATUSES = [
+	HAPPYCHAT_CHAT_STATUS_BLOCKED,
+	HAPPYCHAT_CHAT_STATUS_CLOSED,
+	HAPPYCHAT_CHAT_STATUS_DEFAULT,
+	HAPPYCHAT_CHAT_STATUS_NEW,
+];
+
 /**
  * Returns true if there's an active chat session in-progress. Chat sessions with
  * the status `new`, `default`, or `closed` are considered inactive, as the session
@@ -17,16 +22,6 @@ import 'calypso/state/happychat/init';
  * @param {object} state - global redux state
  * @returns {boolean} Whether there's an active Happychat session happening
  */
-export default createSelector(
-	( state ) =>
-		! includes(
-			[
-				HAPPYCHAT_CHAT_STATUS_BLOCKED,
-				HAPPYCHAT_CHAT_STATUS_CLOSED,
-				HAPPYCHAT_CHAT_STATUS_DEFAULT,
-				HAPPYCHAT_CHAT_STATUS_NEW,
-			],
-			state.happychat.chat.status
-		),
-	( state ) => state.happychat.chat.status
-);
+export default function hasActiveHappychatSession( state ) {
+	return ! INACTIVE_CHAT_STATUSES.includes( state.happychat.chat.status );
+}

--- a/client/state/happychat/selectors/has-unread-messages.js
+++ b/client/state/happychat/selectors/has-unread-messages.js
@@ -1,18 +1,20 @@
-import { createSelector } from '@automattic/state-utils';
-import { get, last } from 'lodash';
-import getHappychatTimeline from 'calypso/state/happychat/selectors/get-happychat-timeline';
-import getLostFocusTimestamp from 'calypso/state/happychat/selectors/get-lostfocus-timestamp';
+import getHappychatTimeline from './get-happychat-timeline';
+import getLostFocusTimestamp from './get-lostfocus-timestamp';
 
-export default createSelector(
-	( state ) => {
-		const lastMessageTimestamp = get( last( getHappychatTimeline( state ) ), 'timestamp' );
-		const lostFocusAt = getLostFocusTimestamp( state );
+import 'calypso/state/happychat/init';
 
-		return (
-			typeof lastMessageTimestamp === 'number' &&
-			typeof lostFocusAt === 'number' &&
-			lastMessageTimestamp >= lostFocusAt
-		);
-	},
-	[ getHappychatTimeline, getLostFocusTimestamp ]
-);
+export default function hasUnreadMessages( state ) {
+	const timeline = getHappychatTimeline( state );
+	if ( timeline.length === 0 ) {
+		return false;
+	}
+
+	const lastMessageTimestamp = timeline[ timeline.length - 1 ].timestamp;
+	const lostFocusAt = getLostFocusTimestamp( state );
+
+	return (
+		typeof lastMessageTimestamp === 'number' &&
+		typeof lostFocusAt === 'number' &&
+		lastMessageTimestamp >= lostFocusAt
+	);
+}

--- a/client/state/happychat/selectors/is-happychat-open.js
+++ b/client/state/happychat/selectors/is-happychat-open.js
@@ -1,4 +1,3 @@
-import { createSelector } from '@automattic/state-utils';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 import 'calypso/state/happychat/init';
@@ -8,9 +7,8 @@ import 'calypso/state/happychat/init';
  * The docked UI should not be displayed when viewing the happychat section
  *
  * @param {object} state - global redux state
- * @returns {boolean}
+ * @returns {boolean} Whether the Happychat UI should be displayed
  */
-export default createSelector(
-	( state ) => state.happychat.ui.isOpen && getSectionName( state ) !== 'happychat',
-	( state ) => [ state.happychat.ui.isOpen, getSectionName( state ) ]
-);
+export default function isHappychatOpen( state ) {
+	return state.happychat.ui.isOpen && getSectionName( state ) !== 'happychat';
+}


### PR DESCRIPTION
Removes usages of `createSelector` from three Happychat selectors. They all perform trivial calculations a return a boolean value, so there's no need for memoization: there's no expensive calculation and there are no objects or arrays returned that would need to preserve identity when there are no changes.

Also removes Lodash from the affected modules.