### PR TITLE
Themes: Add test coverage for shouldShowTryAndCustomize selector

### DIFF
--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -2676,4 +2676,43 @@ describe( '#shouldShowTryAndCustomize', () => {
 		);
 		expect( showTryAndCustomize ).to.be.false;
 	} );
+
+	test( 'should not show Try & Customize action for premium theme unavailable to Jetpack site', () => {
+		const showTryAndCustomize = shouldShowTryAndCustomize(
+			{
+				currentUser: {
+					capabilities: {
+						77203074: { edit_theme_options: true },
+					},
+				},
+				themes: {
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: { mood },
+						} ),
+					},
+				},
+				purchases: {
+					data: [],
+				},
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.net',
+							jetpack: true,
+						},
+					},
+					plans: {
+						77203074: {
+							data: [],
+						},
+					},
+				},
+			},
+			'mood',
+			77203074
+		);
+		expect( showTryAndCustomize ).to.be.false;
+	} );
 } );

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -405,7 +405,7 @@ describe( 'themes selectors', () => {
 			expect( query ).to.deep.equal( {} );
 		} );
 
-		test( 'given a site, should return last `use`d query', () => {
+		test( 'given a site, should return last used query', () => {
 			const query = getLastThemeQuery(
 				{
 					themes: {

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -98,6 +98,9 @@ const quadrat = {
 	template: 'blockbase-premium',
 	demo_uri: 'https://quadratdemo.wordpress.com/',
 	author_uri: 'https://wordpress.com/themes/',
+	taxonomies: {
+		theme_feature: [ { slug: 'auto-loading-homepage' } ],
+	},
 };
 
 const sidekick = {
@@ -2533,25 +2536,6 @@ describe( '#areRecommendedThemesLoading', () => {
 } );
 
 describe( '#shouldShowTryAndCustomize', () => {
-	const state = {
-		currentUser: {
-			capabilities: {
-				2916284: { edit_theme_options: true },
-			},
-		},
-		themes: {
-			queries: {
-				wpcom: new ThemeQueryManager( {
-					items: { quadrat, twentynineteen },
-				} ),
-			},
-			activeThemes: {},
-		},
-		sites: {
-			items: {},
-		},
-	};
-
 	test( 'should hide Try & Customize action when user does not have permissions', () => {
 		const showTryAndCustomize = shouldShowTryAndCustomize(
 			{
@@ -2597,11 +2581,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 					},
 				},
 				themes: {
-					queries: {
-						wpcom: new ThemeQueryManager( {
-							items: { quadrat },
-						} ),
-					},
+					queries: {},
 					activeThemes: {
 						2916284: 'quadrat',
 					},
@@ -2616,13 +2596,57 @@ describe( '#shouldShowTryAndCustomize', () => {
 		expect( showTryAndCustomize ).to.be.false;
 	} );
 
+	//Block-based themes like Quadrat should not show the Try & Customize action
 	test( 'should not show Try & Customize action for new themes', () => {
-		const showTryAndCustomize = shouldShowTryAndCustomize( state, 'quadrat', 2916284 );
+		const showTryAndCustomize = shouldShowTryAndCustomize(
+			{
+				currentUser: {
+					capabilities: {
+						2916284: { edit_theme_options: true },
+					},
+				},
+				themes: {
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: { quadrat },
+						} ),
+					},
+					activeThemes: {},
+				},
+				sites: {
+					items: {},
+				},
+			},
+			'quadrat',
+			2916284
+		);
 		expect( showTryAndCustomize ).to.be.false;
 	} );
 
+	//Customizer-based themes like Twenty Nineteen should still show Try & Customize
 	test( 'should show Try & Customize action for old themes', () => {
-		const showTryAndCustomize = shouldShowTryAndCustomize( state, 'twentynineteen', 2916284 );
+		const showTryAndCustomize = shouldShowTryAndCustomize(
+			{
+				currentUser: {
+					capabilities: {
+						2916284: { edit_theme_options: true },
+					},
+				},
+				themes: {
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: { twentynineteen },
+						} ),
+					},
+					activeThemes: {},
+				},
+				sites: {
+					items: {},
+				},
+			},
+			'twentynineteen',
+			2916284
+		);
 		expect( showTryAndCustomize ).to.be.true;
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -66,16 +66,6 @@ const twentysixteen = {
 	author_uri: 'https://wordpress.org/',
 };
 
-const twentynineteen = {
-	id: 'twentynineteen',
-	name: 'Twenty Nineteen',
-	author: 'the WordPress team',
-	screenshot: 'twentynineteen.jpg',
-	stylesheet: 'pub/twentynineteen',
-	demo_uri: 'https://twentynineteendemo.wordpress.com/',
-	author_uri: 'https://wordpress.org/',
-};
-
 const mood = {
 	id: 'mood',
 	name: 'Mood',
@@ -89,13 +79,6 @@ const mood = {
 
 const quadrat = {
 	id: 'quadrat',
-	name: 'Quadrat',
-	author: 'Automattic',
-	screenshot: 'quadrat.jpg',
-	stylesheet: 'premium/quadrat',
-	template: 'blockbase-premium',
-	demo_uri: 'https://quadratdemo.wordpress.com/',
-	author_uri: 'https://wordpress.com/themes/',
 	taxonomies: {
 		theme_feature: [ { slug: 'auto-loading-homepage' } ],
 	},
@@ -2557,11 +2540,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 					capabilities: {},
 				},
 				themes: {
-					queries: {
-						wpcom: new ThemeQueryManager( {
-							items: { quadrat },
-						} ),
-					},
+					queries: {},
 				},
 			},
 			'quadrat',
@@ -2581,14 +2560,14 @@ describe( '#shouldShowTryAndCustomize', () => {
 				themes: {
 					queries: {},
 					activeThemes: {
-						2916284: 'twentynineteen',
+						2916284: 'quadrat',
 					},
 				},
 				sites: {
 					items: {},
 				},
 			},
-			'twentynineteen',
+			'quadrat',
 			2916284
 		);
 		expect( showTryAndCustomize ).to.be.false;
@@ -2621,7 +2600,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 		expect( showTryAndCustomize ).to.be.false;
 	} );
 
-	//Customizer-based themes like Twenty Nineteen should still show Try & Customize
+	//Customizer-based themes should still show Try & Customize
 	test( 'should show Try & Customize action for old themes', () => {
 		const showTryAndCustomize = shouldShowTryAndCustomize(
 			{
@@ -2633,7 +2612,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 				themes: {
 					queries: {
 						wpcom: new ThemeQueryManager( {
-							items: { twentynineteen },
+							items: { mood },
 						} ),
 					},
 					activeThemes: {},
@@ -2642,7 +2621,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 					items: {},
 				},
 			},
-			'twentynineteen',
+			'mood',
 			2916284
 		);
 		expect( showTryAndCustomize ).to.be.true;

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -2649,5 +2649,28 @@ describe( '#shouldShowTryAndCustomize', () => {
 		expect( showTryAndCustomize ).to.be.true;
 	} );
 
-	//@TODO: should hide Try & Customize when on Jetpack Multisite
+	test( 'should not show Try & Customize action for Jetpack multisite', () => {
+		const showTryAndCustomize = shouldShowTryAndCustomize(
+			{
+				currentUser: {
+					capabilities: {
+						77203074: { edit_theme_options: true },
+					},
+				},
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.net',
+							jetpack: true,
+							is_multisite: true,
+						},
+					},
+				},
+			},
+			'twentynineteen',
+			77203074
+		);
+		expect( showTryAndCustomize ).to.be.false;
+	} );
 } );

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -93,7 +93,6 @@ const quadrat = {
 	name: 'Quadrat',
 	author: 'Automattic',
 	screenshot: 'quadrat.jpg',
-	price: '$50',
 	stylesheet: 'premium/quadrat',
 	template: 'blockbase-premium',
 	demo_uri: 'https://quadratdemo.wordpress.com/',
@@ -2536,7 +2535,7 @@ describe( '#areRecommendedThemesLoading', () => {
 } );
 
 describe( '#shouldShowTryAndCustomize', () => {
-	test( 'should hide Try & Customize action when user does not have permissions', () => {
+	test( 'should not show Try & Customize action when user does not have permissions', () => {
 		const showTryAndCustomize = shouldShowTryAndCustomize(
 			{
 				currentUser: {
@@ -2551,7 +2550,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 		expect( showTryAndCustomize ).to.be.false;
 	} );
 
-	test( 'should hide Try & Customize when logged out', () => {
+	test( 'should not show Try & Customize when logged out', () => {
 		const showTryAndCustomize = shouldShowTryAndCustomize(
 			{
 				currentUser: {
@@ -2572,7 +2571,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 		expect( showTryAndCustomize ).to.be.false;
 	} );
 
-	test( 'should hide Try & Customize for the currently active theme', () => {
+	test( 'should not show Try & Customize for the currently active theme', () => {
 		const showTryAndCustomize = shouldShowTryAndCustomize(
 			{
 				currentUser: {
@@ -2583,14 +2582,14 @@ describe( '#shouldShowTryAndCustomize', () => {
 				themes: {
 					queries: {},
 					activeThemes: {
-						2916284: 'quadrat',
+						2916284: 'twentynineteen',
 					},
 				},
 				sites: {
 					items: {},
 				},
 			},
-			'quadrat',
+			'twentynineteen',
 			2916284
 		);
 		expect( showTryAndCustomize ).to.be.false;

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -70,8 +70,7 @@ const twentynineteen = {
 	id: 'twentynineteen',
 	name: 'Twenty Nineteen',
 	author: 'the WordPress team',
-	screenshot:
-		'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
+	screenshot: 'twentynineteen.jpg',
 	stylesheet: 'pub/twentynineteen',
 	demo_uri: 'https://twentynineteendemo.wordpress.com/',
 	author_uri: 'https://wordpress.org/',

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -2657,6 +2657,9 @@ describe( '#shouldShowTryAndCustomize', () => {
 						77203074: { edit_theme_options: true },
 					},
 				},
+				themes: {
+					queries: {},
+				},
 				sites: {
 					items: {
 						77203074: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I added a new themes selector in #60251; this adds unit tests.
* I'm not sure this is useful in practice, since this selector tests combinations of multiple other selectors. But I need practice with jest and mocking so I figured this would be a good place to start.

#### Testing instructions

* Switch to this PR
* Run tests on the theme selectors: `yarn run test-client client/state/themes/test/selectors.js`
* Everything should pass!
