### PR TITLE
Domains: Fix error when clicking on "Start transfer" button for inbound transfers

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
@@ -20,12 +20,12 @@ import DomainStatus from '../card/domain-status';
 import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 
 class TransferInDomainType extends Component {
-	goToInboundTransferPage() {
+	goToInboundTransferPage = () => {
 		const { domain, selectedSite } = this.props;
 		page(
 			domainUseMyDomain( selectedSite.slug, domain.name, useMyDomainInputMode.startPendingTransfer )
 		);
-	}
+	};
 
 	renderPendingStart() {
 		const { domain, translate } = this.props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes an error where it was not possible to click the "Start transfer" button in the inbound transfer page - without the `domains/settings-page-redesign` flag. 

#### Testing instructions
- Go to any inbound transfer with "pending start" status and check that the "Start transfer" button redirects you to the transfer flow correctly.
- It should work regardless of the `domains/settings-page-redesign` feature flag.