### PR TITLE
Playwright: update logic for authentication via popup page.

### DIFF
--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -44,6 +44,8 @@ export class TestAccount {
 	/**
 	 * Logs in via the login page UI. The verification code will be submitted
 	 * automatically if it's defined in the config file.
+	 *
+	 * @param {Page} page on which actions are to take place.
 	 */
 	async logInViaLoginPage( page: Page ): Promise< void > {
 		const loginPage = new LoginPage( page );
@@ -55,6 +57,23 @@ export class TestAccount {
 		if ( verificationCode ) {
 			await loginPage.submitVerificationCode( verificationCode );
 		}
+	}
+
+	/**
+	 * Logs in via the login page UI, but shown on a popup.
+	 *
+	 * @param {Page} page Handle to the popup Page object.
+	 */
+	async logInViaPopupPage( page: Page ): Promise< void > {
+		const loginPage = new LoginPage( page );
+
+		const [ username, password ] = this.credentials;
+		await loginPage.fillUsername( username );
+		await loginPage.clickSubmit();
+		await loginPage.fillPassword( password );
+
+		// Popup pages close once authentication is successful.
+		await Promise.all( [ page.waitForEvent( 'close' ), loginPage.clickSubmit() ] );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-likes__post.ts
+++ b/test/e2e/specs/specs-playwright/wp-likes__post.ts
@@ -5,10 +5,12 @@
 import {
 	DataHelper,
 	GutenbergEditorPage,
-	LoginPage,
 	PublishedPostPage,
 	TestAccount,
 } from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
 
 /**
  * Constants
@@ -19,15 +21,15 @@ const quote =
 describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 	const postingUser = new TestAccount( 'simpleSitePersonalPlanUser' );
 	const likeUser = new TestAccount( 'defaultUser' );
-	let page;
-	let publishedURL;
-	let publishedPostPage;
+	let page: Page;
+	let publishedURL: string;
+	let publishedPostPage: PublishedPostPage;
 
 	describe( 'As the posting user', function () {
-		let gutenbergEditorPage;
+		let gutenbergEditorPage: GutenbergEditorPage;
 
 		beforeAll( async () => {
-			page = await global.browser.newPage();
+			page = await browser.newPage();
 			gutenbergEditorPage = new GutenbergEditorPage( page );
 			await postingUser.authenticate( page );
 		} );
@@ -61,7 +63,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 
 	describe( 'As the liking user', () => {
 		beforeAll( async () => {
-			page = await global.browser.newPage();
+			page = await browser.newPage();
 		} );
 
 		it( 'Go to the published post page', async () => {
@@ -70,11 +72,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 
 		it( 'Login via popup to like the post', async function () {
 			page.on( 'popup', async ( popup ) => {
-				const loginPage = new LoginPage( popup );
-				await Promise.all( [
-					popup.waitForEvent( 'close' ),
-					loginPage.logInWithCredentials( ...likeUser.credentials ),
-				] );
+				await likeUser.logInViaPopupPage( popup );
 			} );
 
 			publishedPostPage = new PublishedPostPage( page );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the logic handling authentication via a popup page/window.

Key changes:
- create new method in `TestAccount.logInViaPopupPage` that handles popup-only authentication.
- while at it, migrate the spec to TypeScript.

Details:
https://github.com/Automattic/wp-calypso/pull/59811 fundamentally altered the way authentication worked in the `calypso-e2e` framework. It introduced the notion of a `TestAccount` object that is the spiritual successor of the `LoginFlow` object.

The intent is for LoginPage to handle interactions on the `log-in` endpoint only, and for the `TestAccount` object to handle the process of authentication. 

The previous implementation of `logInViaPopupPage` uses the method `logInWithCredentials` provided by `LoginPage`. This method includes a Promise.all at the end that wraps around two calls:
- `waitForNavigation`
- `clickSubmit`

While this is the expected outcome for authenticating against a persistent page, the `waitForNavigation` call introduces a race condition when used in the context of an ephemeral popup. This is evidenced in the original flakey e2e report:

```
page.waitForNavigation: Navigation failed because page was closed!
=========================== logs ===========================
waiting for navigation until "load"
```

Intermittently, due to processing slowdown or other factors outside the control of the framework, the `popup` window closes prior to the `waitForNavigation` call being satisfied and leads to the flakey outcome.

Closes https://github.com/Automattic/wp-calypso/issues/60595.
