### PR TITLE
Tour Kit/Welcome Tour: Mobile & Desktop classNames for Steps

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -217,26 +217,12 @@ $welcome-tour-card-media-extra-padding: 14%; // temporary value, to match the pa
 }
 
 .wpcom-editor-welcome-tour {
-	&.is-mobile {
-		.wpcom-editor-welcome-tour__step {
-			&.is-with-extra-padding {
-				.components-card__media img {
-					left: $welcome-tour-card-media-extra-padding;
-					top: $welcome-tour-card-media-extra-padding;
-					width: 100% - $welcome-tour-card-media-extra-padding;
-				}
-			}
-		}
-	}
-
-	&.is-desktop {
-		.wpcom-editor-welcome-tour__step {
-			&.is-with-extra-padding-desktop {
-				.components-card__media img {
-					left: $welcome-tour-card-media-extra-padding;
-					top: $welcome-tour-card-media-extra-padding;
-					width: 100% - $welcome-tour-card-media-extra-padding;
-				}
+	.wpcom-editor-welcome-tour__step {
+		&.is-with-extra-padding {
+			.components-card__media img {
+				left: $welcome-tour-card-media-extra-padding;
+				top: $welcome-tour-card-media-extra-padding;
+				width: 100% - $welcome-tour-card-media-extra-padding;
 			}
 		}
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -154,7 +154,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 						},
 						options: {
 							classNames: {
-								desktop: [ 'is-with-extra-padding-desktop', 'wpcom-editor-welcome-tour__step' ],
+								desktop: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 								mobile: null,
 							},
 						},

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -51,7 +51,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 			options: {
 				classNames: {
-					desktop: null,
+					desktop: 'wpcom-editor-welcome-tour__step',
 					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 				},
 			},
@@ -68,6 +68,12 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				},
 				imgSrc: getTourAssets( 'allBlocks' ),
 				animation: null,
+			},
+			options: {
+				classNames: {
+					desktop: 'wpcom-editor-welcome-tour__step',
+					mobile: 'wpcom-editor-welcome-tour__step',
+				},
 			},
 		},
 		{
@@ -94,7 +100,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 			options: {
 				classNames: {
-					desktop: null,
+					desktop: 'wpcom-editor-welcome-tour__step',
 					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 				},
 			},
@@ -111,6 +117,12 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				},
 				imgSrc: getTourAssets( 'makeBold' ),
 				animation: null,
+			},
+			options: {
+				classNames: {
+					desktop: 'wpcom-editor-welcome-tour__step',
+					mobile: 'wpcom-editor-welcome-tour__step',
+				},
 			},
 		},
 		{
@@ -131,7 +143,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 			options: {
 				classNames: {
-					desktop: null,
+					desktop: 'wpcom-editor-welcome-tour__step',
 					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 				},
 			},
@@ -176,6 +188,12 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'undo-button',
 				isDesktopOnly: true,
 			},
+			options: {
+				classNames: {
+					desktop: 'wpcom-editor-welcome-tour__step',
+					mobile: 'wpcom-editor-welcome-tour__step',
+				},
+			},
 		},
 		{
 			meta: {
@@ -189,7 +207,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 			},
 			options: {
 				classNames: {
-					desktop: null,
+					desktop: 'wpcom-editor-welcome-tour__step',
 					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
 				},
 			},
@@ -226,6 +244,12 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				},
 				imgSrc: getTourAssets( 'finish' ),
 				animation: 'block-inserter',
+			},
+			options: {
+				classNames: {
+					desktop: 'wpcom-editor-welcome-tour__step',
+					mobile: 'wpcom-editor-welcome-tour__step',
+				},
 			},
 		},
 	];

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -50,7 +50,10 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: null,
 			},
 			options: {
-				classNames: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				classNames: {
+					desktop: null,
+					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				},
 			},
 		},
 		{
@@ -90,7 +93,10 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'block-inserter',
 			},
 			options: {
-				classNames: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				classNames: {
+					desktop: null,
+					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				},
 			},
 		},
 		{
@@ -124,7 +130,10 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: null,
 			},
 			options: {
-				classNames: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				classNames: {
+					desktop: null,
+					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				},
 			},
 		},
 		...( localeSlug === 'en'
@@ -144,7 +153,10 @@ function getTourSteps( localeSlug, referencePositioning ) {
 							isDesktopOnly: true,
 						},
 						options: {
-							classNames: [ 'is-with-extra-padding-desktop', 'wpcom-editor-welcome-tour__step' ],
+							classNames: {
+								desktop: [ 'is-with-extra-padding-desktop', 'wpcom-editor-welcome-tour__step' ],
+								mobile: null,
+							},
 						},
 					},
 			  ]
@@ -176,7 +188,10 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				animation: 'undo-button',
 			},
 			options: {
-				classNames: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				classNames: {
+					desktop: null,
+					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+				},
 			},
 		},
 		{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -155,7 +155,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 						options: {
 							classNames: {
 								desktop: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
-								mobile: null,
+								mobile: 'wpcom-editor-welcome-tour__step',
 							},
 						},
 					},

--- a/packages/tour-kit/src/components/tour-kit-step.tsx
+++ b/packages/tour-kit/src/components/tour-kit-step.tsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
 /**
  * Internal Dependencies
@@ -23,10 +24,13 @@ const TourKitStep: React.FunctionComponent< Props > = ( {
 	setInitialFocusedElement,
 	onGoToStep,
 } ) => {
+	const isMobile = useMobileBreakpoint();
 	const classes = classnames(
 		'tour-kit-step',
 		`is-step-${ currentStepIndex }`,
-		classParser( config.steps[ currentStepIndex ].options?.classNames )
+		classParser(
+			config.steps[ currentStepIndex ].options?.classNames?.[ isMobile ? 'mobile' : 'desktop' ]
+		)
 	);
 
 	return (

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -15,7 +15,13 @@ export type Step = {
 	};
 	options?: {
 		classNames?: {
-			desktop?: string | string[];
+		    /**
+		    * `desktop` classes are applied when min-width is larger or equal to 480px.
+		    */
+		    desktop?: string;
+		    /**
+		    * `mobile` classes are applied when max-width is smaller than 480px.
+		    */
 			mobile?: string | string[];
 		};
 	};

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -15,13 +15,13 @@ export type Step = {
 	};
 	options?: {
 		classNames?: {
-		    /**
-		    * `desktop` classes are applied when min-width is larger or equal to 480px.
-		    */
-		    desktop?: string;
-		    /**
-		    * `mobile` classes are applied when max-width is smaller than 480px.
-		    */
+			/**
+			 * `desktop` classes are applied when min-width is larger or equal to 480px.
+			 */
+			desktop?: string | string[];
+			/**
+			 * `mobile` classes are applied when max-width is smaller than 480px.
+			 */
 			mobile?: string | string[];
 		};
 	};

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -14,7 +14,10 @@ export type Step = {
 		// | ...
 	};
 	options?: {
-		classNames?: string | string[];
+		classNames?: {
+			desktop?: string | string[];
+			mobile?: string | string[];
+		};
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to better manage what CSS style to apply to a specific step based on the viewport (desktop or mobile).
So, we introduced a more granular className definition for Step:

```
// Step:
...
options: {
  classNames: {
	  desktop: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
	  mobile: undefined,
  },
},
```

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  checkout branch
* `yarn dev --sync` from `apps/editing-toolkit` to sync the welcome tour to the sandbox
*  test that Welcome Tour has the correct step CSS classes (in the screenshot you can see the desktop version, without additional classes, and the mobile version, with `is-with-extra-padding`, to reflect the config: 
```
options: {
	classNames: {
		desktop: null,
		mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
	},
},
```
DESKTOP:
![image](https://user-images.githubusercontent.com/52076348/151184839-b4a2ca64-74bd-44c6-b9e3-ac6bf663b3b5.png)

MOBILE:
![Screenshot 2022-01-26 at 15 43 07](https://user-images.githubusercontent.com/52076348/151184190-7b41d2bb-c500-4d8a-870b-3304b17ec172.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60345
Fixes #60345
