### PR TITLE
Add fallback for missing product name in available user licenses dialog

### DIFF
--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -46,17 +46,16 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	}, [ dispatch ] );
 
 	const title = useMemo( () => {
-		/* translators: The 'product' is a fallback if the product name is unavailable. */
-		const productName = detachedUserLicense?.product || 'product';
-
 		if ( hasOneDetachedLicense ) {
-			return preventWidows(
-				translate( 'Your %(productName)s is pending activation', {
-					args: {
-						productName: productName,
-					},
-				} )
-			);
+			return detachedUserLicense?.product
+				? preventWidows(
+						translate( 'Your %(productName)s is pending activation', {
+							args: {
+								productName: detachedUserLicense.product,
+							},
+						} )
+				  )
+				: preventWidows( translate( 'Your product is pending activation' ) );
 		}
 		return preventWidows( translate( 'You have an available product license key' ) );
 	}, [ detachedUserLicense, hasOneDetachedLicense, translate ] );

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -46,11 +46,14 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	}, [ dispatch ] );
 
 	const title = useMemo( () => {
+		/* translators: The 'product' is a fallback if the product name is unavailable. */
+		const productName = detachedUserLicense?.product || 'product';
+
 		if ( hasOneDetachedLicense ) {
 			return preventWidows(
 				translate( 'Your %(productName)s is pending activation', {
 					args: {
-						productName: detachedUserLicense && detachedUserLicense.product,
+						productName: productName,
 					},
 				} )
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds fallback for the product name displayed in the available license dialog. If you have only one license available and, for some reason, the product name is missing, we should show "product" to communicate meaningful messages to the users.

#### Testing instructions

Setup

- Download this PR.
- Start both Calypsos with yarn start and yarn start-jetpack-cloud-p (run the last one after the first one is started).
- Go to https://cloud.jetpack.com/pricing.
- Purchase any Jetpack product other than Jetpack Search, and do not activate the product on any site.

Test the existing flows
- Follow the testing instructions here: https://github.com/Automattic/wp-calypso/pull/59621 to ensure no regression is introduced.

Test missing product name
- To verify if the fallback is working as expected, probably the easiest way would be to simulate these conditions in the code: the `hasOneDetachedLicense` should have a truthy value, and  `detachedUserLicense` should be set to `null`.

**Screenshots**

Before | After
--- | ---
<img width="650" alt="Screenshot 2022-01-19 at 20 32 10" src="https://user-images.githubusercontent.com/1749918/150192568-2c673346-9843-4a6e-8095-5ff1dd1f7edb.png"> | <img width="653" alt="Screenshot 2022-01-19 at 20 31 10" src="https://user-images.githubusercontent.com/1749918/150192588-849084d1-c1d2-4b1d-b96f-eccaf8c98590.png">

Related to 1201509629272450-as-1201673330627964