### PR TITLE
Remove cron job which queues a conflicting docker image build

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -701,14 +701,6 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					-:trunk
 				""".trimIndent()
 			}
-			schedule {
-				schedulingPolicy = cron {
-					minutes = "0/30"
-				}
-				branchFilter = "+:trunk"
-				triggerBuild = always()
-				withPendingChangesOnly = false
-			}
 		}
 
 		failureConditions {


### PR DESCRIPTION
### Changes proposed in this Pull Request
This cron job will queue an extra snapshot dependency on the docker image. If this new build of the docker image tries to push the image of the commit to the docker registry at the same time as the VCS trigger, it causes problems with the deploy system.
