### PR TITLE
`QueryUsersMentions`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/user-mentions/connect.jsx
+++ b/client/blocks/user-mentions/connect.jsx
@@ -21,7 +21,7 @@ const connectUserMentions = ( WrappedComponent ) => {
 		render() {
 			return (
 				<Fragment>
-					{ !! this.props.siteId && <QueryUsersSuggestions siteId={ this.props.siteId } /> }
+					<QueryUsersSuggestions siteId={ this.props.siteId } />
 					<WrappedComponent { ...this.props } />
 				</Fragment>
 			);

--- a/client/components/data/query-users-suggestions/index.jsx
+++ b/client/components/data/query-users-suggestions/index.jsx
@@ -1,53 +1,29 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestUserSuggestions } from 'calypso/state/user-suggestions/actions';
 import { isRequestingUserSuggestions as isRequesting } from 'calypso/state/user-suggestions/selectors';
 
-class QueryUsersSuggestions extends Component {
-	static propTypes = {
-		siteId: PropTypes.number,
-		isRequesting: PropTypes.bool,
-		requestUserSuggestions: PropTypes.func,
-	};
-
-	static defaultProps = {
-		requestUserSuggestions: () => {},
-		isRequesting: false,
-	};
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( ! isRequesting( getState(), siteId ) ) {
+		dispatch( requestUserSuggestions( siteId ) );
 	}
+};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId ) {
-			return;
+function QueryUsersSuggestions( { siteId } ) {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( siteId ) {
+			dispatch( request( siteId ) );
 		}
+	}, [ dispatch, siteId ] );
 
-		this.request( nextProps );
-	}
-
-	request( props ) {
-		if ( props.isRequesting || ! props.siteId ) {
-			return;
-		}
-
-		props.requestUserSuggestions( props.siteId );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			isRequesting: isRequesting( state, ownProps.siteId ),
-		};
-	},
-	{ requestUserSuggestions }
-)( QueryUsersSuggestions );
+QueryUsersSuggestions.propTypes = {
+	siteId: PropTypes.number,
+};
+
+export default QueryUsersSuggestions;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryUsersMentions`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/read/conversations` (for me it was easier to test on `/read/conversations/a8c`)
* Find a conversation where comments aren't closed
* Start typing `@` and verify the user list is shown
* You should also see at least 1 network request to `/suggest/:siteId` (depending on how many conversations are shown)

Related to #58453 
