### PR TITLE
Site Settings: Refactor `TermTreeSelector` away from UNSAFE_ methods

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -290,6 +290,7 @@ class TermFormDialog extends Component {
 						<TermTreeSelectorTerms
 							siteId={ siteId }
 							taxonomy={ taxonomy }
+							key={ taxonomy }
 							isError={ isError }
 							onSearch={ this.onSearch }
 							onChange={ this.onParentChange }

--- a/client/blocks/term-tree-selector/README.md
+++ b/client/blocks/term-tree-selector/README.md
@@ -9,7 +9,7 @@ Under the hood, it uses [`<QueryTerms />`](../../components/data/query-terms) to
 ```jsx
 import TermSelector from 'calypso/blocks/term-tree-selector';
 
-<TermTreeSelector taxonomy="category" />;
+<TermTreeSelector taxonomy="category" key="category" />;
 ```
 
 ## Props
@@ -23,6 +23,8 @@ import TermSelector from 'calypso/blocks/term-tree-selector';
 </table>
 
 The type of taxonomy to query.
+
+In order to provide consistent experience, provide the same value to a `key` prop, as shown in the example above.
 
 ### `multiple`
 

--- a/client/blocks/term-tree-selector/index.jsx
+++ b/client/blocks/term-tree-selector/index.jsx
@@ -43,13 +43,6 @@ export default class TermTreeSelector extends Component {
 		}
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.taxonomy !== this.props.taxonomy ) {
-			this.setState( { search: '' } );
-		}
-	}
-
 	render() {
 		const {
 			taxonomy,
@@ -75,6 +68,7 @@ export default class TermTreeSelector extends Component {
 			<div>
 				<TermTreeSelectorTerms
 					taxonomy={ taxonomy }
+					key={ taxonomy }
 					onSearch={ this.onSearch }
 					onChange={ onChange }
 					query={ query }

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -72,16 +72,14 @@ class TermTreeSelectorList extends Component {
 		height: 300,
 	};
 
-	// initialState is also used to reset state when a the taxonomy prop changes
-	static initialState = {
+	state = {
 		searchTerm: '',
 		requestedPages: Object.freeze( [ 1 ] ),
 	};
 
-	state = this.constructor.initialState;
+	constructor( props ) {
+		super( props );
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
 		this.itemHeights = {};
 		this.hasPerformedSearch = false;
 		this.list = null;
@@ -94,19 +92,12 @@ class TermTreeSelectorList extends Component {
 		}, SEARCH_DEBOUNCE_TIME_MS );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.taxonomy !== this.props.taxonomy ) {
-			this.setState( this.constructor.initialState );
-		}
-
-		if ( this.props.terms !== nextProps.terms ) {
-			this.getTermChildren.cache.clear();
-			this.termIds = map( nextProps.terms, 'ID' );
-		}
-	}
-
 	componentDidUpdate( prevProps ) {
+		if ( prevProps.terms !== this.props.terms ) {
+			this.getTermChildren.cache.clear();
+			this.termIds = map( this.props.terms, 'ID' );
+		}
+
 		const forceUpdate =
 			! isEqual( prevProps.selected, this.props.selected ) ||
 			( prevProps.loading && ! this.props.loading ) ||

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -295,6 +295,7 @@ class PodcastingDetails extends Component {
 					</FormSettingExplanation>
 					<TermTreeSelector
 						taxonomy="category"
+						key="category"
 						selected={ podcastingCategoryId ? [ podcastingCategoryId ] : [] }
 						podcastingCategoryId={ podcastingCategoryId }
 						onChange={ this.onCategorySelected }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `TermTreeSelector` and `TermTreeSelectorList` components away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/settings/podcasting/:site` on a WP.com site that has a paid plan and Podcasting enabled.
* Verify you can still manage categories on multiple levels.
* Verify you can still set a category as the Podcasting one correctly.
* Go to `/settings/taxonomies/category/:site` where `:site` is one of your WP.com sites.
* Add some top level and sub level categories and verify that works well.
* Click on "Tags" and add/edit some tags as well, verify that still works well.
* Use the term search form and change between "Tags" and "Categories" from the sidebar and verify everything works well.