### PR TITLE
Fixes broken dependency for the difm design picker step

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -691,8 +691,13 @@ export function generateSteps( {
 			apiRequestFunction: setDesignIfNewSite,
 			delayApiRequestUntilComplete: true,
 			dependencies: [ 'siteSlug', 'newOrExistingSiteChoice' ],
-			providesDependencies: [ 'selectedDesign', 'selectedSiteCategory', 'isLetUsChooseSelected' ],
-			optionalDependencies: [ 'selectedDesign', 'isLetUsChooseSelected' ],
+			providesDependencies: [
+				'isFSEActive',
+				'selectedDesign',
+				'selectedSiteCategory',
+				'isLetUsChooseSelected',
+			],
+			optionalDependencies: [ 'isFSEActive', 'selectedDesign', 'isLetUsChooseSelected' ],
 			props: {
 				hideSkip: true,
 				hideExternalPreview: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fix for a dependency not replicated in the reused design picker step.

#### Testing instructions
- The difm flow `/start/do-it-for-me` should work and checkout successfully


Related to #60330
