### PR TITLE
Onboarding WordPress importer: show notification if the plan is not compatible

### DIFF
--- a/client/signup/steps/import-from/util.ts
+++ b/client/signup/steps/import-from/util.ts
@@ -1,3 +1,12 @@
+import { FEATURE_UPLOAD_THEMES_PLUGINS, planHasFeature } from '@automattic/calypso-products';
+import { get } from 'lodash';
+import { SitesItem } from 'calypso/state/selectors/get-sites-items';
 import { Importer } from './types';
 
 export const getImporterTypeForEngine = ( engine: Importer ) => `importer-type-${ engine }`;
+
+export function isTargetSitePlanCompatible( targetSite: SitesItem ) {
+	const planSlug = get( targetSite, 'plan.product_slug' );
+
+	return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
+}

--- a/client/signup/steps/import-from/wordpress/import-everything/confirm.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/confirm.tsx
@@ -1,4 +1,4 @@
-import { Title, SubTitle, NextButton } from '@automattic/onboarding';
+import { Title, SubTitle, NextButton, Notice } from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -17,6 +17,7 @@ interface Props {
 	sourceUrlAnalyzedData: UrlData;
 	targetSite: SitesItem | null;
 	targetSiteSlug: string;
+	isTargetSitePlanCompatible: boolean;
 	startImport: () => void;
 }
 
@@ -26,7 +27,14 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	/**
 	 ↓ Fields
 	 */
-	const { sourceSiteUrl, sourceUrlAnalyzedData, targetSite, targetSiteSlug, startImport } = props;
+	const {
+		sourceSiteUrl,
+		sourceUrlAnalyzedData,
+		targetSite,
+		targetSiteSlug,
+		isTargetSitePlanCompatible,
+		startImport,
+	} = props;
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = useState( false );
 
 	return (
@@ -97,9 +105,18 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 					) }
 				</SubTitle>
 
-				<NextButton onClick={ () => setIsModalDetailsOpen( true ) }>
-					{ __( 'Start import' ) }
-				</NextButton>
+				{ ! isTargetSitePlanCompatible && (
+					<>
+						<Notice>{ __( 'You need to upgrade your account to import everything.' ) }</Notice>
+						<NextButton onClick={ startImport }>{ __( 'See plans' ) }</NextButton>
+					</>
+				) }
+
+				{ isTargetSitePlanCompatible && (
+					<NextButton onClick={ () => setIsModalDetailsOpen( true ) }>
+						{ __( 'Start import' ) }
+					</NextButton>
+				) }
 			</div>
 
 			{ isModalDetailsOpen && (

--- a/client/signup/steps/import-from/wordpress/import-everything/index.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/index.tsx
@@ -13,16 +13,19 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { SectionMigrate } from 'calypso/my-sites/migrate/section-migrate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import { SitesItem } from 'calypso/state/selectors/get-sites-items';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { receiveSite, requestSite, updateSiteMigrationMeta } from 'calypso/state/sites/actions';
 import { getSite, getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import DoneButton from '../../components/done-button';
 import NotAuthorized from '../../components/not-authorized';
+import { isTargetSitePlanCompatible } from '../../util';
 import { MigrationStatus, WPImportOption } from '../types';
 import { Confirm } from './confirm';
 
 interface Props {
 	sourceSiteId: number | null;
+	targetSite: SitesItem;
 	targetSiteId: number | null;
 	targetSiteSlug: string;
 }
@@ -100,12 +103,19 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	renderMigrationConfirm() {
-		const { sourceSite, targetSite, targetSiteSlug, sourceUrlAnalyzedData } = this.props;
+		const {
+			sourceSite,
+			targetSite,
+			targetSiteSlug,
+			sourceUrlAnalyzedData,
+			isTargetSitePlanCompatible,
+		} = this.props;
 
 		if ( sourceSite ) {
 			return (
 				<Confirm
 					startImport={ this.startMigration }
+					isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
 					targetSite={ targetSite }
 					targetSiteSlug={ targetSiteSlug }
 					sourceSite={ sourceSite }
@@ -208,6 +218,7 @@ export const connector = connect(
 		return {
 			isTargetSiteAtomic: !! isSiteAutomatedTransfer( state, ownProps.targetSiteId as number ),
 			isTargetSiteJetpack: !! isJetpackSite( state, ownProps.targetSiteId as number ),
+			isTargetSitePlanCompatible: !! isTargetSitePlanCompatible( ownProps.targetSite as SitesItem ),
 			sourceSite: ownProps.sourceSiteId && getSite( state, ownProps.sourceSiteId ),
 			startMigration: !! get( getCurrentQueryArguments( state ), 'start', false ),
 			sourceSiteHasJetpack: false,

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -5,6 +5,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { convertToFriendlyWebsiteName } from 'calypso/signup/steps/import/util';
 import { analyzeUrl } from 'calypso/state/imports/url-analyzer/actions';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
+import { SitesItem } from 'calypso/state/selectors/get-sites-items';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { Importer, ImportJob } from '../types';
 import { ContentChooser } from './content-chooser';
@@ -101,7 +102,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 					url={ fromSite }
 					sourceSiteId={ fromSiteItem?.ID as number }
 					sourceUrlAnalyzedData={ fromSiteAnalyzedData }
-					targetSite={ siteItem }
+					targetSite={ siteItem as SitesItem }
 					targetSiteId={ siteItem?.ID as number }
 					targetSiteSlug={ siteSlug }
 				/>

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -12,4 +12,5 @@ export { default as Progress } from './progress';
 export { default as Hooray } from './hooray';
 export { default as Confetti } from './confetti';
 export { default as MShotsImage } from './mshots-image';
+export { default as Notice } from './notice';
 export type { MShotsOptions } from './mshots-image';

--- a/packages/onboarding/src/notice/index.tsx
+++ b/packages/onboarding/src/notice/index.tsx
@@ -1,0 +1,16 @@
+import { Icon, info } from '@wordpress/icons';
+import classnames from 'classnames';
+import * as React from 'react';
+
+import './style.scss';
+
+const Notice: React.FunctionComponent = ( { children } ) => {
+	return (
+		<div className={ classnames( 'onboarding-notice' ) }>
+			<Icon icon={ info } size={ 28 } />
+			<p>{ children }</p>
+		</div>
+	);
+};
+
+export default Notice;

--- a/packages/onboarding/src/notice/style.scss
+++ b/packages/onboarding/src/notice/style.scss
@@ -1,0 +1,19 @@
+.onboarding-notice {
+	display: flex;
+	color: var( --studio-gray-50 );
+	font-size: 0.875em; /* stylelint-disable-line */
+	margin-bottom: 1.5em;
+
+	svg {
+		align-self: center;
+		fill: var( --color-warning-30 );
+		flex-shrink: 0;
+		margin-right: 1em;
+		transform: rotate( 180deg );
+	}
+
+	p {
+		margin-bottom: 0;
+		line-height: 28px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added logic for checking the current plan compatibility, and if it is not, the proper message will be there.

#### Testing instructions

* Go to `/start/from/importing/wordpress?from={ORIGIN_WP_SITE}&to={SLUG}.wordpress.com`
* Check if origin site has Jetpack installed
* Select option "Everything"
* Check if there is a notification with the "See plans" button

**Note:** **See plans** action goes directly to the **checkout** screen. It will be fixed in the next iteration.

#### Screenshots
![Markup on 2022-01-24 at 23:09:35](https://user-images.githubusercontent.com/1241413/150873344-794744a5-122e-4374-948f-05f81fd1ac11.png)

Related to #59042
