### PR TITLE
Domains: Add domain name property to `calypso_domain_management_transfer_connected_domain_nudge_link_click` event

### DIFF
--- a/client/my-sites/domains/domain-management/components/transfer-connected-domain-nudge/index.tsx
+++ b/client/my-sites/domains/domain-management/components/transfer-connected-domain-nudge/index.tsx
@@ -30,6 +30,7 @@ const TransferConnectedDomainNudge = ( {
 
 	const trackNudgeLinkClick = (): boolean => {
 		recordTracksEvent( 'calypso_domain_management_transfer_connected_domain_nudge_link_click', {
+			domain: domain.name,
 			location,
 		} );
 		return true;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the `calypso_domain_management_transfer_connected_domain_nudge_link_click` tracks event added in #60227 with an additional `domain` property, which stores the name of the domain for which the nudge was shown.

### Testing instructions

- Build this branch locally or open the live Calypso link
- If you don't have a connected domain which is going to expire in less than 45 days at the registry, set up the mocked domains list by adding `define( 'USE_STORE_SANDBOX', true );` and `define( 'USE_MOCKED_DOMAINS_LIST', true );` to your `0-sandbox.php` file
- In your developer console, execute `localStorage.setItem( 'debug', 'calypso:analytics*' );` to turn on the debugging mode of Calypso analytics and reload your page
- Go to the domains list and find the connected domain that's going to expire soon
- Click on the "transferring it" link in the "Consider transferring it to WordPress.com" nudge
- Ensure the `calypso_domain_management_transfer_connected_domain_nudge_link_click` is fired with a `domain` property