### PR TITLE
Render dev helpers in Gutenboarding after extracting a common function

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -17,6 +17,7 @@ import DesktopListeners from 'calypso/lib/desktop-listeners';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getLanguageSlugs } from 'calypso/lib/i18n-utils/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import { attachLogmein } from 'calypso/lib/logmein';
 import { getToken } from 'calypso/lib/oauth-token';
 import { checkFormHandler } from 'calypso/lib/protect-form';
@@ -378,27 +379,7 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 		DesktopListeners.init( reduxStore );
 	}
 
-	if ( config.isEnabled( 'dev/auth-helper' ) && document.querySelector( '.environment.is-auth' ) ) {
-		asyncRequire( 'calypso/lib/auth-helper', ( authHelper ) => {
-			authHelper( document.querySelector( '.environment.is-auth' ), reduxStore );
-		} );
-	}
-	if (
-		config.isEnabled( 'dev/preferences-helper' ) &&
-		document.querySelector( '.environment.is-prefs' )
-	) {
-		asyncRequire( 'calypso/lib/preferences-helper', ( prefHelper ) => {
-			prefHelper( document.querySelector( '.environment.is-prefs' ), reduxStore );
-		} );
-	}
-	if (
-		config.isEnabled( 'dev/features-helper' ) &&
-		document.querySelector( '.environment.is-features' )
-	) {
-		asyncRequire( 'calypso/lib/features-helper', ( featureHelper ) => {
-			featureHelper( document.querySelector( '.environment.is-features' ) );
-		} );
-	}
+	loadDevHelpers( reduxStore );
 
 	if ( config.isEnabled( 'logmein' ) && isUserLoggedIn( reduxStore.getState() ) ) {
 		// Attach logmein handler if we're currently logged in

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -8,6 +8,7 @@ import { isEqual } from 'lodash';
 import ReactDom from 'react-dom';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
+import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import { LocaleContext } from './components/locale-context';
 import { WindowLocaleEffectManager } from './components/window-locale-effect-manager';
 import { setupWpDataDebug } from './devtools';
@@ -46,6 +47,7 @@ window.AppBoot = async () => {
 	addHotJarScript();
 	// Add accessible-focus listener.
 	accessibleFocus();
+	loadDevHelpers();
 
 	// If site was recently created, redirect to customer site home.
 	const shouldRedirect = await checkAndRedirectIfSiteWasCreatedRecently();

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -4,6 +4,7 @@ import debugFactory from 'debug';
 import page from 'page';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
+import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { setRoute } from 'calypso/state/route/actions';
 
@@ -51,26 +52,6 @@ export function setupContextMiddleware() {
 	} );
 }
 
-function renderDevHelpers( reduxStore ) {
-	if ( config.isEnabled( 'dev/preferences-helper' ) ) {
-		const prefHelperEl = document.querySelector( '.environment.is-prefs' );
-		if ( prefHelperEl ) {
-			asyncRequire( 'calypso/lib/preferences-helper', ( prefHelper ) => {
-				prefHelper( prefHelperEl, reduxStore );
-			} );
-		}
-	}
-
-	if ( config.isEnabled( 'features-helper' ) ) {
-		const featureHelperEl = document.querySelector( '.environment.is-features' );
-		if ( featureHelperEl ) {
-			asyncRequire( 'calypso/lib/features-helper', ( featureHelper ) => {
-				featureHelper( featureHelperEl );
-			} );
-		}
-	}
-}
-
 export const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
 
@@ -102,5 +83,5 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	setupContextMiddleware();
 	setRouteMiddleware( reduxStore );
 	setAnalyticsMiddleware( currentUser, reduxStore );
-	renderDevHelpers( reduxStore );
+	loadDevHelpers( reduxStore );
 }

--- a/client/lib/features-helper/style.scss
+++ b/client/lib/features-helper/style.scss
@@ -1,4 +1,4 @@
-.features-helper__current-features {
+.features-helper__current-features.card {
 	display: none;
 }
 

--- a/client/lib/load-dev-helpers/index.js
+++ b/client/lib/load-dev-helpers/index.js
@@ -1,0 +1,26 @@
+import config from '@automattic/calypso-config';
+
+export default function loadDevHelpers( reduxStore ) {
+	if ( config.isEnabled( 'dev/auth-helper' ) ) {
+		const el = document.querySelector( '.environment.is-auth' );
+		if ( el ) {
+			asyncRequire( 'calypso/lib/auth-helper', ( helper ) => helper( el ) );
+		}
+	}
+
+	// preferences helper requires a Redux store to read and write preferences, and can't
+	// be rendered in environments that don't have a Redux store, like Gutenboarding.
+	if ( reduxStore && config.isEnabled( 'dev/preferences-helper' ) ) {
+		const el = document.querySelector( '.environment.is-prefs' );
+		if ( el ) {
+			asyncRequire( 'calypso/lib/preferences-helper', ( helper ) => helper( el, reduxStore ) );
+		}
+	}
+
+	if ( config.isEnabled( 'dev/features-helper' ) ) {
+		const el = document.querySelector( '.environment.is-features' );
+		if ( el ) {
+			asyncRequire( 'calypso/lib/features-helper', ( helper ) => helper( el ) );
+		}
+	}
+}

--- a/client/lib/preferences-helper/style.scss
+++ b/client/lib/preferences-helper/style.scss
@@ -1,4 +1,4 @@
-.preferences-helper__current-preferences {
+.preferences-helper__current-preferences.card {
 	display: none;
 }
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -127,6 +127,11 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	if ( ! request.cookies.country_code && geoIPCountryCode ) {
 		response.cookie( 'country_code', geoIPCountryCode );
 	}
+	const authHelper = config.isEnabled( 'dev/auth-helper' );
+	// preferences helper requires a Redux store, which doesn't exist in Gutenboarding
+	const preferencesHelper =
+		config.isEnabled( 'dev/preferences-helper' ) && entrypoint !== 'entry-gutenboarding';
+	const featuresHelper = config.isEnabled( 'dev/features-helper' );
 
 	const flags = ( request.query.flags || '' ).split( ',' );
 	const context = Object.assign( {}, request.context, {
@@ -142,9 +147,9 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		lang: config( 'i18n_default_locale_slug' ),
 		entrypoint: request.getFilesForEntrypoint( entrypoint ),
 		manifests: request.getAssets().manifests,
-		authHelper: !! config.isEnabled( 'dev/auth-helper' ),
-		preferencesHelper: !! config.isEnabled( 'dev/preferences-helper' ),
-		featuresHelper: !! config.isEnabled( 'dev/features-helper' ),
+		authHelper,
+		preferencesHelper,
+		featuresHelper,
 		devDocsURL: '/devdocs',
 		store: reduxStore,
 		target: 'evergreen',

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -456,16 +456,16 @@ const assertDefaultContext = ( { url, entry } ) => {
 		] );
 	} );
 
-	it( 'sets the preferencesHelper when config is enabled', async () => {
-		app.withConfigEnabled( { 'dev/preferences-helper': true } );
+	it( 'sets the featuresHelper when config is enabled', async () => {
+		app.withConfigEnabled( { 'dev/features-helper': true } );
 		const { request } = await app.run();
-		expect( request.context.preferencesHelper ).toEqual( true );
+		expect( request.context.featuresHelper ).toEqual( true );
 	} );
 
-	it( 'sets the preferencesHelper when config is disabled', async () => {
-		app.withConfigEnabled( { 'dev/preferences-helper': false } );
+	it( 'sets the featuresHelper when config is disabled', async () => {
+		app.withConfigEnabled( { 'dev/features-helper': false } );
 		const { request } = await app.run();
-		expect( request.context.preferencesHelper ).toEqual( false );
+		expect( request.context.featuresHelper ).toEqual( false );
 	} );
 
 	it( 'sets devDocsUrl', async () => {


### PR DESCRIPTION
This PR adds dev helpers rendering to the Gutenboarding entrypoint where they were missing until now:

<img width="300" alt="Screenshot 2022-01-27 at 15 01 33" src="https://user-images.githubusercontent.com/664258/151373798-38321582-955f-4d68-a38a-dc3ede74f4cb.png">

The only helper missing in Gutenboarding will be Preferences because that requires a Redux store while Gutenboarding doesn't use Redux at all.

This PR uses the `loadDevHelpers()` helper after extracting it from `client/boot/common`, and uses it consistently across the main, login, and Gutenboarding entrypoints.

There's also a little CSS fix that adds specificity to a style that hides/shows helper UI:
```
.features-helper__current-features.card {
  display: none;
}
```
Previously there were two styles with the same specificity:
```
.features-helper__current-features {
  display: none;
}

.card {
  display: block;
}
```
and if their order got randomly reversed then funny things started to happen.