### PR TITLE
Domains: Use new design for Site Redirect page

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -27,6 +27,8 @@ const DomainDeleteInfoCard = ( {
 
 	const getDescription = () => {
 		switch ( domain.type ) {
+			case domainType.SITE_REDIRECT:
+				return translate( 'Remove this site redirect permanently' );
 			case domainType.MAPPED:
 				return translate( 'Remove this domain connection permanently' );
 			case domainType.TRANSFER:

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -13,11 +13,12 @@ const DomainEmailInfoCard = ( {
 	selectedSite,
 }: DomainInfoCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
+	const typesUnableToAddEmail = [ domainType.TRANSFER, domainType.SITE_REDIRECT ] as const;
 	const { data, error, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name );
 
 	let emailAddresses: string[] = [];
 
-	if ( domain.type === domainType.TRANSFER ) return null;
+	if ( typesUnableToAddEmail.includes( domain.type ) ) return null;
 
 	if ( ! isLoading && ! error ) {
 		const emailAccounts: EmailAccount[] = data?.accounts;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -10,12 +10,13 @@ const DomainTransferInfoCard = ( {
 	domain,
 	selectedSite,
 }: DomainInfoCardProps ): JSX.Element | null => {
+	const typesUnableToTransfer = [ domainType.TRANSFER, domainType.SITE_REDIRECT ] as const;
 	const translate = useTranslate();
 
 	if (
 		! domain.currentUserIsOwner ||
 		( domain.expired && ! isDomainInGracePeriod( domain ) ) ||
-		domain.type === domainType.TRANSFER
+		typesUnableToTransfer.includes( domain.type )
 	) {
 		return null;
 	}

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -94,11 +94,15 @@ export default {
 	},
 
 	domainManagementSiteRedirect( pageContext, next ) {
+		let component = DomainManagement.SiteRedirect;
+		if ( config.isEnabled( 'domains/settings-page-redesign' ) ) {
+			component = DomainManagement.Settings;
+		}
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementSiteRedirect( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Edit"
-				component={ DomainManagement.SiteRedirect }
+				component={ component }
 				context={ pageContext }
 				needsContactDetails
 				needsDomains

--- a/client/my-sites/domains/domain-management/settings/cards/site-redirect-card.jsx
+++ b/client/my-sites/domains/domain-management/settings/cards/site-redirect-card.jsx
@@ -1,0 +1,228 @@
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+import { withoutHttp } from 'calypso/lib/url';
+import { SITE_REDIRECT } from 'calypso/lib/url/support';
+import { domainManagementSiteRedirect } from 'calypso/my-sites/domains/paths';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
+import {
+	closeSiteRedirectNotice,
+	fetchSiteRedirect,
+	updateSiteRedirect,
+} from 'calypso/state/domains/site-redirect/actions';
+import { getSiteRedirectLocation } from 'calypso/state/domains/site-redirect/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+const noticeOptions = {
+	duration: 5000,
+	id: `site-redirect-update-notification`,
+};
+
+class SiteRedirectCard extends Component {
+	static propTypes = {
+		location: PropTypes.object.isRequired,
+		redesign: PropTypes.bool,
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+	};
+
+	state = {
+		redirectUrl: this.props.location.value,
+	};
+
+	componentDidMount() {
+		this.props.fetchSiteRedirect( this.props.selectedSite.domain );
+	}
+
+	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
+	UNSAFE_componentWillReceiveProps( nextProps ) {
+		if ( this.props.location.value !== nextProps.location.value ) {
+			this.setState( {
+				redirectUrl: nextProps.location.value,
+			} );
+		}
+	}
+
+	componentWillUnmount() {
+		this.closeRedirectNotice();
+	}
+
+	closeRedirectNotice = () => {
+		this.props.closeSiteRedirectNotice( this.props.selectedSite.domain );
+	};
+
+	handleChange = ( event ) => {
+		const redirectUrl = withoutHttp( event.target.value );
+
+		this.setState( { redirectUrl } );
+	};
+
+	handleClick = () => {
+		this.props
+			.updateSiteRedirect( this.props.selectedSite.domain, this.state.redirectUrl )
+			.then( ( success ) => {
+				this.props.recordUpdateSiteRedirectClick(
+					this.props.selectedDomainName,
+					this.state.redirectUrl,
+					success
+				);
+
+				if ( success ) {
+					this.props.fetchSiteDomains( this.props.selectedSite.ID );
+					this.props.fetchSiteRedirect( this.state.redirectUrl.replace( /\/+$/, '' ).trim() );
+
+					page(
+						domainManagementSiteRedirect(
+							this.props.selectedSite.slug,
+							this.state.redirectUrl.replace( /\/+$/, '' ).trim(),
+							this.props.currentRoute
+						)
+					);
+
+					this.props.successNotice(
+						this.props.translate( 'Site redirect updated successfully.' ),
+						noticeOptions
+					);
+				} else {
+					this.props.errorNotice( this.props.location.notice.text );
+				}
+			} );
+	};
+
+	handleFocus = () => {
+		this.props.recordLocationFocus( this.props.selectedDomainName );
+	};
+
+	getNoticeStatus( notice ) {
+		if ( notice?.error ) {
+			return 'is-error';
+		}
+		if ( notice?.success ) {
+			return 'is-success';
+		}
+		return 'is-info';
+	}
+
+	render() {
+		const { location, translate } = this.props;
+		const { isUpdating } = location;
+		const isFetching = location.isFetching;
+
+		return (
+			<div>
+				<form>
+					<FormFieldset>
+						<FormTextInputWithAffixes
+							disabled={ isFetching || isUpdating }
+							name="destination"
+							noWrap
+							onChange={ this.handleChange }
+							onFocus={ this.handleFocus }
+							prefix="http://"
+							value={ this.state.redirectUrl }
+							id="site-redirect__input"
+						/>
+
+						<p className="site-redirect-card__explanation">
+							{ translate(
+								'All domains on this site will redirect here as long as this domain is set as your primary domain. ' +
+									'{{learnMoreLink}}Learn more{{/learnMoreLink}}',
+								{
+									components: {
+										learnMoreLink: (
+											<a href={ SITE_REDIRECT } target="_blank" rel="noopener noreferrer" />
+										),
+									},
+								}
+							) }
+						</p>
+					</FormFieldset>
+
+					<div>
+						<FormButton
+							disabled={ isFetching || isUpdating }
+							onClick={ ( e ) => this.handleClick( e ) }
+						>
+							{ translate( 'Update' ) }
+						</FormButton>
+					</div>
+				</form>
+			</div>
+		);
+	}
+}
+
+const recordCancelClick = ( domainName ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Cancel" Button in Site Redirect',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent( 'calypso_domain_management_site_redirect_cancel_click', {
+			domain_name: domainName,
+		} )
+	);
+
+const recordLocationFocus = ( domainName ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Focused On "Location" Input in Site Redirect',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent( 'calypso_domain_management_site_redirect_location_focus', {
+			domain_name: domainName,
+		} )
+	);
+
+const recordUpdateSiteRedirectClick = ( domainName, location, success ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Update Site Redirect" Button in Site Redirect',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent( 'calypso_domain_management_site_redirect_update_site_redirect_click', {
+			domain_name: domainName,
+			location,
+			success,
+		} )
+	);
+
+export default connect(
+	( state ) => {
+		const selectedSite = getSelectedSite( state );
+		const location = getSiteRedirectLocation( state, selectedSite?.domain );
+		const currentRoute = getCurrentRoute( state );
+		return { selectedSite, location, currentRoute };
+	},
+	{
+		fetchSiteRedirect,
+		fetchSiteDomains,
+		updateSiteRedirect,
+		closeSiteRedirectNotice,
+		recordCancelClick,
+		recordLocationFocus,
+		recordUpdateSiteRedirectClick,
+		successNotice,
+		errorNotice,
+	}
+)( localize( SiteRedirectCard ) );

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -112,3 +112,16 @@
 		color: var( --studio-gray-80 );
 	}
 }
+
+.site-redirect-card__explanation {
+	display: block;
+	margin-top: 5px;
+	margin-bottom: 0;
+	font-size: $font-body-small;
+	font-style: italic;
+	color: var( --color-text-subtle );
+
+	a {
+		white-space: nowrap;
+	}
+}

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -25,7 +25,3 @@ export type NameServersToggleProps = {
 	onToggle: () => void;
 	selectedDomainName: string;
 };
-
-export type SiteRedirectCardOwnProps = {
-	domain: ResponseDomain;
-};

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -25,3 +25,7 @@ export type NameServersToggleProps = {
 	onToggle: () => void;
 	selectedDomainName: string;
 };
+
+export type SiteRedirectCardOwnProps = {
+	domain: ResponseDomain;
+};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -39,6 +39,7 @@ import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-in
 import DomainSecurityDetails from './cards/domain-security-details';
 import NameServersCard from './cards/name-servers-card';
 import RegisteredDomainDetails from './cards/registered-domain-details';
+import SiteRedirectCard from './cards/site-redirect-card';
 import TransferredDomainDetails from './cards/transferred-domain-details';
 import DnsRecords from './dns';
 import { getSslReadableStatus, isSecuredWithUs } from './helpers';
@@ -160,6 +161,20 @@ const Settings = ( {
 					/>
 				</Accordion>
 			);
+		} else if ( domain.type === domainTypes.SITE_REDIRECT ) {
+			return (
+				<Accordion
+					title={ translate( 'Redirect settings', { textOnly: true } ) }
+					subtitle={ 'Update your site redirect' }
+					key="main"
+					expanded
+				>
+					<SiteRedirectCard
+						selectedSite={ selectedSite }
+						selectedDomainName={ selectedDomainName }
+					/>
+				</Accordion>
+			);
 		}
 	};
 
@@ -217,6 +232,10 @@ const Settings = ( {
 	};
 
 	const renderDnsRecords = () => {
+		if ( ! domain || domain.type === domainTypes.SITE_REDIRECT ) {
+			return null;
+		}
+
 		return (
 			<Accordion
 				title={ translate( 'DNS records', { textOnly: true } ) }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,4 +1,3 @@
-//import { isSiteRedirect } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,3 +1,4 @@
+//import { isSiteRedirect } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -389,7 +390,7 @@ export default connect(
 		return {
 			whoisData: getWhoisData( state, ownProps.selectedDomainName ),
 			currentRoute: getCurrentRoute( state ),
-			domain: getSelectedDomain( ownProps ),
+			domain: getSelectedDomain( { ...ownProps, isSiteRedirect: true } ),
 			isLoadingPurchase:
 				isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 			purchase: purchase && purchase.userId === currentUserId ? purchase : null,

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -64,7 +64,11 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 		</Badge>
 	);
 
-	const renderTransferOrMappingBadge = ( type: string ) => {
+	const renderDomainTypeBadge = ( type: string ) => {
+		if ( type === DomainType.SITE_REDIRECT ) {
+			return renderNeutralBadge( __( 'Site Redirect' ) );
+		}
+
 		if ( type === DomainType.MAPPED ) {
 			return renderNeutralBadge( __( 'Registered with an external provider' ) );
 		}
@@ -86,8 +90,10 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 		const { domain } = props;
 		const badges = [];
 
-		if ( [ DomainType.MAPPED, DomainType.TRANSFER ].includes( domain.type ) ) {
-			badges.push( renderTransferOrMappingBadge( domain.type ) );
+		if (
+			[ DomainType.SITE_REDIRECT, DomainType.MAPPED, DomainType.TRANSFER ].includes( domain.type )
+		) {
+			badges.push( renderDomainTypeBadge( domain.type ) );
 		}
 
 		const statusBadge = renderStatusBadge( domain );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Same as #59810, this fixes an old redirect (when using the feature flag) by adding the newly redesigned page for site redirects.
This is part of the domain settings pages redesign project detailed in pcYYhz-m2-p2.

#### Preview
![image](https://user-images.githubusercontent.com/18705930/149586556-4d5d9bda-49ca-46cb-8744-87f2c38d6cce.png)

![image](https://user-images.githubusercontent.com/18705930/149586584-02c28baa-81ab-4782-8656-62481115f5af.png)


#### Testing instructions
- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag;
- Go to "Upgrades > Domains";
- Select any domain with a site redirect;
- Confirm that you are able to see the new design;
- Confirm that you are able to change the redirect and see success/error notices;
- Confirm that other domain types (transfers, mappings, registered domains) still work properly.