### PR TITLE
Update domain only flow: `search domain` step

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -51,14 +51,13 @@ class ReskinSideExplainer extends Component {
 
 	render() {
 		const { title, subtitle, ctaText } = this.getStrings();
-		const { type } = this.props;
 
 		return (
 			/* eslint-disable jsx-a11y/click-events-have-key-events */
 			<div className="reskin-side-explainer">
 				<div className="reskin-side-explainer__title">{ title }</div>
 				<div className="reskin-side-explainer__subtitle">{ subtitle }</div>
-				{ type !== 'free-domain-only-explainer' && (
+				{ ctaText && (
 					<div className="reskin-side-explainer__cta">
 						<span
 							className="reskin-side-explainer__cta-text"

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -32,6 +32,18 @@ class ReskinSideExplainer extends Component {
 				);
 				ctaText = translate( 'Use a domain I own' );
 				break;
+
+			case 'free-domain-only-explainer':
+				title = translate(
+					'Get a {{b}}free{{/b}} one-year domain registration with any paid annual plan.',
+					{
+						components: { b: <strong /> },
+					}
+				);
+				subtitle = translate(
+					'You can also choose to just start with a domain and add a site with a plan later on.'
+				);
+				break;
 		}
 
 		return { title, subtitle, ctaText };
@@ -39,22 +51,25 @@ class ReskinSideExplainer extends Component {
 
 	render() {
 		const { title, subtitle, ctaText } = this.getStrings();
+		const { type } = this.props;
 
 		return (
 			/* eslint-disable jsx-a11y/click-events-have-key-events */
 			<div className="reskin-side-explainer">
 				<div className="reskin-side-explainer__title">{ title }</div>
 				<div className="reskin-side-explainer__subtitle">{ subtitle }</div>
-				<div className="reskin-side-explainer__cta">
-					<span
-						className="reskin-side-explainer__cta-text"
-						role="button"
-						onClick={ this.props.onClick }
-						tabIndex="0"
-					>
-						{ ctaText }
-					</span>
-				</div>
+				{ type !== 'free-domain-only-explainer' && (
+					<div className="reskin-side-explainer__cta">
+						<span
+							className="reskin-side-explainer__cta-text"
+							role="button"
+							onClick={ this.props.onClick }
+							tabIndex="0"
+						>
+							{ ctaText }
+						</span>
+					</div>
+				) }
 			</div>
 			/* eslint-enable jsx-a11y/click-events-have-key-events */
 		);

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -261,7 +261,7 @@ export function generateFlows( {
 			destination: getThankYouNoSiteDestination,
 			description: 'An experimental approach for WordPress.com/domains',
 			disallowResume: true,
-			lastModified: '2020-08-11',
+			lastModified: '2021-01-20',
 			showRecaptcha: true,
 		},
 		{

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -261,7 +261,7 @@ export function generateFlows( {
 			destination: getThankYouNoSiteDestination,
 			description: 'An experimental approach for WordPress.com/domains',
 			disallowResume: true,
-			lastModified: '2021-01-20',
+			lastModified: '2022-01-20',
 			showRecaptcha: true,
 		},
 		{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -441,7 +441,18 @@ class DomainsStep extends Component {
 			'business-monthly',
 			'ecommerce',
 			'ecommerce-monthly',
+			'domain',
 		].includes( flowName );
+	};
+
+	shouldHideUseYourDomain = () => {
+		const { flowName } = this.props;
+		return [ 'domain' ].includes( flowName );
+	};
+
+	shouldDisplayDomainOnlyExplainer = () => {
+		const { flowName } = this.props;
+		return [ 'domain' ].includes( flowName );
 	};
 
 	getSideContent = () => {
@@ -455,12 +466,22 @@ class DomainsStep extends Component {
 						/>
 					</div>
 				) }
-				<div className="domains__domain-side-content">
-					<ReskinSideExplainer
-						onClick={ this.handleUseYourDomainClick }
-						type={ 'use-your-domain' }
-					/>
-				</div>
+				{ ! this.shouldHideUseYourDomain() && (
+					<div className="domains__domain-side-content">
+						<ReskinSideExplainer
+							onClick={ this.handleUseYourDomainClick }
+							type={ 'use-your-domain' }
+						/>
+					</div>
+				) }
+				{ this.shouldDisplayDomainOnlyExplainer() && (
+					<div className="domains__domain-side-content">
+						<ReskinSideExplainer
+							onClick={ this.handleDomainExplainerClick }
+							type={ 'free-domain-only-explainer' }
+						/>
+					</div>
+				) }
 			</div>
 		);
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -638,10 +638,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			return (
-				! stepSectionName &&
-				translate( "Enter your site's name or some descriptive keywords to get started" )
-			);
+			return ! stepSectionName && translate( 'Enter some descriptive keywords to get started' );
 		}
 
 		const subHeaderPropertyName = 'signUpFlowDomainsStepSubheader';

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -198,7 +198,8 @@
 		"business-monthly",
 		"ecommerce",
 		"ecommerce-monthly",
-		"ecommerce-onboarding"
+		"ecommerce-onboarding",
+		"domain"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"difm_typeform_id": "YMiXMYId",


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR enables the reskinned design on domain only flow and updates the first step (domain search).

It's part of the new domain-only flow (pcYYhz-ye-p2)

<img width="1424" alt="Schermata 2022-01-20 alle 14 38 42" src="https://user-images.githubusercontent.com/2797601/150349399-e247cf9c-f634-49a2-9f76-50b8d66077db.png">

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to to `/start/domain/domain-only`
- Verify that the page is displayed as in the screenshot above
- Search for a domain and verify that free domains are not displayed in the the results
- Verify that others steps are reskinned too (white background) and work as before
