### PR TITLE
Editor: Refactor `PostRevisionsDialog` away from `UNSAFE_` methods

### DIFF
--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -36,14 +36,12 @@ class PostRevisionsDialog extends PureComponent {
 		translate: PropTypes.func.isRequired,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.toggleBodyClass( { isVisible: this.props.isVisible } );
 		this.props.selectPostRevision( null );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillUpdate( { isVisible } ) {
+	componentDidUpdate( { isVisible } ) {
 		this.toggleBodyClass( { isVisible } );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `PostRevisionsDialog` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Open a post with revisions.
* Click the "N revisions" button in the Post sidebar.
* Verify the dialog opens, still works well, and closes when you press Escape, click "Cancel" or click outside of it.