### PR TITLE
`QueryPosts`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-posts/index.jsx
+++ b/client/components/data/query-posts/index.jsx
@@ -1,7 +1,7 @@
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import debug from 'debug';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import {
 	requestSitePosts,
 	requestSitePost,
@@ -14,61 +14,44 @@ import { isRequestingPostsForQuery, isRequestingSitePost } from 'calypso/state/p
  */
 const log = debug( 'calypso:query-posts' );
 
-class QueryPosts extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
+const useMemoizedQuery = ( query ) => {
+	const memoizedQuery = useRef();
+	if ( ! isShallowEqual( query, memoizedQuery.current ) ) {
+		memoizedQuery.current = query;
+	}
+	return memoizedQuery.current;
+};
+
+const request = ( siteId, postId, query ) => ( dispatch, getState ) => {
+	const state = getState();
+
+	if ( ! siteId && ! isRequestingPostsForQuery( state, null, query ) ) {
+		log( 'Request post list for all sites using query %o', query );
+		dispatch( requestAllSitesPosts( query ) );
+		return;
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			this.props.siteId === nextProps.siteId &&
-			this.props.postId === nextProps.postId &&
-			isShallowEqual( this.props.query, nextProps.query )
-		) {
-			return;
-		}
-
-		this.request( nextProps );
+	if ( ! postId && ! isRequestingPostsForQuery( state, siteId, query ) ) {
+		log( 'Request post list for site %d using query %o', siteId, query );
+		dispatch( requestSitePosts( siteId, query ) );
+		return;
 	}
 
-	request( props ) {
-		const singleSite = !! props.siteId;
-		const singlePost = !! props.postId;
-
-		if ( singleSite ) {
-			if ( ! singlePost && ! props.requestingPosts ) {
-				log( 'Request post list for site %d using query %o', props.siteId, props.query );
-				props.requestSitePosts( props.siteId, props.query );
-			}
-
-			if ( singlePost && ! props.requestingPost ) {
-				log( 'Request single post for site %d post %d', props.siteId, props.postId );
-				props.requestSitePost( props.siteId, props.postId );
-			}
-		} else if ( ! props.requestingPosts ) {
-			log( 'Request post list for all sites using query %o', props.query );
-			props.requestAllSitesPosts( props.query );
-		}
+	if ( ! isRequestingSitePost( state, siteId, postId ) ) {
+		log( 'Request single post for site %d post %d', siteId, postId );
+		dispatch( requestSitePost( siteId, postId ) );
 	}
+};
 
-	render() {
-		return null;
-	}
+function QueryPosts( { siteId, postId, query } ) {
+	const dispatch = useDispatch();
+	const memoizedQuery = useMemoizedQuery( query );
+
+	useEffect( () => {
+		dispatch( request( siteId, postId, memoizedQuery ) );
+	}, [ dispatch, siteId, postId, memoizedQuery ] );
+
+	return null;
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const { siteId, postId, query } = ownProps;
-		return {
-			requestingPost: siteId && postId && isRequestingSitePost( state, siteId, postId ),
-			requestingPosts: isRequestingPostsForQuery( state, siteId, query ),
-		};
-	},
-	{
-		requestSitePosts,
-		requestAllSitesPosts,
-		requestSitePost,
-	}
-)( QueryPosts );
+export default QueryPosts;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryPosts`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to e.g. `/posts/:site` or `/pages/:site` or `/stats/insights/:site`
* Verify you see a request to `/posts/:siteId`
* Switch your currently active site, another (new) request should be issued
* Go to `/posts` or `/pages` (without `site` param), verify you see a request for all posts on all sites
* Go to `/stats/insights/:site` and hit _Latest post summary_, that should trigger a request for a specific post

Related to #58453 
