### PR TITLE
Remove workaround for themes with parentheses in their title

### DIFF
--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -13,11 +13,6 @@ const STATIC_PREVIEWS = [
 	'jones',
 	'baker',
 	'kingsley',
-	'twentytwentytwo-mint',
-	'twentytwentytwo-red',
-	'twentytwentytwo-blue',
-	'twentytwentytwo-swiss',
-	'twentytwentytwo-pink',
 ];
 
 export interface UseThemeDesignsQueryOptions {

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -141,7 +141,7 @@ describe( 'Design Picker design utils', () => {
 			const mockDesign = availableDesignsConfig.featured[ 0 ];
 
 			expect( getDesignUrl( mockDesign, mockLocale ) ).toEqual(
-				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesign.stylesheet }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&site_title=${ mockDesign.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesign.stylesheet }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true&site_title=${ mockDesign.title }`
 			);
 		} );
 
@@ -149,7 +149,7 @@ describe( 'Design Picker design utils', () => {
 			const mockDesignWithoutFonts = availableDesignsConfig.featured[ 1 ];
 
 			expect( getDesignUrl( mockDesignWithoutFonts, mockLocale ) ).toEqual(
-				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesignWithoutFonts.stylesheet }/${ mockDesignWithoutFonts.template }?site_title=${ mockDesignWithoutFonts.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesignWithoutFonts.stylesheet }/${ mockDesignWithoutFonts.template }?viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true&site_title=${ mockDesignWithoutFonts.title }`
 			);
 		} );
 
@@ -158,7 +158,18 @@ describe( 'Design Picker design utils', () => {
 			const mockDesignMissingStylesheet = availableDesignsConfig.featured[ 6 ];
 
 			expect( getDesignUrl( mockDesignMissingStylesheet, mockLocale ) ).toEqual(
-				`https://public-api.wordpress.com/rest/v1.1/template/demo/pub/${ mockDesignMissingStylesheet.theme }/${ mockDesignMissingStylesheet.template }?site_title=${ mockDesignMissingStylesheet.title }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true`
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/pub/${ mockDesignMissingStylesheet.theme }/${ mockDesignMissingStylesheet.template }?viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true&site_title=${ mockDesignMissingStylesheet.title }`
+			);
+		} );
+
+		// Parentheses in uri components don't usually need to be escaped, but because the design url sometimes appears
+		// in a `background-url: url( ... )` CSS rule the parentheses will break it.
+		it( 'escapes parentheses within the site title', () => {
+			const mockDesign = availableDesignsConfig.featured[ 0 ];
+			mockDesign.title = 'Mock(Design)';
+
+			expect( getDesignUrl( mockDesign, mockLocale ) ).toEqual(
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesign.stylesheet }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true&site_title=Mock%28Design%29`
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -16,18 +16,28 @@ export const getDesignUrl = (
 	const template = encodeURIComponent( design.template );
 
 	// e.g. https://public-api.wordpress.com/rest/v1.1/template/demo/pub/rockfield/rockfield?font_headings=Playfair%20Display&font_base=Fira%20Sans&site_title=Rockfield&viewport_height=700&language=en
-	return addQueryArgs(
+	let url = addQueryArgs(
 		`https://public-api.wordpress.com/rest/v1.1/template/demo/${ repo }/${ theme }/${ template }`,
 		{
 			font_headings: design.fonts?.headings,
 			font_base: design.fonts?.base,
-			site_title: design.title,
 			viewport_height: 700,
 			language: locale,
 			use_screenshot_overrides: true,
 			...options,
 		}
 	);
+
+	if ( design.title ) {
+		// The design url is sometimes used in a `background-image: url()` CSS rule and unescaped
+		// parentheses in the URL break it. `addQueryArgs` and `encodeURIComponent` don't escape
+		// parentheses so we've got to do it ourselves.
+		url +=
+			'&site_title=' +
+			encodeURIComponent( design.title ).replace( '(', '%28' ).replace( ')', '%29' );
+	}
+
+	return url;
 };
 
 // Used for both prefetching and loading design screenshots


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Twenty Twenty-Two colour variation's thumbnails weren't appearing in the design picker:
<img width="1245" alt="Screenshot 2022-01-27 at 16 01 55" src="https://user-images.githubusercontent.com/1500769/151453386-86ea6663-06c7-44e2-8e08-3d0920f0d091.png">

This was worked around in #60559, but it didn't fix the underlying issue. Turns out the problem is with theme titles that contain parentheses e.g. "Twenty Twenty-Two (Pink)". When this happens the URL we ask `mshots` to capture contains unescaped parentheses. This works when the URL appears in a `<img src=" ... ">`, but breaks when it appears in a `<div style="background-image: url( ... )">`.

#60559 rendered the thumbnails as "static previews", which changes the underlying element from a `<div>` to a `<img>` that's why it worked around the issue.

* Revert the workaround in #60559
* `getDesignUrl()` escapes parentheses that appear in the site title
* Re-arrange unit tests since the order of query params has changed

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test at `/start/setup-site?siteSlug=<< site slug >>` where the test site is one that's enrolled in FSE (if you create a site using `calypso.localhost:3000` or using the `/new` flow then your site is guaranteed to be enrolled in FSE)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


p1643295704286400-slack-C029FM1EH
Related to #60559