### PR TITLE
Update domain settings accordion

### DIFF
--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -33,20 +33,16 @@ const Accordion = ( {
 				expanded={ expanded }
 				disabled={ isPlaceholder }
 				actionButton={
-					<>
-						<button className="foldable-card__action foldable-card__expand">
-							<span className="screen-reader-text">More</span>
-							<Icon icon={ chevronDown } viewBox="6 4 12 14" size={ 16 } />
-						</button>
-					</>
+					<button className="foldable-card__action foldable-card__expand">
+						<span className="screen-reader-text">More</span>
+						<Icon icon={ chevronDown } viewBox="6 4 12 14" size={ 16 } />
+					</button>
 				}
 				actionButtonExpanded={
-					<>
-						<button className="foldable-card__action foldable-card__expand">
-							<span className="screen-reader-text">More</span>
-							<Icon icon={ chevronUp } viewBox="6 4 12 14" size={ 16 } />
-						</button>
-					</>
+					<button className="foldable-card__action foldable-card__expand">
+						<span className="screen-reader-text">More</span>
+						<Icon icon={ chevronUp } viewBox="6 4 12 14" size={ 16 } />
+					</button>
 				}
 			>
 				{ children }

--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -28,6 +28,7 @@ const Accordion = ( {
 	return (
 		<div className="accordion">
 			<FoldableCard
+				clickableHeader
 				header={ renderHeader() }
 				expanded={ expanded }
 				disabled={ isPlaceholder }

--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import FoldableCard from 'calypso/components/foldable-card';
 import type { AccordionProps } from './types';
@@ -25,7 +27,27 @@ const Accordion = ( {
 	};
 	return (
 		<div className="accordion">
-			<FoldableCard header={ renderHeader() } expanded={ expanded } disabled={ isPlaceholder }>
+			<FoldableCard
+				header={ renderHeader() }
+				expanded={ expanded }
+				disabled={ isPlaceholder }
+				actionButton={
+					<>
+						<button className="foldable-card__action foldable-card__expand">
+							<span className="screen-reader-text">More</span>
+							<Icon icon={ chevronDown } viewBox="6 4 12 14" size={ 16 } />
+						</button>
+					</>
+				}
+				actionButtonExpanded={
+					<>
+						<button className="foldable-card__action foldable-card__expand">
+							<span className="screen-reader-text">More</span>
+							<Icon icon={ chevronUp } viewBox="6 4 12 14" size={ 16 } />
+						</button>
+					</>
+				}
+			>
 				{ children }
 			</FoldableCard>
 		</div>

--- a/client/components/domains/accordion/style.scss
+++ b/client/components/domains/accordion/style.scss
@@ -11,9 +11,9 @@
 			margin: 0;
 			.foldable-card__content {
 				border-top: none;
-				padding: 0 24px 16px 16px;
+				padding: 0 16px 16px;
 				@include break-small {
-					padding: 0 30px 24px 24px;
+					padding: 0 24px 24px;
 				}
 			}
 			.foldable-card__header {
@@ -23,13 +23,13 @@
 				}
 			}
 		}
-		&__header {
-			padding: 16px 24px 16px 16px;
+		.foldable-card__header {
+			padding: 16px;
 			@include break-small {
-				padding: 24px 30px 24px 24px;
+				padding: 24px;
 			}
 		}
-		&__expand {
+		.foldable__expand {
 			width: 56px;
 			@include break-small {
 				width: 74px;
@@ -38,8 +38,13 @@
 				fill: var( --color-neutral-80 );
 			}
 		}
-		&__secondary {
+		.foldable__secondary {
 			display: none;
+		}
+		.foldable-card__action {
+			@include break-small {
+				right: 4px;
+			}
 		}
 	}
 	&__title {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR address some accordion card style issues, on new domain settings page (see pcYYhz-xC-p2)

> - For the foldable card can we use the Gutenberg chevron-down icon?
> - On desktop: the padding for the .foldable-card__header should be 24px (including the arrow on the right). Don’t change this for mobile, leave as is.
> - foldable card I think this whole section should be clickable to open the card, not just the arrow, just like the “Email setup” section in the “DNS records” page is.

![accordion](https://user-images.githubusercontent.com/2797601/149960160-5891a71f-93d1-4ee9-bcf8-826efa1e4d2a.png)

## Testing instructions
- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades -> Domains" and select a domain
- Verify that the 3 issues described above are fixed (use the screenshot as a reference)
