### PR TITLE
Emails: Show Google Workspace section with reason when unavailable in Email Comparison pages

### DIFF
--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { Button, Card } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { Card } from '@automattic/components';
 import EmailProviderFeatures from 'calypso/my-sites/email/email-provider-features';
-import { isBillingAvailable } from 'calypso/my-sites/email/email-providers-comparison/in-depth/data';
 import EmailProviderPrice from 'calypso/my-sites/email/email-providers-comparison/in-depth/email-provider-price';
 import LearnMoreLink from 'calypso/my-sites/email/email-providers-comparison/in-depth/learn-more-link';
+import SelectButton from 'calypso/my-sites/email/email-providers-comparison/in-depth/select-button';
 import { ComparisonListOrTableProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 import type { ReactElement } from 'react';
 
@@ -17,8 +16,6 @@ const ComparisonList = ( {
 	onSelectEmailProvider,
 	selectedDomainName,
 }: ComparisonListOrTableProps ): ReactElement => {
-	const translate = useTranslate();
-
 	return (
 		<div className="email-providers-in-depth-comparison-list">
 			{ emailProviders.map( ( emailProviderFeatures ) => {
@@ -58,14 +55,13 @@ const ComparisonList = ( {
 							</div>
 						) }
 
-						<Button
+						<SelectButton
 							className="email-providers-in-depth-comparison-list__button"
-							disabled={ ! isBillingAvailable( emailProviderFeatures, intervalLength ) }
-							onClick={ () => onSelectEmailProvider( emailProviderFeatures.slug ) }
-							primary
-						>
-							{ translate( 'Select' ) }
-						</Button>
+							emailProviderSlug={ emailProviderFeatures.slug }
+							intervalLength={ intervalLength }
+							onSelectEmailProvider={ onSelectEmailProvider }
+							selectedDomainName={ selectedDomainName }
+						/>
 					</Card>
 				);
 			} ) }

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { isBillingAvailable } from 'calypso/my-sites/email/email-providers-comparison/in-depth/data';
 import EmailProviderPrice from 'calypso/my-sites/email/email-providers-comparison/in-depth/email-provider-price';
 import LearnMoreLink from 'calypso/my-sites/email/email-providers-comparison/in-depth/learn-more-link';
+import SelectButton from 'calypso/my-sites/email/email-providers-comparison/in-depth/select-button';
 import type { ComparisonListOrTableProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 import type { ReactElement } from 'react';
 
@@ -121,14 +120,13 @@ const ComparisonTable = ( {
 					{ emailProviders.map( ( emailProviderFeatures ) => {
 						return (
 							<td key={ emailProviderFeatures.slug }>
-								<Button
+								<SelectButton
 									className="email-providers-in-depth-comparison-table__button"
-									disabled={ ! isBillingAvailable( emailProviderFeatures, intervalLength ) }
-									onClick={ () => onSelectEmailProvider( emailProviderFeatures.slug ) }
-									primary
-								>
-									{ translate( 'Select' ) }
-								</Button>
+									emailProviderSlug={ emailProviderFeatures.slug }
+									intervalLength={ intervalLength }
+									onSelectEmailProvider={ onSelectEmailProvider }
+									selectedDomainName={ selectedDomainName }
+								/>
 							</td>
 						);
 					} ) }

--- a/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
@@ -9,19 +9,7 @@ import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import { getTitanProductName } from 'calypso/lib/titan';
 import { TITAN_PRODUCT_TYPE } from 'calypso/lib/titan/constants';
 import { ADDING_GSUITE_TO_YOUR_SITE, ADDING_TITAN_TO_YOUR_SITE } from 'calypso/lib/url/support';
-import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import type { EmailProviderFeatures } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
-
-export const isBillingAvailable = (
-	emailProviderFeatures: EmailProviderFeatures,
-	intervalLength: IntervalLength
-) => {
-	if ( intervalLength === IntervalLength.ANNUALLY ) {
-		return true;
-	}
-
-	return emailProviderFeatures.slug !== GOOGLE_WORKSPACE_PRODUCT_TYPE;
-};
 
 export const professionalEmailFeatures: EmailProviderFeatures = {
 	badge: (

--- a/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
@@ -22,7 +22,7 @@ const EmailProviderPrice = ( {
 	} );
 
 	if ( emailProviderSlug === GOOGLE_WORKSPACE_PRODUCT_TYPE ) {
-		return <GoogleWorkspacePrice intervalLength={ intervalLength } />;
+		return <GoogleWorkspacePrice domain={ domain } intervalLength={ intervalLength } />;
 	}
 
 	return <ProfessionalEmailPrice domain={ domain } intervalLength={ intervalLength } />;

--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getSelectedDomain } from 'calypso/lib/domains';
+import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
+import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
+import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { SelectButtonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
+import type { ReactElement } from 'react';
+
+const usePlanAvailable = (
+	emailProviderSlug: string,
+	intervalLength: IntervalLength,
+	selectedDomainName: string
+) => {
+	const selectedSite = useSelector( getSelectedSite );
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+	const domain = getSelectedDomain( {
+		domains,
+		selectedDomainName: selectedDomainName,
+	} );
+
+	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
+
+	if ( emailProviderSlug !== GOOGLE_WORKSPACE_PRODUCT_TYPE ) {
+		return true;
+	}
+
+	if ( ! canPurchaseGSuite || ! hasGSuiteSupportedDomain( [ domain ] ) ) {
+		return false;
+	}
+
+	return intervalLength === IntervalLength.ANNUALLY;
+};
+
+const SelectButton = ( {
+	className,
+	emailProviderSlug,
+	intervalLength,
+	onSelectEmailProvider,
+	selectedDomainName,
+}: SelectButtonProps ): ReactElement => {
+	const translate = useTranslate();
+
+	const isPlanAvailable = usePlanAvailable( emailProviderSlug, intervalLength, selectedDomainName );
+
+	return (
+		<Button
+			className={ className }
+			disabled={ ! isPlanAvailable }
+			onClick={ () => onSelectEmailProvider( emailProviderSlug ) }
+			primary
+		>
+			{ translate( 'Select' ) }
+		</Button>
+	);
+};
+
+export default SelectButton;

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -37,3 +37,11 @@ export type EmailProvidersInDepthComparisonProps = {
 export type LearnMoreLinkProps = {
 	url: string;
 };
+
+export type SelectButtonProps = {
+	className: string;
+	emailProviderSlug: string;
+	intervalLength: IntervalLength;
+	onSelectEmailProvider: ( emailProviderSlug: string ) => void;
+	selectedDomainName: string;
+};

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -7,7 +7,7 @@ import {
 	EmailProviderStackedFeatures,
 	EmailProviderStackedFeaturesToggleButton,
 } from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features';
-import type { ProviderCard } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props';
+import type { ProviderCardProps } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props';
 import type { MouseEvent, ReactElement } from 'react';
 
 import './style.scss';
@@ -31,7 +31,7 @@ const EmailProvidersStackedCard = ( {
 	productName,
 	providerKey,
 	showExpandButton = true,
-}: ProviderCard ): ReactElement => {
+}: ProviderCardProps ): ReactElement => {
 	const [ areFeaturesExpanded, setFeaturesExpanded ] = useState( false );
 
 	const isViewportSizeLowerThan660px = useBreakpoint( '<660px' );

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -187,19 +187,19 @@ const EmailProvidersStackedComparison = ( {
 			<ProfessionalEmailCard
 				comparisonContext={ comparisonContext }
 				detailsExpanded={ detailsExpanded.titan }
-				selectedDomainName={ selectedDomainName }
-				source={ source }
 				intervalLength={ selectedIntervalLength }
 				onExpandedChange={ changeExpandedState }
+				selectedDomainName={ selectedDomainName }
+				source={ source }
 			/>
 
 			<GoogleWorkspaceCard
 				comparisonContext={ comparisonContext }
 				detailsExpanded={ detailsExpanded.google }
-				selectedDomainName={ selectedDomainName }
-				source={ source }
 				intervalLength={ selectedIntervalLength }
 				onExpandedChange={ changeExpandedState }
+				selectedDomainName={ selectedDomainName }
+				source={ source }
 			/>
 
 			<EmailForwardingLink selectedDomainName={ selectedDomainName } />

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -10,7 +10,6 @@ import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
-import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
@@ -23,7 +22,6 @@ import {
 	emailManagementPurchaseNewEmailAccount,
 } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -64,8 +62,6 @@ const EmailProvidersStackedComparison = ( {
 		};
 	} );
 
-	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
-
 	const currentRoute = useSelector( getCurrentRoute );
 
 	const selectedSite = useSelector( getSelectedSite );
@@ -80,8 +76,6 @@ const EmailProvidersStackedComparison = ( {
 	if ( ! domain ) {
 		return <></>;
 	}
-
-	const isGSuiteSupported = canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] );
 
 	const changeExpandedState = ( providerKey: string, isCurrentlyExpanded: boolean ) => {
 		const expandedEntries = Object.entries( detailsExpanded ).map( ( entry ) => {
@@ -138,8 +132,6 @@ const EmailProvidersStackedComparison = ( {
 		);
 	};
 
-	const showGoogleWorkspaceCard =
-		selectedIntervalLength === IntervalLength.ANNUALLY && isGSuiteSupported;
 	const hasExistingEmailForwards = hasEmailForwards( domain );
 
 	return (
@@ -201,16 +193,14 @@ const EmailProvidersStackedComparison = ( {
 				onExpandedChange={ changeExpandedState }
 			/>
 
-			{ showGoogleWorkspaceCard && (
-				<GoogleWorkspaceCard
-					comparisonContext={ comparisonContext }
-					detailsExpanded={ detailsExpanded.google }
-					selectedDomainName={ selectedDomainName }
-					source={ source }
-					intervalLength={ selectedIntervalLength }
-					onExpandedChange={ changeExpandedState }
-				/>
-			) }
+			<GoogleWorkspaceCard
+				comparisonContext={ comparisonContext }
+				detailsExpanded={ detailsExpanded.google }
+				selectedDomainName={ selectedDomainName }
+				source={ source }
+				intervalLength={ selectedIntervalLength }
+				onExpandedChange={ changeExpandedState }
+			/>
 
 			<EmailForwardingLink selectedDomainName={ selectedDomainName } />
 		</Main>

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -38,7 +38,7 @@ import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { EmailProvidersStackedCardProps, ProviderCard } from './provider-card-props';
+import type { EmailProvidersStackedCardProps, ProviderCardProps } from './provider-card-props';
 import type { ReactElement } from 'react';
 
 import './professional-email-card.scss';
@@ -59,11 +59,9 @@ const getTitanFeatures = () => {
 	];
 };
 
-const professionalEmailCardInformation: ProviderCard = {
+const professionalEmailCardInformation: ProviderCardProps = {
 	className: 'professional-email-card',
-	detailsExpanded: true,
 	expandButtonLabel: translate( 'Select' ),
-	onExpandedChange: noop,
 	providerKey: 'titan',
 	showExpandButton: true,
 	description: translate( 'Integrated email solution for your WordPress.com site.' ),
@@ -75,14 +73,13 @@ const professionalEmailCardInformation: ProviderCard = {
 
 const ProfessionalEmailCard = ( {
 	cartDomainName,
+	comparisonContext,
 	detailsExpanded,
+	intervalLength,
 	onExpandedChange,
 	selectedDomainName,
-	intervalLength,
-	comparisonContext,
 	source,
 }: EmailProvidersStackedCardProps ): ReactElement => {
-	const hasCartDomain = Boolean( cartDomainName );
 	const selectedSite = useSelector( getSelectedSite );
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const domain = getSelectedDomain( {
@@ -93,15 +90,17 @@ const ProfessionalEmailCard = ( {
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
 
-	const professionalEmail: ProviderCard = { ...professionalEmailCardInformation };
-	professionalEmail.detailsExpanded = detailsExpanded;
-
 	const [ titanMailbox, setTitanMailbox ] = useState( [
 		buildNewTitanMailbox( selectedDomainName, false ),
 	] );
 	const [ addingToCart, setAddingToCart ] = useState( false );
 	const [ validatedTitanMailboxUuids, setValidatedTitanMailboxUuids ] = useState( [ '' ] );
 	const optionalFields = [ TITAN_PASSWORD_RESET_FIELD, TITAN_FULL_NAME_FIELD ];
+
+	const professionalEmail: ProviderCardProps = { ...professionalEmailCardInformation };
+	professionalEmail.detailsExpanded = detailsExpanded;
+
+	const hasCartDomain = Boolean( cartDomainName );
 
 	const onTitanConfirmNewMailboxes = () => {
 		const validatedTitanMailboxes = validateTitanMailboxes( titanMailbox, optionalFields );

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -4,8 +4,9 @@ import type { AppLogo } from 'calypso/my-sites/email/email-providers-stacked-com
 import type { Site } from 'calypso/my-sites/scan/types';
 import type { TranslateResult } from 'i18n-calypso';
 
-export interface ProviderCard {
+export interface ProviderCardProps {
 	additionalPriceInformation?: TranslateResult;
+	appLogos?: AppLogo[];
 	badge?: ReactElement;
 	billingPeriod?: TranslateResult;
 	children?: any;
@@ -18,7 +19,6 @@ export interface ProviderCard {
 	footerBadge?: ReactElement | null;
 	formFields?: ReactElement;
 	logo?: ReactElement | { path: string; className?: string };
-	appLogos?: AppLogo[];
 	onExpandedChange?: ( providerKey: string, expanded: boolean ) => void;
 	priceBadge?: ReactElement | TranslateResult | null;
 	productName: TranslateResult;


### PR DESCRIPTION
This pull request updates the `Email Comparison` page as well as the `In-Depth Comparison` page to better handle the cases where Google Workspace is unavailable. More specifically, it makes sure we display a message when the user has selected monthly billing (we don't offer it for Google Workspace yet), or when the domain is not allowed (Google Workspace has several restrictions).

This pull request also makes sure the `Select` button on the `In-Depth Comparison` page is disabled when Google Workspace is not supported (a new component was created in order to centralize this logic). Finally, it renames a type, and cleans up the code a bit (by removing unnecessary default values).

##### `Email Comparison`

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150375567-5fcc0a8e-409c-4102-8c3f-d1c83e345186.png)| ![image](https://user-images.githubusercontent.com/594356/150375624-e91f274e-aa4d-40c4-846c-c991f4077cd7.png)


##### `In-Depth Comparison`

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150375903-2425826e-e274-4043-a46d-b98191739d56.png) | ![image](https://user-images.githubusercontent.com/594356/150376006-55d6e7de-1400-450a-9a40-0c49a18e2b19.png)

#### Testing instructions

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout update/google-workspace-in-email-comparison-pages` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/60301#issuecomment-1017633833)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Click the `Pay monthly` toggle
6. Assert that a section is shown for Google Workspace
7. Assert a `Only available with annual billing` message is displayed
8. Click the `See how they compare` link to access the `In-Depth Comparison` page
9. Assert that this message is displayed again

Unfortunately, testing the case where the domain is not allowed is not straightforward. I think the easiest is to modify the following [selector](https://github.com/Automattic/wp-calypso/blob/1e3a21ac02c2c4c1cb719d2527c94caeaea8b975/client/lib/gsuite/can-domain-add-gsuite.js) to return a different result:

```javascript
export function canDomainAddGSuite( domainName ) {
  if ( domainName.endsWith( '.wpcomstaging.com' ) ) {
    return false;
  }

  if ( domainName.endsWith( 'something.com' ) ) {
    return false;
  }

  return true;
}
```

Another option is to modify the WordPress.com API to return `false` for `is_valid_google_apps_country`.