### PR TITLE
Mini-Cart: Show delete button for coupons

### DIFF
--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -64,6 +64,7 @@ export function MiniCartLineItems( {
 						lineItem={ couponLineItem }
 						removeProductFromCart={ removeCoupon }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+						hasDeleteButton
 					/>
 				</MiniCartLineItemWrapper>
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the mini-cart was added, we accidentally didn't enable the delete button for coupons, even though the functionality was present. This corrects that oversight.

Before:

<img width="498" alt="mini-cart-remove-coupon-before" src="https://user-images.githubusercontent.com/2036909/150421259-6398348c-269a-4e4e-92c3-27b570ff726c.png">

After:

<img width="492" alt="mini-cart-remove-coupon-after" src="https://user-images.githubusercontent.com/2036909/150421278-9b46cb88-ba62-4781-a58c-6936dcd668f8.png">


#### Testing instructions

- Add a product to your cart and visit checkout.
- Add a valid coupon to your cart.
- Leave checkout without clearing the cart.
- Click the masterbar cart icon to display the mini-cart.
- Verify you see a "Remove" button underneath the coupon item.
- Click to remove the coupon and verify that it is removed.