### PR TITLE
Plugin Upload: redirect directly to upload on upgrade/downgrade cases

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -288,7 +288,7 @@ const MarketplacePluginInstall = ( {
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
 					action={ translate( 'Continue' ) }
-					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php` }
+					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
 				/>
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR redirects directly to the upload tab of WP Admin instead of the generic plugin install screen

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* in an Atomic site install a wporg plugin
* go to `https://wordpress.com/plugins/upload/[DOMAIN]` and try uploading a zip file of the same plugin
* you should get `This plugin already exists on your site. If you want to upgrade or downgrade the plugin, please continue by uploading the plugin again from WP Admin.` 
* click continue
* you should get redirected to WP Admin plugin upload screen

|Before | After|
|-------|------|
|<img width="1016" alt="SS 2022-01-28 at 20 07 05" src="https://user-images.githubusercontent.com/12430020/151598973-381c12ba-06e7-4cde-9935-8f6dde734bb1.png">|<img width="1021" alt="SS 2022-01-28 at 20 06 46" src="https://user-images.githubusercontent.com/12430020/151598947-d0da29c8-a746-48be-9589-66281da3b9a9.png">|

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related convo p1643334871230049-slack-C03TY6J1A