### PR TITLE
Update form input color.

### DIFF
--- a/client/signup/steps/woocommerce-install/style.scss
+++ b/client/signup/steps/woocommerce-install/style.scss
@@ -98,8 +98,11 @@
 					padding: 0;
 				}
 
-				.components-checkbox-control__label {
-					color: $black;
+				.components-checkbox-control__label,
+				.components-select-control__input,
+				.components-text-control__input,
+				.components-combobox-control__input {
+					color: var( --color-neutral-70 );
 				}
 
 				.components-combobox-control__suggestions-container,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updated form input colors to `var( --color-neutral-70 )`

#### Testing instructions

- Checkout this branch.
- Load the installation flow and observe that the input fields are now a lighter shade of gray.

<table>
<tr valign="top">
<td>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/140841/151073270-c65a22be-b248-494b-818f-9194ae958bdd.png" width="300"/>
<img src="https://user-images.githubusercontent.com/140841/151073275-cb796d3d-ed65-4a8e-818a-f59217befd69.png" width="300"/>
</td>
<td>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/140841/151073281-75da7b07-3943-418e-a1bd-7ffdaf0fb101.png" width="300"/>
<img src="https://user-images.githubusercontent.com/140841/151073287-27d74b20-68a7-4fce-b7f0-e55bc9d512a3.png" width="300"/>
</td>
</tr>

Related to [#60331](https://github.com/Automattic/wp-calypso/issues/60331)
