### PR TITLE
Framework: Refactor `CloseOnEscape` away from Lodash

### DIFF
--- a/client/components/close-on-escape/index.jsx
+++ b/client/components/close-on-escape/index.jsx
@@ -1,4 +1,4 @@
-import { filter, isEmpty, last } from 'lodash';
+import { filter, last } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -7,7 +7,7 @@ const ESC_KEY_CODE = 27;
 let components = [];
 
 function onKeydown( event ) {
-	if ( ! isEmpty( components ) && event.keyCode === ESC_KEY_CODE && ! isInput( event.target ) ) {
+	if ( components.length && event.keyCode === ESC_KEY_CODE && ! isInput( event.target ) ) {
 		const component = last( components );
 
 		component.onEscape();
@@ -28,14 +28,14 @@ function removeKeydownListener() {
 
 function startCloseOnEscForComponent( component, onEscape ) {
 	components.push( { component, onEscape } );
-	if ( ! isEmpty( components ) ) {
+	if ( components.length ) {
 		addKeydownListener();
 	}
 }
 
 function stopCloseOnEscForComponent( component ) {
 	components = filter( components, ( item ) => item.component !== component );
-	if ( isEmpty( components ) ) {
+	if ( ! components.length ) {
 		removeKeydownListener();
 	}
 }

--- a/client/components/close-on-escape/index.jsx
+++ b/client/components/close-on-escape/index.jsx
@@ -1,4 +1,3 @@
-import { last } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -8,7 +7,7 @@ let components = [];
 
 function onKeydown( event ) {
 	if ( components.length && event.keyCode === ESC_KEY_CODE && ! isInput( event.target ) ) {
-		const component = last( components );
+		const component = components[ components.length - 1 ];
 
 		component.onEscape();
 	}

--- a/client/components/close-on-escape/index.jsx
+++ b/client/components/close-on-escape/index.jsx
@@ -46,7 +46,7 @@ class CloseOnEscape extends Component {
 	}
 
 	componentWillUnmount() {
-		stopCloseOnEscForComponent( this, this.props.onEscape );
+		stopCloseOnEscForComponent( this );
 	}
 
 	render() {

--- a/client/components/close-on-escape/index.jsx
+++ b/client/components/close-on-escape/index.jsx
@@ -1,4 +1,4 @@
-import { filter, last } from 'lodash';
+import { last } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -34,7 +34,7 @@ function startCloseOnEscForComponent( component, onEscape ) {
 }
 
 function stopCloseOnEscForComponent( component ) {
-	components = filter( components, ( item ) => item.component !== component );
+	components = components.filter( ( item ) => item.component !== component );
 	if ( ! components.length ) {
 		removeKeydownListener();
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `CloseOnEscape` component away from Lodash and removes a superfluous trailing argument from the unmount method. Pretty small and self-contained, but even easier to understand when reviewing per-commit.

Part of the larger effort to remove all Lodash usage, see p4TIVU-9Bf-p2

#### Testing instructions

* Go to `/home/:site` where `:site` is a simple WP.com site.
* Click "Switch site" to open the site switcher
* Press "Escape" and verify the site switcher still collapses correctly.