### PR TITLE
CI: Minor tweaks to TeamCity configuration

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -97,9 +97,6 @@ open class E2EBuildType(
 			bashNodeScript {
 				name = "Prepare environment"
 				scriptContent = """
-					export NODE_ENV="test"
-					export PLAYWRIGHT_BROWSERS_PATH=0
-
 					# Install deps
 					yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -217,7 +217,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2E
     return E2EBuildType (
 		buildId = "WPComTests_gutenberg_Playwright_$targetDevice",
 		buildUuid = buildUuid,
-		buildName = "Playwright E2E Tests ($targetDevice)",
+		buildName = "Playwright Gutenberg E2E tests ($targetDevice)",
 		buildDescription = "Runs Gutenberg e2e tests on $targetDevice size",
 		testGroup = "gutenberg",
 		buildParams = {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -601,7 +601,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 		""".trimIndent(),
 		testGroup = "calypso-pr",
 		buildParams = {
-			param("env.SAVE_AUTH_COOKIES", "true")
+			param("env.AUTHENTICATE_ACCOUNTS", "true")
 			param("env.LIVEBRANCHES", "true")
 			param("env.TARGET_DEVICE", "$targetDevice")
 		},

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -601,7 +601,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 		""".trimIndent(),
 		testGroup = "calypso-pr",
 		buildParams = {
-			param("env.AUTHENTICATE_ACCOUNTS", "true")
+			param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,defaultUser,eCommerceUser")
 			param("env.LIVEBRANCHES", "true")
 			param("env.TARGET_DEVICE", "$targetDevice")
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes minor changes to the TeamCity configuration.

Key changes:
- adjust name of WPCOM Gutenberg Playwright E2E build configuration to include the term `Gutenberg` for easier differentiation when viewing the build jobs.
- use new environment variable introduced in https://github.com/Automattic/wp-calypso/pull/59811 for saving authentication cookies.

#### Testing instructions

- [x] Ensure that:
  - [x] cookies are being saved in Calypso E2E

