### PR TITLE
[GB 12.5.x] Fix global styles menu selection tracking for G v12.5

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-menu-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-menu-selected.js
@@ -2,8 +2,9 @@ import { __ } from '@wordpress/i18n';
 import tracksRecordEvent from './track-record-event';
 
 function trackGlobalStylesMenuSelected( { path } ) {
+	// Gutenberg 12.5.0 changes the selector for the preview at the top level to have the '*__iframe' suffix.
 	const isAtTopLevel = document.querySelector(
-		'.edit-site-global-styles-sidebar .edit-site-global-styles-preview'
+		'.edit-site-global-styles-sidebar .edit-site-global-styles-preview, .edit-site-global-styles-sidebar .edit-site-global-styles-preview__iframe'
 	);
 
 	if ( ! isAtTopLevel ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In Gutenberg v12.5 the selector used in determining the top level of the global styles panel was changed to add a `*__iframe` suffix. Due to this change, tracking events for menus being selected are no longer firing. Here we add the new selector to the list for the events to be compatible with 12.5.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this wpcom-block-editor build
* Open the site editor on an edge site running Gv12.5.0-rc1 or higher.
* open the global styles panel and select one of the menu buttons
* verify the tracking event is sent (this can be seen in the network tab by filtering t.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60500.
