### PR TITLE
Domains: Refactor `StateSelect` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -4,6 +4,7 @@ import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import { v4 as uuid } from 'uuid';
 import QueryCountryStates from 'calypso/components/data/query-country-states';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -14,8 +15,6 @@ import { getCountryStates } from 'calypso/state/country-states/selectors';
 import Input from './input';
 
 class StateSelect extends PureComponent {
-	static instances = 0;
-
 	inputRef = ( element ) => {
 		this.inputElement = element;
 
@@ -29,11 +28,6 @@ class StateSelect extends PureComponent {
 			this.props.inputRef.current = element;
 		}
 	};
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.instance = ++this.constructor.instances;
-	}
 
 	recordStateSelectClick = () => {
 		const { eventFormName, recordGoogleEvent: recordEvent } = this.props;
@@ -69,6 +63,7 @@ class StateSelect extends PureComponent {
 			selectText,
 		} = this.props;
 		const validationId = `validation-field-${ this.props.name }`;
+		const fieldId = uuid();
 
 		return (
 			<>
@@ -77,13 +72,13 @@ class StateSelect extends PureComponent {
 					<Input inputRef={ this.inputRef } { ...this.props } />
 				) : (
 					<div className={ classes }>
-						<FormLabel htmlFor={ `${ this.constructor.name }-${ this.instance }` }>
+						<FormLabel htmlFor={ `${ this.constructor.name }-${ fieldId }` }>
 							{ this.props.label }
 						</FormLabel>
 						<FormSelect
 							aria-invalid={ isError }
 							aria-describedby={ validationId }
-							id={ `${ this.constructor.name }-${ this.instance }` }
+							id={ `${ this.constructor.name }-${ fieldId }` }
 							name={ name }
 							value={ value }
 							disabled={ disabled }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `StateSelect` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/domains/add/:site` where `:site` is one of your WP.com simple sites.
* Input some random `.com` domain name and click "Select" on the first result.
* If you see the Professional Email (Titan) / Google Workspace, click "Skip"
* On the checkout page, next to "Contact Information", click "Edit".
* On the country field, pick "United States". 
* Verify the state field still works well and gets focused when you click on its corresponding label.