### PR TITLE
Signup: Fix intent of import flow is wrong

### DIFF
--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -50,6 +50,7 @@ export default function IntentStep( props: Props ): React.ReactNode {
 		recordTracksEvent( 'calypso_signup_intent_select', { intent } );
 
 		if ( EXTERNAL_FLOW[ intent ] ) {
+			dispatch( submitSignupStep( { stepName }, { intent } ) );
 			page( getStepUrl( EXTERNAL_FLOW[ intent ], '', '', '', queryObject ) );
 		} else {
 			branchSteps( EXCLUDE_STEPS[ intent ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As https://github.com/Automattic/wp-calypso/pull/60230#issuecomment-1017018162 mentioned, the intent of the importer flow should be `import`.

![image](https://user-images.githubusercontent.com/13596067/150267507-1c09246f-dc7c-44e7-ad43-b60119739735.png)

![image](https://user-images.githubusercontent.com/13596067/150267345-dbfbdfe0-45d2-4b57-b498-eb0cca6aada1.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/`
* Select “Import your site content”
* Click back button.
* The intent of calypso_signup_previous_step_button_click event should be `import`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/60230#issuecomment-1017018162
