### PR TITLE
WooCommerce Install: Swap onboarding steps

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -409,7 +409,7 @@ export function generateFlows( {
 			name: 'woocommerce-install',
 			pageTitle: translate( 'Add WooCommerce to your site' ),
 			steps: isEnabled( 'woop' )
-				? [ 'business-info', 'store-address', 'confirm', 'transfer' ]
+				? [ 'store-address', 'business-info', 'confirm', 'transfer' ]
 				: [ 'confirm', 'transfer' ],
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -77,8 +77,8 @@ const stepNameToModuleName = {
 	ready: 'import',
 	importing: 'import-from',
 	'select-site': 'woocommerce-install/select-site',
-	'business-info': 'woocommerce-install/step-business-info',
 	'store-address': 'woocommerce-install/step-store-address',
+	'business-info': 'woocommerce-install/step-business-info',
 	confirm: 'woocommerce-install/confirm',
 	transfer: 'woocommerce-install/transfer',
 };

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -739,12 +739,12 @@ export function generateSteps( {
 		},
 
 		// Woocommerce Install steps.
-		'business-info': {
-			stepName: 'business-info',
-			dependencies: [ 'site' ],
-		},
 		'store-address': {
 			stepName: 'store-address',
+			dependencies: [ 'site' ],
+		},
+		'business-info': {
+			stepName: 'business-info',
 			dependencies: [ 'site' ],
 		},
 		confirm: {

--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SupportCard from '../components/support-card';
 import { ActionSection, StyledNextButton } from '../confirm';
@@ -19,7 +18,6 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const siteDomain = useSelector( ( state ) => getSiteDomain( state, siteId ) ) as string;
 
 	const { get, save, update } = useSiteSettings( siteId );
 
@@ -204,8 +202,6 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 		<StepWrapper
 			flowName="woocommerce-install"
 			hideSkip={ true }
-			allowBackFirstStep={ true }
-			backUrl={ `/woocommerce-installation/${ siteDomain }` }
 			headerText={ __( 'Tell us a bit about your business' ) }
 			fallbackHeaderText={ __( 'Tell us a bit about your business' ) }
 			subHeaderText={ __( 'We will guide you to get started based on your responses.' ) }

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -10,6 +10,7 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { fetchWooCommerceCountries } from 'calypso/state/countries/actions';
 import getCountries from 'calypso/state/selectors/get-countries';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SupportCard from '../components/support-card';
 import { ActionSection, StyledNextButton } from '../confirm';
@@ -53,6 +54,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	} );
 
 	const { get, save, update } = useSiteSettings( siteId );
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 
 	const { validate, clearError, getError, errors } = useAddressFormValidation( siteId );
 
@@ -198,6 +200,8 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 		<StepWrapper
 			flowName="woocommerce-install"
 			hideSkip={ true }
+			allowBackFirstStep={ true }
+			backUrl={ `/woocommerce-installation/${ domain }` }
 			headerText={ __( 'Add an address to accept payments' ) }
 			fallbackHeaderText={ __( 'Add an address to accept payments' ) }
 			subHeaderText={ __(


### PR DESCRIPTION
The address step needs to be first so that we can use the country data to populate the business info step revenue dropdown.

Fixes #60218

#### Changes proposed in this Pull Request

* Swaps order of the address and business info steps.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://calypso.localhost:3000/woocommerce-installation/
- Choose a test site site
- Click set up my store
- You should be taken to the address step
- Use the Back links to make sure the flow correctly navigates through the steps

