### PR TITLE
Live Links: fix typo in QR code live link

### DIFF
--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Build calypso.live link.
         run: |
           echo '::set-output name=LINK::https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}'
-          echo '::set-output name=QR_CALYPSO::https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl=https%3A%2F%2Fcalypso.live%3Fimage%3Dregistry.a8c.com%2Fcalypso%2Fapp%3Abuild-${{ github.event.pull_request.head.sha }}%26flags%3Doauth&choe=UTF-8'
-          echo '::set-output name=QR_JETPACK::https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl=https%3A%2F%2Fcalypso.live%3Fimage%3Dregistry.a8c.com%2Fcalypso%2Fapp%3Abuild-${{ github.event.pull_request.head.sha }}%26env%3Djetpack%26flags%3Doauth&choe=UTF-8'
+          echo '::set-output name=QR_CALYPSO::https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl=https%3A%2F%2Fcalypso.live%3Fimage%3Dregistry.a8c.com%2Fcalypso%2Fapp%3Acommit-${{ github.event.pull_request.head.sha }}%26flags%3Doauth&choe=UTF-8'
+          echo '::set-output name=QR_JETPACK::https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl=https%3A%2F%2Fcalypso.live%3Fimage%3Dregistry.a8c.com%2Fcalypso%2Fapp%3Acommit-${{ github.event.pull_request.head.sha }}%26env%3Djetpack%26flags%3Doauth&choe=UTF-8'
         id: build_link
       - name: Post comment on PR
         uses: actions/github-script@v3


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a typo in calypso live links used in the QR code produced by the github workflow. 
This was found while trying out the live links generated by https://github.com/Automattic/wp-calypso/pull/60208.

When I noticed that the calypso live links worked for the direct link but not when we used the QR code. 

This PR fixes this. 

#### Testing instructions
* Does the code look like you would expect? 
* Ship and 🤞 

