### PR TITLE
Send woocommerce_onboarding_profile.completed when submitting the business info step

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
+++ b/client/signup/steps/woocommerce-install/hooks/use-site-settings/index.tsx
@@ -5,7 +5,10 @@ import {
 	saveSiteSettings,
 	updateSiteSettings,
 } from 'calypso/state/site-settings/actions';
-import { getSiteSettings } from 'calypso/state/site-settings/selectors';
+import {
+	getSiteSettings,
+	isSiteSettingsSaveSuccessful,
+} from 'calypso/state/site-settings/selectors';
 
 // WooCommerce enable options.
 export const WOOCOMMERCE_STORE_ADDRESS_1 = 'woocommerce_store_address';
@@ -36,6 +39,7 @@ export function useSiteSettings( siteId: number ) {
 	const dispatch = useDispatch();
 
 	const settings = useSelector( ( state ) => getSiteSettings( state, siteId ) );
+	const settingsSaved = useSelector( ( state ) => isSiteSettingsSaveSuccessful( state, siteId ) );
 
 	const [ updates, setUpdates ] = useState( {} as Record< optionNameType, OptionValueType > );
 
@@ -46,7 +50,7 @@ export function useSiteSettings( siteId: number ) {
 		}
 
 		dispatch( requestSiteSettings( siteId ) );
-	}, [ dispatch, siteId ] );
+	}, [ dispatch, siteId, settingsSaved ] );
 
 	// Simple getter helper.
 	function get( option: optionNameType ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Send the `completed: true` value when submitting the business info step.

#### Testing instructions

Final testing requires deactivating and uninstalling woo but you can skip this for most testing

```
wp plugin deactivate woocommerce
wp plugin uninstall woocommerce
```

Final testing should also include testing against a reverted / fresh site to ensure complete is copied over during transfer too (I think this is working so far but haven't confirmed)

Between tests of the installer flow it's a good idea to delete the option via cli

```
wp option delete woocommerce_onboarding_profile
```
Start the test from either the landing page or just go to the first step directly:

- http://calypso.localhost:3000/start/woocommerce-install/?site=wooptestupgrade.wpcomstaging.com
- Enter your address
- When confirming you should see the POST against `/sites/197963111/settings` with changed address values.
- You'll now be on the business info step. 
- When you submit this step, a `completed: true` value should be included in the /sites/settings POST request regardless of whether you changed anything on the options presented or just clicked submit early. At the moment it seems like both scenarios fail to include the completed: true value.
- After submitting you'll be taken to the transfer step where woo will be "installed" or at least checked in our test case
- After this check completes you're taken to the woocommerce admin screen, you should be left on wc admin without being redirected to the setup wizard.

This video shows sort of what I'm testing / how a bit clearer:

https://user-images.githubusercontent.com/811776/150071960-a56cf4ee-dfb4-43b1-ba3b-ce2d493e2287.mp4

The grey screen wsod at the end there is due to a JS error because we send product types as a string instead of an array, this will be fixed separately in https://github.com/Automattic/wp-calypso/issues/60171. If you need to work around it (and get it stuck in local storage state like I did, you can clear your local state out and it shouldn't be a problem as long as you delete it from site options too.

Related to #60228
