### PR TITLE
i18n: Wrap title input on a new line when title examples can't fit

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import * as React from 'react';
+import getTextWidth from '../get-text-width';
 
 import './style.scss';
 
@@ -14,32 +15,6 @@ interface Props {
 	placeholder?: string;
 	id?: string;
 	forwardedRef: React.MutableRefObject< HTMLInputElement | undefined >;
-}
-
-/**
- * A canvas to use to create text and measure its width.
- * This is needed for the underline width.
- */
-const textSizingCanvas = document.createElement( 'canvas' );
-textSizingCanvas.width = 2000;
-textSizingCanvas.height = 100;
-const canvasContext = textSizingCanvas.getContext( '2d' ) as CanvasRenderingContext2D;
-
-/**
- * Gets the font info from an input field then measures the width of the text within
- *
- * @param text the string
- * @param element The input element
- */
-function getTextWidth( text: string, element: HTMLInputElement | undefined ) {
-	if ( ! element || ! text ) {
-		return 0;
-	}
-	const computedCSS = window.getComputedStyle( element );
-
-	// FF returns an empty strong in font prop
-	canvasContext.font = computedCSS.font || `${ computedCSS.fontSize } ${ computedCSS.fontFamily }`;
-	return canvasContext.measureText( text ).width;
 }
 
 const AcquireIntentTextInput: React.FunctionComponent< Props > = ( {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/get-text-width.ts
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/get-text-width.ts
@@ -8,7 +8,7 @@ textSizingCanvas.height = 100;
 const canvasContext = textSizingCanvas.getContext( '2d' ) as CanvasRenderingContext2D;
 
 /**
- * Gets the font info from an input field then measures the width of the text within
+ * Gets the font info from an input field then measures the width of the text within.
  *
  * @param text the string
  * @param element The input element
@@ -19,7 +19,7 @@ function getTextWidth( text: string, element: HTMLInputElement | undefined ) {
 	}
 	const computedCSS = window.getComputedStyle( element );
 
-	// FF returns an empty strong in font prop
+	// FF returns an empty string in font prop.
 	canvasContext.font = computedCSS.font || `${ computedCSS.fontSize } ${ computedCSS.fontFamily }`;
 	return canvasContext.measureText( text ).width;
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/get-text-width.ts
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/get-text-width.ts
@@ -1,0 +1,27 @@
+/**
+ * A canvas to use to create text and measure its width.
+ * This is needed for the underline width.
+ */
+const textSizingCanvas = document.createElement( 'canvas' );
+textSizingCanvas.width = 2000;
+textSizingCanvas.height = 100;
+const canvasContext = textSizingCanvas.getContext( '2d' ) as CanvasRenderingContext2D;
+
+/**
+ * Gets the font info from an input field then measures the width of the text within
+ *
+ * @param text the string
+ * @param element The input element
+ */
+function getTextWidth( text: string, element: HTMLInputElement | undefined ) {
+	if ( ! element || ! text ) {
+		return 0;
+	}
+	const computedCSS = window.getComputedStyle( element );
+
+	// FF returns an empty strong in font prop
+	canvasContext.font = computedCSS.font || `${ computedCSS.fontSize } ${ computedCSS.fontFamily }`;
+	return canvasContext.measureText( text ).width;
+}
+
+export default getTextWidth;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -93,9 +93,10 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 			return false;
 		}
 
-		const labelDomRect = labelRef.current.getBoundingClientRect();
+		const labelMargin = parseFloat( window.getComputedStyle( labelRef.current ).marginRight ) || 0;
+		const { width: labelWidth } = labelRef.current.getBoundingClientRect();
 
-		return maxTitleWidth > formWidth - labelDomRect.width;
+		return maxTitleWidth > formWidth - ( labelWidth + labelMargin );
 	}, [ maxTitleWidth, formWidth, labelRef ] );
 
 	const handleFormSubmit = ( e: React.FormEvent< HTMLFormElement > ) => {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -80,16 +80,16 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 		[ siteTitleExamples, inputElement ]
 	);
 	const [ formWidth, setFormWidth ] = React.useState( 0 );
-	const labelRef = React.useRef< HTMLElement >();
+	const labelRef = React.useRef< HTMLLabelElement | null >( null );
 	const resizeRef = useWindowResizeCallback( ( formDomRect ) => {
 		if ( ! formDomRect ) {
 			return;
 		}
 
 		setFormWidth( formDomRect.width );
-	} );
+	} ) as React.MutableRefObject< HTMLFormElement >;
 	const hasOverflowingPlaceholder = React.useMemo( () => {
-		if ( formWidth === 0 || ! labelRef ) {
+		if ( formWidth === 0 || ! labelRef.current ) {
 			return false;
 		}
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -3,11 +3,13 @@ import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import * as React from 'react';
+import { useWindowResizeCallback } from 'calypso/lib/track-element-size';
 import useTyper from '../../hooks/use-typer';
 import { recordSiteTitleSelection } from '../../lib/analytics';
 import { useIsAnchorFm } from '../../path';
 import { STORE_KEY } from '../../stores/onboard';
 import AcquireIntentTextInput from './acquire-intent-text-input';
+import getTextWidth from './get-text-width';
 import tip from './tip';
 
 interface Props {
@@ -21,47 +23,66 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 	const isAnchorFmSignup = useIsAnchorFm();
 	const { setSiteTitle } = useDispatch( STORE_KEY );
 	const [ isTouched, setIsTouched ] = React.useState( false );
-	const siteTitleExamples = [
-		/* translators: This is an example of a site name,
+	const siteTitleExamples = React.useMemo(
+		() => [
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'The Local Latest', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'The Local Latest', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'North Peak Cycling', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'North Peak Cycling', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Sunshine Daycare', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Sunshine Daycare', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Quick Wins Consulting', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Quick Wins Consulting', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Puns and Pedantry', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Puns and Pedantry', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Yoga For Everyone', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Yoga For Everyone', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Pugs Wearing Bowties', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Pugs Wearing Bowties', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Behind the Lens', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Behind the Lens', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Marketing Magic', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Marketing Magic', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Cortado Coffee', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Cortado Coffee', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Mumbai Bites', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'Mumbai Bites', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'RPM Motors', 'sample site title' ),
-		/* translators: This is an example of a site name,
+			_x( 'RPM Motors', 'sample site title' ),
+			/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
-		_x( 'Max’s Burger Bar', 'sample site title' ),
-	];
+			_x( 'Max’s Burger Bar', 'sample site title' ),
+		],
+		[ _x ]
+	);
+	const inputElement = inputRef.current;
+	const maxTitleWidth = React.useMemo(
+		() =>
+			siteTitleExamples.reduce(
+				( maxWidth, title ) => Math.max( maxWidth, getTextWidth( title, inputElement ) ),
+				0
+			),
+		[ siteTitleExamples, inputElement ]
+	);
+	const [ hasOverflowingPlaceholder, setHasOverflowingPlaceholder ] = React.useState( false );
+	const labelRef = React.useRef();
+	const resizeRef = useWindowResizeCallback( ( formDomRect ) => {
+		const labelDomRect = labelRef.current.getBoundingClientRect();
+
+		setHasOverflowingPlaceholder( maxTitleWidth > formDomRect.width - labelDomRect.width );
+	} );
 
 	const handleFormSubmit = ( e: React.FormEvent< HTMLFormElement > ) => {
 		// hitting 'Enter' when focused on the input field should direct to next step.
@@ -83,10 +104,12 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 
 	return (
 		<form
+			ref={ resizeRef }
 			className={ classnames( 'site-title', { 'is-touched': isTouched } ) }
 			onSubmit={ handleFormSubmit }
 		>
 			<label
+				ref={ labelRef }
 				htmlFor="site-title__input"
 				className="site-title__input-label"
 				data-e2e-string="My site is called"
@@ -94,7 +117,11 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 				{ /* translators: label for site title input in Gutenboarding */ }
 				{ isAnchorFmSignup ? __( 'My podcast is called' ) : __( 'My site is called' ) }
 			</label>
-			<div className="site-title__input-wrapper">
+			<div
+				className={ classnames( 'site-title__input-wrapper', {
+					'has-overflowing-placeholder': hasOverflowingPlaceholder,
+				} ) }
+			>
 				{ /* Adding key makes it more performant
 					because without it the element is recreated
 					for every letter in the typing animation

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -67,6 +67,9 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 		],
 		[ _x ]
 	);
+
+	// Calculate the width of the longest translated title in the examples array
+	// and apply additional class name based on whether it can fit next to the label.
 	const inputElement = inputRef.current;
 	const maxTitleWidth = React.useMemo(
 		() =>
@@ -76,13 +79,24 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 			),
 		[ siteTitleExamples, inputElement ]
 	);
-	const [ hasOverflowingPlaceholder, setHasOverflowingPlaceholder ] = React.useState( false );
-	const labelRef = React.useRef();
+	const [ formWidth, setFormWidth ] = React.useState( 0 );
+	const labelRef = React.useRef< HTMLElement >();
 	const resizeRef = useWindowResizeCallback( ( formDomRect ) => {
+		if ( ! formDomRect ) {
+			return;
+		}
+
+		setFormWidth( formDomRect.width );
+	} );
+	const hasOverflowingPlaceholder = React.useMemo( () => {
+		if ( formWidth === 0 || ! labelRef ) {
+			return false;
+		}
+
 		const labelDomRect = labelRef.current.getBoundingClientRect();
 
-		setHasOverflowingPlaceholder( maxTitleWidth > formDomRect.width - labelDomRect.width );
-	} );
+		return maxTitleWidth > formWidth - labelDomRect.width;
+	}, [ maxTitleWidth, formWidth, labelRef ] );
 
 	const handleFormSubmit = ( e: React.FormEvent< HTMLFormElement > ) => {
 		// hitting 'Enter' when focused on the input field should direct to next step.

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -52,6 +52,7 @@
 
 	&.has-overflowing-placeholder {
 		flex-basis: 100%;
+		max-width: 100%;
 	}
 
 	@include break-small {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -50,6 +50,10 @@
 	position: relative;
 	flex: 1;
 
+	&.has-overflowing-placeholder {
+		flex-basis: 100%;
+	}
+
 	@include break-small {
 		min-width: 300px;
 		max-width: 400px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap title input container on a new "a new line" if the the set of translated example titles can't fit in the space next to the input label.

**Before:**
![CleanShot 2022-01-14 at 16 12 53](https://user-images.githubusercontent.com/2722412/149529106-a722277a-f197-482a-b83c-f6a8a4f92f4d.png)

**After:**
![CleanShot 2022-01-14 at 16 12 17](https://user-images.githubusercontent.com/2722412/149529111-93bf4846-d4e3-4db0-8a03-f3bcb52322b9.png)


#### Testing instructions

* Go to `/new` and change the UI to a language, where the example titles have more characters (e.g. Russian).
* Confirm title input wraps on a new line.
* Switch back to English and confirm title input goes back next to the "My site is called" label. Note that browser viewport should be > ~1400px.

Related to 357-gh-Automattic/i18n-issues
