### PR TITLE
`QueryReaderSite`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -165,7 +165,7 @@ class ReaderCombinedCardComponent extends Component {
 					/>
 				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
-				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
+				{ siteId && <QueryReaderSite siteId={ +siteId } /> }
 			</Card>
 		);
 	}

--- a/client/components/data/query-reader-site/index.jsx
+++ b/client/components/data/query-reader-site/index.jsx
@@ -1,49 +1,24 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { requestSite } from 'calypso/state/reader/sites/actions';
 import { shouldSiteBeFetched } from 'calypso/state/reader/sites/selectors';
 
-class QueryReaderSite extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		if ( this.props.shouldSiteBeFetched ) {
-			this.props.requestSite( this.props.siteId );
+function QueryReaderSite( { siteId } ) {
+	const dispatch = useDispatch();
+	const shouldFetch = useSelector( ( state ) => shouldSiteBeFetched( state, siteId ) );
+
+	useEffect( () => {
+		if ( siteId && shouldFetch ) {
+			dispatch( requestSite( siteId ) );
 		}
-	}
+	}, [ dispatch, siteId, shouldFetch ] );
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.shouldSiteBeFetched || this.props.siteId === nextProps.siteId ) {
-			return;
-		}
-
-		nextProps.requestSite( nextProps.siteId );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QueryReaderSite.propTypes = {
 	siteId: PropTypes.number,
-	shouldSiteBeFetched: PropTypes.bool,
-	requestSite: PropTypes.func,
 };
 
-QueryReaderSite.defaultProps = {
-	requestSite: () => {},
-};
-
-export default connect(
-	( state, ownProps ) => {
-		const { siteId } = ownProps;
-		return {
-			shouldSiteBeFetched: shouldSiteBeFetched( state, siteId ),
-		};
-	},
-	{
-		requestSite,
-	}
-)( QueryReaderSite );
+export default QueryReaderSite;

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -80,10 +80,8 @@ class ReaderPostCardAdapter extends Component {
 				compact={ this.props.compact }
 			>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
-				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
-				{ isDiscover && (
-					<QueryReaderSite siteId={ discoverPostKey.blogId } includeMeta={ false } />
-				) }
+				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } /> }
+				{ isDiscover && <QueryReaderSite siteId={ discoverPostKey.blogId } /> }
 				{ hasDiscoverSourcePost && <QueryReaderPost postKey={ discoverPostKey } /> }
 			</ReaderPostCard>
 		);

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -210,7 +210,7 @@ class CrossPost extends PureComponent {
 					{ post.author && this.getDescription( post.author.first_name ) }
 				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
-				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
+				{ siteId && <QueryReaderSite siteId={ +siteId } /> }
 			</Card>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryReaderSite`: refactor away from `UNSAFE_*`
* remove `includeMeta` prop from some usages (it's not used)

#### Testing instructions

* Go to `/read`
* You'll probably see a few requests to `/read/sites/:siteId` (depends on your feed)
* Navigate away and come back to `/read`, requests shouldn't be issued again

Related to #58453 
