### PR TITLE
Hide masterbar-cart-button at small widths

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
@@ -1,5 +1,9 @@
 .masterbar-cart-button {
 	cursor: pointer;
+	/* Hide at small widths until we can figure out how to improve the alignment: https://github.com/Automattic/wp-calypso/issues/60148 */
+	@include breakpoint-deprecated( '<480px' ) {
+		display: none;
+	}
 }
 
 .masterbar-cart-button__count-container {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This resolves https://github.com/Automattic/wp-calypso/issues/60148 by hiding the masterbar cart button (the `mini-cart` package used in calypso) at small widths. This is not ideal, but until we can find another way to align the items, it will solve the immediate problem.

Before (with arrow to show what happened to the notifications icon):

<img width="353" alt="Screen_Shot_2022-01-17_at_2_23_23_PM" src="https://user-images.githubusercontent.com/2036909/149834483-c649265e-003a-4927-ae99-19fe614edf33.png">

After:

<img width="322" alt="Screen Shot 2022-01-17 at 3 36 32 PM" src="https://user-images.githubusercontent.com/2036909/149834515-2cae5878-f030-46b7-9100-b8f70e0a3b0f.png">


#### Testing instructions

- Add a product to your cart but leave checkout with the cart item remaining.
- View `/home` at various widths.
- Verify that you see the masterbar cart icon displayed at desktop widths, but hidden at small widths.