### PR TITLE
FSE: Add TT2 to design picker

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -32,6 +32,72 @@
 			"features": []
 		},
 		{
+			"title": "Twenty Twenty-Two",
+			"slug": "twentytwentytwo",
+			"template": "twentytwentytwo",
+			"theme": "twentytwentytwo",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"is_featured_picks": true,
+			"features": []
+		},
+		{
+			"title": "Twenty Twenty-Two Swiss",
+			"slug": "twentytwentytwo-swiss",
+			"template": "twentytwentytwo",
+			"theme": "twentytwentytwo-swiss",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"is_featured_picks": true,
+			"features": []
+		},
+		{
+			"title": "Twenty Twenty-Two Pink",
+			"slug": "twentytwentytwo-pink",
+			"template": "twentytwentytwo",
+			"theme": "twentytwentytwo-pink",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"is_featured_picks": true,
+			"features": []
+		},
+		{
+			"title": "Twenty Twenty-Two Mint",
+			"slug": "twentytwentytwo-mint",
+			"template": "twentytwentytwo",
+			"theme": "twentytwentytwo-mint",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"is_featured_picks": true,
+			"features": []
+		},
+		{
+			"title": "Twenty Twenty-Two Red",
+			"slug": "twentytwentytwo-red",
+			"template": "twentytwentytwo",
+			"theme": "twentytwentytwo-red",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"is_featured_picks": true,
+			"features": []
+		},
+		{
+			"title": "Twenty Twenty-Two Blue",
+			"slug": "twentytwentytwo-blue",
+			"template": "twentytwentytwo",
+			"theme": "twentytwentytwo-blue",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"is_featured_picks": true,
+			"features": []
+		},
+		{
 			"title": "Arbutus",
 			"slug": "arbutus",
 			"template": "arbutus",


### PR DESCRIPTION
Closes #58663.

#### Changes proposed in this Pull Request

We're finally adding TT2 to the design picker on FSE site creation flows! 🎉 

#### Testing instructions

Sandbox yourself.

- Create a site through Gutenboarding (`/new`).

You should be able to pick Twenty Twenty-Two from the Design Picker.

- Create a site through onboarding (`/start`)

You should be able to pick Twenty Twenty-Two from the Design Picker.

#### Screenshots

| Gutenboarding `/new` | Onboarding `/start` |
| ---------------------- | -------------------- |
| ![image](https://user-images.githubusercontent.com/26530524/151230568-07f2857f-7b64-4da6-9071-49458890a78a.png) | ![image](https://user-images.githubusercontent.com/26530524/151230687-ecb4f1ad-c9e8-4567-bb08-d2f66855b478.png) |