### PR TITLE
Create widget apps for InlineHelp and Happychat

### DIFF
--- a/apps/happychat/package.json
+++ b/apps/happychat/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@automattic/happychat-app",
+	"version": "1.0.0",
+	"description": "WordPress.com Happychat Panel",
+	"main": "dist/build.min.js",
+	"sideEffects": true,
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/Automattic/wp-calypso.git",
+		"directory": "apps/happychat"
+	},
+	"private": true,
+	"author": "Automattic Inc.",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"scripts": {
+		"clean": "npx rimraf dist",
+		"build": "BROWSERSLIST_ENV=evergreen webpack --config='./webpack.config.js'",
+		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build",
+		"dev-server": "webpack serve",
+		"start": "yarn dev-server",
+		"sync": "yarn clean && yarn build && sh ./bin/wpcom-watch-and-sync.sh"
+	},
+	"dependencies": {
+		"@automattic/calypso-polyfills": "workspace:^",
+		"calypso": "workspace:^",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"react-query": "^3.32.1",
+		"react-redux": "^7.2.6",
+		"redux": "^4.1.2",
+		"redux-thunk": "^2.3.0",
+		"wpcom": "workspace:^",
+		"wpcom-proxy-request": "workspace:^"
+	},
+	"devDependencies": {
+		"@automattic/calypso-babel-config": "workspace:^",
+		"@automattic/calypso-build": "workspace:^",
+		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
+		"@automattic/webpack-inline-constant-exports-plugin": "workspace:^",
+		"autoprefixer": "^10.2.5",
+		"enzyme": "^3.11.0",
+		"html-webpack-plugin": "^5.0.0-beta.4",
+		"jest": "^27.2.4",
+		"postcss": "^8.3.11",
+		"webpack": "^5.63.0",
+		"webpack-bundle-analyzer": "^4.5.0",
+		"webpack-dev-server": "^4.7.2"
+	}
+}

--- a/apps/happychat/package.json
+++ b/apps/happychat/package.json
@@ -48,6 +48,6 @@
 		"postcss": "^8.3.11",
 		"webpack": "^5.63.0",
 		"webpack-bundle-analyzer": "^4.5.0",
-		"webpack-dev-server": "^4.7.2"
+		"webpack-dev-server": "^4.7.3"
 	}
 }

--- a/apps/happychat/src/app.jsx
+++ b/apps/happychat/src/app.jsx
@@ -1,0 +1,65 @@
+/**
+ * Global polyfills
+ */
+import '@automattic/calypso-polyfills';
+
+import ReactDom from 'react-dom';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import { initializeAnalytics } from 'calypso/lib/analytics/init';
+import getSuperProps from 'calypso/lib/analytics/super-props';
+import { rawCurrentUserFetch, filterUserObject } from 'calypso/lib/user/shared-utils';
+import analyticsMiddleware from 'calypso/state/analytics/middleware';
+import consoleDispatcher from 'calypso/state/console-dispatch';
+import { setCurrentUser } from 'calypso/state/current-user/actions';
+import currentUser from 'calypso/state/current-user/reducer';
+import wpcomApiMiddleware from 'calypso/state/data-layer/wpcom-api-middleware';
+import happychatMiddleware from 'calypso/state/happychat/middleware';
+import { openChat } from 'calypso/state/happychat/ui/actions';
+import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
+import { setStore } from 'calypso/state/redux-store';
+import sites from 'calypso/state/sites/reducer';
+import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
+import 'calypso/assets/stylesheets/style.scss';
+import Happychat from './happychat';
+
+async function AppBoot() {
+	const rootReducer = combineReducers( {
+		currentUser,
+		sites,
+	} );
+
+	const store = createStore(
+		rootReducer,
+		compose(
+			consoleDispatcher,
+			addReducerEnhancer,
+			applyMiddleware(
+				thunkMiddleware,
+				wpcomApiMiddleware,
+				analyticsMiddleware,
+				happychatMiddleware
+			)
+		)
+	);
+
+	setStore( store );
+	const user = await rawCurrentUserFetch().then( filterUserObject );
+	if ( user ) {
+		store.dispatch( setCurrentUser( user ) );
+	}
+	initializeAnalytics( user || undefined, getSuperProps( store ) );
+
+	store.dispatch( requestHappychatEligibility() );
+	store.dispatch( openChat() );
+
+	ReactDom.render(
+		<Provider store={ store }>
+			<Happychat />
+		</Provider>,
+		document.getElementById( 'wpcom' )
+	);
+}
+
+AppBoot();

--- a/apps/happychat/src/happychat.jsx
+++ b/apps/happychat/src/happychat.jsx
@@ -1,0 +1,96 @@
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import Composer from 'calypso/components/happychat/composer';
+import HappychatConnection from 'calypso/components/happychat/connection-connected';
+import Notices from 'calypso/components/happychat/notices';
+import Timeline from 'calypso/components/happychat/timeline';
+import { isOutsideCalypso } from 'calypso/lib/url';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import {
+	sendEvent,
+	sendMessage,
+	sendNotTyping,
+	sendTyping,
+} from 'calypso/state/happychat/connection/actions';
+import canUserSendMessages from 'calypso/state/happychat/selectors/can-user-send-messages';
+import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
+import getHappychatConnectionStatus from 'calypso/state/happychat/selectors/get-happychat-connection-status';
+import getCurrentMessage from 'calypso/state/happychat/selectors/get-happychat-current-message';
+import getHappychatTimeline from 'calypso/state/happychat/selectors/get-happychat-timeline';
+import isHappychatServerReachable from 'calypso/state/happychat/selectors/is-happychat-server-reachable';
+import { setCurrentMessage } from 'calypso/state/happychat/ui/actions';
+import './happychat.scss';
+
+function ParentConnection( { chatStatus } ) {
+	const dispatch = useDispatch();
+
+	// listen to messages from parent window
+	useEffect( () => {
+		function onMessage( e ) {
+			const message = e.data;
+			switch ( message.type ) {
+				case 'opened':
+					if ( message.opened ) {
+						dispatch( sendEvent( 'Started looking at Happychat' ) );
+					} else {
+						dispatch( sendEvent( 'Stopped looking at Happychat' ) );
+					}
+					break;
+				case 'route':
+					dispatch( sendEvent( `Looking at ${ message.route }` ) );
+					break;
+			}
+		}
+
+		window.addEventListener( 'message', onMessage );
+		return () => window.removeEventListener( 'message', onMessage );
+	}, [ dispatch ] );
+
+	// notify parent window about chat status changes
+	useEffect( () => {
+		window.parent.postMessage( { chatStatus }, '*' );
+	}, [ chatStatus ] );
+
+	return null;
+}
+
+export default function Happychat() {
+	const dispatch = useDispatch();
+	const currentUser = useSelector( getCurrentUser );
+	const chatStatus = useSelector( getHappychatChatStatus );
+	const connectionStatus = useSelector( getHappychatConnectionStatus );
+	const timeline = useSelector( getHappychatTimeline );
+	const message = useSelector( getCurrentMessage );
+	const isServerReachable = useSelector( isHappychatServerReachable );
+	const disabled = ! useSelector( canUserSendMessages );
+
+	const isMessageFromCurrentUser = ( { user_id, source } ) => {
+		return user_id.toString() === currentUser.ID.toString() && source === 'customer';
+	};
+
+	return (
+		<div className="happychat__container">
+			<HappychatConnection />
+			<ParentConnection chatStatus={ chatStatus } />
+			<Timeline
+				currentUserEmail={ currentUser.email }
+				isCurrentUser={ isMessageFromCurrentUser }
+				isExternalUrl={ isOutsideCalypso }
+				timeline={ timeline }
+			/>
+			<Notices
+				chatStatus={ chatStatus }
+				connectionStatus={ connectionStatus }
+				isServerReachable={ isServerReachable }
+			/>
+			<Composer
+				disabled={ disabled }
+				message={ message }
+				onSendMessage={ ( msg ) => dispatch( sendMessage( msg ) ) }
+				onSendNotTyping={ () => dispatch( sendNotTyping() ) }
+				onSendTyping={ () => dispatch( sendTyping() ) }
+				onSetCurrentMessage={ ( msg ) => dispatch( setCurrentMessage( msg ) ) }
+			/>
+		</div>
+	);
+}

--- a/apps/happychat/src/happychat.scss
+++ b/apps/happychat/src/happychat.scss
@@ -1,0 +1,5 @@
+.happychat__container {
+	height: 100vh;
+	display: flex;
+	flex-direction: column;
+}

--- a/apps/happychat/src/index.ejs
+++ b/apps/happychat/src/index.ejs
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=9">
-	<title>Inline Help</title>
+	<title>Happychat</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<meta name="mobile-web-app-capable" content="yes">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">

--- a/apps/happychat/src/index.ejs
+++ b/apps/happychat/src/index.ejs
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=9">
+	<title>Inline Help</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	<meta name="mobile-web-app-capable" content="yes">
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
+  <% htmlWebpackPlugin.files.css.forEach( ( style ) => {
+    if ( ! style.includes( '.rtl.css' ) ) {
+      %><link rel="stylesheet" href="<%= style %>"><%
+    }
+  } ) %>
+</head>
+
+<body>
+	<div id="wpcom"></div>
+  <script>
+    window.configData = {
+      env_id: 'development',
+      i18n_default_locale_slug: 'en',
+      google_analytics_key: 'UA-10673494-15',
+      client_slug: 'browser',
+      happychat_url: 'https://happychat-io-staging.go-vip.co/customer',
+      site_filter: [],
+      sections: {},
+      enable_all_sections: false,
+      livechat_support_locales: [ 'en' ],
+			upwork_support_locales: [ 'de' ],
+      jetpack_support_blog: 'jetpackme.wordpress.com',
+      wpcom_support_blog: 'en.support.wordpress.com',
+			gutenboarding_url: '/new',
+      features: {
+        happychat: true,
+      }
+    };
+  </script>
+	<% htmlWebpackPlugin.files.js.forEach( function( script ) { %><script charset="UTF-8" src="<%= script %>"></script><% } ) %>
+</body>
+
+</html>

--- a/apps/happychat/webpack.config.js
+++ b/apps/happychat/webpack.config.js
@@ -1,0 +1,116 @@
+const path = require( 'path' );
+const process = require( 'process' ); // eslint-disable-line
+const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
+const Minify = require( '@automattic/calypso-build/webpack/minify' );
+const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
+const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
+const { shouldTranspileDependency } = require( '@automattic/calypso-build/webpack/util' );
+const ExtensiveLodashReplacementPlugin = require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
+const InlineConstantExportsPlugin = require( '@automattic/webpack-inline-constant-exports-plugin' );
+const autoprefixerPlugin = require( 'autoprefixer' );
+const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
+const webpack = require( 'webpack' );
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
+
+const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
+const isDevelopment = process.env.NODE_ENV !== 'production';
+const outputPath = path.join( __dirname, 'dist' );
+
+module.exports = {
+	bail: ! isDevelopment,
+	entry: path.join( __dirname, 'src', 'app' ),
+	mode: isDevelopment ? 'development' : 'production',
+	devtool: false,
+	output: {
+		path: outputPath,
+		filename: 'build.min.js',
+	},
+	optimization: {
+		minimize: ! isDevelopment,
+		minimizer: Minify( {
+			extractComments: false,
+			terserOptions: {
+				ecma: 5,
+				safari10: true,
+				mangle: { reserved: [ '__', '_n', '_nx', '_x' ] },
+			},
+		} ),
+		splitChunks: false,
+	},
+	module: {
+		strictExportPresence: true,
+		rules: [
+			TranspileConfig.loader( {
+				exclude: /node_modules\//,
+				presets: [ require.resolve( '@automattic/calypso-babel-config/presets/default' ) ],
+			} ),
+			TranspileConfig.loader( {
+				include: shouldTranspileDependency,
+				presets: [ require.resolve( '@automattic/calypso-babel-config/presets/dependencies' ) ],
+			} ),
+			SassConfig.loader( {
+				includePaths: [ __dirname ],
+				postCssOptions: {
+					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
+					// This is required because Calypso imports `@automattic/notifications` and that package defines its
+					// own `postcss.config.js` that they use for their webpack bundling process.
+					config: false,
+					plugins: [ autoprefixerPlugin() ],
+				},
+				prelude: `@use '${ require.resolve(
+					'calypso/assets/stylesheets/shared/_utils.scss'
+				) }' as *;`,
+			} ),
+			FileConfig.loader(),
+		],
+	},
+	resolve: {
+		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
+		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
+	},
+	node: false,
+	plugins: [
+		new webpack.DefinePlugin( {
+			global: 'window',
+			'process.env.NODE_DEBUG': JSON.stringify( process.env.NODE_DEBUG || false ),
+		} ),
+		...SassConfig.plugins( {
+			filename: 'build.min.css',
+			minify: ! isDevelopment,
+		} ),
+		new HtmlWebpackPlugin( {
+			filename: path.join( outputPath, 'index.html' ),
+			template: path.join( __dirname, 'src', 'index.ejs' ),
+			title: 'Chat',
+			hash: true,
+			inject: false,
+			isRTL: false,
+		} ),
+		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),
+		new ExtensiveLodashReplacementPlugin(),
+		new InlineConstantExportsPlugin( /\/client\/state\/action-types.js$/ ),
+		shouldEmitStats &&
+			new BundleAnalyzerPlugin( {
+				analyzerMode: 'server',
+				statsOptions: {
+					source: false,
+					reasons: false,
+					optimizationBailout: false,
+					chunkOrigins: false,
+					chunkGroups: true,
+				},
+			} ),
+	].filter( Boolean ),
+	devServer: {
+		host: 'calypso.localhost',
+		port: 3000,
+		static: {
+			directory: path.join( __dirname, 'dist' ),
+		},
+		client: {
+			progress: true,
+		},
+		watchFiles: [ 'dist/**/*' ],
+	},
+};

--- a/apps/inline-help/package.json
+++ b/apps/inline-help/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@automattic/inline-help",
+	"version": "1.0.0",
+	"description": "WordPress.com Inline Help Panel",
+	"main": "dist/build.min.js",
+	"sideEffects": true,
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/Automattic/wp-calypso.git",
+		"directory": "apps/inline-help"
+	},
+	"private": true,
+	"author": "Automattic Inc.",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"scripts": {
+		"clean": "npx rimraf dist",
+		"build": "BROWSERSLIST_ENV=evergreen webpack --config='./webpack.config.js'",
+		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build",
+		"dev-server": "webpack serve",
+		"start": "yarn dev-server",
+		"sync": "yarn clean && yarn build && sh ./bin/wpcom-watch-and-sync.sh"
+	},
+	"dependencies": {
+		"@automattic/calypso-polyfills": "workspace:^",
+		"calypso": "workspace:^",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"react-query": "^3.32.1",
+		"react-redux": "^7.2.6",
+		"redux": "^4.1.2",
+		"redux-thunk": "^2.3.0",
+		"wpcom": "workspace:^",
+		"wpcom-proxy-request": "workspace:^"
+	},
+	"devDependencies": {
+		"@automattic/calypso-babel-config": "workspace:^",
+		"@automattic/calypso-build": "workspace:^",
+		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
+		"@automattic/webpack-inline-constant-exports-plugin": "workspace:^",
+		"autoprefixer": "^10.2.5",
+		"enzyme": "^3.11.0",
+		"html-webpack-plugin": "^5.0.0-beta.4",
+		"jest": "^27.2.4",
+		"postcss": "^8.3.11",
+		"webpack": "^5.63.0",
+		"webpack-bundle-analyzer": "^4.5.0",
+		"webpack-dev-server": "^4.7.2"
+	}
+}

--- a/apps/inline-help/package.json
+++ b/apps/inline-help/package.json
@@ -48,6 +48,6 @@
 		"postcss": "^8.3.11",
 		"webpack": "^5.63.0",
 		"webpack-bundle-analyzer": "^4.5.0",
-		"webpack-dev-server": "^4.7.2"
+		"webpack-dev-server": "^4.7.3"
 	}
 }

--- a/apps/inline-help/src/app.jsx
+++ b/apps/inline-help/src/app.jsx
@@ -1,0 +1,66 @@
+/**
+ * Global polyfills
+ */
+import '@automattic/calypso-polyfills';
+
+import ReactDom from 'react-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import InlineHelpPopoverContent from 'calypso/blocks/inline-help/popover-content';
+import QuerySites from 'calypso/components/data/query-sites';
+import { initializeAnalytics } from 'calypso/lib/analytics/init';
+import getSuperProps from 'calypso/lib/analytics/super-props';
+import { rawCurrentUserFetch, filterUserObject } from 'calypso/lib/user/shared-utils';
+import analyticsMiddleware from 'calypso/state/analytics/middleware';
+import consoleDispatcher from 'calypso/state/console-dispatch';
+import { setCurrentUser } from 'calypso/state/current-user/actions';
+import currentUser from 'calypso/state/current-user/reducer';
+import happychatMiddleware from 'calypso/state/happychat/middleware';
+import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
+import { setStore } from 'calypso/state/redux-store';
+import sites from 'calypso/state/sites/reducer';
+import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
+import 'calypso/assets/stylesheets/style.scss';
+
+async function AppBoot() {
+	const rootReducer = combineReducers( {
+		currentUser,
+		sites,
+	} );
+
+	const store = createStore(
+		rootReducer,
+		compose(
+			consoleDispatcher,
+			addReducerEnhancer,
+			applyMiddleware( thunkMiddleware, analyticsMiddleware, happychatMiddleware )
+		)
+	);
+
+	setStore( store );
+	const user = await rawCurrentUserFetch().then( filterUserObject );
+	if ( user ) {
+		store.dispatch( setCurrentUser( user ) );
+	}
+	initializeAnalytics( user || undefined, getSuperProps( store ) );
+
+	store.dispatch( requestHappychatEligibility() );
+
+	const queryClient = new QueryClient();
+
+	ReactDom.render(
+		<QueryClientProvider client={ queryClient }>
+			<Provider store={ store }>
+				<>
+					<QuerySites allSites />
+					<InlineHelpPopoverContent />
+				</>
+			</Provider>
+		</QueryClientProvider>,
+		document.getElementById( 'wpcom' )
+	);
+}
+
+AppBoot();

--- a/apps/inline-help/src/index.ejs
+++ b/apps/inline-help/src/index.ejs
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=9">
+	<title>Inline Help</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	<meta name="mobile-web-app-capable" content="yes">
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
+  <% htmlWebpackPlugin.files.css.forEach( ( style ) => {
+    if ( ! style.includes( '.rtl.css' ) ) {
+      %><link rel="stylesheet" href="<%= style %>"><%
+    }
+  } ) %>
+</head>
+
+<body>
+	<div id="wpcom"></div>
+  <script>
+    window.configData = {
+      env_id: 'development',
+      i18n_default_locale_slug: 'en',
+      google_analytics_key: 'UA-10673494-15',
+      client_slug: 'browser',
+      twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
+      happychat_url: 'https://happychat-io-staging.go-vip.co/customer',
+      site_filter: [],
+      sections: {},
+      enable_all_sections: false,
+      livechat_support_locales: [ 'en' ],
+			upwork_support_locales: [ 'de' ],
+      jetpack_support_blog: 'jetpackme.wordpress.com',
+      wpcom_support_blog: 'en.support.wordpress.com',
+			gutenboarding_url: '/new',
+      features: {
+        happychat: true,
+      }
+    };
+  </script>
+	<% htmlWebpackPlugin.files.js.forEach( function( script ) { %><script charset="UTF-8" src="<%= script %>"></script><% } ) %>
+</body>
+
+</html>

--- a/apps/inline-help/webpack.config.js
+++ b/apps/inline-help/webpack.config.js
@@ -1,0 +1,116 @@
+const path = require( 'path' );
+const process = require( 'process' ); // eslint-disable-line
+const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
+const Minify = require( '@automattic/calypso-build/webpack/minify' );
+const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
+const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
+const { shouldTranspileDependency } = require( '@automattic/calypso-build/webpack/util' );
+const ExtensiveLodashReplacementPlugin = require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
+const InlineConstantExportsPlugin = require( '@automattic/webpack-inline-constant-exports-plugin' );
+const autoprefixerPlugin = require( 'autoprefixer' );
+const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
+const webpack = require( 'webpack' );
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
+
+const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
+const isDevelopment = process.env.NODE_ENV !== 'production';
+const outputPath = path.join( __dirname, 'dist' );
+
+module.exports = {
+	bail: ! isDevelopment,
+	entry: path.join( __dirname, 'src', 'app' ),
+	mode: isDevelopment ? 'development' : 'production',
+	devtool: false,
+	output: {
+		path: outputPath,
+		filename: 'build.min.js',
+	},
+	optimization: {
+		minimize: ! isDevelopment,
+		minimizer: Minify( {
+			extractComments: false,
+			terserOptions: {
+				ecma: 5,
+				safari10: true,
+				mangle: { reserved: [ '__', '_n', '_nx', '_x' ] },
+			},
+		} ),
+		splitChunks: false,
+	},
+	module: {
+		strictExportPresence: true,
+		rules: [
+			TranspileConfig.loader( {
+				exclude: /node_modules\//,
+				presets: [ require.resolve( '@automattic/calypso-babel-config/presets/default' ) ],
+			} ),
+			TranspileConfig.loader( {
+				include: shouldTranspileDependency,
+				presets: [ require.resolve( '@automattic/calypso-babel-config/presets/dependencies' ) ],
+			} ),
+			SassConfig.loader( {
+				includePaths: [ __dirname ],
+				postCssOptions: {
+					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
+					// This is required because Calypso imports `@automattic/notifications` and that package defines its
+					// own `postcss.config.js` that they use for their webpack bundling process.
+					config: false,
+					plugins: [ autoprefixerPlugin() ],
+				},
+				prelude: `@use '${ require.resolve(
+					'calypso/assets/stylesheets/shared/_utils.scss'
+				) }' as *;`,
+			} ),
+			FileConfig.loader(),
+		],
+	},
+	resolve: {
+		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
+		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
+	},
+	node: false,
+	plugins: [
+		new webpack.DefinePlugin( {
+			global: 'window',
+			'process.env.NODE_DEBUG': JSON.stringify( process.env.NODE_DEBUG || false ),
+		} ),
+		...SassConfig.plugins( {
+			filename: 'build.min.css',
+			minify: ! isDevelopment,
+		} ),
+		new HtmlWebpackPlugin( {
+			filename: path.join( outputPath, 'index.html' ),
+			template: path.join( __dirname, 'src', 'index.ejs' ),
+			title: 'Inline Help',
+			hash: true,
+			inject: false,
+			isRTL: false,
+		} ),
+		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),
+		new ExtensiveLodashReplacementPlugin(),
+		new InlineConstantExportsPlugin( /\/client\/state\/action-types.js$/ ),
+		shouldEmitStats &&
+			new BundleAnalyzerPlugin( {
+				analyzerMode: 'server',
+				statsOptions: {
+					source: false,
+					reasons: false,
+					optimizationBailout: false,
+					chunkOrigins: false,
+					chunkGroups: true,
+				},
+			} ),
+	].filter( Boolean ),
+	devServer: {
+		host: 'calypso.localhost',
+		port: 3000,
+		static: {
+			directory: path.join( __dirname, 'dist' ),
+		},
+		client: {
+			progress: true,
+		},
+		watchFiles: [ 'dist/**/*' ],
+	},
+};

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -54,6 +54,6 @@
 		"postcss": "^8.4.5",
 		"postcss-custom-properties": "^11.0.0",
 		"webpack": "^5.65.0",
-		"webpack-dev-server": "^4.7.2"
+		"webpack-dev-server": "^4.7.3"
 	}
 }

--- a/client/blocks/inline-help/inline-help-query-support-types.jsx
+++ b/client/blocks/inline-help/inline-help-query-support-types.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import QueryTicketSupportConfiguration from 'calypso/components/data/query-ticket-support-configuration';
 import HappychatConnection from 'calypso/components/happychat/connection-connected';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
-import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
 import { initialize as initializeDirectly } from 'calypso/state/help/directly/actions';
 import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
 import {
@@ -26,11 +25,11 @@ class QueryInlineHelpSupportTypes extends Component {
 		this.prepareDirectlyWidget();
 	}
 
-	prepareDirectlyWidget = () => {
+	prepareDirectlyWidget() {
 		if ( this.hasDataToDetermineVariation() && this.props.isDirectlyUninitialized ) {
 			this.props.initializeDirectly();
 		}
-	};
+	}
 
 	/**
 	 * Before determining which variation to assign, certain async data needs to be in place.
@@ -38,14 +37,14 @@ class QueryInlineHelpSupportTypes extends Component {
 	 *
 	 * @returns {boolean} Whether all the data is present to determine the variation to show
 	 */
-	hasDataToDetermineVariation = () => {
+	hasDataToDetermineVariation() {
 		const ticketReadyOrError =
 			this.props.ticketSupportConfigurationReady || this.props.ticketSupportRequestError !== null;
 		const happychatReadyOrDisabled =
 			! config.isEnabled( 'happychat' ) || this.props.isHappychatUserEligible !== null;
 
 		return ticketReadyOrError && happychatReadyOrDisabled;
-	};
+	}
 
 	render() {
 		return (
@@ -68,6 +67,5 @@ export default connect(
 	} ),
 	{
 		initializeDirectly,
-		openHappychat,
 	}
 )( QueryInlineHelpSupportTypes );

--- a/client/lib/happychat/connection-async.js
+++ b/client/lib/happychat/connection-async.js
@@ -9,14 +9,16 @@ export default function buildConnection() {
 	// Async load the connection library and return a promise with its default export.
 	// That's a factory function that creates and returns the `Connection` class instance.
 	function importConnectionLib() {
-		return new Promise( ( resolve ) =>
-			asyncRequire( 'calypso/lib/happychat/connection', resolve )
+		return import(
+			/* webpackChunkName: async-load-calypso-lib-happychat-connection */ 'calypso/lib/happychat/connection'
 		);
 	}
 
 	function getConnection() {
 		if ( ! connection ) {
-			connection = importConnectionLib().then( ( createConnection ) => createConnection() );
+			connection = importConnectionLib().then( ( { default: createConnection } ) =>
+				createConnection()
+			);
 		}
 		return connection;
 	}

--- a/client/lib/happychat/connection-async.js
+++ b/client/lib/happychat/connection-async.js
@@ -10,7 +10,7 @@ export default function buildConnection() {
 	// That's a factory function that creates and returns the `Connection` class instance.
 	function importConnectionLib() {
 		return import(
-			/* webpackChunkName: async-load-calypso-lib-happychat-connection */ 'calypso/lib/happychat/connection'
+			/* webpackChunkName: "async-load-calypso-lib-happychat-connection" */ 'calypso/lib/happychat/connection'
 		);
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,7 +606,7 @@ __metadata:
     redux-thunk: ^2.3.0
     webpack: ^5.63.0
     webpack-bundle-analyzer: ^4.5.0
-    webpack-dev-server: ^4.7.2
+    webpack-dev-server: ^4.7.3
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
@@ -654,7 +654,7 @@ __metadata:
     redux-thunk: ^2.3.0
     webpack: ^5.63.0
     webpack-bundle-analyzer: ^4.5.0
-    webpack-dev-server: ^4.7.2
+    webpack-dev-server: ^4.7.3
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
@@ -957,7 +957,7 @@ __metadata:
     redux-thunk: ^2.3.0
     webpack: ^5.65.0
     webpack-bundle-analyzer: ^4.5.0
-    webpack-dev-server: ^4.7.2
+    webpack-dev-server: ^4.7.3
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
     wpcom-xhr-request: "workspace:^"
@@ -26707,10 +26707,10 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "node-forge@npm:0.10.0"
-  checksum: 9cbf9ac8fc3889a5a46b0248f7238ee4014770bf31d22e04c0c7f04ed91c8be4584c5f534cdf6037e99f236c636c925cba960501ed2b850e077512e152760663
+"node-forge@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "node-forge@npm:1.2.1"
+  checksum: 0563bef5c6abfd031018ebd9cae41432811faef0b25ca7651489fb5f946250c3f8c433f42e76e9fd98f0d7617c12b700f8cbea134a1d284df84f8104c79127c0
   languageName: node
   linkType: hard
 
@@ -33182,12 +33182,12 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"selfsigned@npm:^1.10.11":
-  version: 1.10.11
-  resolution: "selfsigned@npm:1.10.11"
+"selfsigned@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "selfsigned@npm:2.0.0"
   dependencies:
-    node-forge: ^0.10.0
-  checksum: 4054e22f9398efe2bde89302bbd668218d87af1042619528eb370072d6496dfa5389e6a2a2266f8b2e302effd397973432290db4cc9e9c18d44a35379d2c1538
+    node-forge: ^1.2.0
+  checksum: 159e3a18e107f587c5f29ec908458dc315b45f6aada702645d7cb0f59865086443f898c96cc96aab6d57f62e948ef0cd0c131971fbde43777ed52fd154121d3d
   languageName: node
   linkType: hard
 
@@ -37550,9 +37550,9 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:^4.7.2":
-  version: 4.7.2
-  resolution: "webpack-dev-server@npm:4.7.2"
+"webpack-dev-server@npm:^4.7.3":
+  version: 4.7.3
+  resolution: "webpack-dev-server@npm:4.7.3"
   dependencies:
     "@types/bonjour": ^3.5.9
     "@types/connect-history-api-fallback": ^1.3.5
@@ -37576,7 +37576,7 @@ testarmada-magellan@11.0.10:
     p-retry: ^4.5.0
     portfinder: ^1.0.28
     schema-utils: ^4.0.0
-    selfsigned: ^1.10.11
+    selfsigned: ^2.0.0
     serve-index: ^1.9.1
     sockjs: ^0.3.21
     spdy: ^4.0.2
@@ -37590,7 +37590,7 @@ testarmada-magellan@11.0.10:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 862cba6576f5e187e3e6d90a5abb63076f8d2385bde7122d8ee503f5cd0b264d99ab63478cbb4a317880af4d9cb4eda52714ee9bb31cbc3218894c0eca3544fc
+  checksum: 3c488f035a733ff4233592d35c8eeaacccb643fe3de907317188c54030ca19e92f95a85e8acdd6fbda998b077a0342cd3b73a3a824b10a25de357d1641ebf5d9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,6 +583,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/happychat-app@workspace:apps/happychat":
+  version: 0.0.0-use.local
+  resolution: "@automattic/happychat-app@workspace:apps/happychat"
+  dependencies:
+    "@automattic/calypso-babel-config": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
+    "@automattic/calypso-polyfills": "workspace:^"
+    "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
+    "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
+    autoprefixer: ^10.2.5
+    calypso: "workspace:^"
+    enzyme: ^3.11.0
+    html-webpack-plugin: ^5.0.0-beta.4
+    jest: ^27.2.4
+    postcss: ^8.3.11
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-query: ^3.32.1
+    react-redux: ^7.2.6
+    redux: ^4.1.2
+    redux-thunk: ^2.3.0
+    webpack: ^5.63.0
+    webpack-bundle-analyzer: ^4.5.0
+    webpack-dev-server: ^4.7.2
+    wpcom: "workspace:^"
+    wpcom-proxy-request: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@automattic/i18n-utils@workspace:^, @automattic/i18n-utils@workspace:packages/i18n-utils":
   version: 0.0.0-use.local
   resolution: "@automattic/i18n-utils@workspace:packages/i18n-utils"
@@ -599,6 +628,35 @@ __metadata:
     react-test-renderer: ^17.0.2
     tslib: ^2.3.0
     typescript: ^4.5.4
+  languageName: unknown
+  linkType: soft
+
+"@automattic/inline-help@workspace:apps/inline-help":
+  version: 0.0.0-use.local
+  resolution: "@automattic/inline-help@workspace:apps/inline-help"
+  dependencies:
+    "@automattic/calypso-babel-config": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
+    "@automattic/calypso-polyfills": "workspace:^"
+    "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
+    "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
+    autoprefixer: ^10.2.5
+    calypso: "workspace:^"
+    enzyme: ^3.11.0
+    html-webpack-plugin: ^5.0.0-beta.4
+    jest: ^27.2.4
+    postcss: ^8.3.11
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-query: ^3.32.1
+    react-redux: ^7.2.6
+    redux: ^4.1.2
+    redux-thunk: ^2.3.0
+    webpack: ^5.63.0
+    webpack-bundle-analyzer: ^4.5.0
+    webpack-dev-server: ^4.7.2
+    wpcom: "workspace:^"
+    wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Spinoff from #55189 that adds the `inline-help` and `happychat` apps to the `apps/` folder. At this moment they are experimental. Eventually, the contents of the `dist/` folders will be synced to the `widgets.wp.com/help` and `widgets.wp.com/happychat` folders and will be loaded into iframes shown in WP.com masterbar, just like Notifications already are.

**How to test:**
`cd` to the app's directory, either `cd apps/inline-help` or `cd apps/happychat`. Then run `yarn dev-server`. That starts a dev server with the widget apps and you'll be able to access them at `http://calypso.localhost:3000`, just like the full Calypso.

Inline Help:
<img width="612" alt="Screenshot 2022-01-27 at 12 29 13" src="https://user-images.githubusercontent.com/664258/151352539-e0e3fd4e-72a2-4a08-8466-a9a520658a8b.png">

Happychat:
<img width="612" alt="Screenshot 2022-01-27 at 12 27 58" src="https://user-images.githubusercontent.com/664258/151352556-1cd0b613-e769-47fb-af17-6273becd8fa3.png">

Both apps should mostly work, and you should be able to establish a test chat if you have `https://hud-staging.happychat.io/` open in another tab.