### PR TITLE
Update/onboarding importer improvements 2

### DIFF
--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import page from 'page';
 import React, { useEffect, useState } from 'react';
-import { connect, useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
@@ -46,6 +46,7 @@ interface Props {
 	isImporterStatusHydrated: boolean;
 	siteImports: ImportJob[];
 	fetchImporterState: ( siteId: number ) => void;
+	resetImport: ( siteId: number, importerId: string ) => void;
 }
 const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const {
@@ -70,8 +71,6 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const getImportJob = ( engine: Importer ): ImportJob | undefined => {
 		return siteImports.find( ( x ) => x.type === getImporterTypeForEngine( engine ) );
 	};
-
-	const dispatch = useDispatch();
 
 	/**
 	 ↓ Effects
@@ -131,7 +130,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 			case appStates.UPLOAD_SUCCESS:
 			case appStates.UPLOADING:
 			case appStates.UPLOAD_FAILURE:
-				return dispatch( resetImport( siteId, job.importerId ) );
+				return props.resetImport( siteId, job.importerId );
 		}
 	}
 

--- a/client/signup/steps/import-from/wordpress/import-everything/confirm.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/confirm.tsx
@@ -4,6 +4,7 @@ import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React, { useState } from 'react';
+import SiteIcon from 'calypso/blocks/site-icon';
 import { UrlData } from 'calypso/signup/steps/import/types';
 import { convertToFriendlyWebsiteName } from 'calypso/signup/steps/import/util';
 import ConfirmModal from './confirm-modal';
@@ -28,6 +29,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	 ↓ Fields
 	 */
 	const {
+		sourceSite,
 		sourceSiteUrl,
 		sourceUrlAnalyzedData,
 		targetSite,
@@ -49,14 +51,13 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 								{ __( 'Original site' ) }
 							</div>
 
-							<div
-								className={ classnames( 'import_site-mapper-name', {
-									'with-favicon': sourceUrlAnalyzedData?.meta.favicon,
-								} ) }
-							>
+							<div className={ classnames( 'import_site-mapper-name with-favicon' ) }>
 								{ sourceUrlAnalyzedData?.meta.favicon && (
-									<img alt={ 'Icon' } src={ sourceUrlAnalyzedData?.meta.favicon } />
+									<div className={ classnames( 'site-icon' ) }>
+										<img alt={ 'Icon' } src={ sourceUrlAnalyzedData?.meta.favicon } />
+									</div>
 								) }
+								{ ! sourceUrlAnalyzedData?.meta.favicon && <SiteIcon siteId={ sourceSite?.ID } /> }
 								<span>{ sourceUrlAnalyzedData?.meta.title }</span>
 								<small>{ convertToFriendlyWebsiteName( sourceSiteUrl ) }</small>
 							</div>
@@ -68,7 +69,8 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 								{ __( 'New site' ) }
 							</div>
 
-							<div className={ classnames( 'import_site-mapper-name' ) }>
+							<div className={ classnames( 'import_site-mapper-name with-favicon' ) }>
+								<SiteIcon siteId={ targetSite?.ID } />
 								<span>{ targetSite?.name }</span>
 								<small>{ convertToFriendlyWebsiteName( targetSiteSlug ) }</small>
 							</div>

--- a/client/signup/steps/import-from/wordpress/import-everything/style.scss
+++ b/client/signup/steps/import-from/wordpress/import-everything/style.scss
@@ -56,14 +56,14 @@
 			padding-left: 56px;
 		}
 
-		img {
+		.site-icon {
 			position: absolute;
 			top: 0;
 			left: 0;
 			border-radius: 4px;
 			border: solid 1px var( --studio-gray-5 );
-			height: 40px;
-			width: 40px;
+			height: 40px !important;
+			width: 40px !important;
 		}
 
 		span, small {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor: got rid of `useDispatch` and provided the dispatch method through the connect function to follow the existing pattern
* Added check availability for the WordPress importer
* WordPress importer everything flow: add a missing favicon for the target site

#### Testing instructions

**Check availability:**

* Go to `/start/from/importing/wordpress?from={WP_SITE}&to={JETPACK_CONNECTED_WP_SITE}`
* Check redirection, should be redirected to `/import/{JETPACK_CONNECTED_WP_SITE}` (it is the same as how Migration module works when you try to indicate import to the jetpack connected site)

**Favicon:**

* Go to `/start/from/importing/wordpress?from={WP_SITE}&to={SLUG}.wordpress.com&option=everything`
* Check if there is a favicon for the target site

**Favicon case 1:**
<img width="842" alt="Screenshot 2022-01-28 at 14 15 34" src="https://user-images.githubusercontent.com/1241413/151566443-9b41c643-30a5-47a3-be5b-ddd0fb776c9b.png">

**Favicon case 2:**
<img width="845" alt="Screenshot 2022-01-28 at 14 15 52" src="https://user-images.githubusercontent.com/1241413/151566493-69bcd3f6-d64d-41fe-8dd3-ff10bde8fd90.png">


Related to #57131
