### PR TITLE
`QueryContactDetailsCache`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-contact-details-cache/index.jsx
+++ b/client/components/data/query-contact-details-cache/index.jsx
@@ -1,34 +1,27 @@
 import { isEmpty } from 'lodash';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
 import isRequestingContactDetailsCache from 'calypso/state/selectors/is-requesting-contact-details-cache';
 
-class QueryContactDetailsCache extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		if ( this.props.isRequesting || ! isEmpty( this.props.contactDetailsCache ) ) {
-			return;
-		}
-		this.props.requestContactDetailsCache();
+const request = () => ( dispatch, getState ) => {
+	if ( ! isRequestingContactDetailsCache( getState() ) ) {
+		dispatch( requestContactDetailsCache() );
 	}
-
-	render() {
-		return null;
-	}
-}
-
-QueryContactDetailsCache.propTypes = {
-	isRequesting: PropTypes.bool.isRequired,
-	requestContactDetailsCache: PropTypes.func.isRequired,
 };
 
-export default connect(
-	( state ) => ( {
-		contactDetailsCache: getContactDetailsCache( state ),
-		isRequesting: isRequestingContactDetailsCache( state ),
-	} ),
-	{ requestContactDetailsCache }
-)( QueryContactDetailsCache );
+function QueryContactDetailsCache() {
+	const dispatch = useDispatch();
+	const contactDetailsCache = useSelector( getContactDetailsCache );
+
+	useEffect( () => {
+		if ( isEmpty( contactDetailsCache ) ) {
+			dispatch( request() );
+		}
+	}, [ dispatch, contactDetailsCache ] );
+
+	return null;
+}
+
+export default QueryContactDetailsCache;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryContactDetailsCache`: refactor away from `UNSAFE_*`

#### Testing instructions

Before testing make sure to delete the `"redux-state-*:domains"` entry from IndexedDB. Otherwise you might not see the request as described.

* Go to e.g. `/plans/:site`
* Verify you see a request to `/me/domain-contact-information`
* Wait a short period of time and hit reload, this time you shouldn't see a request

Related to #58453 
