### PR TITLE
i18n: Hide TranslatorInvite for default locale

### DIFF
--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -62,6 +63,12 @@ export class TranslatorInvite extends Component {
 	}
 
 	render() {
+		const { locale } = this.props;
+
+		if ( config( 'i18n_default_locale_slug' ) === locale ) {
+			return null;
+		}
+
 		return (
 			<div className="translator-invite">
 				{ this.renderNoticeLabelText() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent `TranslatorInvite` component from rendering its content when the screen is rendered in the default locale (English).

![CleanShot 2022-01-19 at 16 40 31](https://user-images.githubusercontent.com/2722412/150152819-48f8672f-9c41-4661-987b-3651064a4351.png)

#### Testing instructions

* Go to `/log-in` (with English locale) and confirm translator invite link at the bottom of the form is no longer showing.
* Go to localized log-in screen (e.g. `/log-in/de` and confirm the translator invite still appears as expected.

Related to #60246
