### PR TITLE
The Marketplace plugin install thank you page doesn't scroll

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -58,6 +58,7 @@ const ItemStyled = styled( Item )`
 	font-size: 14px;
 	font-weight: 500;
 	padding: 0;
+	justify-content: left;
 
 	&:hover {
 		background: var( --studio-white );

--- a/client/my-sites/marketplace/pages/marketplace-domain-upsell/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-domain-upsell/style.scss
@@ -3,6 +3,7 @@
 		background-color: var( --studio-white );
 		height: 100vh;
 		padding: 0;
+		overflow: inherit;
 		@media ( max-width: 782px ) {
 			padding: 0;
 			background-color: var( --studio-white );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR makes thank you page scrollable. Also, It also aligns the `back to plugins` back button to left. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `https://wordpress.com/marketplace/thank-you/woocommerce/[SITE_URL]`
* Check if the page is scrollable when you resize the screen
* Check if the `Back to plugins` page to aligned on the left end.

| Before | After |
| ----- | ------------- |
| <img width="1776" alt="Screenshot 2022-01-24 at 3 52 22 PM" src="https://user-images.githubusercontent.com/86406124/150765310-3fd46a93-9a6c-48ec-94d4-eaa251152acb.png"> | <img width="1790" alt="Screenshot 2022-01-24 at 3 52 46 PM" src="https://user-images.githubusercontent.com/86406124/150765391-3c7ad890-9bd6-48ba-9327-4effdca9949f.png"> |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60386
