### PR TITLE
Emails: Add email forwarding and support links to In-Depth Comparison page

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -3,6 +3,7 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 const root = localizeUrl( 'https://wordpress.com/support/' ).replace( /\/$/, '' );
 
 export const ADDING_GSUITE_TO_YOUR_SITE = `${ root }/add-email/adding-google-workspace-to-your-site/`;
+export const ADDING_TITAN_TO_YOUR_SITE = `${ root }/add-email/adding-professional-email-to-your-site/`;
 export const AUTO_RENEWAL = `${ root }/manage-purchases/#automatic-renewal`;
 export const CHANGE_NAME_SERVERS = `${ root }/domains/custom-dns/#changing-name-servers-to-point-to-wordpress-com`;
 export const CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS = `${ root }/domains/change-name-servers/#finding-out-your-new-name-server`;

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
@@ -1,0 +1,67 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
+import { getSelectedDomain } from 'calypso/lib/domains';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import {
+	emailManagementAddEmailForwards,
+} from 'calypso/my-sites/email/paths';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+type EmailForwardingLinkProps = {
+	selectedDomainName: string;
+};
+
+const EmailForwardingLink = ( {
+	selectedDomainName,
+}: EmailForwardingLinkProps ): ReactElement | null => {
+	const translate = useTranslate();
+
+	const currentRoute = useSelector( getCurrentRoute );
+	const selectedSite = useSelector( getSelectedSite );
+
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+
+	const domain = getSelectedDomain( {
+		domains,
+		selectedDomainName,
+	} );
+
+	if ( ! domain || ! selectedSite ) {
+		return null;
+	}
+
+	const hasExistingEmailForwards = hasEmailForwards( domain );
+
+	if ( hasExistingEmailForwards ) {
+		return null;
+	}
+
+	return (
+		<div className="email-forwarding_link">
+			<QueryEmailForwards domainName={ selectedDomainName } />
+
+			{ translate( 'Looking for a free email solution? Start with {{a}}Email Forwarding{{/a}}.', {
+				components: {
+					a: (
+						<a
+							href={ emailManagementAddEmailForwards(
+								selectedSite.slug,
+								selectedDomainName,
+								currentRoute,
+								'purchase'
+							) }
+						/>
+					),
+				},
+			} ) }
+		</div>
+	);
+};
+
+export default EmailForwardingLink;

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
@@ -3,9 +3,7 @@ import { useSelector } from 'react-redux';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
-import {
-	emailManagementAddEmailForwards,
-} from 'calypso/my-sites/email/paths';
+import { emailManagementAddEmailForwards } from 'calypso/my-sites/email/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -43,7 +41,7 @@ const EmailForwardingLink = ( {
 	}
 
 	return (
-		<div className="email-forwarding_link">
+		<div className="email-forwarding-link">
 			<QueryEmailForwards domainName={ selectedDomainName } />
 
 			{ translate( 'Looking for a free email solution? Start with {{a}}Email Forwarding{{/a}}.', {

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/style.scss
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/style.scss
@@ -1,0 +1,8 @@
+.email-forwarding_link {
+	margin-top: 1.5em;
+	text-align: center;
+
+	a {
+		text-decoration: underline;
+	}
+}

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/style.scss
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/style.scss
@@ -1,4 +1,5 @@
-.email-forwarding_link {
+.email-forwarding-link {
+	margin-bottom: 1.5em;
 	margin-top: 1.5em;
 	text-align: center;
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -4,6 +4,7 @@ import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import EmailProviderFeatures from 'calypso/my-sites/email/email-provider-features';
 import EmailProviderPrice from 'calypso/my-sites/email/email-providers-comparison/in-depth/email-provider-price';
+import LearnMoreLink from 'calypso/my-sites/email/email-providers-comparison/in-depth/learn-more-link';
 import { ComparisonListOrTableProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 import type { ReactElement } from 'react';
 
@@ -44,6 +45,10 @@ const ComparisonList = ( {
 
 						<div className="email-providers-in-depth-comparison-list__features">
 							<EmailProviderFeatures features={ [ tools, storage, importing, support ] } />
+						</div>
+
+						<div className="email-providers-in-depth-comparison-list__support-link">
+							<LearnMoreLink url={ emailProviderFeatures.supportUrl } />
 						</div>
 
 						<Button

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import EmailProviderPrice from 'calypso/my-sites/email/email-providers-comparison/in-depth/email-provider-price';
+import LearnMoreLink from 'calypso/my-sites/email/email-providers-comparison/in-depth/learn-more-link';
 import type { ComparisonListOrTableProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 import type { ReactElement } from 'react';
 
@@ -92,6 +93,16 @@ const ComparisonTable = ( {
 
 					{ emailProviders.map( ( emailProviderFeatures ) => (
 						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.support }</td>
+					) ) }
+				</tr>
+
+				<tr>
+					<td></td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => (
+						<td key={ emailProviderFeatures.slug }>
+							<LearnMoreLink url={ emailProviderFeatures.supportUrl } />
+						</td>
 					) ) }
 				</tr>
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
@@ -5,6 +5,7 @@ import { translate } from 'i18n-calypso';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getTitanProductName } from 'calypso/lib/titan';
+import { ADDING_GSUITE_TO_YOUR_SITE, ADDING_TITAN_TO_YOUR_SITE } from 'calypso/lib/url/support';
 import type { EmailProviderFeatures } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 
 export const professionalEmailFeatures: EmailProviderFeatures = {
@@ -18,6 +19,7 @@ export const professionalEmailFeatures: EmailProviderFeatures = {
 		support: translate( '24/7 support via email' ),
 		tools: translate( 'Integrated email management, Inbox, Calendar and Contacts' ),
 	},
+	supportUrl: ADDING_TITAN_TO_YOUR_SITE,
 };
 
 export const googleWorkspaceFeatures: EmailProviderFeatures = {
@@ -39,4 +41,5 @@ export const googleWorkspaceFeatures: EmailProviderFeatures = {
 		support: translate( '24/7 support via email' ),
 		tools: translate( 'Gmail, Calendar, Meet, Chat, Drive, Docs, Sheets, Slides and more' ),
 	},
+	supportUrl: ADDING_GSUITE_TO_YOUR_SITE,
 };

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -17,6 +17,7 @@ import {
 	emailManagementInDepthComparison,
 	emailManagementPurchaseNewEmailAccount,
 } from 'calypso/my-sites/email/paths';
+import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
@@ -93,6 +94,8 @@ const EmailProvidersInDepthComparison = ( {
 				onSelectEmailProvider={ selectEmailProvider }
 				selectedDomainName={ selectedDomainName }
 			/>
+
+			<EmailForwardingLink selectedDomainName={ selectedDomainName } />
 		</>
 	);
 };

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -6,6 +6,7 @@ import page from 'page';
 import { useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
+import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import ComparisonList from 'calypso/my-sites/email/email-providers-comparison/in-depth/comparison-list';
 import ComparisonTable from 'calypso/my-sites/email/email-providers-comparison/in-depth/comparison-table';
 import {
@@ -17,7 +18,6 @@ import {
 	emailManagementInDepthComparison,
 	emailManagementPurchaseNewEmailAccount,
 } from 'calypso/my-sites/email/paths';
-import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';

--- a/client/my-sites/email/email-providers-comparison/in-depth/learn-more-link.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/learn-more-link.tsx
@@ -1,0 +1,20 @@
+import { useTranslate } from 'i18n-calypso';
+import type { LearnMoreLinkProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
+import type { ReactElement } from 'react';
+
+const LearnMoreLink = ( { url }: LearnMoreLinkProps ): ReactElement => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ translate( '{{a}}Learn more{{/a}}', {
+				comment: 'Link to support page either for Google Workspace or Professional Email',
+				components: {
+					a: <a href={ url } target="_blank" rel="noopener noreferrer" />,
+				},
+			} ) }
+		</>
+	);
+};
+
+export default LearnMoreLink;

--- a/client/my-sites/email/email-providers-comparison/in-depth/style.scss
+++ b/client/my-sites/email/email-providers-comparison/in-depth/style.scss
@@ -51,8 +51,12 @@
 	}
 }
 
-.email-providers-in-depth-comparison-list__button {
+.email-providers-in-depth-comparison-list__support-link {
 	margin-top: 20px;
+}
+
+.email-providers-in-depth-comparison-list__button {
+	margin-top: 30px;
 }
 
 $table-padding: 15px;

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -25,6 +25,7 @@ export type EmailProviderFeatures = {
 	logo: ReactNode;
 	name: TranslateResult;
 	slug: string;
+	supportUrl: string;
 };
 
 export type EmailProvidersInDepthComparisonProps = {
@@ -33,4 +34,8 @@ export type EmailProvidersInDepthComparisonProps = {
 	selectedIntervalLength: IntervalLength | undefined;
 	siteName: string;
 	source: string;
+};
+
+export type LearnMoreLinkProps = {
+	url: string;
 };

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -15,9 +15,9 @@ import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-f
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import GoogleWorkspaceCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card';
+import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import ProfessionalEmailCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card';
 import {
-	emailManagementAddEmailForwards,
 	emailManagementInDepthComparison,
 	emailManagementPurchaseNewEmailAccount,
 } from 'calypso/my-sites/email/paths';
@@ -35,7 +35,6 @@ type EmailProvidersStackedComparisonProps = {
 	selectedDomainName: string;
 	selectedEmailProviderSlug: string;
 	selectedIntervalLength: IntervalLength | undefined;
-	showEmailForwardLink?: boolean;
 	siteName: string;
 	source: string;
 };
@@ -45,7 +44,6 @@ const EmailProvidersStackedComparison = ( {
 	selectedDomainName,
 	selectedEmailProviderSlug,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
-	showEmailForwardLink = true,
 	siteName,
 	source,
 }: EmailProvidersStackedComparisonProps ): ReactElement => {
@@ -188,25 +186,7 @@ const EmailProvidersStackedComparison = ( {
 				/>
 			) }
 
-			{ ! hasExistingEmailForwards && showEmailForwardLink && selectedSite && (
-				<div className="email-providers-stacked-comparison__email-forward-section">
-					{ translate( 'Looking for a free email solution?' ) }{ ' ' }
-					{ translate( 'Start with {{link}}Email Forwarding{{/link}}.', {
-						components: {
-							link: (
-								<a
-									href={ emailManagementAddEmailForwards(
-										selectedSite.slug,
-										selectedDomainName,
-										currentRoute,
-										'purchase'
-									) }
-								/>
-							),
-						},
-					} ) }
-				</div>
-			) }
+			<EmailForwardingLink selectedDomainName={ selectedDomainName } />
 		</Main>
 	);
 };

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -13,9 +13,9 @@ import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
+import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import GoogleWorkspaceCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card';
-import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import ProfessionalEmailCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card';
 import {
 	emailManagementInDepthComparison,

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -21,12 +21,3 @@
 	font-size: $font-body-small;
 	text-align: center;
 }
-
-.email-providers-stacked-comparison__email-forward-section {
-	margin-top: 1.5em;
-	text-align: center;
-
-	a {
-		text-decoration: underline;
-	}
-}


### PR DESCRIPTION
This pull request updates the `In-Depth Comparison` page to show a link to the support page for each email provider. It also adds a link in the footer to present the Email Forwarding option to users:

Desktop | Mobile
------ | -----
![image](https://user-images.githubusercontent.com/594356/149797660-a534d596-c931-4bdd-ab1f-b216597785a6.png) <br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>| ![image](https://user-images.githubusercontent.com/594356/149798024-2ec66223-0c34-4e35-bb3b-6fb173c76a2b.png)

#### Testing instructions

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout update/in-depth-comparison-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/60131#issuecomment-1014657891)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Click the `See how they compare` link to access the `In-Depth Comparison` page
6. Assert that the `Learn more` links open the right support pages on desktop and mobile
7. Assert that the `Email Forwarding` link opens the `Add New Email Forwards` page on desktop and mobile