### PR TITLE
Importer: Fixes direction of import URL capture button in production

### DIFF
--- a/client/signup/steps/import/capture/index.tsx
+++ b/client/signup/steps/import/capture/index.tsx
@@ -1,5 +1,5 @@
 import { NextButton } from '@automattic/onboarding';
-import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { Icon, chevronRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React, { useEffect, useState } from 'react';
@@ -38,7 +38,7 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 	analyzerError,
 	recordTracksEvent,
 } ) => {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 
 	/**
 	 ↓ Fields
@@ -126,7 +126,7 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 							/>
 							{ showSubmitButton && (
 								<NextButton type={ 'submit' }>
-									<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
+									<Icon className="capture__next-button-icon" icon={ chevronRight } />
 								</NextButton>
 							) }
 							{ ( ! isValid && showError ) ||

--- a/client/signup/steps/import/capture/style.scss
+++ b/client/signup/steps/import/capture/style.scss
@@ -75,4 +75,10 @@ $placeholder-color: #909398;
 		line-height: 1.4286em;
 		margin-top: 8px;
 	}
+
+	.capture__next-button-icon {
+		.rtl & {
+			transform: scaleX( -1 );
+		}
+	}
 }


### PR DESCRIPTION
Despite the direction of the import URL capture button being fixed in #59973, for some reason, the icon still appears to be in the wrong direction when viewed in production.

<img width="1579" alt="Screenshot 2022-01-14 at 12 26 52 PM" src="https://user-images.githubusercontent.com/1500769/149424967-319fe904-5d48-4956-bd61-45d2c1c64947.png">

The icon _is_ in the correct orientation when tested in a development build 🤔 

Debugging the issue, the `isRTL()` function isn't working correctly in production. `isRTL` works by looking up the translation for the special `"ltr"` string, that in RTL languages is translated as `"rtl"`. [See the special translation in glotpress](https://translate.wordpress.com/projects/wpcom/es/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=41881&filters%5Btranslation_id%5D=1608338). But for some reason in production the translation data for `"ltr"` is missing, despite the fact that many of the other strings are present.
@arthur791004 is this another manifestation of the issue you're trying to fix in https://github.com/WordPress/gutenberg/pull/37704?

#### Changes proposed in this Pull Request

This PR changes the logic so that the icon direction is switched the same way the `<GridIcon>` chevron icons get flipped: by relying on the global `.rtl` class.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Test using localhost.calypso:3000 so that Hero Flow will be enabled for non-en
* Change language to something RTL
* To enter the import flow, click the link at the bottom of the intent step of the Hero Flow
* Check that the "next" button in the input capture step is pointing to the _left_ in RTL langauges


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #58859
