### PR TITLE
Plugin Details: remove "Description" tab header when there are no more tabs

### DIFF
--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -321,7 +321,7 @@ class PluginSections extends Component {
 						</SectionNav>
 					</div>
 				) }
-				<Card>
+				<Card className={ classNames( { 'no-header': hasOnlyDescriptionSection } ) }>
 					{ 'faq' === this.getSelected() && this.props.isWpcom && this.getWpcomSupportContent() }
 					{ this.renderSelectedSection() }
 					{ this.renderReadMore() }

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -290,30 +290,37 @@ class PluginSections extends Component {
 	}
 
 	render() {
+		const availableSections = this.getAvailableSections();
 		// Defensively check if this plugin has sections. If not, don't render anything.
-		if ( ! this.props.plugin || ! this.props.plugin.sections || ! this.getAvailableSections() ) {
+		if ( ! this.props.plugin || ! this.props.plugin.sections || ! availableSections ) {
 			return null;
 		}
 
+		const hasOnlyDescriptionSection =
+			availableSections.length === 1 &&
+			availableSections.find( ( section ) => section.key === 'description' );
+
 		return (
 			<div className={ classNames( 'plugin-sections', this.props.className ) }>
-				<div className="plugin-sections__header">
-					<SectionNav selectedText={ this.getNavTitle( this.getSelected() ) }>
-						<NavTabs>
-							{ this.getAvailableSections().map( function ( section ) {
-								return (
-									<NavItem
-										key={ section.key }
-										onClick={ this.setSelectedSection.bind( this, section.key ) }
-										selected={ this.getSelected() === section.key }
-									>
-										{ section.title }
-									</NavItem>
-								);
-							}, this ) }
-						</NavTabs>
-					</SectionNav>
-				</div>
+				{ ! hasOnlyDescriptionSection && (
+					<div className="plugin-sections__header">
+						<SectionNav selectedText={ this.getNavTitle( this.getSelected() ) }>
+							<NavTabs>
+								{ availableSections.map( function ( section ) {
+									return (
+										<NavItem
+											key={ section.key }
+											onClick={ this.setSelectedSection.bind( this, section.key ) }
+											selected={ this.getSelected() === section.key }
+										>
+											{ section.title }
+										</NavItem>
+									);
+								}, this ) }
+							</NavTabs>
+						</SectionNav>
+					</div>
+				) }
 				<Card>
 					{ 'faq' === this.getSelected() && this.props.isWpcom && this.getWpcomSupportContent() }
 					{ this.renderSelectedSection() }

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -129,6 +129,10 @@
 .plugin-details__plugins-sections {
 	.card {
 		padding-top: 44px;
+
+		&.no-header {
+			padding-top: 20px;
+		}
 	}
 
 	.plugin-sections__banner {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Stop showing the section title when only the description section is available.
* Update padding when no header is shown on Plugin Details sections.

#### Testing instructions
* Go to a paid plugin details page (Ex: `plugins/automatewoo/{site}`). Paid plugins only have description tabs currently.
* Check if the description header is being shown. It shouldn't.
* Go to a free plugin details page (Ex: `/plugins/contact-form-7/{site}`). Free plugins usually have more than one tab.
* Check if the description header is being shown. It should still be shown. 

| Before  | After |
| ------------- | ------------- |
| <img width="1170" alt="Screen Shot 2022-01-17 at 17 49 27" src="https://user-images.githubusercontent.com/5039531/149841698-117995cf-1ba6-4b2c-a06f-3de9299bee95.png">|<img width="1170" alt="Screen Shot 2022-01-17 at 18 02 37" src="https://user-images.githubusercontent.com/5039531/149841709-8745b8f3-5913-4db0-b1b2-a24e5b75d102.png">|



---

Fixes #59711
