### PR TITLE
Shopping Cart: Add Tracks events to Masterbar cart actions

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -149,6 +149,7 @@ class MasterbarLoggedIn extends Component {
 	};
 
 	goToCheckout = ( siteId ) => {
+		this.props.recordTracksEvent( 'calypso_masterbar_cart_go_to_checkout' );
 		page( `/checkout/${ siteId }` );
 	};
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -153,6 +153,10 @@ class MasterbarLoggedIn extends Component {
 		page( `/checkout/${ siteId }` );
 	};
 
+	onRemoveCartProduct = ( uuid = 'coupon' ) => {
+		this.props.recordTracksEvent( 'calypso_masterbar_cart_remove_product', { uuid } );
+	};
+
 	isActive = ( section ) => {
 		return section === this.props.section && ! this.props.isNotificationsShowing;
 	};
@@ -292,6 +296,8 @@ class MasterbarLoggedIn extends Component {
 							require="./masterbar-cart/masterbar-cart-wrapper"
 							placeholder={ null }
 							goToCheckout={ this.goToCheckout }
+							onRemoveProduct={ this.onRemoveCartProduct }
+							onRemoveCoupon={ this.onRemoveCartProduct }
 							selectedSiteSlug={ currentSelectedSiteSlug }
 							selectedSiteId={ currentSelectedSiteId }
 						/>

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -14,12 +14,16 @@ export type MasterbarCartButtonProps = {
 	selectedSiteSlug: string | undefined;
 	selectedSiteId: string | number | undefined;
 	goToCheckout: ( siteSlug: string ) => void;
+	onRemoveProduct?: ( uuid: string ) => void;
+	onRemoveCoupon?: () => void;
 };
 
 export function MasterbarCartButton( {
 	selectedSiteSlug,
 	selectedSiteId,
 	goToCheckout,
+	onRemoveProduct,
+	onRemoveCoupon,
 }: MasterbarCartButtonProps ): JSX.Element | null {
 	const { responseCart, reloadFromServer } = useShoppingCart(
 		selectedSiteId ? String( selectedSiteId ) : undefined
@@ -70,6 +74,8 @@ export function MasterbarCartButton( {
 						cartKey={ selectedSiteId }
 						goToCheckout={ goToCheckout }
 						closeCart={ onClose }
+						onRemoveProduct={ onRemoveProduct }
+						onRemoveCoupon={ onRemoveCoupon }
 					/>
 				</CheckoutErrorBoundary>
 			</Popover>

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -4,6 +4,8 @@ import { MiniCart } from '@automattic/mini-cart';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MasterbarItem from '../item';
 
 import './masterbar-cart-button-style.scss';
@@ -25,6 +27,7 @@ export function MasterbarCartButton( {
 	const cartButtonRef = useRef( null );
 	const [ isActive, setIsActive ] = useState( false );
 	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
 
 	if ( ! selectedSiteSlug || ! selectedSiteId || responseCart.products.length < 1 ) {
 		return null;
@@ -33,7 +36,8 @@ export function MasterbarCartButton( {
 	const onClick = () => {
 		setIsActive( ( active ) => {
 			if ( ! active ) {
-				reloadFromServer();
+				reloadFromServer(); // Refresh the cart whenever the popup is made visible.
+				reduxDispatch( recordTracksEvent( 'calypso_masterbar_cart_open' ) );
 			}
 			return ! active;
 		} );

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -95,11 +95,15 @@ export function MiniCart( {
 	cartKey,
 	goToCheckout,
 	closeCart,
+	onRemoveProduct,
+	onRemoveCoupon,
 }: {
 	selectedSiteSlug: string;
 	cartKey: string | number | undefined;
 	goToCheckout: ( siteSlug: string ) => void;
 	closeCart: () => void;
+	onRemoveProduct?: ( uuid: string ) => void;
+	onRemoveCoupon?: () => void;
 } ): JSX.Element | null {
 	const {
 		responseCart,
@@ -110,6 +114,16 @@ export function MiniCart( {
 	} = useShoppingCart( cartKey ? String( cartKey ) : undefined );
 	const { __ } = useI18n();
 	const isDisabled = isLoading || isPendingUpdate;
+
+	const handleRemoveCoupon = () => {
+		onRemoveCoupon?.();
+		return removeCoupon();
+	};
+
+	const handleRemoveProduct = ( uuid: string ) => {
+		onRemoveProduct?.( uuid );
+		return removeProductFromCart( uuid );
+	};
 
 	if ( ! cartKey ) {
 		return null;
@@ -136,8 +150,8 @@ export function MiniCart( {
 					</MiniCartSiteTitle>
 				</MiniCartHeader>
 				<MiniCartLineItems
-					removeCoupon={ removeCoupon }
-					removeProductFromCart={ removeProductFromCart }
+					removeCoupon={ handleRemoveCoupon }
+					removeProductFromCart={ handleRemoveProduct }
 					responseCart={ responseCart }
 				/>
 				<MiniCartTotal responseCart={ responseCart } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds Tracks events to the various actions possible with the Masterbar cart (https://github.com/Automattic/wp-calypso/pull/58467), specifically:

- calypso_masterbar_cart_go_to_checkout
- calypso_masterbar_cart_remove_product
- calypso_masterbar_cart_open

#### Testing instructions

- To see Tracks events fire, load calypso, then write `localStorage.setItem('debug', 'calypso:analytics')` in your JavaScript console, and then reload the page.
- Add a product to your cart and leave checkout, retaining the product in the cart.
- Click on the cart icon in the Masterbar and verify that you see the `calypso_masterbar_cart_open` event fire.
- Click the "Checkout" button in the popup and verify that you see the `calypso_masterbar_cart_go_to_checkout` event fire.
- Leave checkout again and open the Masterbar cart again.
- Click the "Remove" button below a product and verify that you see the `calypso_masterbar_cart_remove_product` event fire.

<img width="478" alt="Screen Shot 2022-01-19 at 7 12 25 PM" src="https://user-images.githubusercontent.com/2036909/150238866-489216df-0941-4668-9bc6-dea5d992ba3c.png">
<img width="474" alt="Screen Shot 2022-01-19 at 7 12 07 PM" src="https://user-images.githubusercontent.com/2036909/150238868-7d21d868-c8a7-4abd-af98-c3599b2fbd89.png">
<img width="470" alt="Screen Shot 2022-01-19 at 7 11 25 PM" src="https://user-images.githubusercontent.com/2036909/150238870-22b66abf-ebb2-4746-a179-c5498f2a56dc.png">


Fixes https://github.com/Automattic/wp-calypso/issues/60267