### PR TITLE
Use Jetpack FullStory on Jetpack Cloud

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -66,6 +66,7 @@ export const TRACKING_IDS = {
 	facebookInit: '823166884443641',
 	facebookJetpackInit: '919484458159593',
 	fullStory: '120RG4',
+	fullStoryJetpack: '181XXV',
 	linkedInPartnerId: '195308',
 	outbrainAdvId: '00f0f5287433c2851cc0cb917c7ff0465e',
 	pinterestInit: '2613194105266',

--- a/client/lib/analytics/fullstory.js
+++ b/client/lib/analytics/fullstory.js
@@ -2,6 +2,7 @@ import { getCurrentUser, getDoNotTrack } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import debug from 'debug';
 import { isE2ETest } from 'calypso/lib/e2e';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { TRACKING_IDS } from './ad-tracking/constants';
 import { mayWeTrackCurrentUserGdpr, isPiiUrl } from './utils';
 
@@ -55,7 +56,7 @@ function maybeAddFullStoryScript() {
 	window._fs_debug = 'development' === process.env.NODE_ENV;
 	window._fs_host = 'fullstory.com';
 	window._fs_script = 'edge.fullstory.com/s/fs.js';
-	window._fs_org = TRACKING_IDS.fullStory;
+	window._fs_org = isJetpackCloud() ? TRACKING_IDS.fullStoryJetpack : TRACKING_IDS.fullStory;
 	window._fs_namespace = 'FS';
 
 	( function ( m, n, e, t, l, o, g, y ) {

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -35,6 +35,7 @@
 		"checkout/google-pay": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
+		"fullstory": true,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/more-informative-scan": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -30,6 +30,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
+		"fullstory": true,
 		"jetpack-cloud": true,
 		"jetpack/more-informative-scan": true,
 		"jetpack/search-product": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -32,6 +32,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": false,
+		"fullstory": true,
 		"i18n/community-translator": false,
 		"jetpack-cloud": true,
 		"jetpack/more-informative-scan": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -32,6 +32,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": false,
+		"fullstory": true,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/more-informative-scan": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add the `jetpackFullStory` org id to tracking constants
- Use the above id for Fullstory on Jetpack Cloud

#### Testing instructions

**NOTE:** Testing must be done on a non-GDPR browser either via manipulating the result of `public-api.wordpress.com/geo` or changing the cookie `country_code`

1. Boot branch as Calypso Blue/WordPress.com
2. Filter Dev Tool network requests for `fullstory`
3. Verify that a `POST rs.fullstory.com/rec/page` request has the param `OrgId` set to `120RG4`
   - There may or may not be further requests, based on the usage remaining on the FullStory account.
4. Boot branch as Calypso Green/Jetpack Cloud
5. Filter Dev Tool network requests for `fullstory`
6. Verify that a `POST rs.fullstory.com/rec/page` request has the param `OrgId` set to `181XXV`
   - There may or may not be further requests, based on the usage remaining on the FullStory account.
