### PR TITLE
Preview: Refactor away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -38,12 +38,6 @@ class PreviewMain extends Component {
 			: 'tablet',
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.updateUrl();
-		this.updateLayout();
-	}
-
 	updateLayout = () => {
 		this.setState( {
 			showingClose: isWithinBreakpoint( '<660px' ),
@@ -53,6 +47,9 @@ class PreviewMain extends Component {
 	debouncedUpdateLayout = debounce( this.updateLayout, 50 );
 
 	componentDidMount() {
+		this.updateUrl();
+		this.updateLayout();
+
 		if ( typeof window !== 'undefined' ) {
 			window.addEventListener( 'resize', this.debouncedUpdateLayout );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `PreviewMain` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Test this on both desktop and mobile (fresh load of the page, not by resizing) and keep an eye on the console for errors.
* Go to `/view/:site`.
* Verify the URL in the top bar gets set correctly.
* Verify the Close button is visible (when viewing on mobile).