### PR TITLE
Remove jetpack/user-licensing feature flag

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	getPlan,
 	TERM_BIENNIALLY,
@@ -72,8 +71,7 @@ export default function PurchaseMeta( {
 		return <PurchaseMetaPlaceholder />;
 	}
 
-	const isJetpackProductOrPlan = isJetpackProduct( purchase ) || isJetpackPlan( purchase );
-	const showJetpackUserLicense = isEnabled( 'jetpack/user-licensing' ) && isJetpackProductOrPlan;
+	const showJetpackUserLicense = isJetpackProduct( purchase ) || isJetpackPlan( purchase );
 
 	return (
 		<>

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { isDomainTransfer, isConciergeSession } from '@automattic/calypso-products';
 import { CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -68,11 +67,9 @@ class PurchaseItem extends Component {
 
 		if ( isDisconnectedSite ) {
 			if ( isJetpackTemporarySite ) {
-				const isJetpackUserLicensingEnabled = isEnabled( 'jetpack/user-licensing' );
-				const errorMessage = isJetpackUserLicensingEnabled
-					? translate( 'Pending activation' )
-					: translate( 'Awaiting site URL' );
-				return <span className="purchase-item__is-error">{ errorMessage }</span>;
+				return (
+					<span className="purchase-item__is-error">{ translate( 'Pending activation' ) }</span>
+				);
 			}
 
 			if ( isJetpack ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -1,5 +1,4 @@
 import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_RESET_PLANS,
@@ -147,23 +146,17 @@ export default function getThankYouPageUrl( {
 
 	// jetpack userless & siteless checkout uses a special thank you page
 	if ( isJetpackCheckout ) {
+		// extract a product from the cart, in userless/siteless checkout there should only be one
+		const productSlug = cart?.products[ 0 ]?.product_slug ?? 'no_product';
+
 		if ( siteSlug ) {
 			debug( 'redirecting to userless jetpack thank you' );
-
-			// extract a product from the cart, in userless checkout there should only be one
-			const productSlug = cart?.products[ 0 ]?.product_slug;
-
-			return `/checkout/jetpack/thank-you/${ siteSlug }/${ productSlug ?? 'no_product' }`;
+			return `/checkout/jetpack/thank-you/${ siteSlug }/${ productSlug }`;
 		}
+
 		// siteless checkout
 		debug( 'redirecting to siteless jetpack thank you' );
-
-		// extract a product from the cart, in siteless checkout there should only be one
-		const productSlug = cart?.products[ 0 ]?.product_slug;
-
-		const thankYouUrl = isEnabled( 'jetpack/user-licensing' )
-			? `/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug ?? 'no_product' }`
-			: `/checkout/jetpack/thank-you/no-site/${ productSlug ?? 'no_product' }`;
+		const thankYouUrl = `/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`;
 
 		const isValidReceiptId =
 			! isNaN( parseInt( pendingOrReceiptId ) ) || pendingOrReceiptId === ':receiptId';

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -4,7 +4,6 @@
  * @jest-environment jsdom
  */
 
-import config from '@automattic/calypso-config';
 import {
 	JETPACK_REDIRECT_URL,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
@@ -26,13 +25,6 @@ jest.mock( '@automattic/calypso-products', () => ( {
 	redirectCheckoutToWpAdmin: jest.fn(),
 } ) );
 
-jest.mock( '@automattic/calypso-config', () => {
-	const mock = jest.fn();
-	mock.isEnabled = jest.fn();
-	return mock;
-} );
-const configMock = ( values ) => ( key ) => values[ key ];
-
 const defaultArgs = {
 	getUrlFromCookie: jest.fn( () => null ),
 	saveUrlToCookie: jest.fn(),
@@ -42,7 +34,6 @@ describe( 'getThankYouPageUrl', () => {
 	beforeEach( () => {
 		isJetpackCloud.mockImplementation( () => false );
 		redirectCheckoutToWpAdmin.mockImplementation( () => false );
-		config.isEnabled.mockImplementation( configMock( { 'jetpack/user-licensing': false } ) );
 	} );
 
 	it( 'redirects to the root page when no site is set', () => {
@@ -1283,26 +1274,6 @@ describe( 'getThankYouPageUrl', () => {
 				isJetpackCheckout: true,
 			} );
 			expect( url ).toBe(
-				'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?receiptId=%3AreceiptId'
-			);
-		} );
-
-		it( 'redirects to the "user-licensing" thank-you page when enabled in Calypso config', () => {
-			config.isEnabled.mockImplementation( configMock( { 'jetpack/user-licensing': true } ) );
-			const cart = {
-				products: [
-					{
-						product_slug: 'jetpack_backup_daily',
-					},
-				],
-			};
-			const url = getThankYouPageUrl( {
-				...defaultArgs,
-				siteSlug: undefined,
-				cart,
-				isJetpackCheckout: true,
-			} );
-			expect( url ).toBe(
 				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=%3AreceiptId'
 			);
 		} );
@@ -1323,7 +1294,7 @@ describe( 'getThankYouPageUrl', () => {
 				receiptId: 80023,
 			} );
 			expect( url ).toBe(
-				'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?receiptId=80023'
+				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023'
 			);
 		} );
 
@@ -1342,7 +1313,9 @@ describe( 'getThankYouPageUrl', () => {
 				isJetpackCheckout: true,
 				receiptId: 'invalid receipt ID',
 			} );
-			expect( url ).toBe( '/checkout/jetpack/thank-you/no-site/jetpack_backup_daily' );
+			expect( url ).toBe(
+				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily'
+			);
 		} );
 
 		it( 'redirects with jetpackTemporarySiteId query param when available', () => {
@@ -1362,7 +1335,7 @@ describe( 'getThankYouPageUrl', () => {
 				jetpackTemporarySiteId: 123456789,
 			} );
 			expect( url ).toBe(
-				'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?receiptId=80023&siteId=123456789'
+				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023&siteId=123456789'
 			);
 		} );
 	} );

--- a/config/development.json
+++ b/config/development.json
@@ -85,7 +85,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/user-licensing": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"lasagna": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -52,7 +52,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/user-licensing": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"lasagna": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,7 +45,6 @@
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/user-licensing": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -38,7 +38,6 @@
 		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/user-licensing": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -42,7 +42,6 @@
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/user-licensing": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/production.json
+++ b/config/production.json
@@ -54,7 +54,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/user-licensing": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -52,7 +52,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/user-licensing": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -63,7 +63,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-v2-banner": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/user-licensing": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
The feature flag was always on in all environments. Except `jetpack-cloud-production`, but that shouldn't matter because the flag is not used in Jetpack Cloud code at all? It's only used in `/me/purchases` and Checkout, which are only in Calypso Blue?

@elliottprogrammer can you confirm that this Jetpack Cloud reasoning is correct? In #58813 you enabled the flag in `production`, for Calypso Blue only.