### PR TITLE
Woo Installer: Make zip field optional.

### DIFF
--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -236,16 +236,14 @@ function useAddressFormValidation( siteId: number ) {
 		errors[ WOOCOMMERCE_STORE_ADDRESS_1 ] = ! get( WOOCOMMERCE_STORE_ADDRESS_1 )
 			? __( 'Please add an address' )
 			: '';
-		errors[ WOOCOMMERCE_STORE_ADDRESS_2 ] = ''; // Optional field
+		errors[ WOOCOMMERCE_STORE_ADDRESS_2 ] = ''; // Optional field.
 		errors[ WOOCOMMERCE_DEFAULT_COUNTRY ] = ! get( WOOCOMMERCE_DEFAULT_COUNTRY )
 			? __( 'Please select a country / region' )
 			: '';
 		errors[ WOOCOMMERCE_STORE_CITY ] = ! get( WOOCOMMERCE_STORE_CITY )
 			? __( 'Please add a city' )
 			: '';
-		errors[ WOOCOMMERCE_STORE_POSTCODE ] = ! get( WOOCOMMERCE_STORE_POSTCODE )
-			? __( 'Please add a postcode' )
-			: '';
+		errors[ WOOCOMMERCE_STORE_POSTCODE ] = ''; // Optional field.
 		errors[ WOOCOMMERCE_ONBOARDING_PROFILE ] = ! emailValidator.validate(
 			get( WOOCOMMERCE_ONBOARDING_PROFILE )?.[ 'store_email' ]
 		)


### PR DESCRIPTION
I've not added an `(optional)` suffix to the label because it's not actually optional. We just don't want it to be blocking.

#### Changes proposed in this Pull Request

* Removes the validation-check for the zip field

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://calypso.localhost:3000/woocommerce-installation/
- Choose a test site site
- Click "Set up my store"
- Submit the address step without a zip


Fixes #60315