### PR TITLE
Remove the `domains/settings-page-redesign` feature flag

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Dialog } from '@automattic/components';
 import { Icon, trash } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
@@ -12,7 +11,7 @@ import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getName } from 'calypso/lib/purchases';
-import { getTitanProductName, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import wpcom from 'calypso/lib/wp';
 import {
 	domainManagementTransferOut,
@@ -38,52 +37,9 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { translate, hasTitanWithUs, slug, currentRoute } = this.props;
+		const { translate, slug, currentRoute } = this.props;
 
-		return ! config.isEnabled( 'domains/settings-page-redesign' ) ? (
-			<Fragment>
-				<p>
-					{ translate(
-						'This will stop all services connected to %(domain)s including your email and website. ' +
-							'If you wish to use %(domain)s with another service or provider you can:',
-						{
-							args: { domain: productName },
-						}
-					) }
-				</p>
-				<ul>
-					<li>
-						<a href={ domainManagementNameServers( slug, productName, currentRoute ) }>
-							{ translate( 'Point %(domain)s to another service', {
-								args: { domain: productName },
-							} ) }
-						</a>
-					</li>
-					<li>
-						<a href={ domainManagementTransferOut( slug, productName, currentRoute ) }>
-							{ translate( 'Move %(domain)s to another provider', {
-								args: { domain: productName },
-							} ) }
-						</a>
-					</li>
-				</ul>
-				<p>
-					{ hasTitanWithUs &&
-						' ' +
-							translate(
-								'You also have an active %(productName)s subscription for this domain, and your emails will stop ' +
-									'working if you delete your domain.',
-								{
-									args: {
-										productName: getTitanProductName(),
-									},
-									comment:
-										'%(productName) is the name of the product, which should be "Professional Email" translated',
-								}
-							) }
-				</p>
-			</Fragment>
-		) : (
+		return (
 			<Fragment>
 				<p>
 					{ translate(
@@ -120,15 +76,10 @@ class RemoveDomainDialog extends Component {
 		return (
 			<Fragment>
 				<FormSectionHeading>
-					{ ! config.isEnabled( 'domains/settings-page-redesign' )
-						? translate( '{{strong}}You are deleting %(domain)s from the web.{{/strong}}', {
-								args: { domain: productName },
-								components: { strong: <strong /> },
-						  } )
-						: translate( '{{strong}}Delete %(domain)s{{/strong}}', {
-								args: { domain: productName },
-								components: { strong: <strong /> },
-						  } ) }
+					{ translate( '{{strong}}Delete %(domain)s{{/strong}}', {
+						args: { domain: productName },
+						components: { strong: <strong /> },
+					} ) }
 				</FormSectionHeading>
 
 				{ this.renderDomainDeletionWarning( productName ) }
@@ -200,17 +151,13 @@ class RemoveDomainDialog extends Component {
 					) }
 				</FormFieldset>
 				<p>
-					{ ! config.isEnabled( 'domains/settings-page-redesign' )
-						? translate(
-								'This domain name will be deleted. Any services related to it will cease to function. Are you sure you wish to proceed?'
-						  )
-						: translate(
-								'{{strong}}%(domain)s{{/strong}} will be deleted. Any services related to it will stop working. Are you sure you want to proceed?',
-								{
-									args: { domain: productName },
-									components: { strong: <strong /> },
-								}
-						  ) }
+					{ translate(
+						'{{strong}}%(domain)s{{/strong}} will be deleted. Any services related to it will stop working. Are you sure you want to proceed?',
+						{
+							args: { domain: productName },
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			</Fragment>
 		);
@@ -274,49 +221,31 @@ class RemoveDomainDialog extends Component {
 	render() {
 		const { purchase, translate, chatButton } = this.props;
 		const productName = getName( purchase );
-		const buttons = ! config.isEnabled( 'domains/settings-page-redesign' )
-			? [
-					{
-						action: 'cancel',
-						disabled: this.props.isRemoving,
-						isPrimary: true,
-						label: translate( 'Never Mind' ),
-					},
-					{
-						action: 'remove',
-						additionalClassNames: [
-							this.props.isRemoving || this.state.isCheckingEmail ? 'is-busy' : '',
-							'is-scary',
-						],
-						label: translate( 'Delete this Domain' ),
-						onClick: this.nextStep,
-					},
-			  ]
-			: [
-					{
-						action: 'cancel',
-						disabled: this.props.isRemoving,
-						label: this.state.step === 3 ? translate( 'Nevermind' ) : translate( 'Cancel' ),
-					},
-					{
-						action: 'remove',
-						additionalClassNames: [
-							this.props.isRemoving || this.state.isCheckingEmail ? 'is-busy' : '',
-							'dialog__button--domains-remove',
-						],
-						isPrimary: true,
-						label:
-							this.state.step === 3 ? (
-								<>
-									<Icon icon={ trash } size={ 18 } />
-									{ translate( 'Delete this domain' ) }
-								</>
-							) : (
-								translate( 'Continue' )
-							),
-						onClick: this.nextStep,
-					},
-			  ];
+		const buttons = [
+			{
+				action: 'cancel',
+				disabled: this.props.isRemoving,
+				label: this.state.step === 3 ? translate( 'Nevermind' ) : translate( 'Cancel' ),
+			},
+			{
+				action: 'remove',
+				additionalClassNames: [
+					this.props.isRemoving || this.state.isCheckingEmail ? 'is-busy' : '',
+					'dialog__button--domains-remove',
+				],
+				isPrimary: true,
+				label:
+					this.state.step === 3 ? (
+						<>
+							<Icon icon={ trash } size={ 18 } />
+							{ translate( 'Delete this domain' ) }
+						</>
+					) : (
+						translate( 'Continue' )
+					),
+				onClick: this.nextStep,
+			},
+		];
 
 		if ( chatButton ) {
 			buttons.unshift( chatButton );

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from 'page';
 import DomainManagementData from 'calypso/components/data/domain-management';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
@@ -73,15 +72,11 @@ export default {
 	},
 
 	domainManagementEdit( pageContext, next ) {
-		let component = DomainManagement.Edit;
-		if ( config.isEnabled( 'domains/settings-page-redesign' ) ) {
-			component = DomainManagement.Settings;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementEdit( ':site', ':domain', pageContext.canonicalPath ) }
 				analyticsTitle="Domain Management > Edit"
-				component={ component }
+				component={ DomainManagement.Settings }
 				context={ pageContext }
 				needsContactDetails
 				needsDomains
@@ -94,15 +89,11 @@ export default {
 	},
 
 	domainManagementSiteRedirect( pageContext, next ) {
-		let component = DomainManagement.SiteRedirect;
-		if ( config.isEnabled( 'domains/settings-page-redesign' ) ) {
-			component = DomainManagement.Settings;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementSiteRedirect( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Edit"
-				component={ component }
+				component={ DomainManagement.Settings }
 				context={ pageContext }
 				needsContactDetails
 				needsDomains
@@ -115,15 +106,11 @@ export default {
 	},
 
 	domainManagementTransferIn( pageContext, next ) {
-		let component = DomainManagement.TransferIn;
-		if ( config.isEnabled( 'domains/settings-page-redesign' ) ) {
-			component = DomainManagement.Settings;
-		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransferIn( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Edit"
-				component={ component }
+				component={ DomainManagement.Settings }
 				context={ pageContext }
 				needsContactDetails
 				needsDomains

--- a/config/development.json
+++ b/config/development.json
@@ -50,7 +50,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"domains/settings-page-redesign": true,
 		"email-accounts/enabled": true,
 		"emails/in-depth-comparison": true,
 		"emails/new-email-comparison": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
We're ready to deploy the new domain settings redesign features to everyone, so we can remove the `domains/settings-page-redesign` feature flag.

#### Testing instructions
Visit the domain settings pages for a site and make sure there are no warnings and that the new designs load when the feature flags are not set.

Example path:
http://calypso.localhost:3000/domains/manage/a8ctest.com?flags=-domains/management-list-redesign