### PR TITLE
Checkout: Always finish loading even if cart has errors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -99,7 +99,7 @@ export default function useAddProductsFromUrl( {
 		if ( couponCodeFromUrl ) {
 			cartPromises.push( applyCoupon( couponCodeFromUrl ) );
 		}
-		Promise.allSettled( cartPromises ).finally( () => {
+		Promise.allSettled( cartPromises ).then( () => {
 			debug( 'initial cart requests have completed' );
 			isMounted.current && setIsLoading( false );
 		} );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -99,7 +99,7 @@ export default function useAddProductsFromUrl( {
 		if ( couponCodeFromUrl ) {
 			cartPromises.push( applyCoupon( couponCodeFromUrl ) );
 		}
-		Promise.all( cartPromises ).finally( () => {
+		Promise.allSettled( cartPromises ).finally( () => {
 			debug( 'initial cart requests have completed' );
 			isMounted.current && setIsLoading( false );
 		} );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -99,7 +99,7 @@ export default function useAddProductsFromUrl( {
 		if ( couponCodeFromUrl ) {
 			cartPromises.push( applyCoupon( couponCodeFromUrl ) );
 		}
-		Promise.all( cartPromises ).then( () => {
+		Promise.all( cartPromises ).finally( () => {
 			debug( 'initial cart requests have completed' );
 			isMounted.current && setIsLoading( false );
 		} );


### PR DESCRIPTION
#### Background

When checkout loads, it may send a request to the server to add products or coupons, based on information in the URL. If it does so, it causes the page to display a loading state while those shopping-cart endpoint requests complete, using `Promise.all().then()` to wait for them.

If the shopping-cart endpoint has a problem with a request, it still returns a 200 response with a valid cart and the error messages included in the response data. Prior to https://github.com/Automattic/wp-calypso/pull/58834 `ShoppingCartManager` we use in calypso previously ignored such errors and relied on the consumer to check for errors in that data. This was problematic for many consumers who weren't checking for errors, particularly ones which relied on Promises, since the Promises would never reject. After that PR, if there are any errors, the Promises will reject instead.

Because `Promise.all()` will reject if any of the promises reject, if any of the requests have an error, checkout to be stuck in a perpetual loading state.

#### Changes proposed in this Pull Request

This PR modifies the logic to use `Promise.allSettled().then()` instead (which waits for all promises even if some reject and never rejects itself) so that it will always mark the requests as complete when they finish.

Before:

<img width="692" alt="Screen Shot 2022-01-13 at 5 34 08 PM" src="https://user-images.githubusercontent.com/2036909/149419720-304eea8e-bf04-44b4-8022-fbc024171899.png">

After:

<img width="694" alt="Screen Shot 2022-01-13 at 5 34 30 PM" src="https://user-images.githubusercontent.com/2036909/149419731-39973517-1f37-47eb-a6a8-746eca603818.png">

Props to @nbloomf for spotting this bug!

#### Testing instructions

- Visit checkout with a URL containing a free theme, like `/checkout/YOUR-SITE-HERE/theme:twentytwenty`.
- Verify that you see an error message displayed, but that checkout finishes loading.