### PR TITLE
Domains: Prefer "Use a domain I own" flow instead of previous transfer one

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1377,10 +1377,7 @@ class RegisterDomainStep extends Component {
 	};
 
 	useYourDomainFunction = () => {
-		const { lastDomainStatus } = this.state;
-		return domainAvailability.MAPPED === lastDomainStatus
-			? this.goToTransferDomainStep
-			: this.goToUseYourDomainStep;
+		return this.goToUseYourDomainStep;
 	};
 
 	renderSearchResults() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
It simply updates the "You can use it as your site’s address" link on the domain search to redirect the user to the "Use a domain I own" flow instead of the old transfer flow.

#### Preview
https://user-images.githubusercontent.com/18705930/151238790-17d543ef-c316-4b56-8c66-5e498e73164a.mov

#### Testing instructions
- Go to "Upgrades > Domains";
- Search for a domain ("Add a domain" > "Search for a domain");
- Try to search for a domain that's already mapped - it should work for other domains too;
- Click on the “use it as your site’s address” link;
- Check that you will get redirected to the "Use a domain I own" flow instead of the previous transfer flow.