### PR TITLE
Signup: Turn on checkout flow in Design Picker

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,7 +86,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
-		"signup/design-picker-premium-themes-checkout": false,
+		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -92,7 +92,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
-		"signup/design-picker-premium-themes-checkout": false,
+		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -93,7 +93,7 @@
 		"signup/social": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
-		"signup/design-picker-premium-themes-checkout": false,
+		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As https://github.com/Automattic/wp-calypso/pull/60181 is shipped and the testing result (sdtkmj-feature-p2) looks good. So, turn on the flag to make the user with the free or personal plan have ability to upgrade their plan for premium themes in Design Picker.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/setup-site?siteSlug=<your_site> with free plan or personal plan
* When you land on the Design Picker, you should see the premium themes with “Upgrade Plan”
* Click on the “Upgrade Plan” button, the checkout modal will open, and the annual premium plan will be already there.
* After you complete the checkout, the modal would be closed and you can see “Start with “ now!
* If you close the checkout modal or remove the plan, the modal will be closed but the text of the button will still be “Upgrade Plan”

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/59229