### PR TITLE
`QuerySupportArticleAlternates`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-support-article-alternates/index.jsx
+++ b/client/components/data/query-support-article-alternates/index.jsx
@@ -1,50 +1,37 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
 import { isPostKeyLike } from 'calypso/reader/post-key';
 import { fetchAlternates } from 'calypso/state/support-articles-alternates/actions';
 import { shouldRequestSupportArticleAlternates } from 'calypso/state/support-articles-alternates/selectors';
 
-class QuerySupportArticleAlternates extends Component {
-	static propTypes = {
-		postKey: PropTypes.object.isRequired,
-		blogId: PropTypes.number,
-		postId: PropTypes.number.isRequired,
-		shouldRequestAlternates: PropTypes.bool,
-	};
-
-	componentDidMount() {
-		this.maybeFetch();
+const request = ( postKey ) => ( dispatch, getState ) => {
+	if ( shouldRequestSupportArticleAlternates( getState(), postKey ) ) {
+		dispatch( fetchAlternates( postKey ) );
 	}
+};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.maybeFetch( nextProps );
-	}
+function QuerySupportArticleAlternates( { blogId, postId } ) {
+	const dispatch = useDispatch();
 
-	maybeFetch = ( props = this.props ) => {
-		if ( isPostKeyLike( props.postKey ) && props.shouldRequestAlternates ) {
-			this.props.fetchAlternates( props.postKey );
+	useEffect( () => {
+		const postKey = {
+			blogId: blogId || SUPPORT_BLOG_ID,
+			postId,
+		};
+
+		if ( isPostKeyLike( postKey ) ) {
+			dispatch( request( postKey ) );
 		}
-	};
+	}, [ dispatch, blogId, postId ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const postKey = {
-			blogId: ownProps.blogId || SUPPORT_BLOG_ID,
-			postId: ownProps.postId,
-		};
+QuerySupportArticleAlternates.propTypes = {
+	blogId: PropTypes.number,
+	postId: PropTypes.number.isRequired,
+};
 
-		return {
-			postKey,
-			shouldRequestAlternates: shouldRequestSupportArticleAlternates( state, postKey ),
-		};
-	},
-	{ fetchAlternates }
-)( QuerySupportArticleAlternates );
+export default QuerySupportArticleAlternates;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QuerySupportArticleAlternates`: refactor away from `UNSAFE_*`

#### Testing instructions

* Make sure your interface language is different from the default one (`en`)
* Go to `/home` and find an inline support link (I found a few for simple sites)
* Hover over the support link and verify there's a request to `/support/alternates/:blogId/posts/:postId`
* If you click on the link, a modal should open which contains the support article in the correct language

Note: the bugfix at https://github.com/Automattic/wp-calypso/pull/45361 shows what it should look like

Related to #58453 
