### PR TITLE
Checkout: Prevent making redirect response if we just did a 3DS confirmation

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -87,7 +87,10 @@ export default async function existingCardProcessor(
 			return stripeResponse;
 		} )
 		.then( ( stripeResponse ) => {
-			if ( stripeResponse?.redirect_url ) {
+			if (
+				stripeResponse?.redirect_url &&
+				! stripeResponse?.message?.payment_intent_client_secret
+			) {
 				debug( 'transaction requires redirect' );
 				return makeRedirectResponse( stripeResponse.redirect_url );
 			}

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -134,7 +134,10 @@ async function stripeCardProcessor(
 			return stripeResponse;
 		} )
 		.then( ( stripeResponse ) => {
-			if ( stripeResponse?.redirect_url ) {
+			if (
+				stripeResponse?.redirect_url &&
+				! stripeResponse?.message?.payment_intent_client_secret
+			) {
 				return makeRedirectResponse( stripeResponse.redirect_url );
 			}
 			return makeSuccessResponse( stripeResponse );


### PR DESCRIPTION
#### Problem

This fixes a small regression added by https://github.com/Automattic/wp-calypso/pull/59746. That PR made it so that we return the original transaction response to the Promise chain after a 3DS purchase completes, so that that result's data (specifically the order ID) can be stored and used to create a "pending" page. 

However, apparently sometimes the original transaction in a 3DS purchase _also_ includes a `redirect_url` (presumably to be used instead of the inline confirmation? I don't know; it only seems to happen for me in signup). 

If this occurs, then the next transaction handler will try to redirect to that URL after the 3DS purchase completes. I don't know what would happen if this worked, but it fails in my experience, leaving us hanging on checkout with a "Redirecting to payment partner" message.

<img width="518" alt="Screen Shot 2022-01-26 at 4 26 28 PM" src="https://user-images.githubusercontent.com/2036909/151249774-466cda2d-135b-4bd0-8016-52b69e3c8065.png">

#### Changes proposed in this Pull Request

This PR changes the transaction handler so that it won't try to redirect if it previously authenticated a 3DS card.

#### Testing instructions

- In a logged-out window, visit `/start`.
- Go through the signup flow, adding a paid plan to your cart.
- When you reach checkout, use a 3DS test card like `4000000000003063`.
- Confirm the purchase in the 3DS modal.
- Verify that the purchase completes and that you are redirected to your site.