### PR TITLE
Export: Refactor away `ExportCard` from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/exporter/container.jsx
+++ b/client/my-sites/exporter/container.jsx
@@ -13,7 +13,7 @@ class ExporterContainer extends Component {
 		return (
 			<div className="exporter">
 				<Notices />
-				<ExportCard siteId={ siteId } />
+				<ExportCard key={ siteId } siteId={ siteId } />
 				{ ! isJetpack && <ExportMediaCard siteId={ siteId } /> }
 			</div>
 		);

--- a/client/my-sites/exporter/export-card/index.jsx
+++ b/client/my-sites/exporter/export-card/index.jsx
@@ -20,16 +20,8 @@ import {
 import AdvancedSettings from './advanced-settings';
 
 class ExportCard extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.props.advancedSettingsFetch( this.props.siteId );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( newProps ) {
-		if ( newProps.siteId !== this.props.siteId ) {
-			this.props.advancedSettingsFetch( newProps.siteId );
-		}
 	}
 
 	render() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ExportCard` component away from the `UNSAFE_` deprecated React component methods.

We add a `key={ siteId }` to the props of `<ExportCard />` in order to require a new instance of the component when the site has changed. That also prevents us from having to request export settings when the site changes.

Part of #58453.

#### Testing instructions
* Go to `/export/:site` where `:site` is a WP.com simple site.
* Verify that an HTTP request to `/sites/:siteId/exports/settings` is made, where `:siteId` is that site's ID.
* Switch to another WP.com simple site.
* Verify that an HTTP request to `/sites/:siteId/exports/settings` is made, where `:siteId` is the new site's ID.