### PR TITLE
Server render: remove default cache key

### DIFF
--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -71,11 +71,11 @@ export function renderJsx( view, props ) {
  * Cache is keyed by stringified element by default.
  *
  * @param {object} element - React element to be rendered to html
- * @param {string} key - (optional) custom key
+ * @param {string} key - cache key
  * @param {object} req - Request object
  * @returns {string} The rendered Layout
  */
-export function render( element, key = JSON.stringify( element ), req ) {
+function render( element, key, req ) {
 	try {
 		const startTime = Date.now();
 		debug( 'cache access for key', key );


### PR DESCRIPTION
A little improvement of server rendering that I noticed when reviewing #59848 by @sgomes. The `JSON.stringify( element )` never makes sense as a cache key -- it would be a big blob of serialized React element tree. And the parameter is always passed from the caller (`serverRender`), calculated from the route, so the default never applies.

I also stopped to export the `render` function as it's used only internally by `serverRender`.