### PR TITLE
Plans: Migrate `PlanFeatures` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -88,6 +88,8 @@ export class PlanFeatures extends Component {
 
 	componentDidMount() {
 		this.isMounted = true;
+		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
+		retargetViewPlans();
 	}
 
 	render() {
@@ -818,12 +820,6 @@ export class PlanFeatures extends Component {
 				/>
 			);
 		} );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
-		retargetViewPlans();
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `PlanFeatures` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/plans/:site` where `:site` is one of your sites.
* Verify that the page loads well and there are no errors in the console.
* Verify that a requests to a gif with the following arg is made:

![](https://cldup.com/qaS3poGQ-M.png)