### PR TITLE
Seller-xp: Added seller intent

### DIFF
--- a/client/signup/steps/intent/intent-screen.tsx
+++ b/client/signup/steps/intent/intent-screen.tsx
@@ -39,7 +39,7 @@ const useIntents = ( { translate }: Pick< Props, 'translate' > ): Intent[] => {
 		intents.push( {
 			key: 'sell',
 			title: translate( 'Sell' ),
-			description: translate( 'Setup an online store' ),
+			description: translate( 'Set up an online store' ),
 			icon: tip,
 			value: 'sell',
 			actionText: translate( 'Start selling' ),

--- a/client/signup/steps/intent/intent-screen.tsx
+++ b/client/signup/steps/intent/intent-screen.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import React from 'react';
-import { build, write } from '../../icons';
+import { build, write, tip } from '../../icons';
 import SelectItems, { SelectItem } from '../../select-items';
 import SelectItemsAlt, { SelectAltItem } from '../../select-items-alt';
 import type { IntentFlag } from './types';
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const useIntents = ( { translate }: Pick< Props, 'translate' > ): Intent[] => {
-	return [
+	const intents: Intent[] = [
 		{
 			key: 'write',
 			title: translate( 'Write' ),
@@ -34,6 +34,19 @@ const useIntents = ( { translate }: Pick< Props, 'translate' > ): Intent[] => {
 			actionText: translate( 'Start building' ),
 		},
 	];
+
+	if ( isEnabled( 'seller-experience' ) ) {
+		intents.push( {
+			key: 'sell',
+			title: translate( 'Sell' ),
+			description: translate( 'Setup an online store' ),
+			icon: tip,
+			value: 'sell',
+			actionText: translate( 'Start selling' ),
+		} );
+	}
+
+	return intents;
 };
 
 const useIntentsAlt = ( {

--- a/client/signup/steps/intent/types.ts
+++ b/client/signup/steps/intent/types.ts
@@ -1,1 +1,1 @@
-export type IntentFlag = 'build' | 'write' | 'import';
+export type IntentFlag = 'build' | 'write' | 'import' | 'sell';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added new "Sell" intent to the `/start/` flow under the `seller-experience` feature flag.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `start/setup-site/intent?siteSlug=<SITE SLUG>` (which doesn't enable the `seller-experience` feature flag)
* Things should be unchanged!
![image](https://user-images.githubusercontent.com/3801502/150015621-5a83ad9d-105e-4122-a6f6-40dfbc841898.png)


* Access `start/setup-site/intent?siteSlug=<SITE SLUG>&flags=seller-experience` (which enables the `seller-experience` feature flag)
* Check the "Sell" intent
![image](https://user-images.githubusercontent.com/3801502/150015569-2747a047-f39c-4373-b577-f9d4d95a1402.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60153
