### PR TITLE
Fix minor typo in contact verification notice text

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -232,7 +232,7 @@ export function resolveDomainStatus(
 			if ( domain.isPendingIcannVerification && domain.currentUserCanManage ) {
 				const noticeText = domain.currentUserIsOwner
 					? translate(
-							'We sent you an email to verify your contact information. Please complete the verification or your domain will stop working. You can also {{a}}change you email address{{/a}} if you like.',
+							'We sent you an email to verify your contact information. Please complete the verification or your domain will stop working. You can also {{a}}change your email address{{/a}} if you like.',
 							{
 								components: {
 									a: <a href={ domainManagementEditContactInfo( siteSlug, domain.name ) }></a>,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The notice for a domain contact that needs verification currently reads "... You can also change you email address if you like."  It should read "... You can also change you**r** email address if you like."

<img width="1075" alt="Domains_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/149407857-1322f691-b4e3-4e4a-84b9-ed26ddcfee17.png">

#### Testing instructions

Change the email address for a domain to something that has not previously been verified.
Verify that the notice on the domains list reads "... You can also change your email address ..."