### PR TITLE
Domains: Fix warnings in domains settings page

### DIFF
--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -36,7 +36,7 @@ Header text of the card
 
 ### `mainText`
 
-- **Type:** `String`
+- **Type:** `Node`
 - **Required:** `yes`
 
 Text that describes the header

--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -29,7 +29,7 @@ function render() {
 
 ### `headerText`
 
-- **Type:** `String`
+- **Type:** `Node`
 - **Required:** `yes`
 
 Header text of the card

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -48,7 +48,7 @@ const ActionCard = ( {
 );
 
 ActionCard.propTypes = {
-	headerText: PropTypes.string.isRequired,
+	headerText: PropTypes.node.isRequired,
 	mainText: PropTypes.node.isRequired,
 	buttonPrimary: PropTypes.bool,
 	buttonText: PropTypes.string,

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -49,7 +49,7 @@ const ActionCard = ( {
 
 ActionCard.propTypes = {
 	headerText: PropTypes.string.isRequired,
-	mainText: PropTypes.string.isRequired,
+	mainText: PropTypes.node.isRequired,
 	buttonPrimary: PropTypes.bool,
 	buttonText: PropTypes.string,
 	buttonIcon: PropTypes.string,

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -175,7 +175,7 @@ const Settings = ( {
 	const getNameServerSectionSubtitle = () => {
 		if ( isLoadingNameservers ) {
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-			return <p className="name-servers-card__loading" />;
+			return <span className="name-servers-card__loading" />;
 		}
 
 		if ( loadingNameserversError ) {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -62,6 +63,13 @@ const Settings = ( {
 	whoisData,
 }: SettingsPageProps ): JSX.Element => {
 	const translate = useTranslate();
+	const contactInformation = findRegistrantWhois( whoisData );
+
+	useEffect( () => {
+		if ( ! contactInformation ) {
+			requestWhois( selectedDomainName );
+		}
+	}, [ contactInformation, selectedDomainName ] );
 
 	const renderBreadcrumbs = () => {
 		const previousPath = domainManagementList( selectedSite?.slug, currentRoute );
@@ -268,8 +276,6 @@ const Settings = ( {
 			></ContactsPrivacyInfo>
 		);
 
-		const contactInformation = findRegistrantWhois( whoisData );
-
 		const { privateDomain } = domain;
 		const titleLabel = translate( 'Contact information', { textOnly: true } );
 		const privacyProtectionLabel = privateDomain
@@ -285,7 +291,6 @@ const Settings = ( {
 		}
 
 		if ( ! contactInformation ) {
-			requestWhois( selectedDomainName );
 			return getPlaceholderAccordion();
 		}
 

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -165,6 +165,7 @@
 .domain-settings-page {
 	.name-servers-card__loading {
 		@include placeholder();
+		display: block;
 		margin-top: 4px;
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

As described in p1642167975015700-slack-C0BNMNMNG, there were 3 (actually 4) warnings that might appear when visiting the redesigned domain settings page:

```
1. Failed prop type: Invalid prop `mainText` of type `object` applied to `ActionCard`, expected `string`
2. validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
3. Cannot update a component (`Connect(MomentProvider)`) while rendering a different component (`Settings`)
4. Failed prop type: Invalid prop `headerText` of type `object` applied to `ActionCard`, expected `string`
```

The first one appeared every time you visited the domain settings page and the transfer options at the side bar contained the lock icon. The second and third ones appeared when you were in the site domains page without the domains data loaded - or cleared the app data of your browser (`Application > Storage > Clear site data` in Chrome) - and accessed a domain. The fourth one occurred when selecting a domain which had email inboxes configured for it - for these domains, a small circled number counting the number of inboxes is shown in the email side card title.

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to the site domains page
- Clear the site data from your browser
- Access a domain
- Ensure there are no warnings shown in the console
- Please test some different types of domains just to be sure