### PR TITLE
Happychat: Remove usage of `_.includes()` in `canUserSendMessages`

### DIFF
--- a/client/state/happychat/selectors/can-user-send-messages.js
+++ b/client/state/happychat/selectors/can-user-send-messages.js
@@ -24,6 +24,8 @@ const CHAT_STATUSES = [
  * @param {object} state - global redux state
  * @returns {boolean} Whether the user is able to send messages
  */
-export default ( state ) =>
+const canUserSendMessages = ( state ) =>
 	isHappychatClientConnected( state ) &&
 	! CHAT_STATUSES.includes( getHappychatChatStatus( state ) );
+
+export default canUserSendMessages;

--- a/client/state/happychat/selectors/can-user-send-messages.js
+++ b/client/state/happychat/selectors/can-user-send-messages.js
@@ -5,8 +5,8 @@ import {
 	HAPPYCHAT_CHAT_STATUS_MISSED,
 	HAPPYCHAT_CHAT_STATUS_PENDING,
 } from 'calypso/state/happychat/constants';
-import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
-import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
+import getHappychatChatStatus from './get-happychat-chat-status';
+import isHappychatClientConnected from './is-happychat-client-connected';
 
 const CHAT_STATUSES = [
 	HAPPYCHAT_CHAT_STATUS_BLOCKED,

--- a/client/state/happychat/selectors/can-user-send-messages.js
+++ b/client/state/happychat/selectors/can-user-send-messages.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import {
 	HAPPYCHAT_CHAT_STATUS_ABANDONED,
 	HAPPYCHAT_CHAT_STATUS_BLOCKED,
@@ -8,6 +7,14 @@ import {
 } from 'calypso/state/happychat/constants';
 import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
 import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
+
+const CHAT_STATUSES = [
+	HAPPYCHAT_CHAT_STATUS_BLOCKED,
+	HAPPYCHAT_CHAT_STATUS_DEFAULT,
+	HAPPYCHAT_CHAT_STATUS_PENDING,
+	HAPPYCHAT_CHAT_STATUS_MISSED,
+	HAPPYCHAT_CHAT_STATUS_ABANDONED,
+];
 
 /**
  * Returns true if the user should be able to send messages to operators based on
@@ -19,13 +26,4 @@ import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-hap
  */
 export default ( state ) =>
 	isHappychatClientConnected( state ) &&
-	! includes(
-		[
-			HAPPYCHAT_CHAT_STATUS_BLOCKED,
-			HAPPYCHAT_CHAT_STATUS_DEFAULT,
-			HAPPYCHAT_CHAT_STATUS_PENDING,
-			HAPPYCHAT_CHAT_STATUS_MISSED,
-			HAPPYCHAT_CHAT_STATUS_ABANDONED,
-		],
-		getHappychatChatStatus( state )
-	);
+	! CHAT_STATUSES.includes( getHappychatChatStatus( state ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the sole usage of Lodash's `includes` inside Happychat's state. The other usage was recently removed in #60030.

#### Testing instructions

* Verify tests pass: `yarn run test-client client/state/happychat/selectors/test/can-user-send-messages.js`
* Smoke test Happychat and verify it still works well.