### PR TITLE
Relaunch the monthly-plans-by-default experiment

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -424,7 +424,7 @@ function getMonthlyToAnnualUpsellUrl( {
 	}
 
 	const monthlyPlansDefaultExperiment = dangerouslyGetExperimentAssignment(
-		'calypso_signup_monthly_plans_default_202201_v1'
+		'calypso_signup_monthly_plans_default_202201_v2'
 	);
 	if ( monthlyPlansDefaultExperiment?.variationName === null ) {
 		return;

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -328,7 +328,7 @@ export default {
 
 		// Pre-fetching the experiment
 		if ( flowName === 'onboarding' || flowName === 'launch-site' ) {
-			await loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v1' );
+			await loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -35,7 +35,7 @@ export class PlansStep extends Component {
 
 	componentWillMount() {
 		if ( this.props.flowName === 'onboarding' || this.props.flowName === 'launch-site' ) {
-			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v1' ).then(
+			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' ).then(
 				( experiment ) => {
 					this.setState( { experiment, experimentLoaded: true } );
 				}
@@ -128,7 +128,7 @@ export class PlansStep extends Component {
 		}
 
 		if (
-			'calypso_signup_monthly_plans_default_202201_v1' === this.state.experiment?.experimentName &&
+			'calypso_signup_monthly_plans_default_202201_v2' === this.state.experiment?.experimentName &&
 			this.state.experiment?.variationName !== null
 		) {
 			return 'monthly';

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -33,23 +33,23 @@ export class PlansStep extends Component {
 		experimentLoaded: false,
 	};
 
-	componentWillMount() {
-		if ( this.props.flowName === 'onboarding' || this.props.flowName === 'launch-site' ) {
-			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' ).then(
-				( experiment ) => {
-					this.setState( { experiment, experimentLoaded: true } );
-				}
-			);
-		} else {
-			this.setState( { experimentLoaded: true } );
-		}
-	}
-
 	componentDidMount() {
 		this.unsubscribe = subscribeIsDesktop( ( matchesDesktop ) =>
 			this.setState( { isDesktop: matchesDesktop } )
 		);
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
+
+		if ( this.props.flowName === 'onboarding' || this.props.flowName === 'launch-site' ) {
+			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' ).then(
+				( experiment ) => {
+					// eslint-disable-next-line react/no-did-mount-set-state
+					this.setState( { experiment, experimentLoaded: true } );
+				}
+			);
+		} else {
+			// eslint-disable-next-line react/no-did-mount-set-state
+			this.setState( { experimentLoaded: true } );
+		}
 	}
 
 	componentWillUnmount() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -150,7 +150,7 @@ export class PlansStep extends Component {
 			<ProvideExperimentData
 				name="calypso_signup_monthly_plans_default_202201_v2"
 				options={ {
-					isEligible: 'onboarding' === this.props.flowName || 'launch-site' === this.props.flowName,
+					isEligible: [ 'onboarding', 'launch-site' ].includes( this.props.flowName ),
 				} }
 			>
 				{ ( isLoading, experimentAssignment ) => {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -155,7 +155,7 @@ export class PlansStep extends Component {
 			>
 				{ ( isLoading, experimentAssignment ) => {
 					if ( isLoading ) {
-						return <PulsingDot active={ true } />;
+						return <PulsingDot active />;
 					}
 					const isTreatmentMonthlyDefault = experimentAssignment?.variationName !== null;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As per the discussions in p1642415263032400-slack-C7HH3V5AS, we're re-launching the experiment in https://github.com/Automattic/wp-calypso/pull/59771 after fixing the Abacus settings. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as https://github.com/Automattic/wp-calypso/pull/59771.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
