### PR TITLE
Email: Refine copy of Email Comparison pages

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -673,7 +673,7 @@ function purchaseType( purchase ) {
 	}
 
 	if ( isGSuiteOrGoogleWorkspace( purchase ) ) {
-		return i18n.translate( 'Productivity Tools and Mailboxes at %(domain)s', {
+		return i18n.translate( 'Mailboxes and Productivity Tools at %(domain)s', {
 			args: {
 				domain: purchase.meta,
 			},

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -612,11 +612,9 @@ class ManagePurchase extends Component {
 		if ( isGSuiteOrGoogleWorkspace( purchase ) || isTitanMail( purchase ) ) {
 			const description = isTitanMail( purchase )
 				? translate(
-						'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
+						'Integrated email solution with powerful features for your WordPress.com site.'
 				  )
-				: translate(
-						'Professional email integrated with Google Meet and other productivity tools from Google.'
-				  );
+				: translate( 'Business email with Gmail and other productivity tools from Google.' );
 
 			if ( purchase.purchaseRenewalQuantity ) {
 				return (

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -615,7 +615,7 @@ class ManagePurchase extends Component {
 						'Integrated email solution with powerful features. Manage your email and more on any device.'
 				  )
 				: translate(
-						'Business email with Gmail. Include other collaboration and productivity tools from Google.'
+						'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
 				  );
 
 			if ( purchase.purchaseRenewalQuantity ) {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -612,9 +612,11 @@ class ManagePurchase extends Component {
 		if ( isGSuiteOrGoogleWorkspace( purchase ) || isTitanMail( purchase ) ) {
 			const description = isTitanMail( purchase )
 				? translate(
-						'Integrated email solution with powerful features for your WordPress.com site.'
+						'Integrated email solution with powerful features. Manage your email and more on any device.'
 				  )
-				: translate( 'Business email with Gmail and other productivity tools from Google.' );
+				: translate(
+						'Business email with Gmail. Include other collaboration and productivity tools from Google.'
+				  );
 
 			if ( purchase.purchaseRenewalQuantity ) {
 				return (

--- a/client/my-sites/email/email-provider-features/index.js
+++ b/client/my-sites/email/email-provider-features/index.js
@@ -25,7 +25,7 @@ function EmailProviderFeatures( { features, logos } ) {
 
 	return (
 		<div className="email-provider-features">
-			{ features.map( ( feature, index ) => (
+			{ features.filter( Boolean ).map( ( feature, index ) => (
 				<EmailProviderFeature key={ index } title={ feature } />
 			) ) }
 
@@ -41,7 +41,8 @@ function EmailProviderFeatures( { features, logos } ) {
 }
 
 EmailProviderFeatures.propTypes = {
-	features: PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ),
+	features: PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ) )
+		.isRequired,
 	logos: PropTypes.arrayOf( PropTypes.object ),
 };
 

--- a/client/my-sites/email/email-provider-features/list.js
+++ b/client/my-sites/email/email-provider-features/list.js
@@ -54,7 +54,9 @@ const getGoogleFeatures = () => {
 		translate( '30GB storage' ),
 		translate( 'Email, calendars, and contacts' ),
 		translate( 'Video calls, docs, spreadsheets, and more' ),
-		translate( 'Work from anywhere on any device – even offline' ),
+		translate( 'Real-time collaboration' ),
+		translate( 'Store and share files in the cloud' ),
+		translate( '24/7 support via email' ),
 	];
 };
 
@@ -64,7 +66,7 @@ const getTitanFeatures = ( isMonthlyProduct = true ) => {
 		translate( 'Send and receive from your custom domain' ),
 		translate( '30GB storage' ),
 		translate( 'Email, calendars, and contacts' ),
-		translate( 'One-click import of existing emails and contacts' ),
+		translate( '24/7 support via email' ),
 	];
 };
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -19,7 +19,14 @@ const ComparisonList = ( {
 	return (
 		<div className="email-providers-in-depth-comparison-list">
 			{ emailProviders.map( ( emailProviderFeatures ) => {
-				const { importing, tools, storage, support } = emailProviderFeatures.list;
+				const {
+					access,
+					collaboration,
+					importing,
+					tools,
+					storage,
+					support,
+				} = emailProviderFeatures.list;
 
 				return (
 					<Card key={ emailProviderFeatures.slug }>
@@ -42,7 +49,9 @@ const ComparisonList = ( {
 						</div>
 
 						<div className="email-providers-in-depth-comparison-list__features">
-							<EmailProviderFeatures features={ [ tools, storage, importing, support ] } />
+							<EmailProviderFeatures
+								features={ [ tools, storage, access, collaboration, importing, support ] }
+							/>
 						</div>
 
 						<div className="email-providers-in-depth-comparison-list__support-link">

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -19,14 +19,7 @@ const ComparisonList = ( {
 	return (
 		<div className="email-providers-in-depth-comparison-list">
 			{ emailProviders.map( ( emailProviderFeatures ) => {
-				const {
-					access,
-					collaboration,
-					importing,
-					tools,
-					storage,
-					support,
-				} = emailProviderFeatures.list;
+				const { collaboration, importing, tools, storage, support } = emailProviderFeatures.list;
 
 				return (
 					<Card key={ emailProviderFeatures.slug }>
@@ -50,7 +43,7 @@ const ComparisonList = ( {
 
 						<div className="email-providers-in-depth-comparison-list__features">
 							<EmailProviderFeatures
-								features={ [ tools, storage, access, collaboration, importing, support ] }
+								features={ [ tools, storage, collaboration, importing, support ] }
 							/>
 						</div>
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -78,16 +78,6 @@ const ComparisonTable = ( {
 
 				<tr className="email-providers-in-depth-comparison-table__separator">
 					<td className="email-providers-in-depth-comparison-table__feature">
-						{ translate( 'Access' ) }
-					</td>
-
-					{ emailProviders.map( ( emailProviderFeatures ) => (
-						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.table.access }</td>
-					) ) }
-				</tr>
-
-				<tr className="email-providers-in-depth-comparison-table__separator">
-					<td className="email-providers-in-depth-comparison-table__feature">
 						{ translate( 'Collaboration' ) }
 					</td>
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -62,7 +62,7 @@ const ComparisonTable = ( {
 					</td>
 
 					{ emailProviders.map( ( emailProviderFeatures ) => (
-						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.tools }</td>
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.table.tools }</td>
 					) ) }
 				</tr>
 
@@ -72,7 +72,29 @@ const ComparisonTable = ( {
 					</td>
 
 					{ emailProviders.map( ( emailProviderFeatures ) => (
-						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.storage }</td>
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.table.storage }</td>
+					) ) }
+				</tr>
+
+				<tr className="email-providers-in-depth-comparison-table__separator">
+					<td className="email-providers-in-depth-comparison-table__feature">
+						{ translate( 'Access' ) }
+					</td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => (
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.table.access }</td>
+					) ) }
+				</tr>
+
+				<tr className="email-providers-in-depth-comparison-table__separator">
+					<td className="email-providers-in-depth-comparison-table__feature">
+						{ translate( 'Collaboration' ) }
+					</td>
+
+					{ emailProviders.map( ( emailProviderFeatures ) => (
+						<td key={ emailProviderFeatures.slug }>
+							{ emailProviderFeatures.table.collaboration }
+						</td>
 					) ) }
 				</tr>
 
@@ -82,7 +104,7 @@ const ComparisonTable = ( {
 					</td>
 
 					{ emailProviders.map( ( emailProviderFeatures ) => (
-						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.importing }</td>
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.table.importing }</td>
 					) ) }
 				</tr>
 
@@ -92,7 +114,7 @@ const ComparisonTable = ( {
 					</td>
 
 					{ emailProviders.map( ( emailProviderFeatures ) => (
-						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.list.support }</td>
+						<td key={ emailProviderFeatures.slug }>{ emailProviderFeatures.table.support }</td>
 					) ) }
 				</tr>
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
@@ -21,30 +21,31 @@ export const professionalEmailFeatures: EmailProviderFeatures = {
 	slug: TITAN_PRODUCT_TYPE,
 	name: getTitanProductName(),
 	description: translate(
-		'Integrated email solution with powerful features for your WordPress.com site.'
+		'Integrated email solution with powerful features. Manage your email and more on any device.'
 	),
 	logo: <Gridicon className="professional-email-logo" icon="my-sites" />,
 	list: {
 		importing: translate( 'One-click import of existing emails and contacts' ),
-		storage: translate( '30GB storage' ),
+		storage: translate( '30GB storage for emails' ),
 		support: translate( '24/7 support via email' ),
-		tools: translate( 'Integrated email management, Inbox, Calendar and Contacts' ),
+		tools: translate( 'Inbox, Calendar and Contacts' ),
 	},
 	supportUrl: ADDING_TITAN_TO_YOUR_SITE,
 	table: {
-		access: translate( 'Online' ),
-		collaboration: translate( 'None' ),
+		collaboration: '-',
 		importing: translate( 'One-click import of existing emails and contacts' ),
-		storage: translate( '30GB storage' ),
+		storage: translate( '30GB for emails' ),
 		support: translate( '24/7 via email' ),
-		tools: translate( 'Integrated email management, Inbox, Calendar and Contacts' ),
+		tools: translate( 'Inbox, Calendar and Contacts' ),
 	},
 };
 
 export const googleWorkspaceFeatures: EmailProviderFeatures = {
 	slug: GOOGLE_WORKSPACE_PRODUCT_TYPE,
 	name: getGoogleMailServiceFamily(),
-	description: translate( 'Business email with Gmail and other productivity tools from Google.' ),
+	description: translate(
+		'Business email with Gmail. Include other collaboration and productivity tools from Google.'
+	),
 	logo: (
 		<img
 			alt={ translate( 'Google Workspace icon', { textOnly: true } ) }
@@ -53,10 +54,9 @@ export const googleWorkspaceFeatures: EmailProviderFeatures = {
 		/>
 	),
 	list: {
-		access: translate( 'Online & offline access' ),
-		collaboration: translate( 'Real-time collaboration' ),
+		collaboration: translate( 'Real-time collaboration for Docs, Sheets, and Slides' ),
 		importing: translate( 'Easy to import your existing emails and contacts' ),
-		storage: translate( '30GB storage with shared files' ),
+		storage: translate( '30GB storage for emails and cloud storage' ),
 		support: translate( '24/7 support via email' ),
 		tools: translate(
 			'Gmail, Calendar, Contacts, Meet, Chat, Drive, Docs, Sheets, Slides and more'
@@ -64,10 +64,9 @@ export const googleWorkspaceFeatures: EmailProviderFeatures = {
 	},
 	supportUrl: ADDING_GSUITE_TO_YOUR_SITE,
 	table: {
-		access: translate( 'Online & offline' ),
-		collaboration: translate( 'Real-time' ),
+		collaboration: translate( 'Real-time for Docs, Sheets, and Slides' ),
 		importing: translate( 'Easy to import your existing emails and contacts' ),
-		storage: translate( '30GB storage with shared files' ),
+		storage: translate( '30GB for emails and cloud storage' ),
 		support: translate( '24/7 via email' ),
 		tools: translate(
 			'Gmail, Calendar, Contacts, Meet, Chat, Drive, Docs, Sheets, Slides and more'

--- a/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
@@ -20,7 +20,9 @@ export const professionalEmailFeatures: EmailProviderFeatures = {
 	),
 	slug: TITAN_PRODUCT_TYPE,
 	name: getTitanProductName(),
-	description: translate( 'Integrated email solution for your WordPress.com site.' ),
+	description: translate(
+		'Integrated email solution with powerful features for your WordPress.com site.'
+	),
 	logo: <Gridicon className="professional-email-logo" icon="my-sites" />,
 	list: {
 		importing: translate( 'One-click import of existing emails and contacts' ),
@@ -29,14 +31,20 @@ export const professionalEmailFeatures: EmailProviderFeatures = {
 		tools: translate( 'Integrated email management, Inbox, Calendar and Contacts' ),
 	},
 	supportUrl: ADDING_TITAN_TO_YOUR_SITE,
+	table: {
+		access: translate( 'Online' ),
+		collaboration: translate( 'None' ),
+		importing: translate( 'One-click import of existing emails and contacts' ),
+		storage: translate( '30GB storage' ),
+		support: translate( '24/7 via email' ),
+		tools: translate( 'Integrated email management, Inbox, Calendar and Contacts' ),
+	},
 };
 
 export const googleWorkspaceFeatures: EmailProviderFeatures = {
 	slug: GOOGLE_WORKSPACE_PRODUCT_TYPE,
 	name: getGoogleMailServiceFamily(),
-	description: translate(
-		'Professional email integrated with Google Meet and other productivity tools from Google.'
-	),
+	description: translate( 'Business email with Gmail and other productivity tools from Google.' ),
 	logo: (
 		<img
 			alt={ translate( 'Google Workspace icon', { textOnly: true } ) }
@@ -45,10 +53,24 @@ export const googleWorkspaceFeatures: EmailProviderFeatures = {
 		/>
 	),
 	list: {
+		access: translate( 'Online & offline access' ),
+		collaboration: translate( 'Real-time collaboration' ),
 		importing: translate( 'Easy to import your existing emails and contacts' ),
-		storage: translate( '30GB storage' ),
+		storage: translate( '30GB storage with shared files' ),
 		support: translate( '24/7 support via email' ),
-		tools: translate( 'Gmail, Calendar, Meet, Chat, Drive, Docs, Sheets, Slides and more' ),
+		tools: translate(
+			'Gmail, Calendar, Contacts, Meet, Chat, Drive, Docs, Sheets, Slides and more'
+		),
 	},
 	supportUrl: ADDING_GSUITE_TO_YOUR_SITE,
+	table: {
+		access: translate( 'Online & offline' ),
+		collaboration: translate( 'Real-time' ),
+		importing: translate( 'Easy to import your existing emails and contacts' ),
+		storage: translate( '30GB storage with shared files' ),
+		support: translate( '24/7 via email' ),
+		tools: translate(
+			'Gmail, Calendar, Contacts, Meet, Chat, Drive, Docs, Sheets, Slides and more'
+		),
+	},
 };

--- a/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/data.tsx
@@ -44,7 +44,7 @@ export const googleWorkspaceFeatures: EmailProviderFeatures = {
 	slug: GOOGLE_WORKSPACE_PRODUCT_TYPE,
 	name: getGoogleMailServiceFamily(),
 	description: translate(
-		'Business email with Gmail. Include other collaboration and productivity tools from Google.'
+		'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
 	),
 	logo: (
 		<img

--- a/client/my-sites/email/email-providers-comparison/in-depth/style.scss
+++ b/client/my-sites/email/email-providers-comparison/in-depth/style.scss
@@ -114,6 +114,7 @@ $table-padding: 15px;
 
 		&:first-child {
 			padding-left: $table-padding;
+			white-space: nowrap;
 		}
 
 		&:nth-child( n + 2 ) {

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -16,7 +16,6 @@ export type EmailProviderPriceProps = {
 };
 
 const EMAIL_PROVIDER_FEATURES_TYPE = [
-	'access',
 	'collaboration',
 	'importing',
 	'storage',

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -15,18 +15,26 @@ export type EmailProviderPriceProps = {
 	selectedDomainName: string;
 };
 
-const EMAIL_PROVIDER_FEATURES_TYPE = [ 'importing', 'storage', 'support', 'tools' ] as const;
+const EMAIL_PROVIDER_FEATURES_TYPE = [
+	'access',
+	'collaboration',
+	'importing',
+	'storage',
+	'support',
+	'tools',
+] as const;
 
 type EmailProviderFeature = typeof EMAIL_PROVIDER_FEATURES_TYPE[ number ];
 
 export type EmailProviderFeatures = {
 	badge?: ReactNode;
 	description: TranslateResult;
-	list: Record< EmailProviderFeature, TranslateResult >;
+	list: Partial< Record< EmailProviderFeature, TranslateResult > >;
 	logo: ReactNode;
 	name: TranslateResult;
 	slug: string;
 	supportUrl: string;
+	table: Record< EmailProviderFeature, TranslateResult >;
 };
 
 export type EmailProvidersInDepthComparisonProps = {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -505,7 +505,7 @@ class EmailProvidersComparison extends Component {
 				title={ getGoogleMailServiceFamily() }
 				starLabel={ starLabel }
 				description={ translate(
-					'Professional email integrated with Google Meet and other productivity tools from Google.'
+					'Business email with Gmail and other productivity tools from Google.'
 				) }
 				formattedPrice={ formattedPrice }
 				discount={ discount }
@@ -651,7 +651,7 @@ class EmailProvidersComparison extends Component {
 				title={ getTitanProductName() }
 				badge={ poweredByTitan }
 				description={ translate(
-					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
+					'Integrated email solution with powerful features for your WordPress.com site.'
 				) }
 				detailsExpanded={ this.state.expanded.titan }
 				onExpandedChange={ this.onExpandedStateChange }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -505,7 +505,7 @@ class EmailProvidersComparison extends Component {
 				title={ getGoogleMailServiceFamily() }
 				starLabel={ starLabel }
 				description={ translate(
-					'Business email with Gmail and other productivity tools from Google.'
+					'Business email with Gmail. Include other collaboration and productivity tools from Google.'
 				) }
 				formattedPrice={ formattedPrice }
 				discount={ discount }
@@ -651,7 +651,7 @@ class EmailProvidersComparison extends Component {
 				title={ getTitanProductName() }
 				badge={ poweredByTitan }
 				description={ translate(
-					'Integrated email solution with powerful features for your WordPress.com site.'
+					'Integrated email solution with powerful features. Manage your email and more on any device.'
 				) }
 				detailsExpanded={ this.state.expanded.titan }
 				onExpandedChange={ this.onExpandedStateChange }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -505,7 +505,7 @@ class EmailProvidersComparison extends Component {
 				title={ getGoogleMailServiceFamily() }
 				starLabel={ starLabel }
 				description={ translate(
-					'Business email with Gmail. Include other collaboration and productivity tools from Google.'
+					'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
 				) }
 				formattedPrice={ formattedPrice }
 				discount={ discount }

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -43,6 +43,10 @@ const GoogleWorkspacePrice = ( {
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
+	if ( ! domain ) {
+		return <></>;
+	}
+
 	const isGSuiteSupported = canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] );
 
 	if ( ! isGSuiteSupported ) {

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -71,7 +71,6 @@
 }
 
 .email-providers-comparison__provider-card.promo-card {
-
 	.action-panel__body {
 		margin-left: 24px;
 	}

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features.tsx
@@ -83,7 +83,9 @@ export const EmailProviderStackedFeaturesToggleButton = ( {
 			onClick={ handleClick }
 		>
 			<span className="email-provider-stacked-features__toggle-text">
-				{ translate( 'Show all features' ) }
+				{ isRelatedContentExpanded
+					? translate( 'Hide all features' )
+					: translate( 'Show all features' ) }
 			</span>
 
 			<Gridicon icon={ isRelatedContentExpanded ? 'chevron-up' : 'chevron-down' } />

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -46,7 +46,7 @@ const EmailProvidersStackedCard = ( {
 	const header = (
 		<div className="email-provider-stacked-card__header">
 			<div className="email-provider-stacked-card__title-container">
-				<h2 className="email-provider-stacked-card__title wp-brand-font"> { productName } </h2>
+				<h2 className="email-provider-stacked-card__title"> { productName } </h2>
 				<p>{ description }</p>
 			</div>
 

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -22,21 +22,10 @@ $width-left-panel-card: 55%;
 		margin-top: 0;
 	}
 
-	&::before {
-		content: '';
-		display: block;
-		height: 1px;
-		margin-bottom: 8px;
-	}
-
-	&:first-child::before {
-		display: none;
-	}
-
 	.gridicon {
 		fill: var( --studio-gray-20 );
 		margin-left: -28px;
-		margin-right: 10px;
+		margin-right: 5px;
 		min-width: 24px;
 	}
 }
@@ -298,15 +287,10 @@ $width-left-panel-card: 55%;
 }
 
 .email-provider-stacked-features__logos {
-	column-gap: 5px;
+	column-gap: 6px;
 	display: flex;
 	flex-wrap: wrap;
-	margin-left: 32px;
-
-	@include break-xlarge {
-		justify-content: space-between;
-		column-gap: 3px;
-	}
+	margin-left: 28px;
 
 	img {
 		width: 32px;

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -102,7 +102,7 @@ $width-left-panel-card: 55%;
 	width: 100%;
 
 	@include break-xlarge {
-		margin-left: 10px;
+		margin-left: 20px;
 		margin-top: 0;
 		width: $width-right-panel-card;
 	}
@@ -240,7 +240,7 @@ $width-left-panel-card: 55%;
 
 .email-provider-stacked-card__provider-right-panel {
 	@include break-xlarge {
-		margin-left: 24px;
+		margin-left: 30px;
 	}
 
 	img {
@@ -251,6 +251,8 @@ $width-left-panel-card: 55%;
 .email-provider-stacked-card__title {
 	font-size: $font-title-small;
 	color: var( --color-neutral-70 );
+
+	@extend .wp-brand-font;
 }
 
 .email-provider-stacked-card__title-container {
@@ -262,6 +264,7 @@ $width-left-panel-card: 55%;
 
 	p {
 		margin-bottom: 0;
+		margin-top: 10px;
 	}
 }
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -66,7 +66,7 @@ const googleWorkspaceCardInformation: ProviderCardProps = {
 	expandButtonLabel: translate( 'Select' ),
 	providerKey: 'google',
 	description: translate(
-		'Business email with Gmail. Include other collaboration and productivity tools from Google.'
+		'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
 	),
 	logo: { path: googleWorkspaceIcon, className: 'google-workspace-icon' },
 	appLogos: getGoogleAppLogos(),

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -57,7 +57,6 @@ const getGoogleFeatures = (): TranslateResult[] => {
 		translate( 'Video calls, docs, spreadsheets, and more' ),
 		translate( 'Real-time collaboration' ),
 		translate( 'Store and share files in the cloud' ),
-		translate( 'Work from anywhere on any device – even offline' ),
 		translate( '24/7 support via email' ),
 	];
 };
@@ -66,7 +65,9 @@ const googleWorkspaceCardInformation: ProviderCardProps = {
 	className: 'google-workspace-card',
 	expandButtonLabel: translate( 'Select' ),
 	providerKey: 'google',
-	description: translate( 'Business email with Gmail and other productivity tools from Google.' ),
+	description: translate(
+		'Business email with Gmail. Include other collaboration and productivity tools from Google.'
+	),
 	logo: { path: googleWorkspaceIcon, className: 'google-workspace-icon' },
 	appLogos: getGoogleAppLogos(),
 	productName: getGoogleMailServiceFamily(),

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -55,7 +55,10 @@ const getGoogleFeatures = (): TranslateResult[] => {
 		translate( '30GB storage' ),
 		translate( 'Email, calendars, and contacts' ),
 		translate( 'Video calls, docs, spreadsheets, and more' ),
+		translate( 'Real-time collaboration' ),
+		translate( 'Store and share files in the cloud' ),
 		translate( 'Work from anywhere on any device – even offline' ),
+		translate( '24/7 support via email' ),
 	];
 };
 
@@ -63,9 +66,7 @@ const googleWorkspaceCardInformation: ProviderCardProps = {
 	className: 'google-workspace-card',
 	expandButtonLabel: translate( 'Select' ),
 	providerKey: 'google',
-	description: translate(
-		'Professional email integrated with Google Meet and other productivity tools from Google.'
-	),
+	description: translate( 'Business email with Gmail and other productivity tools from Google.' ),
 	logo: { path: googleWorkspaceIcon, className: 'google-workspace-icon' },
 	appLogos: getGoogleAppLogos(),
 	productName: getGoogleMailServiceFamily(),

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -66,7 +66,7 @@ const professionalEmailCardInformation: ProviderCardProps = {
 	providerKey: 'titan',
 	showExpandButton: true,
 	description: translate(
-		'Integrated email solution with powerful features for your WordPress.com site.'
+		'Integrated email solution with powerful features. Manage your email and more on any device.'
 	),
 	logo,
 	productName: getTitanProductName(),

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -53,8 +53,9 @@ const badge = (
 
 const getTitanFeatures = () => {
 	return [
-		translate( 'Inbox, calendars, and contacts' ),
+		translate( 'Send and receive from your custom domain' ),
 		translate( '30GB storage' ),
+		translate( 'Email, calendars, and contacts' ),
 		translate( '24/7 support via email' ),
 	];
 };
@@ -64,7 +65,9 @@ const professionalEmailCardInformation: ProviderCardProps = {
 	expandButtonLabel: translate( 'Select' ),
 	providerKey: 'titan',
 	showExpandButton: true,
-	description: translate( 'Integrated email solution for your WordPress.com site.' ),
+	description: translate(
+		'Integrated email solution with powerful features for your WordPress.com site.'
+	),
 	logo,
 	productName: getTitanProductName(),
 	footerBadge: badge,

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -41,10 +41,10 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 
 	if ( isGoogleWorkspace( serverCartItem ) || isGSuiteOrExtraLicenseProductSlug( productSlug ) ) {
 		if ( isRenewalItem ) {
-			return String( translate( 'Productivity Tools and Mailboxes Renewal' ) );
+			return String( translate( 'Mailboxes and Productivity Tools Renewal' ) );
 		}
 
-		return String( translate( 'Productivity Tools and Mailboxes' ) );
+		return String( translate( 'Mailboxes and Productivity Tools' ) );
 	}
 
 	if ( isTitanMail( serverCartItem ) ) {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -669,7 +669,7 @@ function LineItemSublabelAndPrice( {
 						billingInterval,
 					},
 					comment:
-						"Product description and billing interval (already translated) separated by a colon (e.g. 'Productivity Tools and Mailboxes: billed annually')",
+						"Product description and billing interval (already translated) separated by a colon (e.g. 'Mailboxes and Productivity Tools: billed annually')",
 				} ) }
 			</>
 		);


### PR DESCRIPTION
This pull request updates the copy of the `Email Comparison` page as well as the `In-Depth Comparison` page to address a number of comments made internally on Slack. I've also made a number of refinements with the aim of making this copy more consistent as well as providing users with more points of comparison, so that they can chose the most appropriate solution for their needs (some features such as real-time collaboration should make it more obvious why Google Workspace and Professional Email have different price points):


##### `Email Comparison` page

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150798563-17b96aff-3b3d-45ff-af10-a5591c020069.png) | ![image](https://user-images.githubusercontent.com/594356/152180603-bd7e2041-fdbb-4653-abcc-3365ec1ddcaa.png)


##### `In-Depth Comparison` page (desktop)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150798963-e41f8cc5-80ed-460b-884d-d31452c4f129.png)<br/><br/> | ![image](https://user-images.githubusercontent.com/594356/152181018-08435bfd-06f1-4450-88ba-24b839512d5e.png)



##### `In-Depth Comparison` page (mobile)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/150799441-fec9811d-c6a9-4874-a7ff-5946486907ce.png)<br/><br/><br/><br/><br/><br/><br/> | ![image](https://user-images.githubusercontent.com/594356/152181393-757f6c39-9b0d-48c3-8c42-ce1c29a4d8b7.png)


##### `Purchases` page

Note I've also updated the label of Google Workspace on the `Purchases` page, so it mentions mailboxes rather than productivity tools first:

Before | After
------ | -----
<img width="624" alt="BEFORE" src="https://user-images.githubusercontent.com/594356/150803032-d231c3fd-de56-4b3f-9691-46955567540d.png"> | <img width="623" alt="AFTER" src="https://user-images.githubusercontent.com/594356/150803043-2342e1cb-aa98-424d-ae14-e614b659b412.png">


#### Testing instructions

Note you will have to append `?flags=emails/in-depth-comparison` to the url of the page (and reload it) if you're testing those changes on a live branch as this feature has not been enabled on this environment yet:

1. Run `git checkout update/copy-in-email-comparison-pages` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/60303#issuecomment-1017725236)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Assert that the page looks like the screenshots above
6. Click the `See how they compare` link to access the `In-Depth Comparison` page
7. Assert that the page looks like the screenshots above on desktop and mobile
8. Navigate to the [`Purchases` page](http://calypso.localhost:3000/purchases/subscriptions)
9. Assert that Google Workspace and G Suite subscriptions have the right label