### PR TITLE
Support: Remove always-on support-user feature flag

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -274,7 +274,7 @@ class Layout extends Component {
 					<AsyncLoad require="calypso/lib/keyboard-shortcuts/menu" placeholder={ null } />
 				) }
 				{ this.renderMasterbar() }
-				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
+				<SupportUser />
 				<LayoutLoader />
 				{ isJetpackCloud() && (
 					<AsyncLoad require="calypso/jetpack-cloud/style" placeholder={ null } />

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import debugModule from 'debug';
 import { bypassPersistentStorage } from 'calypso/lib/browser-storage';
 import localStorageBypass from 'calypso/lib/local-storage-bypass';
@@ -16,14 +15,9 @@ import wpcom from 'calypso/lib/wp';
 const debug = debugModule( 'calypso:support-user' );
 const STORAGE_KEY = 'boot_support_user';
 const noop = () => {};
-const isEnabled = () => config.isEnabled( 'support-user' );
 
 let _setReduxStore = noop;
 const reduxStoreReady = new Promise( ( resolve ) => {
-	if ( ! isEnabled() ) {
-		return;
-	}
-
 	_setReduxStore = ( reduxStore ) => resolve( reduxStore );
 } );
 export const setSupportSessionReduxStore = _setReduxStore;
@@ -41,10 +35,6 @@ const getStorageItem = () => {
 // module clears the store on change; it could return false if called
 // after boot.
 const _isSupportUserSession = ( () => {
-	if ( ! isEnabled() ) {
-		return false;
-	}
-
 	const supportUser = getStorageItem();
 
 	return supportUser && supportUser.user && supportUser.token;
@@ -54,10 +44,6 @@ export const isSupportUserSession = () => _isSupportUserSession;
 
 // Detect the next-style support session
 export const isSupportNextSession = () => {
-	if ( ! isEnabled() ) {
-		return false;
-	}
-
 	return !! ( typeof window !== 'undefined' && window.isSupportSession );
 };
 
@@ -67,10 +53,6 @@ export const isSupportSession = () => isSupportUserSession() || isSupportNextSes
 let onBeforeUnload;
 
 const storeUserAndToken = ( user, token ) => () => {
-	if ( ! isEnabled() ) {
-		return;
-	}
-
 	if ( user && token ) {
 		window.sessionStorage.setItem( STORAGE_KEY, JSON.stringify( { user, token } ) );
 	}
@@ -80,10 +62,6 @@ const storeUserAndToken = ( user, token ) => () => {
  * Reboot normally as the main user
  */
 export const rebootNormally = () => {
-	if ( ! isEnabled() ) {
-		return;
-	}
-
 	debug( 'Rebooting Calypso normally' );
 
 	window.sessionStorage.removeItem( STORAGE_KEY );
@@ -101,10 +79,6 @@ const onTokenError = ( error ) => {
  * Inject the support user token into all following API calls
  */
 export async function supportUserBoot() {
-	if ( ! isEnabled() ) {
-		return;
-	}
-
 	const { user, token } = getStorageItem();
 	debug( 'Booting Calypso with support user', user );
 
@@ -131,10 +105,6 @@ export async function supportUserBoot() {
 }
 
 export async function supportNextBoot() {
-	if ( ! isEnabled() ) {
-		return;
-	}
-
 	bypassPersistentStorage( true );
 
 	// The following keys will not be bypassed as

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -31,9 +31,7 @@ if ( config.isEnabled( 'oauth' ) ) {
 	);
 }
 
-if ( config.isEnabled( 'support-user' ) ) {
-	wpcom = wpcomSupport( wpcom );
-}
+wpcom = wpcomSupport( wpcom );
 
 if ( 'development' === process.env.NODE_ENV ) {
 	require( './offline-library' ).makeOffline( wpcom );

--- a/client/lib/wp/node.js
+++ b/client/lib/wp/node.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import wpcomXhrRequest from 'wpcom-xhr-request';
 import wpSupportWrapper from 'calypso/lib/wp/support';
 import wpcomOAuthWrapper from 'calypso/lib/wpcom-oauth-wrapper';
@@ -6,9 +5,7 @@ import { injectLocalization } from './localization';
 
 let wpcom = wpcomOAuthWrapper( wpcomXhrRequest );
 
-if ( config.isEnabled( 'support-user' ) ) {
-	wpcom = wpSupportWrapper( wpcom );
-}
+wpcom = wpSupportWrapper( wpcom );
 
 // Inject localization helpers to `wpcom` instance
 wpcom = injectLocalization( wpcom );

--- a/config/client.json
+++ b/config/client.json
@@ -28,7 +28,6 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
-	"support-user",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -140,7 +140,6 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
-		"support-user": true,
 		"themes/premium": false,
 		"titan/iframe-control-panel": false,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,7 +91,6 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": false,
 		"site-indicator": true,
-		"support-user": true,
 		"themes/premium": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -58,7 +58,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"support-user": true,
 		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -50,7 +50,6 @@
 		"oauth": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,
-		"support-user": true,
 		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -52,7 +52,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"support-user": true,
 		"upgrades/redirect-payments": false
 	},
 	"enable_all_sections": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -55,7 +55,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"support-user": true,
 		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,

--- a/config/production.json
+++ b/config/production.json
@@ -98,7 +98,6 @@
 		"signup/starting-point-courses": false,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,
-		"support-user": true,
 		"themes/premium": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,7 +99,6 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": false,
 		"site-indicator": true,
-		"support-user": true,
 		"themes/premium": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/test.json
+++ b/config/test.json
@@ -74,7 +74,6 @@
 		"settings/theme-setup": false,
 		"signup/social": true,
 		"site-indicator": true,
-		"support-user": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -107,7 +107,6 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
-		"support-user": true,
 		"themes/premium": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `support-user` feature flag is always on in all environments. This PR removes it as it's not necessary.

#### Testing instructions

* Verify Calypso builds and tests pass.
* Go to a report card of any user
* Start a support session.
* Test in local Calypso or in calypso.live and verify it still works well.