### PR TITLE
Set the domain name when calling the mapping-settings-info endpoint

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -85,7 +85,7 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 			setDomainSetupInfoError( {} );
 			setLoadingDomainSetupInfo( true );
 			wpcom
-				.domain()
+				.domain( domain )
 				.mappingSetupInfo( selectedSite.ID, domain )
 				.then( ( data ) => {
 					setDomainSetupInfo( { data } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're not passing in the domain name when calling the mapping-setup-info endpoint. We should be passing in the domain name.

#### Testing instructions

Go to the advanced setup for a connected (mapped) domain. Make sure that the correct IP addresses are shown and that the domain name is passed in to the endpoint instead of "undefined."
