### PR TITLE
WooCommerce Install: Update checkbox styles

### DIFF
--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -75,15 +75,20 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 			<>
 				<div className="step-business-info__info-section" />
 				<div className="step-business-info__instructions-container">
-					{ __( 'What type of products will be listed? (optional)' ) }
-					{ productTypes.map( ( { label, value } ) => (
-						<CheckboxControl
-							label={ label }
-							value={ value }
-							onChange={ () => updateProductTypes( value ) }
-							checked={ getProfileValue( 'product_types' ).indexOf( value ) !== -1 }
-						/>
-					) ) }
+					<div className="step-business-info__components-group">
+						<label className="step-business-info__components-group-label">
+							{ __( 'What type of products will be listed? (optional)' ) }
+						</label>
+
+						{ productTypes.map( ( { label, value } ) => (
+							<CheckboxControl
+								label={ label }
+								value={ value }
+								onChange={ () => updateProductTypes( value ) }
+								checked={ getProfileValue( 'product_types' ).indexOf( value ) !== -1 }
+							/>
+						) ) }
+					</div>
 
 					<SelectControl
 						label={ __( 'How many products do you plan to display? (optional)' ) }

--- a/client/signup/steps/woocommerce-install/step-business-info/style.scss
+++ b/client/signup/steps/woocommerce-install/step-business-info/style.scss
@@ -2,4 +2,21 @@
 
 body.is-section-signup .is-woocommerce-install .signup__step.is-business-info {
 	@include woocommerce-install-two-column-layout;
+
+	.step-business-info__components-group .components-checkbox-control:not( :last-child ) {
+		margin-bottom: $grid-unit;
+	}
+}
+
+.step-business-info__components-group-label {
+	box-sizing: border-box;
+	color: currentColor;
+	display: block;
+	max-width: 100%;
+	z-index: 1;
+	font-size: $editor-font-size;
+	margin-bottom: $grid-unit;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }

--- a/client/signup/steps/woocommerce-install/style.scss
+++ b/client/signup/steps/woocommerce-install/style.scss
@@ -23,17 +23,17 @@
 
 			.formatted-header {
 				text-align: inherit;
+
 				@media ( min-width: 1024px ) {
 					margin-left: 24px;
 				}
 
 				.formatted-header__title {
 					text-align: inherit;
+
 					@media ( max-width: 660px ) {
 						padding: 0 10px 0 0;
-
 					}
-
 				}
 
 				.formatted-header__subtitle {
@@ -98,6 +98,10 @@
 					padding: 0;
 				}
 
+				.components-checkbox-control__label {
+					color: $black;
+				}
+
 				.components-combobox-control__suggestions-container,
 				.components-select-control__input,
 				.components-text-control__input {
@@ -119,6 +123,23 @@
 
 			.components-text-control__input {
 				box-sizing: border-box;
+			}
+
+			.step-business-info__components-group-label {
+				box-sizing: border-box;
+				color: currentColor;
+				display: block;
+				max-width: 100%;
+				z-index: 1;
+				font-size: $editor-font-size;
+				margin-bottom: $grid-unit;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			.step-business-info__components-group .components-checkbox-control:not( :last-child ) {
+				margin-bottom: $grid-unit;
 			}
 		}
 	}

--- a/client/signup/steps/woocommerce-install/style.scss
+++ b/client/signup/steps/woocommerce-install/style.scss
@@ -124,23 +124,6 @@
 			.components-text-control__input {
 				box-sizing: border-box;
 			}
-
-			.step-business-info__components-group-label {
-				box-sizing: border-box;
-				color: currentColor;
-				display: block;
-				max-width: 100%;
-				z-index: 1;
-				font-size: $editor-font-size;
-				margin-bottom: $grid-unit;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				white-space: nowrap;
-			}
-
-			.step-business-info__components-group .components-checkbox-control:not( :last-child ) {
-				margin-bottom: $grid-unit;
-			}
 		}
 	}
 }


### PR DESCRIPTION
Brings the new checkbox control design in line with the rest of the form elements.

#### Changes proposed in this Pull Request

* Adds a grouping diff for checkbox options
* Adds styles to adjust margins and text color to correspond with other inputs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/woocommerce-installation/
* Choose a test site site
* Click "Set up my store"
* Click through to the business-info step
* Check that styles are applied.

### Before

<img width="1511" alt="Screen Shot 2022-01-20 at 8 40 33 AM" src="https://user-images.githubusercontent.com/1398304/150396117-119d576b-b3db-4fdb-b72f-eeee601b4f87.png">

### After

<img width="1511" alt="Screen Shot 2022-01-20 at 9 58 48 AM" src="https://user-images.githubusercontent.com/1398304/150396108-fd1f1579-268b-49ea-a62b-316120068b6d.png">

