### PR TITLE
Woo Installer: Update error styles.

### DIFF
--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -2,50 +2,55 @@
 
 body.is-section-signup .is-woocommerce-install .signup__step.is-store-address {
 	@include woocommerce-install-two-column-layout;
-}
 
-.step-store-address__instructions-container {
-	.components-combobox-control__suggestions-container {
-		// Remove `width: 100%;` https://github.com/WordPress/gutenberg/blob/0135921bcb72ceec629fa8f9e755891afab747b9/packages/components/src/combobox-control/style.scss#L32
-		width: unset;
+	.step-store-address__instructions-container {
+		.components-combobox-control__suggestions-container {
+			// Remove `width: 100%;` https://github.com/WordPress/gutenberg/blob/0135921bcb72ceec629fa8f9e755891afab747b9/packages/components/src/combobox-control/style.scss#L32
+			width: unset;
 
-		// Remove margin from component to match text controls.
-		margin-bottom: unset;
-	}
+			// Remove margin from component to match text controls.
+			margin-bottom: unset;
+		}
 
-	.components-form-token-field__suggestions-list {
-		margin: 4px -16px -12px;
-		width: min-content;
-	}
+		.components-form-token-field__suggestions-list {
+			margin: 4px -16px -12px;
+			width: min-content;
+		}
 
-	.components-combobox-control__reset.components-button {
-		// Height of 18 ensures combobox input matches height of text controls.
-		height: 18px;
-	}
+		.components-combobox-control__reset.components-button {
+			// Height of 18 ensures combobox input matches height of text controls.
+			height: 18px;
+		}
 
-	.form-input-validation.is-error {
-		line-height: 1.4rem;
-	}
+		.form-input-validation.is-error {
+			margin-bottom: $grid-unit-30;
+			padding-bottom: 0;
+			padding-top: 0;
+		}
 
-	// On error, color the border of inputs red & remove the blue box shadow
-	// We have to remove the box shadow here because we can't apply box shadow
-	// to the suggestion dropdown conditionally like we can with the text control.
-	.components-base-control.is-error {
-		.components-text-control__input {
-			border-color: var( --color-error );
-			&:focus {
+		// On error, color the border of inputs red & remove the blue box shadow
+		// We have to remove the box shadow here because we can't apply box shadow
+		// to the suggestion dropdown conditionally like we can with the text control.
+		.components-base-control.is-error {
+			margin-bottom: $grid-unit;
+
+			.components-text-control__input {
+				border-color: var( --color-error );
+
+				&:focus {
+					box-shadow: 0 0 0 0 var( --color-error );
+				}
+			}
+
+			.components-combobox-control__suggestions-container {
+				border-color: var( --color-error );
 				box-shadow: 0 0 0 0 var( --color-error );
 			}
-		}
 
-		.components-combobox-control__suggestions-container {
-			border-color: var( --color-error );
-			box-shadow: 0 0 0 0 var( --color-error );
-		}
-
-		.components-base-control__field {
-			// Remove margin-bottom on error so errors are positioned closer to the corresponding field.
-			margin-bottom: unset;
+			.components-base-control__field {
+				// Remove margin-bottom on error so errors are positioned closer to the corresponding field.
+				margin-bottom: unset;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Tip: review with whitespace changes disabled

#### Changes proposed in this Pull Request

* Adjusts error styles with updated margins after the previous round of styling updates to form elements.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://calypso.localhost:3000/woocommerce-installation/
- Choose a test site site
- Click "Set up my store"
- Submit the address step without empty fields and check the styling.


#### Before

<img width="1511" alt="Screen Shot 2022-01-20 at 3 37 46 PM" src="https://user-images.githubusercontent.com/1398304/150440626-054ab91b-0ed8-4e6a-885a-d4cba83c2b8e.png">


#### After

<img width="1511" alt="Screen Shot 2022-01-20 at 3 49 10 PM" src="https://user-images.githubusercontent.com/1398304/150440633-ef61f90f-8b99-45bd-b21f-50b112532954.png">