### PR TITLE
Full Site Editing: hide the core site editor in WP 5.9

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -116,7 +116,7 @@ function unload_core_fse() {
 	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
 
 	// always hide the WP core Site Editor.
-	add_action( 'admin_menu', __NAMESPACE__ . '\hide_core_site_editor' );
+	add_action( 'admin_menu', __NAMESPACE__ . '\maybe_hide_core_site_editor' );
 }
 
 /**
@@ -342,12 +342,16 @@ function display_fse_section() {
 }
 
 /**
- * Always hide the Core Site Editor in favour of the Gutenberg version.
+ * Hide the Core Site Editor in favour of the Gutenberg version.
  *
  * @return void
  */
-function hide_core_site_editor() {
-	remove_submenu_page( 'themes.php', 'site-editor.php' );
+function maybe_hide_core_site_editor() {
+	$is_wpcom            = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	$is_gutenberg_active = $is_wpcom ? true : in_array( 'gutenberg/gutenberg.php', get_option( 'active_plugins' ), true );
+	if ( $is_gutenberg_active ) {
+		remove_submenu_page( 'themes.php', 'site-editor.php' );
+	}
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -114,6 +114,9 @@ function unload_core_fse() {
 	}
 	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
 	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
+
+	// always hide the WP core Site Editor.
+	add_action( 'admin_menu', __NAMESPACE__ . '\hide_core_site_editor' );
 }
 
 /**
@@ -361,9 +364,6 @@ function init() {
 	if ( is_core_fse_active() ) {
 		load_core_fse();
 	}
-
-	// always hide the WP core Site Editor.
-	add_action( 'admin_menu', __NAMESPACE__ . '\hide_core_site_editor' );
 }
 // For WPcom REST API requests to work properly.
 add_action( 'restapi_theme_init', __NAMESPACE__ . '\init' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -339,6 +339,15 @@ function display_fse_section() {
 }
 
 /**
+ * Always hide the Core Site Editor in favour of the Gutenberg version.
+ *
+ * @return void
+ */
+function hide_core_site_editor() {
+	remove_submenu_page( 'themes.php', 'site-editor.php' );
+}
+
+/**
  * Run everything
  *
  * @return void
@@ -352,6 +361,9 @@ function init() {
 	if ( is_core_fse_active() ) {
 		load_core_fse();
 	}
+
+	// always hide the WP core Site Editor.
+	add_action( 'admin_menu', __NAMESPACE__ . '\hide_core_site_editor' );
 }
 // For WPcom REST API requests to work properly.
 add_action( 'restapi_theme_init', __NAMESPACE__ . '\init' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -115,7 +115,7 @@ function unload_core_fse() {
 	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
 	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
 
-	// always hide the WP core Site Editor.
+	// Hide the Site editor added by WP 5.9 (if Gutenberg is active).
 	add_action( 'admin_menu', __NAMESPACE__ . '\maybe_hide_core_site_editor' );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Updates our FSE theme detection to use the Core function (`wp_is_block_theme`), if present. 
- Hides the Site editor sidebar menu item when a Universal theme is active.

WP 5.9 adds the Site editor in a different way than Gutenberg, so needs to be explicitly unhooked.

#### Testing instructions

* `install-plugin.sh etk fix/hide-core-site-editor` on a wpcom sandbox
* Sandbox the site and public-api
* Check both wp-admin and Calypso pages
* On a site without FSE active/eligible, but with a universal theme, you should not see the "Editor" item under the Appearance menu
* On a site where FSE is active and eligible, you should see the Editor menu item
