### PR TITLE
Emails: Enable In-Depth Comparison page in all environments

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
@@ -146,7 +145,7 @@ const EmailProvidersStackedComparison = ( {
 				{ translate( 'Pick an email solution' ) }
 			</h1>
 
-			{ isEnabled( 'emails/in-depth-comparison' ) && selectedSite && (
+			{ selectedSite && (
 				<div className="email-providers-stacked-comparison__sub-header">
 					{ translate( 'Not sure where to start? {{a}}See how they compare{{/a}}.', {
 						components: {

--- a/config/development.json
+++ b/config/development.json
@@ -51,7 +51,6 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
-		"emails/in-depth-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
This very simple pull request enables the new `In-Depth Comparison` page in all environments. To be more specific, it enables the link on the `Email Comparison` page that leads to the former:

![image](https://user-images.githubusercontent.com/594356/150808509-7e20b637-f446-4f4b-a06f-ef6cd55abc7e.png)

#### Testing instructions

1. Access a [live branch](https://github.com/Automattic/wp-calypso/pull/60400#issuecomment-1020195137)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Click the `See how they compare` link to access the `In-Depth Comparison` page