### PR TITLE
Signup: Track the user upgrades plan in Hero Flow

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -161,17 +161,28 @@ export function recordSignupProcessingScreen( flow, previousStep, optionalProps 
  *
  * @param {string} flow Signup flow name
  * @param {string} step The step when the user changes the plan
- * @param {string} currentPlan The plan before changing
- * @param {string} nextPlan The plan after changing
+ * @param {string} previousPlanName The plan name before changing
+ * @param {string} previousPlanSlug The plan slug before changing
+ * @param {string} currentPlanName The plan name after changing
+ * @param {string} currentPlanSlug The plan slug after changing
  */
-export const recordSignupPlanChange = ( flow, step, currentPlan, nextPlan ) => {
+export const recordSignupPlanChange = (
+	flow,
+	step,
+	previousPlanName,
+	previousPlanSlug,
+	currentPlanName,
+	currentPlanSlug
+) => {
 	const device = resolveDeviceTypeByViewPort();
 
 	recordTracksEvent( 'calypso_signup_plan_change ', {
 		flow,
 		step,
 		device,
-		currentPlan,
-		nextPlan,
+		previousPlanName,
+		previousPlanSlug,
+		currentPlanName,
+		currentPlanSlug,
 	} );
 };

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -155,3 +155,23 @@ export function recordSignupProcessingScreen( flow, previousStep, optionalProps 
 		...optionalProps,
 	} );
 }
+
+/**
+ * Records plan change in signup flow
+ *
+ * @param {string} flow Signup flow name
+ * @param {string} step The step when the user changes the plan
+ * @param {string} currentPlan The plan before changing
+ * @param {string} nextPlan The plan after changing
+ */
+export const recordSignupPlanChange = ( flow, step, currentPlan, nextPlan ) => {
+	const device = resolveDeviceTypeByViewPort();
+
+	recordTracksEvent( 'calypso_signup_plan_change ', {
+		flow,
+		step,
+		device,
+		currentPlan,
+		nextPlan,
+	} );
+};

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -266,7 +266,7 @@ class Signup extends Component {
 			this.scrollToTop();
 		}
 
-		if ( sitePlanSlug !== prevProps.sitePlanSlug ) {
+		if ( sitePlanSlug && prevProps.sitePlanSlug && sitePlanSlug !== prevProps.sitePlanSlug ) {
 			recordSignupPlanChange(
 				flowName,
 				stepName,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -32,6 +32,7 @@ import {
 	recordSignupStep,
 	recordSignupInvalidStep,
 	recordSignupProcessingScreen,
+	recordSignupPlanChange,
 } from 'calypso/lib/analytics/signup';
 import * as oauthToken from 'calypso/lib/oauth-token';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
@@ -237,25 +238,29 @@ class Signup extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		const { flowName, stepName, signupDependencies, sitePlanSlug } = this.props;
+
 		if (
-			( this.props.flowName !== prevProps.flowName ||
-				this.props.stepName !== prevProps.stepName ) &&
+			( flowName !== prevProps.flowName || stepName !== prevProps.stepName ) &&
 			! this.state.shouldShowLoadingScreen
 		) {
-			recordSignupStep( this.props.flowName, this.props.stepName, this.getRecordProps() );
+			recordSignupStep( flowName, stepName, this.getRecordProps() );
 		}
 
 		if (
-			get( this.props.signupDependencies, 'siteType' ) !==
-			get( prevProps.signupDependencies, 'siteType' )
+			get( signupDependencies, 'siteType' ) !== get( prevProps.signupDependencies, 'siteType' )
 		) {
 			this.startTrackingForBusinessSite();
 		}
 
-		if ( this.props.stepName !== prevProps.stepName ) {
+		if ( stepName !== prevProps.stepName ) {
 			this.preloadNextStep();
 			// `scrollToTop` here handles cases where the viewport may fall slightly below the top of the page when the next step is rendered
 			this.scrollToTop();
+		}
+
+		if ( sitePlanSlug !== prevProps.sitePlanSlug ) {
+			recordSignupPlanChange( flowName, stepName, prevProps.sitePlanSlug, sitePlanSlug );
 		}
 	}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -61,7 +61,12 @@ import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { submitSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
 import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { getSiteId, isCurrentPlanPaid, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import {
+	getSiteId,
+	isCurrentPlanPaid,
+	getSitePlanSlug,
+	getSitePlanName,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import flows from './config/flows';
 import { getStepComponent } from './config/step-components';
@@ -129,6 +134,8 @@ class Signup extends Component {
 		submitSignupStep: PropTypes.func.isRequired,
 		signupDependencies: PropTypes.object,
 		siteDomains: PropTypes.array,
+		sitePlanName: PropTypes.string,
+		sitePlanSlug: PropTypes.string,
 		isPaidPlan: PropTypes.bool,
 		flowName: PropTypes.string,
 		stepName: PropTypes.string,
@@ -238,7 +245,7 @@ class Signup extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { flowName, stepName, signupDependencies, sitePlanSlug } = this.props;
+		const { flowName, stepName, signupDependencies, sitePlanName, sitePlanSlug } = this.props;
 
 		if (
 			( flowName !== prevProps.flowName || stepName !== prevProps.stepName ) &&
@@ -260,7 +267,14 @@ class Signup extends Component {
 		}
 
 		if ( sitePlanSlug !== prevProps.sitePlanSlug ) {
-			recordSignupPlanChange( flowName, stepName, prevProps.sitePlanSlug, sitePlanSlug );
+			recordSignupPlanChange(
+				flowName,
+				stepName,
+				prevProps.sitePlanName,
+				prevProps.sitePlanSlug,
+				sitePlanName,
+				sitePlanSlug
+			);
 		}
 	}
 
@@ -771,6 +785,7 @@ export default connect(
 			isNewishUser: isUserRegistrationDaysWithinRange( state, null, 0, 7 ),
 			existingSiteCount: getCurrentUserSiteCount( state ),
 			isPaidPlan: isCurrentPlanPaid( state, siteId ),
+			sitePlanName: getSitePlanName( state, siteId ),
 			sitePlanSlug: getSitePlanSlug( state, siteId ),
 			siteDomains,
 			siteId,

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -121,6 +121,14 @@ export default function DesignPickerStep( props ) {
 		};
 	}, [ allThemes ] );
 
+	const getEventPropsByDesign = ( design ) => ( {
+		theme: design?.stylesheet ?? `pub/${ design.theme }`,
+		template: design.template,
+		is_premium: design?.is_premium,
+		flow: flowName,
+		intent: dependencies.intent,
+	} );
+
 	// Update the selected design when the section changes
 	useEffect( () => {
 		setSelectedDesign( designs.find( ( { theme } ) => theme === props.stepSectionName ) );
@@ -172,12 +180,11 @@ export default function DesignPickerStep( props ) {
 	function previewDesign( _selectedDesign ) {
 		const locale = ! userLoggedIn ? getLocaleSlug() : '';
 
-		recordTracksEvent( 'calypso_signup_design_preview_select', {
-			theme: _selectedDesign?.stylesheet ?? `pub/${ _selectedDesign.theme }`,
-			template: _selectedDesign.template,
-			flow: props.flowName,
-			intent: props.signupDependencies.intent,
-		} );
+		recordTracksEvent(
+			'calypso_signup_design_preview_select',
+			getEventPropsByDesign( _selectedDesign )
+		);
+
 		page(
 			getStepUrl( props.flowName, props.stepName, _selectedDesign.theme, locale, queryParams )
 		);
@@ -188,13 +195,7 @@ export default function DesignPickerStep( props ) {
 	}
 
 	function submitDesign( _selectedDesign = selectedDesign ) {
-		recordTracksEvent( 'calypso_signup_select_design', {
-			theme: _selectedDesign?.stylesheet ?? `pub/${ _selectedDesign?.theme }`,
-			template: _selectedDesign?.template,
-			flow: props.flowName,
-			intent: props.signupDependencies.intent,
-		} );
-
+		recordTracksEvent( 'calypso_signup_select_design', getEventPropsByDesign( _selectedDesign ) );
 		props.goToNextStep();
 	}
 

--- a/client/state/sites/selectors/get-site-plan-name.js
+++ b/client/state/sites/selectors/get-site-plan-name.js
@@ -1,0 +1,5 @@
+import getSitePlan from './get-site-plan';
+
+export default function getSitePlanName( state, siteId ) {
+	return getSitePlan( state, siteId )?.product_name_short ?? null;
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -30,6 +30,7 @@ export { default as getSiteId } from './get-site-id';
 export { default as getSiteOption } from './get-site-option';
 export { default as getSiteOptions } from './get-site-options';
 export { default as getSitePlan } from './get-site-plan';
+export { default as getSitePlanName } from './get-site-plan-name';
 export { default as getSitePlanSlug } from './get-site-plan-slug';
 export { default as getSitePostsPage } from './get-site-posts-page';
 export { default as getSiteProducts } from './get-site-products';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `calypso_signup_plan_change` when the plan changed.
   ![image](https://user-images.githubusercontent.com/13596067/151492110-9c4fd1ff-c0ac-41fb-9d61-589104581b28.png)
* Add `is_premium` prop to `calypso_signup_design_preview_select` and `calypso_signup_select_design` event
   ![image](https://user-images.githubusercontent.com/13596067/151346726-4f582b4e-e466-4031-b688-e965162db85a.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your_site>` with free plan
* Select build
* Select `Upgrade Plan` on one of the premium theme
* After you upgrade the plan and back to the design picker, you should see `calypso_signup_plan_change` event
* Select the premium theme again, you should see `calypso_signup_select_design` with `is_premium=true` 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/59229
