### PR TITLE
Domains: Fix renewal price shown in the domain details card

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -66,7 +66,8 @@ const RegisteredDomainDetails = ( {
 
 		if ( purchase && selectedSite.ID ) {
 			const renewalPrice =
-				getRenewalPrice( purchase ) + ( redemptionProduct ? redemptionProduct.cost : 0 );
+				getRenewalPrice( purchase ) +
+				( domain.isRedeemable && redemptionProduct ? redemptionProduct.cost : 0 );
 			const currencyCode = purchase.currencyCode;
 			formattedPrice = formatCurrency( renewalPrice, currencyCode, { stripZeros: true } )!;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Reported in p2MSmN-95K-p2, there was a bug when showing the renewal price of domains - the price being shown was always the renewal + redemption price. This PR fixes that by showing the correct pricing there (most often only the renewal value, unless the domain has slipped into redemption).

This bug was introduced when copying code from `RenewButton` during the settings page redesign in #59180.

### Screenshots

- Before (notice the R$360,95 price 🤑):

![Markup on 2022-01-20 at 19:26:34](https://user-images.githubusercontent.com/5324818/150432270-12524332-53c8-457b-9ca9-7f93aa594d09.png)

- After (showing correct renewal value of R$76,95):

![Markup on 2022-01-20 at 19:27:18](https://user-images.githubusercontent.com/5324818/150432285-d285529b-28dc-4615-8599-a77abce639e2.png)

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to the domain settings page for a registered domain that has auto-renew turned on (Upgrades > Domains > select a registered domain)
- Ensure the renewal price being show is correct