### PR TITLE
Anchor: Remove the My Home prompt for Atomic sites.

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -15,6 +15,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
 	getSiteFrontPage,
@@ -35,6 +36,7 @@ export const QuickLinks = ( {
 	canManageSite,
 	canModerateComments,
 	customizeUrl,
+	isAtomic,
 	isStaticHomePage,
 	showCustomizer,
 	canAddEmail,
@@ -198,15 +200,17 @@ export const QuickLinks = ( {
 						external
 						iconSrc={ fiverrIcon }
 					/>
-					<ActionBox
-						href="https://anchor.fm/wordpressdotcom"
-						onClick={ trackAnchorPodcastAction }
-						target="_blank"
-						label={ translate( 'Create a podcast with Anchor' ) }
-						external
-						iconSrc={ anchorLogoIcon }
-					/>
 				</>
+			) }
+			{ canManageSite && ! isAtomic && (
+				<ActionBox
+					href="https://anchor.fm/wordpressdotcom"
+					onClick={ trackAnchorPodcastAction }
+					target="_blank"
+					label={ translate( 'Create a podcast with Anchor' ) }
+					external
+					iconSrc={ anchorLogoIcon }
+				/>
 			) }
 		</div>
 	);
@@ -398,6 +402,7 @@ const mapStateToProps = ( state ) => {
 		siteSlug,
 		isStaticHomePage,
 		editHomePageUrl,
+		isAtomic: isSiteAtomic( state, siteId ),
 		isExpanded: getPreference( state, 'homeQuickLinksToggleStatus' ) !== 'collapsed',
 		isUnifiedNavEnabled: isNavUnificationEnabled,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),


### PR DESCRIPTION
Atomic sites have been problematic for our Anchor integration; let's remove the prompt to set up an Anchor site from the Quick Links of Atomic sites. With this PR, only simple sites will have the prompt.

| Simple | Atomic |
| --- | --- |
| <img width="328" alt="Screen Shot 2022-01-24 at 2 39 00 PM" src="https://user-images.githubusercontent.com/349751/150877315-d1dc66a7-7fa5-4402-8236-588628b063ca.png"> | <img width="325" alt="Screen Shot 2022-01-24 at 2 38 45 PM" src="https://user-images.githubusercontent.com/349751/150877331-5de846f6-9562-453e-93b3-4964a83e2fc7.png"> |

See: pc4f5j-13S-p2

Fixes: #60211 

**Testing Instructions**
* Load the calypso.live link for this PR.
* Verify that simple sites still have the My Home Quick Link for Anchor.
* Verify that WoA sites do not have the My Home Quick Link for Anchor.