### PR TITLE
Woo Installer: Remove (optional) label from postcode field

### DIFF
--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -144,7 +144,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 
 							<div>
 								<TextControl
-									label={ __( 'Postcode (optional)' ) }
+									label={ __( 'Postcode' ) }
 									value={ get( WOOCOMMERCE_STORE_POSTCODE ) }
 									onChange={ ( value ) => {
 										update( WOOCOMMERCE_STORE_POSTCODE, value );


### PR DESCRIPTION
In #60321 I've not added an (optional) suffix to the label because I saw it as being not actually optional in many cases. We just don't want it to be blocking.

After it was added in #60322, let's discuss if it should remain or be removed.

#### Changes proposed in this Pull Request

* Removes the `(optional)` label for the post code input.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://calypso.localhost:3000/woocommerce-installation/
- Choose a test site site
- Click "Set up my store"
- Observe the Postcode field label


