### PR TITLE
Add timeout on transfers before showing error escape hatch

### DIFF
--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useState } from 'react';
 import { useSelector } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InstallPlugins from './install-plugins';
 import TransferSite from './transfer-site';
@@ -12,6 +13,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 
 	const {
 		goToStep,
@@ -30,6 +32,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			className="transfer__step-wrapper"
 			flowName="woocommerce-install"
 			hideBack={ ! hasFailed }
+			backUrl={ `/woocommerce-installation/${ domain }` }
 			hideNext={ true }
 			hideSkip={ true }
 			hideFormattedHeader={ true }

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -62,7 +62,9 @@ export default function TransferSite( {
 		() => {
 			dispatch( requestLatestAtomicTransfer( siteId ) );
 		},
-		isTransferringStatusFailed || transferStatus === transferStates.COMPLETED ? null : 3000
+		transferFailed || isTransferringStatusFailed || transferStatus === transferStates.COMPLETED
+			? null
+			: 3000
 	);
 
 	// Poll for software status
@@ -71,7 +73,10 @@ export default function TransferSite( {
 			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
 		},
 		// Only poll if the transfer is completed and not failed
-		isTransferringStatusFailed || transferStatus !== transferStates.COMPLETED || softwareApplied
+		transferFailed ||
+			isTransferringStatusFailed ||
+			transferStatus !== transferStates.COMPLETED ||
+			softwareApplied
 			? null
 			: 3000
 	);
@@ -118,6 +123,22 @@ export default function TransferSite( {
 			}, 500 );
 		}
 	}, [ siteId, softwareApplied, wcAdmin ] );
+
+	// Timeout threshold for the install to complete.
+	useEffect( () => {
+		if ( transferFailed ) {
+			return;
+		}
+
+		const timeId = setTimeout( () => {
+			setTransferFailed( true );
+			onFailure();
+		}, 1000 * 80 );
+
+		return () => {
+			window?.clearTimeout( timeId );
+		};
+	}, [ onFailure, transferFailed ] );
 
 	return (
 		<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds timeout for transfer failures.

#### Testing instructions

No real way to test this without modifying code. Easiest approach is just to reduce the [timeout](https://github.com/Automattic/wp-calypso/pull/60382/files#diff-b3fec2b1927aa365b4e61090b14a29a477c73bd2b6cd22d6baa30bbc6e75beb0R136) limit to less than 40~ seconds (usual transfer time)

* Modify timeout limit
* Revert a site for testing
* Open the installer
* Complete the flow
* [ ] See snag error
* [ ] Network polling for updates should stop
* [ ] Back url should take you back to landing page

Failure mode with 10 second timeout, no new polling after snag error.

https://user-images.githubusercontent.com/811776/150730187-6d15d54b-98d5-47a0-8267-8f27da07c6e7.mp4


Related to #59683
