### PR TITLE
Replace getPreviousPath with getPreviousRoute to get query params support

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -13,7 +13,7 @@ import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount, getCurrentUser } from 'calypso/state/current-user/selectors';
-import getPreviousPath from 'calypso/state/selectors/get-previous-path.js';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -362,7 +362,7 @@ export default connect(
 			currentSelectedSiteSlug: currentSelectedSiteId
 				? getSiteSlug( state, currentSelectedSiteId )
 				: undefined,
-			previousPath: getPreviousPath( state ),
+			previousPath: getPreviousRoute( state ),
 			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			isNavUnificationEnabled: isNavUnificationEnabled( state ),

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -38,7 +38,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import getIsIntroOfferRequesting from 'calypso/state/selectors/get-is-requesting-into-offers';
-import getPreviousPath from 'calypso/state/selectors/get-previous-path';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -138,7 +138,7 @@ export default function CompositeCheckout( {
 	/** Customized cancel url for PayPal */
 	customizedCancelUrl?: string;
 } ): JSX.Element {
-	const previousPath = useSelector( getPreviousPath );
+	const previousPath = useSelector( getPreviousRoute );
 	const translate = useTranslate();
 	const isJetpackNotAtomic =
 		useSelector(

--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -3,7 +3,7 @@ import { useCallback, useState, useRef, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import getPreviousPath from 'calypso/state/selectors/get-previous-path';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import useValidCheckoutBackUrl from './use-valid-checkout-back-url';
 import type { RemoveProductFromCart, ResponseCart } from '@automattic/shopping-cart';
 
@@ -15,7 +15,7 @@ export default function useRemoveFromCartAndRedirect(
 	isRemovingProductFromCart: boolean;
 	removeProductFromCartAndMaybeRedirect: RemoveProductFromCart;
 } {
-	const previousPath = useSelector( getPreviousPath );
+	const previousPath = useSelector( getPreviousRoute );
 	const cartKey = useCartKey();
 	const { removeProductFromCart } = useShoppingCart( cartKey );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Support for taking query params from the previous path.

#### Testing instructions for dev environment

* Go to `/start/from/importing/wordpress?from={ORIGIN_WP_SITE}&to={SLUG}.wordpress.com`
  * ORIGIN_WP_SITE should have a Jetpack connection
  * {SLUG}.wordpress.com should be a simple site
* Select the "Import everything" option
* Press the "Start import" button
* It redirects to the "Checkout" screen
* From the checkout screen, click the close (X) button on the top-left corner
* Then, pick "Empty cart" or "Leave items" action
* Check if redirection to the previous page works (should be the same screen as it was before the checkout page)

Related to
- #59042
- #60241
