### PR TITLE
Shopping Cart: Make cart manager aware that site slug and site ID are the same cart

### DIFF
--- a/packages/shopping-cart/src/managers.ts
+++ b/packages/shopping-cart/src/managers.ts
@@ -73,8 +73,9 @@ export function createSubscriptionManager( cartKey: string | undefined ): Subscr
 		} );
 		debug( `completed notification of subscribers for cartKey ${ cartKey }` );
 	};
+	const getSubscribers = () => subscribedClients;
 
-	return { subscribe, notifySubscribers };
+	return { subscribe, notifySubscribers, getSubscribers };
 }
 
 export function createActionPromisesManager(): ActionPromises {
@@ -131,5 +132,6 @@ export const noopManager: ShoppingCartManager = {
 	actions: noopActions,
 	getState: noopGetState,
 	subscribe: () => () => null,
+	getSubscribers: () => [],
 	fetchInitialCart: () => Promise.resolve( emptyCart ),
 };

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -155,7 +155,18 @@ export function createShoppingCartManagerClient( {
 
 	function addCartKeyAlias( aliasKey: string, cartKey: string ): void {
 		debug( `adding cart manager alias from "${ aliasKey }" to "${ cartKey }"` );
+		// Prevent accessing old manager and return new manager instead.
 		cartKeyAliases[ aliasKey ] = cartKey;
+		if ( managersByCartKey[ aliasKey ] && managersByCartKey[ cartKey ] ) {
+			// Resubscribe any existing subscribers to the new manager.
+			// FIXME: how do we do that?
+			// Mutate existing manager just in case any existing references still exist.
+			managersByCartKey[ aliasKey ].actions = managersByCartKey[ cartKey ].actions;
+			managersByCartKey[ aliasKey ].getState = managersByCartKey[ cartKey ].getState;
+			managersByCartKey[ aliasKey ].subscribe = managersByCartKey[ cartKey ].subscribe;
+			managersByCartKey[ aliasKey ].fetchInitialCart =
+				managersByCartKey[ cartKey ].fetchInitialCart;
+		}
 	}
 
 	function forCartKey( cartKey: string | undefined ): ShoppingCartManager {

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -137,6 +137,7 @@ function createShoppingCartManager(
 
 	return {
 		subscribe: subscriptionManager.subscribe,
+		getSubscribers: subscriptionManager.getSubscribers,
 		actions,
 		getState: getCachedManagerState,
 		fetchInitialCart: initialFetch,

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -160,7 +160,9 @@ export function createShoppingCartManagerClient( {
 		cartKeyAliases[ aliasKey ] = cartKey;
 		if ( managersByCartKey[ aliasKey ] && managersByCartKey[ cartKey ] ) {
 			// Resubscribe any existing subscribers to the new manager.
-			// FIXME: how do we do that?
+			managersByCartKey[ aliasKey ]
+				.getSubscribers()
+				.forEach( managersByCartKey[ cartKey ].subscribe );
 			// Mutate existing manager just in case any existing references still exist.
 			managersByCartKey[ aliasKey ].actions = managersByCartKey[ cartKey ].actions;
 			managersByCartKey[ aliasKey ].getState = managersByCartKey[ cartKey ].getState;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -31,6 +31,7 @@ export type ShoppingCartManagerSubscribe = ( callback: SubscribeCallback ) => Un
 export interface SubscriptionManager {
 	subscribe: ShoppingCartManagerSubscribe;
 	notifySubscribers: () => void;
+	getSubscribers: () => SubscribeCallback[];
 }
 
 export interface ShoppingCartManagerState {
@@ -45,12 +46,14 @@ export interface ShoppingCartManagerState {
 type WaitForReady = () => Promise< ResponseCart >;
 
 export type ShoppingCartManagerGetState = () => ShoppingCartManagerState;
+export type ShoppingCartManagerGetSubscribers = () => SubscribeCallback[];
 
 export interface ShoppingCartManager {
 	getState: ShoppingCartManagerGetState;
 	subscribe: ShoppingCartManagerSubscribe;
 	actions: ShoppingCartManagerActions;
 	fetchInitialCart: WaitForReady;
+	getSubscribers: ShoppingCartManagerGetSubscribers;
 }
 
 export type UseShoppingCart = ShoppingCartManagerActions & ShoppingCartManagerState;

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -24,14 +24,14 @@ describe( 'ShoppingCartManager', () => {
 			expect( responseCart.cart_key ).toBe( mainCartKey );
 		} );
 
-		it( 'returns the same responseCart for a site slug that has already been cached by ID', async () => {
+		it( 'returns the same responseCart for a site ID that has already been cached by slug', async () => {
 			const cartManagerClient = createShoppingCartManagerClient( {
 				getCart,
 				setCart,
 			} );
-			const manager1 = cartManagerClient.forCartKey( mainCartKey );
-			const manager2 = cartManagerClient.forCartKey( mainSiteSlug );
+			const manager1 = cartManagerClient.forCartKey( mainSiteSlug );
 			await manager1.actions.addProductsToCart( [ planOne ] );
+			const manager2 = cartManagerClient.forCartKey( mainCartKey );
 			const { responseCart } = manager2.getState();
 			expect( responseCart.products.length ).toBe( 1 );
 			expect( responseCart.products[ 0 ].product_slug ).toBe( planOne.product_slug );

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -1,5 +1,12 @@
 import { createShoppingCartManagerClient, getEmptyResponseCart } from '../src/index';
-import { getCart, setCart, mainCartKey, planOne, planTwo } from './utils/mock-cart-api';
+import {
+	getCart,
+	setCart,
+	mainCartKey,
+	planOne,
+	planTwo,
+	mainSiteSlug,
+} from './utils/mock-cart-api';
 
 /* eslint-disable jest/no-done-callback, jest/no-conditional-expect */
 
@@ -15,6 +22,19 @@ describe( 'ShoppingCartManager', () => {
 			const { responseCart } = manager.getState();
 			expect( responseCart.products.length ).toBe( 0 );
 			expect( responseCart.cart_key ).toBe( mainCartKey );
+		} );
+
+		it( 'returns the same responseCart for a site slug that has already been cached by ID', async () => {
+			const cartManagerClient = createShoppingCartManagerClient( {
+				getCart,
+				setCart,
+			} );
+			const manager1 = cartManagerClient.forCartKey( mainCartKey );
+			const manager2 = cartManagerClient.forCartKey( mainSiteSlug );
+			await manager1.actions.addProductsToCart( [ planOne ] );
+			const { responseCart } = manager2.getState();
+			expect( responseCart.products.length ).toBe( 1 );
+			expect( responseCart.products[ 0 ].product_slug ).toBe( planOne.product_slug );
 		} );
 
 		it( 'returns an empty cart if fetchInitialCart has not been called', async () => {

--- a/packages/shopping-cart/test/utils/mock-cart-api.ts
+++ b/packages/shopping-cart/test/utils/mock-cart-api.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../src/types';
 
 export const mainCartKey = '1';
+export const mainSiteSlug = 'mysite';
 
 const emptyResponseCart = getEmptyResponseCart();
 
@@ -95,6 +96,9 @@ export const renewalTwo: ResponseCartProduct = {
 };
 
 export async function getCart( cartKey: string ): Promise< ResponseCart > {
+	if ( cartKey === mainSiteSlug ) {
+		cartKey = mainCartKey;
+	}
 	if ( cartKey === mainCartKey ) {
 		return {
 			...emptyResponseCart,
@@ -115,6 +119,9 @@ function createProduct( productProps: RequestCartProduct ): ResponseCartProduct 
 }
 
 export async function setCart( cartKey: string, newCart: RequestCart ): Promise< ResponseCart > {
+	if ( cartKey === mainSiteSlug ) {
+		cartKey = mainCartKey;
+	}
 	if ( [ 'no-site', 'no-user', mainCartKey ].includes( cartKey ) ) {
 		// Mock the shopping-cart endpoint response here
 		return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The shopping-cart endpoint (in most cases) requires two pieces of information to create or alter a cart: a logged-in user, and a cart key. (It's possible to use the `'no-user'` cart key to create a temporary cart with no user or site, but this is rare.) The cart key is typically the numeric site ID of the site to which the cart belongs. However, it's also possible to use the site _slug_, which is the domain name of the site. If that's the case, the shopping-cart endpoint will immediately transform the slug into the numeric site ID and use that as the key from that point on.

Since https://github.com/Automattic/wp-calypso/pull/54667, the shopping cart manager in calypso has become capable of caching and operating on multiple cart objects, organized by cart key. Its persistent cache between providers means that totally separate components in the render tree can make requests for shopping cart data and that data will be shared (and automatically updated) between those components if they use the same key. However, as mentioned above, it's possible to use _two different keys to get the same data_. While the endpoint treats these requests as the same, the cart manager believes them to be different.

Subsequently, it's possible for one consumer (eg: [signup](https://github.com/Automattic/wp-calypso/blob/6319d8a6dd0186c53fc2055624291d32e8322f6a/client/lib/signup/step-actions/index.js#L479)) to modify the cart using the site slug and another consumer (eg: the masterbar cart) to not be aware of that change. If the second consumer tries to make requests of its own, things could get very confusing indeed.

This would be greatly simplified if the cart manager was aware that site slugs and cart keys were related, which is the intent of this PR. The biggest advantage is that on every shopping-cart endpoint request, a `cart_key` property is returned which is always the actual cart key (the site ID if a site is selected) even if a slug was used in the request.

Related to https://github.com/Automattic/wp-calypso/issues/59773

#### Testing instructions

TBD