### PR TITLE
E2E: fix mi-rebased test spec for Gutenberg: Experimental features.

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-gutenberg__experimental.ts
+++ b/test/e2e/specs/specs-wpcom/wp-gutenberg__experimental.ts
@@ -3,24 +3,26 @@
  */
 
 import {
-	setupHooks,
+	envVariables,
 	TestAccount,
-	BrowserHelper,
 	DataHelper,
 	GutenbergEditorPage,
 } from '@automattic/calypso-e2e';
-import { Page } from 'playwright';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), function () {
-	const accountName = BrowserHelper.targetGutenbergEdge()
+	const accountName = envVariables.GUTENBERG_EDGE
 		? 'gutenbergSimpleSiteEdgeUser'
 		: 'gutenbergSimpleSiteUser';
 
 	let page: Page;
 	let gutenbergEditorPage: GutenbergEditorPage;
 
-	setupHooks( async ( args ) => {
-		page = args.page;
+	beforeAll( async () => {
+		page = await browser.newPage();
+		gutenbergEditorPage = new GutenbergEditorPage( page );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the boilerplate for the Gutenberg: Experimental features spec introduced in https://github.com/Automattic/wp-calypso/pull/60163.

Key changes:
- use new boilerplate introduced in https://github.com/Automattic/wp-calypso/pull/59811.


#### Testing instructions

- [x] Ensure that Gutenberg: Experimental feature is:
  - [x] run for mobile and desktop.
  - [x] passing for mobile and desktop.

Related to https://github.com/Automattic/wp-calypso/issues/55955.
