### PR TITLE
Fix HappyChat overlapping with domains header breadcrumbs

### DIFF
--- a/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
+++ b/client/my-sites/domains/domain-management/components/breadcrumbs/style.scss
@@ -10,18 +10,18 @@
 		top: var( --masterbar-height );
 		padding: 0 16px;
 		left: 0;
-		right: 0px;
+		right: 0;
 		border-bottom: 1px solid var( --studio-gray-5 );
 
 		@include breakpoint-deprecated( '>660px' ) {
 			padding: 0 24px;
 		}
 
-		@media screen and ( min-width: #{ ($break-medium + 1) } ) {
+		@media screen and ( min-width: #{ ( $break-medium + 1 ) } ) {
 			left: var( --sidebar-width-min );
 		}
 
-		@media screen and ( min-width: #{ ($break-large + 1) } ) {
+		@media screen and ( min-width: #{ ( $break-large + 1 ) } ) {
 			padding: 0 32px;
 		}
 
@@ -183,5 +183,12 @@
 
 	@include breakpoint-deprecated( '<660px' ) {
 		height: 76px;
+	}
+}
+
+/* This prevents breadcrumbs component from being partially hidden when happychat is open */
+.has-docked-chat .breadcrumbs > div:first-child {
+	@include breakpoint-deprecated( '>1040px' ) {
+		right: var( --sidebar-width-max );
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes a bug that prevent some domains header elements from being displayed, when the HappyChat is open.

Related to #60478 (in this case the issue is related to "Add Record" button, but it's actually more generic).

![chat-after](https://user-images.githubusercontent.com/2797601/151210185-fb1f19cc-3d39-4e27-a71a-b242c64d7096.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades -> Domains" and select a registered domain, open the DNS accordion and click on "Manage" button (or you can navigate directly to `/domains/manage/{:your-domain}/dns/{:your-site}`)
- Start a support chat session and verify that the "Add Record" button is now visible (_you need to have viewport >= 1041 px_)


