### PR TITLE
Domains: Fix "Create Site" button white screen after navigation

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -285,6 +285,7 @@ export function generateFlows( {
 			steps: [ 'themes-site-selected', 'plans-site-selected' ],
 			destination: getSiteDestination,
 			providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
+			optionalDependenciesInQuery: [ 'siteId' ],
 			description: 'A flow to test updating an existing site with `Signup`',
 			lastModified: '2017-01-19',
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a specific case where the "create site" button for domain-only sites will break and you get a WSOD.

#### Preview
##### Before
https://user-images.githubusercontent.com/18705930/150822329-794f8812-1a0e-4f62-bb54-fbde839e5079.mov

##### After
https://user-images.githubusercontent.com/18705930/150823103-1990ae38-bf7f-4c92-a465-30bcde2fbda4.mov

#### Testing instructions
- Go to a domain-only site you're the owner of;
- Click the "Create site" button;
- Select a theme and a plan;
- At the checkout page, press the browser's back button;
- Check that you're able to see the theme selection and the plan selection pages correctly (_previously, this would break the flow and you'd get the WSOD, as in the video_) 