### PR TITLE
Design Picker: add Twenty Twenty Two variations as static previews

### DIFF
--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -13,6 +13,11 @@ const STATIC_PREVIEWS = [
 	'jones',
 	'baker',
 	'kingsley',
+	'twentytwentytwo-mint',
+	'twentytwentytwo-red',
+	'twentytwentytwo-blue',
+	'twentytwentytwo-swiss',
+	'twentytwentytwo-pink',
 ];
 
 export interface UseThemeDesignsQueryOptions {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Twenty Twenty Two variations seem to need to use static previews (maybe because they are child themes and don't have their own block patterns?)

#### Testing instructions

* Go to `/start/setup-site?siteSlug=SITE_SLUG`, using the site slug of an FSE enrolled site
* Proceed to the design picker step and make sure you can see previews for the Twenty Twenty Two theme variations
d issue.
-->

Related to p1643295704286400-slack-C029FM1EH