### PR TITLE
Plans: Fix missing key error

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -682,7 +682,7 @@ export class PlanFeatures extends Component {
 					isLaunchPage={ isLaunchPage }
 					nonDotBlogDomains={ nonDotBlogDomains }
 					planPropertiesPlan={ planPropertiesPlan }
-					key={ planPropertiesPlan.productSlug }
+					key={ planPropertiesPlan.planName }
 					redirectToAddDomainFlow={ redirectToAddDomainFlow }
 					selectedPlan={ selectedPlan }
 					selectedSiteSlug={ selectedSiteSlug }
@@ -799,7 +799,6 @@ export class PlanFeatures extends Component {
 			selectedSiteSlug,
 			purchaseId,
 		} = this.props;
-
 		return planProperties.map( ( planPropertiesPlan ) => {
 			return (
 				<PlanFeaturesActionsWrapper
@@ -812,7 +811,7 @@ export class PlanFeatures extends Component {
 					isLaunchPage={ isLaunchPage }
 					nonDotBlogDomains={ nonDotBlogDomains }
 					planPropertiesPlan={ planPropertiesPlan }
-					key={ planPropertiesPlan.productSlug }
+					key={ planPropertiesPlan.planName }
 					redirectToAddDomainFlow={ redirectToAddDomainFlow }
 					selectedPlan={ selectedPlan }
 					selectedSiteSlug={ selectedSiteSlug }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixed the following React Dev error.

<img width="809" alt="Screen Shot 2022-01-25 at 3 48 08 PM" src="https://user-images.githubusercontent.com/115071/151078839-56ed4060-1cbc-4d6c-aeea-78dbbbd3c096.png">

#### Testing instructions

* Load up 
[/start/plans](http://calypso.localhost:3000/start/plans) and notice that the error is not there anymore in the dev console.

