### PR TITLE
Plans: Migrate `PlanFeaturesComparison` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -44,6 +44,11 @@ import './style.scss';
 const noop = () => {};
 
 export class PlanFeaturesComparison extends Component {
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
+		retargetViewPlans();
+	}
+
 	render() {
 		const { isInSignup, planProperties, translate } = this.props;
 		const tableClasses = classNames(
@@ -293,12 +298,6 @@ export class PlanFeaturesComparison extends Component {
 				<td key={ `${ planName }-none` } className="plan-features-comparison__table-item" />
 			);
 		} );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
-		retargetViewPlans();
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `PlanFeaturesComparison` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/start`
* Input a domain name to end up on the plans page.
* Verify that the page loads well and there are no errors in the console.
* Verify that a requests to a gif with the following arg is made:

![](https://cldup.com/qaS3poGQ-M.png)