### PR TITLE
Woo Installer: Balance input margins

### DIFF
--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -13,7 +13,7 @@ body.is-section-signup .is-woocommerce-install .signup__step.is-store-address {
 		}
 
 		.components-form-token-field__suggestions-list {
-			margin: 4px -16px -12px;
+			margin: 12px -16px -12px;
 			width: min-content;
 		}
 


### PR DESCRIPTION
Displays the list of suggestions below the input and maintains a balance with the top margin.

#### Changes proposed in this Pull Request

* Increases margin between country input and suggestions list

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Probably not needed? :) 

### Before
<img width="472" alt="Screen Shot 2022-01-21 at 10 08 02 AM" src="https://user-images.githubusercontent.com/1398304/150578718-2c559097-2fe0-41f1-8cb2-adb87c9bbd6c.png">


### After
<img width="472" alt="Screen Shot 2022-01-21 at 10 09 41 AM" src="https://user-images.githubusercontent.com/1398304/150578723-749605d4-6cdc-489a-840c-e19c9997c6bf.png">

