### PR TITLE
Components: Refactor `Checklist` away from `UNSAFE_` methods

### DIFF
--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Children, PureComponent, cloneElement } from 'react';
@@ -139,7 +139,9 @@ class Checklist extends PureComponent {
 
 const ChecklistForSite = ( props ) => {
 	const siteId = useSelector( getSelectedSiteId );
-	return <Checklist key={ siteId } siteId={ siteId } { ...props } />;
+	const translate = useTranslate();
+
+	return <Checklist key={ siteId } siteId={ siteId } translate={ translate } { ...props } />;
 };
 
-export default localize( ChecklistForSite );
+export default ChecklistForSite;

--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -4,7 +4,7 @@ import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Children, PureComponent, cloneElement } from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import TaskPlaceholder from './task-placeholder';
 
@@ -26,13 +26,6 @@ class Checklist extends PureComponent {
 
 	componentDidMount() {
 		this.notifyCompletion();
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( { siteId } ) {
-		if ( siteId !== this.props.siteId ) {
-			this.setState( { expandedTaskIndex: undefined } );
-		}
 	}
 
 	componentDidUpdate() {
@@ -144,6 +137,9 @@ class Checklist extends PureComponent {
 	}
 }
 
-export default connect( ( state ) => ( {
-	siteId: getSelectedSiteId( state ),
-} ) )( localize( Checklist ) );
+const ChecklistForSite = ( props ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	return <Checklist key={ siteId } siteId={ siteId } { ...props } />;
+};
+
+export default localize( ChecklistForSite );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, in the `Checklist` component, we use `UNSAFE_componentWillReceiveProps` to reset local state when the site changes. However, this is easy to circumvent by wrapping the component in another one that provides `key={ siteId }` and that way ensures a different instance of the checklist for every site. That removes the need to listen to prop updates and reset state.

Part of #58453 where we refactor the rest of the `UNSAFE_` deprecated React lifecycle methods.

#### Testing instructions

* Go to `/plans/my-plan/:site` where `:site` is a Jetpack site.
* Verify the checklist under "Return to your self-hosted WordPress dashboard." still works and looks well
* Switch to another Jetpack site, ideally with a different state of its checklist.
* Verify the checklist gets updated accordingly and still works as it does in production.