### PR TITLE
Welcome Tour: Remove check for translation used in 59488

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -1,7 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, hasTranslation } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 function getTourAssets( key ) {
 	const CDN_PREFIX = 'https://s0.wp.com/i/editor-welcome-tour';
@@ -81,17 +81,10 @@ function getTourSteps( localeSlug, referencePositioning ) {
 						'Click + to open the inserter. Then click the block you want to add.',
 						'full-site-editing'
 					),
-					mobile:
-						localeSlug === 'en' ||
-						hasTranslation?.( 'Tap + to open the inserter. Then tap the block you want to add.' )
-							? __(
-									'Tap + to open the inserter. Then tap the block you want to add.',
-									'full-site-editing'
-							  )
-							: __(
-									'Click + to open the inserter. Then click the block you want to add.',
-									'full-site-editing'
-							  ),
+					mobile: __(
+						'Tap + to open the inserter. Then tap the block you want to add.',
+						'full-site-editing'
+					),
 				},
 				imgSrc: getTourAssets( 'addBlock' ),
 				animation: 'block-inserter',
@@ -125,11 +118,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				heading: __( 'More Options', 'full-site-editing' ),
 				descriptions: {
 					desktop: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
-					mobile:
-						localeSlug === 'en' ||
-						hasTranslation?.( 'Tap the settings icon to see even more options.' )
-							? __( 'Tap the settings icon to see even more options.', 'full-site-editing' )
-							: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
+					mobile: __( 'Tap the settings icon to see even more options.', 'full-site-editing' ),
 				},
 				imgSrc: getTourAssets( 'moreOptions' ),
 				animation: null,
@@ -181,11 +170,7 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				heading: __( 'Drag & drop', 'full-site-editing' ),
 				descriptions: {
 					desktop: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
-					mobile:
-						localeSlug === 'en' ||
-						hasTranslation?.( 'To move blocks around, tap the up and down arrows.' )
-							? __( 'To move blocks around, tap the up and down arrows.', 'full-site-editing' )
-							: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
+					mobile: __( 'To move blocks around, tap the up and down arrows.', 'full-site-editing' ),
 				},
 				imgSrc: getTourAssets( 'moveBlock' ),
 				animation: 'undo-button',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the `hasTranslation` used in [59488](https://github.com/Automattic/wp-calypso/pull/59488) while waiting for the translations (that are now [completed](https://translate.wordpress.com/deliverables/overview/7078353)).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  checkout branch
* `yarn dev --sync` from `apps/editing-toolkit` to sync the welcome tour to the sandbox
* change the language in [https://wordpress.com/me/account ](https://wordpress.com/me/account) and test that text is correctly showing for slides 3,5 and 8 ( "Welcome to WordPress!", "More Options" and "Drag & drop")

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59488
