### PR TITLE
Woo installer: Add failure and redirect tracks events

### DIFF
--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -27,6 +27,10 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 		setHasFailed( true );
 	};
 
+	const trackRedirect = () => {
+		dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
+	};
+
 	if ( siteConfirmed !== siteId ) {
 		goToStep( 'confirm' );
 		return null;
@@ -43,8 +47,12 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			isWideLayout={ props.isReskinned }
 			stepContent={
 				<>
-					{ isAtomic && <InstallPlugins onFailure={ handleTransferFailure } /> }
-					{ ! isAtomic && <TransferSite onFailure={ handleTransferFailure } /> }
+					{ isAtomic && (
+						<InstallPlugins onFailure={ handleTransferFailure } trackRedirect={ trackRedirect } />
+					) }
+					{ ! isAtomic && (
+						<TransferSite onFailure={ handleTransferFailure } trackRedirect={ trackRedirect } />
+					) }
 				</>
 			}
 			{ ...props }

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InstallPlugins from './install-plugins';
@@ -9,6 +10,7 @@ import type { WooCommerceInstallProps } from '../';
 import './style.scss';
 
 export default function Transfer( props: WooCommerceInstallProps ): ReactElement | null {
+	const dispatch = useDispatch();
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
@@ -19,6 +21,11 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 	} = props;
 
 	const [ hasFailed, setHasFailed ] = useState( false );
+
+	const handleTransferFailure = () => {
+		dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_snag_error' ) );
+		setHasFailed( true );
+	};
 
 	if ( siteConfirmed !== siteId ) {
 		goToStep( 'confirm' );
@@ -36,8 +43,8 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			isWideLayout={ props.isReskinned }
 			stepContent={
 				<>
-					{ isAtomic && <InstallPlugins onFailure={ () => setHasFailed( true ) } /> }
-					{ ! isAtomic && <TransferSite onFailure={ () => setHasFailed( true ) } /> }
+					{ isAtomic && <InstallPlugins onFailure={ handleTransferFailure } /> }
+					{ ! isAtomic && <TransferSite onFailure={ handleTransferFailure } /> }
 				</>
 			}
 			{ ...props }

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -22,8 +22,8 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 
 	const [ hasFailed, setHasFailed ] = useState( false );
 
-	const handleTransferFailure = () => {
-		dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_snag_error' ) );
+	const handleTransferFailure = ( type: string ) => {
+		dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_snag_error', { action: type } ) );
 		setHasFailed( true );
 	};
 
@@ -48,10 +48,16 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			stepContent={
 				<>
 					{ isAtomic && (
-						<InstallPlugins onFailure={ handleTransferFailure } trackRedirect={ trackRedirect } />
+						<InstallPlugins
+							onFailure={ () => handleTransferFailure( 'install ' ) }
+							trackRedirect={ trackRedirect }
+						/>
 					) }
 					{ ! isAtomic && (
-						<TransferSite onFailure={ handleTransferFailure } trackRedirect={ trackRedirect } />
+						<TransferSite
+							onFailure={ () => handleTransferFailure( 'transfer' ) }
+							trackRedirect={ trackRedirect }
+						/>
 					) }
 				</>
 			}

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -103,7 +103,7 @@ export default function InstallPlugins( {
 				page( wcAdmin );
 			}, 500 );
 		}
-	}, [ siteId, softwareApplied, wcAdmin, installFailed ] );
+	}, [ siteId, softwareApplied, wcAdmin, installFailed, trackRedirect ] );
 
 	return (
 		<>

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -19,8 +19,10 @@ const TIMEOUT_LIMIT = 1000 * 15; // 15 seconds.
 
 export default function InstallPlugins( {
 	onFailure,
+	trackRedirect,
 }: {
 	onFailure: () => void;
+	trackRedirect: () => void;
 } ): ReactElement | null {
 	const dispatch = useDispatch();
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
@@ -94,6 +96,7 @@ export default function InstallPlugins( {
 		}
 
 		if ( softwareApplied ) {
+			trackRedirect();
 			setProgress( 1 );
 			// Allow progress bar to complete
 			setTimeout( () => {

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -19,8 +19,10 @@ import './style.scss';
 
 export default function TransferSite( {
 	onFailure,
+	trackRedirect,
 }: {
 	onFailure: () => void;
+	trackRedirect: () => void;
 } ): ReactElement | null {
 	const dispatch = useDispatch();
 
@@ -111,6 +113,7 @@ export default function TransferSite( {
 		}
 
 		if ( softwareApplied ) {
+			trackRedirect();
 			setProgress( 1 );
 			// Allow progress bar to complete
 			setTimeout( () => {

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -120,7 +120,7 @@ export default function TransferSite( {
 				page( wcAdmin );
 			}, 500 );
 		}
-	}, [ siteId, softwareApplied, wcAdmin ] );
+	}, [ siteId, softwareApplied, wcAdmin, trackRedirect ] );
 
 	return (
 		<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add tracks event for hit a snag error.
* Add tracks event for redirect to wc-admin.

- [x] Add tracks event for hit a snag
- [x] Add tracks event for about to redirect

#### Testing instructions

- Show tracking in your browser: PCYsg-cae-p2
- Using a non-Atomic site to test, verify that `calypso_woocommerce_dashboard_snag_error` is tracked with `action: transfer` by going through the flow with the API sandboxed and an error hardcoded (see D71706-code "Always trigger transfer error").
- Using an Atomic site to test, verify that `calypso_woocommerce_dashboard_snag_error` is tracked with `action: install` by going through the flow with the API sandboxed and an error hardcoded (see D71706-code "generate an error when installing software").
- Verify that `calypso_woocommerce_dashboard_redirect` is tracked when the flow successfully completes, just before redirecting to wc-admin.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/59926