### PR TITLE
Import type hints inline

### DIFF
--- a/client/components/forms/form-section-heading/index.jsx
+++ b/client/components/forms/form-section-heading/index.jsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { ReactChild, ReactElement } from 'react';
 
 import './style.scss';
 /**
@@ -7,9 +6,9 @@ import './style.scss';
  *
  * @param {Object} props Component props
  * @param {string=} props.className optional extra CSS class(es) to be added to the component
- * @param {ReactChild=} props.children react element props that must contain some children
+ * @param {import('react').ReactChild=} props.children react element props that must contain some children
  * @param {Object=} props.otherProps react element props that must contain some children
- * @returns {ReactElement} React component
+ * @returns {import('react').ReactElement} React component
  */
 const FormSectionHeading = ( { className, children, ...otherProps } ) => (
 	<h3 { ...otherProps } className={ classnames( className, 'form-section-heading' ) }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #60134, I've rebased the chages to `trunk`, but when pushing the changes to the remote, all rebased commits were included in the diff. As the changes in the original PR were minimal, I've rather created a new PR.  

* Remove unused import of React types
* Import types for JSDoc type hints inline

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that there are no regressions

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up for #60134
