### PR TITLE
Extensions Purchased from the Marketplace Don't Have "Installed" Label

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useState, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, DefaultRootState } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
@@ -66,7 +66,7 @@ const MarketplacePluginInstall = ( {
 		getUploadedPluginId( state, siteId )
 	) as string;
 	const pluginUploadComplete = useSelector( ( state ) => isPluginUploadComplete( state, siteId ) );
-	const installedPlugin = useSelector( ( state ) =>
+	const installedPlugin = useSelector( ( state: DefaultRootState ): InstalledPlugin | undefined =>
 		getPluginOnSite( state, siteId, isUploadFlow ? uploadedPluginSlug : productSlug )
 	);
 	const pluginActive = useSelector( ( state ) =>
@@ -204,8 +204,8 @@ const MarketplacePluginInstall = ( {
 		) {
 			dispatch(
 				activatePlugin( siteId, {
-					slug: ( installedPlugin as InstalledPlugin )?.slug,
-					id: ( installedPlugin as InstalledPlugin )?.id,
+					slug: installedPlugin?.slug,
+					id: installedPlugin?.id,
 				} )
 			);
 			setCurrentStep( 2 );
@@ -221,9 +221,7 @@ const MarketplacePluginInstall = ( {
 		) {
 			waitFor( 1 ).then( () =>
 				page.redirect(
-					`/marketplace/thank-you/${
-						( installedPlugin as InstalledPlugin )?.slug || productSlug
-					}/${ selectedSiteSlug }`
+					`/marketplace/thank-you/${ installedPlugin?.slug || productSlug }/${ selectedSiteSlug }`
 				)
 			);
 		}

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -36,6 +36,10 @@ const _filters = {
 	},
 };
 
+export function isEqualSlugOrId( pluginSlug, plugin ) {
+	return plugin.slug === pluginSlug || plugin?.id?.split( '/' ).shift() === pluginSlug;
+}
+
 export function isRequesting( state, siteId ) {
 	if ( typeof state.plugins.installed.isRequesting[ siteId ] === 'undefined' ) {
 		return false;
@@ -102,17 +106,18 @@ export function getPluginsOnSites( state, plugins ) {
 }
 
 export function getPluginOnSites( state, siteIds, pluginSlug ) {
-	return getPlugins( state, siteIds ).find( ( plugin ) => plugin.slug === pluginSlug );
+	return getPlugins( state, siteIds ).find( ( plugin ) => isEqualSlugOrId( pluginSlug, plugin ) );
 }
 
 export function getPluginOnSite( state, siteId, pluginSlug ) {
 	const pluginList = getPlugins( state, [ siteId ] );
-	return find( pluginList, { slug: pluginSlug } );
+	return find( pluginList, ( plugin ) => isEqualSlugOrId( pluginSlug, plugin ) );
 }
 
 export function getSitesWithPlugin( state, siteIds, pluginSlug ) {
 	const pluginList = getPlugins( state, siteIds );
-	const plugin = find( pluginList, { slug: pluginSlug } );
+	const plugin = find( pluginList, ( pluginItem ) => isEqualSlugOrId( pluginSlug, pluginItem ) );
+
 	if ( ! plugin ) {
 		return [];
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- This PR updates selectors to compare for plugin id as well when checking if marketplace plugin is installed. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit https://wordpress.com/plugins/woocommerce-subscriptions/[SITE_ID]
* Make sure your site is on an eCommerce plan
* Purchase marketplace plugin e.g. WooCommerce Subscriptions
* Verify if `Installed` appears when you visit https://wordpress.com/plugins/woocommerce-subscriptions/[SITE_ID]
* Without this PR, `Installed` should not appear. 

#### Screenshot

**Before:**
![](https://cloudup.com/cwrYV7FnY4y+)

**After:**
![](https://cloudup.com/cyF3xcejP07+)
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #60137 
