### PR TITLE
Mini-Cart: add event for when cart is shown

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -3,7 +3,7 @@ import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { MiniCart } from '@automattic/mini-cart';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MasterbarItem from '../item';
@@ -32,8 +32,15 @@ export function MasterbarCartButton( {
 	const [ isActive, setIsActive ] = useState( false );
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
+	const shouldShowCart = selectedSiteSlug && selectedSiteId && responseCart.products.length > 0;
 
-	if ( ! selectedSiteSlug || ! selectedSiteId || responseCart.products.length < 1 ) {
+	useEffect( () => {
+		if ( shouldShowCart ) {
+			reduxDispatch( recordTracksEvent( 'calypso_masterbar_cart_shown' ) );
+		}
+	}, [ shouldShowCart, reduxDispatch ] );
+
+	if ( ! shouldShowCart ) {
 		return null;
 	}
 


### PR DESCRIPTION
As a follow-up to #60274, this adds the `calypso_masterbar_cart_shown` event that fires when the cart is shown to the user. The goal being able to easily track how many people are shown and open the mini-cart.

**To test:**
- run `localStorage.setItem('debug', 'calypso:analytics')` in your browser's console and reload the page
- filter your console for `masterbar_cart` messages
- on a site with no items in the cart, verify that the `calypso_masterbar_cart_open` does not fire
- on a site with items in the cart, verify that the `calypso_masterbar_cart_open` fires once per page load
