### PR TITLE
Removing test config and implementing new mobile registration page

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -89,7 +89,7 @@ class SignupForm extends Component {
 		goToNextStep: PropTypes.func,
 		handleLogin: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
-		isPasswordlessExperiment: PropTypes.bool,
+		isMobile: PropTypes.bool,
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
@@ -111,7 +111,7 @@ class SignupForm extends Component {
 		displayNameInput: false,
 		displayUsernameInput: true,
 		flowName: '',
-		isPasswordlessExperiment: false,
+		isMobie: false,
 		isSocialSignupEnabled: false,
 		horizontal: false,
 	};
@@ -1031,11 +1031,10 @@ class SignupForm extends Component {
 		}
 
 		/*
-			AB Test: passwordlessSignup
 			`<PasswordlessSignupForm />` is for the `onboarding` flow.
-			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
+			Require only email to create account for mobile users.
 		*/
-		if ( this.props.isPasswordlessExperiment ) {
+		if ( this.props.isMobile ) {
 			const logInUrl = this.getLoginLink();
 
 			return (

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1034,7 +1034,7 @@ class SignupForm extends Component {
 			`<PasswordlessSignupForm />` is for the `onboarding` flow.
 			Require only email to create account for mobile users.
 		*/
-		if ( this.props.isMobile ) {
+		if ( this.props.isMobile && this.props.flowName !== 'wpcc' ) {
 			const logInUrl = this.getLoginLink();
 
 			return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -4,16 +4,13 @@ import {
 	isDomainTransfer,
 } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { ExperimentAssignment } from '@automattic/explat-client';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
-import cookie from 'cookie';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
@@ -68,12 +65,6 @@ const CouponEnableButton = styled.button`
 	}
 `;
 
-const GeneratedNameNote = styled.p`
-	font-size: 0.75rem;
-	font-style: italic;
-	margin-top: 4px;
-`;
-
 export default function WPCheckoutOrderReview( {
 	className,
 	removeProductFromCart,
@@ -95,36 +86,10 @@ export default function WPCheckoutOrderReview( {
 } ): JSX.Element {
 	const translate = useTranslate();
 	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
-	const [ experiment, setExperiment ] = useState< ExperimentAssignment | null >( null );
 	const cartKey = useCartKey();
 	const { responseCart, removeCoupon, couponStatus } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 	const reduxDispatch = useDispatch();
-
-	useEffect( () => {
-		function retrieveExperimentName(): string {
-			let experiment = '';
-			try {
-				const cookies = cookie.parse( document.cookie );
-				experiment = cookies.wpcom_signup_experiment_name;
-			} catch ( error ) {
-				reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cookie_read_failed' ) );
-			}
-			return experiment;
-		}
-
-		const experimentCheck = retrieveExperimentName();
-		let shouldCheck = true;
-		experimentCheck &&
-			loadExperimentAssignment( experimentCheck ).then( ( experimentObject ) => {
-				if ( shouldCheck ) {
-					setExperiment( experimentObject );
-				}
-			} );
-		return () => {
-			shouldCheck = false;
-		};
-	}, [ reduxDispatch ] );
 
 	const onRemoveProductCancel = useCallback( () => {
 		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' ) );
@@ -168,7 +133,6 @@ export default function WPCheckoutOrderReview( {
 	};
 
 	const planIsP2Plus = hasP2PlusPlan( responseCart );
-	const shouldShowDomainNote = experiment?.variationName && domainUrl?.includes( '.wordpress.com' );
 	const isPwpoUser = useSelector(
 		( state ) =>
 			getCurrentUser( state ) && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
@@ -179,14 +143,7 @@ export default function WPCheckoutOrderReview( {
 			className={ joinClasses( [ className, 'checkout-review-order', isSummary && 'is-summary' ] ) }
 		>
 			{ ! planIsP2Plus && domainUrl && 'no-user' !== domainUrl && (
-				<SiteSummary>
-					{ translate( 'Site: %s', { args: domainUrl } ) }
-					{ shouldShowDomainNote && (
-						<GeneratedNameNote>
-							{ translate( 'You can change this name at any time in your account settings.' ) }
-						</GeneratedNameNote>
-					) }
-				</SiteSummary>
+				<SiteSummary>{ translate( 'Site: %s', { args: domainUrl } ) }</SiteSummary>
 			) }
 			{ planIsP2Plus && selectedSiteData?.name && (
 				<SiteSummary>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
-import { isDesktop } from '@automattic/viewport';
+import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
-import cookie from 'cookie';
 import { localize } from 'i18n-calypso';
 import { isEmpty, omit, get } from 'lodash';
 import PropTypes from 'prop-types';
@@ -13,7 +12,6 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect-cart-header';
 import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
@@ -100,8 +98,7 @@ export class UserStep extends Component {
 
 	state = {
 		recaptchaClientId: null,
-		experiment: null,
-		isDesktop: isDesktop(),
+		isMobile: isMobile(),
 	};
 
 	componentDidUpdate() {
@@ -128,41 +125,7 @@ export class UserStep extends Component {
 		if ( this.props.oauth2Signup && clientId ) {
 			this.props.fetchOAuth2ClientData( clientId );
 		}
-
-		const signupFlows = [
-			'onboarding',
-			'free',
-			'personal',
-			'premium',
-			'business',
-			'ecommerce',
-			'with-theme',
-			'personal-monthly',
-			'premium-monthly',
-			'business-monthly',
-			'ecommerce-monthly',
-			'with-design-picker',
-		];
-		if ( signupFlows.includes( this.props.flowName ) ) {
-			const experimentCheck = this.state.isDesktop
-				? 'registration_email_only_desktop_v3'
-				: 'registration_email_only_mobile_v3';
-
-			loadExperimentAssignment( experimentCheck ).then( ( experimentName ) => {
-				this.setState( { experiment: experimentName } );
-				experimentName.variationName === 'treatment'
-					? this.persistExperimentName( experimentName.experimentName )
-					: null;
-			} );
-		}
 	}
-
-	persistExperimentName = ( experimentName ) => {
-		const DAY_IN_SECONDS = 3600 * 24;
-		const expirationDate = new Date( new Date().getTime() + DAY_IN_SECONDS * 1000 );
-		const options = { path: '/', expires: expirationDate, sameSite: 'strict' };
-		document.cookie = cookie.serialize( 'wpcom_signup_experiment_name', experimentName, options );
-	};
 
 	getSubHeaderText() {
 		const {
@@ -460,10 +423,6 @@ export class UserStep extends Component {
 		return translate( 'Create your account' );
 	}
 
-	isPasswordlessExperiment() {
-		return this.state.experiment?.variationName === 'treatment';
-	}
-
 	renderSignupForm() {
 		const { oauth2Client, wccomFrom, isReskinned } = this.props;
 		let socialService;
@@ -495,8 +454,7 @@ export class UserStep extends Component {
 					submitButtonText={ this.submitButtonText() }
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
-					isPasswordlessExperiment={ this.isPasswordlessExperiment() }
-					experimentName={ this.state.experiment }
+					isMobile={ this.state.isMobile }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -98,7 +98,6 @@ export class UserStep extends Component {
 
 	state = {
 		recaptchaClientId: null,
-		isMobile: isMobile(),
 	};
 
 	componentDidUpdate() {
@@ -454,7 +453,7 @@ export class UserStep extends Component {
 					submitButtonText={ this.submitButtonText() }
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
-					isMobile={ this.state.isMobile }
+					isMobile={ isMobile() }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }


### PR DESCRIPTION
This PR ends the third email-only registration page test discussed in pbxNRc-1c5-2 (and implemented in #59715). It will launch the test as implemented in the first test (pbxNRc-144-p2 / #57846).

This will launch the email-only experience for all mobile users, but retain the username and password fields for the desktop experience. It also changes back to generating the username and site address based on email address rather than generating a random name (changed in companion diff D73589-code).

#### Testing instructions
* Checkout this branch and start Calypso.
* Apply D73589-code to your sandbox.
* Sandbox public-api.
* Navigate to `/start/new` in your local Calypso in Incognito mode.
* Confirm that the desktop viewport shows email, username, and password fields.
* Change to a mobile viewport and refresh the page. Confirm that the page shows only the the email field.
* Go through registration and site creation for both viewports.
* On the Domain step, select the `View plans` option under 'Get a free one-year domain registration with any paid annual plan.' (which will use domain-generating api).
* Select a paid plan.
* On the checkout, confirm that the domain name for mobile flow is based on the email address, and that the desktop flow is based on username.
* Go through the free flow and confirm that works as expected.
