### PR TITLE
Emails: Clean up Email Comparison page types

### DIFF
--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/index.tsx
@@ -16,7 +16,7 @@ import './style.scss';
 const noop = () => {};
 
 const EmailProvidersStackedCard = ( {
-	children,
+	appLogos = [],
 	className,
 	description,
 	detailsExpanded,
@@ -25,7 +25,6 @@ const EmailProvidersStackedCard = ( {
 	footerBadge,
 	formFields,
 	logo,
-	appLogos = [],
 	onExpandedChange = noop,
 	priceBadge = null,
 	productName,
@@ -99,8 +98,6 @@ const EmailProvidersStackedCard = ( {
 					) }
 				</div>
 			</div>
-
-			{ children }
 		</PromoCard>
 	);
 };

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -5,15 +5,10 @@ import type { Site } from 'calypso/my-sites/scan/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 export interface ProviderCardProps {
-	additionalPriceInformation?: TranslateResult;
 	appLogos?: AppLogo[];
-	badge?: ReactElement;
-	billingPeriod?: TranslateResult;
-	children?: any;
 	className?: string;
 	description: TranslateResult;
 	detailsExpanded?: boolean;
-	discount?: ReactElement | null;
 	expandButtonLabel: TranslateResult;
 	features: TranslateResult[];
 	footerBadge?: ReactElement | null;

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -1,7 +1,6 @@
 import { ReactElement } from 'react';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import type { AppLogo } from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/email-provider-stacked-features';
-import type { Site } from 'calypso/my-sites/scan/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 export interface ProviderCardProps {
@@ -22,27 +21,11 @@ export interface ProviderCardProps {
 }
 
 export type EmailProvidersStackedCardProps = {
-	cart?: any;
 	cartDomainName?: string;
 	comparisonContext: string;
-	currencyCode?: string | null;
-	currentRoute?: string;
 	detailsExpanded: boolean;
-	domain?: any;
-	domainName?: string;
-	domainsWithForwards?: any[];
-	gSuiteProductMonthly?: any;
-	gSuiteProductYearly?: any;
-	hasCartDomain?: boolean;
 	intervalLength: IntervalLength;
-	isGSuiteSupported?: boolean;
-	onExpandedChange?: ( providerKey: string, expand: boolean ) => void;
-	productsList?: string[];
-	requestingSiteDomains?: boolean;
+	onExpandedChange: ( providerKey: string, expand: boolean ) => void;
 	selectedDomainName: string;
-	selectedSite?: Site | null;
-	shoppingCartManager?: any;
 	source: string;
-	titanMailMonthlyProduct?: any;
-	titanMailYearlyProduct?: any;
 };


### PR DESCRIPTION
This pull request removes TypeScript types from the `Email Comparison` page that are no longer needed.

#### Testing instructions

1. Run `git checkout update/provider-card-props` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/60406#issuecomment-1020330089)
2. Log into a WordPress.com account with a domain but no email
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button of that domain to access the `Email Comparison` page
5. Assert that the page still works fine