### PR TITLE
i18n: Localize Support Documents Link on Purchase Thank You Screen

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -146,6 +147,7 @@ const ThankYouSupportSection = ( props: ThankYouSupportSectionProps ) => {
 
 export const ThankYou = ( props: ThankYouProps ): JSX.Element => {
 	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
 
 	const {
 		headerBackgroundColor = 'var( --studio-blue-50 )',
@@ -193,7 +195,7 @@ export const ThankYou = ( props: ThankYouProps ): JSX.Element => {
 				title: translate( 'Ask a question' ),
 			},
 			{
-				href: SUPPORT_ROOT,
+				href: localizeUrl( SUPPORT_ROOT ),
 				title: translate( 'View support documentation' ),
 			},
 		],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Localize Support Documents link on Purchase Thank You screen.

![CleanShot 2022-01-25 at 16 38 55](https://user-images.githubusercontent.com/2722412/150997903-be085393-f8dd-4582-b8e8-7493103f217a.png)


#### Testing instructions

* Checkout the branch locally or use calypso.live.
* Change UI to any Mag-16 language.
* Complete a purchase for Proffesional Email (or Domain).
* Validate that the link to the Support Documents on the Thank You page points to the localized Support Documents site.

Related to 373-gh-Automattic/i18n-issues