### PR TITLE
Signup: Don't track back step in the sub-steps

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -125,7 +125,8 @@ export class NavigationLink extends Component {
 			intent: this.props.intent,
 		};
 
-		if ( this.props.direction === 'back' ) {
+		// We don't need to track if we are in the sub-steps since it's not really going back a step
+		if ( this.props.direction === 'back' && ! this.props.stepSectionName ) {
 			this.props.recordTracksEvent( 'calypso_signup_previous_step_button_click', tracksProps );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As https://github.com/Automattic/wp-calypso/issues/60216#issuecomment-1017075812 and https://github.com/Automattic/wp-calypso/issues/60216#issuecomment-1017116449 mentioned, we want to remove the tracking from the back button if the user is in the sub-steps since it's not really going back a step.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your_site>`
* When you land on the Design Picker step, preview one of the theme. Click the back button should not send the `calypso_signup_previous_step_button_click` tracking event.
* When you land on the import flow, and you're in the sub-steps. Click the back button should not send the above event either.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60216#issuecomment-1017075812 and https://github.com/Automattic/wp-calypso/issues/60216#issuecomment-1017116449
