### PR TITLE
Gutenboarding: Add additional single page designs for FSE

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -796,6 +796,46 @@
 			"is_fse": false,
 			"is_featured_picks": true,
 			"features": []
+		},
+		{
+			"title": "Bennett",
+			"slug": "bennett",
+			"template": "bennett",
+			"theme": "bennett",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Calvin",
+			"slug": "calvin",
+			"template": "calvin",
+			"theme": "calvin",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Farrow",
+			"slug": "farrow",
+			"template": "farrow",
+			"theme": "farrow",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
+			"title": "Barnett",
+			"slug": "barnett",
+			"template": "barnett",
+			"theme": "barnett",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
 		}
 	]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds the following designs to the /new site creation flow

- Bennett
- Barnett
- Calvin
- Farrow

Since all users are now opted into FSE in this flow automatically, I've only added these as FSE designs, rather than duplicating for non-FSE, as well.

#### Testing instructions

* Create a new site using the /new flow
* Select one of the added designs and create a site
* Make sure the site is set up as expected

Context: p7DVsv-dEs-p2