### PR TITLE
Signup: Add intent to back/skip button click event

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { getStepUrl, isFirstStepInFlow } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 import { getFilteredSteps } from '../utils';
@@ -121,6 +122,7 @@ export class NavigationLink extends Component {
 		const tracksProps = {
 			flow: this.props.flowName,
 			step: this.props.stepName,
+			intent: this.props.intent,
 		};
 
 		if ( this.props.direction === 'back' ) {
@@ -190,9 +192,14 @@ export class NavigationLink extends Component {
 }
 
 export default connect(
-	( state ) => ( {
-		userLoggedIn: isUserLoggedIn( state ),
-		signupProgress: getSignupProgress( state ),
-	} ),
+	( state ) => {
+		const { intent } = getSignupDependencyStore( state );
+
+		return {
+			userLoggedIn: isUserLoggedIn( state ),
+			signupProgress: getSignupProgress( state ),
+			intent,
+		};
+	},
 	{ recordTracksEvent, submitSignupStep }
 )( localize( NavigationLink ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As https://github.com/Automattic/wp-calypso/issues/60216 mentioned, we need the intent prop to analyze the user switches their intent in Hero Flow or not.

![image](https://user-images.githubusercontent.com/13596067/150052576-3347a768-9009-4ac2-87bf-ce94e316c73e.png)

![image](https://user-images.githubusercontent.com/13596067/150052651-0cb88374-a9e8-4796-88be-2a54efaa425b.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your_site>`
* Select one of the intent 
* In next step, click “Back” or “Skip”
* Check the following events contain “intent” prop or not
  * calypso_signup_previous_step_button_click
  * calypso_signup_skip_step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60216
