### PR TITLE
Update to confirm step header and button copy.

### DIFF
--- a/client/components/eligibility-warnings/domain-warning/index.tsx
+++ b/client/components/eligibility-warnings/domain-warning/index.tsx
@@ -12,7 +12,7 @@ const DomainEligibilityWarning = ( {
 	wpcomDomain,
 	stagingDomain,
 }: DomainEligibilityWarningProps ): ReactElement => (
-	<Card title={ __( 'New Store Domain' ) }>
+	<Card title={ __( 'Domain change required' ) }>
 		<InfoLabel label={ __( 'New' ) }>{ stagingDomain }</InfoLabel>
 		<p>
 			{ sprintf(

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -87,7 +87,9 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 		}
 
 		return (
-			<PlanWarning title={ __( 'Upgrade your plan' ) }>{ siteUpgrading.description }</PlanWarning>
+			<PlanWarning title={ __( 'Plan upgrade required' ) }>
+				{ siteUpgrading.description }
+			</PlanWarning>
 		);
 	}
 
@@ -137,7 +139,7 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 								goToNextStep();
 							} }
 						>
-							{ __( 'Sounds good' ) }
+							{ __( 'Confirm' ) }
 						</StyledNextButton>
 					</ActionSection>
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update header and button copy to the following.

- "New Store Domain" -> "Domain change required"
- "Upgrade your plan" -> "Plan upgrade required"
- "Sounds good" -> "Confirm"

<table><tr>
<td><h3>BEFORE</h3>
<img alt="before-copy-changes" src="https://user-images.githubusercontent.com/140841/150011590-d6dd0896-d2a6-4d03-9375-2cb83d7e1f62.png">
</td>
<td><h3>AFTER</h3>
<img alt="after-copy-changes" src="https://user-images.githubusercontent.com/140841/150011680-c45cb2b0-2349-490c-b1ee-05a446d7c5ae.png">
</td>
</tr></table>

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Confirm copy changes on "confirm" step.
* http://calypso.localhost:3000/woocommerce-installation/example.wordpress.com

Related to #59485
