### PR TITLE
Fix a TypeError when rendering the RemovePurchase component

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -345,7 +345,7 @@ class RemovePurchase extends Component {
 	shouldHandleMarketplaceSubscriptions() {
 		const { activeSubscriptions } = this.props;
 
-		return activeSubscriptions.length > 0;
+		return activeSubscriptions?.length > 0;
 	}
 
 	renderMarketplaceSubscriptionsDialog() {


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* In #59910 the `shouldHandleMarketplaceSubscriptions` method was introduced but it doesn't account for when `activeSubscriptions` is not set and throws a TypeError. Here's a fix for that case

#### Testing instructions

* Open up any registered domain settings page and verify that it works with and without the feature flag `domains/settings-page-redesign`. You can enable/disable the feature flag with `?flags=-domains/settings-page-redesign` and `?flags=domains/settings-page-redesign` 
