### PR TITLE
Turn on themes/premium flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -141,7 +141,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
-		"themes/premium": false,
+		"themes/premium": true,
 		"titan/iframe-control-panel": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,7 +92,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
-		"themes/premium": false,
+		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -99,7 +99,7 @@
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,
-		"themes/premium": false,
+		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -100,7 +100,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
-		"themes/premium": false,
+		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,7 +108,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
-		"themes/premium": false,
+		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turn on the themes/premium flag

#### Testing instructions

* Use calypso with the softlaunch filter both enabled and disabled
  * while sandboxed, on wpcom, `wp-content/mu-plugins/wpcom-theme-softlaunch.php` both returning an empty array and a array containing premium themes
* The theme showcase + theme switches should continue to work properly in both states

You may also need to turn off the isomorphic attribute to make themes pages load locally.
```diff
diff --git a/client/sections.js b/client/sections.js
index 628832adfd..b1cceaf469 100644
--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
                module: 'calypso/my-sites/themes',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
        },
        {
@@ -219,7 +219,7 @@ const sections = [
                module: 'calypso/my-sites/theme',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
                trackLoadPerformance: true,
        },
```

