### PR TITLE
Premium themes: Activate premium themes after purchase.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -64,7 +64,7 @@ import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customiz
 import { fetchSitePlans, refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { getPlansBySite, getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { getSiteHomeUrl, getSiteSlug, getSite } from 'calypso/state/sites/selectors';
-import { themeActivated } from 'calypso/state/themes/actions';
+import { activate } from 'calypso/state/themes/actions';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AtomicStoreThankYouCard from './atomic-store-thank-you-card';
@@ -266,12 +266,7 @@ export class CheckoutThankYou extends Component {
 			purchases.every( isTheme )
 		) {
 			const themeId = purchases[ 0 ].meta;
-			this.props.themeActivated(
-				'premium/' + themeId,
-				this.props.selectedSite.ID,
-				'calypstore',
-				true
-			);
+			this.props.activate( themeId, this.props.selectedSite.ID, 'calypstore', true );
 			page.redirect( '/themes/' + this.props.selectedSite.slug );
 		}
 	};
@@ -724,6 +719,6 @@ export default connect(
 		fetchSitePlans,
 		refreshSitePlans,
 		recordStartTransferClickInThankYou,
-		themeActivated,
+		activate,
 	}
 )( localize( CheckoutThankYou ) );

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -119,6 +119,13 @@ export class CheckoutThankYou extends Component {
 		siteUnlaunchedBeforeUpgrade: PropTypes.bool,
 	};
 
+	constructor( props ) {
+		super( props );
+		this.state = {
+			didThemeRedirect: false,
+		};
+	}
+
 	componentDidMount() {
 		this.redirectIfThemePurchased();
 
@@ -258,6 +265,12 @@ export class CheckoutThankYou extends Component {
 	};
 
 	redirectIfThemePurchased = () => {
+		// Only do theme redirect once
+		const { didThemeRedirect } = this.state;
+		if ( didThemeRedirect ) {
+			return;
+		}
+
 		const purchases = getPurchases( this.props );
 
 		if (
@@ -266,8 +279,11 @@ export class CheckoutThankYou extends Component {
 			purchases.every( isTheme )
 		) {
 			const themeId = purchases[ 0 ].meta;
-			this.props.requestThenActivate( themeId, this.props.selectedSite.ID, 'calypstore', true );
-			page.redirect( '/themes/' + this.props.selectedSite.slug );
+			// Mark that we've done the redirect, and do the actual redirect once the state is recorded
+			this.setState( { didThemeRedirect: true }, () => {
+				this.props.requestThenActivate( themeId, this.props.selectedSite.ID, 'calypstore', true );
+				page.redirect( '/themes/' + this.props.selectedSite.slug );
+			} );
 		}
 	};
 

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -64,7 +64,7 @@ import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customiz
 import { fetchSitePlans, refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { getPlansBySite, getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { getSiteHomeUrl, getSiteSlug, getSite } from 'calypso/state/sites/selectors';
-import { activate } from 'calypso/state/themes/actions';
+import { requestThenActivate } from 'calypso/state/themes/actions';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AtomicStoreThankYouCard from './atomic-store-thank-you-card';
@@ -266,7 +266,7 @@ export class CheckoutThankYou extends Component {
 			purchases.every( isTheme )
 		) {
 			const themeId = purchases[ 0 ].meta;
-			this.props.activate( themeId, this.props.selectedSite.ID, 'calypstore', true );
+			this.props.requestThenActivate( themeId, this.props.selectedSite.ID, 'calypstore', true );
 			page.redirect( '/themes/' + this.props.selectedSite.slug );
 		}
 	};
@@ -719,6 +719,6 @@ export default connect(
 		fetchSitePlans,
 		refreshSitePlans,
 		recordStartTransferClickInThankYou,
-		activate,
+		requestThenActivate,
 	}
 )( localize( CheckoutThankYou ) );

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -22,6 +22,7 @@ export {
 } from 'calypso/state/themes/actions/trending-themes';
 export { requestActiveTheme } from 'calypso/state/themes/actions/request-active-theme';
 export { requestTheme } from 'calypso/state/themes/actions/request-theme';
+export { requestThenActivate } from 'calypso/state/themes/actions/request-then-activate';
 export { requestThemeFilters } from 'calypso/state/themes/actions/request-theme-filters';
 export { requestThemes } from 'calypso/state/themes/actions/request-themes';
 export { setBackPath } from 'calypso/state/themes/actions/set-back-path';

--- a/client/state/themes/actions/request-theme.js
+++ b/client/state/themes/actions/request-theme.js
@@ -40,7 +40,6 @@ export function requestTheme( themeId, siteId ) {
 					if ( ! theme ) {
 						throw 'Theme not found'; // Will be caught by .catch() below
 					}
-					console.log( 'requestTheme: received theme mark 1' );
 					dispatch( receiveTheme( normalizeWporgTheme( theme ), siteId ) );
 					dispatch( {
 						type: THEME_REQUEST_SUCCESS,
@@ -62,7 +61,6 @@ export function requestTheme( themeId, siteId ) {
 			return wpcom.req
 				.get( `/themes/${ themeId }`, { apiVersion: '1.2' } )
 				.then( ( theme ) => {
-					console.log( 'requestTheme: received theme mark 2' );
 					dispatch( receiveTheme( normalizeWpcomTheme( theme ), siteId ) );
 					dispatch( {
 						type: THEME_REQUEST_SUCCESS,
@@ -88,7 +86,6 @@ export function requestTheme( themeId, siteId ) {
 		return wpcom.req
 			.post( `/sites/${ siteId }/themes`, { themes: themeId } )
 			.then( ( { themes } ) => {
-				console.log( 'requestTheme: received theme mark 3' );
 				dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
 				dispatch( {
 					type: THEME_REQUEST_SUCCESS,

--- a/client/state/themes/actions/request-theme.js
+++ b/client/state/themes/actions/request-theme.js
@@ -40,6 +40,7 @@ export function requestTheme( themeId, siteId ) {
 					if ( ! theme ) {
 						throw 'Theme not found'; // Will be caught by .catch() below
 					}
+					console.log( 'requestTheme: received theme mark 1' );
 					dispatch( receiveTheme( normalizeWporgTheme( theme ), siteId ) );
 					dispatch( {
 						type: THEME_REQUEST_SUCCESS,
@@ -61,6 +62,7 @@ export function requestTheme( themeId, siteId ) {
 			return wpcom.req
 				.get( `/themes/${ themeId }`, { apiVersion: '1.2' } )
 				.then( ( theme ) => {
+					console.log( 'requestTheme: received theme mark 2' );
 					dispatch( receiveTheme( normalizeWpcomTheme( theme ), siteId ) );
 					dispatch( {
 						type: THEME_REQUEST_SUCCESS,
@@ -86,6 +88,7 @@ export function requestTheme( themeId, siteId ) {
 		return wpcom.req
 			.post( `/sites/${ siteId }/themes`, { themes: themeId } )
 			.then( ( { themes } ) => {
+				console.log( 'requestTheme: received theme mark 3' );
 				dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
 				dispatch( {
 					type: THEME_REQUEST_SUCCESS,

--- a/client/state/themes/actions/request-then-activate.js
+++ b/client/state/themes/actions/request-then-activate.js
@@ -1,0 +1,44 @@
+import 'calypso/state/themes/init';
+import { requestTheme, activate } from 'calypso/state/themes/actions';
+import { getTheme } from 'calypso/state/themes/selectors/get-theme';
+
+/**
+ * requestThenActivate: Like activate(), which triggers a network request to
+ * activate a specific theme on a given site, but it calls requestTheme() to
+ * get that theme's information first.
+ *
+ * This allows Calypso to know if the theme is an autoloading homepage theme,
+ * which changes the activation behavior (these themes display a modal to the
+ * user before activating).
+ * Generally it's not needed if you're already on the theme showcase, but if you're
+ * somewhere else on the site, the data might not be available.
+ *
+ * @param  {string}   themeId   Theme ID
+ * @param  {number}   siteId    Site ID
+ * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @param  {boolean}  keepCurrentHomepage Prevent theme from switching homepage content if this is what it'd normally do when activated
+ * @returns {Function}          Action thunk
+ */
+export function requestThenActivate(
+	themeId,
+	siteId,
+	source = 'unknown',
+	purchased = false,
+	keepCurrentHomepage = false
+) {
+	return ( dispatch, getState ) => {
+		// Improvement: Can be conditional and only requestTheme if theme is null
+		const state = getState();
+		const theme = getTheme( state, 'wpcom', themeId );
+		if ( theme ) {
+			console.log( 'TODO: requesting was not needed here' );
+		}
+
+		console.log( 'dispatching requestTheme...' );
+		return dispatch( requestTheme( themeId, siteId ) ).then( () => {
+			console.log( 'dispatching activate...' );
+			dispatch( activate( themeId, siteId, source, purchased, keepCurrentHomepage ) );
+		} );
+	};
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- After purchasing an individual premium theme, Instead of assuming the backend has already activated it, use calypso's theme activate action to activate it
- Allows the 'Would you like to change your homepage?' dialog to appear in most circumstances
- Needs to be used in conjunction with a backend patch to stop the auto activating behavior

Calypso has a feature that shows you a modal before activating a new theme. It lets you decide if you want to change the homepage content or not, and renders dynamic previews.

However, when someone purchases an individual premium theme, they do not get to see the modal and make a choice, because the backend automatically activates the theme during the purchase process. D73399 stops the theme activation from happening on purchase, and this PR lets calypso show the modal after purchase, allowing the user to choose if their homepage should be changed.

![2022-01-19_13-28](https://user-images.githubusercontent.com/937354/150200647-ebd0393f-926b-4b83-a881-1270aad09199.png)
goes directly to
![2022-01-19_13-29](https://user-images.githubusercontent.com/937354/150200664-9db69928-a0c1-4705-a2d5-a7500fffe007.png)


#### Testing instructions


* Apply D73399-code to sandbox
* Sandbox public-api
* Use calypso locally with this PR applied
* On a free plan site, buy a premium theme individually
* After purchase, you should now see the "Do you wish to change your homepage?" modal, allowing you to choose before activating the theme
* The activation should work and honor your choice

You may need to turn off the isomorphic attribute
```diff
diff --git a/client/sections.js b/client/sections.js
index 628832adfd..b1cceaf469 100644
--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
                module: 'calypso/my-sites/themes',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
        },
        {
@@ -219,7 +219,7 @@ const sections = [
                module: 'calypso/my-sites/theme',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               // isomorphic: true,
                title: 'Themes',
                trackLoadPerformance: true,
        },
```


Related to #59996
