### PR TITLE
Handle Disconnected WPCOM Jetpack Sites

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -46,6 +46,7 @@ const PluginDetailsCTA = ( {
 	isPlaceholder,
 	billingPeriod,
 	isMarketplaceProduct,
+	isSiteConnected,
 } ) => {
 	const pluginSlug = plugin.slug;
 	const translate = useTranslate();
@@ -157,6 +158,7 @@ const PluginDetailsCTA = ( {
 					isMarketplaceProduct={ isMarketplaceProduct }
 					billingPeriod={ billingPeriod }
 					shouldUpgrade={ shouldUpgrade }
+					isSiteConnected={ isSiteConnected }
 				/>
 			</div>
 			{ ( ! isJetpackSelfHosted || ! isMarketplaceProduct ) && (
@@ -204,6 +206,7 @@ const CTAButton = ( {
 	isMarketplaceProduct,
 	billingPeriod,
 	isJetpackSelfHosted,
+	isSiteConnected,
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -270,7 +273,7 @@ const CTAButton = ( {
 						billingPeriod,
 					} );
 				} }
-				disabled={ isJetpackSelfHosted && isMarketplaceProduct }
+				disabled={ ( isJetpackSelfHosted && isMarketplaceProduct ) || isSiteConnected === false }
 			>
 				{
 					// eslint-disable-next-line no-nested-ternary

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -23,6 +23,11 @@ import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custo
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
@@ -48,6 +53,7 @@ import {
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
+import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import {
 	isJetpackSite,
@@ -100,6 +106,14 @@ function PluginDetails( props ) {
 	const isWpcom = selectedSite && ! isJetpack;
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
+	const isSiteConnected = useSelector( ( state ) =>
+		getSiteConnectionStatus( state, selectedSite?.ID )
+	);
+	const trackSiteDisconnect = () =>
+		composeAnalytics(
+			recordGoogleEvent( 'Jetpack', 'Clicked in site indicator to start Jetpack Disconnect flow' ),
+			recordTracksEvent( 'calypso_jetpack_site_indicator_disconnect_start' )
+		);
 
 	// Header Navigation and billing period switcher.
 	const isWide = useBreakpoint( '>1280px' );
@@ -243,6 +257,25 @@ function PluginDetails( props ) {
 				plugins={ [ fullPlugin ] }
 			/>
 
+			{ isSiteConnected === false && (
+				<Notice
+					icon="notice"
+					showDismiss={ false }
+					status="is-warning"
+					text={ translate( '%(siteName)s cannot be accessed.', {
+						textOnly: true,
+						args: { siteName: selectedSite.title },
+					} ) }
+				>
+					<NoticeAction
+						onClick={ trackSiteDisconnect }
+						href={ `/settings/disconnect-site/${ selectedSite.slug }?type=down` }
+					>
+						{ translate( 'I’d like to fix this now' ) }
+					</NoticeAction>
+				</Notice>
+			) }
+
 			<div className="plugin-details__page">
 				<div className="plugin-details__layout plugin-details__top-section">
 					<div className="plugin-details__layout-col-left">
@@ -258,6 +291,7 @@ function PluginDetails( props ) {
 							isPlaceholder={ showPlaceholder }
 							billingPeriod={ billingPeriod }
 							isMarketplaceProduct={ isMarketplaceProduct }
+							isSiteConnected={ isSiteConnected }
 						/>
 					</div>
 				</div>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -23,6 +23,8 @@ import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import MainComponent from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import Pagination from 'calypso/components/pagination';
 import { PaginationVariant } from 'calypso/components/pagination/constants';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
@@ -35,7 +37,11 @@ import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
+import {
+	recordTracksEvent,
+	recordGoogleEvent,
+	composeAnalytics,
+} from 'calypso/state/analytics/actions';
 import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
@@ -52,6 +58,7 @@ import {
 } from 'calypso/state/plugins/wporg/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
+import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
@@ -99,6 +106,9 @@ const PluginsBrowser = ( {
 	const jetpackNonAtomic = useSelector(
 		( state ) =>
 			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
+	);
+	const isSiteConnected = useSelector( ( state ) =>
+		getSiteConnectionStatus( state, selectedSite?.ID )
 	);
 	const isVip = useSelector( ( state ) => isVipSite( state, selectedSite?.ID ) );
 	const hasJetpack = useSelector( hasJetpackSites );
@@ -158,6 +168,11 @@ const PluginsBrowser = ( {
 		dispatch( updateBreadcrumbs( items ) );
 	}, [ siteSlug, search ] );
 
+	const trackSiteDisconnect = () =>
+		composeAnalytics(
+			recordGoogleEvent( 'Jetpack', 'Clicked in site indicator to start Jetpack Disconnect flow' ),
+			recordTracksEvent( 'calypso_jetpack_site_indicator_disconnect_start' )
+		);
 	const annoncementPages = [
 		{
 			headline: translate( 'NEW' ),
@@ -257,7 +272,24 @@ const PluginsBrowser = ( {
 					</div>
 				</FixedNavigationHeader>
 			) }
-
+			{ isSiteConnected === false && (
+				<Notice
+					icon="notice"
+					showDismiss={ false }
+					status="is-warning"
+					text={ translate( '%(siteName)s cannot be accessed.', {
+						textOnly: true,
+						args: { siteName: selectedSite.title },
+					} ) }
+				>
+					<NoticeAction
+						onClick={ trackSiteDisconnect }
+						href={ `/settings/disconnect-site/${ selectedSite.slug }?type=down` }
+					>
+						{ translate( 'I’d like to fix this now' ) }
+					</NoticeAction>
+				</Notice>
+			) }
 			<UpgradeNudge
 				selectedSite={ selectedSite }
 				sitePlan={ sitePlan }

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -10,8 +10,6 @@ jest.mock( 'calypso/lib/wporg', () => ( {
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/blocks/upsell-nudge', () => 'upsell-nudge' );
-jest.mock( 'calypso/components/notice', () => 'Notice' );
-jest.mock( 'calypso/components/notice/notice-action', () => 'NoticeAction' );
 
 jest.mock( '@automattic/languages', () => [
 	{
@@ -52,7 +50,10 @@ const initialReduxState = {
 		},
 	},
 	ui: { selectedSiteId: 1 },
-	sites: { items: { 1: { ID: 1, plan: { productSlug: PLAN_FREE } } } },
+	sites: {
+		items: { 1: { ID: 1, title: 'Test Site', plan: { productSlug: PLAN_FREE } } },
+		connection: { items: { 1: true } },
+	},
 	currentUser: { capabilities: { 1: { manage_options: true } } },
 	media: {
 		queries: {
@@ -171,5 +172,15 @@ describe( 'PluginsBrowser basic tests', () => {
 		expect(
 			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
 		).toBe( 0 );
+	} );
+	test( 'should show notice if site is not connected to wpcom', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, {
+			ui: { selectedSiteId: 1 },
+			sites: {
+				items: { 1: { jetpack: false } },
+				connection: { items: { 1: false } },
+			},
+		} );
+		expect( comp.containsMatchingElement( <span>I’d like to fix this now</span> ) ).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display Notice in PluginDetails and disable the CTA button if the site is not connected to WPCOM.
* Display Notice in PluginsBroser if the site is not connected to WPCOM.
* Notices include a notice action that takes the user to the /settings/disconnect-site/ page so that the user is able to fix the connections issue.

#### Testing instructions

- From a local jetpack site with jurassic tube
- Connect it to WordPress.com
- Shut down the tube connection by jetpack docker jt-down
- Visit Plugins and any Plugins Details page on your local calypso
- The notice should be displayed on both pages as shown in the attached image.
- Also, on the Details page the Install button should be disabled.

Plugin Details Page
<img width="1705" alt="Screen Shot 2022-01-31 at 7 39 55 PM" src="https://user-images.githubusercontent.com/351784/151896032-984295e1-c31a-4f4c-ba90-3587c2c95d95.png">

Fixes #59943
