### PR TITLE
Show connection error notice for expiring soon connected domain

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -63,6 +63,31 @@ export function resolveDomainStatus(
 								components: { strong: <strong /> },
 						  } );
 
+				let noticeText = null;
+
+				if ( ! domain.pointsToWpcom ) {
+					const options = {
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									href={ domainMappingSetup(
+										siteSlug,
+										domain.domain,
+										domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update'
+									) }
+									onClick={ ( e ) => e.stopPropagation() }
+								/>
+							),
+						},
+					};
+
+					noticeText = translate(
+						"We noticed that something wasn't updated correctly. Please try {{a}}this setup{{/a}} again.",
+						options
+					);
+				}
+
 				if ( isExpiringSoon( domain, 5 ) ) {
 					return {
 						statusText: expiresMessage,
@@ -72,6 +97,7 @@ export function resolveDomainStatus(
 						listStatusText: expiresMessage,
 						listStatusClass: 'alert',
 						listStatusWeight: 1000,
+						noticeText,
 					};
 				}
 
@@ -83,6 +109,7 @@ export function resolveDomainStatus(
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',
 					listStatusWeight: 800,
+					noticeText,
 				};
 			}
 


### PR DESCRIPTION
##  Changes proposed in this Pull Request

If a connected domain is expiring soon but has some connection errors we are only showing the `expiring soon` badge.

This PR adds a notice to inform the user.

![domain-fix](https://user-images.githubusercontent.com/2797601/150770652-9566e3a7-7560-480d-9e11-3d5973ee876f.png)

![settings-fix](https://user-images.githubusercontent.com/2797601/150770647-a415d4de-3285-4dd0-8483-b0e948f36b55.png)

## Testing instructions

Select a connected (mapped) domain that is expiring soon (< 30 days) and it's not pointing to `wpcom`. Make sure that in the domain list and in the domain settings page there is an alert notice as shown in the screenshots above.