### PR TITLE
Fix domain header's badge size on Firefox

### DIFF
--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -16,7 +16,7 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 	let badgeCounter = 0;
 
 	const renderCircle = () => (
-		<SVG viewBox="0 0 24 24">
+		<SVG viewBox="0 0 24 24" height={ 8 } width={ 8 }>
 			<Circle cx="12" cy="12" r="12" />
 		</SVG>
 	);


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes a rendering issue for domain badges (under the header) on Domain settings page

![badge-before](https://user-images.githubusercontent.com/2797601/149529626-b19c84a4-8608-4f65-9afb-7d8afa3588f7.png)

![badge-after](https://user-images.githubusercontent.com/2797601/149529635-1265f722-f97c-4b37-baad-03d4c892777c.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Select an active domain from your domains and verify that the badge is rendered correctly on Firefox
