### PR TITLE
Add Stewart to the design picker

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -138,6 +138,16 @@
 			"features": []
 		},
 		{
+			"title": "Stewart",
+			"slug": "stewart",
+			"template": "stewart",
+			"theme": "stewart",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
+		},
+		{
 			"title": "Kingsley",
 			"slug": "kingsley",
 			"template": "kingsley",


### PR DESCRIPTION
#### Testing instructions

Sandbox yourself.

- Create a site through Gutenboarding (`/new`).

You should be able to pick Stewart from the Design Picker.

- Create a site through onboarding (`/start`)

You should be able to pick Stewart from the Design Picker.

#### Screenshots

| `/start` | `/new` |
| ------- | ------- |
| ![image](https://user-images.githubusercontent.com/26530524/151427209-da0d570d-bcea-4e03-95ba-350dc1ac0d21.png) | ![image](https://user-images.githubusercontent.com/26530524/151427296-e279ba1a-c2de-4ecc-b45e-02844491ad0f.png) |
