### PR TITLE
Domains: Prevent HEs from transfer locking/unlocking domains via SU

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -43,8 +43,8 @@ import isPrimaryDomainBySiteId from 'calypso/state/selectors/is-primary-domain-b
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { AppState } from 'calypso/types';
 import type { TransferPageProps } from './types';
+import type { AppState } from 'calypso/types';
 
 import './style.scss';
 
@@ -326,7 +326,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return null;
 		}
 
-		if ( isSupportSession ) {
+		if ( isSupportSession || true ) {
 			return (
 				<Notice
 					text={ __(

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -322,7 +322,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return null;
 		}
 
-		if ( ! domain.currentUserCanManage ) {
+		if ( ! domain.currentUserIsOwner ) {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -20,6 +20,7 @@ import { getSelectedDomain, getTopLevelOfTld, isMappedDomain } from 'calypso/lib
 import { DESIGNATED_AGENT, TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
 import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
+import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import SelectIpsTag from 'calypso/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag';
 import {
 	domainManagementEdit,
@@ -54,6 +55,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 	const dispatch = useDispatch();
 	const {
 		currentRoute,
+		domains,
 		isAtomic,
 		isDomainInfoLoading,
 		isDomainLocked,
@@ -66,6 +68,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 	const { __ } = useI18n();
 	const [ isRequestingTransferCode, setIsRequestingTransferCode ] = useState( false );
 	const [ isLockingOrUnlockingDomain, setIsLockingOrUnlockingDomain ] = useState( false );
+	const domain = getSelectedDomain( props );
 
 	const renderBreadcrumbs = () => {
 		const items = [
@@ -226,7 +229,6 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			</span>
 		);
 
-		const domain = getSelectedDomain( props );
 		const disabled = Boolean(
 			! domain?.domainLockingAvailable ||
 				domain?.transferAwayEligibleAt ||
@@ -257,8 +259,6 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 	};
 
 	const renderTransferMessage = () => {
-		const domain = getSelectedDomain( props );
-
 		const registrationDatePlus60Days = moment.utc( domain?.registrationDate ).add( 60, 'days' );
 		const supportLink = moment.utc().isAfter( registrationDatePlus60Days )
 			? DESIGNATED_AGENT
@@ -317,6 +317,23 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 		);
 	};
 
+	const renderContent = (): JSX.Element | null => {
+		if ( ! domain ) {
+			return null;
+		}
+
+		if ( ! domain.currentUserIsOwner ) {
+			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
+		}
+
+		return (
+			<>
+				{ renderTransferOptions() }
+				{ renderAdvancedTransferOptions() }
+			</>
+		);
+	};
+
 	return (
 		<Main className="transfer-page" wideLayout>
 			<QueryDomainInfo domainName={ selectedDomainName } />
@@ -324,10 +341,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			{ renderBreadcrumbs() }
 			<FormattedHeader brandFont headerText={ __( 'Transfer' ) } align="left" />
 			<Layout>
-				<Column type="main">
-					{ renderTransferOptions() }
-					{ renderAdvancedTransferOptions() }
-				</Column>
+				<Column type="main">{ renderContent() }</Column>
 				<Column type="sidebar">
 					<Card className="transfer-page__help-section-card">
 						<p className="transfer-page__help-section-title">{ __( 'How do transfers work?' ) }</p>

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -326,7 +326,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return null;
 		}
 
-		if ( isSupportSession || true ) {
+		if ( isSupportSession ) {
 			return (
 				<Notice
 					text={ __(

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -322,7 +322,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return null;
 		}
 
-		if ( ! domain.currentUserIsOwner ) {
+		if ( ! domain.currentUserCanManage ) {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -14,6 +14,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
 import Spinner from 'calypso/components/spinner';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, getTopLevelOfTld, isMappedDomain } from 'calypso/lib/domains';
@@ -40,7 +41,9 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isPrimaryDomainBySiteId from 'calypso/state/selectors/is-primary-domain-by-site-id';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isSupportSession } from 'calypso/state/support/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { AppState } from 'calypso/types';
 import type { TransferPageProps } from './types';
 
 import './style.scss';
@@ -62,6 +65,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 		isDomainOnly,
 		isMapping,
 		isPrimaryDomain,
+		isSupportSession,
 		selectedDomainName,
 		selectedSite,
 	} = props;
@@ -322,6 +326,18 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return null;
 		}
 
+		if ( isSupportSession ) {
+			return (
+				<Notice
+					text={ __(
+						'Transfers cannot be initiated in a support session - please ask the user to do it instead.'
+					) }
+					status="is-warning"
+					showDismiss={ false }
+				/>
+			);
+		}
+
 		if ( ! domain.currentUserIsOwner ) {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
 		}
@@ -364,7 +380,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 	);
 };
 
-const transferPageComponent = connect( ( state, ownProps: TransferPageProps ) => {
+const transferPageComponent = connect( ( state: AppState, ownProps: TransferPageProps ) => {
 	const domain = getSelectedDomain( ownProps );
 	const siteId = getSelectedSiteId( state );
 	const domainInfo = getDomainWapiInfoByDomainName( state, ownProps.selectedDomainName );
@@ -376,6 +392,7 @@ const transferPageComponent = connect( ( state, ownProps: TransferPageProps ) =>
 		isDomainOnly: isDomainOnlySite( state, siteId ) ?? false,
 		isMapping: Boolean( domain ) && isMappedDomain( domain ),
 		isPrimaryDomain: isPrimaryDomainBySiteId( state, siteId, ownProps.selectedDomainName ),
+		isSupportSession: isSupportSession( state ),
 	};
 } )( TransferPage );
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
@@ -13,6 +13,7 @@ export type TransferPageProps = {
 	isDomainOnly: boolean;
 	isMapping: boolean;
 	isPrimaryDomain: boolean;
+	isSupportSession: boolean;
 	selectedDomainName: string;
 	selectedSite: SiteData;
 	successNotice: ( notice: string, options: Record< string, unknown > ) => NoticeActionCreator;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As reported in p2MSmN-92Z-p2, HEs can unlock the transfer lock and request the auth code for domains of which they are not owners during a Support User session. This PR prevents that by rendering a notice that transfers cannot be initiated in support sessions, as shown in the following screenshot:

<img width="743" alt="Screen Shot 2022-01-14 at 12 58 02" src="https://user-images.githubusercontent.com/5324818/149545923-d4c23eb4-6033-4336-aa57-498b003e0194.png">

If you're not in a support session but try to access a domain of which you're not the owner of, you'll get a similar notice with a different message:

<img width="735" alt="Screen Shot 2022-01-14 at 11 51 31" src="https://user-images.githubusercontent.com/5324818/149535325-e4c40ecc-bd1c-496a-bd8c-bfc7fc198165.png">

#### Testing instructions

- Build this branch locally or open the live Calypso link
- Select a site where you have a domain of which you are not the owner and access its transfer page
- If you built this branch locally, you'll have to access the transfer page URL directly as the "Transfer" option is not rendered in the redesigned settings page if you're not the owner of the domain
  - `/manage/<domain>/transfer/<site_slug>`
- Ensure the non-owner notice is shown in place of the transfer options, like in the screenshot above