### PR TITLE
Remove domain-only sites from `site-picker` (in domain-only signup flow)

### DIFF
--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -17,7 +17,7 @@ class SitePicker extends Component {
 	};
 
 	filterSites = ( site ) => {
-		return site.capabilities.manage_options && ! site.jetpack;
+		return site.capabilities.manage_options && ! site.jetpack && ! site.options.is_domain_only;
 	};
 
 	renderScreen() {


### PR DESCRIPTION
## Changes proposed in this Pull Request

At the moment we are wrongly showing domain-only sites in the signup flow `domain-only` (see screenshot below).

![domain-only-error](https://user-images.githubusercontent.com/2797601/150807933-52e55eb5-1ca0-489e-b177-d1091b0b3a9b.png)

This PR address this issue.

## Testing instructions

_Note: in order to test this you need at least a domain-only site._

Start the domain only-flow (/start/domain/domain-only).
- enter a domain name in the search domain step
- select "Existing WordPress.com website" in the subsequent step.
- verify that site-picker doesn't display any domain only site
