### PR TITLE
WooCommerce Install: Switch product_types to checkboxes

### DIFF
--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -1,5 +1,6 @@
-import { SelectControl, TextControl } from '@wordpress/components';
+import { CheckboxControl, SelectControl, TextControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { without } from 'lodash';
 import { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -22,7 +23,13 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 	const { get, save, update } = useSiteSettings( siteId );
 
 	function updateProductTypes( type: string ) {
-		updateOnboardingProfile( 'product_types', type );
+		const productTypes = getProfileValue( 'product_types' ) || [];
+
+		const newTypes = productTypes.includes( type )
+			? without( productTypes, type )
+			: [ ...productTypes, type ];
+
+		updateOnboardingProfile( 'product_types', newTypes );
 	}
 
 	function updateProductCount( count: string ) {
@@ -41,7 +48,7 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 		updateOnboardingProfile( 'other_platform_name', name );
 	}
 
-	function updateOnboardingProfile( key: string, value: string | boolean ) {
+	function updateOnboardingProfile( key: string, value: string | boolean | Array< string > ) {
 		const onboardingProfile = get( WOOCOMMERCE_ONBOARDING_PROFILE ) || {};
 
 		const updatedOnboardingProfile = {
@@ -59,21 +66,24 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 	}
 
 	function getContent() {
+		const productTypes = [
+			{ label: __( 'Physical Products' ), value: 'physical' },
+			{ label: __( 'Downloads' ), value: 'downloads' },
+		];
+
 		return (
 			<>
 				<div className="step-business-info__info-section" />
 				<div className="step-business-info__instructions-container">
-					<SelectControl
-						label={ __( 'What type of products will be listed? (optional)' ) }
-						value={ getProfileValue( 'product_types' ) }
-						options={ [
-							{ value: '', label: '' },
-							{ value: 'physical', label: __( 'Physical Products' ) },
-							{ value: 'downloads', label: __( 'Downloads' ) },
-							{ value: 'subscriptions', label: __( 'Subscriptions' ) },
-						] }
-						onChange={ updateProductTypes }
-					/>
+					{ __( 'What type of products will be listed? (optional)' ) }
+					{ productTypes.map( ( { label, value } ) => (
+						<CheckboxControl
+							label={ label }
+							value={ value }
+							onChange={ () => updateProductTypes( value ) }
+							checked={ getProfileValue( 'product_types' ).indexOf( value ) !== -1 }
+						/>
+					) ) }
 
 					<SelectControl
 						label={ __( 'How many products do you plan to display? (optional)' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces select dropdown with checkboxes
* Changes productType updater to return an array

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://calypso.localhost:3000/woocommerce-installation/
- Choose a test site site
- Click "Set up my store"
- Navigate through the onboarding steps and note the new checkboxes in the business-info step
- Transfer the site and make sure the values set for product type are reflected in the wp-admin onboarding flow

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### After

<img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/150195144-93058f40-7613-49ea-87fb-ee7e798f9072.png">


Fixes #60171
