### PR TITLE
Add logic to display a premium indicator for themes in the showcase.

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -161,14 +161,14 @@ export class Theme extends Component {
 		} );
 
 		/*
-		 * Check the theme object for the true price.
+		 * Check the theme object (not the price prop) for the true price.
 		 * Sometimes it will be an object, other times it will be a string.
 		 * Check both cases to ensure we have a non-zero price.
 		 */
 		let isPremiumTheme = false;
 		if ( typeof theme.price === 'object' && 0 !== theme.price.value ) {
 			isPremiumTheme = true;
-		} else if ( typeof theme.price === 'string' && ! isEmpty( theme.price ) ) {
+		} else if ( typeof theme.price === 'string' && '' !== theme.price ) {
 			isPremiumTheme = true;
 		}
 

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -160,6 +160,24 @@ export class Theme extends Component {
 			'theme__badge-price-upsell': showUpsell,
 		} );
 
+		/*
+		 * Check the theme object for the true price.
+		 * Sometimes it will be an object, other times it will be a string.
+		 * Check both cases to ensure we have a non-zero price.
+		 */
+		let isPremiumTheme = false;
+		if ( typeof theme.price === 'object' && 0 !== theme.price.value ) {
+			isPremiumTheme = true;
+		} else if ( typeof theme.price === 'string' && ! isEmpty( theme.price ) ) {
+			isPremiumTheme = true;
+		}
+
+		/*
+		 * Only show the Premium badge if we're not already showing the price
+		 * and the theme isn't the active theme.
+		 */
+		const showPremiumBadge = isPremiumTheme && ! hasPrice && ! active;
+
 		const themeDescription = decodeEntities( description );
 
 		// for performance testing
@@ -258,6 +276,9 @@ export class Theme extends Component {
 									context: 'singular noun, the currently active theme',
 								} ) }
 							</span>
+						) }
+						{ showPremiumBadge && (
+							<span className="theme__badge-premium">{ translate( 'Premium' ) }</span>
 						) }
 						<span className={ priceClass }>{ price }</span>
 						{ upsell }

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -78,6 +78,7 @@ $theme-info-height: 54px;
 	font-family: inherit;
 	overflow: hidden;
 	white-space: nowrap;
+	top: -1px;
 
 	&::before {
 		@include long-content-fade();

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -101,6 +101,7 @@ $theme-info-height: 54px;
 .theme__upsell-icon svg {
 	transform: scale( 0.8 );
 	border: 2px solid var( --color-neutral-20 );
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 100%;
 	display: inline-block;
 	width: 22px;
@@ -124,12 +125,20 @@ $theme-info-height: 54px;
 
 .theme__badge-price-upgrade {
 	text-transform: uppercase;
-	font-size: 80%;
+	font-size: $font-body-small;
 }
 
 .theme__badge-active {
 	flex: 0 0 auto;
 	color: var( --color-primary-0 );
+	text-transform: uppercase;
+	font-size: $font-body-extra-small;
+	font-weight: 600;
+}
+
+.theme__badge-premium {
+	color: var( --color-success );
+	flex: 0 0 auto;
 	text-transform: uppercase;
 	font-size: $font-body-extra-small;
 	font-weight: 600;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We talked about adding some kind of indicator for premium themes in #59966, even if the user already has the premium or business plans, to show the value they're getting.
* This has had no design or marketing input; I just wanted to get a handle on the logic. 

**The how**
* I check the `theme.price` prop and not the component `price` prop, as the latter is misleading; it changes depending on the user's access to these themes. So premium themes shown to a user on a premium plan have an empty `price` prop, but the `theme.price` on the object should still be greater than zero.
* Sometimes we get the price as a string and sometimes it's an object. For example, `theme.price` = `$50` on the Recommended tab, but `theme.price` = `{ value: 50, currency: 'USD' ... }` on the Trending or All Themes tabs. This adds some logic and could probably be simplified?

**Before**

<img width="1630" alt="Screen Shot 2022-01-18 at 12 36 07 PM" src="https://user-images.githubusercontent.com/2124984/149995930-7ecad5aa-10d9-48e7-bd29-a4fd244ed8db.png">

**After**

<img width="1618" alt="Screen Shot 2022-01-18 at 12 35 57 PM" src="https://user-images.githubusercontent.com/2124984/149995949-d6c481c9-116a-4c12-9517-23927d7baa59.png">


#### Testing instructions

* Switch to this PR, navigate to `/themes`
* Check the Showcase on each plan type; Free, Personal, Premium, Business

The premium indicator should show for premium themes in the Showcase when:
* The user has a Premium or Business plan.
* The user has purchased an individual premium theme on a Personal or Free plan; the purchased theme(s) will show the indicator, but non-purchased themes will still show the price.
* The theme is not the active theme on the user's site.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
