### PR TITLE
Fix/app banner e2e tests

### DIFF
--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -7,6 +7,7 @@ import {
 	isDismissed,
 	getCurrentSection,
 } from 'calypso/blocks/app-banner/utils';
+import { isE2ETest } from 'calypso/lib/e2e';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
@@ -21,6 +22,10 @@ import { AppState } from 'calypso/types';
  * @returns {boolean} True if App Banner is visible
  */
 export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined => {
+	if ( isE2ETest() ) {
+		return false;
+	}
+
 	// The ToS update banner is displayed in the same position as the mobile app banner. Since the ToS update
 	// has higher priority, we repress all other non-essential sticky banners if the ToS update banner needs to
 	// be displayed.

--- a/client/state/selectors/test/should-display-app-banner.js
+++ b/client/state/selectors/test/should-display-app-banner.js
@@ -1,18 +1,57 @@
+import { isMobile } from '@automattic/viewport';
 import { expect } from 'chai';
 import { isE2ETest } from 'calypso/lib/e2e';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { shouldDisplayAppBanner } from 'calypso/state/selectors/should-display-app-banner';
 
 jest.mock( 'calypso/lib/e2e', () => ( {
 	isE2ETest: jest.fn( () => false ),
 } ) );
+jest.mock( '@automattic/viewport', () => ( {
+	isMobile: jest.fn( () => true ),
+} ) );
+jest.mock( 'calypso/lib/mobile-app', () => ( {
+	isWpMobileApp: jest.fn( () => false ),
+} ) );
 
 describe( 'shouldDisplayAppBanner()', () => {
+	test( 'should return true if state is correct', () => {
+		const state = {
+			ui: {
+				appBannerVisibility: true,
+				layoutFocus: {
+					current: 'not-sidebar',
+				},
+				section: {
+					name: 'gutenberg-editor',
+				},
+			},
+			preferences: {
+				remoteValues: [ 'something' ],
+			},
+		};
+		const output = shouldDisplayAppBanner( state );
+		expect( output ).to.be.true;
+	} );
+
 	test( 'should return false if ToS update banner is displayed', () => {
 		const state = {
 			legal: {
 				tos: {
 					displayPrompt: true,
 				},
+			},
+			ui: {
+				appBannerVisibility: true,
+				layoutFocus: {
+					current: 'not-sidebar',
+				},
+				section: {
+					name: 'gutenberg-editor',
+				},
+			},
+			preferences: {
+				remoteValues: [ 'something' ],
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
@@ -26,6 +65,12 @@ describe( 'shouldDisplayAppBanner()', () => {
 				layoutFocus: {
 					current: 'not-sidebar',
 				},
+				section: {
+					name: 'gutenberg-editor',
+				},
+			},
+			preferences: {
+				remoteValues: [ 'something' ],
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
@@ -39,22 +84,31 @@ describe( 'shouldDisplayAppBanner()', () => {
 				layoutFocus: {
 					current: 'sidebar',
 				},
+				section: {
+					name: 'gutenberg-editor',
+				},
+			},
+			preferences: {
+				remoteValues: [ 'something' ],
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
 		expect( output ).to.be.false;
 	} );
 
-	test( 'should return false if fetching preferences', () => {
+	test( 'should return false if has not received remote preferences', () => {
 		const state = {
 			ui: {
 				appBannerVisibility: true,
 				layoutFocus: {
 					current: 'not-sidebar',
 				},
+				section: {
+					name: 'gutenberg-editor',
+				},
 			},
 			preferences: {
-				fetching: true,
+				remoteValues: null,
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
@@ -73,7 +127,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 				},
 			},
 			preferences: {
-				fetching: false,
+				remoteValues: [ 'something' ],
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
@@ -93,7 +147,47 @@ describe( 'shouldDisplayAppBanner()', () => {
 				},
 			},
 			preferences: {
-				fetching: false,
+				remoteValues: [ 'something' ],
+			},
+		};
+		const output = shouldDisplayAppBanner( state );
+		expect( output ).to.be.false;
+	} );
+
+	test( 'should return false if not on mobile', () => {
+		isMobile.mockReturnValueOnce( false );
+		const state = {
+			ui: {
+				appBannerVisibility: true,
+				layoutFocus: {
+					current: 'not-sidebar',
+				},
+				section: {
+					name: 'gutenberg-editor',
+				},
+			},
+			preferences: {
+				remoteValues: [ 'something' ],
+			},
+		};
+		const output = shouldDisplayAppBanner( state );
+		expect( output ).to.be.false;
+	} );
+
+	test( 'should return false if in the app', () => {
+		isWpMobileApp.mockReturnValueOnce( true );
+		const state = {
+			ui: {
+				appBannerVisibility: true,
+				layoutFocus: {
+					current: 'not-sidebar',
+				},
+				section: {
+					name: 'gutenberg-editor',
+				},
+			},
+			preferences: {
+				remoteValues: [ 'something' ],
 			},
 		};
 		const output = shouldDisplayAppBanner( state );

--- a/client/state/selectors/test/should-display-app-banner.js
+++ b/client/state/selectors/test/should-display-app-banner.js
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
+import { isE2ETest } from 'calypso/lib/e2e';
 import { shouldDisplayAppBanner } from 'calypso/state/selectors/should-display-app-banner';
+
+jest.mock( 'calypso/lib/e2e', () => ( {
+	isE2ETest: jest.fn( () => false ),
+} ) );
 
 describe( 'shouldDisplayAppBanner()', () => {
 	test( 'should return false if ToS update banner is displayed', () => {
@@ -65,6 +70,26 @@ describe( 'shouldDisplayAppBanner()', () => {
 				},
 				section: {
 					name: 'not-allowed',
+				},
+			},
+			preferences: {
+				fetching: false,
+			},
+		};
+		const output = shouldDisplayAppBanner( state );
+		expect( output ).to.be.false;
+	} );
+
+	test( 'should return false if in e2e test', () => {
+		isE2ETest.mockReturnValueOnce( true );
+		const state = {
+			ui: {
+				appBannerVisibility: true,
+				layoutFocus: {
+					current: 'not-sidebar',
+				},
+				section: {
+					name: 'gutenberg-editor',
 				},
 			},
 			preferences: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/58524 moved the App Banner before the Welcome Tour, which seems to break some e2e tests. 
With these changes, we do not show the App Banner during e2e tests

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- checkout the branch
- run `yarn start`
- check that everything is working as usual

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
