### PR TITLE
Design Picker: Update premium badge copy

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -220,7 +220,7 @@ export default function DesignPickerStep( props ) {
 						'design-picker-step__has-categories': showDesignPickerCategories,
 					} ) }
 					highResThumbnails
-					premiumBadge={ <PremiumBadge /> }
+					premiumBadge={ <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } /> }
 					categorization={ showDesignPickerCategories ? categorization : undefined }
 					recommendedCategorySlug={ getCategorizationOptionsForStep().defaultSelection }
 					categoriesHeading={

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -8,9 +8,10 @@ import './style.scss';
 
 interface Props {
 	className?: string;
+	isPremiumThemeAvailable?: boolean;
 }
 
-const PremiumBadge: FunctionComponent< Props > = ( { className } ) => {
+const PremiumBadge: FunctionComponent< Props > = ( { className, isPremiumThemeAvailable } ) => {
 	const { __ } = useI18n();
 
 	return (
@@ -18,10 +19,17 @@ const PremiumBadge: FunctionComponent< Props > = ( { className } ) => {
 			position="top center"
 			// @ts-expect-error: @types/wordpress__components doesn't align with latest @wordpress/components
 			delay={ 300 }
-			text={ __(
-				'Let your site stand out from the crowd with a modern and stylish Premium theme.',
-				__i18n_text_domain__
-			) }
+			text={
+				isPremiumThemeAvailable
+					? __(
+							'Let your site stand out from the crowd with a modern and stylish Premium theme. Premium themes are included in your plan.',
+							__i18n_text_domain__
+					  )
+					: __(
+							'Let your site stand out from the crowd with a modern and stylish Premium theme.',
+							__i18n_text_domain__
+					  )
+			}
 		>
 			<div className={ classNames( 'premium-badge', className ) }>
 				{ /*  eslint-disable-next-line wpcalypso/jsx-gridicon-size */ }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As https://github.com/Automattic/wp-calypso/pull/59293#issuecomment-1015084982 mentioned, add the new copy to the tooltip of `<PremiumBadge />` component.
* Use separated copy to make sure we can hide the new copy for the users with free/personal plan who doesn't have permission to use the premium theme

![image](https://user-images.githubusercontent.com/13596067/150276652-e9b2fb69-b00f-49c3-b91e-10101677d796.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/setup-site/intent?siteSlug=<your_site>&flags=themes/premium
* Select “build”
* Check the tooltip copy of the premium badge is correct

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/59293#issuecomment-1015084982
