### PR TITLE
Adding design setup to sell flow and setting up category sorting

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -111,6 +111,7 @@ const Designs: React.FunctionComponent = () => {
 				onSelect={ onSelect }
 				premiumBadge={ <PremiumBadge /> }
 				highResThumbnails
+				recommendedCategorySlug={ null }
 			/>
 		</div>
 	);

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -385,8 +385,8 @@ export function generateFlows( {
 				'site-options',
 				'starting-point',
 				'courses',
-				'design-setup-site',
 				'store-options',
+				'design-setup-site',
 			],
 			destination: getDestinationFromIntent,
 			description:

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -104,11 +104,29 @@ export default function DesignPickerStep( props ) {
 		setSelectedDesign( designs.find( ( { theme } ) => theme === props.stepSectionName ) );
 	}, [ designs, props.stepSectionName, setSelectedDesign ] );
 
-	const categorization = useCategorization( designs, {
-		showAllFilter: props.showDesignPickerCategoriesAllFilter,
-		defaultSelection: props.signupDependencies.intent === 'write' ? 'blog' : null,
-		sort: sortBlogToTop,
-	} );
+	const getCategorizationOptionsForStep = () => {
+		const result = {
+			showAllFilter: props.showDesignPickerCategoriesAllFilter,
+		};
+		const intent = props.signupDependencies.intent;
+		switch ( intent ) {
+			case 'write':
+				result.defaultSelection = 'blog';
+				result.sort = sortBlogToTop;
+				break;
+			case 'sell':
+				// @TODO: This should be 'ecommerce' once we have some themes with that slug.
+				result.defaultSelection = 'business';
+				result.sort = sortEcommerceToTop;
+				break;
+			default:
+				result.defaultSelection = null;
+				result.sort = sortBlogToTop;
+				break;
+		}
+		return result;
+	};
+	const categorization = useCategorization( designs, getCategorizationOptionsForStep() );
 
 	function pickDesign( _selectedDesign, additionalDependencies = {} ) {
 		// Design picker preview will submit the defaultDependencies via next button,
@@ -168,6 +186,7 @@ export default function DesignPickerStep( props ) {
 				highResThumbnails
 				premiumBadge={ <PremiumBadge /> }
 				categorization={ showDesignPickerCategories ? categorization : undefined }
+				recommendedCategorySlug={ getCategorizationOptionsForStep().defaultSelection }
 				categoriesHeading={
 					<FormattedHeader
 						id={ 'step-header' }
@@ -334,6 +353,19 @@ function sortBlogToTop( a, b ) {
 	} else if ( a.slug === 'blog' ) {
 		return -1;
 	} else if ( b.slug === 'blog' ) {
+		return 1;
+	}
+	return 0;
+}
+// Ensures Ecommerce category appears at the top of the design category list
+// (directly below the All Themes category).
+// @TODO: This should be 'ecommerce' once we have some themes with that slug.
+function sortEcommerceToTop( a, b ) {
+	if ( a.slug === b.slug ) {
+		return 0;
+	} else if ( a.slug === 'business' ) {
+		return -1;
+	} else if ( b.slug === 'business' ) {
 		return 1;
 	}
 	return 0;

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -27,7 +27,7 @@ interface Props {
 const EXCLUDE_STEPS: { [ key: string ]: string[] } = {
 	write: [ 'store-options' ],
 	build: [ 'site-options', 'starting-point', 'courses', 'store-options' ],
-	sell: [ 'site-options', 'starting-point', 'courses', 'design-setup-site' ],
+	sell: [ 'site-options', 'starting-point', 'courses' ],
 };
 
 const EXTERNAL_FLOW: { [ key: string ]: string } = {

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -9,6 +9,7 @@ interface Props {
 	categories: Category[];
 	onSelect: ( selectedSlug: string | null ) => void;
 	selectedCategory: string | null;
+	recommendedCategorySlug: string | null;
 	heading?: ReactNode;
 	footer?: ReactNode;
 }
@@ -19,6 +20,7 @@ export function DesignPickerCategoryFilter( {
 	selectedCategory,
 	heading,
 	footer,
+	recommendedCategorySlug,
 }: Props ): ReactElement | null {
 	const instanceId = useInstanceId( DesignPickerCategoryFilter );
 	const { __ } = useI18n();
@@ -60,7 +62,12 @@ export function DesignPickerCategoryFilter( {
 						tabIndex={ slug === selectedCategory ? undefined : -1 }
 						className="design-picker-category-filter__menu-item"
 					>
-						{ name }
+						<span className="design-picker-category-filter__item-name">{ name }</span>{ ' ' }
+						{ recommendedCategorySlug === slug && (
+							<span className="design-picker-category-filter__recommended-badge">
+								{ __( 'Recommended' ) }
+							</span>
+						) }
 					</MenuItem>
 				) ) }
 			</NavigableMenu>

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -22,19 +22,23 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 		&:active:not( :disabled ) {
 			box-shadow: none;
 			background: transparent;
-			text-decoration: underline;
-			color: $design-picker-category-filter-text-color-active;
+			.design-picker-category-filter__item-name {
+				text-decoration: underline;
+				color: $design-picker-category-filter-text-color-active;
+			}
 		}
 
 		&.is-pressed {
-			text-decoration: underline;
-			font-weight: 500; /* stylelint-disable-line scales/font-weights */
-			color: $design-picker-category-filter-text-color-active;
-			background: transparent;
-
-			&:hover:not( :disabled ) {
+			.design-picker-category-filter__item-name {
+				text-decoration: underline;
+				font-weight: 500; /* stylelint-disable-line scales/font-weights */
 				color: $design-picker-category-filter-text-color-active;
+
+				&:hover:not( :disabled ) {
+					color: $design-picker-category-filter-text-color-active;
+				}
 			}
+			background: transparent;
 
 			&:focus:not( :disabled ),
 			&:focus-visible:not( :disabled ) {
@@ -45,6 +49,17 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 			&:focus:not( :disabled ):not( :focus-visible ) {
 				box-shadow: none;
 			}
+		}
+
+		.design-picker-category-filter__recommended-badge {
+			display: inline-block;
+			font-size: 0.75rem;
+			padding: 0 10px;
+			line-height: 20px;
+			margin-left: 12px;
+			background-color: #b8e6bf;
+			color: #00450c;
+			border-radius: 4px;
 		}
 
 		.components-menu-item__item {

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -211,6 +211,7 @@ export interface DesignPickerProps {
 	categorization?: Categorization;
 	categoriesHeading?: React.ReactNode;
 	categoriesFooter?: React.ReactNode;
+	recommendedCategorySlug: string | null;
 	hideFullScreenPreview?: boolean;
 	hideDesignTitle?: boolean;
 }
@@ -231,6 +232,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	categorization,
 	hideFullScreenPreview,
 	hideDesignTitle,
+	recommendedCategorySlug,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
@@ -252,6 +254,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				<DesignPickerCategoryFilter
 					categories={ categorization.categories }
 					selectedCategory={ categorization.selection }
+					recommendedCategorySlug={ recommendedCategorySlug }
 					onSelect={ categorization.onSelect }
 					heading={ categoriesHeading }
 					footer={ categoriesFooter }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the new (under development) 'sell' flow of the onboarding process to include a design picker step which sorts a category to the top of the categories list and auto-selects it. 
    * Currently this auto-selected category is "Business", contrasting to the 'Write' flow which auto-selects "Blog" as the design category, but it will be "E-Commerce" when we have some themes set up with that category.
* It also updates the design picker view to include a "Recommended" badge on the category associated with the current flow, as indicated in 9XooISHKU1phs4Ju2Yyy5p-fi-211%3A4375

**Note that this new step will eventually be after the "simple vs more" step being developed in #60155, and also requires the addition of appropriately tagged themes as described in #60152 - we will want to either wait to merge this until that additional work is all done, or set up a separate issue to revisit this for the necessary updates.**

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to local Calypso environment.
* Navigate to `/start` and follow the onboarding flow, selecting "Sell" on the intent screen.
* Verify that after site options (name and tagline), the user is next directed to the design picker, and that the "Business" category is auto-selected with a "Recommended" badge.

![image](https://user-images.githubusercontent.com/13437011/150858156-b7c89d36-c6d7-4ead-b155-b017946dfac0.png)

* Verify that if you go back and choose the "Blog" intent, the design picker instead auto-selects the "Blog" category with recommended badge.
* Verify that if you go back and choose the "Build" intent, the design picker auto-selects "Show All" as normal.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #60265 