### PR TITLE
Adjust styling of product cancelation buttons

### DIFF
--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Card, CompactCard, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
@@ -119,8 +120,8 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 						className="memberships__subscription-remove"
 						onClick={ stopSubscription }
 					>
-						<Gridicon icon="trash" />
 						{ translate( 'Stop %s subscription.', { args: subscription.title } ) }
+						<Gridicon className="card__link-indicator" icon="trash" />
 					</CompactCard>
 				</>
 			) }

--- a/client/me/memberships/subscription.scss
+++ b/client/me/memberships/subscription.scss
@@ -131,10 +131,4 @@
 	.accessible-focus &:focus {
 		box-shadow: 0 0 0 2px var( --color-error-light );
 	}
-
-	.gridicon {
-		margin-top: -2px;
-		margin-right: 4px;
-		vertical-align: middle;
-	}
 }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import {
 	isPersonal,
 	isPremium,
@@ -524,7 +525,7 @@ class ManagePurchase extends Component {
 		};
 
 		return (
-			<CompactCard href={ link } className={ `remove-purchase__card` } onClick={ onClick }>
+			<CompactCard href={ link } className="remove-purchase__card" onClick={ onClick }>
 				{ text }
 			</CompactCard>
 		);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -524,7 +524,7 @@ class ManagePurchase extends Component {
 		};
 
 		return (
-			<CompactCard href={ link } onClick={ onClick }>
+			<CompactCard href={ link } className={ `remove-purchase__card` } onClick={ onClick }>
 				{ text }
 			</CompactCard>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -414,7 +414,6 @@ class RemovePurchase extends Component {
 
 		const defaultContent = (
 			<>
-				<Gridicon icon="trash" />
 				{
 					// translators: productName is a product name, like Jetpack
 					translate( 'Remove %(productName)s', { args: { productName } } )
@@ -429,6 +428,7 @@ class RemovePurchase extends Component {
 			<>
 				<Wrapper tagName="button" className={ wrapperClassName } onClick={ this.openDialog }>
 					{ this.props.children ? this.props.children : defaultContent }
+					<Gridicon className="card__link-indicator" icon="trash" />
 				</Wrapper>
 				{ this.shouldShowNonPrimaryDomainWarning() && this.renderNonPrimaryDomainWarningDialog() }
 				{ this.shouldHandleMarketplaceSubscriptions() &&

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import {
 	isDomainMapping,
 	isDomainRegistration,

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -12,9 +12,6 @@
 	}
 
 	.gridicons-trash {
-		margin-block-start: -2px;
-		margin-inline-start: -4px;
-		margin-inline-end: 4px;
 		vertical-align: middle;
 	}
 }

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -1,39 +1,37 @@
-@media ( min-width: 480px ) {
-	.remove-purchase__card {
-		color: var( --color-primary );
-		text-align: left;
-		width: 100%;
-		margin: 16px auto;
-		font-size: 100%;
+.remove-purchase__card {
+	margin: 10px auto;
+	width: 100%;
+	color: var( --color-link );
+	text-align: left;
+	font-size: 100%;
 
-		&:active,
-		&:focus,
-		&:hover {
-			color: var( --color-link-dark );
-		}
-
-		.gridicons-trash {
-			margin-block-start: -2px;
-			margin-inline-start: -4px;
-			margin-inline-end: 4px;
-			vertical-align: middle;
-		}
+	&:active,
+	&:focus,
+	&:hover {
+		color: var( --color-link-dark );
 	}
 
-	.dialog__button--domains-remove {
-		> .dialog__button-label {
-			display: flex;
-			align-items: center;
-			column-gap: 7px;
+	.gridicons-trash {
+		margin-block-start: -2px;
+		margin-inline-start: -4px;
+		margin-inline-end: 4px;
+		vertical-align: middle;
+	}
+}
+.dialog__button--domains-remove {
+	> .dialog__button-label {
+		display: flex;
+		align-items: center;
+		column-gap: 7px;
 
-			> svg {
-				fill: var( --color-text-inverted );
-			}
+		> svg {
+			fill: var( --color-text-inverted );
 		}
 	}
 }
-@media ( max-width: 479px ) {
+
+@media ( min-width: 480px ) {
 	.remove-purchase__card {
-		margin: 10px auto;
+		margin: 16px auto;
 	}
 }

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -1,32 +1,39 @@
-.remove-purchase__card {
-	color: var( --color-primary );
-	text-align: left;
-	width: 100%;
-	margin: 1em auto;
-	font-size: 100%;
+@media ( min-width: 480px ) {
+	.remove-purchase__card {
+		color: var( --color-primary );
+		text-align: left;
+		width: 100%;
+		margin: 16px auto;
+		font-size: 100%;
 
-	&:active,
-	&:focus,
-	&:hover {
-		color: var( --color-link-dark );
+		&:active,
+		&:focus,
+		&:hover {
+			color: var( --color-link-dark );
+		}
+
+		.gridicons-trash {
+			margin-block-start: -2px;
+			margin-inline-start: -4px;
+			margin-inline-end: 4px;
+			vertical-align: middle;
+		}
 	}
 
-	.gridicons-trash {
-		margin-block-start: -2px;
-		margin-inline-start: -4px;
-		margin-inline-end: 4px;
-		vertical-align: middle;
+	.dialog__button--domains-remove {
+		> .dialog__button-label {
+			display: flex;
+			align-items: center;
+			column-gap: 7px;
+
+			> svg {
+				fill: var( --color-text-inverted );
+			}
+		}
 	}
 }
-
-.dialog__button--domains-remove {
-	> .dialog__button-label {
-		display: flex;
-		align-items: center;
-		column-gap: 7px;
-
-		> svg {
-			fill: var( --color-text-inverted );
-		}
+@media ( max-width: 479px ) {
+	.remove-purchase__card {
+		margin: 10px auto;
 	}
 }

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -2,6 +2,8 @@
 	color: var( --color-primary );
 	text-align: left;
 	width: 100%;
+	margin: 1em auto;
+	font-size: 100%;
 
 	&:active,
 	&:focus,
@@ -16,7 +18,6 @@
 		vertical-align: middle;
 	}
 }
-
 
 .dialog__button--domains-remove {
 	> .dialog__button-label {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As noted in #39283, the styling of the Remove [product] button in http://calypso.localhost:3000/purchases/subscriptions appeared different compared to the other listed items. Additionally there were suggestions to make this option stand out from the rest due to its 'destructive' nature.

This PR will break the item out of the list with a top margin, move the trashcan gridicon to the right in-line with the other items' icons, and adjust the font styling of the button text.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to your purchases and click on any product
* Ensure the product has a Remove [product] button that has:
  * Font-size 16px (100%)
  * Right aligned trashcan icon
  * Margin-top 16px
* These changes should apply to any type of product, ie domains, plans, email

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #39283
