### PR TITLE
Marketplace: don't query the product list on every navigation

### DIFF
--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -4,11 +4,14 @@ import { requestProductsList } from 'calypso/state/products-list/actions';
 import { isProductsListFetching, getProductsList } from 'calypso/state/products-list/selectors';
 
 const request = ( props ) => ( dispatch, getState ) => {
-	const productsList = getProductsList( getState() );
-	if (
-		isProductsListFetching( getState() ) ||
-		( productsList && Object.keys( productsList ).length > 0 )
-	) {
+	if ( props.persist ) {
+		const productsList = getProductsList( getState() );
+		if ( productsList && Object.keys( productsList ).length > 0 ) {
+			return;
+		}
+	}
+
+	if ( isProductsListFetching( getState() ) ) {
 		return;
 	}
 
@@ -17,18 +20,19 @@ const request = ( props ) => ( dispatch, getState ) => {
 
 /**
  *
- * @param {object} props 		The list of component props.
- * @param {string} [props.type] The type of products to request:
- * 								  "jetpack" for Jetpack products only, or undefined for all products.
- * @returns {null} 				No visible output.
+ * @param {object} props 			The list of component props.
+ * @param {string} [props.type] 	The type of products to request:
+ *									"jetpack" for Jetpack products only, or undefined for all products.
+ * @param {boolean} [props.persist] Set to true to persist the products list in the store.
+ * @returns {null} 					No visible output.
  */
-export default function QueryProductsList( { type } ) {
+export default function QueryProductsList( { type, persist } ) {
 	const dispatch = useDispatch();
 
 	// Only runs on mount.
 	useEffect( () => {
-		dispatch( request( { type } ) );
-	}, [ dispatch, type ] );
+		dispatch( request( { type, persist } ) );
+	}, [ dispatch, type, persist ] );
 
 	return null;
 }

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -4,9 +4,10 @@ import { requestProductsList } from 'calypso/state/products-list/actions';
 import { isProductsListFetching, getProductsList } from 'calypso/state/products-list/selectors';
 
 const request = ( props ) => ( dispatch, getState ) => {
+	const productsList = getProductsList( getState() );
 	if (
 		isProductsListFetching( getState() ) ||
-		Object.keys( getProductsList( getState() ) ).length > 0
+		( productsList && Object.keys( productsList ).length > 0 )
 	) {
 		return;
 	}

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -1,14 +1,11 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestProductsList } from 'calypso/state/products-list/actions';
-import { isProductsListFetching, getProductsList } from 'calypso/state/products-list/selectors';
+import { isProductsListFetching, getProductsListType } from 'calypso/state/products-list/selectors';
 
-const request = ( props ) => ( dispatch, getState ) => {
-	if ( props.persist ) {
-		const productsList = getProductsList( getState() );
-		if ( productsList && Object.keys( productsList ).length > 0 ) {
-			return;
-		}
+const request = ( { persist, ...props } ) => ( dispatch, getState ) => {
+	if ( persist && props.type === getProductsListType( getState() ) ) {
+		return;
 	}
 
 	if ( isProductsListFetching( getState() ) ) {
@@ -26,7 +23,7 @@ const request = ( props ) => ( dispatch, getState ) => {
  * @param {boolean} [props.persist] Set to true to persist the products list in the store.
  * @returns {null} 					No visible output.
  */
-export default function QueryProductsList( { type, persist } ) {
+export default function QueryProductsList( { type = 'all', persist } ) {
 	const dispatch = useDispatch();
 
 	// Only runs on mount.

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -4,11 +4,10 @@ import { requestProductsList } from 'calypso/state/products-list/actions';
 import { isProductsListFetching, getProductsListType } from 'calypso/state/products-list/selectors';
 
 const request = ( { persist, ...props } ) => ( dispatch, getState ) => {
-	if ( persist && props.type === getProductsListType( getState() ) ) {
-		return;
-	}
-
-	if ( isProductsListFetching( getState() ) ) {
+	if (
+		isProductsListFetching( getState() ) ||
+		( persist && props.type === getProductsListType( getState() ) )
+	) {
 		return;
 	}
 

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -1,10 +1,13 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestProductsList } from 'calypso/state/products-list/actions';
-import { isProductsListFetching } from 'calypso/state/products-list/selectors';
+import { isProductsListFetching, getProductsList } from 'calypso/state/products-list/selectors';
 
 const request = ( props ) => ( dispatch, getState ) => {
-	if ( isProductsListFetching( getState() ) ) {
+	if (
+		isProductsListFetching( getState() ) ||
+		Object.keys( getProductsList( getState() ) ).length > 0
+	) {
 		return;
 	}
 

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -216,7 +216,7 @@ function PluginDetails( props ) {
 			<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
 			<SidebarNavigation />
 			<QueryEligibility siteId={ selectedSite?.ID } />
-			<QueryProductsList />
+			<QueryProductsList persist />
 			<FixedNavigationHeader
 				navigationItems={ getNavigationItems() }
 				compactBreadcrumb={ ! isWide }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -218,7 +218,7 @@ const PluginsBrowser = ( {
 					<QueryWporgPlugins category="featured" />
 				</>
 			) }
-			{ ! jetpackNonAtomic && <QueryProductsList /> }
+			{ ! jetpackNonAtomic && <QueryProductsList persist /> }
 			<QueryJetpackPlugins siteIds={ siteIds } />
 			<PageViewTrackerWrapper
 				category={ category }

--- a/client/state/products-list/actions.js
+++ b/client/state/products-list/actions.js
@@ -9,7 +9,7 @@ import { ensureNumericCost } from './assembler';
 import 'calypso/state/currency-code/init';
 import 'calypso/state/products-list/init';
 
-export function receiveProductsList( productsList ) {
+export function receiveProductsList( productsList, type = null ) {
 	// Since the request succeeded, productsList should be guaranteed non-null;
 	// thus, we don't have any safety checks before this line.
 
@@ -24,6 +24,7 @@ export function receiveProductsList( productsList ) {
 	return {
 		type: PRODUCTS_LIST_RECEIVE,
 		productsList: sanitizedProductsList,
+		productsListType: type,
 	};
 }
 
@@ -41,7 +42,7 @@ export function requestProductsList( query = {} ) {
 
 		return wpcom.req
 			.get( '/products', query )
-			.then( ( productsList ) => dispatch( receiveProductsList( productsList ) ) )
+			.then( ( productsList ) => dispatch( receiveProductsList( productsList, query.type ) ) )
 			.catch( ( error ) =>
 				dispatch( {
 					type: PRODUCTS_LIST_REQUEST_FAILURE,

--- a/client/state/products-list/reducer.js
+++ b/client/state/products-list/reducer.js
@@ -17,6 +17,19 @@ export const items = withSchemaValidation( productsListSchema, ( state = {}, act
 	return state;
 } );
 
+// Stores the type of the last received products list
+export const type = withSchemaValidation(
+	{ type: [ 'string', 'null' ] },
+	( state = null, action ) => {
+		switch ( action.type ) {
+			case PRODUCTS_LIST_RECEIVE:
+				return action.productsListType;
+		}
+
+		return state;
+	}
+);
+
 // Tracks product list fetching state
 export const isFetching = ( state = false, action ) => {
 	switch ( action.type ) {
@@ -34,6 +47,7 @@ export const isFetching = ( state = false, action ) => {
 const combinedReducer = combineReducers( {
 	isFetching,
 	items,
+	type,
 } );
 
 export default withStorageKey( 'productsList', combinedReducer );

--- a/client/state/products-list/selectors/get-products-list-type.ts
+++ b/client/state/products-list/selectors/get-products-list-type.ts
@@ -2,5 +2,5 @@ import type { AppState } from 'calypso/types';
 import 'calypso/state/products-list/init';
 
 export function getProductsListType( state: AppState ): Record< string, string | null > {
-	return state.productsList?.productsListType;
+	return state.productsList?.type;
 }

--- a/client/state/products-list/selectors/get-products-list-type.ts
+++ b/client/state/products-list/selectors/get-products-list-type.ts
@@ -1,0 +1,6 @@
+import type { AppState } from 'calypso/types';
+import 'calypso/state/products-list/init';
+
+export function getProductsListType( state: AppState ): Record< string, string | null > {
+	return state.productsList?.productsListType;
+}

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -8,6 +8,7 @@ export { getProductName } from './get-product-name';
 export { getProductDisplayCost } from './get-product-display-cost';
 export { getProductPriceTierList } from './get-product-price-tiers';
 export { getProductsList } from './get-products-list';
+export { getProductsListType } from './get-products-list-type';
 export { isProductsListFetching } from './is-products-list-fetching';
 export { planSlugToPlanProduct } from './plan-slug-to-plan-product';
 export { isMarketplaceProduct } from './is-marketplace-product';

--- a/client/state/products-list/test/actions.js
+++ b/client/state/products-list/test/actions.js
@@ -32,6 +32,7 @@ describe( 'actions', () => {
 			expect( action ).to.eql( {
 				type: PRODUCTS_LIST_RECEIVE,
 				productsList: { businessPlan },
+				productsListType: null,
 			} );
 		} );
 	} );
@@ -60,6 +61,7 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PRODUCTS_LIST_RECEIVE,
 					productsList: { businessPlan },
+					productsListType: null,
 				} );
 			} );
 		} );

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -7,7 +7,7 @@ import {
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
-import reducer, { items, isFetching } from '../reducer';
+import reducer, { items, isFetching, type } from '../reducer';
 
 describe( 'reducer', () => {
 	useSandbox( ( sandbox ) => {
@@ -15,7 +15,7 @@ describe( 'reducer', () => {
 	} );
 
 	test( 'should include expected keys in return value', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [ 'items', 'isFetching' ] );
+		expect( reducer( undefined, {} ) ).to.have.keys( [ 'items', 'isFetching', 'type' ] );
 	} );
 
 	describe( '#items()', () => {
@@ -122,6 +122,39 @@ describe( 'reducer', () => {
 		test( 'should be false when a request fails', () => {
 			const state = isFetching( true, { type: PRODUCTS_LIST_REQUEST_FAILURE } );
 			expect( state ).to.eql( false );
+		} );
+	} );
+
+	describe( '#type()', () => {
+		test( 'should default to null', () => {
+			const state = type( undefined, {} );
+
+			expect( state ).to.eql( null );
+		} );
+
+		test( 'should store the received type', () => {
+			const state = type( undefined, { type: PRODUCTS_LIST_RECEIVE, productsListType: 'all' } );
+			expect( state ).to.eql( 'all' );
+		} );
+
+		describe( 'persistence', () => {
+			test( 'persists state', () => {
+				const original = deepFreeze( 'jetpack' );
+				const state = serialize( type, original );
+				expect( state ).to.eql( original );
+			} );
+
+			test( 'loads valid persisted state', () => {
+				const original = deepFreeze( 'jetpack' );
+				const state = deserialize( type, original );
+				expect( state ).to.eql( original );
+			} );
+
+			test( 'loads default state when schema does not match', () => {
+				const original = deepFreeze( 0 );
+				const state = deserialize( type, original );
+				expect( state ).to.eql( null );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add a check to the `<QueryProductsList />` component to avoid re-fetching the data on each page load
* add a `type` field to the `productsList` state variable to track which type of list has been fetched

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Number of calls are reduced ([video](https://d.pr/v/Lm4XmR)):
* Open devtools, go to the Network tab, and filter for `products`
* Visit the `/plugins` page
* Visit any plugin page
* Navigate back to the plugin browser page, and perhaps to other plugin pages
* Verify that the `https://public-api.wordpress.com/rest/v1.1/products` request is only sent out once

Caching works correctly when different types are fetched:
* Go to a self-hosted jetpack site
* Delete the `productsList` key in indexedDB
* Visit `/plans/[DOMAIN]`
* Visit `/plugins/[DOMAIN]`
* Verify that there are no regressions

![image](https://user-images.githubusercontent.com/11555574/150160098-40fce8a5-cdc4-4ee2-8390-8d03411c416c.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #59899
