### PR TITLE
Don't allow access to domain settings page for free site URLs

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -29,7 +29,7 @@ export {
 	isMappedDomain,
 	isMappedDomainWithWpcomNameservers,
 } from './mapped-domains';
-export { getRegisteredDomains, isRegisteredDomain } from './registered-domains';
+export { getRegisteredDomains, isFreeUrlDomain, isRegisteredDomain } from './registered-domains';
 export { resendIcannVerification } from './resend-icann-verification';
 export { resolveDomainStatus } from './resolve-domain-status';
 export { startInboundTransfer } from './start-inbound-transfer';

--- a/client/lib/domains/registered-domains.js
+++ b/client/lib/domains/registered-domains.js
@@ -7,3 +7,7 @@ export function getRegisteredDomains( domains ) {
 export function isRegisteredDomain( domain ) {
 	return domain.type === domainTypes.REGISTERED;
 }
+
+export function isFreeUrlDomain( domain ) {
+	return domain.type === domainTypes.WPCOM;
+}

--- a/client/lib/domains/utils/index.js
+++ b/client/lib/domains/utils/index.js
@@ -6,3 +6,4 @@ export { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils/is-domai
 export { parseDomainAgainstTldList } from 'calypso/lib/domains/utils/parse-domain-against-tld-list';
 export { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
 export { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
+export { isFreeUrlDomainName } from 'calypso/lib/domains/utils/is-free-url-domain-name';

--- a/client/lib/domains/utils/is-free-url-domain-name.js
+++ b/client/lib/domains/utils/is-free-url-domain-name.js
@@ -1,0 +1,42 @@
+export function isFreeUrlDomainName( domainName ) {
+	const freeDotBlogSubdomains = [
+		'art',
+		'business',
+		'car',
+		'code',
+		'data',
+		'design',
+		'family',
+		'fashion',
+		'finance',
+		'fitness',
+		'food',
+		'game',
+		'health',
+		'home',
+		'law',
+		'movie',
+		'music',
+		'news',
+		'p2',
+		'photo',
+		'poetry',
+		'politics',
+		'school',
+		'science',
+		'sport',
+		'tech',
+		'travel',
+		'video',
+		'water',
+	];
+
+	const freeUrlDomainNames = freeDotBlogSubdomains.map(
+		( dotBlogSubdomain ) => `.${ dotBlogSubdomain }.blog`
+	);
+	freeUrlDomainNames.unshift( '.wordpress.com', '.wpcomstaging.com' );
+
+	return freeUrlDomainNames.some( ( freeUrlDomainName ) =>
+		domainName.endsWith( freeUrlDomainName )
+	);
+}

--- a/client/my-sites/domains/domain-management/change-site-address/index.jsx
+++ b/client/my-sites/domains/domain-management/change-site-address/index.jsx
@@ -5,9 +5,13 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import SiteAddressChanger from 'calypso/blocks/site-address-changer';
 import Main from 'calypso/components/main';
-import { getSelectedDomain, isRegisteredDomain } from 'calypso/lib/domains';
+import { getSelectedDomain, isFreeUrlDomain, isRegisteredDomain } from 'calypso/lib/domains';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
-import { domainManagementEdit, domainManagementNameServers } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainManagementNameServers,
+} from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 import './style.scss';
@@ -21,9 +25,12 @@ class ChangeSiteAddress extends Component {
 
 	goBack = () => {
 		let path;
+		const selectedDomain = getSelectedDomain( this.props );
 
-		if ( isRegisteredDomain( getSelectedDomain( this.props ) ) ) {
+		if ( isRegisteredDomain( selectedDomain ) ) {
 			path = domainManagementNameServers;
+		} else if ( isFreeUrlDomain( selectedDomain ) ) {
+			path = domainManagementList;
 		} else {
 			path = domainManagementEdit;
 		}

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -72,19 +72,33 @@ export default {
 	},
 
 	domainManagementEdit( pageContext, next ) {
-		pageContext.primary = (
-			<DomainManagementData
-				analyticsPath={ domainManagementEdit( ':site', ':domain', pageContext.canonicalPath ) }
-				analyticsTitle="Domain Management > Edit"
-				component={ DomainManagement.Settings }
-				context={ pageContext }
-				needsContactDetails
-				needsDomains
-				needsPlans
-				needsProductsList
-				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
-			/>
-		);
+		if ( decodeURIComponentIfValid ) {
+			const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+
+			if (
+				selectedDomainName &&
+				( selectedDomainName.endsWith( '.wordpress.com' ) ||
+					selectedDomainName.endsWith( '.wpcomstaging.com' ) )
+			) {
+				const state = pageContext.store.getState();
+				const siteSlug = getSelectedSiteSlug( state );
+				page.redirect( domainManagementList( siteSlug ) );
+			}
+
+			pageContext.primary = (
+				<DomainManagementData
+					analyticsPath={ domainManagementEdit( ':site', ':domain', pageContext.canonicalPath ) }
+					analyticsTitle="Domain Management > Edit"
+					component={ DomainManagement.Settings }
+					context={ pageContext }
+					needsContactDetails
+					needsDomains
+					needsPlans
+					needsProductsList
+					selectedDomainName={ selectedDomainName }
+				/>
+			);
+		}
 		next();
 	},
 

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -1,5 +1,6 @@
 import page from 'page';
 import DomainManagementData from 'calypso/components/data/domain-management';
+import { isFreeUrlDomainName } from 'calypso/lib/domains/utils';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import {
 	domainManagementChangeSiteAddress,
@@ -73,11 +74,7 @@ export default {
 
 	domainManagementEdit( pageContext, next ) {
 		const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
-		if (
-			selectedDomainName &&
-			( selectedDomainName.endsWith( '.wordpress.com' ) ||
-				selectedDomainName.endsWith( '.wpcomstaging.com' ) )
-		) {
+		if ( isFreeUrlDomainName( selectedDomainName ) ) {
 			const state = pageContext.store.getState();
 			const siteSlug = getSelectedSiteSlug( state );
 			page.redirect( domainManagementList( siteSlug ) );

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -72,33 +72,30 @@ export default {
 	},
 
 	domainManagementEdit( pageContext, next ) {
-		if ( decodeURIComponentIfValid ) {
-			const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
-
-			if (
-				selectedDomainName &&
-				( selectedDomainName.endsWith( '.wordpress.com' ) ||
-					selectedDomainName.endsWith( '.wpcomstaging.com' ) )
-			) {
-				const state = pageContext.store.getState();
-				const siteSlug = getSelectedSiteSlug( state );
-				page.redirect( domainManagementList( siteSlug ) );
-			}
-
-			pageContext.primary = (
-				<DomainManagementData
-					analyticsPath={ domainManagementEdit( ':site', ':domain', pageContext.canonicalPath ) }
-					analyticsTitle="Domain Management > Edit"
-					component={ DomainManagement.Settings }
-					context={ pageContext }
-					needsContactDetails
-					needsDomains
-					needsPlans
-					needsProductsList
-					selectedDomainName={ selectedDomainName }
-				/>
-			);
+		const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+		if (
+			selectedDomainName &&
+			( selectedDomainName.endsWith( '.wordpress.com' ) ||
+				selectedDomainName.endsWith( '.wpcomstaging.com' ) )
+		) {
+			const state = pageContext.store.getState();
+			const siteSlug = getSelectedSiteSlug( state );
+			page.redirect( domainManagementList( siteSlug ) );
 		}
+
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementEdit( ':site', ':domain', pageContext.canonicalPath ) }
+				analyticsTitle="Domain Management > Edit"
+				component={ DomainManagement.Settings }
+				context={ pageContext }
+				needsContactDetails
+				needsDomains
+				needsPlans
+				needsProductsList
+				selectedDomainName={ selectedDomainName }
+			/>
+		);
 		next();
 	},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We should not allow access to the domain settings page when the domain name is a WPCOM url (ex. foo.wordpress.com)

The back button from the "/change-site-address" page would lead to a URL like: `https://wordpress.com/domains/manage/{FREESITEURL}/edit/{SITESLUG}`

This PR fixes the back-button URL for the change site address page and also adds a redirect back to the domain list for the selected site in the case where the `/domains/manage/{FREESITEURL}/edit/{SITESLUG}` is entered manually or for some other reason.

#### Testing instructions

Go to the change site address page for the "free WordPress.com address" from a site list. Click on the back button. Make sure that you are returned to the domains list page.

Manually go to a path like `/domains/manage/{FREESITEURL}/edit/{SITESLUG}`.  Make sure you are redirected back to the domains list page for the site.

Related to #60358
