### PR TITLE
Domains: Make domain names in titles all lowercase

### DIFF
--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -22,10 +22,7 @@
 			// Higher specificity needed to override .formatted-header.is-left-align media-query styles
 			header.settings-header__title {
 				margin: 8px 0;
-
-				&::first-letter {
-					text-transform: uppercase;
-				}
+				text-transform: lowercase;
 
 				.formatted-header__title {
 					font-weight: 400;


### PR DESCRIPTION
### Changes proposed in this Pull Request

Since the domain management redesign project (pcYYhz-m2-p2) and specifically #58909, we were showing domain names in page titles with their first letter capitalised. We though about this (p1642646569026000-slack-C020919TDRA) and decided to make them all lowercase, as it's more common to show domain names that way.

#### Screenshots

Before:

<img width="583" alt="Screen Shot 2022-01-25 at 17 00 10" src="https://user-images.githubusercontent.com/5324818/151050353-72f3b57d-f892-4e17-a027-2a3e1e796afa.png">

After:

<img width="595" alt="Screen Shot 2022-01-25 at 16 59 30" src="https://user-images.githubusercontent.com/5324818/151050367-44d9122b-7e90-4e4b-9389-ba2b981925c2.png">

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to the site domains page (Upgrades > Domains)
- Select any domain
- Check that the domain name in the page title is all in lowercase