### PR TITLE
Emails: Track pageviews and events in Email Comparison pages

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -107,7 +107,6 @@ export default {
 				selectedDomainName={ pageContext.params.domain }
 				selectedEmailProviderSlug={ pageContext.query.provider }
 				selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
-				siteName={ pageContext.params.site }
 				source={ pageContext.query.source }
 			/>
 		);
@@ -123,11 +122,8 @@ export default {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
 				<EmailProvidersInDepthComparison
-					comparisonContext="email-in-depth-comparison"
 					selectedDomainName={ pageContext.params.domain }
 					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
-					siteName={ pageContext.params.site }
-					source={ pageContext.query.source }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import ComparisonList from 'calypso/my-sites/email/email-providers-comparison/in-depth/comparison-list';
@@ -73,6 +74,11 @@ const EmailProvidersInDepthComparison = ( {
 
 	return (
 		<>
+			<PageViewTracker
+				path={ emailManagementInDepthComparison( ':site', ':domain' ) }
+				title="Email Comparison > In-Depth Comparison"
+			/>
+
 			<QueryProductsList />
 
 			<h1 className="email-providers-in-depth-comparison__header">

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -3,7 +3,7 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
@@ -19,6 +19,7 @@ import {
 	emailManagementInDepthComparison,
 	emailManagementPurchaseNewEmailAccount,
 } from 'calypso/my-sites/email/paths';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
@@ -30,6 +31,7 @@ const EmailProvidersInDepthComparison = ( {
 	selectedDomainName,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
 }: EmailProvidersInDepthComparisonProps ): ReactElement => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const isMobile = useMobileBreakpoint();
@@ -41,6 +43,13 @@ const EmailProvidersInDepthComparison = ( {
 		if ( selectedSite === null ) {
 			return;
 		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_email_providers_in_depth_billing_interval_toggle_click', {
+				domain_name: selectedDomainName,
+				new_interval: newIntervalLength,
+			} )
+		);
 
 		page(
 			emailManagementInDepthComparison(
@@ -57,6 +66,13 @@ const EmailProvidersInDepthComparison = ( {
 		if ( selectedSite === null ) {
 			return;
 		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_email_providers_in_depth_select_provider_click', {
+				domain_name: selectedDomainName,
+				provider: emailProviderSlug,
+			} )
+		);
 
 		page(
 			emailManagementPurchaseNewEmailAccount(

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -30,11 +30,8 @@ export type EmailProviderFeatures = {
 };
 
 export type EmailProvidersInDepthComparisonProps = {
-	comparisonContext: string;
 	selectedDomainName: string;
 	selectedIntervalLength: IntervalLength | undefined;
-	siteName: string;
-	source: string;
 };
 
 export type LearnMoreLinkProps = {

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -36,7 +36,6 @@ type EmailProvidersStackedComparisonProps = {
 	selectedDomainName: string;
 	selectedEmailProviderSlug: string;
 	selectedIntervalLength: IntervalLength | undefined;
-	siteName: string;
 	source: string;
 };
 
@@ -45,7 +44,6 @@ const EmailProvidersStackedComparison = ( {
 	selectedDomainName,
 	selectedEmailProviderSlug,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
-	siteName,
 	source,
 }: EmailProvidersStackedComparisonProps ): ReactElement => {
 	const translate = useTranslate();
@@ -135,14 +133,14 @@ const EmailProvidersStackedComparison = ( {
 				{ translate( 'Pick an email solution' ) }
 			</h1>
 
-			{ isEnabled( 'emails/in-depth-comparison' ) && (
+			{ isEnabled( 'emails/in-depth-comparison' ) && selectedSite && (
 				<div className="email-providers-stacked-comparison__sub-header">
 					{ translate( 'Not sure where to start? {{a}}See how they compare{{/a}}.', {
 						components: {
 							a: (
 								<a
 									href={ emailManagementInDepthComparison(
-										siteName,
+										selectedSite.slug,
 										selectedDomainName,
 										currentRoute,
 										null,

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -7,6 +7,7 @@ import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
@@ -124,7 +125,13 @@ const EmailProvidersStackedComparison = ( {
 
 	return (
 		<Main className="email-providers-stacked-comparison__main" wideLayout>
+			<PageViewTracker
+				path={ emailManagementPurchaseNewEmailAccount( ':site', ':domain' ) }
+				title="Email Comparison"
+			/>
+
 			<QueryProductsList />
+
 			<QueryEmailForwards domainName={ selectedDomainName } />
 
 			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -2,13 +2,12 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
@@ -23,6 +22,7 @@ import {
 	emailManagementInDepthComparison,
 	emailManagementPurchaseNewEmailAccount,
 } from 'calypso/my-sites/email/paths';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
@@ -47,6 +47,7 @@ const EmailProvidersStackedComparison = ( {
 	selectedIntervalLength = IntervalLength.ANNUALLY,
 	source,
 }: EmailProvidersStackedComparisonProps ): ReactElement => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const [ detailsExpanded, setDetailsExpanded ] = useState( () => {
@@ -94,9 +95,11 @@ const EmailProvidersStackedComparison = ( {
 		} );
 
 		if ( isCurrentlyExpanded ) {
-			recordTracksEvent( 'calypso_email_providers_expand_section_click', {
-				provider: providerKey,
-			} );
+			dispatch(
+				recordTracksEvent( 'calypso_email_providers_expand_section_click', {
+					provider: providerKey,
+				} )
+			);
 		}
 
 		setDetailsExpanded( Object.fromEntries( expandedEntries ) );
@@ -107,6 +110,13 @@ const EmailProvidersStackedComparison = ( {
 			return;
 		}
 
+		dispatch(
+			recordTracksEvent( 'calypso_email_providers_billing_interval_toggle_click', {
+				domain_name: selectedDomainName,
+				new_interval: newIntervalLength,
+			} )
+		);
+
 		page(
 			emailManagementPurchaseNewEmailAccount(
 				selectedSite.slug,
@@ -116,6 +126,15 @@ const EmailProvidersStackedComparison = ( {
 				selectedEmailProviderSlug,
 				newIntervalLength
 			)
+		);
+	};
+
+	const handleCompareClick = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_email_providers_compare_link_click', {
+				domain_name: selectedDomainName,
+				interval: selectedIntervalLength,
+			} )
 		);
 	};
 
@@ -153,6 +172,7 @@ const EmailProvidersStackedComparison = ( {
 										null,
 										selectedIntervalLength
 									) }
+									onClick={ handleCompareClick }
 								/>
 							),
 						},


### PR DESCRIPTION
This pull request updates the `Email Comparison` page as well as the `In-Depth Comparison` page in order to track pageviews as well as several click events:

`Email Comparison` | `In-Depth Comparison`
------ | -----
![image](https://user-images.githubusercontent.com/594356/150151424-65f0742b-2421-41f8-a498-51dc6389a877.png) | ![image](https://user-images.githubusercontent.com/594356/150151673-826f2d16-8da3-4128-8149-5523f70186a8.png)

I didn't add events for links leading to the support pages nor to the `Add New Email Forwards`, as I was mostly interested in understanding how users navigate to and from the new `In-Depth Comparison` page. Finally, this pull request removes unnecessary props that were set in the controller but never used.

#### Testing instructions

Since the events are recorded as Redux events, you can use the [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) to observe them:

![image](https://user-images.githubusercontent.com/594356/150151992-a7a3c9e8-8946-439e-a37b-75282a540f26.png)

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout add/tracking-to-email-comparison-pages` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/60245#issuecomment-1016504390)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Assert a `ANALYTICS_PAGE_VIEW_RECORD` Redux event was triggered with the right data
6. Click the `Pay monthly`  toggle
7. Assert a `ANALYTICS_EVENT_RECORD` Redux event was triggered with the right data
8. Click the `See how they compare` link to access the `In-Depth Comparison` page
9. Assert a `ANALYTICS_EVENT_RECORD` Redux event was triggered with the right data
10. Assert a `ANALYTICS_PAGE_VIEW_RECORD` Redux event was triggered with the right data
11. Click the `Pay monthly`  toggle
12. Assert a `ANALYTICS_EVENT_RECORD` Redux event was triggered with the right data
13. Click a `Select`  button
14. Assert a `ANALYTICS_EVENT_RECORD` Redux event was triggered with the right data
15. Assert a `ANALYTICS_PAGE_VIEW_RECORD` Redux event was triggered with the right data

You should also check that those events were logged in Tracks by using the Tracks Live View.