### PR TITLE
Fix copy for transfer connected domain sections

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -49,8 +49,10 @@ class TransferConfirmationDialog extends PureComponent {
 	}
 
 	renderTargetSiteOnFreePlanWarnings() {
+		const { isMapping } = this.props;
+
 		if ( this.props.primaryWithPlansOnly ) {
-			return (
+			return isMapping ? (
 				<p>
 					{ this.props.translate(
 						"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
@@ -58,15 +60,29 @@ class TransferConfirmationDialog extends PureComponent {
 							'If you upgrade the target site to a paid plan, these features are included in the plan.'
 					) }
 				</p>
+			) : (
+				<p>
+					{ this.props.translate(
+						"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
+							'domain connection subscription when the domain connection next renews. You will not be able to set it as primary either. '
+					) }
+				</p>
 			);
 		}
 
-		return (
+		return isMapping ? (
 			<p>
 				{ this.props.translate(
 					"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
 						'domain mapping subscription when the domain mapping next renews. ' +
 						'If you upgrade the target site to a paid plan, domain mappings (and many more features!) are included in our plans.'
+				) }
+			</p>
+		) : (
+			<p>
+				{ this.props.translate(
+					"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
+						'domain connection subscription when the domain connection next renews.'
 				) }
 			</p>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -29,7 +29,7 @@ class TransferConfirmationDialog extends PureComponent {
 		const targetSiteTitle = get( targetSite, 'title', translate( 'Site Title' ) );
 		if ( isMapping ) {
 			return translate(
-				'Do you want to transfer mapping of {{strong}}%(domainName)s{{/strong}} ' +
+				'Do you want to transfer domain connection of {{strong}}%(domainName)s{{/strong}} ' +
 					'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
 				{
 					args: { domainName, targetSiteTitle },
@@ -51,12 +51,12 @@ class TransferConfirmationDialog extends PureComponent {
 	renderTargetSiteOnFreePlanWarnings() {
 		const { isMapping } = this.props;
 
-		if ( this.props.primaryWithPlansOnly ) {
-			return isMapping ? (
+		if ( isMapping ) {
+			return this.props.primaryWithPlansOnly ? (
 				<p>
 					{ this.props.translate(
 						"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
-							'domain mapping subscription when the domain mapping next renews. You will not be able to set it as primary either. ' +
+							'domain connection subscription when the domain connection next renews. You will not be able to set it as primary either. ' +
 							'If you upgrade the target site to a paid plan, these features are included in the plan.'
 					) }
 				</p>
@@ -64,25 +64,16 @@ class TransferConfirmationDialog extends PureComponent {
 				<p>
 					{ this.props.translate(
 						"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
-							'domain connection subscription when the domain connection next renews. You will not be able to set it as primary either. '
+							'domain connection subscription when the domain connection next renews. ' +
+							'If you upgrade the target site to a paid plan, domain connections (and many more features!) are included in our plans.'
 					) }
 				</p>
 			);
 		}
-
-		return isMapping ? (
+		return (
 			<p>
 				{ this.props.translate(
-					"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
-						'domain mapping subscription when the domain mapping next renews. ' +
-						'If you upgrade the target site to a paid plan, domain mappings (and many more features!) are included in our plans.'
-				) }
-			</p>
-		) : (
-			<p>
-				{ this.props.translate(
-					"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
-						'domain connection subscription when the domain connection next renews.'
+					"The target site doesn't have a paid plan, so you won't be able to set this domain as primary on the site."
 				) }
 			</p>
 		);
@@ -92,7 +83,7 @@ class TransferConfirmationDialog extends PureComponent {
 		const { isMapping, translate } = this.props;
 		const actionLabel = ! isMapping
 			? translate( 'Confirm Transfer' )
-			: translate( 'Confirm Mapping Transfer' );
+			: translate( 'Confirm Domain Connection Transfer' );
 		const buttons = [
 			{
 				action: 'cancel',

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -70,13 +70,13 @@ class TransferConfirmationDialog extends PureComponent {
 				</p>
 			);
 		}
-		return (
+		return this.props.primaryWithPlansOnly ? (
 			<p>
 				{ this.props.translate(
 					"The target site doesn't have a paid plan, so you won't be able to set this domain as primary on the site."
 				) }
 			</p>
-		);
+		) : null;
 	}
 
 	render() {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -225,7 +225,7 @@ class TransferDomainToOtherUser extends Component {
 
 		if ( isMapping ) {
 			return translate(
-				'Do you want to transfer the domain mapping of {{strong}}%(domainName)s{{/strong}} ' +
+				'Do you want to transfer the domain connection of {{strong}}%(domainName)s{{/strong}} ' +
 					'to {{strong}}%(selectedUserDisplay)s{{/strong}}?',
 				{
 					args: { domainName, selectedUserDisplay },
@@ -257,7 +257,7 @@ class TransferDomainToOtherUser extends Component {
 		const { isMapping, translate, users } = this.props;
 		const availableUsers = this.filterAvailableUsers( users );
 		const saveButtonLabel = isMapping
-			? translate( 'Transfer domain mapping' )
+			? translate( 'Transfer domain connection' )
 			: translate( 'Transfer domain' );
 
 		return (
@@ -313,13 +313,13 @@ class TransferDomainToOtherUser extends Component {
 				<>
 					<p>
 						{ translate(
-							'Please choose an administrator to transfer domain mapping of {{strong}}%(domainName)s{{/strong}} to.',
+							'Please choose an administrator to transfer domain connection of {{strong}}%(domainName)s{{/strong}} to.',
 							{ args: { domainName }, components: { strong: <strong /> } }
 						) }
 					</p>
 					<p>
 						{ translate(
-							'You can transfer this domain mapping to any administrator on this site. If the user you want to ' +
+							'You can transfer this domain connection to any administrator on this site. If the user you want to ' +
 								'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
 							{ components: { a: <a href={ `/people/new/${ selectedSite.slug }` } /> } }
 						) }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes some wrong copy in the `transfer-domain-to-another-site` and `transfer-domain-to-another-user` section (in short it replace _domain mapping_ with _domain connection_).

 See p2MSmN-8Th-p2 for more details.

![case 1](https://user-images.githubusercontent.com/2797601/149810047-e6aed3ed-820e-4c8f-af1c-708112eaa871.png)

![case 2](https://user-images.githubusercontent.com/2797601/149808288-dc546744-2c8f-4e3c-a200-9b434c84cb58.png)

![case 3 A](https://user-images.githubusercontent.com/2797601/149910911-e82f606d-1105-4c17-b12b-7915c2d94d74.png)

![case 3 B](https://user-images.githubusercontent.com/2797601/149910935-1c9b76c5-44db-44a3-8e40-e0a5259527e1.png)

![case 4](https://user-images.githubusercontent.com/2797601/149808340-d9fdc606-dc18-4e8b-8d0f-111ecfc095ea.png)

![case 5](https://user-images.githubusercontent.com/2797601/149808347-b5cf8e58-aac4-4700-a86d-1d8a8ca97586.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to the _transfer to site_ page for a connected domain (`domains/manage/[:REGISTERED_DOMAIN/transfer/other-site/[:PLAN]`)
   - Select a free plan and verify that the copy is the same as the screenshot above.
   - Retry the same process with a registered domain
- Navigate to the _transfer to user_ page for a connected domain (`domains/manage/[:REGISTERED_DOMAIN/transfer/other-user/[:PLAN]`)
   - Select a new site administrator and click on `Transfer domain connection`
   - Ensure that the copy are showed as the screenshots above.