### PR TITLE
Woo Installer: Track checkout step required

### DIFF
--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -9,6 +9,7 @@ import EligibilityWarningsList from 'calypso/components/eligibility-warnings/war
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WarningCard from 'calypso/components/warning-card';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ActionSection, StyledNextButton } from '..';
@@ -114,6 +115,11 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 							onClick={ () => {
 								dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
 								if ( siteUpgrading.required ) {
+									dispatch(
+										recordTracksEvent( 'calypso_woocommerce_dashboard_upgrade_required', {
+											site: wpcomDomain,
+										} )
+									);
 									page( siteUpgrading.checkoutUrl );
 									return;
 								}

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -114,22 +114,16 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 							disabled={ isTransferringBlocked || ! isDataReady }
 							onClick={ () => {
 								dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
-								if ( siteUpgrading.required ) {
-									dispatch(
-										recordTracksEvent( 'calypso_woocommerce_dashboard_confirm_submit', {
-											site: wpcomDomain,
-											upgrade_required: true,
-										} )
-									);
-									page( siteUpgrading.checkoutUrl );
-									return;
-								}
 								dispatch(
 									recordTracksEvent( 'calypso_woocommerce_dashboard_confirm_submit', {
 										site: wpcomDomain,
-										upgrade_required: false,
+										upgrade_required: siteUpgrading.required,
 									} )
 								);
+								if ( siteUpgrading.required ) {
+									page( siteUpgrading.checkoutUrl );
+									return;
+								}
 								goToNextStep();
 							} }
 						>

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -116,13 +116,20 @@ export default function Confirm( props: WooCommerceInstallProps ): ReactElement 
 								dispatch( submitSignupStep( { stepName: 'confirm' }, { siteConfirmed: siteId } ) );
 								if ( siteUpgrading.required ) {
 									dispatch(
-										recordTracksEvent( 'calypso_woocommerce_dashboard_upgrade_required', {
+										recordTracksEvent( 'calypso_woocommerce_dashboard_confirm_submit', {
 											site: wpcomDomain,
+											upgrade_required: true,
 										} )
 									);
 									page( siteUpgrading.checkoutUrl );
 									return;
 								}
+								dispatch(
+									recordTracksEvent( 'calypso_woocommerce_dashboard_confirm_submit', {
+										site: wpcomDomain,
+										upgrade_required: false,
+									} )
+								);
 								goToNextStep();
 							} }
 						>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Track confirm step submit with `upgrade_required` and `site` properties.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Show tracking in your browser: PCYsg-cae-p2
* Start with a site on a < Business plan
* Go to /woocommerce-installation/< site id >
* Go through the flow and check that the `calypso_woocommerce_dashboard_confirm_submit` track event is logged with the site domain, after the confirm step.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59478
