### PR TITLE
Remove always-true jetpack/redirect-legacy-plans flag

### DIFF
--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -20,7 +20,6 @@ import {
 	upsellNudge,
 	upsellRedirect,
 } from './controller';
-import { noop } from './utils';
 
 export default function () {
 	page( '/checkout*', recordSiftScienceUser );
@@ -219,7 +218,7 @@ export default function () {
 		'/checkout/:domainOrProduct',
 		redirectLoggedOut,
 		siteSelection,
-		isEnabled( 'jetpack/redirect-legacy-plans' ) ? redirectJetpackLegacyPlans : noop,
+		redirectJetpackLegacyPlans,
 		checkout,
 		makeLayout,
 		clientRender
@@ -229,7 +228,7 @@ export default function () {
 		'/checkout/:product/:domainOrProduct',
 		redirectLoggedOut,
 		siteSelection,
-		isEnabled( 'jetpack/redirect-legacy-plans' ) ? redirectJetpackLegacyPlans : noop,
+		redirectJetpackLegacyPlans,
 		checkout,
 		makeLayout,
 		clientRender

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -1,10 +1,6 @@
 import { untrailingslashit } from 'calypso/lib/route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-export function noop( context: PageJS.Context, next: () => void ): void {
-	next();
-}
-
 export function getDomainOrProductFromContext( { params, store }: PageJS.Context ): string {
 	const { domainOrProduct, product } = params;
 	const state = store.getState();

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { TERM_MONTHLY, TERM_ANNUALLY } from '@automattic/calypso-products';
 import JetpackFreeWelcomePage from 'calypso/components/jetpack/jetpack-free-welcome';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -54,9 +53,7 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 	const urlQueryArgs: QueryArgs = context.query;
 	const { site: siteParam, duration: durationParam } = getParamsFromContext( context );
 	const duration = siteId && ( getCurrentPlanTerm( state, siteId ) as Duration );
-	const planRecommendation = isEnabled( 'jetpack/redirect-legacy-plans' )
-		? getPlanRecommendationFromContext( context )
-		: undefined;
+	const planRecommendation = getPlanRecommendationFromContext( context );
 	const highlightedProducts = getHighlightedProduct( urlQueryArgs.plan ) || undefined;
 
 	const enableUserLicensesDialog = !! (

--- a/config/development.json
+++ b/config/development.json
@@ -84,7 +84,6 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
-		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
 		"jitms": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -53,7 +53,6 @@
 		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
-		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"lasagna": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -42,7 +42,6 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
-		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -39,7 +39,6 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
-		"jetpack/redirect-legacy-plans": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -38,7 +38,6 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
-		"jetpack/redirect-legacy-plans": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"layout/app-banner": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -39,7 +39,6 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
-		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/production.json
+++ b/config/production.json
@@ -53,7 +53,6 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
-		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
 		"jitms": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,6 @@
 		"jetpack/more-informative-scan": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
-		"jetpack/redirect-legacy-plans": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/user-licensing": true,
 		"jitms": true,


### PR DESCRIPTION
The flag was always enabled in all environments, including Jetpack Cloud. Except the `wpcalypso` environment which was an omission rather than intent.

**How to test:**
Go to a checkout URL that intends to add a legacy Jetpack plan to a site:
```
/checkout/jetpack_personal/jetpack-site.blog
```
and verify that you are redirected to a page that recommends a new plan instead of the legacy selection:

<img width="1036" alt="Screenshot 2022-01-26 at 9 48 53" src="https://user-images.githubusercontent.com/664258/151132087-1405274e-b163-46eb-9cc6-ed11769388f1.png">

