### PR TITLE
Shopping Cart: adjust mini-cart count styling

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -74,10 +74,6 @@
 			padding-left: 8px;
 		}
 
-		.masterbar__item.masterbar-cart-button .gridicon + .masterbar__item-content {
-			padding-left: 0;
-		}
-
 		.masterbar__reader .gridicon + .masterbar__item-content {
 			padding-left: 6px;
 		}

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -74,6 +74,10 @@
 			padding-left: 8px;
 		}
 
+		.masterbar__item.masterbar-cart-button .gridicon + .masterbar__item-content {
+			padding-left: 0;
+		}
+
 		.masterbar__reader .gridicon + .masterbar__item-content {
 			padding-left: 6px;
 		}

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
@@ -18,10 +18,9 @@
 	background-color: var( --color-accent );
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 0.6em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 0.6rem; /* stylelint-disable-line scales/font-sizes */
 		padding: 1px 4px;
 		top: 4px;
-		right: 0;
 	}
 }
 

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button-style.scss
@@ -4,19 +4,25 @@
 
 .masterbar-cart-button__count-container {
 	display: inline-block;
-	padding: 1px 6px;
+	padding: 1px 4px;
 	border: 1px solid var( --color-accent );
 	border-radius: 12px; /* stylelint-disable-line scales/radii */
 	font-size: 0.75rem;
 	font-weight: 600;
-	line-height: 14px;
+	line-height: 1;
 	text-align: center;
 	position: absolute;
-	top: 2px;
-	right: 50%;
+	top: 5px;
+	right: 6px;
 	color: var( --color-text-inverted );
 	background-color: var( --color-accent );
-	transform: translateX( 24px );
+
+	@include breakpoint-deprecated( '>480px' ) {
+		font-size: 0.6em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		padding: 1px 4px;
+		top: 4px;
+		right: 0;
+	}
 }
 
 /* The next several rules make the popover nearly fullscreen at mobile widths */

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -457,10 +457,6 @@ $autobar-height: 20px;
 	}
 }
 
-.masterbar-cart-button .gridicon + .masterbar__item-content {
-	padding: 0;
-}
-
 .masterbar__item-me {
 	.gravatar {
 		position: absolute;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -132,6 +132,7 @@ $autobar-height: 20px;
 
 .masterbar__section--center {
 	flex: 1;
+	justify-content: center;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex: 0 0 auto;
@@ -454,6 +455,10 @@ $autobar-height: 20px;
 	.is-group-editor &:hover {
 		background: var( --color-masterbar-item-new-editor-hover-background );
 	}
+}
+
+.masterbar-cart-button .gridicon + .masterbar__item-content {
+	padding: 0;
 }
 
 .masterbar__item-me {


### PR DESCRIPTION
This fixes the no-draft write button's alignment and the desktop positioning and size of the mini-cart count.

| Before      | After |
| ----------- | ----------- |
| ![wordpress com_home_cainsnuxtest2011130906 wordpress com(iPhone XR)](https://user-images.githubusercontent.com/942359/150561883-6bd1e287-c514-4933-ae08-ece650fa6e54.png) | ![calypso localhost_3000_home_cainsnuxtest2011130906 wordpress com(iPhone XR)](https://user-images.githubusercontent.com/942359/150561933-ba93f8b3-89d8-4dd3-866c-c7f80285a0e5.png) |
| <img width="1552" alt="Screen Shot 2022-01-21 at 11 06 45 AM" src="https://user-images.githubusercontent.com/942359/150562005-b49c9d92-83b0-4b95-95b1-0cd1e2091234.png"> | <img width="1552" alt="Screen Shot 2022-01-21 at 11 07 15 AM" src="https://user-images.githubusercontent.com/942359/150562054-901e0646-670b-45ea-a92a-7d691b5ddfe7.png"> |

**To test:**
- on a site without drafts, add some items to the cart and leave Checkout
- verify that the mini-cart appears in the masterbar and that it matches the screenshots above