### PR TITLE
Show the number of sites a plugin is installed on multi sites view.

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -5,7 +5,6 @@ import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
-import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
@@ -213,7 +212,6 @@ function PluginDetails( props ) {
 		<MainComponent wideLayout>
 			<DocumentHead title={ getPageTitle() } />
 			<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
-			<QueryJetpackPlugins siteIds={ siteIds } />
 			<SidebarNavigation />
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QueryProductsList />

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -40,7 +40,7 @@ const PluginsBrowserListElement = ( props ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const sitesWithPlugin = useSelector( ( state ) =>
-		isJetpack && currentSites
+		currentSites
 			? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), plugin.slug )
 			: []
 	);
@@ -151,6 +151,7 @@ const PluginsBrowserListElement = ( props ) => {
 							plugin={ plugin }
 							billingPeriod={ billingPeriod }
 							shouldUpgrade={ shouldUpgrade }
+							currentSites={ currentSites }
 						/>
 					) }
 					<div className="plugins-browser-item__additional-info">
@@ -185,6 +186,7 @@ const InstalledInOrPricing = ( {
 	plugin,
 	billingPeriod,
 	shouldUpgrade,
+	currentSites,
 } ) => {
 	const translate = useTranslate();
 
@@ -193,7 +195,12 @@ const InstalledInOrPricing = ( {
 			/* eslint-disable wpcalypso/jsx-gridicon-size */
 			<div className="plugins-browser-item__installed">
 				<Gridicon icon="checkmark" size={ 14 } />
-				{ translate( 'Installed' ) }
+				{ isWpcomPreinstalled || currentSites.length === 1
+					? translate( 'Installed' )
+					: translate( 'Installed on %d site', 'Installed on %d sites', {
+							args: [ sitesWithPlugin.length ],
+							count: sitesWithPlugin.length,
+					  } ) }
 			</div>
 			/* eslint-enable wpcalypso/jsx-gridicon-size */
 		);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -18,6 +18,7 @@ import announcementImage from 'calypso/assets/images/marketplace/diamond.svg';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
@@ -33,6 +34,7 @@ import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
@@ -104,6 +106,7 @@ const PluginsBrowser = ( {
 	);
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
+	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
 	const pluginsByCategory = useSelector( ( state ) => getPluginsListByCategory( state, category ) );
 	const pluginsByCategoryNew = useSelector( ( state ) => getPluginsListByCategory( state, 'new' ) );
 	const pluginsByCategoryFeatured = useSelector( ( state ) =>
@@ -217,6 +220,7 @@ const PluginsBrowser = ( {
 				</>
 			) }
 			{ isEnabled( 'marketplace-v1' ) && ! jetpackNonAtomic && <QueryProductsList /> }
+			<QueryJetpackPlugins siteIds={ siteIds } />
 			<PageViewTrackerWrapper
 				category={ category }
 				selectedSiteId={ selectedSite?.ID }


### PR DESCRIPTION


#### Changes proposed in this Pull Request
Show the number of sites a plugin is installed on multi-sites view.
To allow this change, the query of plugins was moved from Plugin Details to Browser Plugins page.

#### Testing instructions
* Go to `/plugins` page on a multisite view (no site selected). Use an anonymous tab or clear the indexed DB data.
* Install a plugin and check if the text displays the number of sites it is installed. Ex: Installed on 1 site
* Click on the installed plugin to go to the Plugin Details page
* Check if the Site List area is properly shown. Ex: The site you installed appears as installed.
#### Demo
| Before  | After |
| ------------- | ------------- |
|<img width="1114" alt="Screen Shot 2022-01-18 at 11 59 05" src="https://user-images.githubusercontent.com/5039531/149972711-fb7fd114-1b32-4b6f-a690-f76998c36386.png">|<img width="1114" alt="Screen Shot 2022-01-18 at 11 52 40" src="https://user-images.githubusercontent.com/5039531/149972761-c631c51e-ede3-4948-a807-d860c59542af.png">|



---
Fixes #58504
