### PR TITLE
Shopping Cart: Make cart key always numeric or special

### DIFF
--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -68,7 +68,7 @@ export const transferDomainAction: AuthCodeValidationHandler = (
 			}
 
 			await cartManagerClient
-				.forCartKey( selectedSite.ID.toString() )
+				.forCartKey( selectedSite.ID )
 				.actions.addProductsToCart( [ transfer ] );
 			return page( '/checkout/' + selectedSite.slug );
 		};

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -12,7 +12,7 @@ import './masterbar-cart-button-style.scss';
 
 export type MasterbarCartButtonProps = {
 	selectedSiteSlug: string | undefined;
-	selectedSiteId: string | number | undefined;
+	selectedSiteId: number | undefined;
 	goToCheckout: ( siteSlug: string ) => void;
 	onRemoveProduct?: ( uuid: string ) => void;
 	onRemoveCoupon?: () => void;
@@ -26,7 +26,7 @@ export function MasterbarCartButton( {
 	onRemoveCoupon,
 }: MasterbarCartButtonProps ): JSX.Element | null {
 	const { responseCart, reloadFromServer } = useShoppingCart(
-		selectedSiteId ? String( selectedSiteId ) : undefined
+		selectedSiteId ? selectedSiteId : undefined
 	);
 	const cartButtonRef = useRef( null );
 	const [ isActive, setIsActive ] = useState( false );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -466,7 +466,7 @@ function processItemCart(
 	isFreeThemePreselected,
 	themeSlugWithRepo
 ) {
-	const addToCartAndProceed = () => {
+	const addToCartAndProceed = async () => {
 		debug( 'preparing to add cart items (if any) from', newCartItems );
 		const reduxState = reduxStore.getState();
 		const newCartItemsToAdd = newCartItems
@@ -475,8 +475,9 @@ function processItemCart(
 
 		if ( newCartItemsToAdd.length ) {
 			debug( 'adding products to cart', newCartItemsToAdd );
+			const cartKey = await cartManagerClient.getCartKeyForSiteSlug( siteSlug );
 			cartManagerClient
-				.forCartKey( siteSlug )
+				.forCartKey( cartKey )
 				.actions.addProductsToCart( newCartItemsToAdd )
 				.then( ( updatedCart ) => {
 					debug( 'product add request complete', updatedCart );

--- a/client/my-sites/checkout/cart-manager-client.ts
+++ b/client/my-sites/checkout/cart-manager-client.ts
@@ -1,9 +1,9 @@
 import { createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import wp from 'calypso/lib/wp';
-import type { RequestCart } from '@automattic/shopping-cart';
+import type { RequestCart, CartKey } from '@automattic/shopping-cart';
 
-const wpcomGetCart = ( cartKey: string ) => wp.req.get( `/me/shopping-cart/${ cartKey }` );
-const wpcomSetCart = ( cartKey: string, cartData: RequestCart ) =>
+const wpcomGetCart = ( cartKey: CartKey ) => wp.req.get( `/me/shopping-cart/${ cartKey }` );
+const wpcomSetCart = ( cartKey: CartKey, cartData: RequestCart ) =>
 	wp.req.post( `/me/shopping-cart/${ cartKey }`, cartData );
 
 export const cartManagerClient = createShoppingCartManagerClient( {

--- a/client/my-sites/checkout/get-cart-key.ts
+++ b/client/my-sites/checkout/get-cart-key.ts
@@ -1,4 +1,5 @@
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { CartKey } from '@automattic/shopping-cart';
 
 export default function getCartKey( {
 	selectedSite,
@@ -8,18 +9,15 @@ export default function getCartKey( {
 	selectedSite: SiteData | undefined | null;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
-} ): string | undefined {
+} ): CartKey | undefined {
 	if ( ! selectedSite?.slug && ( isLoggedOutCart || isNoSiteCart ) ) {
 		return 'no-user';
 	}
 	if ( ! selectedSite?.slug && ! isLoggedOutCart && ! isNoSiteCart ) {
 		return 'no-site';
 	}
-	if ( selectedSite?.slug && ( isLoggedOutCart || isNoSiteCart ) ) {
-		return selectedSite.slug;
-	}
 	if ( selectedSite?.ID ) {
-		return String( selectedSite.ID );
+		return selectedSite.ID;
 	}
 	return 'no-site';
 }

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -99,7 +99,7 @@ export function MiniCart( {
 	onRemoveCoupon,
 }: {
 	selectedSiteSlug: string;
-	cartKey: string | number | undefined;
+	cartKey: number | undefined;
 	goToCheckout: ( siteSlug: string ) => void;
 	closeCart: () => void;
 	onRemoveProduct?: ( uuid: string ) => void;
@@ -111,7 +111,7 @@ export function MiniCart( {
 		removeProductFromCart,
 		isLoading,
 		isPendingUpdate,
-	} = useShoppingCart( cartKey ? String( cartKey ) : undefined );
+	} = useShoppingCart( cartKey ? cartKey : undefined );
 	const { __ } = useI18n();
 	const isDisabled = isLoading || isPendingUpdate;
 

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -6,7 +6,9 @@ An older version of this interface exists in calypso's `lib/cart` directory, but
 
 This package provides the following API, as well as a comprehensive set of TypeScript types for the data passed through the cart. Notably, the whole cart object itself is a `ResponseCart` containing `ResponseCartProduct` objects. If adding a new product, the `RequestCart` and `RequestCartProduct` can be used instead (they have fewer required properties).
 
-Every cart is keyed by a cart key; usually this is the WordPress.com site ID (preferred, because it is always unique) or site slug. It can also be `'no-site'` or `'no-user'`. If `undefined`, the cart will not be loaded and the `isLoading` value will be permanently `true`; this can be used to temporarily disable the cart.
+Every cart is keyed by a cart key; usually this is the numeric WordPress.com site ID. It can also be `'no-site'` or `'no-user'`. If `undefined`, the cart will not be loaded and the `isLoading` value will be permanently `true`; this can be used to temporarily disable the cart.
+
+If the site ID is not available, but the site slug is available, the helper function `getCartKeyForSiteSlug` can be used on the [ShoppingCartManagerClient](#createShoppingCartManagerClient) to transform it into a site ID.
 
 ## ShoppingCartProvider
 
@@ -15,13 +17,13 @@ A React context provider component which should be used near the top level of th
 It requires the following props:
 
 - `managerClient: ShoppingCartManagerClient`. The cart manager system. Create one with [createShoppingCartManagerClient](#createShoppingCartManagerClient).
-- `options?: { refetchOnWindowFocus?: boolean, defaultCartKey?: string | undefined }`. Optional. `refetchOnWindowFocus` can be used to trigger `getCart` when the window or tab is hidden and then refocused. `defaultCartKey` can be used to provide a cart key that will be used instead of `undefined` when no cart key is passed to `useShoppingCart` or `withShoppingCart`.
+- `options?: { refetchOnWindowFocus?: boolean, defaultCartKey?: number | 'no-site' | 'no-user' | undefined }`. Optional. `refetchOnWindowFocus` can be used to trigger `getCart` when the window or tab is hidden and then refocused. `defaultCartKey` can be used to provide a cart key that will be used instead of `undefined` when no cart key is passed to `useShoppingCart` or `withShoppingCart`.
 
 ## useShoppingCart
 
 This is a React hook that can be used in any child component under [ShoppingCartProvider](#ShoppingCartProvider) to return a `UseShoppingCart` object. `useShoppingCart` requires one argument:
 
-- `cartKey: string | undefined`. The current cart key to use. If undefined, the cart will not be loaded, although an empty cart and noop functions will still be provided as a return value.
+- `cartKey: number | 'no-site' | 'no-user' | undefined`. The current cart key to use. If undefined, the cart will not be loaded, although an empty cart and noop functions will still be provided as a return value.
 
 The `UseShoppingCart` object contains the following properties. Note that the action functions in this object are requests only; they do not guarantee that the request will be fulfilled by the shopping cart API.
 
@@ -60,7 +62,7 @@ A component wrapped by this HOC will receive the following additional props:
 The HOC has the following arguments. In order to set the cart key, you must provide the second argument to the HOC, `mapPropsToCartKey`.
 
 - `Component: React.ComponentType`. The component to wrap; it will receive the additional props above.
-- `mapPropsToCartKey?: ( props ) => string | undefined`. A function that can be used to set the current cart key based on the component's props. If not set, it will try to use `props.cartKey`.
+- `mapPropsToCartKey?: ( props ) => number | 'no-site' | 'no-user' | undefined`. A function that can be used to set the current cart key based on the component's props. If not set, it will try to use `props.cartKey`.
 
 ## createRequestCartProduct
 
@@ -86,12 +88,13 @@ A function to create a `ShoppingCartManagerClient` which is the state management
 
 It requires an object to be passed in with the following properties:
 
-- `getCart: ( cartKey: string ) => Promise< ResponseCart >`. This is an async function that will fetch the cart from the server.
-- `setCart: ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >`. This is an async function that will send an updated cart to the server.
+- `getCart: ( cartKey: number | 'no-site' | 'no-user' ) => Promise< ResponseCart >`. This is an async function that will fetch the cart from the server.
+- `setCart: ( cartKey: number | 'no-site' | 'no-user', requestCart: RequestCart ) => Promise< ResponseCart >`. This is an async function that will send an updated cart to the server.
 
-Once created, the `ShoppingCartManagerClient` has two properties:
+Once created, the `ShoppingCartManagerClient` has the properties:
 
-- `forCartKey: (cartKey: string| undefined) => ShoppingCartManager`. A function to return a `ShoppingCartManager` for a given cart key. If provided an `undefined` cart key, a `ShoppingCartManager` will still be returned, but its cart will always be loading and empty and its actions will do nothing.
+- `forCartKey: ( cartKey: number | 'no-site' | 'no-user' | undefined ) => ShoppingCartManager`. A function to return a `ShoppingCartManager` for a given cart key. If provided an `undefined` cart key, a `ShoppingCartManager` will still be returned, but its cart will always be loading and empty and its actions will do nothing.
+- `getCartKeyForSiteSlug: ( siteSlug: string ) => Promise< number | 'no-site' | 'no-user' >`. A function to query the server to transform a site slug into a cart key.
 
 A `ShoppingCartManager` has the following properties:
 

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -7,6 +7,8 @@ import type {
 	RequestCartProduct,
 	ResponseCart,
 	ResponseCartProduct,
+	GetCart,
+	CartKey,
 } from './types';
 
 const debug = debugFactory( 'shopping-cart:cart-functions' );
@@ -278,4 +280,16 @@ export function doesResponseCartContainProductMatching(
 			} )
 		);
 	} );
+}
+
+export async function findCartKeyFromSiteSlug(
+	slug: string,
+	getCart: GetCart
+): Promise< CartKey > {
+	try {
+		const cart = await getCart( slug as CartKey );
+		return cart.cart_key;
+	} catch {
+		return 'no-site';
+	}
 }

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -133,7 +133,7 @@ export function doesCartLocationDifferFromResponseCartLocation(
 		country_code: oldCountryCode = '',
 		postal_code: oldPostalCode = '',
 		subdivision_code: oldSubdivisionCode = '',
-	} = cart.tax?.location;
+	} = cart.tax?.location ?? {};
 
 	if ( location.countryCode !== undefined && newCountryCode !== oldCountryCode ) {
 		return true;

--- a/packages/shopping-cart/src/cart-keys.ts
+++ b/packages/shopping-cart/src/cart-keys.ts
@@ -1,1 +1,2 @@
-export const cartKeysThatDoNotAllowFetch = [ 'no-user' ];
+import type { CartKey } from './types';
+export const cartKeysThatDoNotAllowFetch: CartKey[] = [ 'no-user' ];

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -5,7 +5,7 @@ export function getEmptyResponseCart(): ResponseCart {
 		blog_id: '',
 		create_new_blog: false,
 		cart_generated_at_timestamp: 0,
-		cart_key: '',
+		cart_key: 'no-site',
 		products: [],
 		total_tax: '0',
 		total_tax_integer: 0,

--- a/packages/shopping-cart/src/managers.ts
+++ b/packages/shopping-cart/src/managers.ts
@@ -12,6 +12,7 @@ import type {
 	SubscriptionManager,
 	ActionPromises,
 	ShoppingCartManagerActions,
+	CartKey,
 } from './types';
 
 const debug = debugFactory( 'shopping-cart:managers' );
@@ -47,7 +48,7 @@ export function getShoppingCartManagerState( state: ShoppingCartState ): Shoppin
 	};
 }
 
-export function createSubscriptionManager( cartKey: string | undefined ): SubscriptionManager {
+export function createSubscriptionManager( cartKey: CartKey | undefined ): SubscriptionManager {
 	let subscribedClients: SubscribeCallback[] = [];
 	const subscribe = ( callback: SubscribeCallback ): UnsubscribeFunction => {
 		debug( `adding subscriber for cartKey ${ cartKey }` );

--- a/packages/shopping-cart/src/sync.ts
+++ b/packages/shopping-cart/src/sync.ts
@@ -12,6 +12,7 @@ import type {
 	CartSyncManager,
 	GetCart,
 	SetCart,
+	CartKey,
 } from './types';
 import type { Dispatch } from 'react';
 
@@ -20,7 +21,7 @@ const emptyCart = getEmptyResponseCart();
 const getEmptyCart = () => Promise.resolve( emptyCart );
 
 export function createCartSyncManager(
-	cartKey: string,
+	cartKey: CartKey,
 	getCart: GetCart,
 	setCart: SetCart
 ): CartSyncManager {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -8,18 +8,22 @@ export type ShoppingCartReducer = (
 	action: ShoppingCartAction
 ) => ShoppingCartState;
 
-export type GetCart = ( cartKey: string ) => Promise< ResponseCart >;
-export type SetCart = ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >;
+export type CartKey = number | 'no-user' | 'no-site';
+
+export type GetCart = ( cartKey: CartKey ) => Promise< ResponseCart >;
+export type SetCart = ( cartKey: CartKey, requestCart: RequestCart ) => Promise< ResponseCart >;
 
 export interface ShoppingCartManagerOptions {
 	refetchOnWindowFocus?: boolean;
-	defaultCartKey?: string;
+	defaultCartKey?: CartKey;
 }
 
-export type GetManagerForKey = ( cartKey: string | undefined ) => ShoppingCartManager;
+export type GetManagerForKey = ( cartKey: CartKey | undefined ) => ShoppingCartManager;
+export type GetCartKeyForSiteSlug = ( siteSlug: string ) => Promise< CartKey >;
 
 export interface ShoppingCartManagerClient {
 	forCartKey: GetManagerForKey;
+	getCartKeyForSiteSlug: GetCartKeyForSiteSlug;
 }
 
 export type UnsubscribeFunction = () => void;
@@ -219,7 +223,7 @@ export type MinimalRequestCartProduct = Partial< RequestCartProduct > &
 export interface ResponseCart< P = ResponseCartProduct > {
 	blog_id: number | string;
 	create_new_blog: boolean;
-	cart_key: string;
+	cart_key: CartKey;
 	products: P[];
 	total_tax: string; // Please try not to use this
 	total_tax_integer: number;

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -3,6 +3,7 @@ import { useEffect, useContext } from 'react';
 import { cartKeysThatDoNotAllowFetch } from './cart-keys';
 import ShoppingCartOptionsContext from './shopping-cart-options-context';
 import useManagerClient from './use-manager-client';
+import type { CartKey } from './types';
 
 const debug = debugFactory( 'shopping-cart:use-refetch-on-focus' );
 
@@ -27,7 +28,7 @@ function isOffline(): boolean {
 	}
 }
 
-export default function useRefetchOnFocus( cartKey: string | undefined ): void {
+export default function useRefetchOnFocus( cartKey: CartKey | undefined ): void {
 	const managerClient = useManagerClient( 'useRefetchOnFocus' );
 
 	const manager = managerClient.forCartKey( cartKey );

--- a/packages/shopping-cart/src/use-shopping-cart.ts
+++ b/packages/shopping-cart/src/use-shopping-cart.ts
@@ -3,9 +3,9 @@ import { createUseShoppingCartState } from './shopping-cart-hook-manager';
 import ShoppingCartOptionsContext from './shopping-cart-options-context';
 import useManagerClient from './use-manager-client';
 import useRefetchOnFocus from './use-refetch-on-focus';
-import type { UseShoppingCart } from './types';
+import type { UseShoppingCart, CartKey } from './types';
 
-export default function useShoppingCart( cartKey?: string ): UseShoppingCart {
+export default function useShoppingCart( cartKey?: CartKey ): UseShoppingCart {
 	const managerClient = useManagerClient( 'useShoppingCart' );
 
 	const { defaultCartKey } = useContext( ShoppingCartOptionsContext );

--- a/packages/shopping-cart/src/with-shopping-cart.tsx
+++ b/packages/shopping-cart/src/with-shopping-cart.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import useManagerClient from './use-manager-client';
 import useShoppingCart from './use-shopping-cart';
-import type { WithShoppingCartProps } from './types';
+import type { WithShoppingCartProps, CartKey } from './types';
 
 export default function withShoppingCart< ComponentProps >(
 	Component: React.ComponentType< ComponentProps & WithShoppingCartProps >,
-	mapPropsToCartKey?: ( props: ComponentProps ) => string | undefined
+	mapPropsToCartKey?: ( props: ComponentProps ) => CartKey | undefined
 ): React.FC< ComponentProps > {
 	return function ShoppingCartWrapper( props ): JSX.Element {
 		const cartKey = mapPropsToCartKey
 			? mapPropsToCartKey( props )
-			: ( props as Record< string, string | undefined > ).cartKey;
+			: ( props as Record< string, CartKey | undefined > ).cartKey;
 
 		// Even though managerClient isn't used here this guard will provide a
 		// better error message than waiting for the one in useShoppingCart.

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -25,7 +25,7 @@ describe( 'ShoppingCartManager', () => {
 			const manager = cartManagerClient.forCartKey( mainCartKey );
 			const { responseCart } = manager.getState();
 			expect( responseCart.products.length ).toBe( 0 );
-			expect( responseCart.cart_key ).toBe( '' );
+			expect( responseCart.cart_key ).toBe( 'no-site' );
 		} );
 	} );
 

--- a/packages/shopping-cart/test/utils/mock-cart-api.ts
+++ b/packages/shopping-cart/test/utils/mock-cart-api.ts
@@ -4,9 +4,10 @@ import type {
 	ResponseCart,
 	ResponseCartProduct,
 	RequestCartProduct,
+	CartKey,
 } from '../../src/types';
 
-export const mainCartKey = '1';
+export const mainCartKey = 1;
 
 const emptyResponseCart = getEmptyResponseCart();
 
@@ -94,7 +95,7 @@ export const renewalTwo: ResponseCartProduct = {
 	extra: { purchaseType: 'renewal' },
 };
 
-export async function getCart( cartKey: string ): Promise< ResponseCart > {
+export async function getCart( cartKey: CartKey ): Promise< ResponseCart > {
 	if ( cartKey === mainCartKey ) {
 		return {
 			...emptyResponseCart,
@@ -114,7 +115,7 @@ function createProduct( productProps: RequestCartProduct ): ResponseCartProduct 
 	throw new Error( 'Unknown product' );
 }
 
-export async function setCart( cartKey: string, newCart: RequestCart ): Promise< ResponseCart > {
+export async function setCart( cartKey: CartKey, newCart: RequestCart ): Promise< ResponseCart > {
 	if ( [ 'no-site', 'no-user', mainCartKey ].includes( cartKey ) ) {
 		// Mock the shopping-cart endpoint response here
 		return {


### PR DESCRIPTION
#### Background

The shopping-cart endpoint (in most cases) requires two pieces of information to create or alter a cart: a logged-in user, and a cart key. (It's also possible to use the `'no-user'` cart key to create a cart with no user, or the `'no-site'` key to create a cart without a site.) The cart key is typically the numeric site ID of the site to which the cart belongs. However, it's also possible to use the domain name of the site. If that's the case, the shopping-cart endpoint will transform the slug into the numeric site ID itself.

It's not a good idea to use the site slug if the site ID is available because there are situations where domain names can be translated to the wrong site (this was the subject of [a bug fix](https://github.com/Automattic/wp-calypso/pull/44410) a few years ago).

Since https://github.com/Automattic/wp-calypso/pull/54667, the shopping cart manager in calypso has become capable of operating on multiple carts. Its persistent cache means that totally separate components in the render tree can make requests for shopping cart data and that data will be shared (and automatically updated) between those components if they use the same cart key. However, as mentioned above, it's possible to use _two different keys to get the same data_. While the endpoint treats these requests as the same, the cart manager believes them to be different.

Therefore, it's possible for one consumer (eg: [signup](https://github.com/Automattic/wp-calypso/blob/6319d8a6dd0186c53fc2055624291d32e8322f6a/client/lib/signup/step-actions/index.js#L479)) to modify the cart using the site slug and another consumer (eg: the masterbar cart) to not be aware of that change. If the second consumer tries to make requests of its own, things could get very confusing indeed.

#### Changes proposed in this Pull Request

In this PR we modify the shopping cart manager to require a numeric cart key only (or one of the special keys mentioned above). Because there's the possibility that the consumer doesn't have the site ID, this also adds a new helper function to `ShoppingCartManagerClient` called `getCartKeyForSiteSlug()` which uses the shopping-cart endpoint to transform a site slug into a valid cart key so it can be used safely.

The downside to this approach is that it will require an additional HTTP request before a cart item can be added in signup (currently the only place using a site slug), but it greatly simplifies the cart code and prevents possible bugs like those described above by making one source of truth for each cart.

In fact, it's likely that this translation is not even required in signup because by the time the cart request is being made, we should already have a site created (or know that we're using one of the special keys). However, it would require a fair amount of refactoring to guarantee this, and so the helper function is a safe compromise.

**Note:** One possible breaking change caused by this PR is that the `useCartKey` hook loses the ability to return a site slug, which previously it would do if there was a site slug and [`isLoggedOutCart`](https://github.com/Automattic/wp-calypso/blob/cd4630bad5832685e585f0651243e30063c8bcab/client/my-sites/checkout/use-cart-key.ts#L8) or [`isNoSiteCart`](https://github.com/Automattic/wp-calypso/blob/cd4630bad5832685e585f0651243e30063c8bcab/client/my-sites/checkout/use-cart-key.ts#L17-L21) were set. Now the function will return the site ID or `'no-site'` instead in those cases. I believe this is safe because I can't imagine a situation where we would have a site slug set but no ID and be logged out or using Jetpack checkout. It's worth looking for such a situation, though, just to be sure.

Related to https://github.com/Automattic/wp-calypso/issues/59773

A different approach than https://github.com/Automattic/wp-calypso/pull/60071 which wasn't really working.

See also D73119-code which makes sure that numeric `cart_key` values are always numbers on the server, although it's not required here.

#### Testing instructions

This is one of those changes that's difficult to test because its effects are so far-reaching. The most important thing to try is to make sure that the major signup flows still add items to the cart as expected, particularly:

- Adding a plan and a domain to the cart during logged-in signup.
- Adding a plan and a domain to the cart during logged-out signup.
- Adding just a domain to the cart during logged-out signup.
- Adding a plan and a domain to the cart during Jetpack (logged-out) checkout.