### PR TITLE
Settings: Refactor away from `UNSAFE_` methods in `wrapSettingsForm`

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -38,7 +38,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			uniqueEvents: {},
 		};
 
-		UNSAFE_componentWillMount() {
+		componentDidMount() {
 			this.props.replaceFields( getFormSettings( this.props.settings ) );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wrapSettingsForm` HoC away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
Smoke test loading of each and every site settings page (also after switching a site) and verify its current settings load correctly.