### PR TITLE
P2: add p2 and p2 workspace badges to p2 sites to My Sites list

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -14,6 +14,9 @@ import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 
 import './style.scss';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const noop = () => {};
 
@@ -38,6 +41,9 @@ class Site extends Component {
 		// if homeLink is enabled
 		showHomeIcon: true,
 		compact: false,
+
+		isP2Hub: false,
+		isSiteP2: false,
 	};
 
 	static propTypes = {
@@ -54,6 +60,8 @@ class Site extends Component {
 		homeLink: PropTypes.bool,
 		showHomeIcon: PropTypes.bool,
 		compact: PropTypes.bool,
+		isP2Hub: PropTypes.bool,
+		isSiteP2: PropTypes.bool,
 	};
 
 	onSelect = ( event ) => {
@@ -158,6 +166,12 @@ class Site extends Component {
 								: site.domain }
 						</div>
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+						{ this.props.isSiteP2 && ! this.props.isP2Hub && (
+							<span className="site__badge site__badge-p2">P2</span>
+						) }
+						{ this.props.isP2Hub && (
+							<span className="site__badge site__badge-p2-workspace">P2 Workspace</span>
+						) }
 						{ this.props.site.is_private && (
 							<span className="site__badge site__badge-private">
 								{ shouldShowPrivateByDefaultComingSoonBadge
@@ -208,6 +222,8 @@ function mapStateToProps( state, ownProps ) {
 		siteSlug: getSiteSlug( state, siteId ),
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		isNavUnificationEnabled: isNavUnificationEnabled( state ),
+		isSiteP2: isSiteWPForTeams( state, siteId ),
+		isP2Hub: isSiteP2Hub( state, siteId ),
 	};
 }
 

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -166,10 +166,10 @@ class Site extends Component {
 						</div>
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ this.props.isSiteP2 && ! this.props.isP2Hub && (
-							<span className="site__badge site__badge-p2">P2</span>
+							<span className="site__badge is-p2">P2</span>
 						) }
 						{ this.props.isP2Hub && (
-							<span className="site__badge site__badge-p2-workspace">P2 Workspace</span>
+							<span className="site__badge is-p2-workspace">P2 Workspace</span>
 						) }
 						{ this.props.site.is_private && (
 							<span className="site__badge site__badge-private">

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -10,13 +10,12 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 
 import './style.scss';
-import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const noop = () => {};
 

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -177,8 +177,8 @@
 	margin-right: 3px;
 	padding: 1px 10px;
 
-	&.site__badge-p2,
-	&.site__badge-p2-workspace {
+	&.is-p2,
+	&.is-p2-workspace {
 		background: var( --p2-color-link );
 		color: var( --p2-color-white );
 	}
@@ -189,8 +189,8 @@
 	background: var( --color-sidebar-menu-hover-background );
 	color: var( --color-sidebar-menu-hover-text );
 
-	&.site__badge-p2,
-	&.site__badge-p2-workspace {
+	&.is-p2,
+	&.is-p2-workspace {
 		background: var( --p2-color-link-dark );
 		color: var( --p2-color-white );
 	}
@@ -206,8 +206,8 @@
 		background: var( --color-sidebar-menu-hover-background );
 		color: var( --color-sidebar-menu-hover-text );
 
-		&.site__badge-p2,
-		&.site__badge-p2-workspace {
+		&.is-p2,
+		&.is-p2-workspace {
 			background: var( --p2-color-link );
 			color: var( --p2-color-white );
 		}

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -176,12 +176,24 @@
 	margin-top: 6px;
 	margin-right: 3px;
 	padding: 1px 10px;
+
+	&.site__badge-p2,
+	&.site__badge-p2-workspace {
+		background: var( --p2-color-link );
+		color: var( --p2-color-white );
+	}
 }
 
 .current-site .site:hover .site__badge,
 .purchases-site .site:hover .site__badge {
 	background: var( --color-sidebar-menu-hover-background );
 	color: var( --color-sidebar-menu-hover-text );
+
+	&.site__badge-p2,
+	&.site__badge-p2-workspace {
+		background: var( --p2-color-link-dark );
+		color: var( --p2-color-white );
+	}
 }
 
 .layout__secondary {
@@ -193,5 +205,11 @@
 	.site__badge {
 		background: var( --color-sidebar-menu-hover-background );
 		color: var( --color-sidebar-menu-hover-text );
+
+		&.site__badge-p2,
+		&.site__badge-p2-workspace {
+			background: var( --p2-color-link );
+			color: var( --p2-color-white );
+		}
 	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -62,8 +62,8 @@
 	.site__badge {
 		background-color: var( --color-surface );
 
-		&.site__badge-p2,
-		&.site__badge-p2-workspace {
+		&.is-p2,
+		&.is-p2-workspace {
 			background: var( --p2-color-link-dark );
 			color: var( --p2-color-white );
 		}
@@ -93,8 +93,8 @@
 		background: var( --color-sidebar-background );
 		color: var( --color-sidebar-text );
 
-		&.site__badge-p2,
-		&.site__badge-p2-workspace {
+		&.is-p2,
+		&.is-p2-workspace {
 			background: var( --p2-color-link-dark );
 			color: var( --p2-color-white );
 		}
@@ -123,8 +123,8 @@
 	background: var( --color-sidebar-menu-hover-background );
 	color: var( --color-sidebar-menu-hover-text );
 
-	&.site__badge-p2,
-	&.site__badge-p2-workspace {
+	&.is-p2,
+	&.is-p2-workspace {
 		background: var( --p2-color-link );
 		color: var( --p2-color-white );
 	}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -53,16 +53,20 @@
 	}
 }
 
-
 .notouch .site-selector.is-hover-enabled .site:hover,
-.notouch .site-selector.is-hover-enabled .all-sites:hover
-.site-selector .site.is-highlighted,
+.notouch .site-selector.is-hover-enabled .all-sites:hover .site-selector .site.is-highlighted,
 .site-selector .all-sites.is-highlighted {
 	background-color: var( --color-neutral-5 );
 	cursor: pointer;
 
 	.site__badge {
 		background-color: var( --color-surface );
+
+		&.site__badge-p2,
+		&.site__badge-p2-workspace {
+			background: var( --p2-color-link-dark );
+			color: var( --p2-color-white );
+		}
 	}
 
 	.site__title,
@@ -75,14 +79,25 @@
 
 // Highlight & hover effects
 .notouch .layout__secondary .site-selector.is-hover-enabled .site:hover,
-.notouch .layout__secondary .site-selector.is-hover-enabled .all-sites:hover
-.layout__secondary .site-selector .site.is-highlighted,
+.notouch
+	.layout__secondary
+	.site-selector.is-hover-enabled
+	.all-sites:hover
+	.layout__secondary
+	.site-selector
+	.site.is-highlighted,
 .layout__secondary .site-selector .all-sites.is-highlighted {
 	background: var( --color-sidebar-menu-hover-background );
 
 	.site__badge {
 		background: var( --color-sidebar-background );
 		color: var( --color-sidebar-text );
+
+		&.site__badge-p2,
+		&.site__badge-p2-workspace {
+			background: var( --p2-color-link-dark );
+			color: var( --p2-color-white );
+		}
 	}
 
 	.site__title,
@@ -107,6 +122,12 @@
 .layout__secondary .site-selector .site__badge {
 	background: var( --color-sidebar-menu-hover-background );
 	color: var( --color-sidebar-menu-hover-text );
+
+	&.site__badge-p2,
+	&.site__badge-p2-workspace {
+		background: var( --p2-color-link );
+		color: var( --p2-color-white );
+	}
 }
 
 .site-selector .search {


### PR DESCRIPTION
In this PR, we add the "P2" and "P2 Workspace" badges to P2 sites in the My Sites list. It partly addresses some of the confusion between regular WP.com sites and P2 sites (and between P2 vs P2 Workspace sites).

## Testing instructions

Apply the code and check My Sites in the sidebar: all P2 sites should have the badge. It should also have a hover effect. Check http://calypso.localhost:3000/home as well since it has a bit different styling.