### PR TITLE
Remove 'Disabled monthly plans' experiments

### DIFF
--- a/client/my-sites/plan-features-comparison/actions.jsx
+++ b/client/my-sites/plan-features-comparison/actions.jsx
@@ -20,7 +20,6 @@ const PlanFeaturesActionsButton = ( {
 	className,
 	current = false,
 	freePlan = false,
-	isDisabled = false,
 	isPlaceholder = false,
 	isPopular,
 	isInSignup,
@@ -55,11 +54,7 @@ const PlanFeaturesActionsButton = ( {
 
 	if ( ( availableForPurchase || isPlaceholder ) && ! isLaunchPage && isInSignup ) {
 		return (
-			<Button
-				className={ classes }
-				onClick={ handleUpgradeButtonClick }
-				disabled={ isPlaceholder || isDisabled }
-			>
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
 				{ translate( 'Select', {
 					args: {
 						plan: planName,

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -15,37 +15,24 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	renderPlansHeaderNoTabs() {
-		const {
-			disabledClasses,
-			planType,
-			popular,
-			selectedPlan,
-			isMonthlyPlan,
-			monthlyDisabled,
-			title,
-			translate,
-		} = this.props;
+		const { planType, popular, selectedPlan, title, translate } = this.props;
 
 		const headerClasses = classNames(
 			'plan-features-comparison__header',
-			getPlanClass( planType ),
-			disabledClasses
+			getPlanClass( planType )
 		);
-
-		const popularLabel =
-			monthlyDisabled && isMonthlyPlan ? translate( 'Popular on monthly' ) : translate( 'Popular' );
 
 		return (
 			<span>
 				<div>
-					{ popular && ! selectedPlan && <PlanPill isInSignup={ true }>{ popularLabel }</PlanPill> }
+					{ popular && ! selectedPlan && (
+						<PlanPill isInSignup={ true }>{ translate( 'Popular' ) }</PlanPill>
+					) }
 				</div>
 				<header className={ headerClasses }>
-					<h4 className={ classNames( 'plan-features-comparison__header-title', disabledClasses ) }>
-						{ title }
-					</h4>
+					<h4 className="plan-features-comparison__header-title">{ title }</h4>
 				</header>
-				<div className={ classNames( 'plan-features-comparison__pricing', disabledClasses ) }>
+				<div className="plan-features-comparison__pricing">
 					{ this.renderPriceGroup() }
 					{ this.getBillingTimeframe() }
 				</div>
@@ -62,12 +49,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 			translate,
 			annualPricePerMonth,
 			isMonthlyPlan,
-			disabledClasses,
 		} = this.props;
-
-		if ( disabledClasses ) {
-			return null;
-		}
 
 		if ( isMonthlyPlan && annualPricePerMonth < rawPrice ) {
 			const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
@@ -87,21 +69,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	getAnnualDiscount() {
-		const {
-			disabledClasses,
-			isMonthlyPlan,
-			rawPriceForMonthlyPlan,
-			annualPricePerMonth,
-			translate,
-		} = this.props;
-
-		if ( disabledClasses ) {
-			return (
-				<div className="plan-features-comparison__not-available-with-monthly-disclaimer">
-					This plan is only available with annual billing
-				</div>
-			);
-		}
+		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate } = this.props;
 
 		if ( ! isMonthlyPlan ) {
 			const isLoading = typeof rawPriceForMonthlyPlan !== 'number';
@@ -116,7 +84,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 			return (
 				<div
 					className={ classNames( {
-						'plan-features-comparison__header-annual-discount': ! disabledClasses,
+						'plan-features-comparison__header-annual-discount': true,
 						'plan-features-comparison__header-annual-discount-is-loading': isLoading,
 					} ) }
 				>
@@ -138,23 +106,22 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	renderPriceGroup() {
-		const { currencyCode, disabledClasses, rawPrice, discountPrice } = this.props;
-		const displayNotation = ! disabledClasses;
+		const { currencyCode, rawPrice, discountPrice } = this.props;
 
 		if ( discountPrice ) {
 			return (
 				<span className="plan-features-comparison__header-price-group">
-					<div className={ classNames( 'plan-features-comparison__header-price-group-prices' ) }>
+					<div className="plan-features-comparison__header-price-group-prices">
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ rawPrice }
-							displayPerMonthNotation={ displayNotation }
+							displayPerMonthNotation={ true }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountPrice }
-							displayPerMonthNotation={ displayNotation }
+							displayPerMonthNotation={ true }
 							discounted
 						/>
 					</div>
@@ -163,13 +130,11 @@ export class PlanFeaturesComparisonHeader extends Component {
 		}
 
 		return (
-			<div className={ classNames( disabledClasses ) }>
-				<PlanPrice
-					currencyCode={ currencyCode }
-					rawPrice={ rawPrice }
-					displayPerMonthNotation={ displayNotation }
-				/>
-			</div>
+			<PlanPrice
+				currencyCode={ currencyCode }
+				rawPrice={ rawPrice }
+				displayPerMonthNotation={ true }
+			/>
 		);
 	}
 }
@@ -183,17 +148,13 @@ PlanFeaturesComparisonHeader.propTypes = {
 	rawPrice: PropTypes.number,
 	title: PropTypes.string.isRequired,
 	translate: PropTypes.func,
-	disabledClasses: PropTypes.string,
 
 	// For Monthly Pricing test
 	annualPricePerMonth: PropTypes.number,
-
-	monthlyDisabled: PropTypes.bool,
 };
 
 PlanFeaturesComparisonHeader.defaultProps = {
 	popular: false,
-	monthlyDisabled: false,
 };
 
 export default localize( PlanFeaturesComparisonHeader );

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -102,12 +102,11 @@ export class PlanFeaturesComparison extends Component {
 				rawPriceForMonthlyPlan,
 			} = properties;
 
-			const disabledClasses = this.getDisabledClasses( planName );
 			const classes = classNames( 'plan-features-comparison__table-item', {
 				'has-border-top': ! isReskinned,
 			} );
 			const audience = planConstantObj.getAudience?.();
-			const billingTimeFrame = ! disabledClasses ? planConstantObj.getBillingTimeFrame() : null;
+			const billingTimeFrame = planConstantObj.getBillingTimeFrame();
 
 			return (
 				<th scope="col" key={ planName } className={ classes }>
@@ -120,7 +119,6 @@ export class PlanFeaturesComparison extends Component {
 						currencyCode={ currencyCode }
 						discountPrice={ discountPrice }
 						hideMonthly={ hideMonthly }
-						disabledClasses={ disabledClasses }
 						isPlaceholder={ isPlaceholder }
 						planType={ planName }
 						popular={ popular }
@@ -131,7 +129,6 @@ export class PlanFeaturesComparison extends Component {
 						title={ planConstantObj.getTitle() }
 						annualPricePerMonth={ annualPricePerMonth }
 						isMonthlyPlan={ isMonthlyPlan }
-						monthlyDisabled={ this.props.monthlyDisabled }
 					/>
 				</th>
 			);
@@ -163,12 +160,7 @@ export class PlanFeaturesComparison extends Component {
 				planConstantObj,
 				popular,
 			} = properties;
-			const disabledClasses = this.getDisabledClasses( planName );
-			const classes = classNames(
-				'plan-features-comparison__table-item',
-				'is-top-buttons',
-				disabledClasses
-			);
+			const classes = classNames( 'plan-features-comparison__table-item', 'is-top-buttons' );
 
 			return (
 				<td key={ planName } className={ classes }>
@@ -177,7 +169,6 @@ export class PlanFeaturesComparison extends Component {
 						className={ getPlanClass( planName ) }
 						current={ current }
 						freePlan={ isFreePlan( planName ) }
-						isDisabled={ Boolean( disabledClasses ) }
 						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						isInSignup={ isInSignup }
@@ -189,13 +180,6 @@ export class PlanFeaturesComparison extends Component {
 					/>
 				</td>
 			);
-		} );
-	}
-	getDisabledClasses( planName ) {
-		return classNames( {
-			'plan-monthly-disabled-experiment':
-				this.props.monthlyDisabled &&
-				[ 'personal-bundle-monthly', 'value_bundle_monthly' ].includes( planName ),
 		} );
 	}
 
@@ -281,8 +265,7 @@ export class PlanFeaturesComparison extends Component {
 					'is-highlighted':
 						selectedFeature && currentFeature && selectedFeature === currentFeature.getSlug(),
 					'is-bold': rowIndex === 0,
-				},
-				this.getDisabledClasses( planName )
+				}
 			);
 
 			return currentFeature ? (
@@ -314,7 +297,6 @@ PlanFeaturesComparison.propTypes = {
 	selectedFeature: PropTypes.string,
 	purchaseId: PropTypes.number,
 	siteId: PropTypes.number,
-	monthlyDisabled: PropTypes.bool,
 };
 
 PlanFeaturesComparison.defaultProps = {
@@ -322,7 +304,6 @@ PlanFeaturesComparison.defaultProps = {
 	isInSignup: true,
 	siteId: null,
 	onUpgradeClick: noop,
-	monthlyDisabled: false,
 };
 
 export const calculatePlanCredits = ( state, siteId, planProperties ) =>
@@ -355,7 +336,6 @@ export default connect(
 			siteId,
 			visiblePlans,
 			popularPlanSpec,
-			monthlyDisabled,
 		} = ownProps;
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteType = signupDependencies.designType;
@@ -372,13 +352,7 @@ export default connect(
 				const relatedMonthlyPlan = showMonthly
 					? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
 					: null;
-
-				let popular = false;
-				if ( monthlyDisabled && isMonthlyPlan ) {
-					popular = planObject?.product_name_short === 'Business';
-				} else {
-					popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
-				}
+				const popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
 
 				// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
 				const showMonthlyPrice = true;

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -194,12 +194,6 @@ $plan-features-sidebar-width: 272px;
 		}
 	}
 
-	.plan-features-comparison__not-available-with-monthly-disclaimer {
-		color: var( --studio-orange-40 );
-		width: 55%;
-		margin: auto;
-	}
-
 	.is-placeholder {
 		width: 60%;
 		margin: 5px auto;
@@ -496,8 +490,4 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 	}
-}
-
-.plan-monthly-disabled-experiment {
-	opacity: 0.4;
 }

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -35,7 +35,6 @@ const PlanFeaturesActionsButton = ( {
 	freePlan = false,
 	manageHref,
 	isLandingPage,
-	isDisabled = false,
 	isPlaceholder = false,
 	isPopular,
 	isInSignup,
@@ -75,7 +74,7 @@ const PlanFeaturesActionsButton = ( {
 
 	if ( current && ! isInSignup && planType !== PLAN_P2_FREE ) {
 		return (
-			<Button className={ classes } href={ manageHref } disabled={ ! manageHref || isDisabled }>
+			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				{ canPurchase ? translate( 'Manage plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
@@ -87,11 +86,7 @@ const PlanFeaturesActionsButton = ( {
 		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
 	) {
 		return (
-			<Button
-				className={ classes }
-				onClick={ handleUpgradeButtonClick }
-				disabled={ isPlaceholder || isDisabled }
-			>
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
 				{ props.buttonText || translate( 'Upgrade to Yearly' ) }
 			</Button>
 		);
@@ -99,11 +94,7 @@ const PlanFeaturesActionsButton = ( {
 
 	if ( ( availableForPurchase || isPlaceholder ) && ! isLaunchPage && isInSignup ) {
 		return (
-			<Button
-				className={ classes }
-				onClick={ handleUpgradeButtonClick }
-				disabled={ isPlaceholder || isDisabled }
-			>
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
 				{ props.buttonText ||
 					translate( 'Start with %(plan)s', {
 						args: {
@@ -186,7 +177,6 @@ PlanFeaturesActions.propTypes = {
 	currentSitePlanSlug: PropTypes.string,
 	forceDisplayButton: PropTypes.bool,
 	freePlan: PropTypes.bool,
-	isDisabeled: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
 	isLaunchPage: PropTypes.bool,

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -75,8 +75,6 @@ export class PlanFeaturesHeader extends Component {
 			popular,
 			selectedPlan,
 			isInSignup,
-			isMonthlyPlan,
-			monthlyDisabled,
 			title,
 			translate,
 		} = this.props;
@@ -85,8 +83,6 @@ export class PlanFeaturesHeader extends Component {
 			'is-p2-plus': planType === PLAN_P2_PLUS,
 		} );
 		const isCurrent = this.isPlanCurrent();
-		const popularLabel =
-			monthlyDisabled && isMonthlyPlan ? translate( 'Popular on monthly' ) : translate( 'Popular' );
 
 		return (
 			<header className={ headerClasses }>
@@ -107,7 +103,7 @@ export class PlanFeaturesHeader extends Component {
 					<PlanPill isInSignup={ isInSignup }>{ translate( 'Suggested' ) }</PlanPill>
 				) }
 				{ popular && ! selectedPlan && ! isCurrent && (
-					<PlanPill isInSignup={ isInSignup }>{ popularLabel }</PlanPill>
+					<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
 				) }
 				{ newPlan && ! selectedPlan && ! isCurrent && (
 					<PlanPill isInSignup={ isInSignup }>{ translate( 'New' ) }</PlanPill>
@@ -127,8 +123,6 @@ export class PlanFeaturesHeader extends Component {
 			planType,
 			popular,
 			selectedPlan,
-			monthlyDisabled,
-			isMonthlyPlan,
 			title,
 			audience,
 			translate,
@@ -136,8 +130,6 @@ export class PlanFeaturesHeader extends Component {
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 		const isPillInCorner = this.resolveIsPillInCorner();
-		const popularLabel =
-			monthlyDisabled && isMonthlyPlan ? translate( 'Popular on monthly' ) : translate( 'Popular' );
 
 		return (
 			<span>
@@ -148,7 +140,7 @@ export class PlanFeaturesHeader extends Component {
 						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Suggested' ) }</PlanPill>
 					) }
 					{ popular && ! selectedPlan && (
-						<PlanPill isInSignup={ isPillInCorner }>{ popularLabel }</PlanPill>
+						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Popular' ) }</PlanPill>
 					) }
 					{ newPlan && ! selectedPlan && (
 						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'New' ) }</PlanPill>
@@ -530,8 +522,6 @@ PlanFeaturesHeader.propTypes = {
 	relatedYearlyPlan: PropTypes.object,
 
 	isLoggedInMonthlyPricing: PropTypes.bool,
-
-	monthlyDisabled: PropTypes.bool,
 };
 
 PlanFeaturesHeader.defaultProps = {
@@ -549,7 +539,6 @@ PlanFeaturesHeader.defaultProps = {
 	showPlanCreditsApplied: false,
 	siteSlug: '',
 	isLoggedInMonthlyPricing: false,
-	monthlyDisabled: false,
 };
 
 export default connect( ( state, { planType, relatedMonthlyPlan } ) => {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -319,9 +319,6 @@ export class PlanFeatures extends Component {
 		// move any popular plan to the first place in the mobile view.
 		let popularPlanProperties;
 
-		// move disabled plans to the bottom of the list
-		const disabledPlanProperties = [];
-
 		const reorderedPlans = planProperties.filter( ( properties ) => {
 			if ( isFreePlan( properties.planName ) ) {
 				freePlanProperties = properties;
@@ -333,11 +330,6 @@ export class PlanFeatures extends Component {
 				return false;
 			}
 
-			// remove disabled plans.
-			if ( properties.isDisabled ) {
-				disabledPlanProperties.push( properties );
-				return false;
-			}
 			return true;
 		} );
 
@@ -348,8 +340,6 @@ export class PlanFeatures extends Component {
 		if ( freePlanProperties ) {
 			reorderedPlans.push( freePlanProperties );
 		}
-
-		reorderedPlans.push( ...disabledPlanProperties );
 
 		let buttonText = null;
 		let forceDisplayButton = false;
@@ -374,19 +364,13 @@ export class PlanFeatures extends Component {
 				primaryUpgrade,
 				isPlaceholder,
 				hideMonthly,
-				isDisabled,
 			} = properties;
 			const { rawPrice, discountPrice, isMonthlyPlan } = properties;
 			const planDescription = isInVerticalScrollingPlansExperiment
 				? planConstantObj.getShortDescription()
 				: planConstantObj.getDescription();
 			return (
-				<div
-					className={ classNames( 'plan-features__mobile-plan', {
-						'plan-features__mobile-disabled': isDisabled,
-					} ) }
-					key={ planName }
-				>
+				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
 						availableForPurchase={ availableForPurchase }
 						current={ current }
@@ -408,17 +392,11 @@ export class PlanFeatures extends Component {
 						selectedPlan={ selectedPlan }
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
 						isMonthlyPlan={ isMonthlyPlan }
-						monthlyDisabled={ this.props.monthlyDisabled }
 						audience={ planConstantObj.getAudience?.() }
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={ this.props.isLoggedInMonthlyPricing }
 						isInSignup={ isInSignup }
 					/>
-					{ isDisabled && (
-						<p className="plan-features__not-available">
-							This plan is only available with annual billing
-						</p>
-					) }
 					<p className="plan-features__description">{ planDescription }</p>
 					<PlanFeaturesActions
 						availableForPurchase={ availableForPurchase }
@@ -428,7 +406,6 @@ export class PlanFeatures extends Component {
 						className={ getPlanClass( planName ) }
 						current={ current }
 						freePlan={ isFreePlan( planName ) }
-						isDisabled={ isDisabled }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						isLaunchPage={ isLaunchPage }
@@ -545,7 +522,6 @@ export class PlanFeatures extends Component {
 						isLoggedInMonthlyPricing={
 							! isInSignup && ! isJetpack && this.props.kindOfPlanTypeSelector === 'interval'
 						}
-						monthlyDisabled={ this.props.monthlyDisabled }
 					/>
 				</th>
 			);
@@ -847,8 +823,6 @@ PlanFeatures.propTypes = {
 	siteId: PropTypes.number,
 	sitePlan: PropTypes.object,
 	kindOfPlanTypeSelector: PropTypes.oneOf( [ 'interval', 'customer' ] ),
-	monthlyDisabled: PropTypes.bool,
-	intervalType: PropTypes.string,
 };
 
 PlanFeatures.defaultProps = {
@@ -859,7 +833,6 @@ PlanFeatures.defaultProps = {
 	siteId: null,
 	onUpgradeClick: noop,
 	kindOfPlanTypeSelector: 'customer',
-	monthlyDisabled: false,
 };
 
 export const isPrimaryUpgradeByPlanDelta = ( currentPlan, plan ) =>
@@ -899,13 +872,10 @@ const ConnectedPlanFeatures = connect(
 			placeholder,
 			plans,
 			isLandingPage,
-			monthlyDisabled,
 			siteId,
 			visiblePlans,
 			popularPlanSpec,
 			kindOfPlanTypeSelector,
-			intervalType,
-			withScroll,
 		} = ownProps;
 		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
@@ -938,25 +908,7 @@ const ConnectedPlanFeatures = connect(
 				const relatedMonthlyPlan = showMonthly
 					? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
 					: null;
-
-				// label Personal and Premium monthly plan options as disabled for the monthly disabled test
-				let isDisabled = false;
-				if (
-					! withScroll &&
-					intervalType === 'monthly' &&
-					monthlyDisabled &&
-					( planObject?.product_name_short === 'Premium' ||
-						planObject?.product_name_short === 'Personal' )
-				) {
-					isDisabled = true;
-				}
-
-				// Make Business plan popular for the monthly plans disabled test
-				let popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
-				if ( monthlyDisabled ) {
-					popular = planObject?.product_name_short === ( isMonthlyPlan ? 'Business' : 'Premium' );
-				}
-
+				const popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
 				const newPlan = false;
 				const bestValue = isBestValue( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
@@ -1033,7 +985,6 @@ const ConnectedPlanFeatures = connect(
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
 					discountPrice,
 					features: planFeatures,
-					isDisabled,
 					isLandingPage,
 					isMonthlyPlan,
 					isPlaceholder,

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1236,17 +1236,3 @@ button.plan-features__scroll-button {
 		}
 	}
 }
-
-.plan-features__mobile-disabled {
-	.plan-features__header, .plan-features__pricing, .plan-features__description, .foldable-card {
-		opacity: 0.4;
-	}
-
-	.plan-features__not-available {
-		color: var( --studio-orange-40 );
-		font-weight: 600;
-		margin: auto;
-		padding-top: 10px;
-		text-align: center;
-	}
-}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -105,7 +105,6 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			isReskinned,
-			disableMonthlyExperiment,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -145,7 +144,6 @@ export class PlansFeaturesMain extends Component {
 					} ) }
 					siteId={ siteId }
 					isReskinned={ isReskinned }
-					monthlyDisabled={ disableMonthlyExperiment }
 				/>
 			</div>
 		);
@@ -157,7 +155,6 @@ export class PlansFeaturesMain extends Component {
 			customerType,
 			disableBloggerPlanWithNonBlogDomain,
 			domainName,
-			intervalType,
 			isInSignup,
 			isJetpack,
 			isLandingPage,
@@ -172,7 +169,6 @@ export class PlansFeaturesMain extends Component {
 			plansWithScroll,
 			isInVerticalScrollingPlansExperiment,
 			redirectToAddDomainFlow,
-			disableMonthlyExperiment,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -217,8 +213,6 @@ export class PlansFeaturesMain extends Component {
 					siteId={ siteId }
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					kindOfPlanTypeSelector={ this.getKindOfPlanTypeSelector( this.props ) }
-					monthlyDisabled={ disableMonthlyExperiment }
-					intervalType={ intervalType }
 				/>
 			</div>
 		);
@@ -478,7 +472,6 @@ PlansFeaturesMain.propTypes = {
 	planTypes: PropTypes.array,
 	isReskinned: PropTypes.bool,
 	planTypeSelector: PropTypes.string,
-	disableMonthlyExperiment: PropTypes.bool,
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -494,7 +487,6 @@ PlansFeaturesMain.defaultProps = {
 	plansWithScroll: false,
 	isReskinned: false,
 	planTypeSelector: 'interval',
-	disableMonthlyExperiment: false,
 };
 
 export default connect(

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -33,7 +33,6 @@ type Props = {
 	isInSignup: boolean;
 	plans: string[];
 	eligibleForWpcomMonthlyPlans?: boolean;
-	disableMonthlyExperiment?: boolean;
 };
 
 interface PathArgs {
@@ -109,11 +108,7 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 
 type IntervalTypeProps = Pick<
 	Props,
-	| 'intervalType'
-	| 'plans'
-	| 'isInSignup'
-	| 'eligibleForWpcomMonthlyPlans'
-	| 'disableMonthlyExperiment'
+	'intervalType' | 'plans' | 'isInSignup' | 'eligibleForWpcomMonthlyPlans'
 >;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
@@ -124,13 +119,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		'is-signup': isInSignup,
 	} );
 	const popupIsVisible = intervalType === 'monthly' && isInSignup;
-	const maxDiscount = useMaxDiscount(
-		props.plans.filter(
-			( plan ) =>
-				! props.disableMonthlyExperiment ||
-				! [ 'personal-bundle-monthly', 'value_bundle_monthly' ].includes( plan )
-		)
-	);
+	const maxDiscount = useMaxDiscount( props.plans );
 
 	if ( ! eligibleForWpcomMonthlyPlans ) {
 		return null;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -182,7 +182,6 @@ export class PlansStep extends Component {
 								isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 								shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 								isReskinned={ isReskinned }
-								disableMonthlyExperiment={ false }
 							/>
 						</div>
 					);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the deprecated experiments - #57255 and #57888.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start/new`
* On the plans step, the monthly tab should _NOT_ disable any plans.
* Make sure you can purchase Personal or Premium monthly plans without any errors.
