### PR TITLE
New Hire Onboarding: Add placeholder attribute to My Home section

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -58,7 +58,7 @@ const Home = ( { canUserUseCustomerHome, site, siteId, trackViewSiteAction, noti
 	}
 
 	const header = (
-		<div className="customer-home__heading">
+		<div className="customer-home__heading" data-hello="world">
 			<FormattedHeader
 				brandFont
 				headerText={ translate( 'My Home' ) }


### PR DESCRIPTION
This is a dummy commit for new hire onboarding purposes, which does not do anything to the real app.

#### Testing instructions

Run Calypso locally and inspect the "My Home" heading as follows:

![image](https://user-images.githubusercontent.com/1525580/150906994-5a5bc481-8354-4ab6-9c1c-ddd466fd24d6.png)

Resolves #60423 
