### PR TITLE
Jetpack Licensing activation: Adjust css for licensing activation title

### DIFF
--- a/client/components/jetpack/licensing-activation/style.scss
+++ b/client/components/jetpack/licensing-activation/style.scss
@@ -108,6 +108,7 @@
 .licensing-activation__title {
 	font-style: normal;
 	font-weight: bold;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 44px;
 	line-height: 52px;
 

--- a/client/components/jetpack/licensing-activation/style.scss
+++ b/client/components/jetpack/licensing-activation/style.scss
@@ -108,8 +108,8 @@
 .licensing-activation__title {
 	font-style: normal;
 	font-weight: bold;
-	font-size: $font-headline-small;
-	line-height: 44px;
+	font-size: 44px;
+	line-height: 52px;
 
 	margin-bottom: 24px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adjusts the css for the licensing activation title.

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/42627630/151208945-ee830809-75de-4996-8125-20d2f94008ad.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Purchase a Jetpack license, and activate it in the license purchase flow.
2. On the confirmation screen, verify that the title looks like it does in the screenshot above.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
