### PR TITLE
Settings: Fix React warning in Search banner in Performance settings

### DIFF
--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -59,6 +59,7 @@ class Search extends Component {
 	renderLoadingPlaceholder() {
 		return (
 			<Banner
+				title=""
 				jetpack={ this.props.siteIsJetpack }
 				disableHref
 				description={ this.props.translate( 'Loading your purchases…' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a React warning that the developer sees when they access `/settings/performance/:site` on a free plan:

![](https://cldup.com/T3WAkZc27Q.png)

This is caused by this banner:

![](https://cldup.com/bVtSYcaimY.png)

that appears shortly while purchases are loading, after which this one is shown:

![](https://cldup.com/PrTbbdHulP.png)

This was introduced in #55974. 

Found when working on #60045.

#### Testing instructions

* Go to `/settings/performance/:site` where `:site` is a site on a free plan.
* Verify you no longer see the warning.