### PR TITLE
Woo Install: Clean up step handling

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -746,7 +746,6 @@ export function generateSteps( {
 				),
 			},
 			dependencies: [ 'site' ],
-			providesDependencies: [ 'siteConfirmed' ],
 		},
 		confirm: {
 			stepName: 'confirm',

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -47,7 +47,7 @@ export const StyledNextButton = styled( NextButton )`
 `;
 
 export default function Confirm( props: WooCommerceInstallProps ): ReactElement | null {
-	const { goToStep, isReskinned, headerTitle, headerDescription } = props;
+	const { goToNextStep, isReskinned, headerTitle, headerDescription } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
@@ -69,9 +69,9 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		// Automatically start the transfer process when it's ready.
 		if ( isReadyToStart ) {
 			dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
-			goToStep( 'transfer' );
+			goToNextStep();
 		}
-	}, [ dispatch, goToStep, siteId, isDataReady, isReadyToStart ] );
+	}, [ dispatch, goToNextStep, siteId, isDataReady, isReadyToStart ] );
 
 	function getWPComSubdomainWarningContent() {
 		if ( ! wpcomSubdomainWarning ) {
@@ -134,7 +134,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 									page( siteUpgrading.checkoutUrl );
 									return;
 								}
-								goToStep( 'transfer' );
+								goToNextStep();
 							} }
 						>
 							{ __( 'Sounds good' ) }
@@ -158,7 +158,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 			flowName="woocommerce-install"
 			hideSkip={ true }
 			nextLabelText={ __( 'Confirm' ) }
-			allowBackFirstStep={ true }
+			allowBackFirstStep={ isEnabled( 'woop' ) }
 			backUrl={ isEnabled( 'woop' ) ? null : `/woocommerce-installation/${ wpcomDomain }` }
 			headerText={ headerTitle }
 			fallbackHeaderText={ headerTitle }

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -158,7 +158,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 			flowName="woocommerce-install"
 			hideSkip={ true }
 			nextLabelText={ __( 'Confirm' ) }
-			allowBackFirstStep={ isEnabled( 'woop' ) }
+			allowBackFirstStep={ ! isEnabled( 'woop' ) }
 			backUrl={ isEnabled( 'woop' ) ? null : `/woocommerce-installation/${ wpcomDomain }` }
 			headerText={ headerTitle }
 			fallbackHeaderText={ headerTitle }

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -9,6 +9,8 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { fetchWooCommerceCountries } from 'calypso/state/countries/actions';
 import getCountries from 'calypso/state/selectors/get-countries';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SupportCard from '../components/support-card';
 import { ActionSection, StyledNextButton } from '../confirm';
@@ -22,7 +24,6 @@ import {
 	WOOCOMMERCE_ONBOARDING_PROFILE,
 	optionNameType,
 } from '../hooks/use-site-settings';
-import useWooCommerceOnPlansEligibility from '../hooks/use-woop-handling';
 import type { WooCommerceInstallProps } from '..';
 import './style.scss';
 
@@ -37,7 +38,7 @@ const CityZipRow = styled.div`
 `;
 
 export default function StepStoreAddress( props: WooCommerceInstallProps ): ReactElement | null {
-	const { goToStep, isReskinned, headerTitle, headerDescription } = props;
+	const { goToNextStep, isReskinned, headerTitle, headerDescription } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
@@ -53,8 +54,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	} );
 
 	const { get, save, update } = useSiteSettings( siteId );
-
-	const { wpcomDomain } = useWooCommerceOnPlansEligibility( siteId );
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 
 	const { validate, clearError, getError } = useAddressFormValidation( siteId );
 
@@ -174,7 +174,8 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 								setSubmitted( submitted + 1 );
 								if ( validate() ) {
 									save();
-									goToStep( 'confirm' );
+									dispatch( submitSignupStep( { stepName: 'store-address' } ) );
+									goToNextStep();
 								}
 							} }
 						>
@@ -198,9 +199,8 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 		<StepWrapper
 			flowName="woocommerce-install"
 			hideSkip={ true }
-			nextLabelText={ __( 'Confirm' ) }
 			allowBackFirstStep={ true }
-			backUrl={ `/woocommerce-installation/${ wpcomDomain }` }
+			backUrl={ `/woocommerce-installation/${ domain }` }
 			headerText={ headerTitle }
 			fallbackHeaderText={ headerTitle }
 			subHeaderText={ headerDescription }

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -2,7 +2,6 @@ import { ReactElement, useState } from 'react';
 import { useSelector } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InstallPlugins from './install-plugins';
 import TransferSite from './transfer-site';
@@ -19,7 +18,6 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 		signupDependencies: { siteConfirmed },
 	} = props;
 
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 	const [ hasFailed, setHasFailed ] = useState( false );
 
 	if ( siteConfirmed !== siteId ) {
@@ -36,7 +34,6 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			hideSkip={ true }
 			hideFormattedHeader={ true }
 			isWideLayout={ props.isReskinned }
-			backUrl={ `/woocommerce-installation/${ domain }` }
 			stepContent={
 				<>
 					{ isAtomic && <InstallPlugins onFailure={ () => setHasFailed( true ) } /> }


### PR DESCRIPTION
Properly updates step progress now.

#### Changes proposed in this Pull Request

* Removes a step dependency that was copy/pasted.
* Uses `goToNextStep` throughout. Dumbs down steps about where they are in the process.
* Properly updates progress in the address step once form is submitted.
* Removes unneeded backUrl info from transfer step.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to wordpress.com/woocommerce-installation and go through the flow.
* Click the back button here and there and make sure it navigates to the previous step.

