### PR TITLE
Domains: Refactor away from `_.dropRightWhile()`

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -69,10 +69,7 @@ class CustomNameserversForm extends PureComponent {
 		const { translate } = this.props;
 
 		// Remove the empty values from the end, and add one empty one
-		const nameservers = dropRightWhileEmpty(
-			this.props.nameservers,
-			( nameserver ) => ! nameserver
-		);
+		const nameservers = dropRightWhileEmpty( this.props.nameservers );
 
 		if ( nameservers.length < MAX_NAMESERVER_LENGTH ) {
 			nameservers.push( '' );

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -21,14 +21,14 @@ const dropRightWhileEmpty = ( arr ) => {
 
 	for ( let i = arr.length - 1; i >= 0; i-- ) {
 		if ( found || arr[ i ] ) {
-			newArr.push( arr[ i ] );
+			newArr.unshift( arr[ i ] );
 		}
 		if ( arr[ i ] ) {
 			found = true;
 		}
 	}
 
-	return newArr.reverse();
+	return newArr;
 };
 
 class CustomNameserversForm extends PureComponent {

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { dropRightWhile } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -15,6 +14,22 @@ import CustomNameserversRow from './custom-nameservers-row';
 
 const MIN_NAMESERVER_LENGTH = 2;
 const MAX_NAMESERVER_LENGTH = 4;
+
+const dropRightWhileEmpty = ( arr ) => {
+	const newArr = [];
+	let found = false;
+
+	for ( let i = arr.length - 1; i >= 0; i-- ) {
+		if ( found || arr[ i ] ) {
+			newArr.push( arr[ i ] );
+		}
+		if ( arr[ i ] ) {
+			found = true;
+		}
+	}
+
+	return newArr.reverse();
+};
 
 class CustomNameserversForm extends PureComponent {
 	static propTypes = {
@@ -51,9 +66,13 @@ class CustomNameserversForm extends PureComponent {
 	};
 
 	rows() {
-		// Remove the empty values from the end, and add one empty one
 		const { translate } = this.props;
-		const nameservers = dropRightWhile( this.props.nameservers, ( nameserver ) => ! nameserver );
+
+		// Remove the empty values from the end, and add one empty one
+		const nameservers = dropRightWhileEmpty(
+			this.props.nameservers,
+			( nameserver ) => ! nameserver
+		);
 
 		if ( nameservers.length < MAX_NAMESERVER_LENGTH ) {
 			nameservers.push( '' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's a single usage of `_.dropRightWhile` in the entire Calypso codebase, and this PR removes it in favor of a simple vanilla JS implementation. It's a rather simple and old-school one, but quite readable IMHO. I'm happy to take any suggestions for improving it.

#### Testing instructions

* Go to `/domains/manage/:domain/edit/:site` where `:domain` and `:site` are a site with a custom domain you own on WP.com
* Expand "Name Servers".
* If "Point to WordPress.com name servers" is enabled, disable it.
* Tinker with editing and adding name servers.
* Verify that you still always have an empty name server field at the bottom, below all the ones you have already input. 
* Verify that you still have at least 2 name server fields at any given time.