### PR TITLE
Domains: Update free domain with annual plan nudge flow

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -346,7 +346,7 @@ export class PlanFeatures extends Component {
 		let buttonText = null;
 		let forceDisplayButton = false;
 
-		if ( redirectToAddDomainFlow ) {
+		if ( redirectToAddDomainFlow === true ) {
 			buttonText = translate( 'Add to Cart' );
 			forceDisplayButton = true;
 		}
@@ -591,7 +591,7 @@ export class PlanFeatures extends Component {
 			return;
 		}
 
-		if ( redirectToAddDomainFlow ) {
+		if ( redirectToAddDomainFlow === true ) {
 			// In this flow, we add the product to the cart directly and then
 			// redirect to the "add a domain" page.
 			shoppingCartManager

--- a/client/my-sites/plan-features/plan-features-action-wrapper.jsx
+++ b/client/my-sites/plan-features/plan-features-action-wrapper.jsx
@@ -42,7 +42,7 @@ export default function PlanFeaturesActionsWrapper( {
 		}
 	}
 
-	if ( redirectToAddDomainFlow ) {
+	if ( redirectToAddDomainFlow === true ) {
 		buttonText = translate( 'Add to Cart' );
 		forceDisplayButton = true;
 	}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -411,7 +411,7 @@ export class PlansFeaturesMain extends Component {
 
 		// In the "purchase a plan and free domain" flow we do not want to show
 		// monthly plans because monthly plans do not come with a free domain.
-		if ( redirectToAddDomainFlow ) {
+		if ( redirectToAddDomainFlow !== undefined ) {
 			hidePlanSelector = true;
 		}
 

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -34,7 +34,11 @@ export function plans( context, next ) {
 			withDiscount={ context.query.discount }
 			discountEndDate={ context.query.ts }
 			redirectTo={ context.query.redirect_to }
-			redirectToAddDomainFlow={ context.query.addDomainFlow }
+			redirectToAddDomainFlow={
+				context.query.addDomainFlow !== undefined
+					? context.query.addDomainFlow === 'true'
+					: undefined
+			}
 		/>
 	);
 	next();


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the "free domain with an annual plan" nudge (shown for sites which do not have a plan) flow when the `addDomainFlow` parameter is present.

<img width="576" alt="screen-shot-2022-01-07-at-10 48 53-am-1-1-1" src="https://user-images.githubusercontent.com/5324818/151603727-b4dfb12f-960e-4dcf-a299-d70bbaec88c0.png">

- If the `addDomainFlow` parameter is set to `true`, things should remain as they currently are: after the user clicks the CTA button they'll be taken to the plan selection page, then to the domain selection page and finally to checkout
- If it's set to `false`, the user is taken to the plan selection page and straight to checkout after that, like if they had gone to the "Upgrades > Plans" page. The important difference is that the plan selection page should hide monthly plans, as they do not have a free bundled domain with them. Another small difference is that the buttons should read "Upgrade" instead of "Add to cart"

Screenshot of plan selection screen with `addDomainFlow=true` (notice the "Add to cart" button labels):

<img width="1076" alt="Screen Shot 2022-01-28 at 16 09 09" src="https://user-images.githubusercontent.com/5324818/151606913-99cdb7cf-aa82-451d-8de8-2254b353c4ad.png">

Screenshot of plan selection screen with `addDomainFlow=false` (buttons read "Upgrade"):

<img width="1092" alt="Screen Shot 2022-01-28 at 15 25 59" src="https://user-images.githubusercontent.com/5324818/151606709-d5fb75ed-de80-4b2b-8b88-c4d9afc78b29.png">

Screenshot of plan selection screen without `addDomainFlow` query parameter (monthly or annual plan toggle is present):

![Markup on 2022-01-28 at 15:27:59](https://user-images.githubusercontent.com/5324818/151606996-6831d668-4d83-4d52-8d85-f6de53d3187f.png)

This update is required to make sure experiment pbxNRc-1iT-p2 is testing the right hypothesis.

### Testing instructions

- Build this branch locally or open the live Calypso link
- Select a site which doesn't have a plan and go to Upgrades > Plans
- Append `?addDomainFlow=false` to your URL
- Ensure that:
    - There's no "monthly/annual" toggle
    - Buttons read "Upgrade" and
    - When you select a plan, you are taken to the checkout screen
- Please test with `?addDomainFlow=true` too - in this case, after you select a plan, you should be taken to the domain search page
