### PR TITLE
Domains: Fix domain row popover menu text color when in hovered state

### DIFF
--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -201,6 +201,7 @@ body.dns__body-white {
 	.popover__menu-item.is-selected,
 	.popover__menu-item:hover,
 	.popover__menu-item:focus {
+		color: var( --studio-white );
 		svg {
 			fill: var( --studio-white );
 		}

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -351,6 +351,7 @@
 	.popover__menu-item.is-selected,
 	.popover__menu-item:hover,
 	.popover__menu-item:focus {
+		color: var( --studio-white );
 		svg {
 			fill: var( --studio-white );
 		}

--- a/client/my-sites/domains/domain-management/list/free-domain-item.scss
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.scss
@@ -88,6 +88,7 @@
 	.popover__menu-item.is-selected,
 	.popover__menu-item:hover,
 	.popover__menu-item:focus {
+		color: var( --studio-white );
 		svg {
 			fill: var( --studio-white );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

As reported in #59373, sometimes in the domains list page the popover menu text wasn't visible when in hovered state because the text color wasn't changed to white. That happened because sometimes CSS stylesheets can load in different orders, making some rules have a bigger priority than others when they shouldn't. This PR fixes this by explicitly setting the text color for the menu item when in hovered state.

#### Screenshots

- Before:

![Markup on 2022-01-17 at 16:19:45](https://user-images.githubusercontent.com/5324818/149826904-e2edeab7-a66d-46e1-b502-09e374096aee.png)

- After:

![Markup on 2022-01-17 at 16:20:23](https://user-images.githubusercontent.com/5324818/149826916-5a4618bd-de8f-401e-8d06-068689aab089.png)

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to a site's domains list page (Upgrades > Domains)
- Open a domain's three dots menu and ensure the popover text is visible when hovered