### PR TITLE
Add onboarding blogger importer

### DIFF
--- a/client/signup/steps/import-from/blogger/index.tsx
+++ b/client/signup/steps/import-from/blogger/index.tsx
@@ -1,0 +1,151 @@
+import classnames from 'classnames';
+import { translate, TranslateOptions, TranslateOptionsText } from 'i18n-calypso';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import importerConfig from 'calypso/lib/importer/importer-config';
+import { resetImport, startImport } from 'calypso/state/imports/actions';
+import { appStates } from 'calypso/state/imports/constants';
+import { importSite } from 'calypso/state/imports/site-importer/actions';
+import CompleteScreen from '../components/complete-screen';
+import GettingStartedVideo from '../components/getting-started-video';
+import ImporterDrag from '../components/importer-drag';
+import ProgressScreen from '../components/progress-screen';
+import { Importer, ImporterBaseProps, ImportJob, ImportJobParams } from '../types';
+import { getImporterTypeForEngine } from '../util';
+
+export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( props ) => {
+	const importer: Importer = 'blogger';
+	const {
+		job,
+		urlData,
+		siteId,
+		site,
+		siteSlug,
+		fromSite,
+		importSite,
+		startImport,
+		resetImport,
+	} = props;
+	const importerData = importerConfig().blogger;
+
+	populateMessages();
+
+	/**
+	 * Effects
+	 */
+	useEffect( runImport, [ job ] );
+
+	/**
+	 ↓ Methods
+	 */
+	function runImport() {
+		// If there is no existing import job, start a new
+		if ( job === undefined ) {
+			startImport( siteId, getImporterTypeForEngine( importer ) );
+		} else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
+			importSite( prepareImportParams() );
+		}
+	}
+
+	function prepareImportParams(): ImportJobParams {
+		const targetSiteUrl = fromSite.startsWith( 'http' ) ? fromSite : 'https://' + fromSite;
+
+		return {
+			engine: importer,
+			importerStatus: job as ImportJob,
+			params: { engine: importer },
+			site: { ID: siteId },
+			targetSiteUrl,
+			supportedContent: [],
+			unsupportedContent: [],
+		};
+	}
+
+	function checkProgress() {
+		return job?.importerState === appStates.IMPORTING;
+	}
+
+	function checkIsSuccess() {
+		return job?.importerState === appStates.IMPORT_SUCCESS;
+	}
+
+	function showVideoComponent() {
+		return checkProgress() || checkIsSuccess();
+	}
+
+	// Change the default messages
+	function populateMessages() {
+		const options: TranslateOptions = {
+			args: {
+				importerName: 'Blogger',
+			},
+			components: {
+				supportLink: (
+					<InlineSupportLink supportContext="importers-blogger" showIcon={ false }>
+						{ translate( 'Need help exporting your content?' ) }
+					</InlineSupportLink>
+				),
+			},
+		};
+
+		importerData.title = translate( 'Import content from %(importerName)s', {
+			...options,
+			textOnly: true,
+		} as TranslateOptionsText ) as string;
+
+		importerData.description = translate(
+			'Import posts, pages, comments, tags, and images from a %(importerName)s export file.',
+			options
+		);
+	}
+
+	return (
+		<>
+			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
+				{ ( () => {
+					if ( ! job ) {
+						return;
+					} else if ( checkIsSuccess() ) {
+						/**
+						 * Complete screen
+						 */
+						return (
+							<CompleteScreen
+								siteId={ siteId }
+								siteSlug={ siteSlug }
+								job={ job as ImportJob }
+								resetImport={ resetImport }
+							/>
+						);
+					} else if ( checkProgress() ) {
+						/**
+						 * Progress screen
+						 */
+						return <ProgressScreen job={ job } />;
+					}
+
+					/**
+					 * Upload section
+					 */
+					return (
+						<ImporterDrag
+							urlData={ urlData }
+							site={ site }
+							importerData={ importerData }
+							importerStatus={ job }
+						/>
+					);
+				} )() }
+
+				{ showVideoComponent() && <GettingStartedVideo /> }
+			</div>
+		</>
+	);
+};
+
+export default connect( null, {
+	importSite,
+	startImport,
+	resetImport,
+} )( BloggerImporter );

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -16,6 +16,7 @@ import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSite, getSiteId } from 'calypso/state/sites/selectors';
 import { UrlData } from '../import/types';
+import BloggerImporter from './blogger';
 import { Site } from './components/importer-drag';
 import NotAuthorized from './components/not-authorized';
 import NotFound from './components/not-found';
@@ -132,6 +133,24 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 									 * Permission screen
 									 */
 									return <NotAuthorized siteSlug={ siteSlug } />;
+								} else if (
+									engine === 'blogger' &&
+									isEnabled( 'gutenboarding/import-from-blogger' )
+								) {
+									/**
+									 * Blogger importer
+									 */
+									return (
+										<BloggerImporter
+											job={ getImportJob( engine ) }
+											run={ runImportInitially }
+											siteId={ siteId }
+											site={ site }
+											siteSlug={ siteSlug }
+											fromSite={ fromSite }
+											urlData={ urlData }
+										/>
+									);
 								} else if (
 									engine === 'medium' &&
 									isEnabled( 'gutenboarding/import-from-medium' )

--- a/client/signup/steps/import-from/types.ts
+++ b/client/signup/steps/import-from/types.ts
@@ -1,7 +1,7 @@
 import { UrlData } from '../import/types';
 import { Site } from './components/importer-drag';
 
-export type Importer = 'medium' | 'squarespace' | 'wix' | 'wordpress';
+export type Importer = 'blogger' | 'medium' | 'squarespace' | 'wix' | 'wordpress';
 export type QueryObject = {
 	from: string;
 	to: string;

--- a/client/signup/steps/import/index.tsx
+++ b/client/signup/steps/import/index.tsx
@@ -70,10 +70,11 @@ const ImportOnboarding: React.FunctionComponent< Props > = ( props ) => {
 	const goToImporterPage = ( platform: ImporterPlatform ): void => {
 		let importerUrl;
 		if (
-			( platform === 'wordpress' && isEnabled( 'gutenboarding/import-from-wordpress' ) ) ||
+			( platform === 'blogger' && isEnabled( 'gutenboarding/import-from-blogger' ) ) ||
 			( platform === 'medium' && isEnabled( 'gutenboarding/import-from-medium' ) ) ||
 			( platform === 'squarespace' && isEnabled( 'gutenboarding/import-from-squarespace' ) ) ||
-			( platform === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) )
+			( platform === 'wix' && isEnabled( 'gutenboarding/import-from-wix' ) ) ||
+			( platform === 'wordpress' && isEnabled( 'gutenboarding/import-from-wordpress' ) )
 		) {
 			importerUrl = getWpComOnboardingUrl( signupDependencies.siteSlug, platform, urlData.url );
 		} else {

--- a/config/development.json
+++ b/config/development.json
@@ -64,6 +64,7 @@
 		"google-drive": true,
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/import": true,
+		"gutenboarding/import-from-blogger": true,
 		"gutenboarding/import-from-medium": true,
 		"gutenboarding/import-from-squarespace": true,
 		"gutenboarding/import-from-wix": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,6 +43,7 @@
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,
 		"gutenboarding/import": true,
+		"gutenboarding/import-from-blogger": true,
 		"gutenboarding/import-from-medium": true,
 		"gutenboarding/import-from-squarespace": true,
 		"gutenboarding/import-from-wix": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a Blogger importer

#### Testing instructions

* Open http://calypso.localhost:3000/start/importer/capture?siteSlug=SITE_SLUG
* Input a Blogger URL such as https://zaerl.blogger.com/
* Select a Blogger `.xml` export file; you can find one on _Drive > Caribou > Sample Export Files > Blogger_
* Import the XML
* Check if the data have been imported

#### Important
The author list component is missing the favicon because Blogger `analyze-call` returns `null`.