### PR TITLE
Remove emails/new-email-comparison feature flag

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -1,4 +1,3 @@
-import { isEnabled as isConfigEnabled } from '@automattic/calypso-config';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailForwarding from 'calypso/my-sites/email/email-forwarding';
 import EmailForwardsAdd from 'calypso/my-sites/email/email-forwards-add';
@@ -6,7 +5,6 @@ import EmailManagementHome from 'calypso/my-sites/email/email-management/email-h
 import TitanControlPanelRedirect from 'calypso/my-sites/email/email-management/titan-control-panel-redirect';
 import TitanManageMailboxes from 'calypso/my-sites/email/email-management/titan-manage-mailboxes';
 import TitanManagementIframe from 'calypso/my-sites/email/email-management/titan-management-iframe';
-import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
 import EmailProvidersInDepthComparison from 'calypso/my-sites/email/email-providers-comparison/in-depth';
 import { castIntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
@@ -95,24 +93,16 @@ export default {
 	},
 
 	emailManagementPurchaseNewEmailAccount( pageContext, next ) {
-		const comparisonComponent = ! isConfigEnabled( 'emails/new-email-comparison' ) ? (
-			<EmailProvidersComparison
-				comparisonContext="email-purchase"
-				selectedDomainName={ pageContext.params.domain }
-				source={ pageContext.query.source }
-			/>
-		) : (
-			<EmailProvidersStackedComparison
-				comparisonContext="email-purchase"
-				selectedDomainName={ pageContext.params.domain }
-				selectedEmailProviderSlug={ pageContext.query.provider }
-				selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
-				source={ pageContext.query.source }
-			/>
-		);
-
 		pageContext.primary = (
-			<CalypsoShoppingCartProvider>{ comparisonComponent }</CalypsoShoppingCartProvider>
+			<CalypsoShoppingCartProvider>
+				<EmailProvidersStackedComparison
+					comparisonContext="email-purchase"
+					selectedDomainName={ pageContext.params.domain }
+					selectedEmailProviderSlug={ pageContext.query.provider }
+					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
+					source={ pageContext.query.source }
+				/>
+			</CalypsoShoppingCartProvider>
 		);
 
 		next();

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -14,13 +13,11 @@ import SectionHeader from 'calypso/components/section-header';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
-import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
 import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
-import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
 import EmailProvidersComparisonStacked from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
@@ -84,15 +81,8 @@ class EmailManagementHome extends Component {
 			} );
 
 			if ( ! domainHasEmail( selectedDomain ) ) {
-				return isEnabled( 'emails/new-email-comparison' ) ? (
+				return (
 					<EmailProvidersComparisonStacked
-						comparisonContext="email-home-selected-domain"
-						selectedDomainName={ selectedDomainName }
-						source={ source }
-					/>
-				) : (
-					<EmailProvidersComparison
-						backPath={ domainManagementList( selectedSite.slug, null ) }
 						comparisonContext="email-home-selected-domain"
 						selectedDomainName={ selectedDomainName }
 						source={ source }
@@ -117,17 +107,10 @@ class EmailManagementHome extends Component {
 		const domainsWithNoEmail = nonWpcomDomains.filter( ( domain ) => ! domainHasEmail( domain ) );
 
 		if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
-			return isEnabled( 'emails/new-email-comparison' ) ? (
+			return (
 				<EmailProvidersComparisonStacked
 					comparisonContext="email-home-single-domain"
 					selectedDomainName={ domainsWithNoEmail[ 0 ].name }
-					source={ source }
-				/>
-			) : (
-				<EmailProvidersComparison
-					comparisonContext="email-home-single-domain"
-					selectedDomainName={ domainsWithNoEmail[ 0 ].name }
-					skipHeaderElement={ true }
 					source={ source }
 				/>
 			);

--- a/config/development.json
+++ b/config/development.json
@@ -52,7 +52,6 @@
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"emails/in-depth-comparison": true,
-		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -29,7 +29,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -31,7 +31,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,7 +30,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -34,7 +34,6 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
-		"emails/new-email-comparison": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the `emails/new-email-comparison` feature flag from Calypso, as we launched the related features on 2022-01-10.

#### Testing instructions

* Run this patch locally or via [the Calypso live branch](https://github.com/Automattic/wp-calypso/pull/60448#issuecomment-1021168149).
* For a site with multiple domains, with at least one domain not having an email subscription, navigate to Upgrades -> Emails
* Click on "Add Email" for a domain
* Verify that you see the email comparison page with a toggle for monthly and annual billing
* Switch to a site that only has one domain without email, and then navigate to Upgrades -> Emails
* Verify that you see the email comparison page with a toggle for monthly and annual billing
* Navigate to Inbox
* Verify that you see the email comparison page with a toggle for monthly and annual billing