### PR TITLE
Update: licensing prompt dialog wording

### DIFF
--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -49,7 +49,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 		if ( hasOneDetachedLicense ) {
 			return detachedUserLicense?.product
 				? preventWidows(
-						translate( 'Your %(productName)s is pending activation', {
+						translate( 'Activate %(productName)s', {
 							args: {
 								productName: detachedUserLicense.product,
 							},
@@ -57,7 +57,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 				  )
 				: preventWidows( translate( 'Your product is pending activation' ) );
 		}
-		return preventWidows( translate( 'You have an available product license key' ) );
+		return preventWidows( translate( 'Activate your new Jetpack features' ) );
 	}, [ detachedUserLicense, hasOneDetachedLicense, translate ] );
 
 	const activateProductClick = useCallback( () => {

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -91,7 +91,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 			<p className="licensing-prompt-dialog__instructions">
 				{ preventWidows(
 					translate(
-						'{{strong}}Check your email{{/strong}} for your license key. You should have received it after making your purchase.',
+						'Find the license key in your purchase confirmation email to activate your new Jetpack features.',
 						{
 							components: {
 								strong: <strong />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some wording should be changed in the licensing prompt dialogue window when you have detached licenses.
- Description can be found in the task: 1164141197617539-as-1201710570188036/f

#### Testing instructions
Scenario 1:
Shows `Activate {productName}` in dialog window header and body: `Find the license key in your purchase confirmation email to activate your new Jetpack features.`
- Create a new JN site and connect to Jetpack.
- Navigate to https://cloud.jetpack.com/pricing and purchase 1 plan.
- After checkout, don't attach it to a site.
- Navigate to [Calypso](https://calypso.live?image=registry.a8c.com/calypso/app:commit-444d09929b064b33ad872a52fabf2296443da499) and set relative path to `/jetpack/connect/plans/${your-JN-site}`
##### Before
<img width="733" alt="Screenshot 2022-01-26 at 14 48 53" src="https://user-images.githubusercontent.com/60262784/151167051-aa51d493-7b20-47f8-bf77-570f3ba8ceb0.png">

##### After
<img width="697" alt="Screenshot 2022-01-26 at 16 00 10" src="https://user-images.githubusercontent.com/60262784/151176669-17bcd576-db0e-413a-a930-381869142a20.png">



Scenario 2 (after Scenario 1 is done):
Shows `Activate your new Jetpack features` in dialog window header and body: `Find the license key in your purchase confirmation email to activate your new Jetpack features.`
- Navigate to https://cloud.jetpack.com/pricing and purchase another plan.
- After checkout, don't attach it to a site.
- Navigate to [Calypso](https://calypso.live?image=registry.a8c.com/calypso/app:commit-444d09929b064b33ad872a52fabf2296443da499) and set relative path to `/jetpack/connect/plans/${your-JN-site}`
##### Before
<img width="710" alt="Screenshot 2022-01-26 at 14 50 12" src="https://user-images.githubusercontent.com/60262784/151167453-598e065c-7b7a-41c1-beee-64ead5197d1f.png">

##### After
<img width="722" alt="Screenshot 2022-01-26 at 15 58 16" src="https://user-images.githubusercontent.com/60262784/151176701-b80c1454-cfad-4236-af7f-0e885f601382.png">



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead, attach the [Status] Fix Inbound label to
the linked issue.
-->

