### PR TITLE
Woo installer > Address step: Add optional note and disabled prop for button

### DIFF
--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -56,7 +56,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 
 	const { wpcomDomain } = useWooCommerceOnPlansEligibility( siteId );
 
-	const { validate, clearError, getError } = useAddressFormValidation( siteId );
+	const { validate, clearError, getError, errors } = useAddressFormValidation( siteId );
 
 	// @todo: Add a general hook to get and update multi-option data like the profile.
 	function updateProfileEmail( email: string ) {
@@ -106,7 +106,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 					<ControlError error={ address1Error } />
 
 					<TextControl
-						label={ __( 'Address line 2' ) }
+						label={ __( 'Address line 2 (optional)' ) }
 						value={ get( WOOCOMMERCE_STORE_ADDRESS_2 ) }
 						onChange={ ( value ) => {
 							update( WOOCOMMERCE_STORE_ADDRESS_2, value );
@@ -177,6 +177,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 									goToStep( 'confirm' );
 								}
 							} }
+							disabled={ Object.values( errors ).filter( Boolean ).length > 0 }
 						>
 							{ __( 'Continue' ) }
 						</StyledNextButton>
@@ -263,5 +264,6 @@ function useAddressFormValidation( siteId: number ) {
 		validate,
 		clearError,
 		getError,
+		errors,
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `(optional)` note to address line 2 to match design.
* Add `disabled` prop to button to match design.

<img width="497" alt="Screen Shot 2022-01-13 at 1 22 09 PM" src="https://user-images.githubusercontent.com/1689238/149387390-385d943d-10a5-43c8-860f-bfc61478ab9d.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/woocommerce-installation/?flags=woop
* Choose a non atomic site (atomic won't work until JP updates with new country endpoint data)
* Click set up my store
* You should be taken to the address step (when the woop flag is active)
* You should see (optional) next to the address line 2 label.
* You should see the Continue button get a `disabled` attribute when there are errors. Known issue: if you remove the store email, click Continue, then type in the email field, the button will un-disable and the error will disappear. That's because we clear errors when the value changes. But you'll get an error again because the email isn't valid.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #