### PR TITLE
Phone Input: Fix MX number formatting

### DIFF
--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -172,13 +172,12 @@ export function processNumber( inputNumber, numberRegion ) {
 		);
 	}
 
-	if ( numberRegion.nationalPrefix === '0' ) {
-		nationalNumber = nationalNumber.replace( /^0+/, '' );
+	// If the prefix has already been added, remove it because it will be added again later.
+	let prefixRegexp = new RegExp( `^${ prefix }` );
+	if ( numberRegion.nationalPrefix?.length === 1 ) {
+		prefixRegexp = new RegExp( `^${ prefix }+` );
 	}
-
-	if ( numberRegion.nationalPrefix === '01' ) {
-		nationalNumber = nationalNumber.replace( /^01+/, '' );
-	}
+	nationalNumber = nationalNumber.replace( prefixRegexp, '' );
 
 	debug( `National Number: ${ nationalNumber } for ${ inputNumber } in ${ numberRegion.isoCode }` );
 

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -176,6 +176,10 @@ export function processNumber( inputNumber, numberRegion ) {
 		nationalNumber = nationalNumber.replace( /^0+/, '' );
 	}
 
+	if ( numberRegion.nationalPrefix === '01' ) {
+		nationalNumber = nationalNumber.replace( /^01+/, '' );
+	}
+
 	debug( `National Number: ${ nationalNumber } for ${ inputNumber } in ${ numberRegion.isoCode }` );
 
 	if ( inputNumber[ 0 ] === '+' ) {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -267,6 +267,16 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '01243 212 34', countries.MX ), '01243 212 34' );
 				equal( formatNumber( '01243 212 345', countries.MX ), '01243 212 345' );
 				equal( formatNumber( '01243 212 3456', countries.MX ), '01243 212 3456' );
+
+				equal( formatNumber( '2', countries.HU ), '2' );
+				equal( formatNumber( '24', countries.HU ), '24' );
+				equal( formatNumber( '06243', countries.HU ), '0624 3' );
+				equal( formatNumber( '0624 32', countries.HU ), '0624 32' );
+				equal( formatNumber( '0624 321', countries.HU ), '0624 321' );
+				equal( formatNumber( '0624 3212', countries.HU ), '0624 321 2' );
+				equal( formatNumber( '0624 321 23', countries.HU ), '0624 321 23' );
+				equal( formatNumber( '0624 321 234', countries.HU ), '0624 321 234' );
+				equal( formatNumber( '0624 321 2345', countries.HU ), '0624 321 2345' );
 			} );
 
 			test( 'should not add a prefix when the country does not have national prefix', () => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -277,6 +277,14 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '0624 321 23', countries.HU ), '0624 321 23' );
 				equal( formatNumber( '0624 321 234', countries.HU ), '0624 321 234' );
 				equal( formatNumber( '0624 321 2345', countries.HU ), '0624 321 2345' );
+
+				equal( formatNumber( '2', countries.RU ), '2' );
+				equal( formatNumber( '24', countries.RU ), '24' );
+				equal( formatNumber( '8243', countries.RU ), '8243' );
+				equal( formatNumber( '82432', countries.RU ), '8243-2' );
+				equal( formatNumber( '8243-21', countries.RU ), '8243-21' );
+				equal( formatNumber( '8243-212', countries.RU ), '8243-21-2' );
+				equal( formatNumber( '8243-21-23', countries.RU ), '8243-21-23' );
 			} );
 
 			test( 'should not add a prefix when the country does not have national prefix', () => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -212,6 +212,17 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '60465599', countries.US ), '(604) 655-99' );
 				equal( formatNumber( '604655999', countries.US ), '(604) 655-999' );
 				equal( formatNumber( '6046559999', countries.US ), '(604) 655-9999' );
+
+				equal( formatNumber( '5', countries.MX ), '5' );
+				equal( formatNumber( '54', countries.MX ), '54' );
+				equal( formatNumber( '543', countries.MX ), '543' );
+				equal( formatNumber( '5432', countries.MX ), '543 2' );
+				equal( formatNumber( '54321', countries.MX ), '543 21' );
+				equal( formatNumber( '543212', countries.MX ), '543 212' );
+				equal( formatNumber( '5432123', countries.MX ), '543 212 3' );
+				equal( formatNumber( '54321234', countries.MX ), '543 212 34' );
+				equal( formatNumber( '543212345', countries.MX ), '543 212 345' );
+				equal( formatNumber( '5432123456', countries.MX ), '543 212 3456' );
 			} );
 
 			test( 'should not add a prefix when the country does not have national prefix', () => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -213,6 +213,16 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '604655999', countries.US ), '(604) 655-999' );
 				equal( formatNumber( '6046559999', countries.US ), '(604) 655-9999' );
 
+				equal( formatNumber( '5', countries.FR ), '5' );
+				equal( formatNumber( '54', countries.FR ), '54' );
+				equal( formatNumber( '543', countries.FR ), '05 43' );
+				equal( formatNumber( '5432', countries.FR ), '05 43 2' );
+				equal( formatNumber( '54321', countries.FR ), '05 43 21' );
+				equal( formatNumber( '543212', countries.FR ), '05 43 21 2' );
+				equal( formatNumber( '5432123', countries.FR ), '05 43 21 23' );
+				equal( formatNumber( '54321234', countries.FR ), '05 43 21 23 4' );
+				equal( formatNumber( '543212345', countries.FR ), '05 43 21 23 45' );
+
 				equal( formatNumber( '5', countries.MX ), '5' );
 				equal( formatNumber( '54', countries.MX ), '54' );
 				equal( formatNumber( '543', countries.MX ), '543' );

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -235,6 +235,40 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '2432123456', countries.MX ), '01243 212 3456' );
 			} );
 
+			test( 'should format as you type with the formatting included in the input', () => {
+				equal( formatNumber( '6', countries.US ), '6' );
+				equal( formatNumber( '60', countries.US ), '60' );
+				equal( formatNumber( '604', countries.US ), '604' );
+				equal( formatNumber( '604-6', countries.US ), '604-6' );
+				equal( formatNumber( '604-65', countries.US ), '604-65' );
+				equal( formatNumber( '604-655', countries.US ), '604-655' );
+				equal( formatNumber( '604-6559', countries.US ), '604-6559' );
+				equal( formatNumber( '604-65599', countries.US ), '(604) 655-99' );
+				equal( formatNumber( '604-655-999', countries.US ), '(604) 655-999' );
+				equal( formatNumber( '604-655-9999', countries.US ), '(604) 655-9999' );
+
+				equal( formatNumber( '5', countries.FR ), '5' );
+				equal( formatNumber( '54', countries.FR ), '54' );
+				equal( formatNumber( '543', countries.FR ), '05 43' );
+				equal( formatNumber( '05 432', countries.FR ), '05 43 2' );
+				equal( formatNumber( '05 43 21', countries.FR ), '05 43 21' );
+				equal( formatNumber( '05 43 212', countries.FR ), '05 43 21 2' );
+				equal( formatNumber( '05 43 21 23', countries.FR ), '05 43 21 23' );
+				equal( formatNumber( '05 43 21 234', countries.FR ), '05 43 21 23 4' );
+				equal( formatNumber( '05 43 21 23 45', countries.FR ), '05 43 21 23 45' );
+
+				equal( formatNumber( '2', countries.MX ), '2' );
+				equal( formatNumber( '24', countries.MX ), '24' );
+				equal( formatNumber( '01243', countries.MX ), '01243' );
+				equal( formatNumber( '012432', countries.MX ), '01243 2' );
+				equal( formatNumber( '01243 21', countries.MX ), '01243 21' );
+				equal( formatNumber( '01243 212', countries.MX ), '01243 212' );
+				equal( formatNumber( '01243 2123', countries.MX ), '01243 212 3' );
+				equal( formatNumber( '01243 212 34', countries.MX ), '01243 212 34' );
+				equal( formatNumber( '01243 212 345', countries.MX ), '01243 212 345' );
+				equal( formatNumber( '01243 212 3456', countries.MX ), '01243 212 3456' );
+			} );
+
 			test( 'should not add a prefix when the country does not have national prefix', () => {
 				equal( formatNumber( '9876543210', countries.IS ), '9876543210' );
 				equal( formatNumber( '+96', countries.IQ ), '+96' );

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -223,16 +223,16 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '54321234', countries.FR ), '05 43 21 23 4' );
 				equal( formatNumber( '543212345', countries.FR ), '05 43 21 23 45' );
 
-				equal( formatNumber( '5', countries.MX ), '5' );
-				equal( formatNumber( '54', countries.MX ), '54' );
-				equal( formatNumber( '543', countries.MX ), '543' );
-				equal( formatNumber( '5432', countries.MX ), '543 2' );
-				equal( formatNumber( '54321', countries.MX ), '543 21' );
-				equal( formatNumber( '543212', countries.MX ), '543 212' );
-				equal( formatNumber( '5432123', countries.MX ), '543 212 3' );
-				equal( formatNumber( '54321234', countries.MX ), '543 212 34' );
-				equal( formatNumber( '543212345', countries.MX ), '543 212 345' );
-				equal( formatNumber( '5432123456', countries.MX ), '543 212 3456' );
+				equal( formatNumber( '2', countries.MX ), '2' );
+				equal( formatNumber( '24', countries.MX ), '24' );
+				equal( formatNumber( '243', countries.MX ), '01243' );
+				equal( formatNumber( '2432', countries.MX ), '01243 2' );
+				equal( formatNumber( '24321', countries.MX ), '01243 21' );
+				equal( formatNumber( '243212', countries.MX ), '01243 212' );
+				equal( formatNumber( '2432123', countries.MX ), '01243 212 3' );
+				equal( formatNumber( '24321234', countries.MX ), '01243 212 34' );
+				equal( formatNumber( '243212345', countries.MX ), '01243 212 345' );
+				equal( formatNumber( '2432123456', countries.MX ), '01243 212 3456' );
 			} );
 
 			test( 'should not add a prefix when the country does not have national prefix', () => {


### PR DESCRIPTION
#### Background

The logic for phone number formatting was added (I think) in https://github.com/Automattic/wp-calypso/pull/7454 and had a bug: before running any phone number through a series of regexps to determine how to format that number, if the national prefix code for a country is `0`, it strips out any leading `0`, then later adds that `0` back in, but it does this only for `0`.

https://github.com/Automattic/wp-calypso/blob/67250d2baed7ed09e6f6b1f4b3440ffbaea6e140/client/components/phone-input/phone-number.js#L175-L177

For example, the `FR` country code prefix is `0`, so before trying to figure out the formatting of a number like `05432`, it removes the `0` so that it searches for a pattern matching `5432`. The regexps include such a pattern:

https://github.com/Automattic/wp-calypso/blob/67250d2baed7ed09e6f6b1f4b3440ffbaea6e140/client/components/phone-input/data.js#L1961-L1966

And so the code will apply the formatting to turn that into `5 43 2`, and will finally prefix it with the national prefix, so it becomes `05 43 2`. 

When you try to do this with `MX`, which has a national prefix of `01`, it again starts with a number like `01343`; since the national code is not `0`, next it searches for a pattern matching `01343`. The pattern we want is this one:

https://github.com/Automattic/wp-calypso/blob/67250d2baed7ed09e6f6b1f4b3440ffbaea6e140/client/components/phone-input/data.js#L3936-L3941

It does not match that number, but even if it did (I altered the `leadingDigitPattern` to try this) it will still prefixes the result with the national prefix, so it becomes `0101343`.

It's not clear exactly what the cause of the bug is, because it looks like a fundamental flaw in the formatting functionality. Or it could be that the data for `MX` is wrong. The `FR` number includes the prefix as part of its 10 digit number, but the `MX` number is 10 digits and then includes the `01`. I don't know enough about national prefixes to know what this means.

~I wonder if this might also be a problem for the other national prefixes [like `06` for `HU`](https://github.com/Automattic/wp-calypso/blob/dc267b4cf45b31d84b2be9be106ab220fe314263/client/components/phone-input/data.js#L2394). I have not tested those yet.~ This is also a problem for `HU` (national prefix of `06`) and `RU` (national prefix of `8`).

#### Changes proposed in this Pull Request

This PR updates the above mentioned code which strips out prefixes of `0` and also strips out any leading national prefix, which appears to resolve the issue. I can't think of a situation where we would _not_ want to strip out the prefixes before adding them again, but it's possible that the regexps for other countries already handle this somehow.

Fixes https://github.com/Automattic/wp-calypso/issues/60118

<img width="260" alt="Screen Shot 2022-01-21 at 8 09 02 PM" src="https://user-images.githubusercontent.com/2036909/150618573-32703d61-2e17-4ad5-a4aa-bb0941db519d.png">

#### Testing instructions

- Add a domain product to your cart and visit checkout.
- Click "edit" on the contact details step (unless it is already active).
- Click on the county flag button next to the phone number to change it to Mexico.
- Enter 10 numbers into the phone number input field.
- Verify that the numbers gain the prefix of `01` but that it is never duplicated and that the rest of the number is formatted correctly in the format `01XXX-XXX-XXXX`.