### PR TITLE
Themes: Refactor `ThemeSheet` away from `UNSAFE_` lifecycle methods

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -129,9 +129,8 @@ class ThemeSheet extends Component {
 		this.scrollToTop();
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillUpdate( nextProps ) {
-		if ( nextProps.id !== this.props.id ) {
+	componentDidUpdate( prevProps ) {
+		if ( this.props.id !== prevProps.id ) {
 			this.scrollToTop();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ThemeSheet` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/themes/:site`
* Click on a theme to get to a theme sheet page.
* Scroll down to the bottom.
* Click on "Next theme"
* Verify that when the next theme loads, the page still scrolls up.