### PR TITLE
Fix verification error notice not shown on domains page

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -256,7 +256,7 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( domain.isPendingIcannVerification && domain.currentUserCanManage ) {
+			if ( domain.isPendingIcannVerification ) {
 				const noticeText = domain.currentUserIsOwner
 					? translate(
 							'We sent you an email to verify your contact information. Please complete the verification or your domain will stop working. You can also {{a}}change your email address{{/a}} if you like.',


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes an issue that prevented **Pending email verification notice** from being displayed, in site domains/all domains and domain settings page for users with `currentUserCanManage` flag set to `false`.

(see p2MSmN-97q-p2)

![issue-before](https://user-images.githubusercontent.com/2797601/150960568-2f55771f-0b21-41dc-be27-7e16a2946e16.png)

![issue-after](https://user-images.githubusercontent.com/2797601/150960580-9a58983c-6963-4721-b2b4-c4b3f1af06df.png)


## Testing instructions

- Select a site that has a not verified domain with the property `currentUserCanManage` set to false (you can modify the domain property using React dev tools or you can apply this patch on you sandbox 2b766-pb/)
- Verify that under the domain is showed the notice about Email pending verification (and the status is set to `Verify Email`)