### PR TITLE
Purchases: Refactor `ManagePurchase` away from `UNSAFE_` methods

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -151,17 +151,15 @@ class ManagePurchase extends Component {
 		cancelLink: null,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( ! this.isDataValid() ) {
 			page.redirect( this.props.purchaseListUrl );
 			return;
 		}
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
+	componentDidUpdate( prevProps ) {
+		if ( this.isDataValid( prevProps ) && ! this.isDataValid() ) {
 			page.redirect( this.props.purchaseListUrl );
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ManagePurchase` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/me/purchases/:site/:number` where `:site` is one of your sites and `:number` is a random number that does not match one of your purchase IDs.
* Verify you're redirected to `/me/purchases` after a short while.