### PR TITLE
Make info steps forms so enter key works

### DIFF
--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -85,7 +85,8 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 				<div className="step-business-info__info-section" />
 				<div className="step-business-info__instructions-container">
 					<form
-						onSubmit={ () => {
+						onSubmit={ ( e ) => {
+							e.preventDefault();
 							dispatch( submitSignupStep( { stepName: 'business-info' } ) );
 							updateOnboardingProfile( 'completed', true );
 							save();

--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -100,9 +100,9 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 
 							{ productTypes.map( ( { label, value } ) => (
 								<CheckboxControl
-									key={ value }
 									label={ label }
 									value={ value }
+									key={ value }
 									onChange={ () => updateProductTypes( value ) }
 									checked={ getProfileValue( 'product_types' ).indexOf( value ) !== -1 }
 								/>

--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -91,6 +91,7 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 							updateOnboardingProfile( 'completed', true );
 							save();
 							goToNextStep();
+							return false;
 						} }
 					>
 						<div className="step-business-info__components-group">

--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -99,6 +99,7 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 
 							{ productTypes.map( ( { label, value } ) => (
 								<CheckboxControl
+									key={ value }
 									label={ label }
 									value={ value }
 									onChange={ () => updateProductTypes( value ) }

--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -84,142 +84,142 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 			<>
 				<div className="step-business-info__info-section" />
 				<div className="step-business-info__instructions-container">
-					<div className="step-business-info__components-group">
-						<label className="step-business-info__components-group-label">
-							{ __( 'What type of products will be listed? (optional)' ) }
-						</label>
+					<form
+						onSubmit={ () => {
+							dispatch( submitSignupStep( { stepName: 'business-info' } ) );
+							updateOnboardingProfile( 'completed', true );
+							save();
+							goToNextStep();
+						} }
+					>
+						<div className="step-business-info__components-group">
+							<label className="step-business-info__components-group-label">
+								{ __( 'What type of products will be listed? (optional)' ) }
+							</label>
 
-						{ productTypes.map( ( { label, value } ) => (
-							<CheckboxControl
-								label={ label }
-								value={ value }
-								onChange={ () => updateProductTypes( value ) }
-								checked={ getProfileValue( 'product_types' ).indexOf( value ) !== -1 }
-							/>
-						) ) }
-					</div>
-
-					<SelectControl
-						label={ __( 'How many products do you plan to display? (optional)' ) }
-						value={ getProfileValue( 'product_count' ) }
-						options={ [
-							{ value: '', label: '' },
-							{ value: '0', label: __( "I don't have any products yet." ) },
-							{ value: '1-10', label: __( '1-10' ) },
-							{ value: '11-100', label: __( '11-101' ) },
-							{ value: '101-1000', label: __( '101-1000' ) },
-							{ value: '1000+', label: __( '1000+' ) },
-						] }
-						onChange={ updateProductCount }
-					/>
-
-					<SelectControl
-						label={ __( 'Currently selling elsewhere? (optional)' ) }
-						value={ getProfileValue( 'selling_venues' ) }
-						options={ [
-							{ value: '', label: '' },
-							{ value: 'no', label: __( 'No' ) },
-							{ value: 'other', label: __( 'Yes, on another platform' ) },
-							{
-								value: 'other-woocommerce',
-								label: __( 'Yes, I own a different store powered by WooCommerce' ),
-							},
-							{
-								value: 'brick-mortar',
-								label: __( 'Yes, in person at physical stores and/or events' ),
-							},
-							{
-								value: 'brick-mortar-other',
-								label: __(
-									'Yes, on another platform and in person at physical stores and/or events'
-								),
-							},
-						] }
-						onChange={ updateSellingVenues }
-					/>
-
-					{ [ 'other', 'brick-mortar', 'brick-mortar-other', 'other-woocommerce' ].includes(
-						getProfileValue( 'selling_venues' )
-					) && (
-						<SelectControl
-							label={ __( "What's your current annual revenue?" ) }
-							value={ getProfileValue( 'revenue' ) }
-							options={ getRevenueOptions( get( WOOCOMMERCE_DEFAULT_COUNTRY ) ) }
-							onChange={ updateRevenue }
-						/>
-					) }
-
-					{ [ 'other', 'brick-mortar-other' ].includes( getProfileValue( 'selling_venues' ) ) && (
-						<>
-							<SelectControl
-								label={ __( 'Which platform is the store using? (optional)' ) }
-								value={ getProfileValue( 'other_platform' ) }
-								options={ [
-									{ value: '', label: '' },
-									{
-										value: 'shopify',
-										label: __( 'Shopify' ),
-									},
-									{
-										value: 'bigcommerce',
-										label: __( 'BigCommerce' ),
-									},
-									{
-										value: 'magento',
-										label: __( 'Magento' ),
-									},
-									{
-										value: 'wix',
-										label: __( 'Wix' ),
-									},
-									{
-										value: 'amazon',
-										label: __( 'Amazon' ),
-									},
-									{
-										value: 'ebay',
-										label: __( 'eBay' ),
-									},
-									{
-										value: 'etsy',
-										label: __( 'Etsy' ),
-									},
-									{
-										value: 'squarespace',
-										label: __( 'Squarespace' ),
-									},
-									{
-										value: 'other',
-										label: __( 'Other' ),
-									},
-								] }
-								onChange={ updateOtherPlatform }
-								required
-							/>
-
-							{ getProfileValue( 'other_platform' ) === 'other' && (
-								<TextControl
-									label={ __( 'What is the platform name? (optional)' ) }
-									onChange={ updateOtherPlatformName }
-									value={ getProfileValue( 'other_platform_name' ) }
+							{ productTypes.map( ( { label, value } ) => (
+								<CheckboxControl
+									label={ label }
+									value={ value }
+									onChange={ () => updateProductTypes( value ) }
+									checked={ getProfileValue( 'product_types' ).indexOf( value ) !== -1 }
 								/>
-							) }
-						</>
-					) }
+							) ) }
+						</div>
 
-					<ActionSection>
-						<SupportCard />
-						<StyledNextButton
-							onClick={ () => {
-								dispatch( submitSignupStep( { stepName: 'business-info' } ) );
-								updateOnboardingProfile( 'completed', true );
-								save();
-								goToNextStep();
-							} }
-						>
-							{ __( 'Continue' ) }
-						</StyledNextButton>
-					</ActionSection>
+						<SelectControl
+							label={ __( 'How many products do you plan to display? (optional)' ) }
+							value={ getProfileValue( 'product_count' ) }
+							options={ [
+								{ value: '', label: '' },
+								{ value: '0', label: __( "I don't have any products yet." ) },
+								{ value: '1-10', label: __( '1-10' ) },
+								{ value: '11-100', label: __( '11-101' ) },
+								{ value: '101-1000', label: __( '101-1000' ) },
+								{ value: '1000+', label: __( '1000+' ) },
+							] }
+							onChange={ updateProductCount }
+						/>
+
+						<SelectControl
+							label={ __( 'Currently selling elsewhere? (optional)' ) }
+							value={ getProfileValue( 'selling_venues' ) }
+							options={ [
+								{ value: '', label: '' },
+								{ value: 'no', label: __( 'No' ) },
+								{ value: 'other', label: __( 'Yes, on another platform' ) },
+								{
+									value: 'other-woocommerce',
+									label: __( 'Yes, I own a different store powered by WooCommerce' ),
+								},
+								{
+									value: 'brick-mortar',
+									label: __( 'Yes, in person at physical stores and/or events' ),
+								},
+								{
+									value: 'brick-mortar-other',
+									label: __(
+										'Yes, on another platform and in person at physical stores and/or events'
+									),
+								},
+							] }
+							onChange={ updateSellingVenues }
+						/>
+
+						{ [ 'other', 'brick-mortar', 'brick-mortar-other', 'other-woocommerce' ].includes(
+							getProfileValue( 'selling_venues' )
+						) && (
+							<SelectControl
+								label={ __( "What's your current annual revenue?" ) }
+								value={ getProfileValue( 'revenue' ) }
+								options={ getRevenueOptions( get( WOOCOMMERCE_DEFAULT_COUNTRY ) ) }
+								onChange={ updateRevenue }
+							/>
+						) }
+
+						{ [ 'other', 'brick-mortar-other' ].includes( getProfileValue( 'selling_venues' ) ) && (
+							<>
+								<SelectControl
+									label={ __( 'Which platform is the store using? (optional)' ) }
+									value={ getProfileValue( 'other_platform' ) }
+									options={ [
+										{ value: '', label: '' },
+										{
+											value: 'shopify',
+											label: __( 'Shopify' ),
+										},
+										{
+											value: 'bigcommerce',
+											label: __( 'BigCommerce' ),
+										},
+										{
+											value: 'magento',
+											label: __( 'Magento' ),
+										},
+										{
+											value: 'wix',
+											label: __( 'Wix' ),
+										},
+										{
+											value: 'amazon',
+											label: __( 'Amazon' ),
+										},
+										{
+											value: 'ebay',
+											label: __( 'eBay' ),
+										},
+										{
+											value: 'etsy',
+											label: __( 'Etsy' ),
+										},
+										{
+											value: 'squarespace',
+											label: __( 'Squarespace' ),
+										},
+										{
+											value: 'other',
+											label: __( 'Other' ),
+										},
+									] }
+									onChange={ updateOtherPlatform }
+									required
+								/>
+
+								{ getProfileValue( 'other_platform' ) === 'other' && (
+									<TextControl
+										label={ __( 'What is the platform name? (optional)' ) }
+										onChange={ updateOtherPlatformName }
+										value={ getProfileValue( 'other_platform_name' ) }
+									/>
+								) }
+							</>
+						) }
+
+						<ActionSection>
+							<SupportCard />
+							<StyledNextButton type="submit">{ __( 'Continue' ) }</StyledNextButton>
+						</ActionSection>
+					</form>
 				</div>
 			</>
 		);

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -95,7 +95,8 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 				<div className="step-store-address__info-section" />
 				<div className="step-store-address__instructions-container">
 					<form
-						onSubmit={ () => {
+						onSubmit={ ( e ) => {
+							e.preventDefault();
 							setSubmitted( submitted + 1 );
 							if ( validate() ) {
 								save();

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -103,6 +103,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 								dispatch( submitSignupStep( { stepName: 'store-address' } ) );
 								goToNextStep();
 							}
+							return false;
 						} }
 					>
 						<TextControl

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -144,7 +144,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 
 							<div>
 								<TextControl
-									label={ __( 'Postcode' ) }
+									label={ __( 'Postcode (optional)' ) }
 									value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
 									onChange={ ( value ) => {
 										update( WOOCOMMERCE_STORE_POSTCODE, value );

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -94,95 +94,99 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 			<>
 				<div className="step-store-address__info-section" />
 				<div className="step-store-address__instructions-container">
-					<TextControl
-						label={ __( 'Address line 1' ) }
-						value={ get( WOOCOMMERCE_STORE_ADDRESS_1 ) }
-						onChange={ ( value ) => {
-							update( WOOCOMMERCE_STORE_ADDRESS_1, value );
-							clearError( WOOCOMMERCE_STORE_ADDRESS_1 );
+					<form
+						onSubmit={ () => {
+							setSubmitted( submitted + 1 );
+							if ( validate() ) {
+								save();
+								dispatch( submitSignupStep( { stepName: 'store-address' } ) );
+								goToNextStep();
+							}
 						} }
-						className={ address1Error ? 'is-error' : '' }
-					/>
-					<ControlError error={ address1Error } />
-
-					<TextControl
-						label={ __( 'Address line 2 (optional)' ) }
-						value={ get( WOOCOMMERCE_STORE_ADDRESS_2 ) }
-						onChange={ ( value ) => {
-							update( WOOCOMMERCE_STORE_ADDRESS_2, value );
-							clearError( WOOCOMMERCE_STORE_ADDRESS_2 );
-						} }
-						className={ address2Error ? 'is-error' : '' }
-					/>
-					<ControlError error={ address2Error } />
-
-					<CityZipRow>
-						<div>
-							<TextControl
-								label={ __( 'City' ) }
-								value={ get( WOOCOMMERCE_STORE_CITY ) }
-								onChange={ ( value ) => {
-									update( WOOCOMMERCE_STORE_CITY, value );
-									clearError( WOOCOMMERCE_STORE_CITY );
-								} }
-								className={ cityError ? 'is-error' : '' }
-							/>
-							<ControlError error={ cityError } />
-						</div>
-
-						<div>
-							<TextControl
-								label={ __( 'Postcode' ) }
-								value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
-								onChange={ ( value ) => {
-									update( WOOCOMMERCE_STORE_POSTCODE, value );
-									clearError( WOOCOMMERCE_STORE_POSTCODE );
-								} }
-								className={ postcodeError ? 'is-error' : '' }
-							/>
-							<ControlError error={ postcodeError } />
-						</div>
-					</CityZipRow>
-
-					<ComboboxControl
-						label={ __( 'Country / State' ) }
-						value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) }
-						onChange={ ( value: string | null ) => {
-							update( WOOCOMMERCE_DEFAULT_COUNTRY, value || '' );
-							clearError( WOOCOMMERCE_DEFAULT_COUNTRY );
-						} }
-						options={ countriesAsOptions }
-						className={ countryError ? 'is-error' : '' }
-					/>
-					<ControlError error={ countryError } />
-
-					<TextControl
-						label={ __( 'Email address' ) }
-						value={ getProfileEmail() }
-						onChange={ ( value ) => {
-							updateProfileEmail( value );
-							clearError( WOOCOMMERCE_ONBOARDING_PROFILE );
-						} }
-						className={ emailError ? 'is-error' : '' }
-					/>
-					<ControlError error={ emailError } />
-
-					<ActionSection>
-						<SupportCard />
-						<StyledNextButton
-							onClick={ () => {
-								setSubmitted( submitted + 1 );
-								if ( validate() ) {
-									save();
-									dispatch( submitSignupStep( { stepName: 'store-address' } ) );
-									goToNextStep();
-								}
+					>
+						<TextControl
+							label={ __( 'Address line 1' ) }
+							value={ get( WOOCOMMERCE_STORE_ADDRESS_1 ) }
+							onChange={ ( value ) => {
+								update( WOOCOMMERCE_STORE_ADDRESS_1, value );
+								clearError( WOOCOMMERCE_STORE_ADDRESS_1 );
 							} }
-							disabled={ Object.values( errors ).filter( Boolean ).length > 0 }
-						>
-							{ __( 'Continue' ) }
-						</StyledNextButton>
-					</ActionSection>
+							className={ address1Error ? 'is-error' : '' }
+						/>
+						<ControlError error={ address1Error } />
+
+						<TextControl
+							label={ __( 'Address line 2 (optional)' ) }
+							value={ get( WOOCOMMERCE_STORE_ADDRESS_2 ) }
+							onChange={ ( value ) => {
+								update( WOOCOMMERCE_STORE_ADDRESS_2, value );
+								clearError( WOOCOMMERCE_STORE_ADDRESS_2 );
+							} }
+							className={ address2Error ? 'is-error' : '' }
+						/>
+						<ControlError error={ address2Error } />
+
+						<CityZipRow>
+							<div>
+								<TextControl
+									label={ __( 'City' ) }
+									value={ get( WOOCOMMERCE_STORE_CITY ) }
+									onChange={ ( value ) => {
+										update( WOOCOMMERCE_STORE_CITY, value );
+										clearError( WOOCOMMERCE_STORE_CITY );
+									} }
+									className={ cityError ? 'is-error' : '' }
+								/>
+								<ControlError error={ cityError } />
+							</div>
+
+							<div>
+								<TextControl
+									label={ __( 'Postcode' ) }
+									value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
+									onChange={ ( value ) => {
+										update( WOOCOMMERCE_STORE_POSTCODE, value );
+										clearError( WOOCOMMERCE_STORE_POSTCODE );
+									} }
+									className={ postcodeError ? 'is-error' : '' }
+								/>
+								<ControlError error={ postcodeError } />
+							</div>
+						</CityZipRow>
+
+						<ComboboxControl
+							label={ __( 'Country / State' ) }
+							value={ get( WOOCOMMERCE_DEFAULT_COUNTRY ) }
+							onChange={ ( value: string | null ) => {
+								update( WOOCOMMERCE_DEFAULT_COUNTRY, value || '' );
+								clearError( WOOCOMMERCE_DEFAULT_COUNTRY );
+							} }
+							options={ countriesAsOptions }
+							className={ countryError ? 'is-error' : '' }
+						/>
+						<ControlError error={ countryError } />
+
+						<TextControl
+							label={ __( 'Email address' ) }
+							value={ getProfileEmail() }
+							onChange={ ( value ) => {
+								updateProfileEmail( value );
+								clearError( WOOCOMMERCE_ONBOARDING_PROFILE );
+							} }
+							className={ emailError ? 'is-error' : '' }
+						/>
+						<ControlError error={ emailError } />
+
+						<ActionSection>
+							<SupportCard />
+							<StyledNextButton
+								type="submit"
+								disabled={ Object.values( errors ).filter( Boolean ).length > 0 }
+							>
+								{ __( 'Continue' ) }
+							</StyledNextButton>
+						</ActionSection>
+					</form>
 				</div>
 			</>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change woo installer step input forms to use `<form>` elements and onsubmit events instead of onclick events. This lets the enter key submit the form.

#### Testing instructions

* Start the install flow http://calypso.localhost:3000/start/woocommerce-install/?site=wooptestupgrade.wpcomstaging.com
* Using the enter key should allow you to submit the form from any text / checkbox elements. Select dropdown on the business info step won't work. (I think we can ignore this)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60173
