### PR TITLE
Show "Thank you" page for domain-only purchases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -41,7 +41,7 @@ const DomainRegistrationThankYouProps = ( {
 						),
 						stepCta: (
 							<FullWidthButton
-								href={ domainManagementList( selectedSiteSlug, null ) }
+								href={ domainManagementList( selectedSiteSlug ?? domain, null ) }
 								primary
 								busy={ false }
 								disabled={ false }

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -54,7 +54,7 @@ export function buildDomainStepForProfessionalEmail(
 			),
 			stepCta: (
 				<FullWidthButton
-					href={ emailManagementPurchaseNewEmailAccount( selectedSiteSlug, domain ) }
+					href={ emailManagementPurchaseNewEmailAccount( selectedSiteSlug ?? domain, domain ) }
 					className={ `domain-${ domainType }__thank-you-button domain-thank-you__button` }
 					primary={ primary }
 					busy={ false }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -121,7 +121,6 @@ export class CheckoutThankYou extends Component {
 
 	componentDidMount() {
 		this.redirectIfThemePurchased();
-		this.redirectIfDomainOnly( this.props );
 
 		const {
 			gsuiteReceipt,
@@ -163,7 +162,6 @@ export class CheckoutThankYou extends Component {
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		this.redirectIfThemePurchased();
-		this.redirectIfDomainOnly( nextProps );
 
 		if (
 			! this.props.receipt.hasLoadedFromServer &&
@@ -271,17 +269,6 @@ export class CheckoutThankYou extends Component {
 				true
 			);
 			page.redirect( '/themes/' + this.props.selectedSite.slug );
-		}
-	};
-
-	redirectIfDomainOnly = ( props ) => {
-		if ( props.domainOnlySiteFlow && get( props, 'receipt.hasLoadedFromServer', false ) ) {
-			const purchases = getPurchases( props );
-			const failedPurchases = getFailedPurchases( props );
-			if ( purchases.length > 0 && ! failedPurchases.length ) {
-				const domainName = find( purchases, isDomainRegistration ).meta;
-				page.redirect( domainManagementList( domainName ) );
-			}
 		}
 	};
 

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -174,11 +174,15 @@ export class CheckoutThankYou extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { receiptId, selectedSiteSlug } = this.props;
+		const { receiptId, selectedSiteSlug, domainOnlySiteFlow } = this.props;
 
 		// Update route when an ecommerce site goes Atomic and site slug changes
 		// from 'wordpress.com` to `wpcomstaging.com`.
-		if ( selectedSiteSlug && selectedSiteSlug !== prevProps.selectedSiteSlug ) {
+		if (
+			selectedSiteSlug &&
+			selectedSiteSlug !== prevProps.selectedSiteSlug &&
+			! domainOnlySiteFlow
+		) {
 			const receiptPath = receiptId ? `/${ receiptId }` : '';
 			page( `/checkout/thank-you/${ selectedSiteSlug }${ receiptPath }` );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently, for a domain-only purchase, the "Thank you" page is not being shown after checking out. This PR adds it and also adds some fixes so that the action buttons on the thank you page work properly with it.

#### Preview
![image](https://user-images.githubusercontent.com/18705930/149833600-eb9ee983-01e9-454a-b386-8d8204a40f3c.png)


#### Testing instructions
You can do it two ways:
- Go to `/start/domain/domain-only`;
- Select any available domain name;
- Finish the checkout;

Or:
- Get a valid `receiptId` for a previous domain-only purchase of yours;
- Browse to `/checkout/thank-you/no-site/:receiptId`;

---
After that:
- Check that the "Thank you" page is shown and that all the information is correct;
- Also check that both "Manage domains" and "Add email" buttons redirect you to the correct pages;
