### PR TITLE
DIFM Lite: Fixes props for signup submit event (Take 2)

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -1,3 +1,4 @@
+import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { isEmpty, reduce, snakeCase } from 'lodash';
 import { assertValidDependencies } from 'calypso/lib/signup/asserts';
@@ -47,6 +48,11 @@ function recordSubmitStep( stepName, providedDependencies, optionalProps ) {
 			if ( propName === 'email' ) {
 				propName = `user_entered_${ propName }`;
 				propValue = !! propValue;
+			}
+
+			if ( propName === 'cart_item' && propValue?.product_slug === WPCOM_DIFM_LITE ) {
+				const { extra, ...otherProps } = propValue;
+				propValue = otherProps;
 			}
 
 			if ( [ 'cart_item', 'domain_item' ].includes( propName ) && typeof propValue !== 'string' ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Previous PR: https://github.com/Automattic/wp-calypso/pull/60036 - I reverted this change since the `cart_item` is null when the free plan is selected and caused a JS error. I added a check for that in this PR and added some additional testing instructions below.
* Removes the `extra` prop from `cart_item` for the `calypso_signup_actions_submit_step` Tracks event. The `extra` prop contains some form data entered by the user, converted to a string.
 
![image](https://user-images.githubusercontent.com/5436027/149332775-a7a6f776-63ae-4e81-8576-488057a5ce50.png)


### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Testing the DIFM Lite flow
* Start the flow at /start/do-it-for-me/
* Keep the network tab in dev tools open.
* Proceed through the flow till you reach the checkout page.
* Search for `calypso_signup_actions_submit_step` in the Network tab.
* Check the query parameters. The `cart_item` prop's value should be just `product_slug:wp_difm_lite`.
![image](https://user-images.githubusercontent.com/5436027/149332345-2415b773-bb4f-4806-9bd6-6bc63ab5a36c.png)

#### Testing with a free plan & domain
* Start the signup flow at `/start`.
* Select a free domain and free plan.
* Confirm that you can proceed to the intent screen without JS errors.

#### Testing with a paid plan & domain
* Start the signup flow at `/start`.
* Select a paid domain and paid plan.
* Confirm that you can proceed to the checkout screen without JS errors.



