### PR TITLE
Checkout: Hide masterbar on checkout pending page

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -209,6 +209,7 @@ class Layout extends Component {
 			<MasterbarComponent
 				section={ this.props.sectionGroup }
 				isCheckout={ this.props.sectionName === 'checkout' }
+				isCheckoutPending={ this.props.sectionName === 'checkout-pending' }
 			/>
 		);
 	}

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -39,6 +39,7 @@ const LayoutLoggedOut = ( {
 	showGdprBanner,
 } ) => {
 	const isCheckout = sectionName === 'checkout';
+	const isCheckoutPending = sectionName === 'checkout-pending';
 	const isJetpackCheckout =
 		sectionName === 'checkout' && window.location.pathname.startsWith( '/checkout/jetpack' );
 
@@ -87,6 +88,7 @@ const LayoutLoggedOut = ( {
 				title={ sectionTitle }
 				sectionName={ sectionName }
 				isCheckout={ isCheckout }
+				isCheckoutPending={ isCheckoutPending }
 				redirectUri={ redirectUri }
 			/>
 		);

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -16,6 +16,7 @@ interface Props {
 	isJetpackNotAtomic?: boolean;
 	previousPath?: string;
 	siteSlug?: string;
+	isLeavingAllowed?: boolean;
 }
 
 const CheckoutMasterbar: FunctionComponent< Props > = ( {
@@ -23,6 +24,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	isJetpackNotAtomic,
 	previousPath,
 	siteSlug,
+	isLeavingAllowed,
 } ) => {
 	const translate = useTranslate();
 	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( siteSlug );
@@ -61,13 +63,15 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	return (
 		<Masterbar>
 			<div className="masterbar__secure-checkout">
-				<Item
-					icon="cross"
-					className="masterbar__close-button"
-					onClick={ clickClose }
-					tooltip={ String( translate( 'Close Checkout' ) ) }
-					tipTarget="close"
-				/>
+				{ isLeavingAllowed && (
+					<Item
+						icon="cross"
+						className="masterbar__close-button"
+						onClick={ clickClose }
+						tooltip={ String( translate( 'Close Checkout' ) ) }
+						tipTarget="close"
+					/>
+				) }
 				{ ! isJetpack && <WordPressWordmark className="masterbar__wpcom-wordmark" /> }
 				{ isJetpack && <JetpackLogo className="masterbar__jetpack-wordmark" full /> }
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -47,6 +47,7 @@ class MasterbarLoggedIn extends Component {
 		siteSlug: PropTypes.string,
 		hasMoreThanOneSite: PropTypes.bool,
 		isCheckout: PropTypes.bool,
+		isCheckoutPending: PropTypes.bool,
 	};
 
 	handleLayoutFocus = ( currentSection ) => {
@@ -204,6 +205,7 @@ class MasterbarLoggedIn extends Component {
 			domainOnlySite,
 			translate,
 			isCheckout,
+			isCheckoutPending,
 			isMigrationInProgress,
 			previousPath,
 			siteSlug,
@@ -215,7 +217,7 @@ class MasterbarLoggedIn extends Component {
 
 		const { isActionSearchVisible } = this.state;
 
-		if ( isCheckout ) {
+		if ( isCheckout || isCheckoutPending ) {
 			return (
 				<AsyncLoad
 					require="calypso/layout/masterbar/checkout.tsx"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -226,6 +226,7 @@ class MasterbarLoggedIn extends Component {
 					isJetpackNotAtomic={ isJetpackNotAtomic }
 					previousPath={ previousPath }
 					siteSlug={ siteSlug }
+					isLeavingAllowed={ ! isCheckoutPending }
 				/>
 			);
 		}

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -18,6 +18,8 @@ class MasterbarLoggedOut extends Component {
 		redirectUri: PropTypes.string,
 		sectionName: PropTypes.string,
 		title: PropTypes.string,
+		isCheckout: PropTypes.bool,
+		isCheckoutPending: PropTypes.bool,
 
 		// Connected props
 		currentQuery: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
@@ -133,14 +135,15 @@ class MasterbarLoggedOut extends Component {
 	}
 
 	render() {
-		const { title, isCheckout } = this.props;
+		const { title, isCheckout, isCheckoutPending } = this.props;
 
-		if ( isCheckout ) {
+		if ( isCheckout || isCheckoutPending ) {
 			return (
 				<AsyncLoad
 					require="calypso/layout/masterbar/checkout.tsx"
 					placeholder={ null }
 					title={ title }
+					isLeavingAllowed={ ! isCheckoutPending }
 				/>
 			);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -2,6 +2,7 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.is-section-checkout-pending,
 .is-section-checkout-thank-you {
 	background: var( --studio-white );
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -649,11 +649,13 @@
 	}
 }
 
+.is-section-checkout-pending .empty-content__title,
 .is-section-checkout-thank-you .empty-content__title {
 	font-size: $font-title-small;
 	font-weight: normal;
 }
 
+.is-section-checkout-pending .empty-content__line,
 .is-section-checkout-thank-you .empty-content__line {
 	font-size: $font-body;
 	font-weight: normal;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -196,7 +196,7 @@ export function checkoutPending( context, next ) {
 	const orderId = Number( context.params.orderId );
 	const siteSlug = context.params.site;
 
-	setSectionMiddleware( { name: 'checkout-thank-you' } )( context );
+	setSectionMiddleware( { name: 'checkout-pending' } )( context );
 
 	context.primary = (
 		<CheckoutPendingComponent

--- a/client/state/guided-tours/selectors/index.js
+++ b/client/state/guided-tours/selectors/index.js
@@ -16,6 +16,7 @@ import 'calypso/state/guided-tours/init';
 const SECTIONS_WITHOUT_TOURS = [
 	'signup',
 	'upgrades', // checkout
+	'checkout-pending', // checkout pending pager
 	'checkout-thank-you', // thank you page
 ];
 

--- a/client/state/guided-tours/selectors/index.js
+++ b/client/state/guided-tours/selectors/index.js
@@ -16,7 +16,7 @@ import 'calypso/state/guided-tours/init';
 const SECTIONS_WITHOUT_TOURS = [
 	'signup',
 	'upgrades', // checkout
-	'checkout-pending', // checkout pending pager
+	'checkout-pending', // checkout pending page
 	'checkout-thank-you', // thank you page
 ];
 

--- a/client/state/ui/checkout/reducer.js
+++ b/client/state/ui/checkout/reducer.js
@@ -11,7 +11,11 @@ export const upgradeIntent = withSchemaValidation( { type: 'string' }, ( state =
 		return state;
 	}
 
-	if ( [ 'checkout', 'checkout-thank-you', 'plans' ].includes( action.section.name ) ) {
+	if (
+		[ 'checkout', 'checkout-pending', 'checkout-thank-you', 'plans' ].includes(
+			action.section.name
+		)
+	) {
 		// Leave the intent alone for sections that should not clear it
 		return state;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sometimes, after we leave the checkout page, instead of being sent to whatever post-checkout "thank-you" page is configured for a particular purchase, we are instead directed to a "pending" page. This happens, for example, with 3DS payments because such payments have not yet completed when we leave checkout. The pending page requires an order ID in its URL and then polls for status updates on that order until the order succeeds or fails before sending the user to the thank-you page or back to checkout, respectively.

However, the pending page has the regular WordPress.com masterbar shown at the top, which includes links to many different places that would exit the checkout flow. While leaving the pending page is not likely to break anything, it may be confusing for a user.

This PR hides all the masterbar options on the pending page, including the close button that checkout itself has.

Before:

<img width="967" alt="pending-masterbar-before" src="https://user-images.githubusercontent.com/2036909/149851535-3227a123-3f7e-48b8-99b7-2a5cdcda9e5f.png">

After:

<img width="972" alt="pending-masterbar-after-with-styles" src="https://user-images.githubusercontent.com/2036909/149851547-ee751075-3b80-4041-a06b-7eb3d2fb8fbd.png">

Fixes https://github.com/Automattic/wp-calypso/issues/59774

#### Testing instructions

Visit `/checkout/thank-you/YOUR-SITE-HERE/pending/1234` and verify that the masterbar has no buttons.