### PR TITLE
Fix Zero Percent Discount in Cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -209,7 +209,8 @@ function VariantPrice( { variant }: { variant: AvailableProductVariantAndCompare
 			: variant.priceFinal || variant.priceFull;
 	// extremely low "discounts" are possible if the price of the longer term has been rounded
 	// but if the discount is only a few percentage points we should not really call attention to it.
-	const isDiscounted = ( currentPrice - variant.priceFullBeforeDiscount ) / currentPrice >= 0.05;
+	const isDiscounted =
+		( variant.priceFullBeforeDiscount - currentPrice ) / variant.priceFullBeforeDiscount >= 0.05;
 	return (
 		<Fragment>
 			{ isDiscounted && <VariantPriceDiscount variant={ variant } /> }

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -208,9 +208,9 @@ function VariantPrice( { variant }: { variant: AvailableProductVariantAndCompare
 			? variant.introductoryOfferPrice
 			: variant.priceFinal || variant.priceFull;
 	// extremely low "discounts" are possible if the price of the longer term has been rounded
-	// but if the discount is only a few percentage points we should not really call attention to it.
+	// if they cannot be rounded to at least a percentage point we should not show them
 	const isDiscounted =
-		( variant.priceFullBeforeDiscount - currentPrice ) / variant.priceFullBeforeDiscount >= 0.05;
+		Math.floor( 100 - ( currentPrice / variant.priceFullBeforeDiscount ) * 100 ) > 0;
 	return (
 		<Fragment>
 			{ isDiscounted && <VariantPriceDiscount variant={ variant } /> }

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -207,7 +207,9 @@ function VariantPrice( { variant }: { variant: AvailableProductVariantAndCompare
 		variant.introductoryOfferPrice !== null
 			? variant.introductoryOfferPrice
 			: variant.priceFinal || variant.priceFull;
-	const isDiscounted = currentPrice !== variant.priceFullBeforeDiscount;
+	// extremely low "discounts" are possible if the price of the longer term has been rounded
+	// but if the discount is only a few percentage points we should not really call attention to it.
+	const isDiscounted = ( currentPrice - variant.priceFullBeforeDiscount ) / currentPrice >= 0.05;
 	return (
 		<Fragment>
 			{ isDiscounted && <VariantPriceDiscount variant={ variant } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use percentage instead of equality to determine if the discount should be displayed.

| Staging Cart | Branch Cart |
| ------------ | ----------- |
| <img width="568" alt="Screen Shot 2022-01-20 at 12 21 27" src="https://user-images.githubusercontent.com/2810519/150416455-017d9117-6edd-4e6e-bb98-04d6546308ec.png">|<img width="564" alt="Screen Shot 2022-01-20 at 12 21 37" src="https://user-images.githubusercontent.com/2810519/150416471-e85eb8a2-f5a9-44ba-9c5f-94b8b95120b4.png">|
|<img width="569" alt="Screen Shot 2022-01-20 at 12 25 54" src="https://user-images.githubusercontent.com/2810519/150416636-f3fa97b1-ba69-4af6-83f2-0d6374af5a99.png">|<img width="568" alt="Screen Shot 2022-01-20 at 12 26 03" src="https://user-images.githubusercontent.com/2810519/150416655-bcacd0e3-f016-40da-ad63-8c0cf711b6aa.png">|

#### Testing instructions

1. Add Jetpack Search to the cart of a Jetpack Site
2. Navigate to the cart on production/staging
3. Verify that a "Save 0%" discount is being shown
4. Navigate to the cart on this branch
5. Verify that no discount is displayed
6. Add a different Jetpack Product to the cart
7. Verify that now the 50% intro offer is being shown.


Related to #59969
