### PR TITLE
Woo installer: Remove plugins loaded check

### DIFF
--- a/client/my-sites/woocommerce/main.jsx
+++ b/client/my-sites/woocommerce/main.jsx
@@ -5,15 +5,11 @@ import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { isLoaded as arePluginsLoaded } from 'calypso/state/plugins/installed/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import RequiredPluginsInstallView from './dashboard/required-plugins-install-view';
 
 function WooCommerce() {
 	const siteId = useSelector( getSelectedSiteId );
-	const areInstalledPluginsLoadedIntoState = useSelector( ( state ) =>
-		arePluginsLoaded( state, siteId )
-	);
 
 	if ( ! siteId ) {
 		return null;
@@ -26,7 +22,7 @@ function WooCommerce() {
 				<PageViewTracker path="/woocommerce-installation/:site" title="WooCommerce Installation" />
 				<QuerySiteFeatures siteId={ siteId } />
 				<QueryJetpackPlugins siteIds={ [ siteId ] } />
-				{ areInstalledPluginsLoadedIntoState && <RequiredPluginsInstallView siteId={ siteId } /> }
+				<RequiredPluginsInstallView siteId={ siteId } />
 			</Main>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The plugins loaded check is no longer needed, but causing [this issue](https://github.com/Automattic/wp-calypso/issues/59516#issuecomment-1018744111).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the Woo installer flow at /woocommerce-installation/< site id >
* Switch to another site
* You should see the landing page, not a blank page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
