### PR TITLE
Theme Showcase: Fix alignment of "active" indicator

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -129,7 +129,6 @@ $theme-info-height: 54px;
 
 .theme__badge-active {
 	flex: 0 0 auto;
-	padding: 18px 10px 0;
 	color: var( --color-primary-0 );
 	text-transform: uppercase;
 	font-size: $font-body-extra-small;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up to #60009, the "active" theme indicator needs a padding adjustment to match. Quick visual fix.

**Before**

<img width="311" alt="Screen Shot 2022-01-17 at 3 55 57 PM" src="https://user-images.githubusercontent.com/2124984/149836362-0be5a252-cf3d-4bdd-9652-d1935f8275a6.png">

**After**

<img width="308" alt="Screen Shot 2022-01-17 at 4 05 46 PM" src="https://user-images.githubusercontent.com/2124984/149836941-6a63fa3c-f5e4-40e3-9741-99cc17a06ce6.png">


#### Testing instructions

* Switch to this PR, navigate to `/themes`, activate a theme
* Note the alignment of the "Active" text next to the three-dots menu for that theme.
* Make sure other elements in this area are aligned as expected with different plan types (free, premium, etc.)