### PR TITLE
Domains style fixes: Edit contact info and Transfer

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
@@ -34,7 +34,7 @@
 	}
 	.formatted-header__title {
 		font-weight: 400;
-		margin: 0;
+		margin: 0 0 4px;
 		line-height: 100%;
 
 		@include break-zoomed-in {

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -54,6 +54,13 @@
 				margin-bottom: 0;
 				font-size: $font-body-small;
 			}
+
+			&:last-child {
+				margin-bottom: 8px;
+				@include break-mobile {
+					margin-bottom: 0;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR address to small style fixes for the redesigned `Edit concat info` and `Transfer` pages.

- `Transfer`: remove extra margin under "To another WordPress.com site" card
- `Edit concat info`: add 4px bottom margin under page title

![transfer-before](https://user-images.githubusercontent.com/2797601/150996421-f64ba5f1-01d5-421c-afd6-8ebc84d553da.png)

![transfer-after](https://user-images.githubusercontent.com/2797601/150996434-a8514e67-5055-438d-98f4-c3ca262e4a58.png)

![contact-before](https://user-images.githubusercontent.com/2797601/150996475-2621c7d8-7c68-4654-85de-1f22a9960dbd.png)

![contact-after](https://user-images.githubusercontent.com/2797601/150996489-7030133f-ef6c-4201-8f85-44c59718a8c9.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades -> Domains" and select a registered domain.
- Open the` Edit contact info` page and verify that the fix described above is applied
- Open the `Transfer` page and verify that the fix described above is applied