### PR TITLE
Fix domain settings header margins

### DIFF
--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -41,7 +41,7 @@
 			}
 
 			@include breakpoint-deprecated( '<660px' ) {
-				margin-left: 16px;
+				margin: 0 16px 24px;
 			}
 		}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR address some header style issues, on new domain settings page (see pcYYhz-xC-p2)

> - Mobile: .settings-header__container-title change bottom margin to 24px.

Note: I also add a right margin (16px, same as the left one)

![header](https://user-images.githubusercontent.com/2797601/149966053-40e67916-d3c4-4368-a8b6-d78cb0618a05.png)

## Testing instructions
- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades -> Domains" and select a domain
- Verify that that `.settings-header__container-title` margin bottom is 24px on mobile
