### PR TITLE
Lib: Cleanup unnecessary check in Track Element Size library

### DIFF
--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -13,7 +13,7 @@ function rectIsEqual( prevRect: NullableDOMRect, nextRect: NullableDOMRect ) {
 	}
 
 	if ( nextRect === null ) {
-		return prevRect === null;
+		return false;
 	}
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes an unnecessary check I noticed while I was looking at the `lib/track-element-size` library - if `nextRect` is `null`, we check if `prevRect` is null. However, a few lines above, we already did that check and have a `return` in it, so it's impossible that `prevRect` will be null. Therefore, we can remove that second check.

This was introduced in #31952, cc @sgomes.

#### Testing instructions

* Verify the unit tests for `lib/track-element-size` pass.
* Verify that the Stats charts continue to work normally on resize.