### PR TITLE
Update Edit Contact Info page style

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -95,12 +95,19 @@ const EditContactInfoPage = ( {
 			);
 		}
 
+		const backUrl = domainManagementEdit(
+			selectedSite?.slug ?? '',
+			selectedDomainName,
+			currentRoute
+		);
+
 		return (
 			<EditContactInfoFormCard
 				domainRegistrationAgreementUrl={ domain.domainRegistrationAgreementUrl }
 				selectedDomain={ domain }
 				selectedSite={ selectedSite }
 				showContactInfoNote={ false }
+				backUrl={ backUrl }
 			/>
 		);
 	};

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
@@ -4,7 +4,7 @@
 
 .edit-contact-info-page {
 	.contact-details-form-fields {
-		padding: 0 24px 24px;
+		padding: 0 16px 24px;
 		@include breakpoint-deprecated( '>660px' ) {
 			padding: 0 0 24px;
 		}

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
@@ -1,3 +1,7 @@
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .edit-contact-info-page {
 	&__sidebar {
 		padding: 24px;
@@ -14,6 +18,19 @@
 			p {
 				margin-bottom: 0.5em;
 			}
+		}
+	}
+	.formatted-header__title {
+		font-weight: 400;
+		margin: 0;
+		line-height: 100%;
+
+		@include break-zoomed-in {
+			font-size: $font-title-medium;
+		}
+
+		@include break-small {
+			font-size: $font-title-large;
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
@@ -3,9 +3,21 @@
 @import '@wordpress/base-styles/mixins';
 
 .edit-contact-info-page {
+	.contact-details-form-fields {
+		padding: 0 24px 24px;
+		@include breakpoint-deprecated( '>660px' ) {
+			padding: 0 0 24px;
+		}
+		@include break-xlarge {
+			padding: 0;
+		}
+	}
+
 	&__sidebar {
 		padding: 24px;
 		background-color: var( --studio-gray-0 );
+		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		line-height: 20px;
 		&-content {
 			p {
 				margin: 0 0 1em;

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -42,6 +42,7 @@ class EditContactInfoFormCard extends Component {
 		whoisSaveError: PropTypes.object,
 		whoisSaveSuccess: PropTypes.bool,
 		showContactInfoNote: PropTypes.bool,
+		backUrl: PropTypes.string.isRequired,
 	};
 
 	constructor( props ) {
@@ -414,6 +415,10 @@ class EditContactInfoFormCard extends Component {
 		);
 	};
 
+	handleCancelButtonClick = () => {
+		page( this.props.backUrl );
+	};
+
 	getIsFieldDisabled = ( name ) => {
 		const unmodifiableFields = get(
 			this.props,
@@ -462,6 +467,7 @@ class EditContactInfoFormCard extends Component {
 						getIsFieldDisabled={ this.getIsFieldDisabled }
 						onContactDetailsChange={ this.handleContactDetailsChange }
 						onSubmit={ this.handleSubmitButtonClick }
+						onCancel={ this.handleCancelButtonClick }
 						onValidate={ this.validate }
 						labelTexts={ { submitButton: translate( 'Save contact info' ) } }
 						disableSubmitButton={ this.shouldDisableSubmitButton() }

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -1,4 +1,4 @@
-import { Card, Dialog } from '@automattic/components';
+import { Dialog } from '@automattic/components';
 import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty, isEqual, includes, snakeCase } from 'lodash';
@@ -446,7 +446,7 @@ class EditContactInfoFormCard extends Component {
 		const updateWpcomEmailCheckboxDisabled = this.shouldDisableUpdateWpcomEmailCheckbox();
 
 		return (
-			<Card>
+			<>
 				{ showContactInfoNote && (
 					<p className="edit-contact-info__note">
 						<em>
@@ -473,7 +473,7 @@ class EditContactInfoFormCard extends Component {
 					</ContactDetailsFormFields>
 				</form>
 				{ this.renderDialog() }
-			</Card>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR address some sidebar style issues, on new domain transfer page (see pcYYhz-xC-p2)

> - Change title size to 32px, like the rest of the internal pages.
> - Remove border & padding from the form.
> - Right grey text box: change font sizes to match other grey text boxes, 14px for both title & paragraph.
> - Right grey text box on mobile: make sure there is 24px of spacing between the content above and the box.
> - Add a “cancel” button that will take the user back.

![contact info](https://user-images.githubusercontent.com/2797601/150136913-b17c1189-9335-4a7e-a7b8-75f9b20b635b.png)

![contact info mob](https://user-images.githubusercontent.com/2797601/150137308-24f0b52b-cb6c-47ea-9ed9-215e335832b9.png)

## Testing instructions
- Build this branch locally or open the live Calypso link
- Go to "Upgrades -> Domains" and select an owned domain.
- If you have enabled the new setting page redesign (appending `?flags=domains/settings-page-redesign`  on the url) click on `Edit` in the `Contact Info card`, otherwise click on `Update your contact information` and - in the next page - click on `Edit Contact information`
- Verify that the page looks as in the screenshots above (mob/desk)


