### PR TITLE
Collect jetpack self hosted users intentions to buy a plugin 

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -20,7 +20,7 @@ import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { userCan } from 'calypso/lib/site/utils';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
@@ -220,9 +220,14 @@ const CTAButton = ( {
 	const updatedKeepMeUpdatedPreference = useCallback(
 		( isChecked ) => {
 			dispatch( savePreference( keepMeUpdatedPreferenceId, isChecked ) );
-			// TODO: send event
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_availability_jetpack_self_hosted', {
+					user_id: userId,
+					value: isChecked,
+				} )
+			);
 		},
-		[ keepMeUpdatedPreferenceId ]
+		[ keepMeUpdatedPreferenceId, userId ]
 	);
 
 	return (

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -256,6 +256,7 @@ const CTAButton = ( {
 			</Dialog>
 			<Button
 				className="plugin-details-CTA__install-button"
+				primary
 				onClick={ () => {
 					if ( hasEligibilityMessages ) {
 						return setShowEligibility( true );

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -277,14 +277,15 @@ const CTAButton = ( {
 			</Button>
 			{ isJetpackSelfHosted && isMarketplaceProduct && (
 				<div className="plugin-details-CTA__not-available">
-					<p>
+					<p className="plugin-details-CTA__not-available-text">
 						{ translate( 'Thanks for your interest. ' ) }
 						{ translate(
-							'Paid plugins are not yet available for Jetpack Sites but we can notify you when they are ready'
+							'Paid plugins are not yet available for Jetpack Sites but we can notify you when they are ready.'
 						) }
 					</p>
 					{ hasPreferences && (
 						<ToggleControl
+							className="plugin-details-CTA__follow-toggle"
 							label={ translate( 'Keep me updated' ) }
 							checked={ keepMeUpdatedPreference }
 							onChange={ updatedKeepMeUpdatedPreference }

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -65,6 +65,11 @@
 		&:hover {
 			background-color: var( --color-accent-60 );
 		}
+
+		&:disabled {
+			background-color: var( --color-accent-50 );
+			opacity: 70%;
+		}
 	}
 }
 

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -58,18 +58,6 @@
 	.plugin-details-CTA__install-button {
 		width: 100%;
 		padding: 12px 16px;
-		background-color: var( --color-accent-50 );
-		color: var( --studio-white );
-
-		&:focus,
-		&:hover {
-			background-color: var( --color-accent-60 );
-		}
-
-		&:disabled {
-			background-color: var( --color-accent-50 );
-			opacity: 70%;
-		}
 	}
 }
 

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -78,6 +78,18 @@
 	color: var( --studio-gray-50 );
 }
 
+.plugin-details-CTA__not-available {
+	.plugin-details-CTA__not-available-text {
+		color: var( --studio-gray-60 );
+		margin: 16px 0;
+		font-size: $font-body-small;
+	}
+
+	.plugin-details-CTA__follow-toggle label {
+		color: var( --studio-gray-80 );
+	}
+}
+
 .is-placeholder {
 	.plugin-details-CTA__price,
 	.plugin-details-CTA__install,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add keep me updated toggle and connect it with user preferences.
* Send track event on each toggle

### Testing instructions
**Don't display the message for non-self hosted jetpack sites**
* Go to the `/plugins` page (without a selected site)
* Select a paid plugin
* You shouldn't see the `Thanks for your interest...` message


**Display the message for self-hosted jetpack sites**
* Go to the `/plugins` page (without a selected site)
* Select a paid plugin (Ex: `/plugins/woocommerce-bookings/`
* Select a self-hosted jetpack site on the sidebar
* You should see the `Thanks for your interest...` message

**Persists the value on user preferences**
* Click to enable the toggle *Keep me updated*
* Close the page and reopen
* The toggle should remain enabled after the reload

**Send the track event** (automatticians only(
* Go to Tracks and check if the previous steps generated the correct events, the event name is `calypso_plugins_availability_jetpack_self_hosted`.


#### Demo
| Before  | After |
| ------------- | ------------- |
|<img width="409" alt="Screen Shot 2022-01-24 at 14 44 08" src="https://user-images.githubusercontent.com/5039531/150844668-935245e3-ee3d-49f7-b17c-a3cdb142d335.png">|<img width="409" alt="Screen Shot 2022-01-24 at 16 18 26" src="https://user-images.githubusercontent.com/5039531/150858464-264f9946-ab09-46aa-be79-b3e404f6a2c3.png">|



----

Fixes #59670