### PR TITLE
CI: Reduce Quarantined E2E runs to once a day.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -912,8 +912,7 @@ object QuarantinedE2ETests: BuildType( {
 	triggers {
 		schedule {
 			schedulingPolicy = cron {
-				hours = "*/3"
-				dayOfWeek = "2-6"
+				hours = "01"
 			}
 			branchFilter = "+:trunk"
 			triggerBuild = always()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to reduce the Quarantined E2E runs to just once a day, but remove the day of week filter.

As a result the Quarantined E2E task should run once every day of the week.

#### Testing instructions

- [x] Ensure that:
  - [x] TeamCity configuration is valid.

Related to #