### PR TITLE
o2-blocks: Add closer to spoiler blocks after page load

### DIFF
--- a/apps/o2-blocks/src/spoiler/view.js
+++ b/apps/o2-blocks/src/spoiler/view.js
@@ -1,0 +1,42 @@
+class SpoilerCloseButton extends HTMLElement {
+	constructor() {
+		super();
+
+		const shadowRoot = this.attachShadow( { mode: 'open' } );
+		shadowRoot.innerHTML = `
+			<style>
+			div {
+				background-color: blue;
+				border-radius: 2px;
+				color: white;
+			}
+
+			div:hover {
+				background-color: darkblue;
+				color: lightblue;
+			}
+			</style>
+
+			<div role="button" tabindex="0">Close</div>
+		`;
+
+		shadowRoot.querySelector( 'a' ).addEventListener( 'click', ( event ) => {
+			event.preventDefault();
+			this.parentNode.removeAttribute( 'open' );
+		} );
+	}
+}
+
+window.customElements.define( 'spoiler-closer-button', SpoilerCloseButton );
+
+const addCloseButtons = () => {
+	const spoilers = document.querySelectorAll( 'details.wp-block-a8c-spoiler' );
+
+	for ( const spoiler of spoilers ) {
+		if ( spoiler.lastChild ) {
+			spoiler.lastChild.after( document.createElement( 'spoiler-closer-button' ) );
+		}
+	}
+};
+
+document.addEventListener( 'DOMContentLoaded', addCloseButtons );

--- a/apps/o2-blocks/src/view.js
+++ b/apps/o2-blocks/src/view.js
@@ -1,1 +1,2 @@
 import './github-issue-template/view';
+import './spoiler/view';


### PR DESCRIPTION
## Status

Ignore this one.
Really just trying to get the `o2-blocks` to build since they are failing to build locally.

## Description

Exploring adding a close button to the bottom of opened spoiler blocks to give people the option of closing them without having to scroll to the top of long spoilers.