### PR TITLE
useUpdateUserMutation: use response to update user query

### DIFF
--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -9,10 +9,9 @@ function useUpdateUserMutation( siteId, queryOptions = {} ) {
 		( { userId, variables } ) => wp.req.post( `/sites/${ siteId }/users/${ userId }`, variables ),
 		{
 			...queryOptions,
-			onSuccess( ...args ) {
-				const [ { login } ] = args;
-				queryClient.invalidateQueries( getCacheKey( siteId, login ) );
-				queryOptions.onSuccess?.( ...args );
+			onSuccess( data, ...rest ) {
+				queryClient.setQueryData( getCacheKey( siteId, data.login ), data );
+				queryOptions.onSuccess?.( data, ...rest );
 			},
 		}
 	);


### PR DESCRIPTION
When updating a user on the `/people/edit/:site/:user` page, we can use the POST response, which contains the updated user, to update the query cache. Instead of invalidating the cache and triggering a separate GET.

The observable result of this optimization is that the "Save button" will no longer alternate between disabled and enabled state:

![Screen Capture on 2022-01-17 at 16-15-35](https://user-images.githubusercontent.com/664258/149902472-fb4bf232-714e-4c33-8f7d-eb35f33aea53.gif)

This was caused by the following sequence of events:
1. change value, the form becomes dirty, save button gets enabled
2. click save, save is in progress, save button gets disabled
3. save finishes, is no longer in progress, but the form is still dirty because the form state is different from the data in cache, save button gets enabled again (save not in progress + form is dirty)
4. query is invalidated, GET request is issued
5. GET response arrives, cache is updated, form no longer dirty, save button gets disabled

After this patch, the cache is updated immediately when response arrives, so the form is no longer dirty: the form state is the same as the cached data.

Found this bug when reviewing #59946.