### PR TITLE
Remove Lodash from client/login

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
-import { includes } from 'lodash';
 import page from 'page';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
@@ -111,7 +110,7 @@ export function magicLoginUse( context, next ) {
 
 	const { client_id, email, redirect_to, token } = previousQuery;
 
-	const flow = includes( redirect_to, 'jetpack/connect' ) ? 'jetpack' : null;
+	const flow = redirect_to?.includes( 'jetpack/connect' ) ? 'jetpack' : null;
 
 	const PrimaryComponent = getHandleEmailedLinkFormComponent( flow );
 
@@ -155,8 +154,8 @@ export function redirectJetpack( context, next ) {
 	const { redirect_to } = context.query;
 
 	const isUserComingFromPricingPage =
-		includes( redirect_to, 'source=jetpack-plans' ) ||
-		includes( redirect_to, 'source=jetpack-connect-plans' );
+		redirect_to?.includes( 'source=jetpack-plans' ) ||
+		redirect_to?.includes( 'source=jetpack-connect-plans' );
 	/**
 	 * Send arrivals from the jetpack connect process or jetpack's pricing page
 	 * (when site user email matches a wpcom account) to the jetpack branded login.
@@ -167,7 +166,7 @@ export function redirectJetpack( context, next ) {
 	 */
 	if (
 		isJetpack !== 'jetpack' &&
-		( includes( redirect_to, 'jetpack/connect' ) || isUserComingFromPricingPage )
+		( redirect_to?.includes( 'jetpack/connect' ) || isUserComingFromPricingPage )
 	) {
 		return context.redirect( context.path.replace( 'log-in', 'log-in/jetpack' ) );
 	}

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -70,7 +69,7 @@ class HandleEmailedLinkForm extends Component {
 	constructor( props ) {
 		super( props );
 
-		if ( isEmpty( props.emailAddress ) || isEmpty( props.token ) ) {
+		if ( ! props.emailAddress || ! props.token ) {
 			this.props.showMagicLoginLinkExpiredPage();
 		}
 	}

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { defer, get } from 'lodash';
+import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -91,7 +91,7 @@ class RequestLoginEmailForm extends Component {
 	};
 
 	getUsernameOrEmailFromState() {
-		return get( this, 'state.usernameOrEmail', '' );
+		return this.state.usernameOrEmail;
 	}
 
 	render() {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,6 +1,6 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -48,9 +48,11 @@ class RequestLoginEmailForm extends Component {
 		usernameOrEmail: this.props.userEmail || '',
 	};
 
+	usernameOrEmailRef = createRef();
+
 	componentDidUpdate( prevProps ) {
 		if ( ! prevProps.requestError && this.props.requestError ) {
-			this.usernameOrEmail?.focus();
+			this.usernameOrEmailRef.current?.focus();
 		}
 	}
 
@@ -62,10 +64,6 @@ class RequestLoginEmailForm extends Component {
 		if ( this.props.requestError ) {
 			this.props.hideMagicLoginRequestNotice();
 		}
-	};
-
-	saveUsernameOrEmailRef = ( input ) => {
-		this.usernameOrEmail = input;
 	};
 
 	onNoticeDismiss = () => {
@@ -162,7 +160,7 @@ class RequestLoginEmailForm extends Component {
 							disabled={ isFetching || emailRequested }
 							value={ usernameOrEmail }
 							name="usernameOrEmail"
-							ref={ this.saveUsernameOrEmailRef }
+							ref={ this.usernameOrEmailRef }
 							onChange={ this.onUsernameOrEmailFieldChange }
 						/>
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -49,10 +48,9 @@ class RequestLoginEmailForm extends Component {
 		usernameOrEmail: this.props.userEmail || '',
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( ! this.props.requestError && nextProps.requestError ) {
-			defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.requestError && this.props.requestError ) {
+			this.usernameOrEmail?.focus();
 		}
 	}
 

--- a/client/login/ssr.js
+++ b/client/login/ssr.js
@@ -1,5 +1,6 @@
-import { intersection } from 'lodash';
 import { isDefaultLocale } from 'calypso/lib/i18n-utils';
+
+const VALID_QUERY_KEYS = [ 'client_id', 'signup_flow', 'redirect_to' ];
 
 /**
  * A middleware that enables (or disables) server side rendering for the /log-in page.
@@ -12,14 +13,9 @@ import { isDefaultLocale } from 'calypso/lib/i18n-utils';
  * @param {Function} next     Next middleware in the running sequence
  */
 export function setShouldServerSideRenderLogin( context, next ) {
-	const validQueryKeys = [ 'client_id', 'signup_flow', 'redirect_to' ];
-	const queryKeys = Object.keys( context.query );
-
-	// if there are any parameters, they must be ONLY the ones in the list of valid query keys
-	const hasOnlyValidKeys = queryKeys.length === intersection( queryKeys, validQueryKeys ).length;
-
 	context.serverSideRender =
-		hasOnlyValidKeys &&
+		// if there are any parameters, they must be ONLY the ones in the list of valid query keys
+		Object.keys( context.query ).every( ( key ) => VALID_QUERY_KEYS.includes( key ) ) &&
 		isDefaultLocale( context.lang ) &&
 		isRedirectToValidForSsr( context.query.redirect_to );
 
@@ -33,7 +29,7 @@ export function setShouldServerSideRenderLogin( context, next ) {
  * @returns {boolean} If the value of &redirect_to= on the log-in page is compatible with SSR
  */
 function isRedirectToValidForSsr( redirectToQueryValue ) {
-	if ( 'undefined' === typeof redirectToQueryValue ) {
+	if ( redirectToQueryValue === undefined ) {
 		return true;
 	}
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -350,9 +349,8 @@ export default connect(
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		oauth2Client: getCurrentOAuth2Client( state ),
 		query: getCurrentQueryArguments( state ),
-		isJetpackWooCommerceFlow:
-			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
-		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+		isJetpackWooCommerceFlow: 'woocommerce-onboarding' === getCurrentQueryArguments( state ).from,
+		wccomFrom: getCurrentQueryArguments( state )[ 'wccom-from' ],
 	} ),
 	{
 		recordTracksEvent,


### PR DESCRIPTION
This PR removes Lodash usage from the `client/login` directory. Also does two drive-by improvements in `RequestLoginEmailForm`: migrate a legacy lifecycle, and use a modern ref for reffing the input field.

**How to test:**
I tested mainly the `/log-in/link` page. Entered an invalid username so that error is triggered, and verified that the username field is refocused after failed request:

<img width="442" alt="Screenshot 2022-01-20 at 10 53 54" src="https://user-images.githubusercontent.com/664258/150315580-e1e09e1a-60cb-4431-8d3e-c589a564e927.png">

Testing this also proves that the `defer` call wasn't needed: we can call `el.focus()` directly in the `componentDidUpdate` method.