### PR TITLE
Flaky E2E: Handle home redirect in gutenboarding navigation

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -64,7 +64,12 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 		} );
 
 		it( 'Navigate to Home dashboard', async function () {
-			await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'load' } );
+			// When you go to the home dashboard, there is a delayed redirect to '**/home/<sitename>'.
+			// That delayed redirect can disrupt following actions in a race condition, so we must wait for that redirect to finish!
+			await Promise.all( [
+				page.waitForNavigation( { url: '**/home/**' } ),
+				page.goto( DataHelper.getCalypsoURL( 'home' ) ),
+			] );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In `wp-gutenboarding__happy-path.ts`, there was a navigation race condition exposed. After navigating to `/home`, the redirect to `/home/<blogname>` could interrupt following actions that started before the redirect occurred.

We now wait for and catch that redirect before proceeding.

#### Testing instructions

- [ ] `DEBUG=pw:api yarn jest specs/specs-playwright/wp-gutenboarding__happy-path.ts`

^^^ When running that, you should see the long home page redirect captured before the close account actions begin:

```
  pw:api <= page.goto succeeded +7ms
  pw:api   navigated to "https://wordpress.com/home/<sitename>.wordpress.com" +531ms
  pw:api <= page.waitForNavigation succeeded +1ms
```

Fixes #60555
