### PR TITLE
Lengthen transfer and install timeout limits.

### DIFF
--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -15,7 +15,7 @@ import Progress from './progress';
 import './style.scss';
 
 // Timeout limit for the install to complete.
-const TIMEOUT_LIMIT = 1000 * 15; // 15 seconds.
+const TIMEOUT_LIMIT = 1000 * 45; // 45 seconds.
 
 export default function InstallPlugins( {
 	onFailure,

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -136,7 +136,7 @@ export default function TransferSite( {
 		const timeId = setTimeout( () => {
 			setTransferFailed( true );
 			onFailure( 'transfer_timeout' );
-		}, 1000 * 80 );
+		}, 1000 * 180 );
 
 		return () => {
 			window?.clearTimeout( timeId );


### PR DESCRIPTION
I feel like our timeout limits might be too optimistic because I'm seeing false "We hit a snag" errors too often when testing. How do y'all feel about extending them? 

#### Changes proposed in this Pull Request

* Extend timeout limits to prevent false "We hit a snag" error pages.

#### Testing instructions

This is tough to test, but we could run the install flow to make sure nothing is broken.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
