### PR TITLE
Revert "DIFM Lite: Fixes props for signup submit event"

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -1,4 +1,3 @@
-import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { isEmpty, reduce, snakeCase } from 'lodash';
 import { assertValidDependencies } from 'calypso/lib/signup/asserts';
@@ -48,15 +47,6 @@ function recordSubmitStep( stepName, providedDependencies, optionalProps ) {
 			if ( propName === 'email' ) {
 				propName = `user_entered_${ propName }`;
 				propValue = !! propValue;
-			}
-
-			if (
-				propName === 'cart_item' &&
-				propValue.product_slug &&
-				propValue.product_slug === WPCOM_DIFM_LITE
-			) {
-				const { extra, ...otherProps } = propValue;
-				propValue = otherProps;
 			}
 
 			if ( [ 'cart_item', 'domain_item' ].includes( propName ) && typeof propValue !== 'string' ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#60036

If a free plan is selected, `propValue` is null and this causes a breakage.