### PR TITLE
Fix auto-renew dialog max-width styles

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -1,5 +1,5 @@
-.dialog.auto-renew-disabling-dialog {
-	max-width: 440px;
+.dialog.card.auto-renew-disabling-dialog {
+	max-width: 600px;
 }
 
 .auto-renew-disabling-dialog__header {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -1,5 +1,5 @@
 .dialog.card.auto-renew-disabling-dialog {
-	max-width: 600px;
+	max-width: 90%;
 
 	&.atomic-follow-up {
 		ul {
@@ -14,9 +14,18 @@
 			width: 100%;
 		}
 	}
+
+	& > .dialog__content {
+		overflow-wrap: break-word;
+	}
 }
 
 .auto-renew-disabling-dialog__header {
 	font-size: $font-title-medium;
 	margin-bottom: 14px;
+}
+@media ( min-width: 660px ) {
+	.dialog.card.auto-renew-disabling-dialog {
+		max-width: 600px;
+	}
 }

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -1,24 +1,22 @@
 .dialog.card.auto-renew-disabling-dialog {
 	max-width: 600px;
+
+	&.atomic-follow-up {
+		ul {
+			list-style-type: none;
+			margin: 0;
+		}
+
+		.button {
+			margin-bottom: 8px;
+			padding: 8px 10px;
+			text-align: center;
+			width: 100%;
+		}
+	}
 }
 
 .auto-renew-disabling-dialog__header {
 	font-size: $font-title-medium;
 	margin-bottom: 14px;
-}
-
-.dialog.card.auto-renew-disabling-dialog.atomic-follow-up {
-	max-width: 600px;
-
-	ul {
-		list-style-type: none;
-		margin: 0;
-	}
-
-	.button {
-		margin-bottom: 8px;
-		padding: 8px 10px;
-		text-align: center;
-		width: 100%;
-	}
 }

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -7,7 +7,7 @@
 	margin-bottom: 14px;
 }
 
-.dialog.auto-renew-disabling-dialog.atomic-follow-up {
+.dialog.card.auto-renew-disabling-dialog.atomic-follow-up {
 	max-width: 600px;
 
 	ul {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-payment-method-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-payment-method-dialog/style.scss
@@ -1,5 +1,5 @@
-.dialog.auto-renew-payment-method-dialog {
-	max-width: 440px;
+.dialog.card.auto-renew-payment-method-dialog {
+	max-width: 600px;
 }
 
 .auto-renew-payment-method-dialog__header {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-payment-method-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-payment-method-dialog/style.scss
@@ -1,8 +1,17 @@
 .dialog.card.auto-renew-payment-method-dialog {
-	max-width: 600px;
+	max-width: 90%;
+	& > .dialog__content {
+		overflow-wrap: break-word;
+	}
 }
 
 .auto-renew-payment-method-dialog__header {
 	font-size: $font-title-medium;
 	margin-bottom: 14px;
+}
+
+@media ( min-width: 660px ) {
+	.dialog.card.auto-renew-payment-method-dialog {
+		max-width: 600px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As noted in https://github.com/Automattic/wp-calypso/issues/60310, currently the auto-renewal toggle's dialog box stetches to 90% of the window:

![image](https://user-images.githubusercontent.com/16580129/151459390-62781294-02be-451c-b54e-52fab235d533.png)

This is because the `.dialog.card` class is being used rather than the `.dialog.auto-renew-disabling-dialog` class that is found in the stylesheet. 

It looks like the `card` class was added as [part of a refactor](https://github.com/Automattic/wp-calypso/blame/trunk/packages/components/src/dialog/index.tsx#L53-L54) but the class didn't make it into the stylesheet.

This PR adds in the `card` class to:
- `.dialog.auto-renew-disabling-dialog` and 
- `.dialog.auto-renew-payment-method-dialog`
- `.dialog.auto-renew-disabling-dialog.atomic-follow-up`

Additionally, I adjusted the max-width of these cards to be more in line with the existing atomic follow up card. This 600px width is bit easier to read in my opinion than the narrower 440px.

---

#### Testing instructions

There are two primary actions here that prompt the dialog to appear, toggling auto-renewal _off_ and _on_.

Testing toggle ON:
**While completing these steps, check that each card shows a max-width of 600px**
* Start with a purchase that does not have a payment method, you may need to delete a payment method from Payment Admin
* Click the toggle to turn on auto-renewal, you should be prompted to add a payment method like so 
![image](https://user-images.githubusercontent.com/16580129/151462236-d0f9a3f2-751f-40be-baa5-f8c22e9f8983.png)
---
Testing Simple toggle OFF:
**While completing these steps, check that each card shows a max-width of 600px**
* Find a simple site with a plan and toggle auto renewal OFF
* You should see a notice like 
![image](https://user-images.githubusercontent.com/16580129/151462364-2c0abab6-290f-4552-a9e6-a268278b4372.png)
* Click 'turn off auto-renew', this should lead to an exit survey, click skip and auto-renewal should now be off
---
Testing Atomic toggle OFF:
**While completing these steps, check that each card shows a max-width of 600px**
* Find an atomic site with a Business plan and toggle auto renewal OFF
* Click on 'turn off auto-renew'
* You should now see an atomic follow up warning 
![image](https://user-images.githubusercontent.com/16580129/151462628-0eca42de-2671-450d-9e4f-f12ca20c87f8.png)
* Click on 'I dont need a backup...'
* Skip exit survey
* Auto renewal should be off
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60310
