### PR TITLE
No need to push additional tags for TC builds

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -150,8 +150,6 @@ object BuildDockerImage : BuildType({
 				FAILURES=$(curl --silent -X GET -H "Content-Type: text/plain" https://teamcity.a8c.com/guestAuth/app/rest/builds/?locator=id:%teamcity.build.id% | grep -c "FAILURE")
 				if [ ${'$'}FAILURES -ne 0 ]; then
 					ACTION="fail"
-				#else
-				#	docker push "registry.a8c.com/calypso:%build.vcs.number%-%teamcity.build.branch%"
 				fi
 
 				payload=${'$'}(jq -n \


### PR DESCRIPTION
Going to reuse the current tags. This should also
allow for seamless switching between different
docker image builders.

Just cleaning up.

For pMz3w-ebz-p2.