### PR TITLE
Domains: Update name servers card subtitle text

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
@@ -42,7 +42,7 @@ const NameserversToggle = ( { enabled, onToggle, selectedDomainName }: NameServe
 			<ToggleControl
 				onChange={ handleToggle }
 				checked={ enabled }
-				label={ translate( 'Point to WordPress.com name servers' ) }
+				label={ translate( 'Use WordPress.com name servers' ) }
 			/>
 		</form>
 	);

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -208,8 +208,8 @@ const Settings = ( {
 		}
 
 		return areAllWpcomNameServers()
-			? translate( 'Your domain is pointing to WordPress.com', { textOnly: true } )
-			: translate( 'Your domain is pointing to custom name servers', { textOnly: true } );
+			? translate( 'Your domain is using WordPress.com name servers', { textOnly: true } )
+			: translate( 'Your domain is using custom name servers', { textOnly: true } );
 	};
 
 	const renderNameServersSection = () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request

The subtitle in the name servers card in the domain settings page was using some text that's not accurate:

- "Your domain is pointing to custom name servers" and
- "Your domain is pointing to WordPress.com"

These don't make much sense, so we're changing them to

- "Your domain is using custom name servers" and
- "Your domain is using WordPress.com name servers"

This PR also updates the name servers toggle button label, which read "Point to WordPress.com name servers" before and is now "Use WordPress.com name servers".

### Screenshots

- Before:

![Markup on 2022-01-19 at 16:05:54](https://user-images.githubusercontent.com/5324818/150197470-20f7a34e-94a0-4ec1-9b8d-33ebc9523771.png)

- Before (toggle label):

<img width="702" alt="Screen Shot 2022-01-19 at 16 10 02" src="https://user-images.githubusercontent.com/5324818/150198479-285d9088-0ff0-40ff-819e-087f84d9c594.png">

- After:

![Markup on 2022-01-19 at 15:58:03](https://user-images.githubusercontent.com/5324818/150197491-4507c39c-0342-4cbe-bf15-4e9e5772d9c4.png)

- After (toggle label):

<img width="709" alt="Screen Shot 2022-01-19 at 16 08 36" src="https://user-images.githubusercontent.com/5324818/150198409-c9d1b361-88bd-44d2-bed8-a3ee61006184.png">

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to a domain's settings page (Upgrades > Domains > View settings)
- Ensure that the name servers subtitle and toggle label show the correct updated message depending on whether the domain uses WPCOM's name servers or not