### PR TITLE
[ETK/Error-Reporting] Increase segment of users who get Sentry on WPCOM simple sites to 10%

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -68,7 +68,7 @@ function add_crossorigin_to_script_els( $tag ) {
  * @return bool
  */
 function user_in_sentry_test_segment( $user_id ) {
-	$current_segment = 1; // segment of existing users that will get this feature in %.
+	$current_segment = 10; // segment of existing users that will get this feature in %.
 	$user_segment    = $user_id % 100;
 
 	// We get the last two digits of the user id and that will be used to decide in what

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
@@ -50,7 +50,7 @@ class ErrorReporting_Activation_Test extends TestCase {
 	 *
 	 * @var int $current_segment
 	 */
-	private $current_segment = 1;
+	private $current_segment = 10;
 	/**
 	 * A dummy id that represents an a11n user. It's used in the `is_automattician`
 	 * stub defined above.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up to https://github.com/Automattic/wp-calypso/pull/59509.

* Increases the segment of users who get the WP-Admin/Gutenberg Sentry error reporting to 10%. 

#### Testing instructions

The segmentation logic is unit-tested. All tests should pass.