### PR TITLE
Themes: Mobile implement new design 

### DIFF
--- a/client/my-sites/themes/current-theme/index.tsx
+++ b/client/my-sites/themes/current-theme/index.tsx
@@ -44,6 +44,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 		const { currentTheme, currentThemeId, siteId, translate } = this.props;
 		const placeholderText = <span className="current-theme__placeholder">loading...</span>;
 		const text = currentTheme && currentTheme.name ? currentTheme.name : placeholderText;
+		const description = currentTheme && currentTheme.description ? currentTheme.description : '';
 
 		const options = pickBy(
 			this.props.options,
@@ -65,7 +66,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 							{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
 							{ showScreenshot && (
 								<img
-									src={ currentTheme.screenshot + '&w=250' }
+									src={ currentTheme.screenshot + '&w=420' }
 									className="current-theme__img"
 									alt=""
 								/>
@@ -111,6 +112,26 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 									</div>
 								</div>
 							</div>
+						</div>
+						<div className="current-theme__more-info">
+							<p className="current-theme__theme-description">
+								<span>{ description }</span>
+							</p>
+							<a
+								className="current-theme__theme-description-link"
+								href={ options?.info?.getUrl( currentThemeId ) }
+							>
+								{ translate( 'Read more' ) }
+							</a>
+
+							<a
+								className="current-theme__theme-customize"
+								href={ options?.customize?.getUrl( currentThemeId ) }
+							>
+								<Gridicon icon={ options?.customize.icon } size={ 24 } />
+								<span>{ translate( 'Customize theme' ) }</span>
+								<Gridicon icon="chevron-right" size={ 24 } />
+							</a>
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/themes/current-theme/index.tsx
+++ b/client/my-sites/themes/current-theme/index.tsx
@@ -120,6 +120,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 							<a
 								className="current-theme__theme-description-link"
 								href={ options?.info?.getUrl( currentThemeId ) }
+								onClick={ this.trackClick }
 							>
 								{ translate( 'Read more' ) }
 							</a>
@@ -127,6 +128,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 							<a
 								className="current-theme__theme-customize"
 								href={ options?.customize?.getUrl( currentThemeId ) }
+								onClick={ this.trackClick }
 							>
 								<Gridicon icon={ options?.customize.icon } size={ 24 } />
 								<span>{ translate( 'Customize theme' ) }</span>

--- a/client/my-sites/themes/current-theme/index.tsx
+++ b/client/my-sites/themes/current-theme/index.tsx
@@ -39,6 +39,8 @@ interface CurrentThemeProps {
  */
 class CurrentTheme extends Component< CurrentThemeProps > {
 	trackClick = ( event: MouseEvent< HTMLButtonElement > ) => trackClick( 'current theme', event );
+	trackLinkClick = ( event: MouseEvent< HTMLAnchorElement > ) =>
+		trackClick( 'current theme', event );
 
 	render() {
 		const { currentTheme, currentThemeId, siteId, translate } = this.props;
@@ -119,18 +121,18 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 							</p>
 							<a
 								className="current-theme__theme-description-link"
-								href={ options?.info?.getUrl( currentThemeId ) }
-								onClick={ this.trackClick }
+								href={ options.info.getUrl( currentThemeId ) }
+								onClick={ this.trackLinkClick }
 							>
 								{ translate( 'Read more' ) }
 							</a>
 
 							<a
 								className="current-theme__theme-customize"
-								href={ options?.customize?.getUrl( currentThemeId ) }
-								onClick={ this.trackClick }
+								href={ options.customize.getUrl( currentThemeId ) }
+								onClick={ this.trackLinkClick }
 							>
-								<Gridicon icon={ options?.customize.icon } size={ 24 } />
+								<Gridicon icon={ options.customize.icon } size={ 24 } />
 								<span>{ translate( 'Customize theme' ) }</span>
 								<Gridicon icon="chevron-right" size={ 24 } />
 							</a>

--- a/client/my-sites/themes/current-theme/index.tsx
+++ b/client/my-sites/themes/current-theme/index.tsx
@@ -65,7 +65,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 							{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
 							{ showScreenshot && (
 								<img
-									src={ currentTheme.screenshot + '?w=150' }
+									src={ currentTheme.screenshot + '&w=250' }
 									className="current-theme__img"
 									alt=""
 								/>
@@ -80,7 +80,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 									<span className="current-theme__name">{ text }</span>
 								</div>
 								<div className="current-theme__content-wrapper">
-									<p>
+									<p className="current-theme__content-learn-more">
 										{ translate( 'This is the active theme on your site.' ) }{ ' ' }
 										<InlineSupportLink supportContext="themes-switch">
 											{ translate( 'Learn more.' ) }

--- a/client/my-sites/themes/current-theme/index.tsx
+++ b/client/my-sites/themes/current-theme/index.tsx
@@ -119,23 +119,29 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 							<p className="current-theme__theme-description">
 								<span>{ description }</span>
 							</p>
-							<a
-								className="current-theme__theme-description-link"
-								href={ options.info.getUrl( currentThemeId ) }
-								onClick={ this.trackLinkClick }
-							>
-								{ translate( 'Read more' ) }
-							</a>
+							{ options?.info && options?.info?.getUrl && (
+								<a
+									className="current-theme__theme-description-link"
+									href={ options.info.getUrl( currentThemeId ) }
+									onClick={ this.trackLinkClick }
+								>
+									{ translate( 'Read more' ) }
+								</a>
+							) }
 
-							<a
-								className="current-theme__theme-customize"
-								href={ options.customize.getUrl( currentThemeId ) }
-								onClick={ this.trackLinkClick }
-							>
-								<Gridicon icon={ options.customize.icon } size={ 24 } />
-								<span>{ translate( 'Customize theme' ) }</span>
-								<Gridicon icon="chevron-right" size={ 24 } />
-							</a>
+							{ options?.customize && options?.customize?.getUrl && (
+								<a
+									className="current-theme__theme-customize"
+									href={ options.customize.getUrl( currentThemeId ) }
+									onClick={ this.trackLinkClick }
+								>
+									{ options?.customize?.icon && (
+										<Gridicon icon={ options.customize.icon } size={ 24 } />
+									) }
+									<span>{ translate( 'Customize theme' ) }</span>
+									<Gridicon icon="chevron-right" size={ 24 } />
+								</a>
+							) }
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -33,11 +33,13 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__details {
+		padding: 16px;
 		display: flex;
-		flex-direction: column;
+		flex-direction: row;
 		font-size: $font-body-small;
 
 		@include break-small {
+			padding: 0;
 			flex-direction: row;
 			font-size: $font-body;
 			width: 100%;
@@ -45,18 +47,24 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__img {
+		width: 120px;
+		height: 90px;
 		border-bottom: $current-theme-border;
 		max-height: none;
-		width: auto;
+		box-shadow: 0 0 0 1px var( --color-neutral-light ), 0 2px 4px var( --color-neutral-10 );
+
 
 		@include break-small {
+			height: auto;
 			max-height: 160px;
 			border-right: $current-theme-border;
 			border-bottom: none;
+			width: auto;
 		}
 
 		@include break-large {
 			max-height: 130px;
+			width: auto;
 		}
 	}
 
@@ -71,10 +79,17 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		}
 	}
 
+	.current-theme__content-learn-more {
+		display: none;
+		@include break-small {
+			display: block;
+		}
+	}
+
 	.current-theme__title-wrapper {
 		display: flex;
 		flex-direction: column;
-		align-items: center;
+		align-items: start;
 		margin-top: 0;
 		flex-wrap: wrap;
 
@@ -118,7 +133,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		box-sizing: border-box;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		font-size: $font-body;
+		font-size: $font-body-large;
 		max-width: 100%;
 		margin-right: 8px;
 		margin-bottom: 6px;

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -5,14 +5,16 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 
 .current-theme {
 	padding: 0;
-	margin: 0 16px 24px;
+	margin: 0 0 24px;
 	background: #fff;
 	border-radius: 4px;
 	box-shadow: none;
 	filter: drop-shadow( 0 1px 2px rgba( 0, 0, 0, 0.05 ) );
+	@include breakpoint-deprecated( '<660px' ) {
+		margin: 0 16px 24px;
+	}
 	
-	@include break-small {
-		margin: 0 0 24px;
+	@include break-medium {
 		border-radius: 0;
 		box-shadow: 0 0 0 1px var( --color-border-subtle );
 		filter: none;
@@ -36,7 +38,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 			width: 100%;
 			border-top: $current-theme-border;
 
-			@include break-small {
+			@include break-medium {
 				height: 69px;
 			}
 			@include break-xlarge {
@@ -51,7 +53,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		flex-direction: row;
 		font-size: $font-body-small;
 
-		@include break-small {
+		@include break-medium {
 			padding: 0;
 			flex-direction: row;
 			font-size: $font-body;
@@ -68,7 +70,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		border-radius: 4px;
 
 
-		@include break-small {
+		@include break-medium {
 			height: auto;
 			max-height: 160px;
 			border-right: $current-theme-border;
@@ -76,7 +78,6 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 			width: auto;
 			filter: none;
 			border-radius: 0;
-			box-shadow: 0 0 0 1px var( --color-neutral-light ), 0 2px 4px var( --color-neutral-10 );
 		}
 
 		@include break-large {
@@ -98,7 +99,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 
 	.current-theme__content-learn-more {
 		display: none;
-		@include break-small {
+		@include break-medium {
 			display: block;
 		}
 	}
@@ -114,10 +115,11 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 			flex-wrap: initial;
 		}
 
-		@include break-small {
+		@include break-medium {
 			flex-direction: row-reverse;
 			justify-content: flex-end;
 			flex-wrap: wrap;
+			align-items: center;
 		}
 	}
 
@@ -139,7 +141,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 
 		color: var( --color-neutral-30 );
 
-		@include break-small {
+		@include break-medium {
 			font-weight: normal;
 			text-transform: none;
 			color: var( --color-text-inverted );
@@ -166,6 +168,10 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		margin-right: 8px;
 		margin-bottom: 6px;
 
+		@include break-medium {
+			font-size: $font-body;
+		}
+
 		@include breakpoint-deprecated( '>960px' ) {
 			font-size: $font-title-small;
 		}
@@ -175,7 +181,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		display: none;
 		
 
-		@include break-small {
+		@include break-medium {
 			display: flex;
 			align-items: center;
 			justify-content: space-between;
@@ -194,7 +200,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		margin: 12px 16px;
 		width: 100%;
 
-		@include break-small {
+		@include break-medium {
 			align-self: center;
 			margin: 20px 16px 12px;
 		}
@@ -206,7 +212,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 	
 	.current-theme__more-info {
-		@include break-small {
+		@include break-medium {
 			display: none;
 		}
 	}
@@ -219,6 +225,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		padding: 12px 0;
 		color: var( --studio-neutral-100 );
 		display: flex;
+
 		.gridicon {
 			padding: 0 8px 0 16px;
 		}
@@ -227,7 +234,6 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 			right: 8px;
 			color: var( --color-sidebar-gridicon-fil );
 		}
-	
 	}
 	
 	.current-theme__theme-description {
@@ -271,7 +277,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		bottom: 16px;
 		right: 15px;
 
-		@include break-small {
+		@include break-medium {
 			display: flex;
 		}
 

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -5,7 +5,18 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 
 .current-theme {
 	padding: 0;
-	margin-bottom: 24px;
+	margin: 0 16px 24px;
+	background: #fff;
+	border-radius: 4px;
+	box-shadow: none;
+	filter: drop-shadow( 0 1px 2px rgba( 0, 0, 0, 0.05 ) );
+	
+	@include break-small {
+		margin: 0 0 24px;
+		border-radius: 0;
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+		filter: none;
+	}
 }
 
 .current-theme__post-revamp {
@@ -21,11 +32,13 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		&::after {
 			content: '';
 			display: block;
-			background: #fff;
-			height: 69px;
+			height: 48px;
 			width: 100%;
 			border-top: $current-theme-border;
 
+			@include break-small {
+				height: 69px;
+			}
 			@include break-xlarge {
 				content: none;
 			}
@@ -47,11 +60,12 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__img {
-		width: 120px;
-		height: 90px;
+		width: 100px;
+		height: 78px;
 		border-bottom: $current-theme-border;
 		max-height: none;
-		box-shadow: 0 0 0 1px var( --color-neutral-light ), 0 2px 4px var( --color-neutral-10 );
+		filter: drop-shadow( 0 3px 8px rgba( 0, 0, 0, 0.12 ) ) drop-shadow( 0 3px 1px rgba( 0, 0, 0, 0.04 ) );
+		border-radius: 4px;
 
 
 		@include break-small {
@@ -60,6 +74,9 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 			border-right: $current-theme-border;
 			border-bottom: none;
 			width: auto;
+			filter: none;
+			border-radius: 0;
+			box-shadow: 0 0 0 1px var( --color-neutral-light ), 0 2px 4px var( --color-neutral-10 );
 		}
 
 		@include break-large {
@@ -108,21 +125,32 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		display: flex;
 		flex-direction: row-reverse;
 		align-items: center;
-		margin-bottom: 6px;
+
+		@include break-small {
+			margin-bottom: 6px;
+		}
 	}
 
 	.current-theme__label {
 		font-size: $font-body-extra-small;
-		color: var( --color-text-inverted );
+		font-weight: 600;
 		display: inline-block;
-		background: var( --color-neutral-dark );
-		white-space: nowrap;
-		padding: 4px 12px;
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 120px;
-		margin-right: 8px;
+		text-transform: uppercase;
+
+		color: var( --color-neutral-30 );
 
 		@include break-small {
+			font-weight: normal;
+			text-transform: none;
+			color: var( --color-text-inverted );
+			display: inline-block;
+			background: var( --color-neutral-dark );
+			white-space: nowrap;
+			padding: 4px 12px;
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 120px;
+			margin-right: 8px;
+		
 			align-self: center;
 			margin-bottom: 0;
 		}
@@ -144,11 +172,12 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__content-wrapper {
-		display: flex;
-		justify-content: center;
-		align-items: center;
+		display: none;
+		
 
 		@include break-small {
+			display: flex;
+			align-items: center;
 			justify-content: space-between;
 		}
 	}
@@ -160,27 +189,91 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__description {
-		align-self: center;
+		align-self: flex-start;
 		font-size: $font-body-small;
-		margin: 20px 16px 12px;
+		margin: 12px 16px;
 		width: 100%;
+
+		@include break-small {
+			align-self: center;
+			margin: 20px 16px 12px;
+		}
 
 		p {
 			color: var( --color-text-subtle );
 			margin-bottom: 0;
 		}
 	}
+	
+	.current-theme__more-info {
+		@include break-small {
+			display: none;
+		}
+	}
+
+	.current-theme__theme-customize {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		width: 100%;
+		padding: 12px 0;
+		color: var( --studio-neutral-100 );
+		display: flex;
+		.gridicon {
+			padding: 0 8px 0 16px;
+		}
+		.gridicons-chevron-right {
+			position: absolute;
+			right: 8px;
+			color: var( --color-sidebar-gridicon-fil );
+		}
+	
+	}
+	
+	.current-theme__theme-description {
+		font-size: $font-body-small;
+		line-height: 20px;
+		padding: 0 16px 8px;
+		letter-spacing: 0.32px;
+
+		color: var( --color-text-subtle );
+		max-height: 2.2em;
+		overflow: hidden;
+		margin-bottom: 0;
+
+		span {
+			display: -webkit-box;
+  			-webkit-line-clamp: 2;
+  			-webkit-box-orient: vertical;
+			position: relative;
+		}
+
+	}
+
+	.current-theme__theme-description-link {
+		font-weight: 500;
+		font-size: $font-body-small;
+		line-height: 20px;
+		color: var( --studio-black );
+		display: inline-block;
+		border-bottom: 1px solid var( --studio-black );
+		margin: 0 16px 16px;
+	}
 
 	.current-theme__actions {
 		box-sizing: border-box;
 		padding-top: 16px;
-		display: flex;
+		display: none;
 		align-items: flex-end;
 		justify-content: flex-end;
 		flex-grow: 1;
 		position: absolute;
 		bottom: 16px;
 		right: 15px;
+
+		@include break-small {
+			display: flex;
+		}
 
 		@include break-xlarge {
 			padding-top: 0;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -28,10 +28,9 @@
 
 .themes__content {
 	min-height: 100vh;
-	margin: 0 16px;
-
-	@include break-small {
-		margin: 0;
+	
+	@include breakpoint-deprecated( '<660px' ) {
+		margin: 0 16px;
 	}
 }
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 .themes__upload-button {
 	float: right;
 
@@ -25,6 +28,11 @@
 
 .themes__content {
 	min-height: 100vh;
+	margin: 0 16px;
+
+	@include break-small {
+		margin: 0;
+	}
 }
 
 .is-section-themes.has-no-sidebar .themes__content {

--- a/client/my-sites/themes/themes-header.scss
+++ b/client/my-sites/themes/themes-header.scss
@@ -8,9 +8,9 @@
 
 .themes__install-theme-button-container {
 	margin: auto;
-	margin-right: 15px;
+	margin-right: 16px;
 
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-right: 0;
 		margin-bottom: 17px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implement some design fixes for mobile to wordpress.com/themes/example.com 

Before:
<img width="300" src="https://user-images.githubusercontent.com/115071/151281009-0b696f45-3509-4ace-85d3-bf0947fd6961.png" />

After:
Mobile:
<img width="300" src="https://user-images.githubusercontent.com/115071/151623172-45e180ea-14d2-482f-84ef-15bc06936bd2.png" />

Tablet:
<img width="300" src="https://user-images.githubusercontent.com/115071/151623257-76d52927-d811-4f01-9d52-63ba26137cbd.png" />

Desktop: Should be the same as before.
<img width="300" src="https://user-images.githubusercontent.com/115071/151623315-5a8ee8a3-24fc-4798-90d5-9c695fb5df78.png" />



#### Testing instructions

* Visit /themes/example.com on your phone. Does the design look as expected? 
* Visit /themes/example.com on the desktop does it look the same as before.

cc: @annchichi for design review. 