### PR TITLE
Woo Installer: Track timeouts in addition to failures

### DIFF
--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -52,13 +52,13 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 				<>
 					{ isAtomic && (
 						<InstallPlugins
-							onFailure={ ( type ) => handleTransferFailure( type ) }
+							onFailure={ handleTransferFailure }
 							trackRedirect={ trackRedirect }
 						/>
 					) }
 					{ ! isAtomic && (
 						<TransferSite
-							onFailure={ ( type ) => handleTransferFailure( type ) }
+							onFailure={ handleTransferFailure }
 							trackRedirect={ trackRedirect }
 						/>
 					) }

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -52,13 +52,13 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 				<>
 					{ isAtomic && (
 						<InstallPlugins
-							onFailure={ () => handleTransferFailure( 'install ' ) }
+							onFailure={ ( type ) => handleTransferFailure( type ) }
 							trackRedirect={ trackRedirect }
 						/>
 					) }
 					{ ! isAtomic && (
 						<TransferSite
-							onFailure={ () => handleTransferFailure( 'transfer' ) }
+							onFailure={ ( type ) => handleTransferFailure( type ) }
 							trackRedirect={ trackRedirect }
 						/>
 					) }

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -21,7 +21,7 @@ export default function InstallPlugins( {
 	onFailure,
 	trackRedirect,
 }: {
-	onFailure: () => void;
+	onFailure: ( type: string ) => void;
 	trackRedirect: () => void;
 } ): ReactElement | null {
 	const dispatch = useDispatch();
@@ -56,7 +56,7 @@ export default function InstallPlugins( {
 			return;
 		}
 
-		onFailure();
+		onFailure( 'install' );
 	}, [ softwareError, onFailure ] );
 
 	// Timeout threshold for the install to complete.
@@ -67,7 +67,7 @@ export default function InstallPlugins( {
 
 		const timeId = setTimeout( () => {
 			setIsTimeoutError( true );
-			onFailure();
+			onFailure( 'install_timeout' );
 		}, TIMEOUT_LIMIT );
 
 		return () => {

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -107,7 +107,7 @@ export default function TransferSite( {
 		if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
 			setProgress( 1 );
 			setTransferFailed( true );
-			onFailure( 'transfer_timeout' );
+			onFailure( 'transfer' );
 		}
 	}, [ siteId, transferStatus, isTransferringStatusFailed, onFailure ] );
 
@@ -135,8 +135,8 @@ export default function TransferSite( {
 
 		const timeId = setTimeout( () => {
 			setTransferFailed( true );
-			onFailure( 'timeout' );
-		}, 1000 * 80 );
+			onFailure( 'transfer_timeout' );
+		}, 1 );
 
 		return () => {
 			window?.clearTimeout( timeId );

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -136,7 +136,7 @@ export default function TransferSite( {
 		const timeId = setTimeout( () => {
 			setTransferFailed( true );
 			onFailure( 'transfer_timeout' );
-		}, 1 );
+		}, 1000 * 80 );
 
 		return () => {
 			window?.clearTimeout( timeId );

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -21,7 +21,7 @@ export default function TransferSite( {
 	onFailure,
 	trackRedirect,
 }: {
-	onFailure: () => void;
+	onFailure: ( type: string ) => void;
 	trackRedirect: () => void;
 } ): ReactElement | null {
 	const dispatch = useDispatch();
@@ -107,7 +107,7 @@ export default function TransferSite( {
 		if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
 			setProgress( 1 );
 			setTransferFailed( true );
-			onFailure();
+			onFailure( 'transfer_timeout' );
 		}
 	}, [ siteId, transferStatus, isTransferringStatusFailed, onFailure ] );
 
@@ -135,7 +135,7 @@ export default function TransferSite( {
 
 		const timeId = setTimeout( () => {
 			setTransferFailed( true );
-			onFailure();
+			onFailure( 'timeout' );
 		}, 1000 * 80 );
 
 		return () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Send different error actions with the `calypso_woocommerce_dashboard_snag_error` event when there are timeout errors.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Show tracking in your browser: PCYsg-cae-p2
- Using a non-Atomic site to test, verify that `calypso_woocommerce_dashboard_snag_error` is tracked with `action: transfer_timeout` by causing a timeout error (e.g. changing [the timeout](https://github.com/Automattic/wp-calypso/blob/63933103de81499b9a36bfb0d1db930458e61200/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx#L139) to 1).
- Using an Atomic site to test, verify that `calypso_woocommerce_dashboard_snag_error` is tracked with `action: install_timeout` by causing a timeout error.
- Regression: check that transfer and install failures still track correctly.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59478
