### PR TITLE
Activity Log: migrate updates away from data getters

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -13,6 +13,7 @@ import { decodeEntities } from 'calypso/lib/formatting';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
+import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
 import { PLUGIN_INSTALLATION_COMPLETED } from 'calypso/state/plugins/installed/status/constants';
@@ -227,7 +228,7 @@ class ActivityLogTasklist extends Component {
 					} ),
 					{
 						id: `alitemupdate-${ item.slug }`,
-						duration: 3000,
+						duration: DEFAULT_NOTICE_DURATION,
 					}
 				);
 				this.dismiss( item );

--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -2,7 +2,6 @@
 
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { isEmpty, get, includes, find } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -11,12 +10,12 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
+import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getHttpData, requestHttpData } from 'calypso/state/data-layer/http-data';
-import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
+import { PLUGIN_INSTALLATION_COMPLETED } from 'calypso/state/plugins/installed/status/constants';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSite, getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import WithItemsToUpdate from './to-update';
@@ -25,22 +24,14 @@ import ActivityLogTaskUpdate from './update';
 import './style.scss';
 
 /**
- * Checks if the supplied core update, plugins, or themes are being updated.
- *
- * @param {Array} updatables List of plugin, theme or core update objects to check their update status.
- * @returns {boolean}  True if one or more plugins or themes are updating.
- */
-const isItemUpdating = ( updatables ) =>
-	updatables.some( ( item ) => 'inProgress' === get( item, 'updateStatus.status' ) );
-
-/**
  * Checks if the plugin, theme or core update is enqueued to be updated, searching it in the list by its slug.
  *
  * @param {string} updateSlug  Plugin or theme slug, or 'wordpress' for core updates.
  * @param {Array}  updateQueue Collection of plugins or themes currently queued to be updated.
  * @returns {boolean}   True if the plugin or theme is enqueued to be updated.
  */
-const isItemEnqueued = ( updateSlug, updateQueue ) => !! find( updateQueue, { slug: updateSlug } );
+const isItemEnqueued = ( updateSlug, updateQueue ) =>
+	updateQueue.some( ( item ) => item.slug === updateSlug );
 
 const union = ( ...arrays ) => [ ...new Set( [].concat( ...arrays ) ) ];
 
@@ -64,17 +55,7 @@ class ActivityLogTasklist extends Component {
 		trackUpdate: PropTypes.func.isRequired,
 		trackDismissAll: PropTypes.func.isRequired,
 		trackDismiss: PropTypes.func.isRequired,
-
-		// WordPress core
-		coreWithUpdate: PropTypes.arrayOf( PropTypes.object ).isRequired,
-
-		// Plugins already updated + those with pending updates.
-		// This extends plugins with the plugin update status.
-		pluginWithUpdate: PropTypes.arrayOf( PropTypes.object ).isRequired,
 		goManagePlugins: PropTypes.func.isRequired,
-
-		// Themes
-		themeWithUpdate: PropTypes.arrayOf( PropTypes.object ).isRequired,
 
 		// Localize
 		translate: PropTypes.func.isRequired,
@@ -86,6 +67,7 @@ class ActivityLogTasklist extends Component {
 	state = {
 		dismissed: [],
 		queued: [],
+		itemUpdating: false,
 		expandedView: false,
 	};
 
@@ -98,26 +80,14 @@ class ActivityLogTasklist extends Component {
 	 */
 	dismiss = ( item ) => {
 		// ToDo: this should update some record in the tasklist API
-		const {
-			pluginWithUpdate,
-			themeWithUpdate,
-			coreWithUpdate,
-			trackDismiss,
-			trackDismissAll,
-		} = this.props;
+		const { plugins, themes, core, trackDismiss, trackDismissAll } = this.props;
 		let items;
 
 		if ( 'string' === typeof item.slug ) {
 			items = [ item.slug ];
 			trackDismiss( item );
 		} else {
-			items = union(
-				pluginWithUpdate.map( ( plugin ) => plugin.slug ),
-				themeWithUpdate.map( ( theme ) => theme.slug ),
-				// Although core doesn't have a slug, we call it 'wordpress'
-				// to work with it like plugins or themes.
-				coreWithUpdate.map( ( core ) => core.slug )
-			);
+			items = union( plugins, themes, core ).map( ( it ) => it.slug );
 			trackDismissAll();
 		}
 
@@ -152,12 +122,7 @@ class ActivityLogTasklist extends Component {
 	 * If so, updates the next plugin.
 	 */
 	continueQueue = () => {
-		const allUpdatableItems = union(
-			this.props.coreWithUpdate,
-			this.props.pluginWithUpdate,
-			this.props.themeWithUpdate
-		);
-		if ( 0 < this.state.queued.length && ! isItemUpdating( allUpdatableItems ) ) {
+		if ( 0 < this.state.queued.length && ! this.state.itemUpdating ) {
 			this.updateItem( this.state.queued[ 0 ] );
 		}
 	};
@@ -183,10 +148,11 @@ class ActivityLogTasklist extends Component {
 	 *
 	 * @returns {undefined}
 	 */
-	dequeue = () =>
+	finishUpdate = () =>
 		this.setState(
 			{
 				queued: this.state.queued.slice( 1 ),
+				itemUpdating: false,
 			},
 			this.continueQueue
 		);
@@ -198,12 +164,7 @@ class ActivityLogTasklist extends Component {
 		this.props.trackUpdateAll();
 		this.setState(
 			{
-				queued: union(
-					this.state.queued,
-					this.props.coreWithUpdate,
-					this.props.pluginWithUpdate,
-					this.props.themeWithUpdate
-				),
+				queued: union( this.state.queued, this.props.core, this.props.plugins, this.props.themes ),
 			},
 			this.continueQueue
 		);
@@ -229,14 +190,22 @@ class ActivityLogTasklist extends Component {
 	 * }
 	 */
 	updateItem = ( item ) => {
-		const { showInfoNotice, siteName, updateSingle, translate, trackUpdate } = this.props;
+		const {
+			showInfoNotice,
+			showSuccessNotice,
+			showErrorNotice,
+			siteId,
+			siteName,
+			updateSingle,
+			translate,
+			trackUpdate,
+		} = this.props;
 
 		// if the item was enqueued by `updateAll` it has no `from` field because we don't want
 		// to record a track event for each item individually.
 		if ( item.from !== undefined ) {
 			trackUpdate( item );
 		}
-		updateSingle( item );
 
 		showInfoNotice(
 			translate( 'Updating %(item)s on %(siteName)s.', {
@@ -247,6 +216,37 @@ class ActivityLogTasklist extends Component {
 				showDismiss: false,
 			}
 		);
+
+		this.setState( { itemUpdating: true } );
+
+		updateSingle( item, siteId )
+			.then( () => {
+				showSuccessNotice(
+					translate( 'Successfully updated %(item)s on %(siteName)s.', {
+						args: { item: decodeEntities( item.name ), siteName },
+					} ),
+					{
+						id: `alitemupdate-${ item.slug }`,
+						duration: 3000,
+					}
+				);
+				this.dismiss( item );
+			} )
+			.catch( () => {
+				showErrorNotice(
+					translate( 'An error occurred while updating %(item)s on %(siteName)s.', {
+						args: { item: decodeEntities( item.name ), siteName },
+					} ),
+					{
+						id: `alitemupdate-${ item.slug }`,
+						button: translate( 'Try again' ),
+						onClick: () => this.enqueue( item, '_from_error' ),
+					}
+				);
+			} )
+			.finally( () => {
+				this.finishUpdate();
+			} );
 	};
 
 	componentDidMount() {
@@ -262,66 +262,6 @@ class ActivityLogTasklist extends Component {
 				() => page.replace( `/activity-log/${ this.props.siteSlug }`, null, false, false ),
 				0
 			);
-		} );
-	}
-
-	componentDidUpdate( prevProps ) {
-		const itemsWithUpdate = union(
-			this.props.coreWithUpdate,
-			this.props.pluginWithUpdate,
-			this.props.themeWithUpdate
-		);
-		if ( isEmpty( itemsWithUpdate ) ) {
-			return;
-		}
-
-		const { showErrorNotice, showSuccessNotice, siteName, translate } = this.props;
-
-		itemsWithUpdate.forEach( ( item ) => {
-			const { slug, updateStatus, type, name } = item;
-			// Finds in prevProps.pluginWithUpdate, prevProps.themeWithUpdate or prevpros.coreWithUpdate
-			const prevItemWithUpdate = find( prevProps[ `${ type }WithUpdate` ], { slug } );
-
-			if ( false === get( prevItemWithUpdate, [ 'updateStatus' ], false ) ) {
-				return;
-			}
-
-			if (
-				get( prevItemWithUpdate, [ 'updateStatus', 'status' ], false ) ===
-					get( updateStatus, 'status', false ) ||
-				isItemUpdating( [ item ] )
-			) {
-				return;
-			}
-
-			const noticeArgs = {
-				args: { item: decodeEntities( name ), siteName },
-			};
-
-			switch ( updateStatus.status ) {
-				case 'error':
-					showErrorNotice(
-						translate( 'An error occurred while updating %(item)s on %(siteName)s.', noticeArgs ),
-						{
-							id: `alitemupdate-${ slug }`,
-							button: translate( 'Try again' ),
-							onClick: () => this.enqueue( item, '_from_error' ),
-						}
-					);
-					this.dequeue();
-					break;
-				case 'completed':
-					showSuccessNotice(
-						translate( 'Successfully updated %(item)s on %(siteName)s.', noticeArgs ),
-						{
-							id: `alitemupdate-${ slug }`,
-							duration: 3000,
-						}
-					);
-					this.dismiss( item );
-					this.dequeue();
-					break;
-			}
 		} );
 	}
 
@@ -367,13 +307,11 @@ class ActivityLogTasklist extends Component {
 	}
 
 	render() {
-		const itemsToUpdate = union(
-			this.props.coreWithUpdate,
-			this.props.pluginWithUpdate,
-			this.props.themeWithUpdate
-		).filter( ( item ) => ! includes( this.state.dismissed, item.slug ) );
+		const itemsToUpdate = union( this.props.core, this.props.plugins, this.props.themes ).filter(
+			( item ) => ! this.state.dismissed.includes( item.slug )
+		);
 
-		if ( isEmpty( itemsToUpdate ) ) {
+		if ( itemsToUpdate.length === 0 ) {
 			return null;
 		}
 
@@ -432,158 +370,46 @@ class ActivityLogTasklist extends Component {
 	}
 }
 
-/**
- * Normalizes the state result so it's the same than plugins.
- * This normalization allows to reuse methods for plugins, themes, and core.
- *
- * @param {string}  state            Current state of update progress.
- * @param {boolean} isUpdateComplete If update actually produced what is expected to be after a successful update.
- *                                   In themes, the 'update' prop of the theme object is nullified when an update is succesful.
- * @returns {boolean|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
- * the update is running, failed, or was successfully completed, respectively.
- */
-const getNormalizedStatus = ( state, isUpdateComplete ) => {
-	if ( 'pending' === state ) {
-		return { status: 'inProgress' };
+const updateSingle = ( item, siteId ) => ( dispatch, getState ) => {
+	switch ( item.type ) {
+		case 'core':
+			// No need to pass version as a param: if it's missing, WP will be updated to latest core version.
+			return wpcom.req.post( `/sites/${ siteId }/core/update` ).then( ( response ) => {
+				// When core is successfully updated, the response includes an array with the new version.
+				if ( response.version[ 0 ] !== item.version ) {
+					return Promise.reject( 'Core update failed' );
+				}
+			} );
+		case 'plugin':
+			return dispatch( updatePlugin( siteId, item ) ).then( () => {
+				if ( getStatusForPlugin( getState(), siteId, item.id ) !== PLUGIN_INSTALLATION_COMPLETED ) {
+					return Promise.reject( 'Plugin update failed' );
+				}
+			} );
+		case 'theme':
+			return wpcom.req
+				.post( `/sites/${ siteId }/themes`, { action: 'update', themes: item.slug } )
+				.then( ( response ) => {
+					// When a theme successfully updates, the theme 'update' property is nullified.
+					if ( response.themes[ 0 ].update !== null ) {
+						return Promise.reject( 'Theme update failed' );
+					}
+				} );
 	}
-	if ( 'failure' === state ) {
-		return { status: 'error' };
-	}
-	if ( 'success' === state ) {
-		if ( isUpdateComplete ) {
-			return { status: 'completed' };
-		}
-		return { status: 'error' };
-	}
-	return false;
 };
 
-/**
- * Converts statuses for network request for theme update into something matching the plugin update.
- *
- * @param {number} siteId  Site Id.
- * @param {string} themeId Theme slug.
- * @returns {boolean|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
- * the update is running, failed, or was successfully completed, respectively.
- */
-const getStatusForTheme = ( siteId, themeId ) => {
-	const httpData = getHttpData( `theme-update-${ siteId }-${ themeId }` );
-	// When a theme successfully updates, the theme 'update' property is nullified.
-	const isThemeUpdateComplete = null === get( httpData, 'data.themes.0.update' );
-	return getNormalizedStatus( httpData.state, isThemeUpdateComplete );
-};
-
-/**
- * Get data about the status of a core update.
- *
- * @param {number} siteId      Site Id.
- * @param {string} coreVersion Version of core that the WP installation will be updated to.
- * @returns {boolean|object}      False is update hasn't started. One of 'inProgress', 'error', 'completed', when
- * the update is running, failed, or was successfully completed, respectively.
- */
-const getStatusForCore = ( siteId, coreVersion ) => {
-	const httpData = getHttpData( `core-update-${ siteId }` );
-	// When core is successfully updated, the response includes an array with the new version.
-	const isCoreUpdateComplete = coreVersion === get( httpData, 'data.version.0' );
-	return getNormalizedStatus( httpData.state, isCoreUpdateComplete );
-};
-
-/**
- * Creates an object, keyed by plugin/theme slug, of objects containing plugin/theme information
- * {
- * 		{string}       id     Plugin/theme directory and base file name without extension
- * 		{string}       slug   Plugin/theme directory
- * 		{string}       name   Plugin/theme name
- * 		{object|false} status Current update status
- * }
- * themeUpdate: PropTypes.shape( {
-		state: PropTypes.oneOf( [ 'uninitialized', 'failure', 'success', 'pending' ] ),
-		error: PropTypes.object,
-	} )
- *
- * @param {Array}  itemList Collection of plugins/themes that will be updated.
- * @param {number} siteId   ID of the site where the plugin/theme is installed.
- * @param {object} state    App state tree.
- * @returns {Array} List of plugins/themes to update with their status.
- */
-const makeUpdatableList = ( itemList, siteId, state = null ) =>
-	itemList.map( ( item ) => ( {
-		...item,
-		updateStatus:
-			'plugin' === item.type
-				? getStatusForPlugin( state, siteId, item.id )
-				: getStatusForTheme( siteId, item.slug ),
-	} ) );
-
-/**
- * Start updating the theme on the specified site.
- *
- * @param {number} siteId  Site Id.
- * @param {string} themeId Theme slug.
- * @returns {*} Stored data container for request.
- */
-const updateTheme = ( siteId, themeId ) =>
-	requestHttpData(
-		`theme-update-${ siteId }-${ themeId }`,
-		http( {
-			method: 'POST',
-			path: `/sites/${ siteId }/themes`,
-			body: { action: 'update', themes: themeId },
-		} ),
-		{
-			freshness: -Infinity,
-		}
-	);
-
-/**
- * Start updating WordPress core on the specified site.
- *
- * @param {number} siteId  Site Id.
- * @returns {*} Stored data container for request.
- */
-const updateCore = ( siteId ) =>
-	requestHttpData(
-		`core-update-${ siteId }`,
-		http( {
-			method: 'POST',
-			path: `/sites/${ siteId }/core/update`,
-			// No need to pass version: if it's missing, WP will be updated to latest core version.
-		} ),
-		{
-			freshness: -Infinity,
-		}
-	);
-
-const mapStateToProps = ( state, { siteId, plugins, themes, core } ) => {
+const mapStateToProps = ( state, { siteId } ) => {
 	const site = getSite( state, siteId );
 	return {
-		siteId,
 		siteSlug: site.slug,
 		siteName: site.name,
-		pluginWithUpdate: makeUpdatableList( plugins, siteId, state ),
-		themeWithUpdate: makeUpdatableList( themes, siteId ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		jetpackNonAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
-		coreWithUpdate: isEmpty( core )
-			? []
-			: [
-					{
-						...core[ 0 ],
-						updateStatus: getStatusForCore( siteId, core[ 0 ].version ),
-					},
-			  ],
 	};
 };
 
-const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
-	updateSingle: ( item ) => {
-		if ( 'core' === item.type ) {
-			return updateCore( siteId );
-		}
-		return 'plugin' === item.type
-			? dispatch( updatePlugin( siteId, item ) )
-			: updateTheme( siteId, item.slug );
-	},
+const mapDispatchToProps = ( dispatch ) => ( {
+	updateSingle: ( item, siteId ) => dispatch( updateSingle( item, siteId ) ),
 	showErrorNotice: ( error, options ) => dispatch( errorNotice( error, options ) ),
 	showInfoNotice: ( info, options ) => dispatch( infoNotice( info, options ) ),
 	showSuccessNotice: ( success, options ) => dispatch( successNotice( success, options ) ),


### PR DESCRIPTION
This is a followup to #60393 which migrated the Site Alerts data getter to React Query. Now we're migrating the POST requests (mutations) that update a theme or Core from a data getter to a plain `wpcom.req.post` request.

It quite a major rewrite of the entire component, here's some info how to best understand it:

The component is getting `plugins`, `themes` and `core` props with the list of available updates, and is getting them from Redux (plugins) and React Query site alerts (themes and core). Before this PR, there were also `pluginsWithUpdate` derived props that added an `updateStatus` field with the status of the update.

The `updateStatus` field was used only for two purposes:
- a `componentDidUpdate` method was detecting changes in `updateStatus` and then showed notices on success or error
- the queue processing code (`continueQueue`) started processing another item only when no other item was updating (`isItemUpdating` helper that checks for `inProgress` status)

This PR replaces that with:
- `then` and `catch` handlers on the promise returned by `updateSingle`
- `this.state.itemUpdating` boolean flag that's set before and after `updateSingle`

The `*WithUpdate` props and their logic is now no longer needed and can completely disappear: we only need the `plugins`/`themes`/`core` props.

**How to test:**
Create a Jurassic Ninja site with a WP Downgrade plugin and put it into state where there are pending Core, plugins and theme updates:

<img width="621" alt="Screenshot 2022-01-24 at 10 18 15" src="https://user-images.githubusercontent.com/664258/151335019-e761d327-6aff-4404-986e-8d705fddf6ec.png">

Now click the "Update" buttons and verify that the updates proceeded successfully.

There's one caveat with a Core update: the WP Downgrade plugin registers some filters that pretend that the current Core version is the latest one. A Core update with the active plugin will therefore return a "WordPress is at the latest version" error. You'll need to deactivate the WP Downgrade plugin to make the Core update succeed. 