### PR TITLE
Gutenboarding: pass products to checkout URL instead of adding to cart

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -81,6 +81,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 						siteId={ selectedSiteId ?? undefined }
 						siteSlug={ site?.slug }
 						productAliasFromUrl={ commaSeparatedProductSlugs }
+						productSourceFromUrl="editor-checkout-modal"
 						onAfterPaymentComplete={ handleAfterPaymentComplete }
 					/>
 				</StripeHookProvider>

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -71,8 +71,8 @@ export default function useOnSiteCreation(): void {
 					: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 
 				const redirectionUrl = shouldRedirectToEditorAfterCheckout
-					? `/checkout/${ newSite.site_slug }/${ joinedProducts }?redirect_to=%2F${ editorUrl }`
-					: `/checkout/${ newSite.site_slug }/${ joinedProducts }`;
+					? `/checkout/${ newSite.site_slug }/${ joinedProducts }?source=gutenboarding&redirect_to=%2F${ editorUrl }`
+					: `/checkout/${ newSite.site_slug }/${ joinedProducts }?source=gutenboarding`;
 				window.location.href = redirectionUrl;
 				return;
 			}

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -1,8 +1,5 @@
-import { createRequestCartProduct } from '@automattic/shopping-cart';
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useEffect } from 'react';
-import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { clearLastNonEditorRoute } from '../lib/clear-last-non-editor-route';
 import { useOnboardingFlow } from '../path';
@@ -11,7 +8,6 @@ import { PLANS_STORE } from '../stores/plans';
 import { SITE_STORE } from '../stores/site';
 import { USER_STORE } from '../stores/user';
 import { useSelectedPlan, useShouldRedirectToEditorAfterCheckout } from './use-selected-plan';
-import type { RequestCartProduct } from '@automattic/shopping-cart';
 
 /**
  * After a new site has been created there are 3 scenarios to cover:
@@ -54,52 +50,30 @@ export default function useOnSiteCreation(): void {
 			setIsRedirecting( true );
 
 			if ( selectedPlan && ! selectedPlan?.isFree && planProductSource ) {
-				const planProduct: RequestCartProduct = createRequestCartProduct( {
-					product_id: planProductSource.productId,
-					product_slug: planProductSource.storeSlug,
-					extra: {
-						source: 'gutenboarding',
-					},
-				} );
+				const productSlugsToAddToCart: string[] = [ planProductSource.storeSlug ];
 
-				let domainProduct: RequestCartProduct | null = null;
 				if ( domain?.product_id && domain?.product_slug ) {
-					domainProduct = createRequestCartProduct( {
-						meta: domain.domain_name,
-						product_id: domain.product_id,
-						product_slug: domain.product_slug,
-						extra: {
-							privacy: domain.supports_privacy,
-							source: 'gutenboarding',
-						},
-					} );
+					productSlugsToAddToCart.push( domain.product_slug + ':' + domain.domain_name );
 				}
 
-				const go = async () => {
-					if ( planProduct || domainProduct ) {
-						await cartManagerClient
-							.forCartKey( String( newSite.blogid ) )
-							.actions.addProductsToCart( [ planProduct, domainProduct ].filter( isValueTruthy ) );
-					}
-					resetOnboardStore();
-					clearLastNonEditorRoute();
-					setSelectedSite( newSite.blogid );
-
-					const editorUrl = design?.is_fse
-						? `site-editor%2F${ newSite.site_slug }`
-						: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
-
-					const redirectionUrl = shouldRedirectToEditorAfterCheckout
-						? `/checkout/${ newSite.site_slug }?redirect_to=%2F${ editorUrl }`
-						: `/checkout/${ newSite.site_slug }`;
-					window.location.href = redirectionUrl;
-				};
 				recordOnboardingComplete( {
 					...flowCompleteTrackingParams,
 					hasCartItems: true,
 					flow,
 				} );
-				go();
+				const joinedProducts = productSlugsToAddToCart.join( ',' );
+				resetOnboardStore();
+				clearLastNonEditorRoute();
+				setSelectedSite( newSite.blogid );
+
+				const editorUrl = design?.is_fse
+					? `site-editor%2F${ newSite.site_slug }`
+					: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
+
+				const redirectionUrl = shouldRedirectToEditorAfterCheckout
+					? `/checkout/${ newSite.site_slug }/${ joinedProducts }?redirect_to=%2F${ editorUrl }`
+					: `/checkout/${ newSite.site_slug }/${ joinedProducts }`;
+				window.location.href = redirectionUrl;
 				return;
 			}
 			recordOnboardingComplete( {

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -28,6 +28,7 @@ const logCheckoutError = ( error ) => {
 
 export default function CheckoutSystemDecider( {
 	productAliasFromUrl,
+	productSourceFromUrl,
 	purchaseId,
 	selectedFeature,
 	couponCode,
@@ -83,6 +84,7 @@ export default function CheckoutSystemDecider( {
 							siteSlug={ siteSlug }
 							siteId={ selectedSiteId }
 							productAliasFromUrl={ productAliasFromUrl }
+							productSourceFromUrl={ productSourceFromUrl }
 							purchaseId={ purchaseId }
 							couponCode={ couponCode }
 							redirectTo={ redirectTo }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -92,6 +92,7 @@ export default function CompositeCheckout( {
 	siteSlug,
 	siteId,
 	productAliasFromUrl,
+	productSourceFromUrl,
 	overrideCountryList,
 	redirectTo,
 	feature,
@@ -113,6 +114,7 @@ export default function CompositeCheckout( {
 	siteSlug: string | undefined;
 	siteId: number | undefined;
 	productAliasFromUrl?: string | undefined;
+	productSourceFromUrl?: string;
 	overrideCountryList?: CountryListItem[];
 	redirectTo?: string | undefined;
 	feature?: string | undefined;
@@ -189,6 +191,7 @@ export default function CompositeCheckout( {
 		isJetpackCheckout,
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
+		source: productSourceFromUrl,
 	} );
 
 	const cartKey = useCartKey();

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -45,6 +45,7 @@ export default function usePrepareProductsForCart( {
 	isJetpackCheckout,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
+	source,
 }: {
 	productAliasFromUrl: string | null | undefined;
 	purchaseId: string | number | null | undefined;
@@ -57,6 +58,7 @@ export default function usePrepareProductsForCart( {
 	isJetpackCheckout?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
+	source?: string;
 } ): PreparedProductsForCart {
 	const [ state, dispatch ] = useReducer( preparedProductsReducer, initialPreparedProductsState );
 
@@ -105,6 +107,7 @@ export default function usePrepareProductsForCart( {
 		isJetpackCheckout,
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
+		source,
 	} );
 	useAddRenewalItems( {
 		originalPurchaseId,
@@ -341,6 +344,7 @@ function useAddProductFromSlug( {
 	isJetpackCheckout,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
+	source,
 }: {
 	productAliasFromUrl: string | undefined | null;
 	dispatch: ( action: PreparedProductsAction ) => void;
@@ -350,6 +354,7 @@ function useAddProductFromSlug( {
 	isJetpackCheckout?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
+	source?: string;
 } ) {
 	const products = useSelector( getProductsList );
 	const translate = useTranslate();
@@ -397,6 +402,7 @@ function useAddProductFromSlug( {
 				jetpackSiteSlug,
 				jetpackPurchaseToken,
 				privacy: product.is_privacy_protection_product_purchase_allowed,
+				source,
 			} )
 		);
 
@@ -436,6 +442,7 @@ function useAddProductFromSlug( {
 		dispatch,
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
+		source,
 	] );
 }
 
@@ -516,6 +523,7 @@ function createItemToAddToCart( {
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	privacy,
+	source,
 }: {
 	productSlug: string;
 	productAlias: string;
@@ -523,6 +531,7 @@ function createItemToAddToCart( {
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	privacy?: boolean;
+	source?: string;
 } ): RequestCartProduct {
 	// Allow setting meta (theme name or domain name) from products in the URL by
 	// using a colon between the product slug and the meta.
@@ -541,18 +550,16 @@ function createItemToAddToCart( {
 		privacy
 	);
 
-	return addContextToProduct(
-		createRequestCartProduct( {
-			product_slug: productSlug,
-			extra: { isJetpackCheckout, jetpackSiteSlug, jetpackPurchaseToken, privacy },
-			...( cartMeta ? { meta: cartMeta } : {} ),
-		} )
-	);
-}
-
-function addContextToProduct( product: RequestCartProduct ): RequestCartProduct {
-	return {
-		...product,
-		extra: { ...product.extra, context: 'calypstore' },
-	};
+	return createRequestCartProduct( {
+		product_slug: productSlug,
+		extra: {
+			isJetpackCheckout,
+			jetpackSiteSlug,
+			jetpackPurchaseToken,
+			privacy,
+			context: 'calypstore',
+			source: source ?? undefined,
+		},
+		...( cartMeta ? { meta: cartMeta } : {} ),
+	} );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -526,35 +526,16 @@ function createItemToAddToCart( {
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 } ): RequestCartProduct {
-	debug( 'creating product with', productSlug, productAlias );
 	const [ , meta ] = productAlias.split( ':' );
 	// Some meta values contain slashes, so we decode them
 	const cartMeta = meta ? decodeProductFromUrl( meta ) : '';
-
-	if ( productAlias.startsWith( 'theme:' ) ) {
-		debug( 'creating theme product' );
-		return addContextToProduct(
-			createRequestCartProduct( {
-				product_slug: productSlug,
-				meta: cartMeta,
-			} )
-		);
-	}
-
-	if ( productAlias.startsWith( 'domain-mapping:' ) ) {
-		debug( 'creating domain mapping product' );
-		return addContextToProduct(
-			createRequestCartProduct( {
-				product_slug: productSlug,
-				meta: cartMeta,
-			} )
-		);
-	}
+	debug( 'creating product with', productSlug, productAlias, 'and meta', cartMeta );
 
 	return addContextToProduct(
 		createRequestCartProduct( {
 			product_slug: productSlug,
 			extra: { isJetpackCheckout, jetpackSiteSlug, jetpackPurchaseToken },
+			...( cartMeta ? { meta: cartMeta } : {} ),
 		} )
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -351,12 +351,7 @@ function useAddProductFromSlug( {
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 } ) {
-	const products: Record<
-		string,
-		{
-			product_slug: string;
-		}
-	> = useSelector( getProductsList );
+	const products = useSelector( getProductsList );
 	const translate = useTranslate();
 
 	// If `productAliasFromUrl` has a comma ',' in it, we will assume it's because it's
@@ -401,6 +396,7 @@ function useAddProductFromSlug( {
 				isJetpackCheckout,
 				jetpackSiteSlug,
 				jetpackPurchaseToken,
+				privacy: product.is_privacy_protection_product_purchase_allowed,
 			} )
 		);
 
@@ -519,22 +515,36 @@ function createItemToAddToCart( {
 	isJetpackCheckout,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
+	privacy,
 }: {
 	productSlug: string;
 	productAlias: string;
 	isJetpackCheckout?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
+	privacy?: boolean;
 } ): RequestCartProduct {
+	// Allow setting meta (theme name or domain name) from products in the URL by
+	// using a colon between the product slug and the meta.
 	const [ , meta ] = productAlias.split( ':' );
 	// Some meta values contain slashes, so we decode them
 	const cartMeta = meta ? decodeProductFromUrl( meta ) : '';
-	debug( 'creating product with', productSlug, productAlias, 'and meta', cartMeta );
+
+	debug(
+		'creating product with',
+		productSlug,
+		'from alias',
+		productAlias,
+		'with meta',
+		cartMeta,
+		'and privacy',
+		privacy
+	);
 
 	return addContextToProduct(
 		createRequestCartProduct( {
 			product_slug: productSlug,
-			extra: { isJetpackCheckout, jetpackSiteSlug, jetpackPurchaseToken },
+			extra: { isJetpackCheckout, jetpackSiteSlug, jetpackPurchaseToken, privacy },
 			...( cartMeta ? { meta: cartMeta } : {} ),
 		} )
 	);

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -67,6 +67,7 @@ export function checkoutSiteless( context, next ) {
 	context.primary = (
 		<CheckoutSystemDecider
 			productAliasFromUrl={ product }
+			productSourceFromUrl={ context.query.source }
 			couponCode={ couponCode }
 			isComingFromUpsell={ !! context.query.upgrade }
 			redirectTo={ context.query.redirect_to }
@@ -153,6 +154,7 @@ export function checkout( context, next ) {
 	context.primary = (
 		<CheckoutSystemDecider
 			productAliasFromUrl={ product }
+			productSourceFromUrl={ context.query.source }
 			purchaseId={ purchaseId }
 			selectedFeature={ feature }
 			couponCode={ couponCode }

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -23,6 +23,7 @@ export interface ProductListItem {
 		expires?: string;
 	};
 	sale_cost?: number;
+	is_privacy_protection_product_purchase_allowed?: boolean;
 }
 
 export function getProductsList( state: AppState ): Record< string, ProductListItem > {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors gutenboarding's final step so that instead of adding any selected domain and plan to the cart before redirecting to checkout, it redirects to checkout with the products in the URL. Checkout itself will then add the products while it loads.

This has several advantages:

First, the existing code to add products to the cart had no error handling (it just causes [the progress bar to hang forever](https://github.com/Automattic/wp-calypso/pull/60100#issuecomment-1017750662) if there's a problem), and it's not clear to me what sort of UX would be best for an error without some additional design work. Checkout already has error handling for problems adding items to the cart, displaying the error for the user and allowing them to continue or return to their site.

Second, testing [sometimes](https://github.com/Automattic/wp-calypso/pull/60100#issuecomment-1017750662) has revealed possible race conditions where adding products to the cart fails due to a permissions error. By the time that checkout loads after a full page redirect, all such race conditions should hopefully be resolved.

Third, it's just one less thing for Gutenboarding to have to do! Since the final action is no longer async, the code can be simplified to remove [the `go()` sub function](https://github.com/Automattic/wp-calypso/blob/407d2695cee9e8773f7ca4cfae6249140f453140/client/landing/gutenboarding/hooks/use-on-site-creation.ts#L78).

#### Testing instructions

- When logged-out, visit `/new`.
- Follow the signup flow, selecting a paid plan and a domain.
- Verify that you end up in checkout with the selected items in your cart.