### PR TITLE
Emails: Change behaviour of Google Workspace continue button on add new mailboxes

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'calypso/lib/gsuite/new-users';
 import GSuiteNewUser from './new-user';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -36,7 +37,7 @@ const GSuiteNewUserList = ( {
 	showAddAnotherMailboxButton = true,
 	users = [],
 	validatedMailboxUuids = [],
-}: GSuiteNewUserListProps ) => {
+}: GSuiteNewUserListProps ): ReactElement => {
 	const translate = useTranslate();
 
 	const onUserValueChange = ( uuid: string ) => (

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -1,12 +1,13 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, FunctionComponent, ReactNode, useState } from 'react';
+import { Fragment, FunctionComponent, ReactNode } from 'react';
 import {
 	newUser,
 	GSuiteNewUser as NewUser,
 	sanitizeEmail,
 	validateUsers,
 } from 'calypso/lib/gsuite/new-users';
+import GSuiteNewUser from './new-user';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
 
 import './style.scss';
@@ -21,6 +22,7 @@ interface GSuiteNewUserListProps {
 	onUsersChange: ( users: NewUser[] ) => void;
 	onReturnKeyPress: ( event: Event ) => void;
 	users: NewUser[];
+	validatedMailboxUuids?: string[];
 }
 
 const GSuiteNewUserList: FunctionComponent< GSuiteNewUserListProps > = ( {
@@ -32,10 +34,10 @@ const GSuiteNewUserList: FunctionComponent< GSuiteNewUserListProps > = ( {
 	onReturnKeyPress,
 	selectedDomainName,
 	showAddAnotherMailboxButton = true,
-	users,
+	users = [],
+	validatedMailboxUuids = [],
 } ) => {
 	const translate = useTranslate();
-	const [ validatedMailboxUuids, setValidatedMailboxUuids ] = useState< string[] >( [] );
 
 	const onUserValueChange = ( uuid: string ) => (
 		fieldName: string,
@@ -55,7 +57,6 @@ const GSuiteNewUserList: FunctionComponent< GSuiteNewUserListProps > = ( {
 
 			return changedUser;
 		} );
-		setValidatedMailboxUuids( changedUsers.map( ( changedUser ) => changedUser.uuid ) );
 		onUsersChange( validateUsers( changedUsers, extraValidation ) );
 	};
 

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -1,21 +1,19 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, FunctionComponent, ReactNode } from 'react';
+import { Fragment, FunctionComponent, ReactNode, useState } from 'react';
 import {
 	newUser,
 	GSuiteNewUser as NewUser,
 	sanitizeEmail,
 	validateUsers,
 } from 'calypso/lib/gsuite/new-users';
-import GSuiteNewUser from './new-user';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
 
 import './style.scss';
 
-interface Props {
+interface GSuiteNewUserListProps {
 	autoFocus?: boolean;
 	children?: ReactNode;
-	dirty?: boolean;
 	domains?: SiteDomain[];
 	extraValidation: ( user: NewUser ) => NewUser;
 	selectedDomainName: string;
@@ -25,10 +23,9 @@ interface Props {
 	users: NewUser[];
 }
 
-const GSuiteNewUserList: FunctionComponent< Props > = ( {
+const GSuiteNewUserList: FunctionComponent< GSuiteNewUserListProps > = ( {
 	autoFocus = false,
 	children,
-	dirty = false,
 	domains,
 	extraValidation,
 	onUsersChange,
@@ -38,6 +35,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 	users,
 } ) => {
 	const translate = useTranslate();
+	const [ validatedMailboxUuids, setValidatedMailboxUuids ] = useState< string[] >( [] );
 
 	const onUserValueChange = ( uuid: string ) => (
 		fieldName: string,
@@ -57,7 +55,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 
 			return changedUser;
 		} );
-
+		setValidatedMailboxUuids( changedUsers.map( ( changedUser ) => changedUser.uuid ) );
 		onUsersChange( validateUsers( changedUsers, extraValidation ) );
 	};
 
@@ -77,7 +75,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 				<Fragment key={ user.uuid }>
 					<GSuiteNewUser
 						autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
-						dirty={ dirty }
+						showAllErrors={ validatedMailboxUuids.includes( user.uuid ) }
 						domains={
 							domains ? domains.map( ( domain ) => domain.name ?? '' ) : [ selectedDomainName ]
 						}

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, FunctionComponent, ReactNode } from 'react';
+import { Fragment, ReactNode } from 'react';
 import {
 	newUser,
 	GSuiteNewUser as NewUser,
@@ -25,7 +25,7 @@ interface GSuiteNewUserListProps {
 	validatedMailboxUuids?: string[];
 }
 
-const GSuiteNewUserList: FunctionComponent< GSuiteNewUserListProps > = ( {
+const GSuiteNewUserList = ( {
 	autoFocus = false,
 	children,
 	domains,
@@ -36,7 +36,7 @@ const GSuiteNewUserList: FunctionComponent< GSuiteNewUserListProps > = ( {
 	showAddAnotherMailboxButton = true,
 	users = [],
 	validatedMailboxUuids = [],
-} ) => {
+}: GSuiteNewUserListProps ) => {
 	const translate = useTranslate();
 
 	const onUserValueChange = ( uuid: string ) => (

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -15,6 +15,7 @@ import './style.scss';
 interface Props {
 	autoFocus?: boolean;
 	children?: ReactNode;
+	dirty?: boolean;
 	domains?: SiteDomain[];
 	extraValidation: ( user: NewUser ) => NewUser;
 	selectedDomainName: string;
@@ -27,6 +28,7 @@ interface Props {
 const GSuiteNewUserList: FunctionComponent< Props > = ( {
 	autoFocus = false,
 	children,
+	dirty = false,
 	domains,
 	extraValidation,
 	onUsersChange,
@@ -75,6 +77,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 				<Fragment key={ user.uuid }>
 					<GSuiteNewUser
 						autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+						dirty={ dirty }
 						domains={
 							domains ? domains.map( ( domain ) => domain.name ?? '' ) : [ selectedDomainName ]
 						}

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -36,7 +36,7 @@ interface GSuiteNewUserProps {
 	user: NewUser;
 }
 
-const GSuiteNewUser: FunctionComponent< GSuiteNewUserProps > = ( {
+const GSuiteNewUser = ( {
 	autoFocus,
 	domains,
 	onUserRemove,
@@ -52,7 +52,7 @@ const GSuiteNewUser: FunctionComponent< GSuiteNewUserProps > = ( {
 	selectedDomainName,
 	showAllErrors = false,
 	showTrashButton = true,
-} ) => {
+}: GSuiteNewUserProps ) => {
 	const translate = useTranslate();
 	const isRtl = useRtl();
 

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -24,21 +24,20 @@ const LabelWrapper: FunctionComponent< LabelWrapperProps > = ( { label, children
 	);
 };
 
-interface Props {
+interface GSuiteNewUserProps {
 	autoFocus: boolean;
-	dirty?: boolean;
 	domains: string[];
 	onUserRemove: () => void;
 	onUserValueChange: ( field: string, value: string, mailBoxFieldTouched?: boolean ) => void;
 	onReturnKeyPress: ( event: Event ) => void;
 	selectedDomainName: string;
 	showTrashButton: boolean;
+	showAllErrors?: boolean;
 	user: NewUser;
 }
 
-const GSuiteNewUser: FunctionComponent< Props > = ( {
+const GSuiteNewUser: FunctionComponent< GSuiteNewUserProps > = ( {
 	autoFocus,
-	dirty = false,
 	domains,
 	onUserRemove,
 	onUserValueChange,
@@ -51,6 +50,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 		password: { value: password, error: passwordError },
 	},
 	selectedDomainName,
+	showAllErrors = false,
 	showTrashButton = true,
 } ) => {
 	const translate = useTranslate();
@@ -69,10 +69,10 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	const [ mailBoxFieldTouched, setMailBoxFieldTouched ] = useState( false );
 	const [ passwordFieldTouched, setPasswordFieldTouched ] = useState( false );
 
-	const hasMailBoxError = ( dirty || mailBoxFieldTouched ) && null !== mailBoxError;
-	const hasFirstNameError = ( dirty || firstNameFieldTouched ) && null !== firstNameError;
-	const hasLastNameError = ( dirty || lastNameFieldTouched ) && null !== lastNameError;
-	const hasPasswordError = ( dirty || passwordFieldTouched ) && null !== passwordError;
+	const hasMailBoxError = ( showAllErrors || mailBoxFieldTouched ) && null !== mailBoxError;
+	const hasFirstNameError = ( showAllErrors || firstNameFieldTouched ) && null !== firstNameError;
+	const hasLastNameError = ( showAllErrors || lastNameFieldTouched ) && null !== lastNameError;
+	const hasPasswordError = ( showAllErrors || passwordFieldTouched ) && null !== passwordError;
 
 	const emailAddressLabel = translate( 'Email address' );
 

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -10,7 +10,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { GSuiteNewUser as NewUser } from 'calypso/lib/gsuite/new-users';
 import GSuiteDomainsSelect from './domains-select';
-
 import type { ReactElement } from 'react';
 
 interface LabelWrapperProps {

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -11,6 +11,8 @@ import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-w
 import { GSuiteNewUser as NewUser } from 'calypso/lib/gsuite/new-users';
 import GSuiteDomainsSelect from './domains-select';
 
+import type { ReactElement } from 'react';
+
 interface LabelWrapperProps {
 	label: TranslateResult;
 }
@@ -52,7 +54,7 @@ const GSuiteNewUser = ( {
 	selectedDomainName,
 	showAllErrors = false,
 	showTrashButton = true,
-}: GSuiteNewUserProps ) => {
+}: GSuiteNewUserProps ): ReactElement => {
 	const translate = useTranslate();
 	const isRtl = useRtl();
 

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -26,6 +26,7 @@ const LabelWrapper: FunctionComponent< LabelWrapperProps > = ( { label, children
 
 interface Props {
 	autoFocus: boolean;
+	dirty?: boolean;
 	domains: string[];
 	onUserRemove: () => void;
 	onUserValueChange: ( field: string, value: string, mailBoxFieldTouched?: boolean ) => void;
@@ -37,6 +38,7 @@ interface Props {
 
 const GSuiteNewUser: FunctionComponent< Props > = ( {
 	autoFocus,
+	dirty = false,
 	domains,
 	onUserRemove,
 	onUserValueChange,
@@ -67,10 +69,10 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	const [ mailBoxFieldTouched, setMailBoxFieldTouched ] = useState( false );
 	const [ passwordFieldTouched, setPasswordFieldTouched ] = useState( false );
 
-	const hasMailBoxError = mailBoxFieldTouched && null !== mailBoxError;
-	const hasFirstNameError = firstNameFieldTouched && null !== firstNameError;
-	const hasLastNameError = lastNameFieldTouched && null !== lastNameError;
-	const hasPasswordError = passwordFieldTouched && null !== passwordError;
+	const hasMailBoxError = ( dirty || mailBoxFieldTouched ) && null !== mailBoxError;
+	const hasFirstNameError = ( dirty || firstNameFieldTouched ) && null !== firstNameError;
+	const hasLastNameError = ( dirty || lastNameFieldTouched ) && null !== lastNameError;
+	const hasPasswordError = ( dirty || passwordFieldTouched ) && null !== passwordError;
 
 	const emailAddressLabel = translate( 'Email address' );
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -288,7 +288,7 @@ class EmailProvidersComparison extends Component {
 		const { googleUsers } = this.state;
 		const validatedUsers = validateUsers( googleUsers );
 
-		const usersAreValid = areAllUsersValid( googleUsers );
+		const usersAreValid = areAllUsersValid( validatedUsers );
 		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
 
 		this.setState( {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -43,7 +43,12 @@ import {
 	GOOGLE_PROVIDER_NAME,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 } from 'calypso/lib/gsuite/constants';
-import { areAllUsersValid, getItemsForCart, newUsers } from 'calypso/lib/gsuite/new-users';
+import {
+	areAllUsersValid,
+	getItemsForCart,
+	newUsers,
+	validateUsers,
+} from 'calypso/lib/gsuite/new-users';
 import {
 	getTitanProductName,
 	isDomainEligibleForTitanFreeTrial,
@@ -281,9 +286,15 @@ class EmailProvidersComparison extends Component {
 	onGoogleConfirmNewUsers = () => {
 		const { comparisonContext, domain, gSuiteProduct, hasCartDomain, source } = this.props;
 		const { googleUsers } = this.state;
+		const validatedUsers = validateUsers( googleUsers );
 
 		const usersAreValid = areAllUsersValid( googleUsers );
 		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
+
+		this.setState( {
+			validatedMailboxUuids: validatedUsers.map( ( user ) => user.uuid ),
+			googleUsers: validatedUsers,
+		} );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
 			context: comparisonContext,
@@ -368,6 +379,8 @@ class EmailProvidersComparison extends Component {
 			skipButtonLabel,
 			translate,
 		} = this.props;
+
+		const { validatedMailboxUuids } = this.state;
 
 		// TODO: Improve handling of this case
 		if ( ! isGSuiteSupported ) {
@@ -476,6 +489,7 @@ class EmailProvidersComparison extends Component {
 						selectedDomainName={ selectedDomainName }
 						users={ googleUsers }
 						onReturnKeyPress={ this.onGoogleFormReturnKeyPress }
+						validatedMailboxUuids={ validatedMailboxUuids }
 					>
 						<div className="email-providers-comparison__gsuite-user-list-actions-container">
 							<Button

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -130,7 +130,7 @@ class EmailProvidersComparison extends Component {
 		const { selectedDomainName, shouldPromoteGoogleWorkspace } = props;
 
 		this.state = {
-			googleUsers: [],
+			googleUsers: newUsers( selectedDomainName ),
 			titanMailboxes: [ buildNewTitanMailbox( selectedDomainName, false ) ],
 			expanded: this.getDefaultExpandedState( shouldPromoteGoogleWorkspace ),
 			addingToCart: false,

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -75,7 +75,7 @@ class GSuiteAddUsers extends Component {
 		const { domains, productType, selectedSite } = this.props;
 		const { users } = this.state;
 		const validatedUsers = validateUsers( users );
-		const canContinue = areAllUsersValid( users );
+		const canContinue = areAllUsersValid( validatedUsers );
 
 		this.setState( {
 			validatedMailboxUuids: validatedUsers.map( ( user ) => user.uuid ),

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -46,7 +46,7 @@ import './style.scss';
 
 class GSuiteAddUsers extends Component {
 	state = {
-		dirty: false,
+		showAllErrors: false,
 		users: [],
 	};
 
@@ -75,7 +75,7 @@ class GSuiteAddUsers extends Component {
 		const canContinue = areAllUsersValid( users );
 
 		this.setState( {
-			dirty: true,
+			showAllErrors: true,
 		} );
 
 		this.recordClickEvent( 'calypso_email_management_gsuite_add_users_continue_button_click' );
@@ -185,7 +185,7 @@ class GSuiteAddUsers extends Component {
 			userCanPurchaseGSuite,
 		} = this.props;
 
-		const { users, dirty } = this.state;
+		const { users, showAllErrors } = this.state;
 
 		const selectedDomainInfo = getGSuiteSupportedDomains( domains ).filter(
 			( { domainName } ) => selectedDomainName === domainName
@@ -204,7 +204,7 @@ class GSuiteAddUsers extends Component {
 						<GSuiteNewUserList
 							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 							extraValidation={ ( user ) => validateAgainstExistingUsers( user, gsuiteUsers ) }
-							dirty={ dirty }
+							showAllErrors={ showAllErrors }
 							domains={ selectedDomainInfo }
 							onUsersChange={ this.handleUsersChange }
 							selectedDomainName={ getEligibleGSuiteDomain( selectedDomainName, domains ) }

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -29,8 +29,9 @@ import {
 	areAllUsersValid,
 	getItemsForCart,
 	newUsers,
-	validateAgainstExistingUsers, validateUsers
-} from "calypso/lib/gsuite/new-users";
+	validateAgainstExistingUsers,
+	validateUsers,
+} from 'calypso/lib/gsuite/new-users';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -46,6 +46,7 @@ import './style.scss';
 
 class GSuiteAddUsers extends Component {
 	state = {
+		dirty: false,
 		users: [],
 	};
 
@@ -72,6 +73,10 @@ class GSuiteAddUsers extends Component {
 		const { domains, productType, selectedSite } = this.props;
 		const { users } = this.state;
 		const canContinue = areAllUsersValid( users );
+
+		this.setState( {
+			dirty: true,
+		} );
 
 		this.recordClickEvent( 'calypso_email_management_gsuite_add_users_continue_button_click' );
 
@@ -180,13 +185,11 @@ class GSuiteAddUsers extends Component {
 			userCanPurchaseGSuite,
 		} = this.props;
 
-		const { users } = this.state;
+		const { users, dirty } = this.state;
 
 		const selectedDomainInfo = getGSuiteSupportedDomains( domains ).filter(
 			( { domainName } ) => selectedDomainName === domainName
 		);
-
-		const canContinue = areAllUsersValid( users );
 
 		return (
 			<>
@@ -201,6 +204,7 @@ class GSuiteAddUsers extends Component {
 						<GSuiteNewUserList
 							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 							extraValidation={ ( user ) => validateAgainstExistingUsers( user, gsuiteUsers ) }
+							dirty={ dirty }
 							domains={ selectedDomainInfo }
 							onUsersChange={ this.handleUsersChange }
 							selectedDomainName={ getEligibleGSuiteDomain( selectedDomainName, domains ) }
@@ -210,7 +214,7 @@ class GSuiteAddUsers extends Component {
 							<div className="gsuite-add-users__buttons">
 								<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>
 
-								<Button primary disabled={ ! canContinue } onClick={ this.handleContinue }>
+								<Button primary onClick={ this.handleContinue }>
 									{ translate( 'Continue' ) }
 								</Button>
 							</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Makes the form to validate when user clicks on Continue button

#### Testing instructions

**Test 1**

1. Have a Google Workspace with an account (Go to upgrades -> email, then choose a Google Workspace account, then click on Add new mailboxes)
2. Click on continue (without filling)
3. Add a new mailbox and click on add (without filling)
4. Add a new mailbox, fill one single field and click on add (without filling more)

Assert that in 2, 3, 4 the fields that are wrong are presented with a validation message.

Finally assert that you can add all those mailboxes when you clear the errors

**Test 2**

1. Go to upgrades
2. Go to domains
3. Add a domain to the cart
4. In the email upsell, expand the Google Workspace and click on add (without filling)
5. Add a new mailbox and click on add (without filling)
6. Add a new mailbox, fill one single field and click on add (without filling more)

Assert that in 4, 5, 6 the fields that are wrong are presented with a validation message.

Finally assert that you can add all those mailboxes when you clear the errors

| BEFORE        | AFTER           |
| ------------- |:-------------:|
|![video](https://user-images.githubusercontent.com/5689927/150363221-e20a3c22-4c27-493d-8f8e-c1f0a67aeaf9.gif) | ![validation google](https://user-images.githubusercontent.com/5689927/150362966-88b0a5be-4216-41aa-8203-72f1101b73f5.gif) |

Related to 1165571745647867-as-1201610662130527
