### PR TITLE
Update `isJetpackProductSite` for sites without the Full Plugin

### DIFF
--- a/client/state/sites/selectors/is-jetpack-product-site.ts
+++ b/client/state/sites/selectors/is-jetpack-product-site.ts
@@ -1,5 +1,5 @@
 import getRawSite from 'calypso/state/selectors/get-raw-site';
-import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { AppState } from 'calypso/types';
 
 type Site = {
@@ -24,7 +24,7 @@ export default function isJetpackProductSite( state: AppState, siteId: number ):
 		return null;
 	}
 
-	if ( isSiteWpcom( state, siteId ) ) {
+	if ( isAtomicSite( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/sites/test/is-jetpack-product-site.js
+++ b/client/state/sites/test/is-jetpack-product-site.js
@@ -20,13 +20,14 @@ describe( 'isJetpackProductSite', () => {
 		expect( isJetpackProductSite( getSiteState(), siteId + 1 ) ).toEqual( null );
 	} );
 
-	test( 'should return false if the site is hosted on WordPress.com', () => {
+	test( 'should return false if the site is hosted on WordPress.com, even if a product plugin is installed', () => {
 		expect( isJetpackProductSite( getSiteState( { jetpack: false } ), siteId ) ).toEqual( false );
 		expect(
 			isJetpackProductSite(
 				getSiteState( {
 					options: {
 						is_automated_transfer: true,
+						jetpack_connection_active_plugins: [ 'jetpack-backup' ],
 					},
 				} ),
 				siteId
@@ -53,6 +54,20 @@ describe( 'isJetpackProductSite', () => {
 			isJetpackProductSite(
 				getSiteState( {
 					jetpack: true,
+					options: {
+						jetpack_connection_active_plugins: [ 'jetpack-backup' ],
+					},
+				} ),
+				siteId
+			)
+		).toEqual( true );
+	} );
+
+	test( 'should return true if the site has a standalone Jetpack plugin installed, but not the full plugin', () => {
+		expect(
+			isJetpackProductSite(
+				getSiteState( {
+					jetpack: false,
 					options: {
 						jetpack_connection_active_plugins: [ 'jetpack-backup' ],
 					},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1201666604855409

##### Rationale
the `isJetpackProductSite` was updated with `isWpcomSite` to prevent rendering the Jetpack Plans page on WoA Sites. However, `isWpcomSite` takes an "eliminative" approach, i.e. if the site is neither Atomic/WoA nor Jetpack it must be WPCOM. However, Jetpack product sites do not _look_ like a traditional Jetpack site, so it was incorrectly missing self-hosted sites without the main Jetpack plugin

##### Changes
* update `isJetpackProductSite` to work correctly for sites without the full Jetpack Plugin
* update `isJetpackProductSite` tests

#### Testing instructions

1. Test each site/plans page combo below ( `calypso.localhost:3000/plans/:siteSlug` )
   - Jetpack Site with Main Jetpack Plugin - Jetpcack Plans Page
   - Jetpack Site without Main Jetpack Plugin but a product plugin - Jetpack Plans Page
   - WoA/Atomic Site - WPCOM Plans Page
   - Simple Site - WPCOM Plans Page
2. Verify `yarn test-client client/state/sites/test/is-jetpack-product-site.js` all pass

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56276
