### PR TITLE
FSE: increase rollout percentage to 50

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -43,7 +43,7 @@ import { getSiteId } from 'calypso/state/sites/selectors';
 const Visibility = Site.Visibility;
 const debug = debugFactory( 'calypso:signup:step-actions' );
 
-const FSE_BETA_ROLLOUT_PERCENTAGE_START_FLOW = 10;
+const FSE_BETA_ROLLOUT_PERCENTAGE_START_FLOW = 50;
 
 const isUserAssignedFSEBeta = ( userId ) => {
 	if ( ! userId ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enroll 50% of users that enter the /start flow in FSE.

#### Testing instructions

Same as https://github.com/Automattic/wp-calypso/pull/60330.