### PR TITLE
Fix the breadcrumb URL ordering on Plugin Details page.

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -184,7 +184,10 @@ function PluginDetails( props ) {
 		// - change the first breadcrumb if prev page wasn't plugins page (eg activity log)
 		const navigationItems = [
 			{ label: translate( 'Plugins' ), href: `/plugins/${ selectedSite?.slug || '' }` },
-			{ label: fullPlugin.name, href: `/plugins/${ selectedSite?.slug }/${ fullPlugin.slug }` },
+			{
+				label: fullPlugin.name,
+				href: `/plugins/${ fullPlugin.slug }/${ selectedSite?.slug || '' }`,
+			},
 		];
 
 		return navigationItems;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add the selectedSite as the last piece of the URL.
Before this change the plugin slug was the last one, resulting in an incorrect URL.

#### Testing instructions
* Go to `/plugins` page, without a selected website
* Click on a plugin to go Plugin Details page
* On the Plugins page, click on the last breadcrumb (it should have the plugin name)
* You should stay on the same page
* On your sidebar, select a website
* Click again on the last breadcrumb
* You should again stay on the same page

#### Demo
![Kapture 2022-01-20 at 09 09 18](https://user-images.githubusercontent.com/5039531/150345019-d12fec93-d9ec-44b2-bcb3-733302c1da56.gif)


---
Fixes  #60292