### PR TITLE
Checkout: disable AssignToAllPaymentMethods when form is busy

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/assign-to-all-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/assign-to-all-payment-methods.tsx
@@ -11,9 +11,11 @@ const CheckboxWrapper = styled.div`
 
 export default function AssignToAllPaymentMethods( {
 	isChecked,
+	isDisabled,
 	onChange,
 }: {
 	isChecked: boolean;
+	isDisabled?: boolean;
 	onChange: ( isChecked: boolean ) => void;
 } ): JSX.Element {
 	const translate = useTranslate();
@@ -32,6 +34,7 @@ export default function AssignToAllPaymentMethods( {
 	return (
 		<CheckboxWrapper>
 			<CheckboxControl
+				disabled={ isDisabled }
 				checked={ isChecked }
 				onChange={ handleChangeEvent }
 				label={ translate(

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -172,6 +172,7 @@ export default function CreditCardFields( {
 					{ allowUseForAllSubscriptions && (
 						<AssignToAllPaymentMethods
 							isChecked={ useForAllSubscriptions }
+							isDisabled={ isDisabled }
 							onChange={ setUseForAllSubscriptions }
 						/>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/56736 we added a checkbox to checkout (and other places that use the credit card form) which reads "Use this payment method for all subscriptions on my account". The checkbox form element, however, was not disabled when the rest of the form was disabled (when loading or submitting, for example).

<img width="494" alt="Screen_Shot_2022-01-20_at_7_08_30_PM" src="https://user-images.githubusercontent.com/2036909/150442007-2c4638eb-b71e-418c-bda0-83e5ba374171.png">

This PR disables the field when the other fields are disabled.

Fixes 654-gh-Automattic/payments-shilling

#### Testing instructions

- Add a product to your cart and enter checkout.
- Choose the "Credit or debit card" payment method and fill out the form. Use a [test card](https://stripe.com/docs/testing#cards-responses) that will always fail like `4000000000009995`.
- Submit the form and while the page is pending, try to interact with the "Use this payment method for all subscriptions on my account" checkbox.
- Verify that the checkbox is disabled while the form is submitting, but becomes enabled again when the purchase fails.