### PR TITLE
WPCOM Block Editor: Send save click tracks event with more data

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
@@ -16,14 +16,14 @@ export const wpcomBlockEditorSaveClick = () => ( {
 		const isSiteEditor = getEditorType() === 'site';
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const isEditedPostBeingScheduled = select( 'core/editor' ).isEditedPostBeingScheduled();
-		let actionType = 'publishing';
+		let actionType = 'publish';
 
 		if ( isSiteEditor ) {
-			actionType = 'saving';
+			actionType = 'save';
 		} else if ( isEditedPostBeingScheduled ) {
-			actionType = 'scheduling';
+			actionType = 'schedule';
 		} else if ( isCurrentPostPublished ) {
-			actionType = 'updating';
+			actionType = 'update';
 		}
 
 		tracksRecordEvent( 'wpcom_block_editor_save_click', {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
@@ -12,16 +12,17 @@ export const wpcomBlockEditorSaveClick = () => ( {
 		'.editor-entities-saved-states__save-button, .editor-post-publish-button:not(.has-changes-dot)',
 	type: 'click',
 	handler: () => {
+		const isSiteEditor = Boolean( select( 'core/edit-site' ) );
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const isEditedPostBeingScheduled = select( 'core/editor' ).isEditedPostBeingScheduled();
-		let actionType;
+		let actionType = 'publishing';
 
-		if ( isEditedPostBeingScheduled ) {
+		if ( isSiteEditor ) {
+			actionType = 'saving';
+		} else if ( isEditedPostBeingScheduled ) {
 			actionType = 'scheduling';
 		} else if ( isCurrentPostPublished ) {
 			actionType = 'updating';
-		} else {
-			actionType = 'publishing';
 		}
 
 		tracksRecordEvent( 'wpcom_block_editor_save_click', {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
@@ -8,19 +8,20 @@ import tracksRecordEvent from './track-record-event';
  */
 export const wpcomBlockEditorSaveClick = () => ( {
 	id: 'wpcom-block-editor-save-click',
-	// The first selector is for site editing. The second is for post editing.
 	selector:
 		'.editor-entities-saved-states__save-button, .editor-post-publish-button:not(.has-changes-dot)',
 	type: 'click',
 	handler: () => {
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
-		const isCurrentPostScheduled = select( 'core/editor' ).isCurrentPostScheduled();
+		const isEditedPostBeingScheduled = select( 'core/editor' ).isEditedPostBeingScheduled();
 		let actionType;
 
-		if ( isCurrentPostPublished || isCurrentPostScheduled ) {
-			actionType = 'update';
+		if ( isEditedPostBeingScheduled ) {
+			actionType = 'scheduling';
+		} else if ( isCurrentPostPublished ) {
+			actionType = 'updating';
 		} else {
-			actionType = 'publish';
+			actionType = 'publishing';
 		}
 
 		tracksRecordEvent( 'wpcom_block_editor_save_click', {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
@@ -1,4 +1,5 @@
 import { select } from '@wordpress/data';
+import { getEditorType } from '../utils';
 import tracksRecordEvent from './track-record-event';
 
 /**
@@ -12,7 +13,7 @@ export const wpcomBlockEditorSaveClick = () => ( {
 		'.editor-entities-saved-states__save-button, .editor-post-publish-button:not(.has-changes-dot)',
 	type: 'click',
 	handler: () => {
-		const isSiteEditor = Boolean( select( 'core/edit-site' ) );
+		const isSiteEditor = getEditorType() === 'site';
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const isEditedPostBeingScheduled = select( 'core/editor' ).isEditedPostBeingScheduled();
 		let actionType = 'publishing';

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
@@ -1,3 +1,4 @@
+import { select } from '@wordpress/data';
 import tracksRecordEvent from './track-record-event';
 
 /**
@@ -12,7 +13,19 @@ export const wpcomBlockEditorSaveClick = () => ( {
 		'.editor-entities-saved-states__save-button, .editor-post-publish-button:not(.has-changes-dot)',
 	type: 'click',
 	handler: () => {
-		tracksRecordEvent( 'wpcom_block_editor_save_click' );
+		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
+		const isCurrentPostScheduled = select( 'core/editor' ).isCurrentPostScheduled();
+		let actionType;
+
+		if ( isCurrentPostPublished || isCurrentPostScheduled ) {
+			actionType = 'update';
+		} else {
+			actionType = 'publish';
+		}
+
+		tracksRecordEvent( 'wpcom_block_editor_save_click', {
+			action_type: actionType,
+		} );
 	},
 } );
 
@@ -22,6 +35,8 @@ export const wpcomBlockEditorSaveDraftClick = () => ( {
 	type: 'click',
 	capture: true,
 	handler: () => {
-		tracksRecordEvent( 'wpcom_block_editor_save_click' );
+		tracksRecordEvent( 'wpcom_block_editor_save_click', {
+			action_type: 'save_draft',
+		} );
 	},
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds more contextual data to the editor save click tracks event that includes information about what kind of changes were being persisted (scheduling, publishing, updating, saving, etc.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Sandbox a site and wp widgets
2. Run `install-plugin.sh wpcom-block-editor update/save-click-tracks-event-with-action-data` in the sandbox
3. Navigate to the site editor
4. Make modifications to a template part
5. Open the dev console and switch to the `Network Requests` tab
6. Filter requests by `t.gif`
7. Save the changes to the editor
8. Verify that a tracking `t.gif` event was sent for `wpcom_block_editor_save_click`
9. Verify that there is an `action_type` property describing what kind of change was made (save)
10. Repeat steps 3 to 8 for the page editor and the post editor
11. Verify that there is an `action_type` property describing what kind of changes were made (publish, update or schedule)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/wp-calypso/issues/60579
