### PR TITLE
Use new IntroOffer API to calculate discounts on Jetpack Pricing Page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -24,6 +24,7 @@ type OwnProps = {
 	isFree?: boolean;
 	isIncludedInPlan?: boolean;
 	isOwned?: boolean;
+	pricesAreFetching: boolean | null;
 	showAbovePriceText?: boolean;
 	originalPrice?: number;
 	productName: TranslateResult;
@@ -44,6 +45,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	showAbovePriceText,
 	hideSavingLabel,
 	originalPrice,
+	pricesAreFetching,
 	productName,
 	tooltipText,
 } ) => {
@@ -73,6 +75,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 		<Paid
 			discountedPrice={ discountedPrice }
 			originalPrice={ originalPrice }
+			pricesAreFetching={ pricesAreFetching }
 			billingTerm={ billingTerm }
 			currencyCode={ currencyCode }
 			displayFrom={ displayFrom }

--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -24,7 +24,7 @@ type OwnProps = {
 	isFree?: boolean;
 	isIncludedInPlan?: boolean;
 	isOwned?: boolean;
-	pricesAreFetching: boolean | null;
+	pricesAreFetching?: boolean | null;
 	showAbovePriceText?: boolean;
 	originalPrice?: number;
 	productName: TranslateResult;

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -11,7 +11,7 @@ import type { ReactNode } from 'react';
 type OwnProps = {
 	discountedPrice?: number;
 	originalPrice?: number;
-	pricesAreFetching: boolean | null;
+	pricesAreFetching?: boolean | null;
 	billingTerm: Duration;
 	currencyCode?: string | null;
 	displayFrom?: boolean;

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from 'react';
 type OwnProps = {
 	discountedPrice?: number;
 	originalPrice?: number;
+	pricesAreFetching: boolean | null;
 	billingTerm: Duration;
 	currencyCode?: string | null;
 	displayFrom?: boolean;
@@ -21,6 +22,7 @@ type OwnProps = {
 const Paid: React.FC< OwnProps > = ( {
 	discountedPrice,
 	originalPrice,
+	pricesAreFetching,
 	billingTerm,
 	currencyCode,
 	displayFrom,
@@ -29,7 +31,7 @@ const Paid: React.FC< OwnProps > = ( {
 } ) => {
 	const { price: finalPrice } = useCouponDiscount( originalPrice, discountedPrice );
 
-	if ( ! currencyCode || ! originalPrice ) {
+	if ( ! currencyCode || ! originalPrice || pricesAreFetching ) {
 		return (
 			<>
 				<div className="display-price__price-placeholder" />

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -27,7 +27,7 @@ const Paid: React.FC< OwnProps > = ( {
 	tooltipText,
 	expiryDate,
 } ) => {
-	const { price: finalPrice } = useCouponDiscount( billingTerm, originalPrice, discountedPrice );
+	const { price: finalPrice } = useCouponDiscount( originalPrice, discountedPrice );
 
 	if ( ! currencyCode || ! originalPrice ) {
 		return (

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -23,6 +23,7 @@ type OwnProps = {
 	description?: ReactNode;
 	originalPrice?: number;
 	discountedPrice?: number;
+	pricesAreFetching: boolean | null;
 	hidePrice?: boolean;
 	buttonLabel: TranslateResult;
 	buttonPrimary: boolean;
@@ -61,6 +62,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	description,
 	originalPrice,
 	discountedPrice,
+	pricesAreFetching = null,
 	hidePrice,
 	buttonLabel,
 	buttonPrimary,
@@ -163,6 +165,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 						discountedPrice={ discountedPrice }
 						currencyCode={ item.displayCurrency }
 						originalPrice={ originalPrice ?? 0 }
+						pricesAreFetching={ pricesAreFetching }
 						displayFrom={ displayFrom }
 						showAbovePriceText={ showAbovePriceText }
 						belowPriceText={ item.belowPriceText }

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -23,7 +23,7 @@ type OwnProps = {
 	description?: ReactNode;
 	originalPrice?: number;
 	discountedPrice?: number;
-	pricesAreFetching: boolean | null;
+	pricesAreFetching?: boolean | null;
 	hidePrice?: boolean;
 	buttonLabel: TranslateResult;
 	buttonPrimary: boolean;
@@ -62,7 +62,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	description,
 	originalPrice,
 	discountedPrice,
-	pricesAreFetching = null,
+	pricesAreFetching,
 	hidePrice,
 	buttonLabel,
 	buttonPrimary,

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -83,12 +83,11 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	scrollCardIntoView,
 	collapseFeaturesOnMobile,
 } ) => {
-	const billingTerm = item.displayTerm || item.term;
 	const isFree = item.isFree;
 
 	const translate = useTranslate();
 	const anchorRef = useRef< HTMLDivElement >( null );
-	const { discount } = useCouponDiscount( billingTerm, originalPrice, discountedPrice );
+	const { discount } = useCouponDiscount( originalPrice, discountedPrice );
 	const showDiscountLabel =
 		! hideSavingLabel &&
 		discount &&

--- a/client/components/jetpack/card/jetpack-product-card/test/use-coupon-discount.js
+++ b/client/components/jetpack/card/jetpack-product-card/test/use-coupon-discount.js
@@ -1,7 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import { INTRO_PRICING_DISCOUNT_PERCENTAGE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import useCouponDiscount from '../use-coupon-discount';
 
 const mockStore = configureStore( [] );
@@ -16,18 +15,6 @@ describe( 'useCouponDiscount', () => {
 		const { result } = renderHook( () => useCouponDiscount(), { wrapper: wrapper() } );
 
 		expect( result.current ).toEqual( {} );
-	} );
-
-	test( 'should apply the default discount if there is no coupon', () => {
-		const originalPrice = 100;
-		const { result } = renderHook( () => useCouponDiscount( originalPrice ), {
-			wrapper: wrapper(),
-		} );
-
-		expect( result.current ).toEqual( {
-			price: originalPrice * ( 1 - INTRO_PRICING_DISCOUNT_PERCENTAGE / 100 ),
-			discount: INTRO_PRICING_DISCOUNT_PERCENTAGE,
-		} );
 	} );
 
 	test( 'should take into account initial discounted price when computing total discount', () => {

--- a/client/components/jetpack/card/jetpack-product-card/test/use-coupon-discount.js
+++ b/client/components/jetpack/card/jetpack-product-card/test/use-coupon-discount.js
@@ -1,4 +1,3 @@
-import { TERM_MONTHLY, TERM_ANNUALLY } from '@automattic/calypso-products';
 import { renderHook } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -19,21 +18,9 @@ describe( 'useCouponDiscount', () => {
 		expect( result.current ).toEqual( {} );
 	} );
 
-	test( 'should not apply the default discount for a monthly term', () => {
-		const originalPrice = 100;
-		const { result } = renderHook( () => useCouponDiscount( TERM_MONTHLY, originalPrice ), {
-			wrapper: wrapper(),
-		} );
-
-		expect( result.current ).toEqual( {
-			price: originalPrice,
-			discount: 0,
-		} );
-	} );
-
 	test( 'should apply the default discount if there is no coupon', () => {
 		const originalPrice = 100;
-		const { result } = renderHook( () => useCouponDiscount( TERM_ANNUALLY, originalPrice ), {
+		const { result } = renderHook( () => useCouponDiscount( originalPrice ), {
 			wrapper: wrapper(),
 		} );
 
@@ -47,12 +34,9 @@ describe( 'useCouponDiscount', () => {
 		const originalPrice = 100;
 		const discountedPrice = 50;
 		const couponPercentage = 50;
-		const { result } = renderHook(
-			() => useCouponDiscount( TERM_ANNUALLY, originalPrice, discountedPrice ),
-			{
-				wrapper: wrapper( couponPercentage ),
-			}
-		);
+		const { result } = renderHook( () => useCouponDiscount( originalPrice, discountedPrice ), {
+			wrapper: wrapper( couponPercentage ),
+		} );
 
 		expect( result.current ).toEqual( {
 			price: 25,

--- a/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
+++ b/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
@@ -33,7 +33,7 @@ export default function useCouponDiscount(
 	const hasDiscount = jetpackSaleDiscountRatio > 0 || introDiscountRatio > 0;
 
 	return {
-		price: hasDiscount ? finalPrice : originalPrice ?? discountedPrice,
+		price: hasDiscount ? finalPrice : discountedPrice ?? originalPrice,
 		discount: hasDiscount ? finalDiscount : 0,
 	};
 }

--- a/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
+++ b/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
@@ -20,7 +20,7 @@ export default function useCouponDiscount(
 
 	const finalDiscount = Math.floor( ( ( originalPrice - finalPrice ) / originalPrice ) * 100 );
 
-	const hasDiscount = jetpackSaleDiscountRatio > 0;
+	const hasDiscount = finalPrice < originalPrice;
 
 	return {
 		price: hasDiscount ? finalPrice : discountedPrice ?? originalPrice,

--- a/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
+++ b/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
@@ -22,7 +22,7 @@ export default function useCouponDiscount(
 
 	const finalPrice =
 		Math.floor(
-			( originalPrice ?? discountedPrice ) *
+			( discountedPrice ?? originalPrice ) *
 				( 1 - jetpackSaleDiscountRatio ) *
 				( 1 - introDiscountRatio ) *
 				100

--- a/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
+++ b/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
@@ -1,11 +1,7 @@
-import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import { useSelector } from 'react-redux';
-import { INTRO_PRICING_DISCOUNT_PERCENTAGE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { getJetpackSaleCouponDiscountRatio } from 'calypso/state/marketing/selectors';
-import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 export default function useCouponDiscount(
-	billingTerm: Duration,
 	originalPrice?: number,
 	discountedPrice?: number
 ): {
@@ -13,24 +9,18 @@ export default function useCouponDiscount(
 	discount?: number;
 } {
 	const jetpackSaleDiscountRatio = useSelector( getJetpackSaleCouponDiscountRatio );
-	const introDiscountRatio =
-		billingTerm === TERM_ANNUALLY ? INTRO_PRICING_DISCOUNT_PERCENTAGE / 100 : 0;
 
 	if ( ! originalPrice ) {
 		return {};
 	}
 
 	const finalPrice =
-		Math.floor(
-			( discountedPrice ?? originalPrice ) *
-				( 1 - jetpackSaleDiscountRatio ) *
-				( 1 - introDiscountRatio ) *
-				100
-		) / 100;
+		Math.floor( ( discountedPrice ?? originalPrice ) * ( 1 - jetpackSaleDiscountRatio ) * 100 ) /
+		100;
 
 	const finalDiscount = Math.floor( ( ( originalPrice - finalPrice ) / originalPrice ) * 100 );
 
-	const hasDiscount = jetpackSaleDiscountRatio > 0 || introDiscountRatio > 0;
+	const hasDiscount = jetpackSaleDiscountRatio > 0;
 
 	return {
 		price: hasDiscount ? finalPrice : discountedPrice ?? originalPrice,

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -91,11 +91,12 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 		return false;
 	}, [ item.productSlug, sitePlan, siteProducts ] );
 	// Calculate the product price.
-	const { originalPrice, discountedPrice, priceTierList } = useItemPrice(
-		siteId,
-		item,
-		item?.monthlyProductSlug || ''
-	);
+	const {
+		originalPrice,
+		discountedPrice,
+		priceTierList,
+		isFetching: pricesAreFetching,
+	} = useItemPrice( siteId, item, item?.monthlyProductSlug || '' );
 
 	const isItemPlanFeature = !! (
 		sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug )
@@ -216,6 +217,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			hideSavingLabel={ hideSavingLabel }
 			scrollCardIntoView={ scrollCardIntoView }
 			collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
+			pricesAreFetching={ pricesAreFetching }
 		/>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { useCallback, useEffect, useState } from 'react';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
 import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
 import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';
 import QueryJetpackUserLicensesCounts from 'calypso/components/data/query-jetpack-user-licenses-counts';
@@ -213,6 +214,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 				/>
 
 				<QueryProductsList type="jetpack" />
+				<QueryIntroOffers siteId={ siteId ?? 'none' } />
 				{ siteId && <QuerySiteProducts siteId={ siteId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				{ siteId && <QuerySites siteId={ siteId } /> }

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -1,6 +1,7 @@
 import {
 	PRODUCT_JETPACK_CRM,
 	PRODUCT_JETPACK_CRM_MONTHLY,
+	TERM_MONTHLY,
 	isJetpackSearch,
 } from '@automattic/calypso-products';
 import { useMemo } from 'react';
@@ -112,6 +113,9 @@ const useIntroductoryOfferPrices = (
 	};
 };
 
+const getMonthlyPrice = ( yearlyPrice: number ): number =>
+	Math.ceil( ( yearlyPrice / 12 ) * 100 ) / 100;
+
 const useItemPrice = (
 	siteId: number | null,
 	item: SelectorProduct | null,
@@ -139,14 +143,21 @@ const useItemPrice = (
 		};
 	}
 
-	// Calculate the monthly prices with cents rounded up.
-	let originalPrice = itemCost ? Math.ceil( ( itemCost / 12 ) * 100 ) / 100 : 0;
-	let discountedPrice = introductoryOfferPrices.introOfferCost
-		? Math.ceil( ( introductoryOfferPrices.introOfferCost / 12 ) * 100 ) / 100
-		: undefined;
+	let originalPrice = 0;
+	let discountedPrice = undefined;
+
+	if ( item && itemCost ) {
+		originalPrice = itemCost;
+		if ( item.term !== TERM_MONTHLY ) {
+			originalPrice = getMonthlyPrice( itemCost );
+			discountedPrice = introductoryOfferPrices.introOfferCost
+				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
+				: undefined;
+		}
+	}
 
 	// Introductory offer pricing is not yet supported for tiered plans, so we need to hard-code it for now.
-	if ( item && isJetpackSearch( item ) ) {
+	if ( item && item.term !== TERM_MONTHLY && isJetpackSearch( item ) ) {
 		discountedPrice = originalPrice * ( 1 - INTRO_PRICING_DISCOUNT_PERCENTAGE / 100 );
 	}
 

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -139,9 +139,10 @@ const useItemPrice = (
 		};
 	}
 
-	let originalPrice = itemCost ? itemCost / 12 : 0;
+	// Calculate the monthly prices with cents rounded up.
+	let originalPrice = itemCost ? Math.ceil( ( itemCost / 12 ) * 100 ) / 100 : 0;
 	let discountedPrice = introductoryOfferPrices.introOfferCost
-		? introductoryOfferPrices.introOfferCost / 12
+		? Math.ceil( ( introductoryOfferPrices.introOfferCost / 12 ) * 100 ) / 100
 		: undefined;
 
 	// Introductory offer pricing is not yet supported for tiered plans, so we need to hard-code it for now.

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -95,7 +95,7 @@ const useIntroductoryOfferPrices = (
 	);
 
 	const isFetching =
-		useSelector( ( state ) => siteId && !! isRequestingIntroOffers( state, siteId ) ) || null;
+		useSelector( ( state ) => !! isRequestingIntroOffers( state, siteId ?? undefined ) ) || null;
 	const introOfferCost =
 		useSelector(
 			( state ) => product && getIntroOfferPrice( state, product.product_id, siteId ?? 'none' )
@@ -118,7 +118,7 @@ const useItemPrice = (
 
 	const isFetching = siteId
 		? sitePrices.isFetching
-		: listPrices.isFetching && introductoryOfferPrices.isFetching;
+		: listPrices.isFetching || introductoryOfferPrices.isFetching;
 	const itemCost = siteId ? sitePrices.itemCost : listPrices.itemCost;
 
 	const priceTierList = useMemo(

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -146,7 +146,7 @@ const useItemPrice = (
 
 	// Introductory offer pricing is not yet supported for tiered plans, so we need to hard-code it for now.
 	if ( item && isJetpackSearch( item ) ) {
-		discountedPrice = originalPrice * ( INTRO_PRICING_DISCOUNT_PERCENTAGE / 100 );
+		discountedPrice = originalPrice * ( 1 - INTRO_PRICING_DISCOUNT_PERCENTAGE / 100 );
 	}
 
 	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -134,8 +134,10 @@ const useItemPrice = (
 		};
 	}
 
-	let originalPrice = itemCost ?? 0;
-	let discountedPrice = introductoryOfferPrices.introOfferCost ?? undefined;
+	let originalPrice = itemCost ? itemCost / 12 : 0;
+	let discountedPrice = introductoryOfferPrices.introOfferCost
+		? introductoryOfferPrices.introOfferCost / 12
+		: undefined;
 
 	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
 	if ( item && [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -1,6 +1,11 @@
-import { PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY } from '@automattic/calypso-products';
+import {
+	PRODUCT_JETPACK_CRM,
+	PRODUCT_JETPACK_CRM_MONTHLY,
+	isJetpackSearch,
+} from '@automattic/calypso-products';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { INTRO_PRICING_DISCOUNT_PERCENTAGE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getProductCost } from 'calypso/state/products-list/selectors/get-product-cost';
 import { getProductPriceTierList } from 'calypso/state/products-list/selectors/get-product-price-tiers';
@@ -138,6 +143,11 @@ const useItemPrice = (
 	let discountedPrice = introductoryOfferPrices.introOfferCost
 		? introductoryOfferPrices.introOfferCost / 12
 		: undefined;
+
+	// Introductory offer pricing is not yet supported for tiered plans, so we need to hard-code it for now.
+	if ( item && isJetpackSearch( item ) ) {
+		discountedPrice = originalPrice * ( INTRO_PRICING_DISCOUNT_PERCENTAGE / 100 );
+	}
 
 	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
 	if ( item && [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {

--- a/packages/format-currency/src/index.js
+++ b/packages/format-currency/src/index.js
@@ -58,11 +58,11 @@ export function getCurrencyObject( number, code, options = {} ) {
 	const sign = number < 0 ? '-' : '';
 	const absNumber = Math.abs( number );
 	const rawInteger = Math.floor( absNumber );
-	const integer = numberFormat( rawInteger, {
-		decimals: 0,
+	const integer = numberFormat( absNumber, {
+		decimals: precision,
 		thousandsSep: grouping,
 		decPoint: decimal,
-	} );
+	} ).split( decimal )[ 0 ];
 	const fraction =
 		precision > 0
 			? numberFormat( absNumber - rawInteger, {

--- a/packages/format-currency/test/index.js
+++ b/packages/format-currency/test/index.js
@@ -119,6 +119,24 @@ describe( 'formatCurrency', () => {
 				sign: '-',
 			} );
 		} );
+		test( 'handles values that round up', () => {
+			const money = getCurrencyObject( 9.99876, 'USD' );
+			expect( money ).toEqual( {
+				symbol: '$',
+				integer: '10',
+				fraction: '.00',
+				sign: '',
+			} );
+		} );
+		test( 'handles values that round down', () => {
+			const money = getCurrencyObject( 9.99432, 'USD' );
+			expect( money ).toEqual( {
+				symbol: '$',
+				integer: '9',
+				fraction: '.99',
+				sign: '',
+			} );
+		} );
 		describe( 'supported currencies', () => {
 			test( 'USD', () => {
 				const money = getCurrencyObject( 9800900.32, 'USD' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The objective of this PR is to remove the use of a fixed constant for calculating introductory pricing discounts on the [Jetpack pricing page](https://cloud.jetpack.com/pricing/), and replace it with data from the new `/introductory-offers` endpoint ( D72857-code ).

Task: 1201295898168937-as-1201654603947464

* Ensures the data is loaded by triggering a query for intro offers in `<SelectorPage />`
* Retrieves intro offer price and loading state in `useItemPrice()`.
* Removes consideration of introductory offers from `useCouponDiscount()`, as the `discountedPrice` parameter already has the intro discount applied to it.
* Passes intro offer loading state from initial call of `useItemPrice()` all the way down into `<Paid />` to ensure the price placeholder remains active until the intro offer data has been fetched.
* Updates `getCurrencyObject()` to add support for formatting numbers that round up. Currently, values such as `4.999...` would be displayed as `4.00` instead of `5.00`.

#### Notes
* Prices from the `/introductory-offers` endpoint are yearly, while the pricing page displays them as monthly. This PR divides the provided values by 12, and then rounds up the cents (i.e. `9.991` will still round up to `10.00` as not to advertise a lower than actual monthly cost).
* After adjusting `getCurrencyObject()` to support rounding numbers, I then made that fix irrelevant for this PR via 59d80f91ce42bf985957ff2e35412461aacd7707. I've kept the change though, as I think it makes `getCurrencyObject()` more robust. I noticed as well that even still, due to floating point numbers there will still be certain number values that will not be rounded correctly by `getCurrencyObject()` or the deeper `numberFormat()` function. I've drafted a new PR (#60411) to detail and discuss if these package functions should be able to handle any valid number thrown at them, and some paths forward in tackling that.
* This PR **does not address** the copy on the page i.e. "Get 50% off your first year".

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Run `yarn start-jetpack-cloud` and visit http://jetpack.cloud.localhost:3000/pricing
* Open the Network tab
* Validate the `introductory-offers` XHR request is successful.
* Compare the data from the `introductory-offers` endpoint with the discounted prices displayed on the screen. Each price should be divided into 12 months and accurately rounded to the nearest cents value.
* Compare the original and discounted price for each product, and validate that the discount badge (i.e. 50% off) is accurate.

<img width="1510" alt="Screen Shot 2022-01-26 at 9 06 53 AM" src="https://user-images.githubusercontent.com/10933065/151200938-88d45ef6-1660-4cf8-ab44-57f6844587b1.png">

* Using redux dev tools, validate that the prices are not displayed until the `SITE_INTRO_OFFER_REQUEST_SUCCESS` action has fired.

<img width="1510" alt="Screen Shot 2022-01-26 at 9 10 45 AM" src="https://user-images.githubusercontent.com/10933065/151201420-e4775114-f179-4e15-8994-4c3d07f5b44d.png">

* Visit http://jetpack.cloud.localhost:3000/pricing/monthly and ensure that the introductory offer pricing is **not** applied.