### PR TITLE
Activity Log: don't send broken tracks events on Update All

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -231,7 +231,11 @@ class ActivityLogTasklist extends Component {
 	updateItem = ( item ) => {
 		const { showInfoNotice, siteName, updateSingle, translate, trackUpdate } = this.props;
 
-		trackUpdate( item );
+		// if the item was enqueued by `updateAll` it has no `from` field because we don't want
+		// to record a track event for each item individually.
+		if ( item.from !== undefined ) {
+			trackUpdate( item );
+		}
 		updateSingle( item );
 
 		showInfoNotice(


### PR DESCRIPTION
Fixes the following bug in Activity Log:
- when there are updates (plugin, theme, core, ...) available, activity log will show them:

<img width="621" alt="Screenshot 2022-01-24 at 10 18 15" src="https://user-images.githubusercontent.com/664258/150755641-04a4aa5c-830c-45d0-ac8b-fe5b23bf56bc.png">

- after clicking on Update All, all updates are done sequentially
- only one tracks event should be sent, `calypso_activitylog_tasklist_update_all`, but we're sending also events with malformed names for each individual item, like `calypso_activitylog_tasklist_update_pluginundefined`.

Look at the Tracks dashboard to see which kind of events are we receiving:

<img width="709" alt="Screenshot 2022-01-24 at 10 14 56" src="https://user-images.githubusercontent.com/664258/150755770-7b4bc154-1055-4b6b-9d86-d127356baade.png">

This PR fixes the bug by sending the tracks event only when the `item.from` field has a value. This is the original behavior before this bug was introduced by #25911 -- to track only the `update_all` event and not the individual ones.