### PR TITLE
Remove unused 'displayname' and 'jetpack-user' steps

### DIFF
--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -55,7 +55,6 @@ const stepNameToModuleName = {
 	'user-new': 'user',
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',
-	displayname: 'user',
 	'reader-landing': 'reader-landing',
 	passwordless: 'passwordless',
 	'p2-details': 'p2-details',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -374,21 +374,6 @@ export function generateSteps( {
 			delayApiRequestUntilComplete: true,
 		},
 
-		'jetpack-user': {
-			stepName: 'jetpack-user',
-			apiRequestFunction: createAccount,
-			providesToken: true,
-			props: {
-				get headerText() {
-					return i18n.translate( 'Create an account for Jetpack' );
-				},
-				get subHeaderText() {
-					return i18n.translate( "You're moments away from connecting Jetpack." );
-				},
-			},
-			providesDependencies: [ 'bearer_token', 'username' ],
-		},
-
 		'oauth2-user': {
 			stepName: 'oauth2-user',
 			apiRequestFunction: createAccount,
@@ -423,18 +408,6 @@ export function generateSteps( {
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				oauth2Signup: true,
-				displayNameInput: true,
-				displayUsernameInput: false,
-			},
-		},
-
-		displayname: {
-			stepName: 'displayname',
-			apiRequestFunction: createAccount,
-			providesToken: true,
-			providesDependencies: [ 'bearer_token', 'username' ],
-			props: {
-				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				displayNameInput: true,
 				displayUsernameInput: false,
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While testing #60330 I noticed these steps weren't being used in any flows. This PR removes that dead code.

* Remove `jetpack-user` step definition
* Remove `displayname` step definition

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the signup framework to make sure everything still works
* I also tested jetpack signup using an ephemeral site to be 100% sure the `jetpack-user` step isn't secretly being used anywhere

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
