### PR TITLE
App Banner: Removed session storage access from selector

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -58,6 +58,13 @@ export class AppBanner extends Component {
 		userAgent: typeof window !== 'undefined' ? window.navigator.userAgent : '',
 	};
 
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isBloggerFlow: false,
+		};
+	}
+
 	stopBubblingEvents = ( event ) => {
 		event.stopPropagation();
 	};
@@ -104,6 +111,15 @@ export class AppBanner extends Component {
 		this.props.recordAppBannerOpen( this.props.currentSection );
 	};
 
+	UNSAFE_componentWillMount() {
+		if (
+			typeof window !== 'undefined' &&
+			window.sessionStorage.getItem( 'wpcom_signup_complete_show_draft_post_modal' )
+		) {
+			this.setState( { isBloggerFlow: true } );
+		}
+	}
+
 	getDeepLink() {
 		const { currentRoute, currentSection } = this.props;
 
@@ -131,7 +147,7 @@ export class AppBanner extends Component {
 	render() {
 		const { translate, currentSection } = this.props;
 
-		if ( ! this.props.shouldDisplayAppBanner ) {
+		if ( ! this.props.shouldDisplayAppBanner || this.state.isBloggerFlow ) {
 			return null;
 		}
 

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -60,9 +60,15 @@ export class AppBanner extends Component {
 
 	constructor( props ) {
 		super( props );
-		this.state = {
-			isBloggerFlow: false,
-		};
+
+		if (
+			typeof window !== 'undefined' &&
+			window.sessionStorage.getItem( 'wpcom_signup_complete_show_draft_post_modal' )
+		) {
+			this.state = { isBloggerFlow: true };
+		} else {
+			this.state = { isBloggerFlow: false };
+		}
 	}
 
 	stopBubblingEvents = ( event ) => {
@@ -110,15 +116,6 @@ export class AppBanner extends Component {
 	openApp = () => {
 		this.props.recordAppBannerOpen( this.props.currentSection );
 	};
-
-	UNSAFE_componentWillMount() {
-		if (
-			typeof window !== 'undefined' &&
-			window.sessionStorage.getItem( 'wpcom_signup_complete_show_draft_post_modal' )
-		) {
-			this.setState( { isBloggerFlow: true } );
-		}
-	}
 
 	getDeepLink() {
 		const { currentRoute, currentSection } = this.props;

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -65,9 +65,9 @@ export class AppBanner extends Component {
 			typeof window !== 'undefined' &&
 			window.sessionStorage.getItem( 'wpcom_signup_complete_show_draft_post_modal' )
 		) {
-			this.state = { isBloggerFlow: true };
+			this.state = { isDraftPostModalShown: true };
 		} else {
-			this.state = { isBloggerFlow: false };
+			this.state = { isDraftPostModalShown: false };
 		}
 	}
 
@@ -144,7 +144,7 @@ export class AppBanner extends Component {
 	render() {
 		const { translate, currentSection } = this.props;
 
-		if ( ! this.props.shouldDisplayAppBanner || this.state.isBloggerFlow ) {
+		if ( ! this.props.shouldDisplayAppBanner || this.state.isDraftPostModalShown ) {
 			return null;
 		}
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -865,6 +865,10 @@ const mapStateToProps = (
 		fseParentPageId
 	);
 
+	// We don't check if we're in Blogger Flow in shouldDisplayAppBanner for performance reasons.
+	// So we know that we are not showing the App Banner because of Blogger Flow if showDraftPostModal is true.
+	const displayAppBanner = shouldDisplayAppBanner( state ) && ! showDraftPostModal;
+
 	return {
 		closeUrl,
 		closeLabel,
@@ -889,7 +893,7 @@ const mapStateToProps = (
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		site: getSite( state, siteId ?? 0 ),
 		parentPostId,
-		shouldDisplayAppBanner: shouldDisplayAppBanner( state ),
+		shouldDisplayAppBanner: displayAppBanner,
 		appBannerDismissed: isAppBannerDismissed( state ),
 	};
 };

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -865,8 +865,9 @@ const mapStateToProps = (
 		fseParentPageId
 	);
 
-	// We don't check if we're in Blogger Flow in shouldDisplayAppBanner for performance reasons.
-	// So we know that we are not showing the App Banner because of Blogger Flow if showDraftPostModal is true.
+	// 'shouldDisplayAppBanner' does not check if we're in Blogger Flow, because it is a selector reading from the Redux state, and
+	// the Blogger Flow information is not in the Redux state, but in the session storage value wpcom_signup_complete_show_draft_post_modal.
+	// So instead we get that information from 'showDraftPostModal'
 	const displayAppBanner = shouldDisplayAppBanner( state ) && ! showDraftPostModal;
 
 	return {

--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -42,13 +42,6 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 		return false;
 	}
 
-	if (
-		typeof window !== 'undefined' &&
-		window.sessionStorage.getItem( 'wpcom_signup_complete_show_draft_post_modal' )
-	) {
-		return false;
-	}
-
 	const sectionName = getSectionName( state );
 	const isNotesOpen = isNotificationsOpen( state );
 	const currentSection = getCurrentSection( sectionName, isNotesOpen );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With [58524](https://github.com/Automattic/wp-calypso/pull/58524) we introduced a new selector, [should-display-app-banner](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/selectors/should-display-app-banner.ts), to check if we need to show the App Banner.

Inside it checked the session storage to see if we are in the Blogger Flow. That caused performances problems, as we should not access session storage in selectors.

This PR moves the session storage check from the selector to the App Banner, checking it only once at the beginning.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout branch, and `yarn start` from wp-calypso folder
- Ensure that the welcome tour is showing
- Open devtools and switch to mobile view
- Test the blogger flow, (if you cannot go through the blogger flow, add 'wpcom_signup_complete_show_draft_post_modal' with value 1 in ì browser console -> Application -> Session Storage). So the order of modals will be: blogger modal -> Dismiss -> Refresh -> App Banner -> Dismiss -> Editor Welcome Tour)
 ![Screenshot 2021-12-01 at 14 48 57](https://user-images.githubusercontent.com/52076348/144246007-1d7b8a65-63b3-473f-87bc-0fafdc858771.png)
- Test that the Blogger Modal is shown. When you dismiss that and refresh you should see the App Banner and immediately after you dismiss that, the Editor Welcome Tour.
- If you don't see the App Banner, you may have already dismissed it and you'll need to test with a new website

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60129
Fixes #60129
