### PR TITLE
Show Manage Connection UI when connected via Jetpack standalone products

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -22,7 +22,11 @@ import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-s
 import isJetpackUserConnectionOwner from 'calypso/state/selectors/is-jetpack-user-connection-owner';
 import { transferPlanOwnership } from 'calypso/state/sites/plans/actions';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
-import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
+import {
+	isCurrentPlanPaid,
+	isJetpackSite,
+	isJetpackProductSite,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import OwnershipInformation from './ownership-information';
 
@@ -287,7 +291,7 @@ export default connect(
 			isPaidPlan,
 			siteId,
 			siteIsConnected: isJetpackSiteConnected( state, siteId ),
-			siteIsJetpack: isJetpackSite( state, siteId ),
+			siteIsJetpack: isJetpackSite( state, siteId ) || isJetpackProductSite( state, siteId ),
 			siteIsInDevMode: isJetpackSiteInDevelopmentMode( state, siteId ),
 			userIsConnectionOwner: isJetpackUserConnectionOwner( state, siteId ),
 		};

--- a/client/my-sites/site-settings/redirect-non-jetpack/index.jsx
+++ b/client/my-sites/site-settings/redirect-non-jetpack/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, isJetpackProductSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const redirectNonJetpack = ( redirectRoute ) => ( WrappedComponent ) => {
@@ -51,7 +51,7 @@ const redirectNonJetpack = ( redirectRoute ) => ( WrappedComponent ) => {
 
 		return {
 			siteIsAtomic: isSiteAutomatedTransfer( state, siteId ),
-			siteIsJetpack: isJetpackSite( state, siteId ),
+			siteIsJetpack: isJetpackSite( state, siteId ) || isJetpackProductSite( state, siteId ),
 			siteSlug: getSelectedSiteSlug( state ),
 		};
 	} )( RedirectNonJetpack );

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -17,7 +17,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, isJetpackProductSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import SiteToolsLink from './link';
 
@@ -166,7 +166,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSelectedSiteSlug( state );
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
-		const isJetpack = isJetpackSite( state, siteId );
+		const isJetpack = isJetpackSite( state, siteId ) || isJetpackProductSite( state, siteId );
 		const isVip = isVipSite( state, siteId );
 		const isP2 = isSiteWPForTeams( state, siteId );
 		const isP2Hub = isSiteP2Hub( state, siteId );


### PR DESCRIPTION
When using Jetpack standalone products/plugins like Backup, the Manage Connection UI remains hidden even after the site is connected.

Fixes 1164141197617539-as-1201184988980026

#### Changes proposed in this Pull Request

* Use `isJetpackProductSite` check apart from `isJetpackSite` when deciding whether the site is a Jetpack site in site tools UI and Manage Connection UI.

#### Testing instructions

- Create a JN site
- Goto wp-admin > Plugins and uninstall Jetpack plugin
- Download Jetpack backup plugin from [here](https://github.com/Automattic/jetpack/tree/master/projects/plugins/backup) and install and activate it.
- Connect Jetpack
- Checkout this branch and run `yarn start`
- Goto `http://calypso.localhost:3000/settings/general/:site`
- Check if **Manage Connection** option is visible
- Click on **Manage Connection**
- Check if the Ownership is displayed is correct

Before:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/18226415/151300777-507e4eae-2a5a-4cad-a35a-8ef9848953a6.png">

After
<img width="553" alt="image" src="https://user-images.githubusercontent.com/18226415/151300801-dd7ab008-73ad-431d-8aec-6b1348bef415.png">
<img width="560" alt="image" src="https://user-images.githubusercontent.com/18226415/151300829-d58f6b41-e1ab-488c-ac97-81e54f5d554f.png">

Follow up: Disconnection doesn't actually work and it fails with this error in API response:
```json
{
    "error":"direct_login_required",
    "message":"Please login to {{site name here}} directly to disconnect it from your account."
}
```
Asana task for the follow up: 1164141197617539-as-1201726523088193