### PR TITLE
Jetpack Cloud: Fix Purchases menu item never highlighted

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import SidebarItem from 'calypso/layout/sidebar/item';
-import { settingsPath, purchasesPath } from 'calypso/lib/jetpack/paths';
+import { settingsPath, purchasesPath, purchasesBasePath } from 'calypso/lib/jetpack/paths';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -62,7 +62,7 @@ export default ( { path } ) => {
 					} ) }
 					link={ purchasesPath( siteSlug ) }
 					onNavigate={ onNavigate }
-					selected={ itemLinkMatches( [ purchasesPath( siteSlug ) ], path ) }
+					selected={ itemLinkMatches( [ purchasesBasePath() ], path ) }
 				/>
 			) }
 		</>

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -22,6 +22,6 @@ export const settingsHostSelectionPath = ( siteSlug?: string ): string =>
 export const settingsCredentialsPath = ( siteSlug: string, host: string ): string =>
 	settingsPath( siteSlug, `credentials/${ host }` );
 
-const purchasesBasePath = () => '/purchases/subscriptions';
+export const purchasesBasePath = () => '/purchases';
 export const purchasesPath = ( siteSlug?: string ): string =>
 	siteSlug ? `${ purchasesBasePath() }/${ siteSlug }` : purchasesBasePath();

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -22,6 +22,6 @@ export const settingsHostSelectionPath = ( siteSlug?: string ): string =>
 export const settingsCredentialsPath = ( siteSlug: string, host: string ): string =>
 	settingsPath( siteSlug, `credentials/${ host }` );
 
-const purchasesBasePath = () => '/purchases';
+const purchasesBasePath = () => '/purchases/subscriptions';
 export const purchasesPath = ( siteSlug?: string ): string =>
 	siteSlug ? `${ purchasesBasePath() }/${ siteSlug }` : purchasesBasePath();


### PR DESCRIPTION
Fixes 1164141197617539-as-1201657432370144

#### Changes proposed in this Pull Request

* Make Jetpack Cloud aware of the actual path for Purchases section by changing `purchasesBasePath` from `/purchases` to `/purchases/subscriptions`.
* This is in parity with Calypso Blue Purchases section

#### How does that fix the UI bug?
`<SidebarItem />` in `client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx` receives `selected={ itemLinkMatches( [ purchasesPath( siteSlug ) ], path ) }`, therefore making the `selected` prop dependent upon the URL path.

#### Testing instructions

* Checkout the PR branch
* Fire up the rockets - `yarn start-jetpack-cloud-p`
* Goto [`jetpack.cloud.localhost:3001`](http://jetpack.cloud.localhost:3001)
* Goto **Purchases** section
* Ensure that **Purchases** menu item is highlighted
* Choose some other section
* Check that Purchases menu item is no more highlighted
* Check for any regression.

BEFORE

<img width="656" alt="image" src="https://user-images.githubusercontent.com/18226415/149332685-ef78a609-4a7a-431e-8c13-3d66c4812ec5.png">

AFTER

<img width="659" alt="image" src="https://user-images.githubusercontent.com/18226415/149332705-b96e8170-bf01-4cd8-bff0-53523f28c57f.png">
