### PR TITLE
i18n: Wrap "Try again" team list fetch retry button  in translate call

### DIFF
--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -18,7 +18,7 @@ const useErrorNotice = ( error, refetch ) => {
 		dispatch(
 			errorNotice( translate( 'There was an error retrieving users' ), {
 				id: 'site-users-notice',
-				button: 'Try again.',
+				button: translate( 'Try again' ),
 				onClick: () => {
 					dispatch( removeNotice( 'site-users-notice' ) );
 					refetch();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap "Try again." retrieve users re-try button with translate call.
* Remove "." from the label, so that the original that is already translated can be reused. Also, it's not really needed since it's a button.

**Before:**
![CleanShot 2022-01-25 at 15 50 19](https://user-images.githubusercontent.com/2722412/150989765-47b25339-ea86-489d-9c1a-0a2010603a4d.png)

**After:**
![CleanShot 2022-01-25 at 15 49 47](https://user-images.githubusercontent.com/2722412/150989776-2a7261fd-06b6-453f-b07c-c9773154fe83.png)


#### Testing instructions

* Checkout the branch locally or use calypso.live image.
* Change the UI to a Mag-16 language and go to `/people/team/`.
* Block the request to `public-api.wordpress.com/rest/v1.1/sites/*/users` in order to get the error notice. In Chrome, you can use the `Enable requests blocking` tab. In Firefox, requests can be blocked from the Network tab. Other browsers should have similar functionality, please refer to their respective documentation. 
* Confirm the "Try again" button is translated.

Related to 374-gh-Automattic/i18n-issues
