### PR TITLE
Inline Help: Remove sole usage of `_.intersection`

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -451,7 +451,7 @@ export function filterListBySearchTerm( searchTerm = '', collection = [], limit 
 			partialMatches.push( item );
 		} else if (
 			'en' === getLocaleSlug() &&
-			( item.synonyms ?? [] ).some( ( s ) => searchTermWords.includes( s ) )
+			item.synonyms?.some( ( s ) => searchTermWords.includes( s ) )
 		) {
 			synonymMatches.push( item );
 		}

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -1,6 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
 import { translate } from 'i18n-calypso';
-import { intersection } from 'lodash';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
@@ -452,7 +451,9 @@ export function filterListBySearchTerm( searchTerm = '', collection = [], limit 
 			partialMatches.push( item );
 		} else if (
 			'en' === getLocaleSlug() &&
-			intersection( item.synonyms, searchTermWords ).length > 0
+			[ item.synonyms ?? [], searchTermWords ].reduce( ( a, b ) =>
+				a.filter( ( c ) => b.includes( c ) )
+			).length > 0
 		) {
 			synonymMatches.push( item );
 		}

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -451,9 +451,7 @@ export function filterListBySearchTerm( searchTerm = '', collection = [], limit 
 			partialMatches.push( item );
 		} else if (
 			'en' === getLocaleSlug() &&
-			[ item.synonyms ?? [], searchTermWords ].reduce( ( a, b ) =>
-				a.filter( ( c ) => b.includes( c ) )
-			).length > 0
+			( item.synonyms ?? [] ).some( ( s ) => searchTermWords.includes( s ) )
 		) {
 			synonymMatches.push( item );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the sole usage of Lodash's `intersection` inside Inline Help in favor of native JS.

#### Testing instructions

* Go to `/posts/:site`
* Click on the inline help question mark.
* Search for some common terms and verify search works the same way as on prod.
* Verify tests still pass: `yarn run test-client client/blocks/inline-help/test/admin-sections.js`