### PR TITLE
Migrate the resolveDomainStatus function to TypeScript

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -18,7 +18,7 @@ import {
 	domainMappingSetup,
 } from 'calypso/my-sites/domains/paths';
 import { transferStatus, type as domainTypes, gdprConsentStatus } from './constants';
-import { ResponseDomain } from './types';
+import type { ResponseDomain } from './types';
 import type { ReactChild } from 'react';
 
 export type ResolveDomainStatusReturn =

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -102,7 +102,7 @@ export function resolveDomainStatus(
 							a: (
 								<a
 									href={ domainMappingSetup(
-										siteSlug,
+										siteSlug as string,
 										domain.domain,
 										domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update'
 									) }

--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -74,6 +74,7 @@ export type ResponseDomain = {
 	hasZone: boolean;
 	isAutoRenewing: boolean;
 	isEligibleForInboundTransfer: boolean;
+	isIcannVerificationSuspended: boolean;
 	isLocked: boolean;
 	isPendingIcannVerification: boolean;
 	isPendingRenewal: boolean;

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -118,8 +118,7 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 		const { noticeText, statusClass } = resolveDomainStatus( domain, null, {
 			siteSlug: site?.slug,
 			getMappingErrors: true,
-			email: null,
-		} as any );
+		} );
 
 		if ( noticeText && statusClass )
 			return (


### PR DESCRIPTION
This is more of an excersise for me to figure out how to typescriptify stuff. Thanks for the help @gius80 

#### Changes proposed in this Pull Request

* Migrate the resolveDomainStatus function to TypeScript - that's it

#### Testing instructions

* Verify that you can load the different domain statuses using the mocked domains list
