### PR TITLE
Add import cancel button

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -33,6 +33,10 @@ const sum = ( a, b ) => a + b;
  * }
  */
 export const calculateProgress = ( progress ) => {
+	if ( ! progress ) {
+		return 0;
+	}
+
 	const { attachment = {} } = progress;
 
 	if ( attachment.total > 0 && attachment.completed >= 0 ) {

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -33,6 +33,7 @@ const sum = ( a, b ) => a + b;
  * }
  */
 export const calculateProgress = ( progress ) => {
+	// The backend does not output the 'progress' field for all the enqueued not running imports.
 	if ( ! progress ) {
 		return 0;
 	}

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -16,6 +16,7 @@ import './style.scss';
 
 export class NavigationLink extends Component {
 	static propTypes = {
+		goToPreviousStep: PropTypes.func,
 		goToNextStep: PropTypes.func,
 		direction: PropTypes.oneOf( [ 'back', 'forward' ] ),
 		flowName: PropTypes.string.isRequired,
@@ -111,8 +112,8 @@ export class NavigationLink extends Component {
 			);
 
 			this.props.goToNextStep();
-		} else if ( this.props.goToNextStep ) {
-			this.props.goToNextStep();
+		} else if ( this.props.goToPreviousStep ) {
+			this.props.goToPreviousStep();
 		}
 
 		if ( ! this.props.disabledTracks ) {

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -111,6 +111,8 @@ export class NavigationLink extends Component {
 			);
 
 			this.props.goToNextStep();
+		} else if ( this.props.goToNextStep ) {
+			this.props.goToNextStep();
 		}
 
 		if ( ! this.props.disabledTracks ) {

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -40,6 +40,7 @@ describe( 'NavigationLink', () => {
 
 	afterEach( () => {
 		getStepUrl.mockReset();
+		props.goToPreviousStep.mockReset();
 		props.goToNextStep.mockReset();
 	} );
 

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -26,6 +26,7 @@ describe( 'NavigationLink', () => {
 		},
 		recordTracksEvent: noop,
 		submitSignupStep: noop,
+		goToPreviousStep: jest.fn(),
 		goToNextStep: jest.fn(),
 		translate: ( str ) => `translated:${ str }`,
 		userLoggedIn: true,
@@ -123,6 +124,22 @@ describe( 'NavigationLink', () => {
 		expect( props.goToNextStep ).not.toHaveBeenCalled();
 		wrapper.simulate( 'click' );
 		expect( props.goToNextStep ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should call goToPreviousStep() only when the direction is back and clicked', () => {
+		const wrapper = shallow( <NavigationLink { ...props } direction="back" /> );
+
+		expect( props.goToPreviousStep ).not.toHaveBeenCalled();
+		wrapper.simulate( 'click' );
+		expect( props.goToPreviousStep ).toHaveBeenCalled();
+	} );
+
+	test( 'should not call goToPreviousStep() when the direction is forward', () => {
+		const wrapper = shallow( <NavigationLink { ...props } direction="forward" /> );
+
+		expect( props.goToPreviousStep ).not.toHaveBeenCalled();
+		wrapper.simulate( 'click' );
+		expect( props.goToPreviousStep ).not.toHaveBeenCalled();
 	} );
 
 	test( 'getPreviousStep() When in 2nd step should return 1st step', () => {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -47,7 +47,7 @@ class StepWrapper extends Component {
 		return (
 			<NavigationLink
 				direction="back"
-				goToNextStep={ this.props.goToPreviousStep }
+				goToPreviousStep={ this.props.goToPreviousStep }
 				flowName={ this.props.flowName }
 				positionInFlow={ this.props.positionInFlow }
 				stepName={ this.props.stepName }

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -47,6 +47,7 @@ class StepWrapper extends Component {
 		return (
 			<NavigationLink
 				direction="back"
+				goToNextStep={ this.props.goToPreviousStep }
 				flowName={ this.props.flowName }
 				positionInFlow={ this.props.positionInFlow }
 				stepName={ this.props.stepName }

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -2,12 +2,14 @@ import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import page from 'page';
 import React, { useEffect, useState } from 'react';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { fetchImporterState } from 'calypso/state/imports/actions';
+import { getStepUrl } from 'calypso/signup/utils';
+import { fetchImporterState, resetImport } from 'calypso/state/imports/actions';
+import { appStates } from 'calypso/state/imports/constants';
 import {
 	getImporterStatusForSiteId,
 	isImporterStatusHydrated,
@@ -48,6 +50,7 @@ interface Props {
 const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const {
 		urlData,
+		stepName,
 		stepSectionName,
 		siteId,
 		site,
@@ -56,6 +59,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 		siteImports,
 		isImporterStatusHydrated,
 		fromSite,
+		path,
 	} = props;
 
 	/**
@@ -66,6 +70,8 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const getImportJob = ( engine: Importer ): ImportJob | undefined => {
 		return siteImports.find( ( x ) => x.type === getImporterTypeForEngine( engine ) );
 	};
+
+	const dispatch = useDispatch();
 
 	/**
 	 ↓ Effects
@@ -96,7 +102,33 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 		// because of the browser's back edge case
 		if ( searchParams.get( 'run' ) === 'true' ) {
 			setRunImportInitially( true );
-			page.replace( props.path.replace( '&run=true', '' ).replace( 'run=true', '' ) );
+			page.replace( path.replace( '&run=true', '' ).replace( 'run=true', '' ) );
+		}
+	}
+
+	function shouldHideBackBtn() {
+		return false;
+	}
+
+	function getBackUrl() {
+		if ( stepName === 'importing' ) {
+			return getStepUrl( 'importer', 'capture', '', '', { siteSlug } );
+		}
+	}
+
+	function goToPreviousStep() {
+		const job = getImportJob( engine );
+
+		if ( ! job ) {
+			return;
+		}
+
+		switch ( job.importerState ) {
+			case appStates.UPLOADING:
+			case appStates.UPLOAD_PROCESSING:
+			case appStates.UPLOAD_SUCCESS:
+			case appStates.MAP_AUTHORS:
+				return dispatch( resetImport( siteId, job.importerId ) );
 		}
 	}
 
@@ -105,9 +137,12 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 			<Interval onTick={ fetchImporters } period={ EVERY_FIVE_SECONDS } />
 
 			<StepWrapper
-				flowName={ 'import-from' }
+				flowName={ 'importer' }
+				stepName={ stepName }
 				hideSkip={ true }
-				hideBack={ true }
+				hideBack={ shouldHideBackBtn() }
+				backUrl={ getBackUrl() }
+				goToPreviousStep={ goToPreviousStep }
 				hideNext={ true }
 				hideFormattedHeader={ true }
 				stepContent={
@@ -246,5 +281,6 @@ export default connect(
 	},
 	{
 		fetchImporterState,
+		resetImport,
 	}
 )( ImportOnboardingFrom );

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -124,10 +124,13 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 		}
 
 		switch ( job.importerState ) {
-			case appStates.UPLOADING:
+			case appStates.IMPORTING:
+			case appStates.MAP_AUTHORS:
+			case appStates.READY_FOR_UPLOAD:
 			case appStates.UPLOAD_PROCESSING:
 			case appStates.UPLOAD_SUCCESS:
-			case appStates.MAP_AUTHORS:
+			case appStates.UPLOADING:
+			case appStates.UPLOAD_FAILURE:
 				return dispatch( resetImport( siteId, job.importerId ) );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a back button on importing flows
* Add support for a `goToPreviousStep` callback on `StepWrapper` and `NavigationLink` components and update the tests

A back button on these flows must cancel the ongoing import job if any:

- `start/importer/ready/preview`
- `start/importer/capture`
- `start/from/importing/<IMPORTER>`
- `start/from/importing/<IMPORTER>` (author mapping)

The back button does not send you to `start/importer/ready/preview` from `start/from/importing/<IMPORTER>` but directly to `start/importer/capture`. I think this is the intended behavior.

#### Testing instructions

- Go to http://calypso.localhost:3000/start/importer/capture?siteSlug=YOUR-SITE
- Move forward on the importing flows and check that the top-left "Back" button is always visible
- The button must redirect you to the previous step and cancel the ongoing job

Related to [#60336](https://github.com/Automattic/wp-calypso/issues/60336)
