### PR TITLE
Masterbar: Remove unnecessary margins from items

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -211,7 +211,6 @@
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
 		.masterbar__item-notifications {
-			margin-right: 10px;
 			width: 26px;
 
 			.gridicon {
@@ -227,9 +226,6 @@
 
 	@include breakpoint-deprecated( '<480px' ) {
 		.masterbar__item-notifications {
-			margin-top: 0;
-			margin-left: auto;
-			margin-right: auto;
 			width: auto;
 		}
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -479,12 +479,6 @@ $autobar-height: 20px;
 }
 
 .masterbar__item-notifications {
-	margin-right: 12px;
-
-	@include breakpoint-deprecated( '<480px' ) {
-		margin-right: 0;
-	}
-
 	.gridicon {
 		fill: var( --color-text-inverted );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since https://github.com/Automattic/wp-calypso/pull/60168 now performs its layout mostly with flexbox, the margins and padding on masterbar items have mostly been removed. This removes some additional margins that are not needed.

#### Testing instructions

View the masterbar at different widths and verify that everything looks ok.