### PR TITLE
CI: add new project for MarTech/Legal.

### DIFF
--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -39,6 +39,11 @@ object ToSAcceptanceTracking: BuildType {
 	name = "ToS Acceptance Tracking"
 	description = "Captures screenshots of locations where Terms of Service are shown."
 
+
+	artifactRules = """
+		screenshots => screenshots
+	""".trimIndent()
+
 	vcs {
 		root(Settings.WpCalypso)
 		cleanCheckout = true
@@ -98,13 +103,7 @@ object ToSAcceptanceTracking: BuildType {
 				set -x
 
 				mkdir -p screenshots
-				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
-
-				mkdir -p logs
-				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
-
-				mkdir -p trace
-				find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
+				find test/e2e -type f -path '*tos*.png' -print0 | xargs -r -0 mv -t screenshots
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -5,6 +5,7 @@ import _self.bashNodeScript
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -102,7 +102,7 @@ object ToSAcceptanceTracking: BuildType ({
 	triggers {
 		schedule {
 			schedulingPolicy = cron {
-				hour = '*/3'
+				hours = "*/3"
 			}
 			branchFilter = """
 				+:trunk

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -91,6 +91,16 @@ object ToSAcceptanceTracking: BuildType ({
 	features {
 		perfmon {
 		}
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#martech-tos-alerts"
+				messageFormat = simpleMessageFormat()
+			}
+			buildFailedToStart = true
+			buildFailed = true
+			buildProbablyHanging = true
+		}
 	}
 
 	triggers {

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -30,7 +30,7 @@ object MarTech : Project({
 	buildType(ToSAcceptanceTracking)
 })
 
-object ToSAcceptanceTracking: BuildType {
+object ToSAcceptanceTracking: BuildType ({
 	name = "ToS Acceptance Tracking"
 	description = "Captures screenshots of locations where Terms of Service are shown."
 
@@ -138,4 +138,4 @@ object ToSAcceptanceTracking: BuildType {
 			}
 		}
 	}
-}
+})

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -1,0 +1,112 @@
+package _self.projects
+
+import Settings
+import _self.bashNodeScript
+import _self.lib.customBuildType.E2EBuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
+import jetbrains.buildServer.configs.kotlin.v2019_2.Project
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.buildReportTab
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
+
+object MarTech : Project({
+	id("MarTech")
+	name = "MarTech"
+	description = "Tasks run by MarTech."
+
+	params {
+		param("docker_image", "%docker_image_e2e%")
+	}
+
+	features {
+		buildReportTab {
+			title = "VR Report"
+			startPage= "vr-report.zip!vr-report.zip!/test/visual/backstop_data/html_report/index.html"
+		}
+	}
+
+	// Keep the previous ID in order to preserve the historical data
+	buildType(ToSAcceptanceTracking)
+})
+
+object ToSAcceptanceTracking: BuildType {
+	name = "ToS Acceptance Tracking"
+	description = "Captures screenshots of locations where Terms of Service are shown."
+
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+
+	params {
+		param("env.NODE_CONFIG_ENV", "test")
+		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
+		param("env.TEAMCITY_VERSION", "2021")
+		param("env.HEADLESS", "false")
+		param("env.LOCALE", "en")
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Prepare environment"
+			scriptContent = """
+				# Install deps
+				yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
+
+				# Build packages
+				yarn workspace @automattic/calypso-e2e build
+			""".trimIndent()
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Capture screenshots"
+			scriptContent = """
+				# Configure bash shell.
+				shopt -s globstar
+				set -x
+
+				# Enter testing directory.
+				cd test/e2e
+				mkdir temp
+
+				# Decrypt config
+				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%E2E_CONFIG_ENCRYPTION_KEY%"
+
+				# As noted above, Calypso E2E build configuration exports the URL
+				# environment variable in the Run tests step. Therefore, the export
+				# for NODE_CONFIG variable has to be done here instead of
+				# within the Kotlin DSL as a param() value.
+				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL/}\"}"
+
+				# Run suite.
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=legal
+			"""
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Collect results"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -x
+
+				mkdir -p screenshots
+				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+
+				mkdir -p logs
+				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+
+				mkdir -p trace
+				find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
+			""".trimIndent()
+			dockerImage = "%docker_image_e2e%"
+		}
+	}
+}

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -70,12 +70,6 @@ object ToSAcceptanceTracking: BuildType ({
 				# Decrypt config
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%E2E_CONFIG_ENCRYPTION_KEY%"
 
-				# As noted above, Calypso E2E build configuration exports the URL
-				# environment variable in the Run tests step. Therefore, the export
-				# for NODE_CONFIG variable has to be done here instead of
-				# within the Kotlin DSL as a param() value.
-				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL/}\"}"
-
 				# Run suite.
 				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=legal
 			"""

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -7,7 +7,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.buildReportTab
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 
 object MarTech : Project({
@@ -19,14 +18,6 @@ object MarTech : Project({
 		param("docker_image", "%docker_image_e2e%")
 	}
 
-	features {
-		buildReportTab {
-			title = "VR Report"
-			startPage= "vr-report.zip!vr-report.zip!/test/visual/backstop_data/html_report/index.html"
-		}
-	}
-
-	// Keep the previous ID in order to preserve the historical data
 	buildType(ToSAcceptanceTracking)
 })
 
@@ -110,9 +101,8 @@ object ToSAcceptanceTracking: BuildType ({
 
 	triggers {
 		schedule {
-			schedulingPolicy = daily {
-				// Time in UTC. Roughly EU mid day, before US starts
-				hour = 11
+			schedulingPolicy = cron {
+				hour = '*/3'
 			}
 			branchFilter = """
 				+:trunk

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -28,7 +28,7 @@ object ToSAcceptanceTracking: BuildType ({
 
 
 	artifactRules = """
-		screenshots => screenshots
+		tos_screenshots => tos_screenshots
 	""".trimIndent()
 
 	vcs {
@@ -82,8 +82,8 @@ object ToSAcceptanceTracking: BuildType ({
 			scriptContent = """
 				set -x
 
-				mkdir -p screenshots
-				find test/e2e -type f -path '*tos*.png' -print0 | xargs -r -0 mv -t screenshots
+				mkdir -p tos_screenshots
+				find test/e2e -type f -path '*tos*.png' -print0 | xargs -r -0 mv -t tos_screenshots
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new project, named `MarTech` and a new build configuration, named `ToSAcceptanceTracking` to TeamCity.

I've chosen to add a separate project in case MarTech team decide to expand the number of build configurations in the future (eg. capture further EULA agreements, signup pages, etc).

Furthermore, the `WPCOM Tests` project already contains 11 configurations and adding yet another will only make the UI be overwhelming.

Context of project: pau2Xa-3my-p2

Key changes:
- new project and new build configuration.

#### Testing instructions

Related to #57741.