### PR TITLE
E2E: migrate Editor: Trash Post spec to Playwright.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -12,5 +12,6 @@ export * from './domain-search-component';
 export * from './isolated-block-editor-component';
 export * from './block-widget-editor-component';
 export * from './revisions-component';
+export * from './snackbar-notice-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/snackbar-notice-component.ts
+++ b/packages/calypso-e2e/src/lib/components/snackbar-notice-component.ts
@@ -1,0 +1,52 @@
+import { Page } from 'playwright';
+
+type NoticeType = 'Success' | 'Error' | 'Info';
+
+/**
+ * Represents the Snackbar Notice compoonent.
+ *
+ * These are elements that appear to float on top of the main DOM
+ * and typically carry information about an action performed on a page
+ * that results in forced navigation.
+ */
+export class SnackbarNoticeComponent {
+	private page: Page;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Verifies the content of the snackbar notice on page.
+	 *
+	 * This method requires either full or partial text of the snackbar notice
+	 * to be supplied as parameter.
+	 *
+	 * Optionally, it is possible to specify the `type` parameter to limit
+	 * validation to a certain type of snackbar notices eg. `error`.
+	 *
+	 * @param {string} text Full or partial text to validate on page.
+	 * @param param1 Optional parameters.
+	 * @param {NoticeType} param1.type Type of snackbar notice to limit validation to.
+	 * @returns {Promise<boolean>} True if text is found in target snackbar notice.
+	 * 	False otherwise.
+	 */
+	async validateNoticeShown(
+		text: string,
+		{ type }: { type?: NoticeType } = {}
+	): Promise< boolean > {
+		const noticeType = `.is-${ type?.toLowerCase() }` || '';
+
+		const selector = `div.notice${ noticeType } :text("${ text }")`;
+
+		const locator = this.page.locator( selector );
+		await locator.waitFor( { state: 'visible' } );
+
+		return Boolean( await locator.count() );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -47,9 +47,14 @@ const selectors = {
 	// corner. This addresses the bug where the post-publish panel is immediately
 	// closed when publishing with certain blocks on the editor canvas.
 	// See https://github.com/Automattic/wp-calypso/issues/54421.
+<<<<<<< HEAD
 	viewButton: 'text=/View (Post|Page)/',
+=======
+	viewButton: 'a.components-button:has-text("View"):visible',
+>>>>>>> 8752a238c9 (Change approach used in GutenbergEditorPage to detect for the presence of welcome tour.)
 	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
 	closePublishPanel: 'button[aria-label="Close panel"]',
+	snackbarViewButton: 'a.components-snackbar__action:has-text("View Post"):visible',
 
 	// Welcome tour
 	welcomeTourCloseButton: 'button[aria-label="Close Tour"]',
@@ -424,6 +429,7 @@ export class GutenbergEditorPage {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * Obtains the published article's URL from post-publish panels.
 	 *
 	 * This method is only able to obtain the published article's URL if immediately
@@ -431,11 +437,21 @@ export class GutenbergEditorPage {
 	 * being visible.
 	 *
 	 * @returns {Promise<string>} Published article's URL.
+=======
+	 *
+	 * @returns
+>>>>>>> 8752a238c9 (Change approach used in GutenbergEditorPage to detect for the presence of welcome tour.)
 	 */
 	async getPublishedURL(): Promise< string > {
 		const frame = await this.getEditorFrame();
 
+<<<<<<< HEAD
 		const viewPublishedArticleButton = await frame.waitForSelector( selectors.viewButton );
+=======
+		const viewPublishedArticleButton = await frame.waitForSelector(
+			`${ selectors.viewButton }, ${ selectors.snackbarViewButton }`
+		);
+>>>>>>> 8752a238c9 (Change approach used in GutenbergEditorPage to detect for the presence of welcome tour.)
 		return ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -47,11 +47,7 @@ const selectors = {
 	// corner. This addresses the bug where the post-publish panel is immediately
 	// closed when publishing with certain blocks on the editor canvas.
 	// See https://github.com/Automattic/wp-calypso/issues/54421.
-<<<<<<< HEAD
 	viewButton: 'text=/View (Post|Page)/',
-=======
-	viewButton: 'a.components-button:has-text("View"):visible',
->>>>>>> 8752a238c9 (Change approach used in GutenbergEditorPage to detect for the presence of welcome tour.)
 	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
 	closePublishPanel: 'button[aria-label="Close panel"]',
 	snackbarViewButton: 'a.components-snackbar__action:has-text("View Post"):visible',
@@ -429,7 +425,6 @@ export class GutenbergEditorPage {
 	}
 
 	/**
-<<<<<<< HEAD
 	 * Obtains the published article's URL from post-publish panels.
 	 *
 	 * This method is only able to obtain the published article's URL if immediately
@@ -437,21 +432,13 @@ export class GutenbergEditorPage {
 	 * being visible.
 	 *
 	 * @returns {Promise<string>} Published article's URL.
-=======
-	 *
-	 * @returns
->>>>>>> 8752a238c9 (Change approach used in GutenbergEditorPage to detect for the presence of welcome tour.)
 	 */
 	async getPublishedURL(): Promise< string > {
 		const frame = await this.getEditorFrame();
 
-<<<<<<< HEAD
-		const viewPublishedArticleButton = await frame.waitForSelector( selectors.viewButton );
-=======
 		const viewPublishedArticleButton = await frame.waitForSelector(
 			`${ selectors.viewButton }, ${ selectors.snackbarViewButton }`
 		);
->>>>>>> 8752a238c9 (Change approach used in GutenbergEditorPage to detect for the presence of welcome tour.)
 		return ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
 	}
 

--- a/test/e2e/specs/specs-wpcom/wp-editor__post-trash.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__post-trash.ts
@@ -1,0 +1,65 @@
+/**
+ * @group gutenberg
+ */
+
+import {
+	DataHelper,
+	GutenbergEditorPage,
+	setupHooks,
+	EditorSettingsSidebarComponent,
+	TestAccount,
+	BrowserHelper,
+	SnackbarNoticeComponent,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( `Editor: Trash Post` ), function () {
+	const accountName = BrowserHelper.targetGutenbergEdge()
+		? 'gutenbergSimpleSiteEdgeUser'
+		: 'simpleSitePersonalPlanUser';
+	const postTitle = `Trashed post - ${ DataHelper.getTimestamp() }`;
+
+	let page: Page;
+	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
+
+	setupHooks( async ( args ) => {
+		page = args.page;
+
+		const testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+		gutenbergEditorPage = new GutenbergEditorPage( page );
+		await gutenbergEditorPage.visit( 'post' );
+	} );
+
+	it( 'Enter post title', async function () {
+		await gutenbergEditorPage.enterTitle( postTitle );
+	} );
+
+	it( 'Save draft', async function () {
+		await gutenbergEditorPage.saveDraft();
+	} );
+
+	it( 'Trash post', async function () {
+		await gutenbergEditorPage.openSettings();
+		const frame = await gutenbergEditorPage.getEditorFrame();
+
+		editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
+		await editorSettingsSidebarComponent.clickTab( 'Post' );
+		await editorSettingsSidebarComponent.trashPost();
+	} );
+
+	it( 'User is navigated to trashed posts page', async function () {
+		await page.waitForNavigation( { url: /.*\/posts\/trashed\// } );
+	} );
+
+	it( 'Success notice is shown', async function () {
+		const snackbarNoticeComponent = new SnackbarNoticeComponent( page );
+		const success = await snackbarNoticeComponent.validateNoticeShown(
+			'Post successfully moved to trash.',
+			{ type: 'Success' }
+		);
+
+		expect( success ).toStrictEqual( true );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `Trash Post` spec to Playwright.

Key changes:
- addition of `trashPost` method in `EditorSettingsSidebarComponent` to trigger the post to be trashed.
- creation of dedicated `SnackbarNoticeComponent` to deal with floating snackbar notices.
- migration of the spec faithfully to the original to Playwright.

#### Testing instructions

- [ ] Ensure that in CI:
  - [ ] Editor: Trash Post spec is registered to have been run;
  - [ ] Editor: Trash Post spec completes without failure

Partially completes #55950.
Depends on https://github.com/Automattic/wp-calypso/pull/59467.
