### PR TITLE
Checkout: Render "please wait" page when checkout is complete before redirecting

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-complete-redirecting.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-complete-redirecting.tsx
@@ -1,0 +1,24 @@
+import { CheckoutStepBody } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+
+export function CheckoutCompleteRedirecting(): JSX.Element {
+	return (
+		<CheckoutStepBody
+			stepId="checkout-complete-redirecting"
+			isStepActive={ false }
+			isStepComplete={ true }
+			titleContent={ <CheckoutCompleteRedirectingTitle /> }
+			completeStepContent={ <CheckoutCompleteRedirectingContent /> }
+		/>
+	);
+}
+
+function CheckoutCompleteRedirectingTitle(): JSX.Element {
+	const translate = useTranslate();
+	return <>{ translate( 'Your purchase has been completed!' ) }</>;
+}
+
+function CheckoutCompleteRedirectingContent(): JSX.Element {
+	const translate = useTranslate();
+	return <>{ translate( 'Please wait…' ) }</>;
+}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-complete-redirecting.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-complete-redirecting.tsx
@@ -8,7 +8,6 @@ export function CheckoutCompleteRedirecting(): JSX.Element {
 			isStepActive={ false }
 			isStepComplete={ true }
 			titleContent={ <CheckoutCompleteRedirectingTitle /> }
-			completeStepContent={ <CheckoutCompleteRedirectingContent /> }
 		/>
 	);
 }
@@ -16,9 +15,4 @@ export function CheckoutCompleteRedirecting(): JSX.Element {
 function CheckoutCompleteRedirectingTitle(): JSX.Element {
 	const translate = useTranslate();
 	return <>{ translate( 'Your purchase has been completed!' ) }</>;
-}
-
-function CheckoutCompleteRedirectingContent(): JSX.Element {
-	const translate = useTranslate();
-	return <>{ translate( 'Please wait…' ) }</>;
 }

--- a/client/my-sites/checkout/composite-checkout/components/empty-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/empty-cart.tsx
@@ -4,8 +4,9 @@ import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
-export default function EmptyCart(): JSX.Element {
+export function EmptyCart(): JSX.Element {
 	const reduxDispatch = useDispatch();
 	const previousPath = useSelector( getPreviousPath );
 	const referrer = window?.document?.referrer ?? '';
@@ -43,4 +44,35 @@ function EmptyCartExplanation(): JSX.Element {
 			) }
 		</>
 	);
+}
+
+export function shouldShowEmptyCartPage( {
+	responseCart,
+	areWeRedirecting,
+	areThereErrors,
+	isCartPendingUpdate,
+	isInitialCartLoading,
+}: {
+	responseCart: ResponseCart;
+	areWeRedirecting: boolean;
+	areThereErrors: boolean;
+	isCartPendingUpdate: boolean;
+	isInitialCartLoading: boolean;
+} ): boolean {
+	if ( responseCart.products.length > 0 ) {
+		return false;
+	}
+	if ( areWeRedirecting ) {
+		return false;
+	}
+	if ( areThereErrors ) {
+		return true;
+	}
+	if ( isCartPendingUpdate ) {
+		return false;
+	}
+	if ( isInitialCartLoading ) {
+		return false;
+	}
+	return true;
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -305,6 +305,11 @@ export default function WPCheckout( {
 				<NonCheckoutContentWrapper>
 					<NonCheckoutContentInnerWrapper>
 						<CheckoutCompleteRedirecting />
+						<SubmitButtonWrapper>
+							<Button buttonType="primary" fullWidth isBusy disabled>
+								{ translate( 'Please wait…' ) }
+							</Button>
+						</SubmitButtonWrapper>
 					</NonCheckoutContentInnerWrapper>
 				</NonCheckoutContentWrapper>
 			</MainContentWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -1,6 +1,11 @@
 import { isYearly, isJetpackPurchasableItem, isMonthlyProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
+	CheckoutStepAreaWrapper,
+	SubmitButtonWrapper,
+	Button,
+	useTransactionStatus,
+	TransactionStatus,
 	Checkout,
 	CheckoutStep,
 	CheckoutStepArea,
@@ -21,7 +26,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
-import { useDispatch as useReduxDispatch } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
 	hasGoogleApps,
@@ -29,8 +34,11 @@ import {
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
+import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import useUpdateCartLocationWhenPaymentMethodChanges from '../hooks/use-update-cart-location-when-payment-method-changes';
 import { validateContactDetails } from '../lib/contact-validation';
@@ -38,7 +46,9 @@ import getContactDetailsType from '../lib/get-contact-details-type';
 import badge14Src from './assets/icons/badge-14.svg';
 import badge7Src from './assets/icons/badge-7.svg';
 import badgeGenericSrc from './assets/icons/badge-generic.svg';
+import { CheckoutCompleteRedirecting } from './checkout-complete-redirecting';
 import CheckoutHelpLink from './checkout-help-link';
+import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import PaymentMethodStep from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
@@ -126,6 +136,10 @@ export default function WPCheckout( {
 	showErrorMessageBriefly,
 	siteId,
 	siteUrl,
+	isRemovingProductFromCart,
+	areThereErrors,
+	isInitialCartLoading,
+	customizedPreviousPath,
 }: {
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	changePlanLength: OnChangeItemVariant;
@@ -139,6 +153,10 @@ export default function WPCheckout( {
 	showErrorMessageBriefly: ( error: string ) => void;
 	siteId: number | undefined;
 	siteUrl: string | undefined;
+	isRemovingProductFromCart: boolean;
+	areThereErrors: boolean;
+	isInitialCartLoading: boolean;
+	customizedPreviousPath?: string;
 } ): JSX.Element {
 	const cartKey = useCartKey();
 	const {
@@ -268,6 +286,49 @@ export default function WPCheckout( {
 		? String( translate( 'Updating cart…' ) )
 		: String( translate( 'Please wait…' ) );
 
+	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( siteUrl );
+	const previousPath = useSelector( getPreviousRoute );
+	const goToPreviousPage = () =>
+		leaveCheckout( {
+			siteSlug: siteUrl,
+			jetpackCheckoutBackUrl,
+			previousPath: customizedPreviousPath || previousPath,
+			tracksEvent: 'calypso_checkout_composite_empty_cart_clicked',
+		} );
+
+	const { transactionStatus } = useTransactionStatus();
+
+	if ( transactionStatus === TransactionStatus.COMPLETE ) {
+		debug( 'rendering post-checkout redirecting page' );
+		return (
+			<CheckoutStepAreaWrapper>
+				<CheckoutCompleteRedirecting />
+			</CheckoutStepAreaWrapper>
+		);
+	}
+
+	if (
+		shouldShowEmptyCartPage( {
+			responseCart,
+			areWeRedirecting: isRemovingProductFromCart,
+			areThereErrors,
+			isCartPendingUpdate,
+			isInitialCartLoading,
+		} )
+	) {
+		debug( 'rendering empty cart page' );
+		return (
+			<CheckoutStepAreaWrapper>
+				<EmptyCart />
+				<SubmitButtonWrapper>
+					<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
+						{ translate( 'Go back' ) }
+					</Button>
+				</SubmitButtonWrapper>
+			</CheckoutStepAreaWrapper>
+		);
+	}
+
 	return (
 		<Checkout>
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
@@ -372,7 +433,7 @@ export default function WPCheckout( {
 					{ contactDetailsType !== 'none' && (
 						<CheckoutStep
 							stepId={ 'contact-form' }
-							isCompleteCallback={ () => {
+							isCompleteCallback={ async () => {
 								setShouldShowContactDetailsValidationErrors( true );
 								// Touch the fields so they display validation errors
 								touchContactFields();

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -1,7 +1,7 @@
 import { isYearly, isJetpackPurchasableItem, isMonthlyProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
-	CheckoutStepAreaWrapper,
+	MainContentWrapper,
 	SubmitButtonWrapper,
 	Button,
 	useTransactionStatus,
@@ -301,9 +301,13 @@ export default function WPCheckout( {
 	if ( transactionStatus === TransactionStatus.COMPLETE ) {
 		debug( 'rendering post-checkout redirecting page' );
 		return (
-			<CheckoutStepAreaWrapper>
-				<CheckoutCompleteRedirecting />
-			</CheckoutStepAreaWrapper>
+			<MainContentWrapper>
+				<NonCheckoutContentWrapper>
+					<NonCheckoutContentInnerWrapper>
+						<CheckoutCompleteRedirecting />
+					</NonCheckoutContentInnerWrapper>
+				</NonCheckoutContentWrapper>
+			</MainContentWrapper>
 		);
 	}
 
@@ -318,14 +322,18 @@ export default function WPCheckout( {
 	) {
 		debug( 'rendering empty cart page' );
 		return (
-			<CheckoutStepAreaWrapper>
-				<EmptyCart />
-				<SubmitButtonWrapper>
-					<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
-						{ translate( 'Go back' ) }
-					</Button>
-				</SubmitButtonWrapper>
-			</CheckoutStepAreaWrapper>
+			<MainContentWrapper>
+				<NonCheckoutContentWrapper>
+					<NonCheckoutContentInnerWrapper>
+						<EmptyCart />
+						<SubmitButtonWrapper>
+							<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
+								{ translate( 'Go back' ) }
+							</Button>
+						</SubmitButtonWrapper>
+					</NonCheckoutContentInnerWrapper>
+				</NonCheckoutContentWrapper>
+			</MainContentWrapper>
 		);
 	}
 
@@ -722,5 +730,31 @@ const SubmitButtonHeaderWrapper = styled.div`
 		&:hover {
 			color: ${ ( props ) => props.theme.colors.highlightOver };
 		}
+	}
+`;
+
+const NonCheckoutContentWrapper = styled.div`
+	display: flex;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		align-items: flex-start;
+		flex-direction: row;
+		justify-content: center;
+		width: 100%;
+	}
+`;
+
+const NonCheckoutContentInnerWrapper = styled.div`
+	background: ${ ( props ) => props.theme.colors.surface };
+	width: 100%;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+		max-width: 556px;
+		margin: 0 auto;
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		margin: 0;
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -7,6 +7,8 @@ import {
 	SubmitButtonWrapper,
 	checkoutTheme,
 	Button,
+	useTransactionStatus,
+	TransactionStatus,
 } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useIsWebPayAvailable, isValueTruthy } from '@automattic/wpcom-checkout';
@@ -42,6 +44,7 @@ import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { CheckoutCompleteRedirecting } from './components/checkout-complete-redirecting';
 import EmptyCart from './components/empty-cart';
 import WPCheckout from './components/wp-checkout';
 import useActOnceOnStrings from './hooks/use-act-once-on-strings';
@@ -678,8 +681,6 @@ export default function CompositeCheckout( {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
 	}, [ reduxDispatch, translate ] );
 
-	// The goToPreviousPage function and subsequent conditional statement controls the 'back' button functionality on the empty cart page
-
 	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( updatedSiteSlug );
 
 	const goToPreviousPage = () =>
@@ -689,6 +690,24 @@ export default function CompositeCheckout( {
 			previousPath: customizedPreviousPath || previousPath,
 			tracksEvent: 'calypso_checkout_composite_empty_cart_clicked',
 		} );
+
+	const { transactionStatus } = useTransactionStatus();
+
+	if ( transactionStatus === TransactionStatus.COMPLETE ) {
+		debug( 'rendering post-checkout redirecting page' );
+		return (
+			<Fragment>
+				<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
+				<ThemeProvider theme={ theme }>
+					<MainContentWrapper>
+						<CheckoutStepAreaWrapper>
+							<CheckoutCompleteRedirecting />
+						</CheckoutStepAreaWrapper>
+					</MainContentWrapper>
+				</ThemeProvider>
+			</Fragment>
+		);
+	}
 
 	if (
 		shouldShowEmptyCartPage( {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -1,18 +1,8 @@
 import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
-import {
-	CheckoutProvider,
-	CheckoutStepAreaWrapper,
-	MainContentWrapper,
-	SubmitButtonWrapper,
-	checkoutTheme,
-	Button,
-	useTransactionStatus,
-	TransactionStatus,
-} from '@automattic/composite-checkout';
+import { CheckoutProvider, checkoutTheme } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useIsWebPayAvailable, isValueTruthy } from '@automattic/wpcom-checkout';
-import { ThemeProvider } from '@emotion/react';
 import { useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
@@ -29,8 +19,6 @@ import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import wp from 'calypso/lib/wp';
 import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
-import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
-import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import {
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	translateCheckoutPaymentMethodToTracksPaymentMethod,
@@ -40,12 +28,9 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import getIsIntroOfferRequesting from 'calypso/state/selectors/get-is-requesting-into-offers';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { CheckoutCompleteRedirecting } from './components/checkout-complete-redirecting';
-import EmptyCart from './components/empty-cart';
 import WPCheckout from './components/wp-checkout';
 import useActOnceOnStrings from './hooks/use-act-once-on-strings';
 import useAddProductsFromUrl from './hooks/use-add-products-from-url';
@@ -79,7 +64,6 @@ import { StoredCard } from './types/stored-cards';
 import { emptyManagedContactDetails } from './types/wpcom-store-state';
 import type { PaymentProcessorOptions } from './types/payment-processors';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
-import type { ResponseCart } from '@automattic/shopping-cart';
 import type {
 	ManagedContactDetails,
 	CountryListItem,
@@ -138,7 +122,6 @@ export default function CompositeCheckout( {
 	isUserComingFromLoginForm?: boolean;
 	customizedPreviousPath?: string;
 } ): JSX.Element {
-	const previousPath = useSelector( getPreviousRoute );
 	const translate = useTranslate();
 	const isJetpackNotAtomic =
 		useSelector(
@@ -318,9 +301,10 @@ export default function CompositeCheckout( {
 		);
 	} );
 
-	const errors = responseCart.messages?.errors ?? [];
+	const responseCartErrors = responseCart.messages?.errors ?? [];
 	const areThereErrors =
-		[ ...errors, cartLoadingError, cartProductPrepError ].filter( isValueTruthy ).length > 0;
+		[ ...responseCartErrors, cartLoadingError, cartProductPrepError ].filter( isValueTruthy )
+			.length > 0;
 
 	const {
 		isRemovingProductFromCart,
@@ -681,64 +665,6 @@ export default function CompositeCheckout( {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
 	}, [ reduxDispatch, translate ] );
 
-	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( updatedSiteSlug );
-
-	const goToPreviousPage = () =>
-		leaveCheckout( {
-			siteSlug,
-			jetpackCheckoutBackUrl,
-			previousPath: customizedPreviousPath || previousPath,
-			tracksEvent: 'calypso_checkout_composite_empty_cart_clicked',
-		} );
-
-	const { transactionStatus } = useTransactionStatus();
-
-	if ( transactionStatus === TransactionStatus.COMPLETE ) {
-		debug( 'rendering post-checkout redirecting page' );
-		return (
-			<Fragment>
-				<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
-				<ThemeProvider theme={ theme }>
-					<MainContentWrapper>
-						<CheckoutStepAreaWrapper>
-							<CheckoutCompleteRedirecting />
-						</CheckoutStepAreaWrapper>
-					</MainContentWrapper>
-				</ThemeProvider>
-			</Fragment>
-		);
-	}
-
-	if (
-		shouldShowEmptyCartPage( {
-			responseCart,
-			areWeRedirecting: isRemovingProductFromCart,
-			areThereErrors,
-			isCartPendingUpdate,
-			isInitialCartLoading,
-		} )
-	) {
-		debug( 'rendering empty cart page' );
-
-		return (
-			<Fragment>
-				<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
-				<ThemeProvider theme={ theme }>
-					<MainContentWrapper>
-						<CheckoutStepAreaWrapper>
-							<EmptyCart />
-							<SubmitButtonWrapper>
-								<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
-									{ translate( 'Go back' ) }
-								</Button>
-							</SubmitButtonWrapper>
-						</CheckoutStepAreaWrapper>
-					</MainContentWrapper>
-				</ThemeProvider>
-			</Fragment>
-		);
-	}
-
 	return (
 		<Fragment>
 			<QueryIntroOffers siteId={ updatedSiteId } />
@@ -771,6 +697,10 @@ export default function CompositeCheckout( {
 				initiallySelectedPaymentMethodId={ paymentMethods?.length ? paymentMethods[ 0 ].id : null }
 			>
 				<WPCheckout
+					customizedPreviousPath={ customizedPreviousPath }
+					isRemovingProductFromCart={ isRemovingProductFromCart }
+					areThereErrors={ areThereErrors }
+					isInitialCartLoading={ isInitialCartLoading }
 					addItemToCart={ addItemAndLog }
 					changePlanLength={ changePlanLength }
 					countriesList={ countriesList }
@@ -837,35 +767,4 @@ function getAnalyticsPath(
 	}
 
 	return { analyticsPath, analyticsProps };
-}
-
-function shouldShowEmptyCartPage( {
-	responseCart,
-	areWeRedirecting,
-	areThereErrors,
-	isCartPendingUpdate,
-	isInitialCartLoading,
-}: {
-	responseCart: ResponseCart;
-	areWeRedirecting: boolean;
-	areThereErrors: boolean;
-	isCartPendingUpdate: boolean;
-	isInitialCartLoading: boolean;
-} ): boolean {
-	if ( responseCart.products.length > 0 ) {
-		return false;
-	}
-	if ( areWeRedirecting ) {
-		return false;
-	}
-	if ( areThereErrors ) {
-		return true;
-	}
-	if ( isCartPendingUpdate ) {
-		return false;
-	}
-	if ( isInitialCartLoading ) {
-		return false;
-	}
-	return true;
 }


### PR DESCRIPTION
#### Problem

When wpcom checkout completes, the payment complete handler [will redirect](https://github.com/Automattic/wp-calypso/blob/eb8d2e3fd128d86aa4064760b9842eb7b72c3752/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx#L241) to a post-checkout page. Sometimes, as in the case of some Jetpack purchases, that page will be outside calypso. If that's the case and the post-checkout page takes a while to load, we may see an "empty cart" checkout page.

This happens because [just before the redirect, we trigger a cart refresh](https://github.com/Automattic/wp-calypso/blob/eb8d2e3fd128d86aa4064760b9842eb7b72c3752/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx#L240) so that the post-checkout page (assuming it is within calypso and we are doing an SPA redirect) can have an up-to-date cart (which should be empty). If loading the post-checkout page takes a while, then the checkout page may re-render during that time and display the empty cart. This can be confusing for the user.

<img width="899" alt="Screen Shot 2022-01-27 at 7 44 17 PM" src="https://user-images.githubusercontent.com/2036909/151467204-808e4564-2d71-4f25-9544-f8b2fcc834cb.png">

#### Changes proposed in this Pull Request

In this PR, we add a "please wait" page that will be rendered by checkout if checkout is complete (and hopefully we are redirecting) which is shown even if the cart is empty.

In order to do this properly, we also needed to move rendering the empty cart page itself from `CompositeCheckout` (basically the checkout page _wrapper_) into `WPCheckout` (basically the checkout page _contents_) so that we have access to the transaction status and so it can be lower priority than the new page.

<img width="901" alt="Screen Shot 2022-01-27 at 7 42 02 PM" src="https://user-images.githubusercontent.com/2036909/151466984-82c0f4bb-91c4-4d89-bcfd-e8bba0ef8f36.png">

Fixes https://github.com/Automattic/wp-calypso/issues/60575

#### Testing instructions

First it's a good idea to make sure the empty cart page still looks and works as normal by visiting `/checkout/YOUR_SITE_HERE` with an empty cart.

The easiest way to inspect the new "please wait" page is to hard-code the transaction to "complete" and then verify that the page looks good.

<details>

```diff
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -298,7 +298,7 @@ export default function WPCheckout( {

        const { transactionStatus } = useTransactionStatus();

-       if ( transactionStatus === TransactionStatus.COMPLETE ) {
+       if ( true ) {
                debug( 'rendering post-checkout redirecting page' );
                return (
                        <MainContentWrapper>
```

</details>

To actually test the functionality, follow these instructions:

- Use a Jetpack site.
- Add a product to your cart and visit checkout.
- Complete the purchase and verify that you see the new "please wait" page just before you are redirected to the post-checkout page.