### PR TITLE
Emails: Add small margin between 3 months free label, and renewal description

### DIFF
--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -203,6 +203,7 @@
 			.email-providers-comparison__discount-with-renewal span {
 				color: var( --color-text-subtle );
 				font-weight: 400;
+				margin-left: 0.5em;
 			}
 
 			.email-providers-comparison__discount-with-renewal .info-popover {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There is a small issue that prevents the 3 Months label to be separated from the Renewal description in the Professional Email card.

#### Testing instructions

1. Go to upgrade
2. Click on domains
3. Add a domain to your cart
4. Check that the Professional Email upsell card looks like the following screenshot

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5689927/151196457-5a6d184e-5030-4aec-a3bc-556e37470fb6.png) | ![image](https://user-images.githubusercontent.com/5689927/151196329-fd70b046-fa68-4b99-bf79-fd7b61a2b14c.png) |

Related to 1200182182542585-as-1201715173541050
