### PR TITLE
Update gutenboarding 'calypso_fse_enrolled' tracks event to site creation step.

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -16,7 +16,6 @@ import { usePageViewTracksEvents } from './hooks/use-page-view-tracks-events';
 import useSignup from './hooks/use-signup';
 import useSiteTitle from './hooks/use-site-title';
 import useTrackOnboardingStart from './hooks/use-track-onboarding-start';
-import { trackEventWithFlow } from './lib/analytics';
 import { name, settings } from './onboarding-block';
 import './style.scss';
 import '@wordpress/components/build-style/style.css';
@@ -33,10 +32,6 @@ const Gutenboard: React.FunctionComponent = () => {
 	useSiteTitle();
 	const { showSignupDialog, onSignupDialogClose } = useSignup();
 	const effectiveFontPairings = useFontPairings();
-
-	React.useEffect( () => {
-		trackEventWithFlow( 'calypso_fse_enrolled' );
-	}, [] );
 
 	// Enable anti-aliasing font smoothing on Gutenboarding.
 	React.useEffect( () => {

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -3,8 +3,10 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
 import { useInterval } from '../../../../lib/interval/use-interval';
+import { FLOW_ID } from '../../constants';
 import { useSelectedPlan } from '../../hooks/use-selected-plan';
 import { useTrackStep } from '../../hooks/use-track-step';
+import { trackEventWithFlow } from '../../lib/analytics';
 import { STORE_KEY } from '../../stores/onboard';
 
 import './style.scss';
@@ -28,6 +30,12 @@ const CreateSite: React.FunctionComponent = () => {
 	const totalSteps = steps.current.length;
 
 	const [ currentStep, setCurrentStep ] = React.useState( 0 );
+
+	// Gutenboarding now always enrolls the user in FSE, so this event should always fire on site
+	// creation.
+	React.useEffect( () => {
+		trackEventWithFlow( 'calypso_fse_enrolled', { site_enrolled: true, flow: FLOW_ID } );
+	}, [] );
 
 	/**
 	 * Completion progress: 0 <= progress <= 1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently the `calypso_fse_enrolled` event is being sent as gutenboarding is loaded. Instead, we don't want this event to fire until the site is actually in the creation stage. Here we move the useEffect hook to the CreateSite step and add extra properties for better segmentation.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the event is no longer triggered at the first step of `/new`.
* Verify the event is sent once the site is created with added properties `site_enrolled: true` and `flow: 'gutenboarding'`.

Event sent can be seen by filtering the network tab of the browser inspection by `t.gif`:

![Screen Shot 2022-01-25 at 8 54 07 AM](https://user-images.githubusercontent.com/28742426/150989940-31b8364b-940e-4efa-a4a7-98dcfe5783a9.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
