### PR TITLE
Add improved support to getCurrencyObject() and numberFormat() to handle rounded numbers

### DIFF
--- a/packages/format-currency/src/index.js
+++ b/packages/format-currency/src/index.js
@@ -58,11 +58,11 @@ export function getCurrencyObject( number, code, options = {} ) {
 	const sign = number < 0 ? '-' : '';
 	const absNumber = Math.abs( number );
 	const rawInteger = Math.floor( absNumber );
-	const integer = numberFormat( rawInteger, {
-		decimals: 0,
+	const integer = numberFormat( absNumber, {
+		decimals: precision,
 		thousandsSep: grouping,
 		decPoint: decimal,
-	} );
+	} ).split( decimal )[ 0 ];
 	const fraction =
 		precision > 0
 			? numberFormat( absNumber - rawInteger, {

--- a/packages/format-currency/src/index.js
+++ b/packages/format-currency/src/index.js
@@ -58,6 +58,8 @@ export function getCurrencyObject( number, code, options = {} ) {
 	const sign = number < 0 ? '-' : '';
 	const absNumber = Math.abs( number );
 	const rawInteger = Math.floor( absNumber );
+	const rawFraction =
+		Number( Math.round( absNumber + `e+${ precision }` ) + `e-${ precision }` ) - rawInteger;
 	const integer = numberFormat( absNumber, {
 		decimals: precision,
 		thousandsSep: grouping,
@@ -65,7 +67,7 @@ export function getCurrencyObject( number, code, options = {} ) {
 	} ).split( decimal )[ 0 ];
 	const fraction =
 		precision > 0
-			? numberFormat( absNumber - rawInteger, {
+			? numberFormat( rawFraction, {
 					decimals: precision,
 					thousandsSep: grouping,
 					decPoint: decimal,

--- a/packages/format-currency/test/index.js
+++ b/packages/format-currency/test/index.js
@@ -119,6 +119,24 @@ describe( 'formatCurrency', () => {
 				sign: '-',
 			} );
 		} );
+		test( 'handles values that round up', () => {
+			const money = getCurrencyObject( 9.995, 'USD' );
+			expect( money ).toEqual( {
+				symbol: '$',
+				integer: '10',
+				fraction: '.00',
+				sign: '',
+			} );
+		} );
+		test( 'handles values that round down', () => {
+			const money = getCurrencyObject( 9.994, 'USD' );
+			expect( money ).toEqual( {
+				symbol: '$',
+				integer: '9',
+				fraction: '.99',
+				sign: '',
+			} );
+		} );
 		describe( 'supported currencies', () => {
 			test( 'USD', () => {
 				const money = getCurrencyObject( 9800900.32, 'USD' );

--- a/packages/i18n-calypso/src/number-format.js
+++ b/packages/i18n-calypso/src/number-format.js
@@ -6,8 +6,7 @@
  * @see https://github.com/kvz/phpjs/blob/ffe1356af23a6f2512c84c954dd4e828e92579fa/functions/strings/number_format.js
  */
 function toFixedFix( n, prec ) {
-	const k = Math.pow( 10, prec );
-	return '' + ( Math.round( n * k ) / k ).toFixed( prec );
+	return '' + Number( Math.round( +n + `e+${ prec }` ) + `e-${ prec }` ).toFixed( prec );
 }
 
 export default function number_format( number, decimals, dec_point, thousands_sep ) {

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -228,6 +228,9 @@ describe( 'I18n', function () {
 					} )
 				).toBe( '150,00' );
 			} );
+			it( 'should round 0.005 to 0.01', function () {
+				expect( numberFormat( 0.005, 2 ) ).toBe( '0,01' );
+			} );
 		} );
 
 		describe( 'overriding defaults', function () {


### PR DESCRIPTION
When computing the integer value of the currency object, `getCurrencyObject()` is currently always using the floored `rawInteger` value and not considering if it should be rounded up based on the full `absNumber` and `precision` values. 

For example, a provided value of `4.999` will result in `{ integer: '4', fraction: '.00' }`.

#### Changes proposed in this Pull Request

##### Fixes for `getCurrencyObject()`:

* Base the calculation of `integer` on the full `absNumber` value instead of the floored `rawInteger`.
* Provide the `precision` value to the calculation of `integer` so that the final rounded result is considered.
* Providing the `precision` will result in the decimal values being included in the final `integer` value, so I've cut them out via `split( decimal )[ 0 ]`.
* Add test case for rounding up and down.

##### Fixes for `numberFormat()`:

* Modify the rounding logic in `toFixedFix()` to apply the precision via numeric strings in scientific notation.
* Add test case for rounding `0.005` to `0.01`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run tests

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
