### PR TITLE
Emails: Fix font and alignment issues in Email Comparison pages

### DIFF
--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -26,13 +26,13 @@ const ComparisonList = ( {
 
 				return (
 					<Card key={ emailProviderFeatures.slug }>
-						<div className="email-providers-in-depth-comparison-table__provider">
+						<div className="email-providers-in-depth-comparison-list__provider">
 							{ emailProviderFeatures.logo }
 
-							<div className="email-providers-in-depth-comparison-table__provider-info">
+							<div className="email-providers-in-depth-comparison-list__provider-info">
 								<h2>{ emailProviderFeatures.name }</h2>
 
-								{ emailProviderFeatures.description }
+								<p>{ emailProviderFeatures.description }</p>
 							</div>
 						</div>
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -33,7 +33,7 @@ const ComparisonTable = ( {
 									<div className="email-providers-in-depth-comparison-table__provider-info">
 										<h2>{ emailProviderFeatures.name }</h2>
 
-										{ emailProviderFeatures.description }
+										<p>{ emailProviderFeatures.description }</p>
 									</div>
 								</div>
 							</td>

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
@@ -89,7 +90,7 @@ const EmailProvidersInDepthComparison = ( {
 	const ComparisonComponent = isMobile ? ComparisonList : ComparisonTable;
 
 	return (
-		<>
+		<Main wideLayout>
 			<PageViewTracker
 				path={ emailManagementInDepthComparison( ':site', ':domain' ) }
 				title="Email Comparison > In-Depth Comparison"
@@ -118,7 +119,7 @@ const EmailProvidersInDepthComparison = ( {
 			/>
 
 			<EmailForwardingLink selectedDomainName={ selectedDomainName } />
-		</>
+		</Main>
 	);
 };
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/style.scss
+++ b/client/my-sites/email/email-providers-comparison/in-depth/style.scss
@@ -32,6 +32,8 @@
 
 .email-providers-in-depth-comparison-list,
 .email-providers-in-depth-comparison-table {
+	font-size: $font-body-small;
+
 	.google-workspace-logo {
 		height: 48px;
 		width: 48px;
@@ -42,6 +44,27 @@
 		height: 48px;
 		min-width: 48px;
 		width: 48px;
+	}
+}
+
+.email-providers-in-depth-comparison-list__provider,
+.email-providers-in-depth-comparison-table__provider {
+	display: flex;
+}
+
+.email-providers-in-depth-comparison-list__provider-info,
+.email-providers-in-depth-comparison-table__provider-info {
+	margin-left: 12px;
+
+	h2 {
+		font-size: $font-title-small;
+
+		@extend .wp-brand-font;
+	}
+
+	p {
+		font-size: $font-body;
+		margin-bottom: 0;
 	}
 }
 
@@ -82,7 +105,6 @@ $table-padding: 15px;
 
 .email-providers-in-depth-comparison-table {
 	border-collapse: collapse;
-	font-size: $font-body-small;
 	margin-top: 40px;
 	table-layout: fixed;
 
@@ -132,19 +154,8 @@ $table-padding: 15px;
 	}
 }
 
-.email-providers-in-depth-comparison-table__provider {
-	display: flex;
-}
-
 .email-providers-in-depth-comparison-table__provider-info {
-	margin-left: 12px;
 	margin-right: $table-padding;
-
-	h2 {
-		font-size: $font-title-small;
-
-		@extend .wp-brand-font;
-	}
 }
 
 .email-providers-in-depth-comparison-table__feature {

--- a/client/my-sites/email/email-providers-comparison/in-depth/style.scss
+++ b/client/my-sites/email/email-providers-comparison/in-depth/style.scss
@@ -1,15 +1,33 @@
 @import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.email-providers-in-depth-comparison__header,
+.email-providers-in-depth-comparison__sub-header {
+	padding-left: 16px;
+	padding-right: 16px;
+	text-align: center;
+
+	@include break-medium {
+		padding: 0;
+	}
+}
 
 .email-providers-in-depth-comparison__header {
 	font-size: $font-title-large;
-	text-align: center;
+	padding-left: 16px;
+	padding-right: 16px;
+	padding-top: 16px;
 
 	@extend .wp-brand-font;
+
+	@include break-medium {
+		padding: 0;
+	}
 }
 
 .email-providers-in-depth-comparison__sub-header {
 	font-size: $font-body-small;
-	text-align: center;
 }
 
 .email-providers-in-depth-comparison-list,

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -79,14 +79,14 @@ const EmailProvidersStackedCard = ( {
 			}
 			icon={ '' }
 		>
-			<div className="email-provider-stacked-card__provider-price-and-button">
-				{ showFeaturesToggleButton && (
+			{ showFeaturesToggleButton && (
+				<div className="email-provider-stacked-card__provider-price-and-button">
 					<EmailProviderStackedFeaturesToggleButton
 						handleClick={ () => setFeaturesExpanded( ! areFeaturesExpanded ) }
 						isRelatedContentExpanded={ areFeaturesExpanded }
 					/>
-				) }
-			</div>
+				</div>
+			) }
 
 			<div className="email-provider-stacked-card__provider-form-and-right-panel">
 				<div className="email-provider-stacked-card__provider-form">{ formFields }</div>

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -127,6 +127,10 @@ $width-left-panel-card: 55%;
 .email-providers-stacked-comparison__provider-card {
 	@include break-medium {
 		padding-top: 36px;
+
+		&.action-panel {
+			padding-bottom: 36px;
+		}
 	}
 
 	&.card.action-panel.promo-card {
@@ -141,7 +145,7 @@ $width-left-panel-card: 55%;
 			color: var( --color-text );
 
 			p {
-				margin-bottom: 0.5em;
+				margin-bottom: 0;
 			}
 		}
 
@@ -182,6 +186,7 @@ $width-left-panel-card: 55%;
 		flex-direction: column;
 
 		@include break-xlarge {
+			align-items: center;
 			flex-direction: row;
 		}
 
@@ -190,14 +195,11 @@ $width-left-panel-card: 55%;
 
 			@include break-xlarge {
 				margin-left: 10px;
+				margin-top: 0;
 			}
 
 			.button {
 				width: 100%;
-
-				@include break-xlarge {
-					width: 100%;
-				}
 			}
 		}
 	}
@@ -262,7 +264,8 @@ $width-left-panel-card: 55%;
 .email-provider-stacked-card__title-container {
 	@include break-xlarge {
 		margin-right: 10px;
-		width: $width-left-panel-card;
+		min-width: $width-left-panel-card;
+		max-width: $width-left-panel-card;
 	}
 
 	p {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -43,6 +43,7 @@ $width-left-panel-card: 55%;
 
 .email-provider-stacked-card__provider__action-panel.is-primary {
 	flex-direction: column;
+
 	@include break-mobile {
 		flex-direction: row;
 	}
@@ -109,7 +110,7 @@ $width-left-panel-card: 55%;
 
 .email-provider-stacked-card__title-price-badge {
 	font-size: $font-body-small;
-	margin-top: 0.5em;
+	margin-top: 10px;
 	width: 100%;
 
 	@include break-xlarge {
@@ -124,7 +125,9 @@ $width-left-panel-card: 55%;
 }
 
 .email-providers-stacked-comparison__provider-card {
-	padding-top: 36px;
+	@include break-medium {
+		padding-top: 36px;
+	}
 
 	&.card.action-panel.promo-card {
 		display: flex;
@@ -146,7 +149,7 @@ $width-left-panel-card: 55%;
 			display: flex;
 			flex-direction: row;
 			margin-bottom: 0;
-			margin-top: 3px;
+			margin-top: 0;
 			padding-right: 12px;
 			text-align: left;
 
@@ -252,25 +255,18 @@ $width-left-panel-card: 55%;
 }
 
 .email-provider-stacked-card__title {
-	margin-top: 4px;
 	font-size: $font-title-small;
-	line-height: 24px;
 	color: var( --color-neutral-70 );
 }
 
 .email-provider-stacked-card__title-container {
-	display: flex;
-	flex-direction: column;
-	font-size: $font-body-small;
-	max-width: 100%;
-
 	@include break-xlarge {
+		margin-right: 10px;
 		width: $width-left-panel-card;
 	}
 
 	p {
 		margin-bottom: 0;
-		margin-right: 10px;
 	}
 }
 

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -80,7 +80,6 @@ $width-left-panel-card: 55%;
 	align-items: center;
 	display: flex;
 	justify-content: space-between;
-	margin-bottom: 1em;
 	order: 3;
 
 	.email-provider-stacked-features__toggle-button {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -124,6 +124,10 @@ $width-left-panel-card: 55%;
 }
 
 .email-providers-stacked-comparison__provider-card {
+	&.action-panel {
+		padding-bottom: 24px;
+	}
+
 	@include break-medium {
 		padding-top: 36px;
 

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -143,7 +143,7 @@ const EmailProvidersStackedComparison = ( {
 	const hasExistingEmailForwards = hasEmailForwards( domain );
 
 	return (
-		<Main className="email-providers-stacked-comparison" wideLayout>
+		<Main wideLayout>
 			<PageViewTracker
 				path={ emailManagementPurchaseNewEmailAccount( ':site', ':domain' ) }
 				title="Email Comparison"

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -143,7 +143,7 @@ const EmailProvidersStackedComparison = ( {
 	const hasExistingEmailForwards = hasEmailForwards( domain );
 
 	return (
-		<Main className="email-providers-stacked-comparison__main" wideLayout>
+		<Main className="email-providers-stacked-comparison" wideLayout>
 			<PageViewTracker
 				path={ emailManagementPurchaseNewEmailAccount( ':site', ':domain' ) }
 				title="Email Comparison"

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -1,23 +1,31 @@
+@import '@automattic/typography/styles/variables';
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
-@import '@automattic/typography/styles/variables';
 
-.email-providers-stacked-comparison {
-	padding: 0 20px 20px;
+.email-providers-stacked-comparison__header,
+.email-providers-stacked-comparison__sub-header {
+	padding-left: 16px;
+	padding-right: 16px;
+	text-align: center;
 
-	@include break-mobile {
-		padding: 0 24px 24px;
+	@include break-medium {
+		padding: 0;
 	}
 }
 
 .email-providers-stacked-comparison__header {
 	font-size: $font-title-large;
-	text-align: center;
+	padding-left: 16px;
+	padding-right: 16px;
+	padding-top: 16px;
 
 	@extend .wp-brand-font;
+
+	@include break-medium {
+		padding: 0;
+	}
 }
 
 .email-providers-stacked-comparison__sub-header {
 	font-size: $font-body-small;
-	text-align: center;
 }

--- a/client/my-sites/email/email-providers-stacked-comparison/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/style.scss
@@ -2,7 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 @import '@automattic/typography/styles/variables';
 
-.email-providers-stacked-comparison__main {
+.email-providers-stacked-comparison {
 	padding: 0 20px 20px;
 
 	@include break-mobile {


### PR DESCRIPTION
This pull request fixes a number of subtle display issues in the `Email Comparison` page as well as the `In-Depth Comparison` page. More specifically, it:

* Limits the width of the content on wide screens
* Makes sure the margin around this content is consistent with other pages
* Removes the left and right margins on mobile
* Add margin around the headers and sub-headers
* Fix font sizes that were not consistent between those two pages on mobile
* Fix the padding of cards on mobile that was not consistent between those two pages
* Fix prices that were misaligned on the `Email Comparison` page

##### `Email Comparison`

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150192212-3d0afac4-4358-4f0c-b178-62f7f72d62fe.png) | ![image](https://user-images.githubusercontent.com/594356/150192378-fac6e7f2-eda5-4b58-8946-c8618267eb0c.png)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150193597-59a6a934-8aaa-4410-aba1-4fed154df16c.png) | ![image](https://user-images.githubusercontent.com/594356/150196017-b3424e20-7f6f-4f8d-a8fe-29ab8efd02b8.png) <br/><br/><br/><br/>


##### `In-Depth Comparison`

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150194307-702d646e-4127-4bd8-877e-3f9a6ef1e768.png) |![image](https://user-images.githubusercontent.com/594356/150192595-4e7b5f43-3a44-4aba-98cd-258bdd57dd31.png)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150194141-18fea370-f49e-4314-88df-f6e802db2b99.png) |  ![image](https://user-images.githubusercontent.com/594356/150193643-dbec3fea-3e93-40b7-9947-5bffb4080514.png)

#### Testing instructions

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout update/email-comparison-pages` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/60259#issuecomment-1016732391)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Assert that the page looks like the screenshots above on desktop and mobile
6. Click the `See how they compare` link to access the `In-Depth Comparison` page
7. Assert that the page looks like the screenshots above on desktop and mobile