### PR TITLE
Fix browser history after selecting a domain in domain management list

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -81,17 +81,7 @@ class DomainRow extends PureComponent {
 		return (
 			<div className="domain-row__domain-cell">
 				<div className="domain-row__domain-name">
-					{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
-					<a
-						href="#"
-						onClick={ ( event ) => {
-							event.preventDefault();
-							this.handleClick();
-						} }
-					>
-						{ domain.domain }
-					</a>
-					{ /* eslint-enable jsx-a11y/anchor-is-valid */ }
+					<button onClick={ this.handleClick }>{ domain.domain }</button>
 				</div>
 				{ domainTypeText && <div className="domain-row__domain-type-text">{ domainTypeText }</div> }
 				{ domain?.isPrimary && ! isManagingAllSites && this.renderPrimaryBadge() }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -82,7 +82,13 @@ class DomainRow extends PureComponent {
 			<div className="domain-row__domain-cell">
 				<div className="domain-row__domain-name">
 					{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
-					<a href="#" onClick={ this.handleClick }>
+					<a
+						href="#"
+						onClick={ ( event ) => {
+							event.preventDefault();
+							this.handleClick();
+						} }
+					>
 						{ domain.domain }
 					</a>
 					{ /* eslint-enable jsx-a11y/anchor-is-valid */ }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -200,10 +200,12 @@
 		font-size: $font-body;
 		font-weight: 500; /* stylelint-disable-line */
 
-		a {
+		button {
 			color: var( --studio-gray-90 );
+			cursor: pointer;
+			font-weight: 500;
 		}
-		a:hover {
+		button:hover {
 			color: var( --color-link );
 		}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

After selecting a domain in Domains list page and going to Settings page, users need to click twice on the browser back button to return to the previous page (p1643126573145900-slack-C0761SX4K)

This PR fixes this issue.

Bug reported here: p1643126573145900-slack-C0761SX4K

## Testing instructions

- Build this branch locally or open the live Calypso link
- Select a site,  go to "Upgrades -> Domains" and click on a domain row, in order to open Settings page.
- Click the back browser button and verify that it leads to the previous page just clicking once