### PR TITLE
DIFM Lite: Hide the design title and preview

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -709,6 +709,8 @@ export function generateSteps( {
 				showDesignPickerCategories: true,
 				showDesignPickerCategoriesAllFilter: false,
 				showLetUsChoose: true,
+				hideFullScreenPreview: true,
+				hideDesignTitle: true,
 			},
 		},
 		'site-info-collection': {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -35,6 +35,8 @@ export default function DesignPickerStep( props ) {
 		queryParams,
 		showDesignPickerCategories,
 		showLetUsChoose,
+		hideFullScreenPreview,
+		hideDesignTitle,
 	} = props;
 
 	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
@@ -166,6 +168,8 @@ export default function DesignPickerStep( props ) {
 					/>
 				}
 				categoriesFooter={ renderCategoriesFooter() }
+				hideFullScreenPreview={ hideFullScreenPreview }
+				hideDesignTitle={ hideDesignTitle }
 			/>
 		);
 	}

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -56,7 +56,6 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	premiumBadge,
 	highRes,
 	disabled,
-	hideFullScreenPreview,
 	hideDesignTitle,
 } ) => {
 	const { __ } = useI18n();
@@ -88,10 +87,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					'design-picker__image-frame',
 					'design-picker__image-frame-landscape',
 					design.preview === 'static' ? 'design-picker__static' : 'design-picker__scrollable',
-					{ 'design-picker__image-frame-blank': isBlankCanvas },
-					{
-						'design-picker__image-frame-hide-preview': hideFullScreenPreview,
-					}
+					{ 'design-picker__image-frame-blank': isBlankCanvas }
 				) }
 			>
 				{ isBlankCanvas ? (
@@ -179,7 +175,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 
 	if ( ! onPreview || props.hideFullScreenPreview ) {
 		return (
-			<div className="design-button-container">
+			<div className="design-button-container design-button-container--without-preview">
 				<DesignButton { ...props } />
 			</div>
 		);

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -177,7 +177,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	const isDesktop = useViewportMatch( 'large' );
 	const isBlankCanvas = isBlankCanvasDesign( props.design );
 
-	if ( ! onPreview ) {
+	if ( ! onPreview || props.hideFullScreenPreview ) {
 		return (
 			<div className="design-button-container">
 				<DesignButton { ...props } />
@@ -276,7 +276,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						design={ design }
 						locale={ locale }
 						onSelect={ onSelect }
-						onPreview={ hideFullScreenPreview ? undefined : onPreview }
+						onPreview={ onPreview }
 						premiumBadge={ premiumBadge }
 						highRes={ highResThumbnails }
 						hideFullScreenPreview={ hideFullScreenPreview }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -45,6 +45,8 @@ interface DesignButtonProps {
 	premiumBadge?: React.ReactNode;
 	highRes: boolean;
 	disabled?: boolean;
+	hideFullScreenPreview?: boolean;
+	hideDesignTitle?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -54,6 +56,8 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	premiumBadge,
 	highRes,
 	disabled,
+	hideFullScreenPreview,
+	hideDesignTitle,
 } ) => {
 	const { __ } = useI18n();
 
@@ -84,7 +88,10 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					'design-picker__image-frame',
 					'design-picker__image-frame-landscape',
 					design.preview === 'static' ? 'design-picker__static' : 'design-picker__scrollable',
-					{ 'design-picker__image-frame-blank': isBlankCanvas }
+					{ 'design-picker__image-frame-blank': isBlankCanvas },
+					{
+						'design-picker__image-frame-hide-preview': hideFullScreenPreview,
+					}
 				) }
 			>
 				{ isBlankCanvas ? (
@@ -99,7 +106,9 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			</span>
 			<span className="design-picker__option-overlay">
 				<span id={ makeOptionId( design ) } className="design-picker__option-meta">
-					<span className="design-picker__option-name">{ designTitle }</span>
+					{ ! hideDesignTitle && (
+						<span className="design-picker__option-name">{ designTitle }</span>
+					) }
 					{ design.is_premium && premiumBadge && (
 						<Tooltip
 							position="bottom center"
@@ -213,6 +222,8 @@ export interface DesignPickerProps {
 	categorization?: Categorization;
 	categoriesHeading?: React.ReactNode;
 	categoriesFooter?: React.ReactNode;
+	hideFullScreenPreview?: boolean;
+	hideDesignTitle?: boolean;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -230,6 +241,8 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	categoriesHeading,
 	categoriesFooter,
 	categorization,
+	hideFullScreenPreview,
+	hideDesignTitle,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
@@ -263,9 +276,11 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						design={ design }
 						locale={ locale }
 						onSelect={ onSelect }
-						onPreview={ onPreview }
+						onPreview={ hideFullScreenPreview ? undefined : onPreview }
 						premiumBadge={ premiumBadge }
 						highRes={ highResThumbnails }
+						hideFullScreenPreview={ hideFullScreenPreview }
+						hideDesignTitle={ hideDesignTitle }
 					/>
 				) ) }
 			</div>

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -146,12 +146,6 @@
 			background-color: transparent;
 			transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 		}
-
-		&.design-picker__image-frame-hide-preview {
-			&::after {
-				display: none;
-			}
-		}
 	}
 
 	// The Aspect ratio trick: padding % is relative to width, so we use
@@ -385,6 +379,21 @@
 			@include break-large {
 				width: calc( 50% - 24px );
 			}
+		}
+	}
+}
+
+// layout without preview
+.design-button-container--without-preview {
+	.design-picker__image-frame::after {
+		pointer-events: none;
+	}
+
+	&:hover,
+	&:focus-within {
+		.design-picker__image-frame::after {
+			// `!important` is used because there is a default `background-color` with high specificity.
+			background-color: transparent !important; // to override 
 		}
 	}
 }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -146,6 +146,12 @@
 			background-color: transparent;
 			transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 		}
+
+		&.design-picker__image-frame-hide-preview {
+			&::after {
+				display: none;
+			}
+		}
 	}
 
 	// The Aspect ratio trick: padding % is relative to width, so we use


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pdh1Xd-lI-p2#comment-729

This change hides the design title and preview in the design picker when in the DIFM Lite flow. This is currently experimental and may/may not be merged.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the flow at `/start/do-it-for-me`
* On the design picker step, confirm that the design title is hidden:
![image](https://user-images.githubusercontent.com/5436027/149463908-2130e746-b9fd-43ae-bf57-cc9456b02985.png)
* Hovering on the design should scroll the image.
![Kapture 2022-01-14 at 12 20 40](https://user-images.githubusercontent.com/5436027/149464132-3ef3d9a9-9d9c-4a3b-8425-7c3c2b76968e.gif)
* Confirm that clicking on the image takes you to the next step.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
