### PR TITLE
Signup: reskin minor flows

### DIFF
--- a/client/signup/steps/reader-landing/style.scss
+++ b/client/signup/steps/reader-landing/style.scss
@@ -1,3 +1,4 @@
+@import '@automattic/onboarding/styles/mixins';
 
 .reader-landing {
 	margin: 0 20px;
@@ -58,7 +59,7 @@
 }
 
 .reader-landing__feature-image {
-	border: 2px solid var( --color-neutral-10 );
+	border: 1px solid var( --color-neutral-10 );
 	border-radius: 2px;
 	width: 100%;
 
@@ -74,8 +75,8 @@
 }
 
 .reader-landing__feature-heading {
+	@include onboarding-font-recoleta;
 	font-size: 1.2em;
-	font-weight: 600;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 1.6em;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -193,7 +193,8 @@
 		"business",
 		"business-monthly",
 		"ecommerce",
-		"ecommerce-monthly"
+		"ecommerce-monthly",
+		"ecommerce-onboarding"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"difm_typeform_id": "YMiXMYId",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -186,6 +186,7 @@
 		"from",
 		"main",
 		"reader",
+		"simple",
 		"woocommerce-install",
 		"with-theme",
 		"free",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -181,6 +181,7 @@
 		"account",
 		"do-it-for-me",
 		"desktop",
+		"developer",
 		"importer",
 		"from",
 		"main",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -180,6 +180,7 @@
 		"setup-site",
 		"account",
 		"do-it-for-me",
+		"desktop",
 		"importer",
 		"from",
 		"main",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -178,6 +178,7 @@
 		"onboarding",
 		"onboarding-with-email",
 		"setup-site",
+		"account",
 		"do-it-for-me",
 		"importer",
 		"from",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -181,6 +181,7 @@
 		"do-it-for-me",
 		"importer",
 		"from",
+		"reader",
 		"woocommerce-install",
 		"with-theme",
 		"free",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -182,6 +182,7 @@
 		"importer",
 		"from",
 		"woocommerce-install",
+		"with-theme",
 		"free",
 		"personal",
 		"personal-monthly",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -182,6 +182,7 @@
 		"do-it-for-me",
 		"importer",
 		"from",
+		"main",
 		"reader",
 		"woocommerce-install",
 		"with-theme",


### PR DESCRIPTION
This takes any of the flows where all of their steps have been reskinned in other flows, and adds them to the configuration to be reskinned. I left off the `wpcc` and `crowdsignal` flows, since the oauth step needs some design work, and we'll need to test the Woo and Jetpack versions of the flow. I think we should follow this up with a review of the lesser-used flows and remove some.

See: p58i-bxw-p2

**To test:**
- In an incognito window, visit the following flows and verify that the steps aren't visually broken
- `/start/with-theme/?theme=quadrat-green`
- `/start/reader/`
- `/start/account/`
- `/start/ecommerce-onboarding/`
- `/start/main/`
- `/start/desktop/`
- `/start/developer/`
- `/start/simple/`