### PR TITLE
Videos UI: Scroll blogging quickstart modal to top on load

### DIFF
--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import VideosUi from 'calypso/components/videos-ui';
 import ModalFooterBar from 'calypso/components/videos-ui/modal-footer-bar';
@@ -8,6 +9,13 @@ import './style.scss';
 
 const BloggingQuickStartModal = ( props ) => {
 	const { isVisible = false, onClose = () => {} } = props;
+
+	// Scroll to top on initial load regardless of previous page position
+	useEffect( () => {
+		if ( isVisible ) {
+			window.scrollTo( 0, 0 );
+		}
+	}, [ isVisible ] );
 
 	return (
 		isVisible && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the Blogging Quickstart Modal component to automatically scroll to the top when it is rendered, regardless of where the user was scrolled to on the homepage before opening it.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to local Calypso. 
* Load the home page and scroll down a bit before opening the videos UI.
* Verify that the videos UI scrolls back to the top when rendered.

Before:

![scroll-top-before](https://user-images.githubusercontent.com/13437011/149373260-22fcfd06-daa9-42a2-8659-ec94ce36ca7b.gif)

After:
![scroll-top-after](https://user-images.githubusercontent.com/13437011/149373297-6f2c8120-7583-405e-a41c-2e013e471100.gif)


<!--

Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59925 
