### PR TITLE
Checkout: Preserve checkout query string in PayPal cancel_url

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -111,7 +111,6 @@ export default function CompositeCheckout( {
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
 	customizedPreviousPath,
-	customizedCancelUrl,
 }: {
 	siteSlug: string | undefined;
 	siteId: number | undefined;
@@ -135,8 +134,6 @@ export default function CompositeCheckout( {
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
 	customizedPreviousPath?: string;
-	/** Customized cancel url for PayPal */
-	customizedCancelUrl?: string;
 } ): JSX.Element {
 	const previousPath = useSelector( getPreviousPath );
 	const translate = useTranslate();
@@ -449,7 +446,6 @@ export default function CompositeCheckout( {
 			stripeConfiguration,
 			stripe,
 			recaptchaClientId,
-			customizedCancelUrl,
 		} ),
 		[
 			contactDetails,
@@ -464,7 +460,6 @@ export default function CompositeCheckout( {
 			stripeConfiguration,
 			updatedSiteSlug,
 			recaptchaClientId,
-			customizedCancelUrl,
 		]
 	);
 

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -32,27 +32,26 @@ export default async function payPalProcessor(
 
 	const thankYouUrl = getThankYouUrl();
 	let currentUrl;
-	let currentBaseUrl;
-	let currentUrlQuery;
 	try {
-		currentUrl = window.location.href;
-		currentBaseUrl = window.location.origin;
-		currentUrlQuery = window.location.search;
+		currentUrl = new URL( window.location.href );
 	} catch ( error ) {
-		currentUrl = `https://wordpress.com/checkout/${ siteSlug }`;
-		currentBaseUrl = 'https://wordpress.com';
-		currentUrlQuery = '';
+		currentUrl = new URL( `https://wordpress.com/checkout/${ siteSlug }` );
 	}
-	const currentUrlWithoutQuery = currentUrl.split( /\?|#/ )[ 0 ];
-	const updatedQuery = new URLSearchParams( currentUrlQuery );
-	const successUrl = thankYouUrl.startsWith( 'http' ) ? thankYouUrl : currentBaseUrl + thankYouUrl;
+	// We must strip out the hash value because it may break URL encoding when
+	// this value is passed back and forth to PayPal and through our own
+	// endpoints. Otherwise we may end up with an incorrect URL like
+	// 'http://wordpress.com/checkout?cart=no-user#step2?paypal=ABCDEFG'.
+	currentUrl.hash = '';
+	// The successUrl must always be absolute but getThankYouUrl can return
+	// relative paths, so we must check.
+	const successUrl = thankYouUrl.startsWith( 'http' )
+		? thankYouUrl
+		: currentUrl.origin + thankYouUrl;
 	if ( createUserAndSiteBeforeTransaction ) {
-		updatedQuery.set( 'cart', 'no-user' );
+		// It's not clear if this is still required but it may be.
+		currentUrl.searchParams.set( 'cart', 'no-user' );
 	}
-	const updatedQueryString = updatedQuery.toString();
-	const cancelUrl = updatedQueryString.length
-		? currentUrlWithoutQuery + '?' + updatedQueryString
-		: currentUrlWithoutQuery;
+	const cancelUrl = currentUrl.toString();
 
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		responseCart,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -47,7 +47,7 @@ export default async function payPalProcessor(
 	const updatedQuery = new URLSearchParams( currentUrlQuery );
 	const successUrl = thankYouUrl.startsWith( 'http' ) ? thankYouUrl : currentBaseUrl + thankYouUrl;
 	if ( createUserAndSiteBeforeTransaction ) {
-		updatedQuery.append( 'cart', 'no-user' );
+		updatedQuery.set( 'cart', 'no-user' );
 	}
 	const updatedQueryString = updatedQuery.toString();
 	const cancelUrl = updatedQueryString.length

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -34,26 +34,31 @@ export default async function payPalProcessor(
 	const thankYouUrl = getThankYouUrl();
 	let currentUrl;
 	let currentBaseUrl;
+	let currentUrlQuery;
 	try {
 		currentUrl = window.location.href;
 		currentBaseUrl = window.location.origin;
+		currentUrlQuery = window.location.search;
 	} catch ( error ) {
 		currentUrl = `https://wordpress.com/checkout/${ siteSlug }`;
 		currentBaseUrl = 'https://wordpress.com';
+		currentUrlQuery = '';
 	}
 	const currentUrlWithoutQuery = currentUrl.split( /\?|#/ )[ 0 ];
+	const updatedQuery = new URLSearchParams( currentUrlQuery );
 	const successUrl = thankYouUrl.startsWith( 'http' ) ? thankYouUrl : currentBaseUrl + thankYouUrl;
-	let cancelUrl = customizedCancelUrl;
-	if ( ! cancelUrl ) {
-		cancelUrl = createUserAndSiteBeforeTransaction
-			? currentUrlWithoutQuery + '?cart=no-user'
-			: currentUrlWithoutQuery;
+	if ( createUserAndSiteBeforeTransaction ) {
+		updatedQuery.append( 'cart', 'no-user' );
 	}
+	const updatedQueryString = updatedQuery.toString();
+	const cancelUrl = updatedQueryString.length
+		? currentUrlWithoutQuery + '?' + updatedQueryString
+		: currentUrlWithoutQuery;
 
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		responseCart,
 		successUrl,
-		cancelUrl,
+		cancelUrl: customizedCancelUrl || cancelUrl,
 		siteId,
 		domainDetails:
 			getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) || null,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -27,7 +27,6 @@ export default async function payPalProcessor(
 		siteId,
 		siteSlug,
 		contactDetails,
-		customizedCancelUrl,
 	} = transactionOptions;
 	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'paypal' } ) );
 
@@ -58,7 +57,7 @@ export default async function payPalProcessor(
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		responseCart,
 		successUrl,
-		cancelUrl: customizedCancelUrl || cancelUrl,
+		cancelUrl,
 		siteId,
 		domainDetails:
 			getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) || null,

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -62,7 +62,7 @@ describe( 'genericRedirectProcessor', () => {
 			stored_details_id: undefined,
 			street_number: undefined,
 			success_url:
-				'https://wordpress.com/checkout/thank-you/no-site/pending?redirectTo=https%3A%2F%2Fwordpress.com',
+				'https://wordpress.com/checkout/thank-you/no-site/pending?redirectTo=%2Fthank-you',
 			tef_bank: undefined,
 			zip: '10001',
 		},
@@ -165,7 +165,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fwordpress.com',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=%2Fthank-you',
 			},
 		} );
 	} );
@@ -287,7 +287,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fwordpress.com',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=%2Fthank-you',
 			},
 		} );
 	} );
@@ -323,7 +323,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fwordpress.com',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=%2Fthank-you',
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -17,6 +17,7 @@ import {
 	expectedCreateAccountRequest,
 	mockCreateAccountSiteCreatedResponse,
 	mockCreateAccountSiteNotCreatedResponse,
+	setMockLocation,
 } from './util';
 
 describe( 'payPalExpressProcessor', () => {
@@ -51,8 +52,16 @@ describe( 'payPalExpressProcessor', () => {
 		country: '',
 		domain_details: null,
 		postal_code: '',
-		success_url: 'https://example.com',
+		success_url: 'https://example.com/thank-you',
 	};
+
+	beforeEach( () => {
+		setMockLocation( {
+			href: 'https://example.com/',
+			origin: 'https://example.com',
+			search: '',
+		} );
+	} );
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {
 		const transactionsEndpoint = mockPayPalEndpoint( mockPayPalRedirectResponse );
@@ -231,6 +240,38 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			cancel_url: 'https://example.com/?cart=no-user',
+			cart: {
+				...basicExpectedRequest.cart,
+				blog_id: '0',
+				cart_key: 'no-site',
+				coupon: '',
+				create_new_blog: true,
+			},
+		} );
+	} );
+
+	it( 'creates an account before sending the correct data with a site creation request to the endpoint with no site and a query string in the original URL', async () => {
+		setMockLocation( {
+			href: 'https://wordpress.com/checkout/no-site?signup=1&isDomainOnly=1',
+			origin: 'https://wordpress.com',
+			search: '?signup=1&isDomainOnly=1',
+		} );
+		const transactionsEndpoint = mockPayPalEndpoint( mockPayPalRedirectResponse );
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		await expect(
+			payPalExpressProcessor( {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+					email,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedRequest,
+			cancel_url: 'https://wordpress.com/checkout/no-site?signup=1&isDomainOnly=1',
+			success_url: 'https://wordpress.com/thank-you',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '0',

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -754,11 +754,9 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 	return transactionsEndpoint;
 }
 
-export function setMockLocation( mockLocation ) {
-	jest.spyOn( window, 'location', 'get' ).mockReturnValue( {
-		...window.location,
-		...mockLocation,
-	} );
+export function setMockLocation( url ) {
+	const location = new URL( url );
+	jest.spyOn( window, 'location', 'get' ).mockReturnValue( location );
 }
 
 export const mockCreateAccountSiteNotCreatedResponse = () => [ 200, { success: true } ];

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -18,7 +18,7 @@ export const processorOptions = {
 	stripeConfiguration,
 	reduxDispatch: () => null,
 	responseCart: getEmptyResponseCart(),
-	getThankYouUrl: () => '',
+	getThankYouUrl: () => '/thank-you',
 	siteSlug: undefined,
 	siteId: undefined,
 	contactDetails: undefined,
@@ -752,6 +752,13 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 		.reply( transactionsEndpointResponse );
 
 	return transactionsEndpoint;
+}
+
+export function setMockLocation( mockLocation ) {
+	jest.spyOn( window, 'location', 'get' ).mockReturnValue( {
+		...window.location,
+		...mockLocation,
+	} );
 }
 
 export const mockCreateAccountSiteNotCreatedResponse = () => [ 200, { success: true } ];

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -66,7 +66,7 @@ describe( 'weChatProcessor', () => {
 			stored_details_id: undefined,
 			street_number: undefined,
 			success_url:
-				'https://example.com/checkout/thank-you/no-site/pending?redirectTo=https%3A%2F%2Fexample.com',
+				'https://example.com/checkout/thank-you/no-site/pending?redirectTo=https%3A%2F%2Fexample.com%2Fthank-you',
 			tef_bank: undefined,
 			zip: '10001',
 		},
@@ -144,7 +144,7 @@ describe( 'weChatProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com',
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com%2Fthank-you',
 			},
 		} );
 	} );
@@ -189,7 +189,7 @@ describe( 'weChatProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com',
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com%2Fthank-you',
 			},
 		} );
 	} );
@@ -224,7 +224,7 @@ describe( 'weChatProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com',
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=https%3A%2F%2Fexample.com%2Fthank-you',
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -18,5 +18,4 @@ export interface PaymentProcessorOptions {
 	siteId: number | undefined;
 	contactDetails: ManagedContactDetails | undefined;
 	recaptchaClientId?: number;
-	customizedCancelUrl?: string;
 }

--- a/client/my-sites/checkout/modal/index.tsx
+++ b/client/my-sites/checkout/modal/index.tsx
@@ -87,7 +87,6 @@ const CheckoutModal: FunctionComponent< Props > = ( {
 						// Custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
 						redirectTo={ redirectTo || previousRoute }
 						customizedPreviousPath={ previousRoute }
-						customizedCancelUrl={ window.location.href }
 						isInModal
 						disabledThankYouPage
 						onAfterPaymentComplete={ handleAfterPaymentComplete }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When submitting a PayPal Express transaction, the HTTP API payload includes a `cancel_url` property which is used if the user cancels the payment after they have been redirected to the PayPal site. This URL is set by the `payPalProcessor()` function to the current URL with its query string removed. Typically this will be wpcom checkout.

However, by removing the query string, important data may be lost, such as the flags that allow viewing checkout for a domain-only purchase.

In this PR we modify the processor function to preserve the query string from the current URL.

Fixes https://github.com/Automattic/wp-calypso/issues/60067

#### Testing instructions

- Visit `/start/domain/domain-only`.
- Search for and select a domain, then press "Just buy a domain", and visit checkout.
- Select PayPal as the payment method and submit the purchase.
- Once on the PayPal site, press "cancel and return to site".
- Verify that you return to checkout with the domain still in the cart.