### PR TITLE
Plugin Browser and Details: Show placeholder while prices are loading

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -89,7 +89,9 @@ const PluginDetailsCTA = ( {
 					<div className="plugin-details-CTA__price align-right">
 						<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
 							{ ( { isFetching, price, period } ) =>
-								! isFetching && (
+								isFetching ? (
+									<div className="plugin-details-CTA__price-placeholder">...</div>
+								) : (
 									<>
 										{ price + ' ' }
 										<span className="plugin-details-CTA__period">{ period }</span>
@@ -119,7 +121,9 @@ const PluginDetailsCTA = ( {
 			<div className="plugin-details-CTA__price">
 				<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
 					{ ( { isFetching, price, period } ) =>
-						! isFetching && (
+						isFetching ? (
+							<div className="plugin-details-CTA__price-placeholder">...</div>
+						) : (
 							<>
 								{ price ? (
 									<>

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -20,6 +20,12 @@
 	}
 }
 
+.plugin-details-CTA__price-placeholder {
+	width: 100%;
+
+	@extend %placeholder;
+}
+
 .plugin-details-CTA__period {
 	font-family: $sans;
 	font-size: $font-body-extra-small;

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -203,7 +203,9 @@ const InstalledInOrPricing = ( {
 		<div className="plugins-browser-item__pricing">
 			<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
 				{ ( { isFetching, price, period } ) =>
-					! isFetching && (
+					isFetching ? (
+						<div className="plugins-browser-item__pricing-placeholder">...</div>
+					) : (
 						<>
 							{ price ? (
 								<>

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -1,3 +1,4 @@
+@use '../variables';
 @import '@automattic/color-studio/dist/color-variables';
 
 .plugins-browser-item {
@@ -138,6 +139,12 @@
 .plugins-browser-item__installed {
 	font-size: $font-body;
 	color: $studio-black;
+}
+
+.plugins-browser-item__pricing-placeholder {
+	width: 150px;
+
+	@extend %placeholder;
 }
 
 .plugins-browser-item__installed {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add placeholder on prices on Plugins Browser page.
* Add placeholder on prices on the Plugin Details page.

#### Testing instructions
* Go to `/plugins` page
* Check if the placeholder is being showed on paid plugins (after the load a price is shown)
*  Check if the placeholder is being showed on free plugins (after the load the text "Free" is shown)
* Click on a paid plugin and check if a placeholder is shown while the price is loading
*  Go to back to `/plugins` page
* Click on a free plugin and check if  a placeholder is shown before the "Free" text is shown

#### Demo
![Kapture 2022-01-18 at 09 29 16](https://user-images.githubusercontent.com/5039531/149947063-550c5be3-e2d2-4d33-874c-26f620ed2e7e.gif)

---
Fixes #59291
