### PR TITLE
Fix post checkout flow for Professional Email upsell

### DIFF
--- a/client/my-sites/checkout/post-checkout-upsell-experiment-redirector/index.tsx
+++ b/client/my-sites/checkout/post-checkout-upsell-experiment-redirector/index.tsx
@@ -44,11 +44,16 @@ export default function PostCheckoutUpsellExperimentRedirector( {
 		}
 
 		if ( upsellExperimentAssignmentName === experimentAssignment?.variationName ) {
-			page( upsellUrl );
-			return;
+			//page( upsellUrl );
+			//return;
+			if ( getThankYouUrl() ) {
+				// remove this condition
+			}
 		}
 
-		page( getThankYouUrl() );
+		//page( getThankYouUrl() );
+
+		page( upsellUrl );
 	} );
 
 	return null;

--- a/client/my-sites/checkout/post-checkout-upsell-experiment-redirector/index.tsx
+++ b/client/my-sites/checkout/post-checkout-upsell-experiment-redirector/index.tsx
@@ -44,16 +44,11 @@ export default function PostCheckoutUpsellExperimentRedirector( {
 		}
 
 		if ( upsellExperimentAssignmentName === experimentAssignment?.variationName ) {
-			//page( upsellUrl );
-			//return;
-			if ( getThankYouUrl() ) {
-				// remove this condition
-			}
+			page( upsellUrl );
+			return;
 		}
 
-		//page( getThankYouUrl() );
-
-		page( upsellUrl );
+		page( getThankYouUrl() );
 	} );
 
 	return null;

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -34,6 +34,7 @@ import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
+	persistSignupDestination,
 } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -370,11 +371,7 @@ export class UpsellNudge extends Component {
 		}
 	}
 
-	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
-		const { trackUpsellButtonClick, upsellType } = this.props;
-
-		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
-
+	getThankYouPageUrlForIncomingCart = ( shouldHideUpsellNudges = true ) => {
 		const getThankYouPageUrlArguments = {
 			siteSlug: this.props.siteSlug,
 			receiptId: this.props.receiptId || 'noPreviousPurchase',
@@ -383,7 +380,15 @@ export class UpsellNudge extends Component {
 			isEligibleForSignupDestinationResult: this.props.isEligibleForSignupDestinationResult,
 		};
 
-		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
+		return getThankYouPageUrl( getThankYouPageUrlArguments );
+	};
+
+	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
+		const { trackUpsellButtonClick, upsellType } = this.props;
+
+		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
+
+		const url = this.getThankYouPageUrlForIncomingCart( shouldHideUpsellNudges );
 
 		// Removes the destination cookie only if redirecting to the signup destination.
 		// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
@@ -428,6 +433,13 @@ export class UpsellNudge extends Component {
 		// Professional Email needs to add the locally built cartItem to the cart,
 		// as we need to handle validation failures before redirecting to checkout.
 		if ( PROFESSIONAL_EMAIL_UPSELL === upsellType ) {
+			// Make sure we store the original post-checkout destination in a cookie
+			const destinationFromCookie = retrieveSignupDestination();
+			if ( ! destinationFromCookie ) {
+				const initialThankYouUrl = this.getThankYouPageUrlForIncomingCart( true );
+				persistSignupDestination( initialThankYouUrl );
+			}
+
 			this.props.shoppingCartManager.replaceProductsInCart( [ productToAdd ] ).then( () => {
 				if ( this.props?.cart?.messages ) {
 					const { errors } = this.props.cart.messages;

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -433,12 +433,12 @@ export class UpsellNudge extends Component {
 		// Professional Email needs to add the locally built cartItem to the cart,
 		// as we need to handle validation failures before redirecting to checkout.
 		if ( PROFESSIONAL_EMAIL_UPSELL === upsellType ) {
-			// Make sure we store the original post-checkout destination in a cookie
+			// If we don't have an existing destination, calculate the thank you destination for
+			// the original cart contents, and only store it if the cart update succeeds.
 			const destinationFromCookie = retrieveSignupDestination();
-			if ( ! destinationFromCookie ) {
-				const initialThankYouUrl = this.getThankYouPageUrlForIncomingCart( true );
-				persistSignupDestination( initialThankYouUrl );
-			}
+			const destinationToPersist = destinationFromCookie
+				? null
+				: this.getThankYouPageUrlForIncomingCart( true );
 
 			this.props.shoppingCartManager.replaceProductsInCart( [ productToAdd ] ).then( () => {
 				if ( this.props?.cart?.messages ) {
@@ -448,6 +448,11 @@ export class UpsellNudge extends Component {
 						return;
 					}
 				}
+
+				if ( destinationToPersist ) {
+					persistSignupDestination( destinationToPersist );
+				}
+
 				page( '/checkout/' + siteSlug );
 			} );
 			return;

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -17,20 +17,32 @@ import {
 	transformMailboxForCart,
 	validateMailboxes,
 } from 'calypso/lib/titan/new-mailbox';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { TranslateResult } from 'i18n-calypso';
+import type { ChangeEvent } from 'react';
 
 import './style.scss';
 
-const noopWithCallback = ( ignored, callback = () => {} ) => {
+const noopWithCallback = ( cartItem: MinimalRequestCartProduct, callback = () => {} ) => {
 	callback();
 };
 
-const ProfessionalEmailFeature = ( { children } ) => {
+const ProfessionalEmailFeature = ( { children }: { children: TranslateResult } ) => {
 	return (
 		<li>
-			<Gridicon icon="checkmark" size="18" />
+			<Gridicon icon="checkmark" size={18} />
 			<span>{ children }</span>
 		</li>
 	);
+};
+
+type ProfessionalEmailUpsellProps = {
+	currencyCode: string;
+	domainName: string;
+	handleClickAccept: ( action: string ) => void;
+	handleClickDecline: () => void;
+	productCost?: number | null;
+	setCartItem: ( cartItem: MinimalRequestCartProduct, callback: () => void ) => void;
 };
 
 const ProfessionalEmailUpsell = ( {
@@ -40,7 +52,7 @@ const ProfessionalEmailUpsell = ( {
 	handleClickDecline,
 	productCost,
 	setCartItem = noopWithCallback,
-} ) => {
+}: ProfessionalEmailUpsellProps ) => {
 	const translate = useTranslate();
 
 	const [ mailboxData, setMailboxData ] = useState( buildNewTitanMailbox( domainName, false ) );
@@ -67,7 +79,7 @@ const ProfessionalEmailUpsell = ( {
 		comment: '{{price/}} is the formatted price, e.g. $20',
 	} );
 
-	const onMailboxValueChange = ( fieldName, fieldValue ) => {
+	const onMailboxValueChange = ( fieldName: string, fieldValue: string | null ) => {
 		const updatedMailboxData = {
 			...mailboxData,
 			[ fieldName ]: { value: fieldValue, error: null },
@@ -76,7 +88,10 @@ const ProfessionalEmailUpsell = ( {
 			[ updatedMailboxData ],
 			optionalMailboxFields
 		).pop();
-		setMailboxData( validatedMailboxData );
+
+		if ( validatedMailboxData ) {
+			setMailboxData( validatedMailboxData );
+		}
 	};
 
 	const handleAddEmail = () => {
@@ -143,7 +158,7 @@ const ProfessionalEmailUpsell = ( {
 							<FormTextInputWithAffixes
 								value={ mailboxData.mailbox.value }
 								isError={ hasMailboxError }
-								onChange={ ( event ) => {
+								onChange={ ( event: ChangeEvent<HTMLInputElement> ) => {
 									onMailboxValueChange( 'mailbox', event.target.value.toLowerCase() );
 								} }
 								onBlur={ () => {
@@ -165,7 +180,7 @@ const ProfessionalEmailUpsell = ( {
 								value={ mailboxData.password.value }
 								maxLength={ 100 }
 								isError={ hasPasswordError }
-								onChange={ ( event ) => {
+								onChange={ ( event: ChangeEvent<HTMLInputElement> ) => {
 									onMailboxValueChange( 'password', event.target.value );
 								} }
 								onBlur={ () => {
@@ -203,7 +218,7 @@ const ProfessionalEmailUpsell = ( {
 					<img
 						className="professional-email-upsell__titan-logo"
 						src={ poweredByTitanLogo }
-						alt={ translate( 'Powered by Titan' ) }
+						alt={ translate( 'Powered by Titan', { textOnly: true } ) }
 					/>
 				</div>
 			</div>

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -23,11 +23,6 @@ import type { ChangeEvent } from 'react';
 
 import './style.scss';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noopWithCallback = ( cartItem: MinimalRequestCartProduct, callback = () => {} ) => {
-	callback();
-};
-
 const ProfessionalEmailFeature = ( { children }: { children: TranslateResult } ) => {
 	return (
 		<li>
@@ -52,7 +47,7 @@ const ProfessionalEmailUpsell = ( {
 	handleClickAccept,
 	handleClickDecline,
 	productCost,
-	setCartItem = noopWithCallback,
+	setCartItem,
 }: ProfessionalEmailUpsellProps ) => {
 	const translate = useTranslate();
 

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -23,6 +23,7 @@ import type { ChangeEvent } from 'react';
 
 import './style.scss';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 const noopWithCallback = ( cartItem: MinimalRequestCartProduct, callback = () => {} ) => {
 	callback();
 };
@@ -30,7 +31,7 @@ const noopWithCallback = ( cartItem: MinimalRequestCartProduct, callback = () =>
 const ProfessionalEmailFeature = ( { children }: { children: TranslateResult } ) => {
 	return (
 		<li>
-			<Gridicon icon="checkmark" size={18} />
+			<Gridicon icon="checkmark" size={ 18 } />
 			<span>{ children }</span>
 		</li>
 	);
@@ -158,7 +159,7 @@ const ProfessionalEmailUpsell = ( {
 							<FormTextInputWithAffixes
 								value={ mailboxData.mailbox.value }
 								isError={ hasMailboxError }
-								onChange={ ( event: ChangeEvent<HTMLInputElement> ) => {
+								onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
 									onMailboxValueChange( 'mailbox', event.target.value.toLowerCase() );
 								} }
 								onBlur={ () => {
@@ -180,7 +181,7 @@ const ProfessionalEmailUpsell = ( {
 								value={ mailboxData.password.value }
 								maxLength={ 100 }
 								isError={ hasPasswordError }
-								onChange={ ( event: ChangeEvent<HTMLInputElement> ) => {
+								onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
 									onMailboxValueChange( 'password', event.target.value );
 								} }
 								onBlur={ () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The goal of this PR is to ensure that when users are shown the Professional Email upsell and are then redirected to a full-page checkout, we store the original post-checkout location so we can get sent there after the user completes checkout. The logic only specifies a post-checkout location when no other location has been stored before, and only does so when we know we ought to redirect to checkout.

#### Testing instructions

The biggest issue with testing is that there are multiple sets of changes occurring with signup flows at the moment, so I would _love_ some help from @Automattic/cylon and @Automattic/ganon to identify whether there are any flows and/or user cases that we need to test.

The core test cases are as follows:
* **Test Case 1:**  For an existing user and site with an existing domain, purchase a plan other than the Premium plan using a payment method other than a credit card
  - Verify that you see an offer for Professional Email
  - Complete the form and proceed with accepting the upsell
  - Verify that you see a full-page checkout for Professional Email and complete the purchase
  - Verify that you're taken to the thank you page for your plan purchase
* **Test Case 2:** For an existing user, create a new site, and purchase a domain and a plan other than the Premium plan using a payment method other than a credit card
  - Verify that you see an offer for Professional Email
  - Complete the form and proceed with accepting the upsell
  - Verify that you see a full-page checkout for Professional Email and complete the purchase
  - Verify that you're not taken to the email thank you page - **_this is where I need some help! What ought to happen?_**
     + I believe you should be taken to the page editor with Full Site Editing enabled
* **Test Case 3:** Work through signup using a new user, and create a new site with a domain and a plan other than the Premium plan, ensuring that you complete the purchase using a payment method other than a credit card
  - Verify that you see an offer for Professional Email
  - Complete the form and proceed with accepting the upsell
  - Verify that you see a full-page checkout for Professional Email and complete the purchase
  - Verify that you're not taken to the email thank you page and are taken to the hero flow to guide you through your next steps

_Note that we show a business plan upsell for Premium plan purchases, and that we need a non-card payment method to ensure that we show the full-page checkout instead of a modal checkout._