### PR TITLE
Remove `Primary site address` badge for domain-only sites

### DIFF
--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -2,12 +2,18 @@ import { Circle, SVG } from '@wordpress/components';
 import { home, Icon, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { connect } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { resolveDomainStatus } from 'calypso/lib/domains';
 import { type as DomainType } from 'calypso/lib/domains/constants';
 import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-management/components/transfer-connected-domain-nudge';
-import type { SettingsHeaderProps } from './types';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import type {
+	SettingsHeaderConnectedProps,
+	SettingsHeaderOwnProps,
+	SettingsHeaderProps,
+} from './types';
 import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
@@ -88,7 +94,7 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 	};
 
 	const renderBadges = () => {
-		const { domain } = props;
+		const { domain, isDomainOnlySite } = props;
 		const badges = [];
 
 		if (
@@ -102,7 +108,7 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 			badges.push( statusBadge );
 		}
 
-		if ( domain.isPrimary ) {
+		if ( domain.isPrimary && ! isDomainOnlySite ) {
 			badges.push( renderSuccessBadge( __( 'Primary site address' ), home ) );
 		}
 
@@ -165,4 +171,10 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 	);
 };
 
-export default SettingsHeader;
+export default connect(
+	( state, ownProps: SettingsHeaderOwnProps ): SettingsHeaderConnectedProps => {
+		return {
+			isDomainOnlySite: !! isDomainOnlySite( state, ownProps.site.ID ),
+		};
+	}
+)( SettingsHeader );

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -49,10 +49,16 @@ export type SettingsPageConnectedDispatchProps = {
 	recordTracksEvent: typeof recordTracksEvent;
 };
 
-export type SettingsHeaderProps = {
+export type SettingsHeaderOwnProps = {
 	domain: ResponseDomain;
 	site: SiteData;
 };
+
+export type SettingsHeaderConnectedProps = {
+	isDomainOnlySite: boolean;
+};
+
+export type SettingsHeaderProps = SettingsHeaderOwnProps & SettingsHeaderConnectedProps;
 
 export type SettingsPageProps = SettingsPagePassedProps &
 	SettingsPageConnectedProps &


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Removes the "Primary site address" badge from the redesign management page for domain-only sites. 
This is part of the domain settings pages redesign project detailed in pcYYhz-m2-p2.

#### Preview
##### Before
![image](https://user-images.githubusercontent.com/18705930/149977687-2761b8a8-513f-4a90-97e1-97257eba7b3f.png)

##### After
![image](https://user-images.githubusercontent.com/18705930/149977766-de74c397-f6bb-4fdf-a41d-560fc52da4cf.png)

#### Testing instructions
- Build this branch locally or open the live Calypso link
  - If you're in the live Calypso link, please append `?flags=domains/settings-page-redesign` to your URL to enable the appropriate feature flag;
- Select any domain-only site;
- Go to "Upgrades > Domains";
- Confirm that you don't see the "Primary site address" badge on its management page;