### PR TITLE
Misc: Migrate `componentWillMount` to `componentDidMount` in READMEs

### DIFF
--- a/client/lib/keyboard-shortcuts/README.md
+++ b/client/lib/keyboard-shortcuts/README.md
@@ -10,7 +10,7 @@ This module can be used outside of React, but this is a typical use within React
 import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
 
 class MyComponent extends React.Component {
-	componentWillMount() {
+	componentDidMount() {
 		KeyboardShortcuts.on( 'open-selection', this.openSelectedPost );
 	}
 

--- a/client/state/sharing/keyring/README.md
+++ b/client/state/sharing/keyring/README.md
@@ -16,7 +16,7 @@ import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions
 import { isKeyringConnectionsFetching } from 'calypso/state/sharing/keyring/selectors';
 
 class QueryKeyringConnections extends Component {
-	componentWillMount() {
+	componentDidMount() {
 		if ( ! this.props.isRequesting ) {
 			this.props.requestKeyringConnections();
 		}

--- a/client/state/sharing/services/README.md
+++ b/client/state/sharing/services/README.md
@@ -16,7 +16,7 @@ import { requestKeyringServices } from 'calypso/state/sharing/services/actions';
 import { isKeyringServicesFetching } from 'calypso/state/sharing/services/selectors';
 
 class QueryKeyringServices extends Component {
-	componentWillMount() {
+	componentDidMount() {
 		if ( ! this.props.isRequesting ) {
 			this.props.requestKeyringServices();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates a few instances of `componentWillMount` in READMEs to use `componentDidMount`.

Part of #58453.

#### Testing instructions

Testing is not needed as we're touching READMEs, just check if the changes make sense. 