### PR TITLE
Themes: Update Themes Selection Header to Typescript

### DIFF
--- a/client/my-sites/themes/themes-selection-header/index.tsx
+++ b/client/my-sites/themes/themes-selection-header/index.tsx
@@ -1,10 +1,14 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import PropTypes from 'prop-types';
 
 import './style.scss';
 
-const ThemesSelectionHeader = ( { label, noMarginBeforeHeader } ) => {
+interface ThemesSelectionHeaderProps {
+	label: string;
+	noMarginBeforeHeader: boolean;
+}
+
+const ThemesSelectionHeader = ( { label, noMarginBeforeHeader }: ThemesSelectionHeaderProps ) => {
 	const translate = useTranslate();
 
 	const classes = classNames( 'themes__themes-selection-header', {
@@ -16,11 +20,6 @@ const ThemesSelectionHeader = ( { label, noMarginBeforeHeader } ) => {
 			<h2>{ label || translate( 'WordPress.com themes' ) }</h2>
 		</div>
 	);
-};
-
-ThemesSelectionHeader.propTypes = {
-	label: PropTypes.string,
-	count: PropTypes.number,
 };
 
 export default ThemesSelectionHeader;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Convert current theme selection header jsx file to typescript

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open files in the editor and ensure no typescript errors are being thrown

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

https://github.com/Automattic/wp-calypso/issues/60530
