### PR TITLE
Home: Add Site Icon and site info on mobile view

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -73,8 +73,12 @@ const Home = ( { canUserUseCustomerHome, site, siteId, trackViewSiteAction, noti
 				<SiteIcon site={ site } size={ 58 } />
 				<div className="customer-home__site-info">
 					<div className="customer-home__site-title">{ site.name }</div>
-					<ExternalLink href={ site.URL } className="customer-home__site-domain">
-						{ site.domain }
+					<ExternalLink
+						href={ site.URL }
+						className="customer-home__site-domain"
+						onClick={ trackViewSiteAction }
+					>
+						<span className="customer-home__site-domain-text">{ site.domain }</span>
 					</ExternalLink>
 				</div>
 			</div>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
 import { connect, useDispatch } from 'react-redux';
+import SiteIcon from 'calypso/blocks/site-icon';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import EmptyContent from 'calypso/components/empty-content';
@@ -66,6 +67,15 @@ const Home = ( { canUserUseCustomerHome, site, siteId, trackViewSiteAction, noti
 				align="left"
 				hasScreenOptions
 			/>
+
+			<div className="customer-home__site-content">
+				<SiteIcon site={ site } size={ 64 } />
+				<div className="customer-home__site-info">
+					<div className="customer-home__site-title">{ site.name }</div>
+					<div className="customer-home__site-domain">{ site.domain }</div>
+				</div>
+			</div>
+
 			<div className="customer-home__view-site-button">
 				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
 					{ translate( 'Visit site' ) }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
@@ -72,7 +73,9 @@ const Home = ( { canUserUseCustomerHome, site, siteId, trackViewSiteAction, noti
 				<SiteIcon site={ site } size={ 64 } />
 				<div className="customer-home__site-info">
 					<div className="customer-home__site-title">{ site.name }</div>
-					<div className="customer-home__site-domain">{ site.domain }</div>
+					<ExternalLink href={ site.URL } className="customer-home__site-domain">
+						{ site.domain }
+					</ExternalLink>
 				</div>
 			</div>
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -70,7 +70,7 @@ const Home = ( { canUserUseCustomerHome, site, siteId, trackViewSiteAction, noti
 			/>
 
 			<div className="customer-home__site-content">
-				<SiteIcon site={ site } size={ 64 } />
+				<SiteIcon site={ site } size={ 58 } />
 				<div className="customer-home__site-info">
 					<div className="customer-home__site-title">{ site.name }</div>
 					<ExternalLink href={ site.URL } className="customer-home__site-domain">

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -14,13 +14,10 @@ body.is-section-home.theme-default.color-scheme {
 		display: none;
 	}
 
-	@include breakpoint-deprecated( '<660px' ) {
-		padding-right: 16px;
-	}
-
 	.customer-home__site-content {
 		display: flex;
 		padding: 0 16px 16px;
+		align-items: center;
 
 		@include breakpoint-deprecated( '>660px' ) {
 			padding:0 0 16px;
@@ -34,25 +31,27 @@ body.is-section-home.theme-default.color-scheme {
 		border-radius: 4px;
 		max-width: 58px;
 		height: auto;
-		margin-bottom: 8px;
 		flex: 1 0 auto;
 	}
 
 	.customer-home__site-domain {
 		display: flex;
 		flex-direction: row;
+		align-items: center;
 
 		.customer-home__site-domain-text {
 			white-space: nowrap;
-    		overflow: hidden;
-    		text-overflow: ellipsis;
-			width: calc( 100vw - 120px );
+			overflow: hidden;
+			text-overflow: ellipsis;
+			width: calc( 100vw - 132px );
 			max-width: fit-content;
+			font-size: $font-body-small;
+			line-height: 18px;
 		}
 	}
 
 	.components-external-link__icon {
-		margin-top: 1px;
+		margin: 1px 0 0 7px;
 	}
 
 	.customer-home__site-title {
@@ -63,6 +62,7 @@ body.is-section-home.theme-default.color-scheme {
 		line-height: 27px;
 		letter-spacing: -0.32px;
 		color: var( --studio-black );
+		margin-bottom: 4px;
 	}
 
 	.formatted-header {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -20,7 +20,6 @@ body.is-section-home.theme-default.color-scheme {
 
 	.customer-home__site-content {
 		display: flex;
-		flex-wrap: wrap;
 		padding: 0 16px 16px;
 
 		@include breakpoint-deprecated( '>660px' ) {
@@ -33,14 +32,27 @@ body.is-section-home.theme-default.color-scheme {
 		border: 1px solid var( --studio-gray-5 );
 		box-sizing: border-box;
 		border-radius: 4px;
-		width: 32px;
+		max-width: 58px;
 		height: auto;
 		margin-bottom: 8px;
+		flex: 1 0 auto;
+	}
 
-		@include break-small {
-			width: 58px;
-			height: auto;
+	.customer-home__site-domain {
+		display: flex;
+		flex-direction: row;
+
+		.customer-home__site-domain-text {
+			white-space: nowrap;
+    		overflow: hidden;
+    		text-overflow: ellipsis;
+			width: calc( 100vw - 120px );
+			max-width: fit-content;
 		}
+	}
+
+	.components-external-link__icon {
+		margin-top: 1px;
 	}
 
 	.customer-home__site-title {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,4 +1,6 @@
 @import './grid-mixins.scss';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 body.is-section-home.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
@@ -6,11 +8,65 @@ body.is-section-home.theme-default.color-scheme {
 
 .customer-home__heading {
 	display: flex;
+	flex: 0 0 auto;
+	padding: 16px;
+	position: relative;
 
-	@include breakpoint-deprecated( '<660px' ) {
-		padding-right: 16px;
+	@include breakpoint-deprecated( '>660px' ) {
+		padding: 0;
 	}
 
+	.formatted-header {
+		display: none;
+	}
+
+	.customer-home__site-content {
+		display: flex;
+		flex-wrap: wrap;
+		margin-bottom: 16px;
+	}
+
+	.site-icon {
+		margin-right: 10px;
+		border: 1px solid var( --studio-gray-5 );
+		box-sizing: border-box;
+		border-radius: 4px;
+		width: 32px;
+		height: auto;
+
+		@include break-small {
+			width: 64px;
+			height: auto;
+		}
+	}
+
+	.customer-home__site-info {
+		padding-top: 10px;
+	}
+
+	.customer-home__site-title {
+		font-family: $brand-serif;
+		font-style: normal;
+		font-weight: normal;
+		font-size: $font-title-medium;
+		line-height: 33px;
+		letter-spacing: -0.32px;
+		color: var( --studio-black );
+	}
+
+	.customer-home__site-domain {
+		color: var( --studio-gray-40 );
+	}
+
+	@include break-medium {
+		.customer-home__site-content {
+			display: none;
+		}
+		.formatted-header {
+			display: block;
+		}
+	}
+	
 	.formatted-header {
 		margin-right: 12px;
 	}
@@ -20,8 +76,19 @@ body.is-section-home.theme-default.color-scheme {
 	}
 
 	.customer-home__view-site-button {
+		position: absolute;
+		top: 16px;
+		right: 16px;
 		margin: auto;
 		margin-right: 0;
+		flex-grow: 0;
+		flex-shrink: 0;
+
+		@include break-small {
+			position: relative;
+			top: auto;
+			right: auto;
+		}
 
 		.button {
 			text-align: center;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -7,8 +7,7 @@ body.is-section-home.theme-default.color-scheme {
 }
 
 .customer-home__heading {
-	display: flex;
-	flex: 0 0 auto;
+	display: block;
 	padding: 16px;
 	position: relative;
 
@@ -16,7 +15,8 @@ body.is-section-home.theme-default.color-scheme {
 		padding: 0;
 	}
 
-	.formatted-header {
+	.customer-home__view-site-button,
+	.formatted-header__subtitle {
 		display: none;
 	}
 
@@ -55,14 +55,21 @@ body.is-section-home.theme-default.color-scheme {
 	}
 
 	.customer-home__site-domain {
-		color: var( --studio-gray-40 );
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	@include break-medium {
+		.customer-home__heading {
+			display: flex;
+			flex: 0 0 auto;
+		}
 		.customer-home__site-content {
 			display: none;
 		}
-		.formatted-header {
+		.customer-home__view-site-button,
+		.formatted-header__subtitle {
 			display: block;
 		}
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -8,22 +8,24 @@ body.is-section-home.theme-default.color-scheme {
 
 .customer-home__heading {
 	display: block;
-	padding: 16px;
-	position: relative;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		padding: 0;
-	}
 
 	.customer-home__view-site-button,
 	.formatted-header__subtitle {
 		display: none;
 	}
 
+	@include breakpoint-deprecated( '<660px' ) {
+		padding-right: 16px;
+	}
+
 	.customer-home__site-content {
 		display: flex;
 		flex-wrap: wrap;
-		margin-bottom: 16px;
+		padding: 0 16px 16px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			padding:0 0 16px;
+		}
 	}
 
 	.site-icon {
@@ -33,47 +35,24 @@ body.is-section-home.theme-default.color-scheme {
 		border-radius: 4px;
 		width: 32px;
 		height: auto;
+		margin-bottom: 8px;
 
 		@include break-small {
-			width: 64px;
+			width: 58px;
 			height: auto;
 		}
-	}
-
-	.customer-home__site-info {
-		padding-top: 10px;
 	}
 
 	.customer-home__site-title {
 		font-family: $brand-serif;
 		font-style: normal;
 		font-weight: normal;
-		font-size: $font-title-medium;
-		line-height: 33px;
+		font-size: $font-title-small;
+		line-height: 27px;
 		letter-spacing: -0.32px;
 		color: var( --studio-black );
 	}
 
-	.customer-home__site-domain {
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-
-	@include break-medium {
-		.customer-home__heading {
-			display: flex;
-			flex: 0 0 auto;
-		}
-		.customer-home__site-content {
-			display: none;
-		}
-		.customer-home__view-site-button,
-		.formatted-header__subtitle {
-			display: block;
-		}
-	}
-	
 	.formatted-header {
 		margin-right: 12px;
 	}
@@ -83,25 +62,28 @@ body.is-section-home.theme-default.color-scheme {
 	}
 
 	.customer-home__view-site-button {
-		position: absolute;
-		top: 16px;
-		right: 16px;
 		margin: auto;
 		margin-right: 0;
-		flex-grow: 0;
-		flex-shrink: 0;
-
-		@include break-small {
-			position: relative;
-			top: auto;
-			right: auto;
-		}
 
 		.button {
 			text-align: center;
 			white-space: nowrap;
 		}
 	}
+	@include break-medium {
+		display: flex;
+		flex: 0 0 auto;
+	
+		.customer-home__site-content {
+			display: none;
+		}
+
+		.customer-home__view-site-button,
+		.formatted-header__subtitle {
+			display: block;
+		}
+	}
+	
 }
 
 .customer-home__layout {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes that we add a site info section to the Custom Home screen on mobile. 

Why: Currently when you are on the home screen there is no indicator as to what site you are managing. 
On desktop as a user you have a few different clues. 
1. The site urls is usally in the URL that you are looking. 
2. The sidebar has the site info. 

On mobile web, these 2 clues are gone. 
1. Mobile browsers usually just show the top level domain. 
2. The sidebar is hidden. 

By adding the site info to the home page we hope to make it more clear what site you are on. 
Maybe this should only be shown if the user has more than 1 site?

We have similar info available on the WordPress mobile app.
See:
<img src="https://user-images.githubusercontent.com/115071/150001028-25a47623-8ad9-40d1-a842-b92be726f73d.png" width="400" />

Before:
Mobile:
<img src="https://user-images.githubusercontent.com/115071/150000916-028d6d68-94be-4ff8-a26e-a90f4ded1922.png"  width="400" />

After:

Tablet:
<img width="400" src="https://user-images.githubusercontent.com/115071/151036388-530edadd-02a5-4bf2-a672-4588ca4d4787.png" />


Mobile:
<img width="400" src="https://user-images.githubusercontent.com/115071/151036207-05c5d68c-9f65-4b55-9107-503d4beac6bb.png" />


Desktop: Unchanged
<img width="400" src="https://user-images.githubusercontent.com/115071/150000627-2b7ea439-1e21-4215-b1a1-03cfa4afaa3f.png" />

#### Testing instructions

* Load this PR. 
* Notice that the home page now shows you what site you are on instead of the text.

cc: @annchichi 