### PR TITLE
Reader: Refactor `QueryReaderLists` away from `UNSAFE_` React lifecycle methods

### DIFF
--- a/client/components/data/query-reader-lists/index.jsx
+++ b/client/components/data/query-reader-lists/index.jsx
@@ -1,40 +1,13 @@
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestSubscribedLists } from 'calypso/state/reader/lists/actions';
-import { isRequestingSubscribedLists } from 'calypso/state/reader/lists/selectors';
 
-class QueryReaderLists extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		if ( this.props.isRequestingSubscribedLists ) {
-			return;
-		}
+export default function QueryReaderLists() {
+	const dispatch = useDispatch();
 
-		this.props.requestSubscribedLists();
-	}
+	useEffect( () => {
+		dispatch( requestSubscribedLists() );
+	}, [ dispatch ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
-
-QueryReaderLists.propTypes = {
-	isRequestingSubscribedLists: PropTypes.bool,
-	requestSubscribedLists: PropTypes.func,
-};
-
-QueryReaderLists.defaultProps = {
-	requestSubscribedLists: () => {},
-};
-
-export default connect(
-	( state ) => {
-		return {
-			isRequestingSubscribedLists: isRequestingSubscribedLists( state ),
-		};
-	},
-	{
-		requestSubscribedLists,
-	}
-)( QueryReaderLists );

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -16,17 +16,6 @@ export function isRequestingList( state ) {
 }
 
 /**
- * Returns true if currently requesting Reader lists, or
- * false otherwise.
- *
- * @param  {object}  state  Global state tree
- * @returns {boolean}        Whether lists are being requested
- */
-export function isRequestingSubscribedLists( state ) {
-	return !! state.reader.lists.isRequestingLists;
-}
-
-/**
  * Returns true if currently creating a Reader list.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/reader/lists/test/selectors.js
+++ b/client/state/reader/lists/test/selectors.js
@@ -1,6 +1,5 @@
 import {
 	isRequestingList,
-	isRequestingSubscribedLists,
 	getSubscribedLists,
 	isUpdatedList,
 	getListByOwnerAndSlug,
@@ -29,32 +28,6 @@ describe( 'selectors', () => {
 				reader: {
 					lists: {
 						isRequestingList: true,
-					},
-				},
-			} );
-
-			expect( isRequesting ).toBeTruthy();
-		} );
-	} );
-
-	describe( '#isRequestingSubscribedLists()', () => {
-		test( 'should return false if not fetching', () => {
-			const isRequesting = isRequestingSubscribedLists( {
-				reader: {
-					lists: {
-						isRequestingLists: false,
-					},
-				},
-			} );
-
-			expect( isRequesting ).toBeFalsy();
-		} );
-
-		test( 'should return true if fetching', () => {
-			const isRequesting = isRequestingSubscribedLists( {
-				reader: {
-					lists: {
-						isRequestingLists: true,
 					},
 				},
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `QueryReaderLists` component away from the `UNSAFE_` deprecated React component methods. We convert it to a functional component, and remove the `isRequestingSubscribedLists` call, because this request uses the data layer and it will already deduplicate it. Furthermore, we delete the `isRequestingSubscribedLists` selector because it's no longer used (not its reducer though, because it's still used).

Part of #58453.

#### Testing instructions
* Go to `/read`
* Verify a request to `read/lists` is made and the lists in the Reader sidebar populate properly.