### PR TITLE
Fix domain settings sidebar

### DIFF
--- a/client/components/domains/layout/style.scss
+++ b/client/components/domains/layout/style.scss
@@ -10,6 +10,10 @@
 
 	&__content {
 		grid-column: 1 / 2;
+		padding-bottom: 1px;
+		@include break-xlarge {
+			padding-bottom: 0;
+		}
 	}
 
 	&__sidebar {

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -1,52 +1,56 @@
 .domain-info-card {
-    &.action-card {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 24px 0;
-        box-shadow: none;
+	&.action-card {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		padding: 24px 0;
+		box-shadow: none;
 
-        & ~ & {
-            border-top: 1px solid var( --studio-gray-5 );
-        }
+		@include breakpoint-deprecated( '<660px' ) {
+			padding: 16px;
+		}
 
-        .action-card__main {
-            .action-card__heading {
-                margin: 0;
-                font-weight: 600;
-                line-height: 24px;
-                font-size: $font-body;
-                display: flex;
-                column-gap: 8px;
-                align-items: center;
-            }
+		& ~ & {
+			border-top: 1px solid var( --studio-gray-5 );
+		}
 
-            p {
-                margin: 5px 0 16px;
-                font-size: $font-body-small;
-                color: var( --studio-gray-50 );
-                display: flex;
-                align-items: center;
+		.action-card__main {
+			.action-card__heading {
+				margin: 0;
+				font-weight: 600;
+				line-height: 24px;
+				font-size: $font-body;
+				display: flex;
+				column-gap: 8px;
+				align-items: center;
+			}
 
-                svg {
-                    fill: var( --studio-gray-50 );
-                    margin: 0 8px 0 3px;
-                }
-            }
-        }
+			p {
+				margin: 0 0 16px;
+				font-size: $font-body-small;
+				color: var( --studio-gray-50 );
+				display: flex;
+				align-items: center;
 
-        .action-card__button-container {
-            align-self: unset;
+				svg {
+					fill: var( --studio-gray-50 );
+					margin: 0 8px 0 3px;
+				}
+			}
+		}
 
-            > .button {
-                margin-left: 0;
-                padding: 7px 12px;
-                box-shadow: none;
+		.action-card__button-container {
+			align-self: unset;
+			margin-bottom: 0;
+			> .button {
+				margin-left: 0;
+				padding: 7px 12px;
+				box-shadow: none;
 
-                &:hover {
-                    color: var( --color-text-subtle );
-                }
-            }
-        }
-    }
+				&:hover {
+					color: var( --color-text-subtle );
+				}
+			}
+		}
+	}
 }

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -41,7 +41,7 @@
 			}
 
 			@include breakpoint-deprecated( '<660px' ) {
-				margin-left: 16px;
+				margin: 0 16px 24px;
 			}
 		}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR address some sidebar style issues, on new domain settings page (see pcYYhz-xC-p2)

> - “Email/Transfer/Delete”: There is a top margin for the `<p>` below the titles of 5px, remove it. That way it is identical to the titles and sub-titles on the left side.
> - The “Email/Transfer/Delete” column on mobile has no padding on the sides. Add 16px padding on the sides.

_Note: This also fix a small bug on the last accordion border bottom (it wasn't visibile)_

![Markup on 2022-01-18 at 17:00:13](https://user-images.githubusercontent.com/2797601/149973341-71ce30ae-8ecc-4711-af3f-2c5b01a1c27c.png)


## Testing instructions
- Build this branch locally or open the live Calypso link
- If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag
- Go to "Upgrades -> Domains" and select a domain
- Verify that that the issue described above are fixed (see screenshot)
