### PR TITLE
Playwright: change selector to dismiss Welcome Guide to CSS selector to avoid English US/UK differences.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
@@ -3,9 +3,11 @@ import { Page } from 'playwright';
 const selectors = {
 	editor: '#widgets-editor',
 
-	welcomeModalDismissButton: 'button[aria-label="Close dialog"]',
+	// Welcome Guide and Welcome Tour
+	welcomeModalDismissButton: 'div.components-modal__header > button', // Instead of aria-label, which changes depending on English UK/US.
 	welcomeTourDismissButton: 'button[aria-label="Close Tour"]',
 
+	// Block Widget editor
 	addBlockButton: 'button[aria-label="Add block"]',
 	blockSearch: 'input[placeholder="Search"]',
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR switches the selector to a CSS selector instead of using `aria-label` due to slight difference between English US/UK.

For details, please see attached issue.

#### Testing instructions

Closes #60582.
