### PR TITLE
Dispatch the sitePluginUpdated action after plugin update

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -241,7 +241,7 @@ export function updatePlugin( siteId, plugin ) {
 		const successCallback = ( data ) => {
 			dispatch( { ...defaultAction, type: PLUGIN_UPDATE_REQUEST_SUCCESS, data } );
 			afterUpdateCallback( undefined );
-			sitePluginUpdated( siteId );
+			dispatch( sitePluginUpdated( siteId ) );
 		};
 
 		const errorCallback = ( error ) => {

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -34,6 +34,7 @@ import {
 	PLUGIN_REMOVE_REQUEST,
 	PLUGIN_REMOVE_REQUEST_SUCCESS,
 	PLUGIN_REMOVE_REQUEST_FAILURE,
+	SITE_PLUGIN_UPDATED,
 } from 'calypso/state/action-types';
 import {
 	fetchSitePlugins,
@@ -297,6 +298,20 @@ describe( 'actions', () => {
 					siteId: 2916284,
 					pluginId: 'jetpack/jetpack',
 					data: jetpackUpdated,
+				} );
+			} );
+		} );
+
+		test( 'should dispatch site update action when request completes', () => {
+			const response = updatePlugin( site.ID, {
+				slug: 'jetpack',
+				id: 'jetpack/jetpack',
+				update: {},
+			} )( spy, getState );
+			return response.then( () => {
+				expect( spy ).toHaveBeenCalledWith( {
+					type: SITE_PLUGIN_UPDATED,
+					siteId: 2916284,
 				} );
 			} );
 		} );


### PR DESCRIPTION
Fixes a little bug in the `updatePlugin` action where it didn't dispatch the `sitePluginUpdated` action: it only created the action object and then did nothing with it.

The action updates the `site.updates` object used to display the site indicator in sidebar:

<img width="277" alt="Screenshot 2022-01-24 at 10 46 11" src="https://user-images.githubusercontent.com/664258/150761735-c3d1f6ce-5feb-4410-9bf5-9086529b93c6.png">

**How to test:**
Verify that unit tests pass. Also, when a site has only plugin updates, verify that the site indicator about updates disappears after the plugins are all updated from Activity Log.