### PR TITLE
Disable external mailbox management links in mobile environments

### DIFF
--- a/client/components/vertical-nav/README.md
+++ b/client/components/vertical-nav/README.md
@@ -32,6 +32,7 @@ The following components can be used to display rows of links.
 `VerticalNavItem` is usually used to display some text passed as `children`, and accepts the following props:
 
 - **className** - String _optional_ - additional class name to tag this component with.
+- **disabled** - Boolean _optional_ - determines whether or not the link should be clickable. When the link is disabled, the returned element is the `<CompactCard />` and not the `<a/>` tag.
 - **external** - Boolean _optional_ - determines whether or not the link is opened in a new window.
 - **isPlaceholder** - Boolean _optional_ - determines whether or not the placeholder styles are used.
 - **onClick** - Function _optional_ - called when the item is clicked.
@@ -40,6 +41,8 @@ The following components can be used to display rows of links.
 `VerticalNavItemEnhanced` can also display a description as well as an icon. It no longer relies on `children` but
 instead on the following props:
 
+- **className** - String _optional_ - additional class name to tag this component with.
+- **disabled** - Boolean _optional_ - determines whether or not the link should be clickable. When the link is disabled, the returned element is the `<CompactCard />` and not the `<a/>` tag.
 - **description** - String _required_ - some longer copy displayed below the text.
 - **external** - Boolean _optional_ - determines whether or not the link is opened in a new window.
 - **gridicon** - String _optional_ - the identifier of the [Gridicon icon](../../../docs/icons.md) to show in front of the text and description (if `materialIcon` wasn't specified).

--- a/client/components/vertical-nav/item/enhanced.jsx
+++ b/client/components/vertical-nav/item/enhanced.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import MaterialIcon from 'calypso/components/material-icon';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
@@ -26,18 +27,23 @@ const Icon = ( { gridicon, materialIcon } ) => {
 };
 
 const VerticalNavItemEnhanced = ( {
+	className,
 	description,
+	disabled,
 	external,
 	gridicon,
 	materialIcon,
-	path,
 	onClick,
+	path,
 	text,
 } ) => {
+	const classes = classnames( 'vertical-nav-item-enhanced', className, { disabled } );
+
 	return (
 		<VerticalNavItem
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-			className="vertical-nav-item-enhanced"
+			className={ classes }
+			disabled={ disabled }
 			external={ external }
 			onClick={ onClick }
 			path={ path }
@@ -56,7 +62,9 @@ const VerticalNavItemEnhanced = ( {
 };
 
 VerticalNavItemEnhanced.propTypes = {
+	className: PropTypes.string,
 	description: PropTypes.string.isRequired,
+	disabled: PropTypes.bool,
 	external: PropTypes.bool,
 	gridicon: PropTypes.string,
 	materialIcon: PropTypes.string,

--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -11,6 +11,7 @@ class VerticalNavItem extends Component {
 	static propTypes = {
 		children: PropTypes.any,
 		className: PropTypes.string,
+		disabled: PropTypes.bool,
 		external: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		onClick: PropTypes.func,
@@ -46,7 +47,7 @@ class VerticalNavItem extends Component {
 	};
 
 	render() {
-		const { isPlaceholder, external, onClick, path, className, children } = this.props;
+		const { children, className, disabled, external, isPlaceholder, onClick, path } = this.props;
 
 		if ( isPlaceholder ) {
 			return this.renderPlaceholder();
@@ -56,13 +57,20 @@ class VerticalNavItem extends Component {
 
 		const linkProps = external ? { target: '_blank', rel: 'noreferrer' } : {};
 
+		const navItemCard = (
+			<CompactCard className={ compactCardClassNames }>
+				{ this.getIcon() }
+				<span>{ children }</span>
+			</CompactCard>
+		);
+
+		if ( disabled ) {
+			return navItemCard;
+		}
+
 		return (
 			<a href={ path } onClick={ onClick } { ...linkProps }>
-				<CompactCard className={ compactCardClassNames }>
-					{ this.getIcon() }
-
-					<span>{ children }</span>
-				</CompactCard>
+				{ navItemCard }
 			</a>
 		);
 	}

--- a/client/components/vertical-nav/item/style.scss
+++ b/client/components/vertical-nav/item/style.scss
@@ -8,6 +8,12 @@
 			top: 0;
 			right: 16px;
 	}
+
+	&.disabled {
+		> svg, span {
+			opacity: 0.5;
+		}
+	}
 }
 
 .vertical-nav-item.is-placeholder {

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
@@ -1,3 +1,5 @@
+import { CompactCard } from '@automattic/components';
+import { isDesktop as isDesktopViewport } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -9,6 +11,7 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItemEnhanced from 'calypso/components/vertical-nav/item/enhanced';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -39,6 +42,8 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySite } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
+import './style.scss';
+
 class TitanManageMailboxes extends Component {
 	static propTypes = {
 		// Props passed to this component
@@ -62,6 +67,61 @@ class TitanManageMailboxes extends Component {
 		page( emailManagement( selectedSite.slug, selectedDomainName, currentRoute ) );
 	};
 
+	buildNavItem = ( { context, description, disabled = false, materialIcon, text } ) => ( {
+		description,
+		disabled,
+		materialIcon,
+		path: this.getPath( context ),
+		text,
+	} );
+
+	getManagedItems = () => {
+		const { isDesktop, disabled = ! isDesktop, translate } = this.props;
+
+		return [
+			{
+				context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_DESKTOP_APP,
+				disabled,
+				description: translate( 'View settings required to configure third-party email apps' ),
+				materialIcon: 'dvr',
+				text: translate( 'Configure desktop app' ),
+			},
+			{
+				context: TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP,
+				description: translate(
+					'Download our Android and iOS apps to access your emails on the go'
+				),
+				materialIcon: 'smartphone',
+				text: translate( 'Get mobile app' ),
+			},
+			{
+				context: TITAN_CONTROL_PANEL_CONTEXT_IMPORT_EMAIL_DATA,
+				disabled,
+				description: translate( 'Migrate existing emails from a remote server via IMAP' ),
+				materialIcon: 'move_to_inbox',
+				text: translate( 'Import email data' ),
+			},
+			{
+				context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_CATCH_ALL_EMAIL,
+				disabled,
+				description: translate(
+					'Route all undelivered emails to your domain to a specific mailbox'
+				),
+				materialIcon: 'mediation',
+				text: translate( 'Configure catch-all email' ),
+			},
+			{
+				context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_INTERNAL_FORWARDING,
+				disabled,
+				description: translate(
+					'Create email aliases that forward messages to one or several mailboxes'
+				),
+				materialIcon: 'forward_to_inbox',
+				text: translate( 'Set up internal forwarding' ),
+			},
+		].map( this.buildNavItem );
+	};
+
 	getPath = ( context ) => {
 		const { currentRoute, domain, selectedSite } = this.props;
 
@@ -78,12 +138,13 @@ class TitanManageMailboxes extends Component {
 		const {
 			domain,
 			hasSubscription,
+			isDesktop,
 			isLoadingPurchase,
 			purchase,
 			selectedSite,
 			translate,
 		} = this.props;
-
+		window.console.log( [ 'KRKK', 'RENDER', isDesktop, this.getManagedItems() ] );
 		return (
 			<>
 				<PageViewTracker
@@ -113,54 +174,29 @@ class TitanManageMailboxes extends Component {
 						selectedSite={ selectedSite }
 					/>
 
+					{ isDesktop || (
+						<CompactCard>
+							<Notice
+								className="titan-manage-mailboxes__mobile-warning"
+								status="is-error"
+								showDismiss={ false }
+							>
+								{ translate(
+									'Please switch to a desktop device to access all email management features.'
+								) }
+							</Notice>
+						</CompactCard>
+					) }
+
 					<VerticalNav>
-						<VerticalNavItemEnhanced
-							description={ translate(
-								'View settings required to configure third-party email apps'
-							) }
-							external={ true }
-							materialIcon="dvr"
-							path={ this.getPath( TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_DESKTOP_APP ) }
-							text={ translate( 'Configure desktop app' ) }
-						/>
-
-						<VerticalNavItemEnhanced
-							description={ translate(
-								"Download Titan's Android and iOS apps to access your emails on the go"
-							) }
-							external={ true }
-							materialIcon="smartphone"
-							path={ this.getPath( TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP ) }
-							text={ translate( 'Get mobile app' ) }
-						/>
-
-						<VerticalNavItemEnhanced
-							description={ translate( 'Migrate existing emails from a remote server via IMAP' ) }
-							external={ true }
-							materialIcon="move_to_inbox"
-							path={ this.getPath( TITAN_CONTROL_PANEL_CONTEXT_IMPORT_EMAIL_DATA ) }
-							text={ translate( 'Import email data' ) }
-						/>
-
-						<VerticalNavItemEnhanced
-							description={ translate(
-								'Route all undelivered emails to your domain to a specific mailbox'
-							) }
-							external={ true }
-							materialIcon="mediation"
-							path={ this.getPath( TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_CATCH_ALL_EMAIL ) }
-							text={ translate( 'Configure catch-all email' ) }
-						/>
-
-						<VerticalNavItemEnhanced
-							description={ translate(
-								'Create email aliases that forward messages to one or several mailboxes'
-							) }
-							external={ true }
-							materialIcon="forward_to_inbox"
-							path={ this.getPath( TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_INTERNAL_FORWARDING ) }
-							text={ translate( 'Set up internal forwarding' ) }
-						/>
+						{ this.getManagedItems().map( ( navProps ) => (
+							<VerticalNavItemEnhanced
+								key={ navProps.path }
+								external
+								className="titan-manage-mailboxes__manage-titan-link"
+								{ ...navProps }
+							/>
+						) ) }
 					</VerticalNav>
 				</Main>
 			</>
@@ -176,11 +212,12 @@ export default connect( ( state, ownProps ) => {
 		isSiteRedirect: false,
 		selectedDomainName: ownProps.selectedDomainName,
 	} );
-
+	window.console.log( [ 'KRKK', 'CONNECT', isDesktopViewport() ] );
 	return {
 		currentRoute: getCurrentRoute( state ),
 		domain,
 		hasSubscription: hasEmailSubscription( domain ),
+		isDesktop: isDesktopViewport(),
 		isLoadingPurchase:
 			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 		purchase: getEmailPurchaseByDomain( state, domain ),

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
@@ -103,7 +103,7 @@ class TitanManageMailboxes extends Component {
 			{
 				context: TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP,
 				description: translate(
-					'Download our Android and iOS apps to access your emails on the go'
+					"Download Titan's Android and iOS apps to access your emails on the go"
 				),
 				materialIcon: 'smartphone',
 				text: translate( 'Get mobile app' ),

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
@@ -88,7 +88,7 @@ class TitanManageMailboxes extends Component {
 		text,
 	} );
 
-	getManagedItems = () => {
+	getNavigationItems = () => {
 		const { translate } = this.props;
 		const isDisabled = ! this.state.isDesktop;
 
@@ -203,12 +203,12 @@ class TitanManageMailboxes extends Component {
 
 					{ hasSubscription && (
 						<VerticalNav>
-							{ this.getManagedItems().map( ( navProps ) => (
+							{ this.getNavigationItems().map( ( navigationItem ) => (
 								<VerticalNavItemEnhanced
 									className="titan-manage-mailboxes__manage-titan-link"
 									external
-									key={ navProps.path }
-									{ ...navProps }
+									key={ navigationItem.path }
+									{ ...navigationItem }
 								/>
 							) ) }
 						</VerticalNav>

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/style.scss
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/style.scss
@@ -1,0 +1,17 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.notice.titan-manage-mailboxes__mobile-warning {
+	margin-bottom: 0;
+	border-radius: 4px;
+	overflow: hidden;
+}
+
+.titan-manage-mailboxes__manage-titan-link {
+	small {
+		display: none;
+		@include break-mobile {
+			display: unset;
+		}
+	}
+}


### PR DESCRIPTION
This PR adopts changes from #53179 and furthers the work of disabling the links for mobile items.

#### Changes proposed in this Pull Request

* The external links from the Manage Mailbox view are disabled when viewed from a small screen i.e. `<= 960px`
* Users are prompted with a notice to use a device with a larger screen for optimal viewing
* `VerticalNavItemEnhanced` and `VerticalNavItem` are enhanced with a `disabled` prop to support a disabled state. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch, or use the [calypso live preview](https://github.com/Automattic/wp-calypso/pull/60533#issuecomment-1022952153)
* Ensure you have at least one Professional Email subscription
* Navigate to [ **Upgrades** -> **Emails** -> **Manage all mailboxes** ] for that subscription.
* Locate the browser Dev Tools and switch to the responsive mode. Adjust the width of the device and observe the behaviour of the page when the width goes below and above 960px
* When the width is < 960px, all external links to the Titan CP should be disabled, except the `Get mobile app` link.
* To optimise for small screens with maximum width of 480px, extra text descriptions below the main links should not display

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshots

- For device widths < 960px ( i.e. disabled links )

<img width="601" alt="Screenshot 2022-01-27 at 3 58 58 PM" src="https://user-images.githubusercontent.com/277661/151384357-759ba12d-50ac-42a9-a737-0b8f0ad2e8e4.png">

- For devices with widths 480px or less ( i.e. hidden descriptive texts )

<img width="432" alt="Screenshot 2022-01-27 at 7 28 14 PM" src="https://user-images.githubusercontent.com/277661/151422166-b43ecab7-21af-4fc0-b5a1-85661d05379d.png">

