### PR TITLE
Reader: Refactor `ConversationCommentList` away from `UNSAFE_` methods

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -110,9 +110,8 @@ export class ConversationCommentList extends Component {
 		this.reqMoreComments();
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { hiddenComments, commentsTree, siteId, commentErrors } = nextProps;
+	componentDidUpdate() {
+		const { hiddenComments, commentsTree, siteId, commentErrors } = this.props;
 
 		// if we are running low on comments to expand then fetch more
 		if ( size( hiddenComments ) < FETCH_NEW_COMMENTS_THRESHOLD ) {
@@ -129,7 +128,7 @@ export class ConversationCommentList extends Component {
 		inaccessible
 			.filter( ( commentId ) => ! commentErrors[ getErrorKey( siteId, commentId ) ] )
 			.forEach( ( commentId ) => {
-				nextProps.requestComment( {
+				this.props.requestComment( {
 					commentId,
 					siteId,
 				} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ConversationCommentList` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/read/conversations`
* Scroll to a post with many (hundreds) of comments.
* Keep clicking on the "Load previous comments from USER and others"
* Verify after a few clicks you start getting requests to `/rest/v1.1/sites/:siteId/comments/:commentId`
* Verify comments load correctly and keep an eye on the console for errors.