### PR TITLE
Welcome Tour: Abstract tour rating store access

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -30,7 +30,7 @@ const config = {
 			// Desc: A function hook that takes a rating and returns an updated or same rating back
 			// @todo clk - Type polymorphically, we may have different types of ratings (boolean or discrete/point-based)
 			// @todo clk - Update Tracks event to just "rating" maybe (vs "thumbs_up") - but rethink. Ensure queryable in Tracks first.
-			useTourRatingx: ( rating ) => {
+			useTourRating: ( rating ) => {
 				const { setTourRating } = useDispatch( 'automattic/wpcom-welcome-guide' );
 				const tourRating = useSelect( ( select ) =>
 					select( 'automattic/wpcom-welcome-guide' ).getTourRating()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses #60080 

Abstracts the store access for rating the tour into a hook. This is a temporary solution to allow extracting the rating component into Tour Kit. Obviously, this will become part of the tour config. We don't yet have a concept of tour ID either, so also subject to change once we do. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Sandbox a site, checkout branch, and `yarn dev --sync` from `apps/editing-toolkit` to sync sandbox.
2. Open the sidebar and from there click on "Welcome Guide".
3. Navigate to the last slide and rate the tour. Ensure you can only rate **once** while still on the last slide.
4. "Restart tour" and ensure rating persisted. It should be possible to update the rating (but see notes/todo below).
5. Reload the page and ensure rating persisted. It should be possible to update the rating (but see notes/todo below).
6. Check out `trunk`, reload the page, and ensure the rating persisted.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### TODO

A follow-up is needed **before merging**:

- [ ] ❗ Points 4 & 5 in the testing above behave differently in `trunk`. Currently, a user can only rate the tour once until they clear their browser storage. This branch allows rerating the tour when restarted or reloaded. It feels crude to only allow a single rating, but probably implemented that way due to the way we record this event in Tracks. We should probably revert the logic back to the original but create a follow-up issue. 🤔 
- [ ] ❓ Not sure about the approach either (passing a hook to handle store access). There might be a better way. 🤔

#### Media

![Kapture 2022-01-18 at 15 57 22](https://user-images.githubusercontent.com/1705499/149951055-4784f072-31d3-4e19-bd12-af920a1a9df0.gif)

Fixes #60080
