### PR TITLE
Launch new WooCommerce install steps by removing woop flag checks.

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -415,9 +415,7 @@ export function generateFlows( {
 		{
 			name: 'woocommerce-install',
 			pageTitle: translate( 'Add WooCommerce to your site' ),
-			steps: isEnabled( 'woop' )
-				? [ 'store-address', 'business-info', 'confirm', 'transfer' ]
-				: [ 'confirm', 'transfer' ],
+			steps: [ 'store-address', 'business-info', 'confirm', 'transfer' ],
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',
 			providesDependenciesInQuery: [ 'site' ],

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
@@ -142,8 +141,6 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 			flowName="woocommerce-install"
 			hideSkip={ true }
 			nextLabelText={ __( 'Confirm' ) }
-			allowBackFirstStep={ ! isEnabled( 'woop' ) }
-			backUrl={ isEnabled( 'woop' ) ? null : `/woocommerce-installation/${ wpcomDomain }` }
 			headerText={ __( 'One final step' ) }
 			fallbackHeaderText={ __( 'One final step' ) }
 			subHeaderText={ __(

--- a/config/development.json
+++ b/config/development.json
@@ -149,7 +149,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"woocommerce/extension-referrers": true,
-		"woop": true,
+		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removed woop flag checks from the installation flow, exposing the address and business profile steps to users.

#### Testing instructions

* Try installing WooCommerce on your test site without a woop flag in your URL.
* You should see the address and business profile steps.
* Going "back" on the confirm page should take you back to the profile page step.
