### PR TITLE
Domains: Refactor `DomainSearch` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -97,24 +97,20 @@ class DomainSearch extends Component {
 			} );
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.checkSiteIsUpgradeable( this.props );
+
+		this.isMounted = true;
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.selectedSiteId !== this.props.selectedSiteId ) {
-			this.checkSiteIsUpgradeable( nextProps );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.selectedSiteId !== this.props.selectedSiteId ) {
+			this.checkSiteIsUpgradeable( this.props );
 		}
 	}
 
 	componentWillUnmount() {
 		this.isMounted = false;
-	}
-
-	componentDidMount() {
-		this.isMounted = true;
 	}
 
 	checkSiteIsUpgradeable( props ) {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -98,14 +98,14 @@ class DomainSearch extends Component {
 	};
 
 	componentDidMount() {
-		this.checkSiteIsUpgradeable( this.props );
+		this.checkSiteIsUpgradeable();
 
 		this.isMounted = true;
 	}
 
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.selectedSiteId !== this.props.selectedSiteId ) {
-			this.checkSiteIsUpgradeable( this.props );
+			this.checkSiteIsUpgradeable();
 		}
 	}
 
@@ -113,8 +113,8 @@ class DomainSearch extends Component {
 		this.isMounted = false;
 	}
 
-	checkSiteIsUpgradeable( props ) {
-		if ( props.selectedSite && ! props.isSiteUpgradeable ) {
+	checkSiteIsUpgradeable() {
+		if ( this.props.selectedSite && ! this.props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add' );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `DomainSearch` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/domains/add/:site` where `:site` is a WP.com simple site where your user is an admin.
* Verify you can still search for domains and add them to your cart.
* Switch to a site where you're an author or editor.
* Verify you're redirected to the site picker.
* Verify that after selecting a site you're an admin of, you can see the domain search form again.