### PR TITLE
Videos UI: Remove ellipsis cutoff from videos UI chapter titles

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -152,6 +152,7 @@
 					color: rgba( 255, 255, 255, 0.5 );
 					display: inline-block;
 					flex-basis: 34px;
+					margin-right: 10px;
 				}
 
 				.videos-ui__completed-checkmark {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -182,6 +182,10 @@
 
 				.videos-ui__video-title {
 					margin-right: 10px;
+					display: -webkit-box;
+					-webkit-line-clamp: 2;
+					-webkit-box-orient: vertical;
+					overflow: hidden;
 				}
 
 				.videos-ui__chapter-accordion-toggle {

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -181,9 +181,6 @@
 				}
 
 				.videos-ui__video-title {
-					white-space: nowrap;
-					overflow: hidden;
-					text-overflow: ellipsis;
 					margin-right: 10px;
 				}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the videos UI chapter display to use `line-clamp` to cut off video titles at two lines for browser that support it. (It also fixes spacing on the video duration information.)

![image](https://user-images.githubusercontent.com/13437011/149973855-b34be51b-9800-4322-a08f-e4e3773219ff.png)



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to local Calypso.
* Open the videos UI and, using the dev tools, lengthen the title of a chapter to be multiple lines long.
* Verify that the title is cut off after two lines with an ellipsis and that the duration info is spaced correctly.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59808 
