### PR TITLE
Remove required from business info step in woo installer

### DIFF
--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -205,7 +205,6 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ): Reac
 										},
 									] }
 									onChange={ updateOtherPlatform }
-									required
 								/>
 
 								{ getProfileValue( 'other_platform' ) === 'other' && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove required from optional dropdown

#### Testing instructions

* Start the woo installer http://calypso.localhost:3000/start/woocommerce-install/store-address?site=wooptestupgrade.wpcomstaging.com
* Go to business info step
* Answer yes, on another platform
* Add a revenue
* Leave the where you're selling question blank
* You should be able to submit the form

![Screenshot(54)](https://user-images.githubusercontent.com/811776/151480900-a8edd0d2-dd6f-4b5b-af94-bc837ae6f8e5.png)



Related to #60588
