### PR TITLE
Masterbar: Move nowrap to masterbar item content

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -29,7 +29,6 @@ $autobar-height: 20px;
 	transition: transform 0.2s ease-out;
 	box-sizing: border-box;
 	justify-content: space-between;
-	white-space: nowrap;
 
 	.is-support-session & {
 		// Use generic colors so that they override whatever theme colors the user has picked.
@@ -174,6 +173,7 @@ $autobar-height: 20px;
 	}
 
 	.masterbar__item-content {
+		white-space: nowrap;
 		color: var( --color-masterbar-text );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a regression added by https://github.com/Automattic/wp-calypso/pull/60168. That change keeps the masterbar button text from wrapping by adding `white-space: nowrap` to `.masterbar`. However, that also can affect other elements that are "inside" the masterbar like popups triggered by masterbar items.

This PR will prevent it from applying to misc. elements inside the masterbar (eg: popups) that aren't the buttons themselves.

Fixes https://github.com/Automattic/wp-calypso/issues/60268

Before:
<img width="646" alt="Screen Shot 2022-01-19 at 4 15 37 PM" src="https://user-images.githubusercontent.com/2036909/150214944-7265ca5c-b061-4067-964f-5fac18e20956.png">

After:
<img width="427" alt="Screen Shot 2022-01-19 at 4 09 32 PM" src="https://user-images.githubusercontent.com/2036909/150214933-159f964e-05ef-4b46-a7b9-a64ed2f84692.png">



For clarity, this is what the `nowrap` is meant to solve:

<img width="731" alt="Screen Shot 2022-01-19 at 4 14 17 PM" src="https://user-images.githubusercontent.com/2036909/150214789-be6b6d81-7fed-4732-9aba-79846fc8559a.png">

Here is it with `nowrap` enabled (both before and after this PR):

<img width="731" alt="Screen Shot 2022-01-19 at 4 14 25 PM" src="https://user-images.githubusercontent.com/2036909/150214849-026e183b-e179-4875-8b6c-6f0718f04687.png">


#### Testing instructions

- Add a product to your cart and visit checkout. 
- Click the "X" in the masterbar to leave checkout and verify that the text in the modal does not overflow the modal itself.