### PR TITLE
Bug fix: Hide free plan option if a custom domain is selected

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -300,7 +300,7 @@ export function domainRegistration( properties: {
 	domain: string;
 	source?: string;
 	extra?: RequestCartProductExtra;
-} ): MinimalRequestCartProduct {
+} ): MinimalRequestCartProduct & { is_domain_registration: boolean } {
 	return {
 		...domainItem( properties.productSlug, properties.domain, properties.source ),
 		is_domain_registration: true,

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -303,6 +303,7 @@ export function domainRegistration( properties: {
 } ): MinimalRequestCartProduct {
 	return {
 		...domainItem( properties.productSlug, properties.domain, properties.source ),
+		is_domain_registration: true,
 		...( properties.extra ? { extra: properties.extra } : {} ),
 	};
 }

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -211,7 +211,6 @@ export interface RequestCartProduct {
 	volume: number;
 	quantity: number | null;
 	extra: RequestCartProductExtra;
-	is_domain_registration: boolean;
 }
 
 export type MinimalRequestCartProduct = Partial< RequestCartProduct > &

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -211,6 +211,7 @@ export interface RequestCartProduct {
 	volume: number;
 	quantity: number | null;
 	extra: RequestCartProductExtra;
+	is_domain_registration: boolean;
 }
 
 export type MinimalRequestCartProduct = Partial< RequestCartProduct > &


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug wherein the "start with a free site" option is shown in the plans step of the signup `onboarding` flow even when a custom domain is selected in the domains step.
* This bug is causing a decrease in ARRPS (refer pcbrnV-4eQ#comment-5400).
* It looks to be caused by the deletion of the prop `is_domain_registration: true` for `domainRegistration()` in https://github.com/Automattic/wp-calypso/pull/58609/files#diff-714454bbda35db73ee6b97540a366f11099f7dda3aaeffe33ece9e3c51ceee82L417.

**Cause of the bug**

Hiding the free plan option is determined by the value of [hideFreePlan](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/main.jsx#L629). When a custom domain is selected in the signup flow, `hideFreePlan` is expected to be `true` but it's erroneously getting set to `false` because [isDomainRegistration( domainItem )](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/main.jsx#L621) is is returning a `false` value.

Here's the `domainItem` object in signup dependency store:
<img width="453" alt="Screenshot 2022-01-22 at 12 45 18 AM" src="https://user-images.githubusercontent.com/1269602/150597772-420005c7-7d0c-4483-8cfd-90645f6858e9.png">

The `isDomainRegistration( domainItem )` check [expects the prop `is_domain_registration` to be `true`](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-products/src/is-domain-registration.ts#L5) but this prop is [missing in `domainItem`](https://github.com/Automattic/wp-calypso/blob/eb6c024a1424d353ddfb945ba8c35377f7ab2bbf/client/signup/steps/domains/index.jsx#L273) object as it was deleted in https://github.com/Automattic/wp-calypso/pull/58609. 

This PR restores the `is_domain_registration: true` prop for a `domainRegistration()` product.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and signup for a new account
* In the domains step, select a custom domain and verify that the "start with a free site" link is not shown in the plans step.
* In the domains step, select a free *.wordpress.com subdomain and verify that the "start with a free site" link is displayed in the plans step.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
