### PR TITLE
Woop Installer: Move descriptive text into individual steps

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -745,26 +745,10 @@ export function generateSteps( {
 		},
 		'store-address': {
 			stepName: 'store-address',
-			props: {
-				headerTitle: i18n.translate( 'Add an address to accept payments' ),
-				headerDescription: i18n.translate(
-					'This will be used as your default business address. You can change it later if you need to.'
-				),
-			},
 			dependencies: [ 'site' ],
 		},
 		confirm: {
 			stepName: 'confirm',
-			props: {
-				get headerTitle() {
-					return i18n.translate( 'One final step' );
-				},
-				get headerDescription() {
-					return i18n.translate(
-						'We’ve highlighted a few important details you should review before we create your store. '
-					);
-				},
-			},
 			dependencies: [ 'site' ],
 			providesDependencies: [ 'siteConfirmed' ],
 		},

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -47,7 +47,7 @@ export const StyledNextButton = styled( NextButton )`
 `;
 
 export default function Confirm( props: WooCommerceInstallProps ): ReactElement | null {
-	const { goToNextStep, isReskinned, headerTitle, headerDescription } = props;
+	const { goToNextStep, isReskinned } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
@@ -160,10 +160,14 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 			nextLabelText={ __( 'Confirm' ) }
 			allowBackFirstStep={ ! isEnabled( 'woop' ) }
 			backUrl={ isEnabled( 'woop' ) ? null : `/woocommerce-installation/${ wpcomDomain }` }
-			headerText={ headerTitle }
-			fallbackHeaderText={ headerTitle }
-			subHeaderText={ headerDescription }
-			fallbackSubHeaderText={ headerDescription }
+			headerText={ __( 'One final step' ) }
+			fallbackHeaderText={ __( 'One final step' ) }
+			subHeaderText={ __(
+				'We’ve highlighted a few important details you should review before we create your store. '
+			) }
+			fallbackSubHeaderText={ __(
+				'We’ve highlighted a few important details you should review before we create your store. '
+			) }
 			align={ isReskinned ? 'left' : 'center' }
 			stepContent={ getContent() }
 			isWideLayout={ isReskinned }

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -37,7 +37,7 @@ const CityZipRow = styled.div`
 `;
 
 export default function StepStoreAddress( props: WooCommerceInstallProps ): ReactElement | null {
-	const { goToNextStep, isReskinned, headerTitle, headerDescription } = props;
+	const { goToNextStep, isReskinned } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
@@ -198,10 +198,14 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 		<StepWrapper
 			flowName="woocommerce-install"
 			hideSkip={ true }
-			headerText={ headerTitle }
-			fallbackHeaderText={ headerTitle }
-			subHeaderText={ headerDescription }
-			fallbackSubHeaderText={ headerDescription }
+			headerText={ __( 'Add an address to accept payments' ) }
+			fallbackHeaderText={ __( 'Add an address to accept payments' ) }
+			subHeaderText={ __(
+				'This will be used as your default business address. You can change it later if you need to.'
+			) }
+			fallbackSubHeaderText={ __(
+				'This will be used as your default business address. You can change it later if you need to.'
+			) }
 			align={ isReskinned ? 'left' : 'center' }
 			stepContent={ getContent() }
 			isWideLayout={ isReskinned }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves descriptive text (headers) to props in the Address and Confirm steps, instead of props in `steps/config-pure.js`. That way we keep all of the text for that step in one place.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the WooCommerce installation flow at /woocommerce-installation/< site-id >
* Verify that the step headers and subheaders display correctly for the following steps:

Address step
<img width="455" alt="Screen Shot 2022-01-18 at 10 07 21 AM" src="https://user-images.githubusercontent.com/1689238/149963256-d75ac518-92cc-41c7-855e-d0efb111c693.png">

Confirm step
<img width="474" alt="Screen Shot 2022-01-18 at 10 07 30 AM" src="https://user-images.githubusercontent.com/1689238/149963253-3cc37984-73b3-49cf-b6cd-821b7f7fb1ea.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #58430
