### PR TITLE
Tour Kit: Allow CSV and array for custom classes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -136,7 +136,7 @@ function WelcomeTour() {
 					[]
 				),
 			],
-			className: 'wpcom-editor-welcome-tour',
+			classes: 'wpcom-editor-welcome-tour',
 		},
 	};
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -136,7 +136,7 @@ function WelcomeTour() {
 					[]
 				),
 			],
-			classes: 'wpcom-editor-welcome-tour',
+			className: 'wpcom-editor-welcome-tour',
 		},
 	};
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -136,7 +136,7 @@ function WelcomeTour() {
 					[]
 				),
 			],
-			className: 'wpcom-editor-welcome-tour',
+			classNames: 'wpcom-editor-welcome-tour',
 		},
 	};
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -86,7 +86,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: null,
 			},
 			options: {
-				className: 'is-with-extra-padding',
+				classes: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -129,7 +129,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'block-inserter',
 			},
 			options: {
-				className: 'is-with-extra-padding',
+				classes: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -163,7 +163,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: null,
 			},
 			options: {
-				className: 'is-with-extra-padding',
+				classes: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -195,7 +195,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'undo-button',
 			},
 			options: {
-				className: 'is-with-extra-padding',
+				classes: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -86,7 +86,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: null,
 			},
 			options: {
-				classes: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				className: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -129,7 +129,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'block-inserter',
 			},
 			options: {
-				classes: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				className: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -163,7 +163,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: null,
 			},
 			options: {
-				classes: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				className: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -195,7 +195,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'undo-button',
 			},
 			options: {
-				classes: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				className: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -86,7 +86,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: null,
 			},
 			options: {
-				className: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				classNames: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -129,7 +129,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'block-inserter',
 			},
 			options: {
-				className: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				classNames: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -163,7 +163,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: null,
 			},
 			options: {
-				className: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				classNames: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{
@@ -195,7 +195,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'undo-button',
 			},
 			options: {
-				className: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				classNames: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 			},
 		},
 		{

--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -14,7 +14,7 @@ A tour is made up of the following components:
   - some arbitrary metadata
   - a set of optional reference elements selectors for rendering a step near
   - a set of options:
-	- className: optional custom CSS class that will be applied to the step
+	- classNames: optional custom CSS class that will be applied to the step
 - Two renderers (used as render props internally):
   - a step renderer (React component/function passed a set of properties)
   - a minimized view renderer (for rendering a minimized view instead of closing)
@@ -110,7 +110,7 @@ The main API for configuring a tour is the config object. See example usage and 
 
 - `referenceElements` (optional): A set of `deskop` & `mobile` selectors to render the step near.
 - `meta`: Arbitrary object that encloses the content we want to render for each step.
-- `className` (optional): Optional CSS class applied to a step.
+- `classNames` (optional): An array or CSV of CSS classes applied to a step.
 
 `config.closeHandler`: The callback responsible for closing the tour.
 
@@ -135,7 +135,7 @@ The main API for configuring a tour is the config object. See example usage and 
 
 `config.options` (optional):
 
-- `className`: Optional CSS class to enclose the main tour frame with. If provided, implementations will also receive a CSS class `.[className]__step` in the step renderers.
+- `classNames` (optional): An array or CSV of CSS classes to enclose the main tour frame with.
 
 - `effects`: An object to enable/disable/combine various tour effects:
 

--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -14,7 +14,7 @@ A tour is made up of the following components:
   - some arbitrary metadata
   - a set of optional reference elements selectors for rendering a step near
   - a set of options:
-	- classNames: optional custom CSS class that will be applied to the step
+	- classNames: optional custom CSS classes that will be applied to the step
 - Two renderers (used as render props internally):
   - a step renderer (React component/function passed a set of properties)
   - a minimized view renderer (for rendering a minimized view instead of closing)

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -190,7 +190,7 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 		'tour-kit-frame',
 		isMobile ? 'is-mobile' : 'is-desktop',
 		{ 'is-visible': tourReady },
-		classParser( config.options?.classes )
+		classParser( config.options?.className )
 	);
 
 	useStepTracking( currentStepIndex, config.options?.callbacks?.onStepViewOnce );

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -9,6 +9,7 @@ import { usePopper } from 'react-popper';
  * Internal Dependencies
  */
 import useStepTracking from '../hooks/use-step-tracking';
+import { classParser } from '../utils';
 import KeyboardNavigation from './keyboard-navigation';
 import TourKitMinimized from './tour-kit-minimized';
 import Overlay from './tour-kit-overlay';
@@ -185,11 +186,11 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 		}
 	}, [ popperUpdate, referenceElement ] );
 
-	const classNames = classnames(
+	const classes = classnames(
 		'tour-kit-frame',
-		config.options?.className,
 		isMobile ? 'is-mobile' : 'is-desktop',
-		{ 'is-visible': tourReady }
+		{ 'is-visible': tourReady },
+		classParser( config.options?.classes )
 	);
 
 	useStepTracking( currentStepIndex, config.options?.callbacks?.onStepViewOnce );
@@ -204,7 +205,7 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 				tourContainerRef={ tourContainerRef }
 				isMinimized={ isMinimized }
 			/>
-			<div className={ classNames } ref={ tourContainerRef }>
+			<div className={ classes } ref={ tourContainerRef }>
 				{ showOverlay() && <Overlay visible={ true } /> }
 				{ showSpotlight() && (
 					<Spotlight

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -190,7 +190,7 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 		'tour-kit-frame',
 		isMobile ? 'is-mobile' : 'is-desktop',
 		{ 'is-visible': tourReady },
-		classParser( config.options?.className )
+		classParser( config.options?.classNames )
 	);
 
 	useStepTracking( currentStepIndex, config.options?.callbacks?.onStepViewOnce );

--- a/packages/tour-kit/src/components/tour-kit-step.tsx
+++ b/packages/tour-kit/src/components/tour-kit-step.tsx
@@ -26,7 +26,7 @@ const TourKitStep: React.FunctionComponent< Props > = ( {
 	const classes = classnames(
 		'tour-kit-step',
 		`is-step-${ currentStepIndex }`,
-		classParser( config.steps[ currentStepIndex ].options?.className )
+		classParser( config.steps[ currentStepIndex ].options?.classNames )
 	);
 
 	return (

--- a/packages/tour-kit/src/components/tour-kit-step.tsx
+++ b/packages/tour-kit/src/components/tour-kit-step.tsx
@@ -26,7 +26,7 @@ const TourKitStep: React.FunctionComponent< Props > = ( {
 	const classes = classnames(
 		'tour-kit-step',
 		`is-step-${ currentStepIndex }`,
-		classParser( config.steps[ currentStepIndex ].options?.classes )
+		classParser( config.steps[ currentStepIndex ].options?.className )
 	);
 
 	return (

--- a/packages/tour-kit/src/components/tour-kit-step.tsx
+++ b/packages/tour-kit/src/components/tour-kit-step.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 /**
  * Internal Dependencies
  */
+import { classParser } from '../utils';
 import type { Config, TourStepRendererProps } from '../types';
 
 interface Props extends TourStepRendererProps {
@@ -22,15 +23,14 @@ const TourKitStep: React.FunctionComponent< Props > = ( {
 	setInitialFocusedElement,
 	onGoToStep,
 } ) => {
-	const classNames = classnames(
+	const classes = classnames(
 		'tour-kit-step',
 		`is-step-${ currentStepIndex }`,
-		config.options?.className ? `${ config.options?.className }__step` : '',
-		config.steps[ currentStepIndex ].options?.className
+		classParser( config.steps[ currentStepIndex ].options?.classes )
 	);
 
 	return (
-		<div className={ classNames }>
+		<div className={ classes }>
 			{ config.renderers.tourStep( {
 				steps,
 				currentStepIndex,

--- a/packages/tour-kit/src/storybook/index.stories.tsx
+++ b/packages/tour-kit/src/storybook/index.stories.tsx
@@ -106,7 +106,7 @@ const Tour = ( { onClose, options }: { onClose: () => void; options?: Config[ 'o
 		},
 		closeHandler: onClose,
 		options: {
-			className: 'mytour',
+			classNames: [ 'mytour' ],
 			...options,
 		},
 	};

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -14,7 +14,7 @@ export type Step = {
 		// | ...
 	};
 	options?: {
-		className?: string;
+		classes?: string | Array< string >;
 	};
 };
 
@@ -51,7 +51,7 @@ export interface Config {
 	};
 	closeHandler: CloseHandler;
 	options?: {
-		className?: string;
+		classes?: string | Array< string >;
 		callbacks?: {
 			onMinimize?: Callback;
 			onMaximize?: Callback;

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -14,7 +14,7 @@ export type Step = {
 		// | ...
 	};
 	options?: {
-		classes?: string | Array< string >;
+		className?: string | Array< string >;
 	};
 };
 
@@ -51,7 +51,7 @@ export interface Config {
 	};
 	closeHandler: CloseHandler;
 	options?: {
-		classes?: string | Array< string >;
+		className?: string | Array< string >;
 		callbacks?: {
 			onMinimize?: Callback;
 			onMaximize?: Callback;

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -14,7 +14,7 @@ export type Step = {
 		// | ...
 	};
 	options?: {
-		className?: string | Array< string >;
+		classNames?: string | string[];
 	};
 };
 
@@ -51,7 +51,7 @@ export interface Config {
 	};
 	closeHandler: CloseHandler;
 	options?: {
-		className?: string | Array< string >;
+		classNames?: string | string[];
 		callbacks?: {
 			onMinimize?: Callback;
 			onMaximize?: Callback;

--- a/packages/tour-kit/src/utils.ts
+++ b/packages/tour-kit/src/utils.ts
@@ -1,0 +1,7 @@
+export function classParser( classes?: string | Array< string > ) {
+	if ( classes ) {
+		return classes?.toString().split( ',' );
+	}
+
+	return null;
+}

--- a/packages/tour-kit/src/utils.ts
+++ b/packages/tour-kit/src/utils.ts
@@ -1,7 +1,0 @@
-export function classParser( classes?: string | Array< string > ) {
-	if ( classes ) {
-		return classes?.toString().split( ',' );
-	}
-
-	return null;
-}

--- a/packages/tour-kit/src/utils/index.ts
+++ b/packages/tour-kit/src/utils/index.ts
@@ -6,7 +6,7 @@
  */
 export function classParser( classes?: string | string[] ): string[] | null {
 	if ( classes?.length ) {
-		return classes?.toString().split( ',' );
+		return classes.toString().split( ',' );
 	}
 
 	return null;

--- a/packages/tour-kit/src/utils/index.ts
+++ b/packages/tour-kit/src/utils/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Helper to convert CSV of `classes` to an array.
+ *
+ * @param classes String or array of classes to format.
+ * @returns Array of classes
+ */
+export function classParser( classes?: string | string[] ): string[] | null {
+	if ( classes?.length ) {
+		return classes?.toString().split( ',' );
+	}
+
+	return null;
+}

--- a/packages/tour-kit/src/utils/test/utils.ts
+++ b/packages/tour-kit/src/utils/test/utils.ts
@@ -1,0 +1,35 @@
+import { classParser } from '../index';
+
+describe( 'classParser function', () => {
+	const expected = [ 'class-1', 'class-2', 'class-3' ];
+
+	test( 'accepts null', () => {
+		expect( classParser( null ) ).toBeNull();
+	} );
+
+	test( 'accepts empty string', () => {
+		expect( classParser( '' ) ).toBeNull();
+	} );
+
+	test( 'accepts empty array', () => {
+		expect( classParser( [] ) ).toBeNull();
+	} );
+
+	test( 'accepts a string', () => {
+		const string = 'class-1class-2class-3';
+		expect( classParser( string ) ).toEqual( [ string ] );
+	} );
+
+	test( 'accepts a CSV', () => {
+		expect( classParser( 'class-1,class-2,class-3' ) ).toEqual( expected );
+	} );
+
+	test( 'accepts an array', () => {
+		expect( classParser( expected ) ).toEqual( expected );
+	} );
+
+	test( 'accepts array of CSVs', () => {
+		const csvArray = [ 'class-1,class-2', 'class-3' ];
+		expect( classParser( csvArray ) ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
## Changes proposed in this Pull Request
As suggested in the GH issue #59710 this allows both the frame and step elements to accept CSV and arrays for the `classname` option.

To simplify this I brought the logic for both elements into the frame and passed the step classes down to the step. This allowed me to create a small function to filter and split any CSV without having to duplicate the same code in the frame and step elements.

*I am not 100% sure I updated the config* properly so please be sure to double-check that : ) I am not seeing any TS errors in my testing.

## Screenshots
![Screen Capture on 2022-01-19 at 13-29-47](https://user-images.githubusercontent.com/33258733/150132546-81e68353-30cd-48f1-91ec-a7e864037803.gif)

## Testing instructions

1. Checkout branch
2. Go to `apps/editing-toolkit/` and run `yarn dev --sync` to push changes to your sandbox
3. Edit `apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js` and set `className` option to be an array or CSV and save.
4. Do the same to `apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js`
5. Open the Welcome Guide in your sandbox site and check to make sure the classes appear properly

Related to #59710 
