### PR TITLE
Moved updateOnboardingProfile to onMouseDown event.

### DIFF
--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -175,9 +175,11 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 					<ActionSection>
 						<SupportCard />
 						<StyledNextButton
+							onMouseDown={ () => {
+								updateOnboardingProfile( 'completed', true );
+							} }
 							onClick={ () => {
 								dispatch( submitSignupStep( { stepName: 'business-info' } ) );
-								updateOnboardingProfile( 'completed', true );
 								save();
 								goToNextStep();
 							} }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moved `updateOnboardingProfile` to onMouseDown event in an effort to save the `completed` boolean field to `woocommerce_onboarding_profile`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Start the test from either the landing page or just go to the first step directly:

* http://calypso.localhost:3000/start/woocommerce-install/?site=wooptestupgrade.wpcomstaging.com
* Enter your address
* When confirming you should see the POST against /sites/197963111/settings with changed address values.
* You'll now be on the business info step.
* When you submit this step, a completed: true value should be included in the /sites/settings POST request regardless of whether you changed anything on the options presented or just clicked submit early.
* After submitting you'll be taken to the transfer step where woo will be "installed" or at least checked in our test case
* After this check completes you're taken to the woocommerce admin screen, you should be left on wc admin without being redirected to the setup wizard.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60228
