### PR TITLE
P2 signup: pass email truce campaign info

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -777,6 +777,7 @@ export function createWpForTeamsSite( callback, dependencies, stepData, reduxSto
 			timezone_string: guessTimezone(),
 			is_wpforteams_site: true,
 			p2_initialize_as_hub: true,
+			...( stepData.campaign && { p2_signup_campaign: stepData.campaign } ),
 		},
 		validate: false,
 		locale,

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -38,6 +38,9 @@ const SITE_TAKEN_ERROR_CODES = [
 
 const WPCOM_SUBDOMAIN_SUFFIX_SUGGESTIONS = [ 'p2', 'team', 'work' ];
 
+const EMAIL_TRUCE_CAMPAIGN_REF = 'p2-email-truce';
+const EMAIL_TRUCE_CAMPAIGN_ID = 'p2-email-truce';
+
 /**
  * Module variables
  */
@@ -280,12 +283,18 @@ class P2Site extends Component {
 
 			this.resetAnalyticsData();
 
-			this.props.submitSignupStep( {
+			const stepData = {
 				stepName: this.props.stepName,
 				form: this.state.form,
 				site,
 				siteTitle,
-			} );
+			};
+
+			if ( this.props.refParameter === EMAIL_TRUCE_CAMPAIGN_REF ) {
+				stepData.campaign = EMAIL_TRUCE_CAMPAIGN_ID;
+			}
+
+			this.props.submitSignupStep( stepData );
 
 			this.props.goToNextStep();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* During signup, if the `ref` parameter is present, and matches the email truce campaign ID, we store this info on the newly created hub site, as it will be checked later for customized onboarding.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Sandbox `public-api.wordpress.com`
* Go to `calypso.localhost:3000/start/p2?ref=p2-email-truce` and sign up for a new site. (The `ref` param is important.)
* When the site is created, verify the meta was stored via `wp option get options --url=<your-test-site>.wordpress.com`. You should see a `p2_signup_campaign` field with value `p2-email-truce` in the array returned.

cc @lamosty on the `ref` flag
