### PR TITLE
Emails: Add list of features to In-Depth Comparison page

### DIFF
--- a/client/my-sites/email/email-provider-features/index.js
+++ b/client/my-sites/email/email-provider-features/index.js
@@ -41,7 +41,7 @@ function EmailProviderFeatures( { features, logos } ) {
 }
 
 EmailProviderFeatures.propTypes = {
-	features: PropTypes.arrayOf( PropTypes.string ),
+	features: PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ),
 	logos: PropTypes.arrayOf( PropTypes.object ),
 };
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import EmailProviderFeatures from 'calypso/my-sites/email/email-provider-features';
+import EmailProviderPrice from 'calypso/my-sites/email/email-providers-comparison/in-depth/email-provider-price';
+import { ComparisonListOrTableProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+const ComparisonList = ( {
+	emailProviders,
+	intervalLength,
+	onSelectEmailProvider,
+	selectedDomainName,
+}: ComparisonListOrTableProps ): ReactElement => {
+	const translate = useTranslate();
+
+	return (
+		<div className="email-providers-in-depth-comparison-list">
+			{ emailProviders.map( ( emailProviderFeatures ) => {
+				const { importing, tools, storage, support } = emailProviderFeatures.list;
+
+				return (
+					<Card key={ emailProviderFeatures.slug }>
+						<div className="email-providers-in-depth-comparison-table__provider">
+							{ emailProviderFeatures.logo }
+
+							<div className="email-providers-in-depth-comparison-table__provider-info">
+								<h2>{ emailProviderFeatures.name }</h2>
+
+								{ emailProviderFeatures.description }
+							</div>
+						</div>
+
+						<div className="email-providers-in-depth-comparison-list__price">
+							<EmailProviderPrice
+								emailProviderSlug={ emailProviderFeatures.slug }
+								intervalLength={ intervalLength }
+								selectedDomainName={ selectedDomainName }
+							/>
+						</div>
+
+						<div className="email-providers-in-depth-comparison-list__features">
+							<EmailProviderFeatures features={ [ tools, storage, importing, support ] } />
+						</div>
+
+						<Button
+							className="email-providers-in-depth-comparison-list__button"
+							onClick={ () => onSelectEmailProvider( emailProviderFeatures.slug ) }
+							primary
+						>
+							{ translate( 'Select' ) }
+						</Button>
+					</Card>
+				);
+			} ) }
+		</div>
+	);
+};
+
+export default ComparisonList;

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -2,91 +2,118 @@
 
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
-import { useSelector } from 'react-redux';
-import { getSelectedDomain } from 'calypso/lib/domains';
-import GoogleWorkspacePrice from 'calypso/my-sites/email/email-providers-comparison/price/google-workspace';
-import ProfessionalEmailPrice from 'calypso/my-sites/email/email-providers-comparison/price/professional-email';
-import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type {
-	ComparisonTableProps,
-	ComparisonTablePriceProps,
-	EmailProviderFeatures,
-} from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
+import EmailProviderPrice from 'calypso/my-sites/email/email-providers-comparison/in-depth/email-provider-price';
+import type { ComparisonListOrTableProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 import type { ReactElement } from 'react';
 
-const ComparisonTablePrice = ( {
-	domain,
-	emailProviderSlug,
-	intervalLength,
-}: ComparisonTablePriceProps ): ReactElement => {
-	if ( emailProviderSlug === 'google-workspace' ) {
-		return <GoogleWorkspacePrice intervalLength={ intervalLength } />;
-	}
-
-	return <ProfessionalEmailPrice domain={ domain } intervalLength={ intervalLength } />;
-};
+import './style.scss';
 
 const ComparisonTable = ( {
 	emailProviders,
 	intervalLength,
+	onSelectEmailProvider,
 	selectedDomainName,
-}: ComparisonTableProps ): ReactElement => {
+}: ComparisonListOrTableProps ): ReactElement => {
 	const translate = useTranslate();
 
-	const selectedSite = useSelector( getSelectedSite );
-	const currentRoute = useSelector( getCurrentRoute );
-
-	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
-	const domain = getSelectedDomain( {
-		domains,
-		selectedDomainName: selectedDomainName,
-	} );
-
-	const selectEmailProvider = ( emailProviderSlug: string ) => {
-		if ( selectedSite === null ) {
-			return;
-		}
-
-		page(
-			emailManagementPurchaseNewEmailAccount(
-				selectedSite.slug,
-				selectedDomainName,
-				currentRoute,
-				null,
-				emailProviderSlug,
-				intervalLength
-			)
-		);
-	};
-
 	return (
-		<div className="email-providers-in-depth-comparison-table">
-			{ emailProviders.map( ( emailProviderFeatures: EmailProviderFeatures ) => {
-				return (
-					<div key={ emailProviderFeatures.slug }>
-						<div className="email-providers-in-depth-comparison-table__provider-name">
-							{ emailProviderFeatures.logo }
+		<table className="email-providers-in-depth-comparison-table">
+			<tbody>
+				<tr>
+					<td></td>
 
-							<h2>{ emailProviderFeatures.name }</h2>
-						</div>
+					{ emailProviders.map( ( emailProviderFeatures ) => {
+						return (
+							<td key={ emailProviderFeatures.slug }>
+								<div className="email-providers-in-depth-comparison-table__provider">
+									{ emailProviderFeatures.logo }
 
-						<ComparisonTablePrice
-							domain={ domain }
-							emailProviderSlug={ emailProviderFeatures.slug }
-							intervalLength={ intervalLength }
-						/>
+									<div className="email-providers-in-depth-comparison-table__provider-info">
+										<h2>{ emailProviderFeatures.name }</h2>
 
-						<Button onClick={ () => selectEmailProvider( emailProviderFeatures.slug ) } primary>
-							{ translate( 'Select' ) }
-						</Button>
-					</div>
-				);
-			} ) }
-		</div>
+										{ emailProviderFeatures.description }
+									</div>
+								</div>
+							</td>
+						);
+					} ) }
+				</tr>
+
+				<tr>
+					<td></td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => {
+						return (
+							<td key={ emailProviderFeatures.slug }>
+								<EmailProviderPrice
+									emailProviderSlug={ emailProviderFeatures.slug }
+									intervalLength={ intervalLength }
+									selectedDomainName={ selectedDomainName }
+								/>
+							</td>
+						);
+					} ) }
+				</tr>
+
+				<tr>
+					<td className="email-providers-in-depth-comparison-table__feature">
+						{ translate( 'Tools' ) }
+					</td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => (
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.tools }</td>
+					) ) }
+				</tr>
+
+				<tr className="email-providers-in-depth-comparison-table__separator">
+					<td className="email-providers-in-depth-comparison-table__feature">
+						{ translate( 'Storage' ) }
+					</td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => (
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.storage }</td>
+					) ) }
+				</tr>
+
+				<tr className="email-providers-in-depth-comparison-table__separator">
+					<td className="email-providers-in-depth-comparison-table__feature">
+						{ translate( 'Importing' ) }
+					</td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => (
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.importing }</td>
+					) ) }
+				</tr>
+
+				<tr className="email-providers-in-depth-comparison-table__separator">
+					<td className="email-providers-in-depth-comparison-table__feature">
+						{ translate( 'Support' ) }
+					</td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => (
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.support }</td>
+					) ) }
+				</tr>
+
+				<tr>
+					<td></td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => {
+						return (
+							<td key={ emailProviderFeatures.slug }>
+								<Button
+									className="email-providers-in-depth-comparison-table__button"
+									onClick={ () => onSelectEmailProvider( emailProviderFeatures.slug ) }
+									primary
+								>
+									{ translate( 'Select' ) }
+								</Button>
+							</td>
+						);
+					} ) }
+				</tr>
+			</tbody>
+		</table>
 	);
 };
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
@@ -10,16 +10,22 @@ import type { EmailProviderFeatures } from 'calypso/my-sites/email/email-provide
 export const professionalEmailFeatures: EmailProviderFeatures = {
 	slug: 'professional-email',
 	name: getTitanProductName(),
+	description: translate( 'Integrated email solution for your WordPress.com site.' ),
 	logo: <Gridicon className="professional-email-logo" icon="my-sites" />,
-	tools: translate( 'Integrated email management, Inbox, calendar and contacts' ),
-	storage: translate( '30GB storage' ),
-	importing: translate( 'One-click import of existing emails and contacts' ),
-	support: translate( '24/7 support via email' ),
+	list: {
+		importing: translate( 'One-click import of existing emails and contacts' ),
+		storage: translate( '30GB storage' ),
+		support: translate( '24/7 support via email' ),
+		tools: translate( 'Integrated email management, Inbox, Calendar and Contacts' ),
+	},
 };
 
 export const googleWorkspaceFeatures: EmailProviderFeatures = {
 	slug: 'google-workspace',
 	name: getGoogleMailServiceFamily(),
+	description: translate(
+		'Professional email integrated with Google Meet and other productivity tools from Google.'
+	),
 	logo: (
 		<img
 			alt={ translate( 'Google Workspace icon', { textOnly: true } ) }
@@ -27,8 +33,10 @@ export const googleWorkspaceFeatures: EmailProviderFeatures = {
 			src={ googleWorkspaceIcon }
 		/>
 	),
-	tools: translate( 'Gmail, Calendar, Meet, Chat, Drive, Docs, Sheets, Slides and more' ),
-	storage: translate( '30GB storage' ),
-	importing: translate( 'Easy to import your existing emails and contacts' ),
-	support: translate( '24/7 support via email' ),
+	list: {
+		importing: translate( 'Easy to import your existing emails and contacts' ),
+		storage: translate( '30GB storage' ),
+		support: translate( '24/7 support via email' ),
+		tools: translate( 'Gmail, Calendar, Meet, Chat, Drive, Docs, Sheets, Slides and more' ),
+	},
 };

--- a/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
@@ -7,9 +7,6 @@ import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getTitanProductName } from 'calypso/lib/titan';
 import type { EmailProviderFeatures } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 export const professionalEmailFeatures: EmailProviderFeatures = {
 	slug: 'professional-email',
 	name: getTitanProductName(),
@@ -18,7 +15,6 @@ export const professionalEmailFeatures: EmailProviderFeatures = {
 	storage: translate( '30GB storage' ),
 	importing: translate( 'One-click import of existing emails and contacts' ),
 	support: translate( '24/7 support via email' ),
-	selectCallback: noop,
 };
 
 export const googleWorkspaceFeatures: EmailProviderFeatures = {
@@ -35,5 +31,4 @@ export const googleWorkspaceFeatures: EmailProviderFeatures = {
 	storage: translate( '30GB storage' ),
 	importing: translate( 'Easy to import your existing emails and contacts' ),
 	support: translate( '24/7 support via email' ),
-	selectCallback: noop,
 };

--- a/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
@@ -1,0 +1,30 @@
+import { useSelector } from 'react-redux';
+import { getSelectedDomain } from 'calypso/lib/domains';
+import GoogleWorkspacePrice from 'calypso/my-sites/email/email-providers-comparison/price/google-workspace';
+import ProfessionalEmailPrice from 'calypso/my-sites/email/email-providers-comparison/price/professional-email';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { EmailProviderPriceProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
+import type { ReactElement } from 'react';
+
+const EmailProviderPrice = ( {
+	emailProviderSlug,
+	intervalLength,
+	selectedDomainName,
+}: EmailProviderPriceProps ): ReactElement => {
+	const selectedSite = useSelector( getSelectedSite );
+
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+	const domain = getSelectedDomain( {
+		domains,
+		selectedDomainName: selectedDomainName,
+	} );
+
+	if ( emailProviderSlug === 'google-workspace' ) {
+		return <GoogleWorkspacePrice intervalLength={ intervalLength } />;
+	}
+
+	return <ProfessionalEmailPrice domain={ domain } intervalLength={ intervalLength } />;
+};
+
+export default EmailProviderPrice;

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -1,19 +1,24 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
+import ComparisonList from 'calypso/my-sites/email/email-providers-comparison/in-depth/comparison-list';
 import ComparisonTable from 'calypso/my-sites/email/email-providers-comparison/in-depth/comparison-table';
 import {
 	professionalEmailFeatures,
 	googleWorkspaceFeatures,
 } from 'calypso/my-sites/email/email-providers-comparison/in-depth/data';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
-import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
+import {
+	emailManagementInDepthComparison,
+	emailManagementPurchaseNewEmailAccount,
+} from 'calypso/my-sites/email/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 import type { ReactElement } from 'react';
 
@@ -25,17 +30,19 @@ const EmailProvidersInDepthComparison = ( {
 }: EmailProvidersInDepthComparisonProps ): ReactElement => {
 	const translate = useTranslate();
 
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const isMobile = useMobileBreakpoint();
+
+	const selectedSite = useSelector( getSelectedSite );
 	const currentRoute = useSelector( getCurrentRoute );
 
 	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
-		if ( selectedSiteSlug === null ) {
+		if ( selectedSite === null ) {
 			return;
 		}
 
 		page(
 			emailManagementInDepthComparison(
-				selectedSiteSlug,
+				selectedSite.slug,
 				selectedDomainName,
 				currentRoute,
 				null,
@@ -43,6 +50,25 @@ const EmailProvidersInDepthComparison = ( {
 			)
 		);
 	};
+
+	const selectEmailProvider = ( emailProviderSlug: string ) => {
+		if ( selectedSite === null ) {
+			return;
+		}
+
+		page(
+			emailManagementPurchaseNewEmailAccount(
+				selectedSite.slug,
+				selectedDomainName,
+				currentRoute,
+				null,
+				emailProviderSlug,
+				selectedIntervalLength
+			)
+		);
+	};
+
+	const ComparisonComponent = isMobile ? ComparisonList : ComparisonTable;
 
 	return (
 		<>
@@ -61,9 +87,10 @@ const EmailProvidersInDepthComparison = ( {
 				onIntervalChange={ changeIntervalLength }
 			/>
 
-			<ComparisonTable
+			<ComparisonComponent
 				emailProviders={ [ professionalEmailFeatures, googleWorkspaceFeatures ] }
 				intervalLength={ selectedIntervalLength }
+				onSelectEmailProvider={ selectEmailProvider }
 				selectedDomainName={ selectedDomainName }
 			/>
 		</>

--- a/client/my-sites/email/email-providers-comparison/in-depth/style.scss
+++ b/client/my-sites/email/email-providers-comparison/in-depth/style.scss
@@ -12,28 +12,121 @@
 	text-align: center;
 }
 
+.email-providers-in-depth-comparison-list,
 .email-providers-in-depth-comparison-table {
-	display: flex;
-	gap: 20px;
-}
-
-.email-providers-in-depth-comparison-table__provider-name {
-	display: flex;
-
-	h2 {
-		font-size: $font-title-medium;
-		margin-left: 5px;
-
-		@extend .wp-brand-font;
-	}
-
 	.google-workspace-logo {
+		height: 48px;
 		width: 48px;
 	}
 
 	.professional-email-logo {
 		color: var( --color-wordpress-com );
 		height: 48px;
+		min-width: 48px;
 		width: 48px;
 	}
+}
+
+.email-providers-in-depth-comparison-list__button,
+.email-providers-in-depth-comparison-table__button {
+	width: 100%;
+}
+
+.email-providers-in-depth-comparison-list__price {
+	margin-left: 60px;
+	margin-top: 10px;
+}
+
+.email-providers-in-depth-comparison-list__features {
+	margin-top: 40px;
+
+	.email-provider-features__feature {
+		&::before {
+			border-bottom: none;
+		}
+
+		.gridicon {
+			fill: var( --studio-gray-20 );
+		}
+	}
+}
+
+.email-providers-in-depth-comparison-list__button {
+	margin-top: 20px;
+}
+
+$table-padding: 15px;
+
+.email-providers-in-depth-comparison-table {
+	border-collapse: collapse;
+	font-size: $font-body-small;
+	margin-top: 40px;
+
+	td {
+		padding-bottom: $table-padding;
+		padding-top: $table-padding;
+
+		&:first-child {
+			padding-left: $table-padding;
+		}
+
+		&:nth-child( n + 2 ) {
+			padding-left: 60px;
+		}
+
+		&:last-child {
+			padding-right: $table-padding;
+		}
+	}
+
+	tr:first-child {
+		td:nth-child( n + 1 ) {
+			padding-left: 0;
+		}
+	}
+
+	tr:nth-child( n + 2 ) {
+		td {
+			vertical-align: middle;
+		}
+	}
+
+	tr:nth-child( 3 ) {
+		td {
+			padding-top: 30px;
+		}
+	}
+}
+
+.email-providers-in-depth-comparison-table__provider {
+	display: flex;
+}
+
+.email-providers-in-depth-comparison-table__provider-info {
+	margin-left: 12px;
+	margin-right: $table-padding;
+
+	h2 {
+		font-size: $font-title-small;
+
+		@extend .wp-brand-font;
+	}
+}
+
+.email-providers-in-depth-comparison-table__feature {
+	color: var( --color-text-subtle );
+	font-weight: 600;
+	text-align: right;
+}
+
+.email-providers-in-depth-comparison-table__separator {
+	td {
+		border-top-color: var( --color-neutral-10 );
+		border-top-width: 1px;
+		border-top-style: solid;
+	}
+}
+
+.email-providers-in-depth-comparison-table__button {
+	max-width: 250px;
 }

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -1,28 +1,30 @@
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
-import type { SiteDomain } from 'calypso/state/sites/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactNode } from 'react';
 
-export type ComparisonTableProps = {
+export type ComparisonListOrTableProps = {
 	emailProviders: EmailProviderFeatures[];
+	intervalLength: IntervalLength;
+	onSelectEmailProvider: ( emailProviderSlug: string ) => void;
+	selectedDomainName: string;
+};
+
+export type EmailProviderPriceProps = {
+	emailProviderSlug: string;
 	intervalLength: IntervalLength;
 	selectedDomainName: string;
 };
 
-export type ComparisonTablePriceProps = {
-	domain: SiteDomain | undefined;
-	emailProviderSlug: string;
-	intervalLength: IntervalLength;
-};
+const EMAIL_PROVIDER_FEATURES_TYPE = [ 'importing', 'storage', 'support', 'tools' ] as const;
+
+type EmailProviderFeature = typeof EMAIL_PROVIDER_FEATURES_TYPE[ number ];
 
 export type EmailProviderFeatures = {
-	slug: string;
-	name: TranslateResult;
+	description: TranslateResult;
+	list: Record< EmailProviderFeature, TranslateResult >;
 	logo: ReactNode;
-	tools: TranslateResult;
-	storage: TranslateResult;
-	importing: TranslateResult;
-	support: TranslateResult;
+	name: TranslateResult;
+	slug: string;
 };
 
 export type EmailProvidersInDepthComparisonProps = {

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -23,7 +23,6 @@ export type EmailProviderFeatures = {
 	storage: TranslateResult;
 	importing: TranslateResult;
 	support: TranslateResult;
-	selectCallback: () => void;
 };
 
 export type EmailProvidersInDepthComparisonProps = {

--- a/client/my-sites/email/email-providers-comparison/price-badge/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price-badge/style.scss
@@ -1,7 +1,12 @@
 @import '@automattic/calypso-color-schemes';
+@import '@automattic/typography/styles/variables';
 
 .price-badge {
-	.promo-card__price .price__discount {
+	.price__cost > span {
+		font-size: $font-title-medium;
+	}
+
+	.price__discount {
 		text-decoration: line-through;
 		color: var( --studio-gray-60 );
 	}

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -1,3 +1,4 @@
+@import '@automattic/typography/styles/variables';
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
@@ -252,7 +253,7 @@ $width-left-panel-card: 55%;
 
 .email-provider-stacked-card__title {
 	margin-top: 4px;
-	font-size: 1.25rem;
+	font-size: $font-title-small;
 	line-height: 24px;
 	color: var( --color-neutral-70 );
 }


### PR DESCRIPTION
This pull request updates the `In-Depth Comparison` page to show a list of features for each email provider. That information is either displayed as a table on desktop devices, or as a list on mobile devices:

Desktop | Mobile
------ | -----
![image](https://user-images.githubusercontent.com/594356/149547076-b333d3d0-3f63-4205-9cd5-4dbc66b50114.png) | ![image](https://user-images.githubusercontent.com/594356/149550750-ed5a2fcd-b863-46b3-9cfa-acf6becaf76f.png)


Different options were explored in https://github.com/Automattic/wp-calypso/pull/59535 and https://github.com/Automattic/wp-calypso/pull/59543 to see if we could manage visual differences only with CSS. In the end, I've opted to use two distinct components given how much the layout differs between desktop and mobiles devices.

Note the following are out of scope:
* Adding a tooltip for each feature
* Showing `Learn more` links
* Showing a logo for Titan
* Adding a footer with a link to the Email Forwarding option

#### Testing instructions

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout add/features-in-in-depth-comparison-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/60050#issuecomment-1012352209)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Click the `See how they compare` link to access the `In-Depth Comparison` page
6. Assert that the page looks like the screenshots above on desktop and mobile