### PR TITLE
Fix transfer sidebar style

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -361,7 +361,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 				<Column type="sidebar">
 					<Card className="transfer-page__help-section-card">
 						<p className="transfer-page__help-section-title">{ __( 'How do transfers work?' ) }</p>
-						<span className="transfer-page__help-section-text">
+						<p className="transfer-page__help-section-text">
 							{ __( 'Transferring a domain within WordPress.com is immediate.' ) }
 							<br />
 							{ createInterpolateElement(
@@ -372,7 +372,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 									a: createElement( 'a', { href: TRANSFER_DOMAIN_REGISTRATION } ),
 								}
 							) }
-						</span>
+						</p>
 					</Card>
 				</Column>
 			</Layout>

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -19,6 +19,7 @@
 	.card {
 		color: var( --studio-gray-50 );
 		padding: 16px;
+		margin-bottom: 24px;
 
 		@include break-mobile {
 			padding: 24px;
@@ -86,6 +87,7 @@
 			color: var( --studio-gray-50 );
 			font-size: $font-body-small;
 			line-height: 20px;
+			margin-bottom: 0;
 
 			br {
 				content: ' ';


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR address some sidebar style issues, on new domain transfer page (see pcYYhz-xC-p2)

> “Transfer” page – the grey box with the text explanation on the right:
> - The line height of the explanation paragraph looks wrong, the css says “20px”, but I think because it’s a span it’s not rendering correctly. In comparison the same type of box in the “Add a new DNS record” page looks good.
> - On mobile: make sure there is 24px of spacing between the content above and the box.

![transfer](https://user-images.githubusercontent.com/2797601/149979389-81bdceeb-6cf6-4fb8-a6ef-30940eaf5e10.png)

## Testing instructions
- Build this branch locally or open the live Calypso link
- Go to "Upgrades -> Domains" and select a transferrable domain, then click on the transfer button (on the right sidebar)
- Verify that that the issue described above are fixed (see screenshot)
