### PR TITLE
Add event tracking to the i18n support link in the courses page

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -80,6 +80,12 @@ const VideosUi = ( {
 		}
 	};
 
+	const onVideoTranslationSupportLinkClick = () => {
+		recordTracksEvent( 'calypso_courses_translation_support_link_click', {
+			course: course.slug,
+		} );
+	};
+
 	useEffect( () => {
 		if ( course ) {
 			recordTracksEvent( 'calypso_courses_view', {
@@ -99,7 +105,9 @@ const VideosUi = ( {
 							'These videos are currently only available in English. Please {{supportLink}}let us know{{/supportLink}} if you would like them translated.',
 							{
 								components: {
-									supportLink: <a href="/help/contact" />,
+									supportLink: (
+										<a href="/help/contact" onClick={ onVideoTranslationSupportLinkClick } />
+									),
 								},
 							}
 						) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the event `calypso_courses_translation_support_link_click` to track users clicking the support link that shows up when user's WP  language settings is non-English. The support link contains the following messaging:

> These videos are currently only available in English. Please {{supportLink}}let us know{{/supportLink}} if you would like them translated.

The translation link can be found [here](https://translate.wordpress.com/projects/wpcom/-all-translated/711691/).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your WP language settings to non-English.
* Go to My Home, and on the "Blog like an expert from day one" click on the Start learning button. 
![Screen Shot 2022-01-28 at 1 47 29 PM](https://user-images.githubusercontent.com/797888/151494174-6d6475df-7dd1-4fdf-86dd-8fefffe927a5.png)
* An overlay will show up, with the i18n notice displayed (if the language is set to non-English). Open the browser's dev tools and then click on the support link as indicated in the screenshot.
![Screen Shot 2022-01-28 at 1 37 33 PM](https://user-images.githubusercontent.com/797888/151493596-39472980-cf6b-4952-85c5-3b079a6b6f96.png)
* Check in the Network tab that the click event tracking has been fired.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60055
