### PR TITLE
Masterbar cart: Add vertical scrolling

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
@@ -46,8 +46,14 @@
 		position: fixed;
 		top: var( --masterbar-height );
 		right: 0;
-		bottom: 0;
+		bottom: 1em;
 		background-color: var( --color-surface );
+	}
+}
+
+.masterbar-cart-button__popover .mini-cart-line-items {
+	@include breakpoint-deprecated( '<480px' ) {
+		max-height: none;
 	}
 }
 

--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -18,6 +18,8 @@ const MiniCartLineItemsWrapper = styled.ul< { theme?: Theme } >`
 	box-sizing: border-box;
 	margin: 20px 0;
 	padding: 0;
+	overflow-y: scroll;
+	max-height: 50vh;
 `;
 
 const MiniCartLineItemWrapper = styled.li`
@@ -42,7 +44,7 @@ export function MiniCartLineItems( {
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 
 	return (
-		<MiniCartLineItemsWrapper>
+		<MiniCartLineItemsWrapper className="mini-cart-line-items">
 			{ responseCart.products.map( ( product ) => {
 				return (
 					<MiniCartLineItemWrapper key={ product.uuid }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the shopping cart contains a large number of items, it's possible for the cart in the masterbar to become unusable as it overflows the page and hides the "Go to checkout" button.

This PR adds vertical scrolling for the item list.

Fixes https://github.com/Automattic/wp-calypso/issues/60132

#### Videos

Desktop width:

https://user-images.githubusercontent.com/2036909/150035331-413bc4d0-bb9a-4843-b3b1-14d2a23d809c.mov

Mobile width:

https://user-images.githubusercontent.com/2036909/150035349-a4722868-2c78-4778-a8eb-01c8665a51d0.mov


#### Testing instructions

First you'll need to get a large number of items in your cart. Probably the easiest way to do this is to add a large number of domains to the cart by visiting `/domains/manage/YOUR-SITE-HERE` and repeatedly selecting a new domain, then returning to the page again.

Next, click on the masterbar cart icon and verify that the resulting popup does not overflow the viewport and that it scrolls comfortably.

Because we have temporarily [disabled the masterbar cart at mobile width](https://github.com/Automattic/wp-calypso/pull/60157), if you wish to test this at small widths you'll need to modify the CSS in this diff as follows:

```diff
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
@@ -1,9 +1,5 @@
 .masterbar-cart-button {
        cursor: pointer;
-       /* Hide at small widths until we can figure out how to improve the alignment: https://github.com/Automattic/wp-calypso/issues/60148 */
-       @include breakpoint-deprecated( '<480px' ) {
-               display: none;
-       }
 }

 .masterbar-cart-button__count-container {
```