### PR TITLE
Masterbar: Update to use dynamic button alignment rather than padding

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -81,7 +81,6 @@
 
 	// New post button
 	.masterbar__item-new {
-		padding: 0 8px;
 		font-size: $nav-unification-masterbar-font-size;
 		background: var( --studio-white );
 		color: $nav-unification-primary;
@@ -150,7 +149,6 @@
 			height: 36px;
 			margin-top: 5px;
 			width: auto;
-			padding: 0 8px;
 		}
 
 		.masterbar__toggle-drafts.button.is-borderless {
@@ -199,9 +197,6 @@
 
 	// Notifications button
 	.masterbar__item-notifications {
-		padding-right: 5px;
-		padding-left: 5px;
-
 		.gridicon {
 			margin-top: 1px;
 		}
@@ -217,7 +212,6 @@
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item-notifications {
 			margin-right: 10px;
-			padding: 0 15px;
 			width: 26px;
 
 			.gridicon {
@@ -236,7 +230,6 @@
 			margin-top: 0;
 			margin-left: auto;
 			margin-right: auto;
-			padding: 0 8px;
 			width: auto;
 		}
 	}

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -48,7 +48,7 @@
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item {
-		padding: 0 8px;
+		padding: 0;
 		font-size: $nav-unification-masterbar-font-size;
 	}
 
@@ -69,7 +69,6 @@
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item {
 			font-size: $nav-unification-masterbar-mobile-font-size;
-			padding: 0 15px;
 		}
 
 		.masterbar__item .gridicon + .masterbar__item-content {
@@ -164,9 +163,6 @@
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item-me {
-		padding-right: 10px;
-		padding-left: 8px;
-
 		.gravatar {
 			top: 50%;
 			left: 50%;
@@ -176,8 +172,6 @@
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item-me {
-			padding: 0 13px 0 15px;
-
 			// fix for profile picture currently hidden in production
 			.masterbar__item-content {
 				display: block;
@@ -197,8 +191,6 @@
 
 	@include breakpoint-deprecated( '<480px' ) {
 		.masterbar__item-me {
-			padding: 0 11px;
-
 			.gravatar {
 				width: 19px;
 				height: 19px;

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -48,7 +48,6 @@
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item {
-		padding: 0;
 		font-size: $nav-unification-masterbar-font-size;
 	}
 

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -9,7 +9,7 @@ const noop = () => {};
 
 interface MasterbarItemProps {
 	url?: string;
-	innerRef?: LegacyRef< HTMLButtonElement >;
+	innerRef?: LegacyRef< HTMLButtonElement | HTMLAnchorElement >;
 	tipTarget?: string;
 	onClick?: () => void;
 	tooltip?: string;
@@ -84,20 +84,24 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 
 		if ( this.props.url ) {
 			return (
-				<a { ...attributes } href={ this.props.url }>
+				<a
+					{ ...attributes }
+					href={ this.props.url }
+					ref={ this.props.innerRef as LegacyRef< HTMLAnchorElement > }
+				>
 					{ this.renderChildren() }
 				</a>
 			);
 		}
 
 		return (
-			<button { ...attributes } ref={ this.props.innerRef }>
+			<button { ...attributes } ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > }>
 				{ this.renderChildren() }
 			</button>
 		);
 	}
 }
 
-export default forwardRef< HTMLButtonElement, MasterbarItemProps >( ( props, ref ) => (
-	<MasterbarItem innerRef={ ref } { ...props } />
-) );
+export default forwardRef< HTMLButtonElement | HTMLAnchorElement, MasterbarItemProps >(
+	( props, ref ) => <MasterbarItem innerRef={ ref } { ...props } />
+);

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -241,81 +241,89 @@ class MasterbarLoggedIn extends Component {
 					/>
 				) : null }
 				<Masterbar>
-					{ this.renderMySites() }
-					<Item
-						tipTarget="reader"
-						className="masterbar__reader"
-						url="/read"
-						icon="reader"
-						onClick={ this.clickReader }
-						isActive={ this.isActive( 'reader' ) }
-						tooltip={ translate( 'Read the blogs and topics you follow' ) }
-						preloadSection={ this.preloadReader }
-					>
-						{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
-					</Item>
-					{ ( this.props.isSupportSession || config.isEnabled( 'quick-language-switcher' ) ) && (
-						<AsyncLoad require="./quick-language-switcher" placeholder={ null } />
-					) }
-					{ isWordPressActionSearchFeatureEnabled && (
+					<div className="masterbar__section masterbar__section--left">
+						{ this.renderMySites() }
 						<Item
-							tipTarget="Action Search"
-							icon="search"
-							onClick={ this.clickSearchActions }
-							isActive={ false }
-							className="masterbar__item-action-search"
-							tooltip={ translate( 'Search' ) }
+							tipTarget="reader"
+							className="masterbar__reader"
+							url="/read"
+							icon="reader"
+							onClick={ this.clickReader }
+							isActive={ this.isActive( 'reader' ) }
+							tooltip={ translate( 'Read the blogs and topics you follow' ) }
+							preloadSection={ this.preloadReader }
+						>
+							{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
+						</Item>
+						{ ( this.props.isSupportSession || config.isEnabled( 'quick-language-switcher' ) ) && (
+							<AsyncLoad require="./quick-language-switcher" placeholder={ null } />
+						) }
+						{ isWordPressActionSearchFeatureEnabled && (
+							<Item
+								tipTarget="Action Search"
+								icon="search"
+								onClick={ this.clickSearchActions }
+								isActive={ false }
+								className="masterbar__item-action-search"
+								tooltip={ translate( 'Search' ) }
+								preloadSection={ this.preloadMe }
+							>
+								{ translate( 'Search Actions' ) }
+							</Item>
+						) }
+					</div>
+					<div className="masterbar__section masterbar__section--center">
+						<AsyncLoad require="calypso/my-sites/resume-editing" placeholder={ null } />
+						{ ! domainOnlySite && ! isMigrationInProgress && (
+							<AsyncLoad
+								require="./publish"
+								placeholder={ null }
+								isActive={ this.isActive( 'post' ) }
+								className="masterbar__item-new"
+								tooltip={ translate( 'Create a New Post' ) }
+							>
+								{ translate( 'Write' ) }
+							</AsyncLoad>
+						) }
+					</div>
+					<div className="masterbar__section masterbar__section--right">
+						<AsyncLoad
+							require="./masterbar-cart/masterbar-cart-wrapper"
+							placeholder={ null }
+							goToCheckout={ this.goToCheckout }
+							selectedSiteSlug={ currentSelectedSiteSlug }
+							selectedSiteId={ currentSelectedSiteId }
+						/>
+						<Item
+							tipTarget="me"
+							url="/me"
+							icon="user-circle"
+							onClick={ this.clickMe }
+							isActive={ this.isActive( 'me' ) }
+							className="masterbar__item-me"
+							tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 							preloadSection={ this.preloadMe }
 						>
-							{ translate( 'Search Actions' ) }
+							<Gravatar user={ this.props.user } alt={ translate( 'My Profile' ) } size={ 18 } />
+							<span className="masterbar__item-me-label">
+								{ translate( 'My Profile', {
+									context: 'Toolbar, must be shorter than ~12 chars',
+								} ) }
+							</span>
 						</Item>
-					) }
-					<AsyncLoad require="calypso/my-sites/resume-editing" placeholder={ null } />
-					{ ! domainOnlySite && ! isMigrationInProgress && (
-						<AsyncLoad
-							require="./publish"
-							placeholder={ null }
-							isActive={ this.isActive( 'post' ) }
-							className="masterbar__item-new"
-							tooltip={ translate( 'Create a New Post' ) }
+						<Notifications
+							isShowing={ this.props.isNotificationsShowing }
+							isActive={ this.isActive( 'notifications' ) }
+							className="masterbar__item-notifications"
+							tooltip={ translate( 'Manage your notifications' ) }
 						>
-							{ translate( 'Write' ) }
-						</AsyncLoad>
-					) }
-					<AsyncLoad
-						require="./masterbar-cart/masterbar-cart-wrapper"
-						placeholder={ null }
-						goToCheckout={ this.goToCheckout }
-						selectedSiteSlug={ currentSelectedSiteSlug }
-						selectedSiteId={ currentSelectedSiteId }
-					/>
-					<Item
-						tipTarget="me"
-						url="/me"
-						icon="user-circle"
-						onClick={ this.clickMe }
-						isActive={ this.isActive( 'me' ) }
-						className="masterbar__item-me"
-						tooltip={ translate( 'Update your profile, personal settings, and more' ) }
-						preloadSection={ this.preloadMe }
-					>
-						<Gravatar user={ this.props.user } alt={ translate( 'My Profile' ) } size={ 18 } />
-						<span className="masterbar__item-me-label">
-							{ translate( 'My Profile', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
-						</span>
-					</Item>
-					<Notifications
-						isShowing={ this.props.isNotificationsShowing }
-						isActive={ this.isActive( 'notifications' ) }
-						className="masterbar__item-notifications"
-						tooltip={ translate( 'Manage your notifications' ) }
-					>
-						<span className="masterbar__item-notifications-label">
-							{ translate( 'Notifications', {
-								comment: 'Toolbar, must be shorter than ~12 chars',
-							} ) }
-						</span>
-					</Notifications>
+							<span className="masterbar__item-notifications-label">
+								{ translate( 'Notifications', {
+									comment: 'Toolbar, must be shorter than ~12 chars',
+								} ) }
+							</span>
+						</Notifications>
+					</div>
 				</Masterbar>
 			</>
 		);

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
@@ -1,9 +1,5 @@
 .masterbar-cart-button {
 	cursor: pointer;
-	/* Hide at small widths until we can figure out how to improve the alignment: https://github.com/Automattic/wp-calypso/issues/60148 */
-	@include breakpoint-deprecated( '<480px' ) {
-		display: none;
-	}
 }
 
 .masterbar-cart-button__count-container {

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -22,6 +22,7 @@ class MasterbarItemNotifications extends Component {
 	};
 
 	notificationLink = createRef();
+	notificationPanel = createRef();
 
 	state = {
 		animationState: 0,
@@ -40,15 +41,20 @@ class MasterbarItemNotifications extends Component {
 		// focus on main window if we just closed the notes panel
 		if ( this.props.isNotificationsOpen && ! nextProps.isNotificationsOpen ) {
 			this.notificationLink.current.blur();
+			this.notificationPanel.current.blur();
 			window.focus();
 		}
 	}
 
 	checkToggleNotes = ( event, forceToggle ) => {
 		const target = event ? event.target : false;
-		const notificationNode = this.notificationLink.current;
 
-		if ( target && notificationNode.contains( target ) ) {
+		// Ignore clicks or other events which occur inside of the notification panel.
+		if (
+			target &&
+			( this.notificationLink.current.contains( target ) ||
+				this.notificationPanel.current.contains( target ) )
+		) {
 			return;
 		}
 
@@ -96,14 +102,14 @@ class MasterbarItemNotifications extends Component {
 	};
 
 	render() {
-		const classes = classNames( this.props.className, {
+		const classes = classNames( this.props.className, 'masterbar__notifications', {
 			'is-active': this.props.isNotificationsOpen,
 			'has-unread': this.state.newNote,
 			'is-initial-load': this.state.animationState === -1,
 		} );
 
 		return (
-			<div className="masterbar__notifications" ref={ this.notificationLink }>
+			<>
 				<MasterbarItem
 					url="/notifications"
 					icon="bell"
@@ -111,6 +117,7 @@ class MasterbarItemNotifications extends Component {
 					isActive={ this.props.isActive }
 					tooltip={ this.props.tooltip }
 					className={ classes }
+					ref={ this.notificationLink }
 				>
 					{ this.props.children }
 					<span
@@ -120,14 +127,16 @@ class MasterbarItemNotifications extends Component {
 						}
 					/>
 				</MasterbarItem>
-				<AsyncLoad
-					require="calypso/notifications"
-					isShowing={ this.props.isNotificationsOpen }
-					checkToggle={ this.checkToggleNotes }
-					setIndicator={ this.setNotesIndicator }
-					placeholder={ null }
-				/>
-			</div>
+				<div className="masterbar__notifications-panel" ref={ this.notificationPanel }>
+					<AsyncLoad
+						require="calypso/notifications"
+						isShowing={ this.props.isNotificationsOpen }
+						checkToggle={ this.checkToggleNotes }
+						setIndicator={ this.setNotesIndicator }
+						placeholder={ null }
+					/>
+				</div>
+			</>
 		);
 	}
 }

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -103,7 +103,7 @@ class MasterbarItemNotifications extends Component {
 		} );
 
 		return (
-			<div className="masterbar__notifications masterbar__item" ref={ this.notificationLink }>
+			<div className="masterbar__notifications" ref={ this.notificationLink }>
 				<MasterbarItem
 					url="/notifications"
 					icon="bell"

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -103,7 +103,7 @@ class MasterbarItemNotifications extends Component {
 		} );
 
 		return (
-			<div className="masterbar__notifications" ref={ this.notificationLink }>
+			<div className="masterbar__notifications masterbar__item" ref={ this.notificationLink }>
 				<MasterbarItem
 					url="/notifications"
 					icon="bell"

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -27,6 +27,7 @@ $autobar-height: 20px;
 	-webkit-font-smoothing: subpixel-antialiased;
 	transition: transform 0.2s ease-out;
 	box-sizing: border-box;
+	justify-content: space-between;
 
 	.is-support-session & {
 		// Use generic colors so that they override whatever theme colors the user has picked.

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -29,6 +29,7 @@ $autobar-height: 20px;
 	transition: transform 0.2s ease-out;
 	box-sizing: border-box;
 	justify-content: space-between;
+	white-space: nowrap;
 
 	.is-support-session & {
 		// Use generic colors so that they override whatever theme colors the user has picked.

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -496,10 +496,6 @@ $autobar-height: 20px;
 		}
 	}
 
-	.masterbar__notifications {
-		display: flex;
-	}
-
 	.masterbar__item-notifications-label {
 		display: none;
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -122,13 +122,10 @@ $autobar-height: 20px;
 .masterbar__section {
 	flex: 2;
 	display: flex;
-}
 
-.masterbar__section--left {
 	@include breakpoint-deprecated( '>480px' ) {
 		.masterbar__item {
-			flex-grow: 0;
-			min-width: 100px;
+			flex: 0 0 auto;
 		}
 	}
 }
@@ -137,17 +134,13 @@ $autobar-height: 20px;
 	flex: 1;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		flex-grow: 0;
+		flex: 0 0 auto;
 	}
 }
 
 .masterbar__section--right {
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-grow: 0;
-
-		.masterbar__item {
-			min-width: 50px;
-		}
 	}
 }
 
@@ -165,7 +158,7 @@ $autobar-height: 20px;
 	font-size: $font-body-small;
 	height: var( --masterbar-height );
 	line-height: var( --masterbar-height );
-	padding: 0;
+	padding: 0 8px;
 	text-decoration: none;
 	cursor: default;
 	transition: all 0.2s ease-in-out;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -496,6 +496,10 @@ $autobar-height: 20px;
 		}
 	}
 
+	.masterbar__notifications {
+		display: flex;
+	}
+
 	.masterbar__item-notifications-label {
 		display: none;
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -145,7 +145,7 @@ $autobar-height: 20px;
 		flex-grow: 0;
 
 		.masterbar__item {
-			min-width: 40px;
+			min-width: 50px;
 		}
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -710,12 +710,6 @@ $autobar-height: 20px;
 	margin-bottom: 35px;
 }
 
-.masterbar__notifications {
-	@include breakpoint-deprecated( '>480px' ) {
-		flex-grow: 0;
-	}
-}
-
 a.masterbar__quick-language-switcher {
 	cursor: pointer;
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -118,7 +118,7 @@ $autobar-height: 20px;
 }
 
 .masterbar__item {
-	flex: 0 1 auto;
+	flex: 1;
 	display: flex;
 	align-items: center;
 	position: relative;
@@ -126,7 +126,7 @@ $autobar-height: 20px;
 	font-size: $font-body-small;
 	height: var( --masterbar-height );
 	line-height: var( --masterbar-height );
-	padding: 0 15px;
+	padding: 0;
 	text-decoration: none;
 	cursor: default;
 	transition: all 0.2s ease-in-out;
@@ -219,8 +219,6 @@ $autobar-height: 20px;
 	}
 
 	@include breakpoint-deprecated( '<480px' ) {
-		flex: 1 1 auto;
-
 		.gridicon {
 			margin: 0 auto;
 		}
@@ -674,8 +672,6 @@ $autobar-height: 20px;
 }
 
 .masterbar__notifications {
-	flex: 1 1 auto;
-
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-grow: 0;
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -23,6 +23,7 @@ $autobar-height: 20px;
 	left: 0;
 	top: 0;
 	width: 100%;
+	max-width: 100vw;
 	z-index: z-index( 'root', '.masterbar' );
 	-webkit-font-smoothing: subpixel-antialiased;
 	transition: transform 0.2s ease-out;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -118,6 +118,43 @@ $autobar-height: 20px;
 	}
 }
 
+.masterbar__section {
+	flex: 2;
+	display: flex;
+}
+
+.masterbar__section--left {
+	@include breakpoint-deprecated( '>480px' ) {
+		.masterbar__item {
+			flex-grow: 0;
+			min-width: 100px;
+		}
+	}
+}
+
+.masterbar__section--center {
+	flex: 1;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		flex-grow: 0;
+	}
+}
+
+.masterbar__section--right {
+	@include breakpoint-deprecated( '>480px' ) {
+		flex-grow: 0;
+
+		.masterbar__item {
+			min-width: 40px;
+		}
+	}
+}
+
+
+.masterbar__drafts {
+	white-space: nowrap;
+}
+
 .masterbar__item {
 	flex: 1;
 	display: flex;
@@ -131,6 +168,7 @@ $autobar-height: 20px;
 	text-decoration: none;
 	cursor: default;
 	transition: all 0.2s ease-in-out;
+	justify-content: center;
 
 	&:visited {
 		color: var( --color-masterbar-text );


### PR DESCRIPTION
#### Background

The buttons in the masterbar are spaced using CSS `padding` even though the masterbar container uses flexbox. The result is that the position and spacing of the buttons relies on a large number of small adjustments in button-specific overrides and media queries (the notifications button in particular is very awkward) that can fall apart if a button is added or removed, causing unexpected wrapping, push elements off the page, and prevent the "Write" button from being centered.

Because of this issue, we've had to [hide the shopping cart button at small widths](https://github.com/Automattic/wp-calypso/issues/60148). However, there are more optional buttons that sometimes may appear like the Quick Language Switcher and the Action Search bar, so this could be a problem in several cases.

#### Changes proposed in this Pull Request

This PR modifies the masterbar so that instead of being a **single container** for a variable number of buttons, it is a box containing **three _masterbar sections_**. Each masterbar section contains a variable number of buttons. Typically, the left section contains the Sites and Reader buttons, the center section contains the Write buttons, and the right section contains the User and Notifications buttons.

At small widths, the two outer sections have equal widths and the center section has a slightly smaller width. This keeps the Write button centered at all times but not taking up any more space than necessary, allowing space for additional buttons (like the Cart) in the left and right sections.

At wide widths, the center and right section take up a small width and the left section is given a large width. This collapses the Write button up against the right section buttons.

Fixes https://github.com/Automattic/wp-calypso/issues/60158

Reverts https://github.com/Automattic/wp-calypso/pull/60157

#### Screenshots

Mobile width when the cart icon is not visible:

<img width="328" alt="Screen Shot 2022-01-18 at 2 35 59 PM" src="https://user-images.githubusercontent.com/2036909/150006414-34702334-dd3f-4097-adc0-5c9f635d0e55.png">

Mobile width when the cart icon is visible:

<img width="329" alt="Screen Shot 2022-01-18 at 2 36 44 PM" src="https://user-images.githubusercontent.com/2036909/150006525-ac5dbb4f-b7c2-4645-9e66-d6b1bb7d7a61.png">

Desktop width:

<img width="931" alt="Screen Shot 2022-01-18 at 12 12 06 PM" src="https://user-images.githubusercontent.com/2036909/149985365-e56987c5-2946-4efd-8ea4-6e18c1688650.png">

Desktop width when all currently possible buttons are visible:

<img width="927" alt="with-all-buttons" src="https://user-images.githubusercontent.com/2036909/149985561-a4186256-fbdf-47f9-ac12-f093697db57b.png">

Mobile width without nav unification:

<img width="329" alt="Screen Shot 2022-01-18 at 3 04 47 PM" src="https://user-images.githubusercontent.com/2036909/150010373-948b84cb-f4bb-4c4c-9fc6-d9d1c6d48d20.png">

Desktop width without nav unification:

<img width="859" alt="Screen Shot 2022-01-18 at 3 04 29 PM" src="https://user-images.githubusercontent.com/2036909/150010397-94b3f2f6-99ae-4a6d-baf1-d78a83bef2a5.png">

Logged-out masterbar at mobile width:

<img width="327" alt="Screen Shot 2022-01-18 at 4 33 41 PM" src="https://user-images.githubusercontent.com/2036909/150022265-4bee7306-8c70-4746-93b1-051a4bb8c4e8.png">

Logged-out masterbar at desktop width:

<img width="1024" alt="Screen Shot 2022-01-18 at 4 33 26 PM" src="https://user-images.githubusercontent.com/2036909/150022276-79c51da6-9432-40c9-912a-a2ab6182e66f.png">

Jetpack cloud at mobile width:

<img width="329" alt="Screen Shot 2022-01-18 at 4 39 41 PM" src="https://user-images.githubusercontent.com/2036909/150023010-e9349ea3-b675-4e89-b7bc-701562448218.png">


Jetpack cloud at desktop width:

<img width="1024" alt="Screen Shot 2022-01-18 at 4 39 54 PM" src="https://user-images.githubusercontent.com/2036909/150023021-9d8aed8a-aac1-4719-861e-64f8df7c84a6.png">

#### Testing instructions

View the masterbar at different widths to verify that nothing looks awkward and that the "Write" button remains centered.

Remember that the cart icon will not be displayed unless there are items currently in the cart.