### PR TITLE
Update the podcasting card button in My Home to open in a new tab

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/podcasting/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/podcasting/index.jsx
@@ -14,6 +14,7 @@ const Podcasting = () => {
 			) }
 			actionText={ translate( 'Create an Anchor account' ) }
 			actionUrl={ `https://anchor.fm/wordpressdotcom` }
+			actionTarget="_blank"
 			illustration={ podcastingIllustration }
 			taskId={ TASK_PODCASTING }
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the button in the podcasting card (AnchorFM) to open the external URL `https://anchor.fm/wordpressdotcom` in a new tab instead of opening in the same tab. 

The reason of this update is that it's a common confusion to close the page when the brand has changed (WP.com → AnchorFM), and therefore also accidentally closing the way back to WP.com.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![Screen Shot 2022-01-27 at 4 53 30 PM](https://user-images.githubusercontent.com/797888/151324935-99a802ae-fff3-4318-8d12-8c15a9960e46.png)

* Go to My Home.
* Locate the podcasting card from the cards dot-pager/carousel (order is randomized).
* Check that the podcasting card's button has `target="blank"` as per screenshot above.
* Clicking the button opens a new tab that loads the external URL `https://anchor.fm/wordpressdotcom`.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59367


