### PR TITLE
E2E: wait until `networkidle` is reached in Gutenboarding spec.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -58,19 +58,13 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 
 		it( 'Create account', async function () {
 			await Promise.all( [
-				page.waitForNavigation(),
+				page.waitForNavigation( { waitUntil: 'networkidle' } ),
 				gutenboardingFlow.signup( email, signupPassword ),
 			] );
 		} );
 
-		it( 'Land in Home dashboard', async function () {
-			await page.waitForURL( '**/site-editor/**' );
-			const currentURL = page.url();
-			expect( currentURL ).toContain( siteTitle );
-		} );
-
 		it( 'Navigate to Home dashboard', async function () {
-			await page.goto( DataHelper.getCalypsoURL( 'home' ) );
+			await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'load' } );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a hotfix for Gutenboarding, which was changed by https://github.com/Automattic/wp-calypso/pull/60328.

It appears the new path for users, `site-editor` was not always happening and some users were still being diverted to the older `home` path.

In any case, waiting until `networkidle` is fired, then forcibly redirecting to `/home` to proceed with account closure is a suitable workaround.

#### Testing instructions


Related to #60328.