### PR TITLE
Restore Hidden Variant Selectors in WPCOM Cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -313,13 +313,11 @@ export default function WPCheckout( {
 					isStepActive={ isOrderReviewActive }
 					isStepComplete={ true }
 					goToThisStep={
-						isJetpackCheckout
-							? () => undefined
-							: () => setIsOrderReviewActive( ! isOrderReviewActive )
+						isJetpackCheckout ? undefined : () => setIsOrderReviewActive( ! isOrderReviewActive )
 					}
 					goToNextStep={
 						isJetpackCheckout
-							? () => undefined
+							? undefined
 							: () => {
 									setIsOrderReviewActive( ! isOrderReviewActive );
 									reduxDispatch(
@@ -362,10 +360,8 @@ export default function WPCheckout( {
 							/>
 						)
 					}
-					editButtonText={ isJetpackCheckout ? undefined : String( translate( 'Edit' ) ) }
-					editButtonAriaLabel={
-						isJetpackCheckout ? undefined : String( translate( 'Edit your order' ) )
-					}
+					editButtonText={ String( translate( 'Edit' ) ) }
+					editButtonAriaLabel={ String( translate( 'Edit your order' ) ) }
 					nextStepButtonText={ String( translate( 'Save order' ) ) }
 					nextStepButtonAriaLabel={ String( translate( 'Save your order' ) ) }
 					validatingButtonText={ validatingButtonText }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -302,6 +302,7 @@ export default function WPCheckout( {
 			<CheckoutStepArea
 				submitButtonHeader={ <SubmitButtonHeader /> }
 				submitButtonFooter={ <SubmitButtonFooter /> }
+				disableSubmitButton={ isOrderReviewActive }
 			>
 				{ infoMessage }
 				<CheckoutStepBody
@@ -368,7 +369,7 @@ export default function WPCheckout( {
 					validatingButtonAriaLabel={ validatingButtonText }
 					formStatus={ formStatus }
 				/>
-				<CheckoutSteps>
+				<CheckoutSteps areStepsActive={ ! isOrderReviewActive }>
 					{ contactDetailsType !== 'none' && (
 						<CheckoutStep
 							stepId={ 'contact-form' }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -21,7 +21,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
-import { useDispatch as useReduxDispatch, useSelector as useReduxSelector } from 'react-redux';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
 	hasGoogleApps,
@@ -114,29 +114,31 @@ const OrderReviewTitle = () => {
 const paymentMethodStep = getDefaultPaymentMethodStep();
 
 export default function WPCheckout( {
-	removeProductFromCart,
+	addItemToCart,
 	changePlanLength,
+	countriesList,
+	createUserAndSiteBeforeTransaction,
+	infoMessage,
+	isJetpackNotAtomic,
+	isLoggedOutCart,
+	onPageLoadError,
+	removeProductFromCart,
+	showErrorMessageBriefly,
 	siteId,
 	siteUrl,
-	countriesList,
-	addItemToCart,
-	showErrorMessageBriefly,
-	isLoggedOutCart,
-	infoMessage,
-	createUserAndSiteBeforeTransaction,
-	onPageLoadError,
 }: {
-	removeProductFromCart: RemoveProductFromCart;
+	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	changePlanLength: OnChangeItemVariant;
+	countriesList: CountryListItem[];
+	createUserAndSiteBeforeTransaction: boolean;
+	infoMessage?: JSX.Element;
+	isJetpackNotAtomic: boolean;
+	isLoggedOutCart: boolean;
+	onPageLoadError: CheckoutPageErrorCallback;
+	removeProductFromCart: RemoveProductFromCart;
+	showErrorMessageBriefly: ( error: string ) => void;
 	siteId: number | undefined;
 	siteUrl: string | undefined;
-	countriesList: CountryListItem[];
-	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
-	showErrorMessageBriefly: ( error: string ) => void;
-	isLoggedOutCart: boolean;
-	infoMessage?: JSX.Element;
-	createUserAndSiteBeforeTransaction: boolean;
-	onPageLoadError: CheckoutPageErrorCallback;
 } ): JSX.Element {
 	const cartKey = useCartKey();
 	const {
@@ -161,9 +163,8 @@ export default function WPCheckout( {
 		sel( 'wpcom-checkout' ).getContactInfo()
 	);
 
-	// const isJetpackSite = useReduxSelector
-
-	const isJetpackCheckout = window.location.pathname.startsWith( '/checkout/jetpack' );
+	const isJetpackCheckout =
+		isJetpackNotAtomic || window.location.pathname.startsWith( '/checkout/jetpack' );
 
 	const {
 		touchContactFields,
@@ -361,8 +362,10 @@ export default function WPCheckout( {
 							/>
 						)
 					}
-					editButtonText={ String( translate( 'Edit' ) ) }
-					editButtonAriaLabel={ String( translate( 'Edit your order' ) ) }
+					editButtonText={ isJetpackCheckout ? undefined : String( translate( 'Edit' ) ) }
+					editButtonAriaLabel={
+						isJetpackCheckout ? undefined : String( translate( 'Edit your order' ) )
+					}
 					nextStepButtonText={ String( translate( 'Save order' ) ) }
 					nextStepButtonAriaLabel={ String( translate( 'Save your order' ) ) }
 					validatingButtonText={ validatingButtonText }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -18,9 +18,10 @@ import {
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
+import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
-import { useDispatch as useReduxDispatch } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector as useReduxSelector } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
 	hasGoogleApps,
@@ -48,6 +49,8 @@ import type { OnChangeItemVariant } from '../components/item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
+
+const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -157,6 +160,11 @@ export default function WPCheckout( {
 	const contactInfo: ManagedContactDetails = useSelect( ( sel ) =>
 		sel( 'wpcom-checkout' ).getContactInfo()
 	);
+
+	// const isJetpackSite = useReduxSelector
+
+	const isJetpackCheckout = window.location.pathname.startsWith( '/checkout/jetpack' );
+
 	const {
 		touchContactFields,
 		applyDomainContactValidationResults,
@@ -173,6 +181,30 @@ export default function WPCheckout( {
 	// starts collapsed and can be expanded; at wider widths (as a sidebar) it is
 	// always visible. It is not a step and its visibility is managed manually.
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
+
+	// The "Order review" step is not managed by Composite Checkout and is shown/hidden manually.
+	// If the page includes a 'order-review=true' query string, then start with
+	// the order review step visible.
+	const [ isOrderReviewActive, setIsOrderReviewActive ] = useState( () => {
+		if ( isJetpackCheckout ) {
+			return false;
+		}
+
+		try {
+			const shouldInitOrderReviewStepActive =
+				window?.location?.search.includes( 'order-review=true' ) ?? false;
+			if ( shouldInitOrderReviewStepActive ) {
+				return true;
+			}
+		} catch ( error ) {
+			// If there's a problem loading the query string, just default to false.
+			debug(
+				'Error loading query string to determine if we should see the order review step at load',
+				error
+			);
+		}
+		return false;
+	} );
 
 	const { formStatus } = useFormStatus();
 
@@ -276,19 +308,62 @@ export default function WPCheckout( {
 					onError={ onReviewError }
 					className="wp-checkout__review-order-step"
 					stepId="review-order-step"
-					isStepActive={ false }
+					isStepActive={ isOrderReviewActive }
 					isStepComplete={ true }
-					titleContent={ <OrderReviewTitle /> }
-					completeStepContent={
-						<WPCheckoutOrderReview
-							removeProductFromCart={ removeProductFromCart }
-							couponFieldStateProps={ couponFieldStateProps }
-							onChangePlanLength={ changePlanLength }
-							siteUrl={ siteUrl }
-							siteId={ siteId }
-							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-						/>
+					goToThisStep={
+						isJetpackCheckout
+							? () => undefined
+							: () => setIsOrderReviewActive( ! isOrderReviewActive )
 					}
+					goToNextStep={
+						isJetpackCheckout
+							? () => undefined
+							: () => {
+									setIsOrderReviewActive( ! isOrderReviewActive );
+									reduxDispatch(
+										recordTracksEvent( 'calypso_checkout_composite_step_complete', {
+											step: 0,
+											step_name: 'review-order-step',
+										} )
+									);
+							  }
+					}
+					titleContent={ <OrderReviewTitle /> }
+					activeStepContent={
+						isJetpackCheckout ? null : (
+							<WPCheckoutOrderReview
+								removeProductFromCart={ removeProductFromCart }
+								couponFieldStateProps={ couponFieldStateProps }
+								onChangePlanLength={ changePlanLength }
+								siteUrl={ siteUrl }
+								siteId={ siteId }
+								createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+							/>
+						)
+					}
+					completeStepContent={
+						isJetpackCheckout ? (
+							<WPCheckoutOrderReview
+								removeProductFromCart={ removeProductFromCart }
+								couponFieldStateProps={ couponFieldStateProps }
+								onChangePlanLength={ changePlanLength }
+								siteUrl={ siteUrl }
+								siteId={ siteId }
+								createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+							/>
+						) : (
+							<WPCheckoutOrderReview
+								isSummary
+								removeProductFromCart={ removeProductFromCart }
+								couponFieldStateProps={ couponFieldStateProps }
+								siteUrl={ siteUrl }
+							/>
+						)
+					}
+					editButtonText={ String( translate( 'Edit' ) ) }
+					editButtonAriaLabel={ String( translate( 'Edit your order' ) ) }
+					nextStepButtonText={ String( translate( 'Save order' ) ) }
+					nextStepButtonAriaLabel={ String( translate( 'Save your order' ) ) }
 					validatingButtonText={ validatingButtonText }
 					validatingButtonAriaLabel={ validatingButtonText }
 					formStatus={ formStatus }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -743,17 +743,18 @@ export default function CompositeCheckout( {
 				initiallySelectedPaymentMethodId={ paymentMethods?.length ? paymentMethods[ 0 ].id : null }
 			>
 				<WPCheckout
-					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
-					changePlanLength={ changePlanLength }
-					siteId={ updatedSiteId }
-					siteUrl={ updatedSiteSlug }
-					countriesList={ countriesList }
 					addItemToCart={ addItemAndLog }
-					showErrorMessageBriefly={ showErrorMessageBriefly }
-					isLoggedOutCart={ !! isLoggedOutCart }
+					changePlanLength={ changePlanLength }
+					countriesList={ countriesList }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 					infoMessage={ infoMessage }
+					isJetpackNotAtomic={ isJetpackNotAtomic }
+					isLoggedOutCart={ !! isLoggedOutCart }
 					onPageLoadError={ onPageLoadError }
+					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
+					showErrorMessageBriefly={ showErrorMessageBriefly }
+					siteId={ updatedSiteId }
+					siteUrl={ updatedSiteSlug }
 				/>
 			</CheckoutProvider>
 		</Fragment>

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -148,12 +148,30 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			} ) );
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
+
 			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 			fireEvent.click( editOrderButton );
 
-			expect(
-				screen.getByText( getVariantItemTextForInterval( expectedVariant ) )
-			).toBeInTheDocument();
+			expect( screen.getByText( getVariantItemTextForInterval( expectedVariant ) ) ).toBeVisible();
+		}
+	);
+
+	it.each( [
+		{ activePlan: 'none', cartPlan: 'yearly', expectedVariant: 'yearly' },
+		{ activePlan: 'none', cartPlan: 'yearly', expectedVariant: 'two-year' },
+	] )(
+		'does not render the $expectedVariant variant for a $cartPlan plan when the current plan is $activePlan and the order is not being edited',
+		async ( { activePlan, cartPlan, expectedVariant } ) => {
+			getPlansBySiteId.mockImplementation( () => ( {
+				data: getActivePersonalPlanDataForType( activePlan ),
+			} ) );
+			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
+			render( <MyCheckout cartChanges={ cartChanges } /> );
+
+			const renderedVariant = await screen.findByText(
+				getVariantItemTextForInterval( expectedVariant )
+			);
+			expect( renderedVariant ).not.toBeVisible();
 		}
 	);
 
@@ -234,9 +252,11 @@ describe( 'CompositeCheckout with a variant picker', () => {
 		}
 	);
 
-	it( 'does not render the variant picker if there are no variants', async () => {
+	it( 'does not render the variant picker if there are no variants after clicking into edit mode', async () => {
 		const cartChanges = { products: [ domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
 
 		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
@@ -265,6 +285,8 @@ describe( 'CompositeCheckout with a variant picker', () => {
 		const currentPlanRenewal = { ...planWithoutDomain, extra: { purchaseType: 'renewal' } };
 		const cartChanges = { products: [ currentPlanRenewal ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
 
 		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -3,7 +3,7 @@
  */
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { render, screen, within, waitFor } from '@testing-library/react';
+import { render, fireEvent, screen, within, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
@@ -148,12 +148,12 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			} ) );
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
+			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+			fireEvent.click( editOrderButton );
 
-			const getVariantItemText = await screen.findByText(
-				getVariantItemTextForInterval( expectedVariant )
-			);
-
-			expect( getVariantItemText ).toBeInTheDocument();
+			expect(
+				screen.getByText( getVariantItemTextForInterval( expectedVariant ) )
+			).toBeInTheDocument();
 		}
 	);
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -575,7 +575,7 @@ describe( 'CompositeCheckout', () => {
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
 		);
-		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 1 );
+		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 2 );
 		fireEvent.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
 		const confirmButton = await within( confirmModal ).findByText( 'Continue' );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -62,6 +62,7 @@ describe( 'CompositeCheckout', () => {
 		hasLoadedSiteDomains.mockImplementation( () => true );
 		getDomainsBySiteId.mockImplementation( () => [] );
 		isMarketplaceProduct.mockImplementation( () => false );
+		isJetpackSite.mockImplementation( () => false );
 
 		container = document.createElement( 'div' );
 		document.body.appendChild( container );
@@ -790,7 +791,7 @@ describe( 'CompositeCheckout', () => {
 			screen
 				.getAllByLabelText( 'WordPress.com Personal' )
 				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
-			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
+			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
 			screen
 				.getAllByLabelText( 'bar.com' )
 				.map( ( element ) => expect( element ).toHaveTextContent( 'R$0' ) );
@@ -819,8 +820,8 @@ describe( 'CompositeCheckout', () => {
 			container
 		);
 		await waitFor( async () => {
-			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'foo.cash' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'foo.cash' ) ).toHaveLength( 3 );
 		} );
 	} );
 
@@ -832,8 +833,8 @@ describe( 'CompositeCheckout', () => {
 			container
 		);
 		await waitFor( async () => {
-			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 3 );
 		} );
 	} );
 
@@ -848,9 +849,9 @@ describe( 'CompositeCheckout', () => {
 			container
 		);
 		await waitFor( () => {
-			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 4 );
+			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 6 );
 		} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -568,9 +568,11 @@ describe( 'CompositeCheckout', () => {
 		} );
 	} );
 
-	it( 'removes a product from the cart after clicking to remove', async () => {
+	it( 'removes a product from the cart after clicking to remove it in edit mode', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
@@ -585,9 +587,28 @@ describe( 'CompositeCheckout', () => {
 		} );
 	} );
 
+	it( 'removes a product from the cart after clicking to remove it outside of edit mode', async () => {
+		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
+		const removeProductButton = await within( activeSection ).findByLabelText(
+			'Remove WordPress.com Personal from cart'
+		);
+		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 2 );
+		fireEvent.click( removeProductButton );
+		const confirmModal = await screen.findByRole( 'dialog' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
+		fireEvent.click( confirmButton );
+		await waitFor( async () => {
+			expect( screen.queryAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 0 );
+		} );
+	} );
+
 	it( 'redirects to the plans page if the cart is empty after removing the last product', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'

--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -52,7 +52,7 @@ function useShowStaleCartNotice() {
 				infoNotice( translate( 'Your cart is awaiting payment.' ), {
 					id: staleCartItemNoticeId,
 					button: translate( 'View your cart' ),
-					href: `/checkout/${ selectedSiteSlug }`,
+					href: `/checkout/${ selectedSiteSlug }?order-review=true`, // Redirect to the order-review step`,
 					onClick: () => {
 						reduxDispatch( recordTracksEvent( 'calypso_cart_abandonment_notice_click' ) );
 					},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restore Hidden Variants/Edit and Save Order to carts for WordPress.com sites
* Preserve new "Show all Variants" behavior on carts for Jetpack sites 

| WordPress.com Cart | Jetpack Cart |
| ------------------ | ------------ |
| ![Screen Shot 2022-01-18 at 16 06 47](https://user-images.githubusercontent.com/2810519/150039885-247ee5e2-dbbe-4998-a3e8-e1db522728eb.png) | ![Screen Shot 2022-01-18 at 16 08 01](https://user-images.githubusercontent.com/2810519/150039901-169192cf-e59b-469a-b374-a60466214055.png) |


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Boot Calypso Blue on this branch.
2. Add a WordPress.com product to the cart.
3. Go to the cart and verify it matches the original cart behavior ( see screenshot above ).
   * The Variant Selectors (Monthly/Annual/Bi-Annual) **should not** be shown when navigating to the cart.
   * There should be an edit button in the right-hand corner.
   * When clicked the cart should go into an edit state where a product variant can be selected.
   * The "Save Order" button can be used to return to the non-edit state.
4. Add a Jetpack product to the cart.
5. Go to the cart and verify it matches the new cart behavior ( see screenshot above ).
    * The Variant Selectors (Monthly/Annual) **should** be shown when navigating to the cart.
   * There should **not** be an edit button in the right-hand corner.

Related to #59838
