### PR TITLE
Bring back crossed out UI to show the first-year discount.

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -411,6 +411,7 @@ export class PlanFeaturesHeader extends Component {
 			discountPrice,
 			rawPrice,
 			relatedMonthlyPlan,
+			isFirstYearPromotionalDiscount,
 			isLoggedInMonthlyPricing,
 		} = this.props;
 
@@ -430,10 +431,15 @@ export class PlanFeaturesHeader extends Component {
 					relatedMonthlyPlan.raw_price * 12,
 					discountPrice || rawPrice
 				);
+			} else if ( discountPrice ) {
+				return this.renderPriceGroup( rawPrice, discountPrice );
 			}
 		}
 
-		return this.renderPriceGroup( rawPrice, discountPrice );
+		if ( isFirstYearPromotionalDiscount ) {
+			return this.renderPriceGroup( rawPrice, discountPrice );
+		}
+		return this.renderPriceGroup( rawPrice );
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {
@@ -599,12 +605,19 @@ export default connect( ( state, { planType, relatedMonthlyPlan } ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
 	const isYearly = !! relatedMonthlyPlan;
+	const relatedYearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( planType ) );
+
+	const isFirstYearPromotionalDiscount =
+		isYearly &&
+		relatedYearlyPlan &&
+		'first_year_promotional_discounts' === relatedYearlyPlan.overridden_price_reason;
 
 	return {
 		currentSitePlan,
 		isSiteAT: isSiteAutomatedTransfer( state, selectedSiteId ),
 		isYearly,
-		relatedYearlyPlan: getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
+		isFirstYearPromotionalDiscount,
+		relatedYearlyPlan: isYearly ? null : relatedYearlyPlan,
 		siteSlug: getSiteSlug( state, selectedSiteId ),
 	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -401,12 +401,10 @@ export class PlanFeaturesHeader extends Component {
 					relatedMonthlyPlan.raw_price * 12,
 					discountPrice || rawPrice
 				);
-			} else if ( discountPrice ) {
-				return this.renderPriceGroup( rawPrice, discountPrice );
 			}
 		}
 
-		return this.renderPriceGroup( rawPrice );
+		return this.renderPriceGroup( rawPrice, discountPrice );
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -590,8 +590,6 @@ PlanFeaturesHeader.propTypes = {
 	relatedYearlyPlan: PropTypes.object,
 
 	isLoggedInMonthlyPricing: PropTypes.bool,
-
-	monthlyDisabled: PropTypes.bool,
 	eligibleForWpcomMonthlyPlans: PropTypes.bool,
 };
 
@@ -610,7 +608,6 @@ PlanFeaturesHeader.defaultProps = {
 	showPlanCreditsApplied: false,
 	siteSlug: '',
 	isLoggedInMonthlyPricing: false,
-	monthlyDisabled: false,
 	eligibleForWpcomMonthlyPlans: false,
 };
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -94,6 +94,7 @@ export class PlanFeaturesHeader extends Component {
 				<div className="plan-features__header-text">
 					<h4 className="plan-features__header-title">{ title }</h4>
 					{ this.getPlanFeaturesPrices() }
+					{ this.getAnnualDiscount() }
 					{ this.getBillingTimeframe() }
 				</div>
 				{ ! isInSignup && isCurrent && (
@@ -222,6 +223,34 @@ export class PlanFeaturesHeader extends Component {
 		return translate(
 			"You'll receive a discount from the full price of %(price)s because you already have a plan.",
 			{ args: { price } }
+		);
+	}
+
+	getAnnualDiscount() {
+		const { isMonthlyPlan, discountPrice, translate, rawPrice, relatedMonthlyPlan } = this.props;
+
+		if ( isMonthlyPlan || ! relatedMonthlyPlan ) {
+			return;
+		}
+
+		const price = discountPrice || rawPrice;
+		const isLoading = typeof price !== 'number';
+		const discountRate = Math.round(
+			( 100 * ( relatedMonthlyPlan.raw_price - price ) ) / relatedMonthlyPlan.raw_price
+		);
+		const annualDiscountText = translate( `You're saving %(discountRate)s%% by paying annually`, {
+			args: { discountRate },
+		} );
+
+		return (
+			<div
+				className={ classNames( {
+					'plan-features__header-annual-discount': true,
+					'plan-features__header-annual-discount-is-loading': isLoading,
+				} ) }
+			>
+				<span>{ annualDiscountText }</span>
+			</div>
 		);
 	}
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1243,3 +1243,29 @@ button.plan-features__scroll-button {
 		}
 	}
 }
+
+.plan-features__mobile-disabled {
+	.plan-features__header, .plan-features__pricing, .plan-features__description, .foldable-card {
+		opacity: 0.4;
+	}
+
+	.plan-features__not-available {
+		color: var( --studio-orange-40 );
+		font-weight: 600;
+		margin: auto;
+		padding-top: 10px;
+		text-align: center;
+	}
+}
+
+.plan-features__header-annual-discount {
+	color: var( --color-accent );
+	font-size: 0.75rem;
+    line-height: normal;
+	margin-bottom: 0.75rem;
+
+	&-is-loading {
+		display: none;
+	}
+}
+

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -563,6 +563,18 @@ describe( 'PlanFeaturesHeader.getPlanFeaturesPrices()', () => {
 			expect( wrapper.find( PlanPrice ).length ).toBe( 1 );
 			expect( wrapper.find( PlanPrice ).get( 0 ).props.rawPrice ).toBe( 50 );
 		} );
+
+		test( 'Should return crossed price when First Year Promotional discount is applied', () => {
+			const comp = new PlanFeaturesHeader( {
+				...baseProps,
+				discountPrice: 30,
+				isFirstYearPromotionalDiscount: true,
+			} );
+			const wrapper = shallow( <span>{ comp.getPlanFeaturesPrices() }</span> );
+			expect( wrapper.find( PlanPrice ).length ).toBe( 2 );
+			expect( wrapper.find( PlanPrice ).get( 0 ).props.rawPrice ).toBe( 50 );
+			expect( wrapper.find( PlanPrice ).get( 1 ).props.rawPrice ).toBe( 30 );
+		} );
 	} );
 
 	describe( 'has only rawPrice', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More context: pdgrnI-he-p2
This brings back the crossed-out UI to show the first-year discount on the /plans page.
<img width="257" alt="Screenshot 2022-01-13 at 5 35 17 PM (1)" src="https://user-images.githubusercontent.com/2749938/149906985-ff6ca838-0ecb-44b8-934b-04b708f9ceee.png">


#### Testing instructions

* Create or Log in to an account that benefits from 1st-year promotional pricing (more info p7DVsv-9lB-p2)
* Go to the /plans page
* Under the `Pay annually` tab you should be able to see the crossed-out discounted prices with the saving % calculation
<img width="480" alt="Screenshot on 2022-01-18 at 13-34-41" src="https://user-images.githubusercontent.com/2749938/149930250-a7acdbd0-32f0-441d-bfa3-a3367d4f2e88.png">

* Make sure there're no related JS errors in the console.

