### PR TITLE
Checkout: fix annual plan upsell feature list

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -123,9 +123,11 @@ function LoadingCheckoutSummaryFeaturesList() {
 function SwitchToAnnualPlan( {
 	plan,
 	onChangePlanLength,
+	linkText,
 }: {
 	plan: ResponseCartProduct;
 	onChangePlanLength: ( uuid: string, productSlug: string, productId: number ) => void;
+	linkText?: React.ReactNode;
 } ): JSX.Element {
 	const translate = useTranslate();
 	const handleClick = () => {
@@ -134,12 +136,9 @@ function SwitchToAnnualPlan( {
 			onChangePlanLength?.( plan.uuid, annualPlan.getStoreSlug(), annualPlan.getProductId() );
 		}
 	};
+	const text = linkText ?? translate( 'Switch to an annual plan and save!' );
 
-	return (
-		<SwitchToAnnualPlanButton onClick={ handleClick }>
-			{ translate( 'Switch to an annual plan and save!' ) }
-		</SwitchToAnnualPlanButton>
-	);
+	return <SwitchToAnnualPlanButton onClick={ handleClick }>{ text }</SwitchToAnnualPlanButton>;
 }
 
 function CheckoutSummaryFeaturesList( props: {
@@ -321,9 +320,13 @@ function CheckoutSummaryAnnualUpsell( props: {
 	}
 
 	return (
-		<CheckoutSummaryFeatures>
+		<CheckoutSummaryFeaturesUpsell>
 			<CheckoutSummaryFeaturesTitle>
-				{ translate( 'Included with an annual plan' ) }
+				<SwitchToAnnualPlan
+					plan={ props.plan }
+					onChangePlanLength={ props.onChangePlanLength }
+					linkText={ translate( 'Included with an annual plan' ) }
+				/>
 			</CheckoutSummaryFeaturesTitle>
 			<CheckoutSummaryFeaturesListWrapper>
 				<CheckoutSummaryFeaturesListItem isSupported={ false }>
@@ -336,9 +339,9 @@ function CheckoutSummaryAnnualUpsell( props: {
 						{ translate( 'Live chat support' ) }
 					</CheckoutSummaryFeaturesListItem>
 				) }
-				<SwitchToAnnualPlan plan={ props.plan } onChangePlanLength={ props.onChangePlanLength } />
 			</CheckoutSummaryFeaturesListWrapper>
-		</CheckoutSummaryFeatures>
+			<SwitchToAnnualPlan plan={ props.plan } onChangePlanLength={ props.onChangePlanLength } />
+		</CheckoutSummaryFeaturesUpsell>
 	);
 }
 
@@ -355,17 +358,35 @@ const CheckoutSummaryCard = styled( CheckoutSummaryCardUnstyled )`
 `;
 
 const CheckoutSummaryFeatures = styled.div`
-	padding: 20px 20px 0;
+	padding: 24px 24px 0;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		padding: 20px;
+		padding: 24px;
+	}
+`;
+
+const CheckoutSummaryFeaturesUpsell = styled( CheckoutSummaryFeatures )`
+	padding: 12px 24px 0;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		padding: 0 24px 24px;
+	}
+
+	& svg {
+		opacity: 50%;
 	}
 `;
 
 const CheckoutSummaryFeaturesTitle = styled.h3`
-	font-size: 16px;
-	font-weight: ${ ( props ) => props.theme.weights.normal };
+	font-size: 14px;
+	font-weight: ${ ( props ) => props.theme.weights.bold };
 	margin-bottom: 6px;
+
+	& button {
+		font-size: 14px;
+		font-weight: ${ ( props ) => props.theme.weights.bold };
+		text-decoration: none;
+	}
 `;
 
 const CheckoutSummaryFeaturesListWrapper = styled.ul`
@@ -410,7 +431,7 @@ const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isSupported?: boolean 
 	padding-left: 24px;
 	position: relative;
 	overflow-wrap: break-word;
-	color: ${ ( props ) => ( props.isSupported ? 'inherit' : 'var( --color-neutral-30 )' ) };
+	color: ${ ( props ) => ( props.isSupported ? 'inherit' : 'var( --color-neutral-40 )' ) };
 
 	.rtl & {
 		padding-right: 24px;
@@ -422,7 +443,7 @@ CheckoutSummaryFeaturesListItem.defaultProps = {
 };
 
 const CheckoutSummaryAmountWrapper = styled.div`
-	padding: 20px;
+	padding: 24px;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
@@ -479,7 +500,6 @@ const LoadingCopy = styled.p`
 `;
 
 const SwitchToAnnualPlanButton = styled.button`
-	margin-top: 16px;
 	text-align: left;
 	text-decoration: underline;
 	color: var( --color-link );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -7,6 +7,8 @@ import {
 	isDomainProduct,
 	isDomainTransfer,
 	isDIFMProduct,
+	isWpComPersonalPlan,
+	isWpComPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
@@ -82,23 +84,7 @@ export default function WPCheckoutOrderSummary( {
 				) }
 			</CheckoutSummaryFeatures>
 			{ ! isCartUpdating && ! hasRenewalInCart && plan && hasMonthlyPlanInCart && (
-				<CheckoutSummaryFeatures>
-					<CheckoutSummaryFeaturesTitle>
-						{ translate( 'Included with an annual plan' ) }
-					</CheckoutSummaryFeaturesTitle>
-					<CheckoutSummaryFeaturesListWrapper>
-						<CheckoutSummaryFeaturesListItem isSupported={ false }>
-							<WPCheckoutCheckIcon id={ 'annual-domain-credit' } />
-							{ translate( 'Free domain for one year' ) }
-						</CheckoutSummaryFeaturesListItem>
-						{ /* Only on Premium and up */ }
-						<CheckoutSummaryFeaturesListItem isSupported={ false }>
-							<WPCheckoutCheckIcon id={ 'annual-live-chat' } />
-							{ translate( 'Live chat support' ) }
-						</CheckoutSummaryFeaturesListItem>
-						<SwitchToAnnualPlan plan={ plan } onChangePlanLength={ onChangePlanLength } />
-					</CheckoutSummaryFeaturesListWrapper>
-				</CheckoutSummaryFeatures>
+				<CheckoutSummaryAnnualUpsell plan={ plan } onChangePlanLength={ onChangePlanLength } />
 			) }
 			<CheckoutSummaryAmountWrapper>
 				{ couponLineItem && (
@@ -151,7 +137,7 @@ function SwitchToAnnualPlan( {
 
 	return (
 		<SwitchToAnnualPlanButton onClick={ handleClick }>
-			{ translate( 'Switch to annual plan and save!' ) }
+			{ translate( 'Switch to an annual plan and save!' ) }
 		</SwitchToAnnualPlanButton>
 	);
 }
@@ -320,6 +306,39 @@ function CheckoutSummaryPlanFeatures( props: {
 				);
 			} ) }
 		</>
+	);
+}
+
+function CheckoutSummaryAnnualUpsell( props: {
+	plan: ResponseCartProduct;
+	onChangePlanLength: ( uuid: string, productSlug: string, productId: number ) => void;
+} ) {
+	const translate = useTranslate();
+	const productSlug = props.plan?.product_slug;
+
+	if ( ! productSlug || ! isWpComPlan( productSlug ) ) {
+		return null;
+	}
+
+	return (
+		<CheckoutSummaryFeatures>
+			<CheckoutSummaryFeaturesTitle>
+				{ translate( 'Included with an annual plan' ) }
+			</CheckoutSummaryFeaturesTitle>
+			<CheckoutSummaryFeaturesListWrapper>
+				<CheckoutSummaryFeaturesListItem isSupported={ false }>
+					<WPCheckoutCheckIcon id={ 'annual-domain-credit' } />
+					{ translate( 'Free domain for one year' ) }
+				</CheckoutSummaryFeaturesListItem>
+				{ ! isWpComPersonalPlan( productSlug ) && (
+					<CheckoutSummaryFeaturesListItem isSupported={ false }>
+						<WPCheckoutCheckIcon id={ 'annual-live-chat' } />
+						{ translate( 'Live chat support' ) }
+					</CheckoutSummaryFeaturesListItem>
+				) }
+				<SwitchToAnnualPlan plan={ props.plan } onChangePlanLength={ props.onChangePlanLength } />
+			</CheckoutSummaryFeaturesListWrapper>
+		</CheckoutSummaryFeatures>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -208,14 +208,7 @@ function CheckoutSummaryFeaturesList( props: {
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
 				domains.map( ( domain ) => {
-					return (
-						<CheckoutSummaryFeaturesListDomainItem
-							domain={ domain }
-							key={ domain.uuid }
-							hasMonthlyPlanInCart={ hasMonthlyPlanInCart }
-							nextDomainIsFree={ nextDomainIsFree }
-						/>
-					);
+					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.uuid } />;
 				} ) }
 			{ hasPlanInCart && (
 				<CheckoutSummaryPlanFeatures
@@ -254,15 +247,7 @@ function SupportText( {
 	return <span>{ translate( 'Customer support via email' ) }</span>;
 }
 
-function CheckoutSummaryFeaturesListDomainItem( {
-	domain,
-	hasMonthlyPlanInCart,
-	nextDomainIsFree,
-}: {
-	domain: ResponseCartProduct;
-	hasMonthlyPlanInCart: boolean;
-	nextDomainIsFree: boolean;
-} ) {
+function CheckoutSummaryFeaturesListDomainItem( { domain }: { domain: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const bundledText = translate( 'free for one year' );
 	const bundledDomain = translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
@@ -276,14 +261,12 @@ function CheckoutSummaryFeaturesListDomainItem( {
 		comment: 'domain name and bundling message, separated by a dash',
 	} );
 
-	const isDomainBundledWithCart = ! nextDomainIsFree && ! hasMonthlyPlanInCart;
-
-	// Return early if the domain is using a credit.
-	if ( domain.is_bundled || ! isDomainBundledWithCart ) {
+	// If domain is using existing credit or bundled with cart, show bundled text.
+	if ( domain.is_bundled ) {
 		return (
 			<CheckoutSummaryFeaturesListItem>
 				<WPCheckoutCheckIcon id={ `feature-list-domain-item-${ domain.meta }` } />
-				<strong>{ domain.meta }</strong>
+				{ bundledDomain }
 			</CheckoutSummaryFeaturesListItem>
 		);
 	}
@@ -291,7 +274,7 @@ function CheckoutSummaryFeaturesListDomainItem( {
 	return (
 		<CheckoutSummaryFeaturesListItem>
 			<WPCheckoutCheckIcon id={ `feature-list-domain-item-${ domain.meta }` } />
-			{ bundledDomain }
+			<strong>{ domain.meta }</strong>
 		</CheckoutSummaryFeaturesListItem>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -26,7 +26,6 @@ import styled from '@emotion/styled';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
-import { isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -146,6 +145,8 @@ function CheckoutSummaryFeaturesList( props: {
 	hasMonthlyPlan: boolean;
 	nextDomainIsFree: boolean;
 } ) {
+	const { hasMonthlyPlan = false, siteId, nextDomainIsFree } = props;
+
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const hasDomainsInCart = responseCart.products.some(
@@ -157,11 +158,9 @@ function CheckoutSummaryFeaturesList( props: {
 	const hasPlanInCart = responseCart.products.some( ( product ) => isPlan( product ) );
 	const hasDIFMLiteInCart = responseCart.products.some( ( product ) => isDIFMProduct( product ) );
 	const translate = useTranslate();
-	const siteId = props.siteId;
 	const isJetpackNotAtomic = useSelector( ( state ) =>
 		siteId ? isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) : undefined
 	);
-	const { hasMonthlyPlan = false } = props;
 
 	const showRefundText = responseCart.total_cost > 0;
 
@@ -197,18 +196,20 @@ function CheckoutSummaryFeaturesList( props: {
 						<CheckoutSummaryFeaturesListDomainItem
 							domain={ domain }
 							key={ domain.uuid }
-							{ ...props }
+							hasMonthlyPlan={ hasMonthlyPlan }
+							nextDomainIsFree={ nextDomainIsFree }
 						/>
 					);
 				} ) }
-			{ hasPlanInCart && <CheckoutSummaryPlanFeatures /> }
+			{ hasPlanInCart && (
+				<CheckoutSummaryPlanFeatures
+					hasDomainsInCart={ hasDomainsInCart }
+					nextDomainIsFree={ nextDomainIsFree }
+				/>
+			) }
 			<CheckoutSummaryFeaturesListItem>
 				<WPCheckoutCheckIcon id="features-list-support-text" />
-				<SupportText
-					hasPlanInCart={ hasPlanInCart }
-					isJetpackNotAtomic={ isJetpackNotAtomic }
-					{ ...props }
-				/>
+				<SupportText hasPlanInCart={ hasPlanInCart } isJetpackNotAtomic={ isJetpackNotAtomic } />
 			</CheckoutSummaryFeaturesListItem>
 			{ showRefundText &&
 				Array.from( refundTexts.values() ).map( ( refundText, index ) => (
@@ -289,18 +290,19 @@ function CheckoutSummaryFeaturesListDomainItem( {
 	);
 }
 
-function CheckoutSummaryPlanFeatures() {
+function CheckoutSummaryPlanFeatures( props: {
+	hasDomainsInCart: boolean;
+	nextDomainIsFree: boolean;
+} ) {
+	const { hasDomainsInCart, nextDomainIsFree } = props;
+
 	const translate = useTranslate();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
-	const hasDomainsInCart = responseCart.products.some(
-		( product ) => product.is_domain_registration || product.product_slug === 'domain_transfer'
-	);
 	const planInCart = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasRenewalInCart = responseCart.products.some(
 		( product ) => product.extra.purchaseType === 'renewal'
 	);
-	const nextDomainIsFree = isNextDomainFree( responseCart );
 	const planFeatures = getPlanFeatures(
 		planInCart,
 		translate,

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -30,21 +30,10 @@ export default function getPlanFeatures(
 		? String( translate( 'Free domain for one year' ) )
 		: undefined;
 	const googleAnalytics = String( translate( 'Track your stats with Google Analytics' ) );
-	const annualPlanOnly = ( feature: string | undefined ): string | null => {
-		if ( ! feature ) {
-			return null;
-		}
-
-		const label = translate( '(annual plans only)', {
-			comment: 'Label attached to a feature',
-		} );
-
-		return `~~${ feature } ${ label }`;
-	};
 
 	if ( isWpComPersonalPlan( productSlug ) ) {
 		return [
-			isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
+			! isMonthlyPlan && freeOneYearDomain,
 			String( translate( 'Best-in-class hosting' ) ),
 			String( translate( 'Dozens of Free Themes' ) ),
 		].filter( isValueTruthy );
@@ -52,8 +41,8 @@ export default function getPlanFeatures(
 
 	if ( isWpComPremiumPlan( productSlug ) ) {
 		return [
-			isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
-			isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
+			! isMonthlyPlan && freeOneYearDomain,
+			! isMonthlyPlan && liveChatSupport,
 			isEnabled( 'themes/premium' )
 				? String( translate( 'Unlimited access to our library of Premium Themes' ) )
 				: null,
@@ -66,8 +55,8 @@ export default function getPlanFeatures(
 
 	if ( isWpComBusinessPlan( productSlug ) ) {
 		return [
-			isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
-			isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
+			! isMonthlyPlan && freeOneYearDomain,
+			! isMonthlyPlan && liveChatSupport,
 			String( translate( 'Install custom plugins and themes' ) ),
 			String( translate( 'Drive traffic to your site with our advanced SEO tools' ) ),
 			String( translate( 'Track your stats with Google Analytics' ) ),
@@ -77,8 +66,8 @@ export default function getPlanFeatures(
 
 	if ( isWpComEcommercePlan( productSlug ) ) {
 		return [
-			isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
-			isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
+			! isMonthlyPlan && freeOneYearDomain,
+			! isMonthlyPlan && liveChatSupport,
 			String( translate( 'Install custom plugins and themes' ) ),
 			String( translate( 'Accept payments in 60+ countries' ) ),
 			String( translate( 'Integrations with top shipping carriers' ) ),


### PR DESCRIPTION
This aims to clear up the Checkout sidebar feature list for carts with monthly plans or different domain bundling situations. It pulls the `x {feature} - annual plans only` pattern out into a separate list of items. It also ties the `mydomain.com - free for one year` messaging to whether or not a domain is bundled in the cart.

Replaces: #54764
Fixes: #54761

| Before      | After |
| ----------- | ----------- |
| ![Screen Shot 2022-01-14 at 11 22 19 AM](https://user-images.githubusercontent.com/942359/149578182-eb666bea-9840-4f7e-a7e7-f67936732f15.png) | ![Screen Shot 2022-01-14 at 11 22 50 AM](https://user-images.githubusercontent.com/942359/149578063-f28b3339-b071-435d-8f9d-2c888bdb8cb9.png) |

**To test:**
- Add a monthly plan to your cart and visit Checkout
- Verify that the sidebar has an "Included with an annual plan" callout (a monthly Personal plan _should not_ show live chat with the annual plan)
- Verify that clicking the title or link of the callout changes the plan to the equivalent yearly plan
- Leave Checkout, add a domain to your cart, and return to Checkout
- Verify that in the sidebar, the domain has a "free for one year" message when bundled with a yearly plan
- Switch to the monthly variant
- Verify that in the sidebar, the domain no longer shows a "free for one year message"
- Remove the plan from the cart
- Verify that the upsell is no longer shown