### PR TITLE
Remove irrelevant menu items for P2s

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -14,6 +14,8 @@ import {
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import hasCancelableSitePurchases from 'calypso/state/selectors/has-cancelable-site-purchases';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -166,6 +168,8 @@ export default connect(
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 		const isVip = isVipSite( state, siteId );
+		const isP2 = isSiteWPForTeams( state, siteId );
+		const isP2Hub = isSiteP2Hub( state, siteId );
 		const rewindState = getRewindState( state, siteId );
 		const sitePurchasesLoaded = hasLoadedSitePurchasesFromServer( state );
 
@@ -176,10 +180,11 @@ export default connect(
 			siteSlug,
 			purchasesError: getPurchasesError( state ),
 			cloneUrl,
-			showChangeAddress: ! isJetpack && ! isVip,
+			showChangeAddress: ! isJetpack && ! isVip && ! isP2,
 			showClone: 'active' === rewindState.state && ! isAtomic,
-			showThemeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
-			showDeleteContent: ! isJetpack && ! isVip,
+			showThemeSetup:
+				config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip && ! isP2,
+			showDeleteContent: ! isJetpack && ! isVip && ! isP2Hub,
 			showDeleteSite: ( ! isJetpack || isAtomic ) && ! isVip && sitePurchasesLoaded,
 			showManageConnection: isJetpack && ! isAtomic,
 			siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the "Change your site address" item under Site tools ( `https://wordpress.com/settings/general/<site>.wordpress.com` ) for all P2s. Also removes the theme setup item. They are not needed.
For hubs, it also removes the "Delete your content" item.

How it will look on a P2:
<img width="868" alt="Screen Shot 2022-01-25 at 17 40 50" src="https://user-images.githubusercontent.com/193283/151078554-68541db1-709b-44d5-987e-7bb1164bd51e.png">

And on a P2 hub:

<img width="840" alt="Screen Shot 2022-01-25 at 17 40 36" src="https://user-images.githubusercontent.com/193283/151078578-ab685e0b-b866-45ba-9ec9-e6b36fe1ca3b.png">

#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a P2 - verify that the site tools only shows the two items from the first screen shot
* On a P2 hub- verify that the site tools only shows the one item from the second screen shot
* On a non-P2 - verify that the tools items still show as they should.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See 4222-gh-Automattic/p2
