### PR TITLE
Add Hotjar poll targeting users from India

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -3,7 +3,7 @@ import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
-import { connect, useDispatch } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
@@ -11,6 +11,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -19,6 +20,7 @@ import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import { canCurrentUserUseCustomerHome, getSiteOption } from 'calypso/state/sites/selectors';
@@ -48,6 +50,19 @@ const Home = ( { canUserUseCustomerHome, site, siteId, trackViewSiteAction, noti
 
 		return;
 	}, [ shouldShowNotice, translate, reduxDispatch, noticeType ] );
+
+	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
+	useEffect( () => {
+		if ( 'IN' !== detectedCountryCode ) {
+			return;
+		}
+
+		addHotJarScript();
+
+		if ( window && window.hj ) {
+			window.hj( 'trigger', 'in_survey_1' );
+		}
+	}, [ detectedCountryCode ] );
 
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For context, read pbMDip-35-p2. This PR implements a Hotjar poll in Customer Home targeting users from India.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proxy through an Indian IP and load Customer Home. You should see the Hotjar poll load up for new and existing users.
* Without submitting a response, any number of reloads of Customer Home should always show the poll.
* Submit a response on the popover poll, and reload Customer Home. You should not be prompted again for the poll. Verify that your response is captured on Hotjar, using the instructions described in 2b858-pb.
* Proxy through any other country IP and load Customer Home. You _should not_ be prompted for the poll. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
