### PR TITLE
Decrease Marketplace Plugin Details Cache Time

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -33,7 +33,7 @@ const fetchWPCOMPlugins = ( type: Type, searchTerm?: string ) => {
 export const useWPCOMPlugins = (
 	type: Type,
 	searchTerm?: string,
-	{ enabled = true, staleTime = 1000 * 60 * 60 * 24, refetchOnMount = false }: UseQueryOptions = {}
+	{ enabled = true, staleTime = 1000 * 60 * 60 * 2, refetchOnMount = true }: UseQueryOptions = {}
 ): UseQueryResult => {
 	return useQuery( getCacheKey( type + searchTerm ), () => fetchWPCOMPlugins( type, searchTerm ), {
 		select: ( data ) => normalizePluginsList( data.results ),
@@ -59,7 +59,7 @@ const fetchWPCOMPlugin = ( slug: string ) => {
  */
 export const useWPCOMPlugin = (
 	slug: string,
-	{ enabled = true, staleTime = 1000 * 60 * 60 * 24, refetchOnMount = false }: UseQueryOptions = {}
+	{ enabled = true, staleTime = 1000 * 60 * 60 * 2, refetchOnMount = true }: UseQueryOptions = {}
 ): UseQueryResult => {
 	return useQuery( getCacheKey( slug ), () => fetchWPCOMPlugin( slug ), {
 		select: ( data ) => normalizePluginData( { detailsFetched: Date.now() }, data ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Decrease the [useQuery](https://react-query.tanstack.com/reference/useQuery) stale time that retrieves the plugin details from 24 hours to 2 hours.
* Set refetchOnMount to true so that the data is updated when mounting the PluginDetails component.

#### Testing instructions

- Go to Plugins
- Click on a marketplace plugin to go to the details.
- If the plugin's data was updated more than 2 hours ago then a request to `https://public-api.wordpress.com/wpcom/v2/marketplace/products/woocommerce-bookings?_envelope=1` should be made.

`dataUpdatedAt` can be seen in the `indexedDB -> query-state-{site-id} -> clientState -> queries -> queryObject -> state -> dataUpdatedAt`

Related to #59938
