### PR TITLE
Jetpack Cloud: Update price per license copy on billing page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -30,7 +30,7 @@ export default function BillingDetails(): ReactElement {
 							<div className="billing-details__product">
 								{ product.productName }
 								<span className="billing-details__line-item-meta">
-									{ translate( 'Price per license: %(price)s', {
+									{ translate( 'Price per license per month: %(price)s', {
 										args: { price: formatCurrency( product.productCost, 'USD' ) },
 									} ) }
 								</span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR simply changes the text string from "Price per license" to "Price per license per month" in a single place.

#### Testing instructions

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2
* Issue some license(s)
* In order to test this you have to have billing records generated 👉🏻   pdpAdu-4M-p2
* Then go to [Jetpack Cloud - Billing](https://cloud.jetpack.com/partner-portal/billing)
* You should see the text about the license price for each license per month.

#### Screenshots
![image](https://user-images.githubusercontent.com/5550190/149820933-1e148afa-469a-4078-a342-ca15b14c87eb.png)
