### PR TITLE
Remove jquery from wpcom block editor

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -42,7 +42,6 @@
 		"@wordpress/rich-text": "^5.0.7",
 		"@wordpress/url": "^3.3.1",
 		"debug": "^4.3.3",
-		"jquery": "^1.12.3",
 		"lodash": "^4.17.21",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -56,6 +56,11 @@ function handleClosestEvent( e ) {
 	const allSelectors = Object.keys( clickOverrides ).join( ', ' );
 	const matchingElement = e.target.closest( allSelectors );
 
+	if ( ! matchingElement ) {
+		return;
+	}
+
+	// Find the correct callback to use for this clicked element.
 	for ( const [ selector, cb ] of Object.entries( clickOverrides ) ) {
 		if ( matchingElement.matches( selector ) ) {
 			e.preventDefault();

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -6,6 +6,7 @@ import {
 	__experimentalNavigationBackButton as NavigationBackButton,
 } from '@wordpress/components';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -1259,9 +1260,12 @@ function initPort( message ) {
 	window.removeEventListener( 'message', initPort, false );
 }
 
-( function () {
+// Note: domReady is used instead of `(function() { ... })()` because certain
+// things in `initPort` require other scripts to be loaded. (For example, ETK
+// scripts need to be available before some things will work correctly.)
+domReady( () => {
 	window.addEventListener( 'message', initPort, false );
 
 	//signal module loaded
 	sendMessage( { action: 'loaded' } );
-} )();
+} );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -42,7 +42,7 @@ function addEditorListener( selector, cb ) {
 	clickOverrides[ selector ] = cb;
 
 	if ( ! addedListener ) {
-		document.querySelector( '#editor' )?.addEventListener( 'click', handleClosestEvent );
+		document.querySelector( '#editor' )?.addEventListener( 'click', triggerOverrideHandler );
 		addedListener = true;
 	}
 }
@@ -52,7 +52,7 @@ function addEditorListener( selector, cb ) {
 // from the DOM dynamically after the listeners are created. We need to handle
 // clicks anyways, so directly accessing the elements and adding listeners to them
 // is not viable.
-function handleClosestEvent( e ) {
+function triggerOverrideHandler( e ) {
 	const allSelectors = Object.keys( clickOverrides ).join( ', ' );
 	const matchingElement = e.target.closest( allSelectors );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,7 +1415,6 @@ __metadata:
     debug: ^4.3.3
     enzyme: ^3.11.0
     jest: ^27.3.1
-    jquery: ^1.12.3
     lodash: ^4.17.21
     npm-run-all: ^4.1.5
     postcss: ^8.4.5
@@ -23358,13 +23357,6 @@ fsevents@~2.1.2:
   version: 0.4.3
   resolution: "jpeg-js@npm:0.4.3"
   checksum: f1d6f38e5250e80f0ff9020f09f216f1493d4bd1ce091fff1ae361fcdab199df5df03a6d81a418964074b572b8f6ecfad3cf4ea807e5aa96477c092b3d247a12
-  languageName: node
-  linkType: hard
-
-"jquery@npm:^1.12.3":
-  version: 1.12.3
-  resolution: "jquery@npm:1.12.3"
-  checksum: bd69cd957822669dc228c8e6a6a461b344e7b878b86f3597f37b04bebb8905f509dbef59fef179dbf958cdea428a99a64824f2395a9e3bb554d46cf0f4b250b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Removes jquery dependency from wpcom-block-editor. It is at fault for the "We found potential security vulnerabilities" message on the front screen. Importantly, jquery is loaded from wp-admin, so this legacy version isn't even used in prod.

This wasn't too hard to do, since `$` was only used in 6 places in wpcom block editor:
1. The code which opens calypso revisions instead of wp-admin
2. The code which opens the "view post" link in the new post publish snackbar
3. The code which opens the customizer for some FSE/widgets blocks. I was unable to find where this was used though.
4. The code which overrides legacy full screen close buttons. I believe this can be deleted, as we are many Gutenberg versions in the future at this point.
5. The code which opens template parts in legacy dotcom FSE in the iframe.
6. The code which initializes the script.

Now, the one weird thing is that we're replecating `$( el ).on`. In other words, we need to listen to all clicks, and then detect if they match our selectors. We can't attach selectors to the elements, because they might not exist at init, and they can be dynamically added/removed by react. I have an implementation similar to some stuff I found on the web, which calls the callback if `e.target.closest( selector )` is true.

My concern is that this will be bad for performance. That said, I imagine jquery's implementation can't be great for performance either. Any thoughts?

### Testing instructions
1. Make sure `widgets.wp.com` and a test site is sandboxed.
2. Sync changes to your sandbox (`install-plugin.sh wbe remove-jquery-wpcom-block-editor`)
3. Force reload the editor on that site to get new copies of the file. (E.g. make sure the files don't come from the browser cache)
4. Test each of the sections above. In particular:
- Publish a post and click the link in the snackbar. Does it redirect the page to the front end post?
- Click on the revisions button in the sidebar. Does it open calypso revisions instead of redirecting?
- Test using the calypso media modal
- Test using the editor close buttons (the W button in the top left)
