### PR TITLE
Jetpack Pricing page: add Agencies menu item to top nav

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -110,6 +110,10 @@ const JetpackComMasterbar: React.FC = () => {
 				href: '/pricing/',
 			},
 			{
+				label: translate( 'Agencies' ),
+				href: '/for/agencies/',
+			},
+			{
 				label: translate( 'Support' ),
 				href: '/support/',
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds new “Agencies” top nav item that links to jetpack.com/for/agencies
* Complementary to D73471-code

#### Testing instructions

* Fire up this PR in Calypso Green.
* Go to `/pricing/`.
* Ensure the new menu item is visible and works as expected.

#### Screenshot

![image](https://user-images.githubusercontent.com/390760/150364189-c3d62a75-44f4-4719-a10d-b1fd791ec34e.png)


Related to 1161179020265237-as-1201692040304221/f