### PR TITLE
Tour Kit: update visibility class to is-visible

### DIFF
--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -131,7 +131,7 @@ The main API for configuring a tour is the config object. See example usage and 
   - `steps`: The steps defined for the tour.
   - `currentStepIndex`
   - `onDismiss`: Handler that dismissed/closes the tour.
-  - `onMiximize`: Handler that expands the tour (passes rendering to `tourStep`).
+  - `onMaximize`: Handler that expands the tour (passes rendering to `tourStep`).
 
 `config.options` (optional):
 

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -187,7 +187,7 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 		'tour-kit-frame',
 		config.options?.className,
 		isMobile ? 'is-mobile' : 'is-desktop',
-		{ '--visible': tourReady }
+		{ 'is-visible': tourReady }
 	);
 
 	return (

--- a/packages/tour-kit/src/components/tour-kit-overlay.tsx
+++ b/packages/tour-kit/src/components/tour-kit-overlay.tsx
@@ -11,7 +11,7 @@ const TourKitOverlay: React.FunctionComponent< Props > = ( { visible } ) => {
 	return (
 		<div
 			className={ classnames( 'tour-kit-overlay', {
-				'--visible': visible,
+				'is-visible': visible,
 			} ) }
 		/>
 	);

--- a/packages/tour-kit/src/components/tour-kit-spotlight.tsx
+++ b/packages/tour-kit/src/components/tour-kit-spotlight.tsx
@@ -80,7 +80,7 @@ const TourKitSpotlight: React.FunctionComponent< Props > = ( { referenceElement,
 			<Overlay visible={ ! clipRepositionProps } />
 			<div
 				className={ classnames( 'tour-kit-spotlight', {
-					'--visible': !! clipRepositionProps,
+					'is-visible': !! clipRepositionProps,
 				} ) }
 				ref={ sePopperElement }
 				{ ...clipRepositionProps }

--- a/packages/tour-kit/src/storybook/index.stories.tsx
+++ b/packages/tour-kit/src/storybook/index.stories.tsx
@@ -98,7 +98,7 @@ const Tour = ( { onClose, options }: { onClose: () => void; options?: Config[ 'o
 					<div className="storybook__tourkit-minimized">
 						<div className="storybook__tourkit-minimized-controls">
 							<button onClick={ onDismiss( 'main-btn' ) }>Close</button>
-							<button onClick={ onMaximize }>Miximize</button>
+							<button onClick={ onMaximize }>Maximize</button>
 						</div>
 					</div>
 				);

--- a/packages/tour-kit/src/styles.scss
+++ b/packages/tour-kit/src/styles.scss
@@ -1,7 +1,7 @@
 .tour-kit-frame {
     visibility: hidden;
 
-    &.--visible {
+    &.is-visible {
         visibility: visible;
     }
 }
@@ -28,13 +28,13 @@
 	background: rgba( 0, 0, 0 );
 	opacity: 0;
 
-	&.--visible {
+	&.is-visible {
 		opacity: 0.5;
 	}
 }
 
 .tour-kit-spotlight {
-	&.--visible {
+	&.is-visible {
 		position: fixed;
 		overflow: hidden;
 		// box-shadow: 0 0 0 9999px rgba(0, 0, 255, 0.2);


### PR DESCRIPTION
## Summary
I replaced three instances of `--visible` and updated the corresponding style.scss. This changes it to match the calypso standard `is-visible`.

Along with that, I noticed there was a typo in the storybook. `Miximize` probably should be `Maximize` so I adjusted the spelling on the button and the README.

## Results
#### Storybook - overlay
![Screen Capture on 2022-01-13 at 12-52-37](https://user-images.githubusercontent.com/33258733/149328464-48ec4342-62b9-45dc-9f8d-63b5b4606827.gif)

#### Storybook - spotlight
![Screen Capture on 2022-01-13 at 12-53-03](https://user-images.githubusercontent.com/33258733/149328565-6679abdc-57e9-4907-a7a0-d8841122f44b.gif)

#### Storybook - default
![Screen Capture on 2022-01-13 at 12-53-49](https://user-images.githubusercontent.com/33258733/149328602-a454ed02-2802-495d-91aa-5ae18d1453cb.gif)

#### Welcome Guide
*before*
<img width="750" alt="Markup 2022-01-13 at 13 27 02" src="https://user-images.githubusercontent.com/33258733/149332013-bbb50c6e-46ee-40c0-b43d-e4ac518c87bc.png">

*after*
<img width="727" alt="Markup 2022-01-13 at 13 25 19" src="https://user-images.githubusercontent.com/33258733/149331978-38321376-7915-4eb7-91c1-bbbd8c29f104.png">

## Testing
1. Checkout branch and launch storybook from `packages/tour-kit]` with `yarn run storybook`
2. Cycles through all the versions and make sure it operates normally. You can also check the `tour-kit-frame` and make sure `is-visible` is showing properly
3. Next go to `apps/editing-toolkit/` and run `yarn dev --sync` to push changes to your sandbox
4. Open your sandbox and check the Welcome Guide to see if its functioning and the `is-visible` class appears.

Fixes #59905 