### PR TITLE
Themes: Update Trending Themes to Typescript

### DIFF
--- a/client/my-sites/themes/current-theme/index.tsx
+++ b/client/my-sites/themes/current-theme/index.tsx
@@ -8,6 +8,7 @@ import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { IAppState } from 'calypso/state/types';
 import { CanonicalTheme } from 'calypso/types';
 import { trackClick } from '../helpers';
 import { connectOptions } from '../theme-options';
@@ -169,7 +170,7 @@ const CurrentThemeWithOptions = ( {
 	/>
 );
 
-export default connect( ( state, { siteId }: { siteId: number } ) => {
+export default connect( ( state: IAppState, { siteId }: { siteId: number } ) => {
 	const currentThemeId = getActiveTheme( state, siteId );
 	return {
 		currentThemeId,

--- a/client/my-sites/themes/current-theme/index.tsx
+++ b/client/my-sites/themes/current-theme/index.tsx
@@ -8,7 +8,7 @@ import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
-import { Theme } from 'calypso/types';
+import { CanonicalTheme } from 'calypso/types';
 import { trackClick } from '../helpers';
 import { connectOptions } from '../theme-options';
 
@@ -25,7 +25,7 @@ interface Option {
 }
 
 interface CurrentThemeProps {
-	currentTheme: Theme | null;
+	currentTheme: CanonicalTheme | null;
 	currentThemeId: string | null;
 	name: string;
 	options: Record< string, Option >;
@@ -157,7 +157,7 @@ const CurrentThemeWithOptions = ( {
 	currentTheme,
 	currentThemeId,
 }: {
-	currentTheme: Theme | null;
+	currentTheme: CanonicalTheme | null;
 	currentThemeId: string | null;
 	siteId: number;
 } ) => (

--- a/client/my-sites/themes/trending-themes.tsx
+++ b/client/my-sites/themes/trending-themes.tsx
@@ -5,16 +5,25 @@ import {
 	getTrendingThemes as getTrendingThemesSelector,
 	areTrendingThemesLoading,
 } from 'calypso/state/themes/selectors';
+import { TrendingTheme, TrendingThemesFilter } from 'calypso/types';
 import { ConnectedThemesSelection } from './themes-selection';
 
-class TrendingThemes extends Component {
+interface TrendingThemesProps {
+	customizedThemesList: TrendingTheme[];
+	filter: TrendingThemesFilter;
+	getTrendingThemes: ( filter: TrendingThemesFilter ) => Promise< void >;
+	isLoading: boolean;
+	scrollToSearchInput: () => void;
+}
+
+class TrendingThemes extends Component< TrendingThemesProps > {
 	componentDidMount() {
 		if ( ! this.props.customizedThemesList.length ) {
 			this.fetchThemes();
 		}
 	}
 
-	componentDidUpdate( prevProps ) {
+	componentDidUpdate( prevProps: { isLoading: boolean; filter: TrendingThemesFilter } ) {
 		// Wait until rec themes to be loaded to scroll to search input if its in use.
 		const { isLoading, scrollToSearchInput, filter } = this.props;
 		if ( prevProps.isLoading !== isLoading && isLoading === false ) {

--- a/client/my-sites/themes/trending-themes.tsx
+++ b/client/my-sites/themes/trending-themes.tsx
@@ -23,7 +23,7 @@ class TrendingThemes extends Component< TrendingThemesProps > {
 		}
 	}
 
-	componentDidUpdate( prevProps: { isLoading: boolean; filter: TrendingThemesFilter } ) {
+	componentDidUpdate( prevProps: TrendingThemesProps ) {
 		// Wait until rec themes to be loaded to scroll to search input if its in use.
 		const { isLoading, scrollToSearchInput, filter } = this.props;
 		if ( prevProps.isLoading !== isLoading && isLoading === false ) {

--- a/client/my-sites/themes/trending-themes.tsx
+++ b/client/my-sites/themes/trending-themes.tsx
@@ -11,7 +11,7 @@ import { ConnectedThemesSelection } from './themes-selection';
 interface TrendingThemesProps {
 	customizedThemesList: TrendingTheme[];
 	filter: TrendingThemesFilter;
-	getTrendingThemes: ( filter: TrendingThemesFilter ) => Promise< void >;
+	getTrendingThemes: () => Promise< void >;
 	isLoading: boolean;
 	scrollToSearchInput: () => void;
 }
@@ -35,7 +35,7 @@ class TrendingThemes extends Component< TrendingThemesProps > {
 	}
 
 	fetchThemes() {
-		this.props.getTrendingThemes( this.props.filter );
+		this.props.getTrendingThemes();
 	}
 
 	render() {

--- a/client/state/themes/actions/trending-themes.ts
+++ b/client/state/themes/actions/trending-themes.ts
@@ -1,10 +1,11 @@
+import { Dispatch } from 'redux';
 import wpcom from 'calypso/lib/wp';
 import {
 	TRENDING_THEMES_FAIL,
 	TRENDING_THEMES_FETCH,
 	TRENDING_THEMES_SUCCESS,
 } from 'calypso/state/themes/action-types';
-import { TrendingTheme, TrendingThemesFilter } from 'calypso/types';
+import { TrendingTheme } from 'calypso/types';
 
 import 'calypso/state/themes/init';
 
@@ -14,7 +15,7 @@ import 'calypso/state/themes/init';
  * @param {Array} themes array of received theme objects
  * @returns {Function} Action thunk
  */
-export function receiveTrendingThemes( themes: TrendingTheme[] ): ( dispatch: any ) => void {
+export function receiveTrendingThemes( themes: TrendingTheme[] ): ( dispatch: Dispatch ) => void {
 	return ( dispatch ) => {
 		dispatch( { type: TRENDING_THEMES_SUCCESS, payload: themes } );
 	};
@@ -22,14 +23,10 @@ export function receiveTrendingThemes( themes: TrendingTheme[] ): ( dispatch: an
 
 /**
  * Initiates network request for trending themes.
- *
- * @param {TrendingThemesFilter} filter A filter string for a theme query
  */
-export function getTrendingThemes(
-	filter: TrendingThemesFilter
-): ( dispatch: any ) => Promise< void > {
+export function getTrendingThemes(): ( dispatch: any ) => Promise< void > {
 	return async ( dispatch ) => {
-		dispatch( { type: TRENDING_THEMES_FETCH, filter } );
+		dispatch( { type: TRENDING_THEMES_FETCH } );
 		try {
 			const res = await wpcom.req.get( '/themes', {
 				sort: 'trending',

--- a/client/state/themes/actions/trending-themes.ts
+++ b/client/state/themes/actions/trending-themes.ts
@@ -4,6 +4,7 @@ import {
 	TRENDING_THEMES_FETCH,
 	TRENDING_THEMES_SUCCESS,
 } from 'calypso/state/themes/action-types';
+import { TrendingTheme, TrendingThemesFilter } from 'calypso/types';
 
 import 'calypso/state/themes/init';
 
@@ -13,7 +14,7 @@ import 'calypso/state/themes/init';
  * @param {Array} themes array of received theme objects
  * @returns {Function} Action thunk
  */
-export function receiveTrendingThemes( themes ) {
+export function receiveTrendingThemes( themes: TrendingTheme[] ): ( dispatch: any ) => void {
 	return ( dispatch ) => {
 		dispatch( { type: TRENDING_THEMES_SUCCESS, payload: themes } );
 	};
@@ -22,10 +23,11 @@ export function receiveTrendingThemes( themes ) {
 /**
  * Initiates network request for trending themes.
  *
- * @param {string} filter A filter string for a theme query
- * @returns {Function} Action thunk
+ * @param {TrendingThemesFilter} filter A filter string for a theme query
  */
-export function getTrendingThemes( filter ) {
+export function getTrendingThemes(
+	filter: TrendingThemesFilter
+): ( dispatch: any ) => Promise< void > {
 	return async ( dispatch ) => {
 		dispatch( { type: TRENDING_THEMES_FETCH, filter } );
 		try {

--- a/client/state/themes/selectors/get-canonical-theme.js
+++ b/client/state/themes/selectors/get-canonical-theme.js
@@ -1,6 +1,6 @@
 import { find } from 'lodash';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
-import { Theme } from 'calypso/types';
+import { CanonicalTheme } from 'calypso/types';
 import 'calypso/state/themes/init';
 
 /**
@@ -39,7 +39,7 @@ export const knownConflictingThemes = new Set( [ 'bistro' ] );
  * @param  {object}  state   Global state tree
  * @param  {number}  siteId  Jetpack Site ID to fall back to
  * @param  {string | null}  themeId Theme ID
- * @returns {?Theme}         Theme object
+ * @returns {?CanonicalTheme}         Theme object
  */
 export function getCanonicalTheme( state, siteId, themeId ) {
 	let searchOrder = [ 'wpcom', 'wporg', siteId ];

--- a/client/state/themes/selectors/get-canonical-theme.ts
+++ b/client/state/themes/selectors/get-canonical-theme.ts
@@ -1,6 +1,6 @@
 import { find } from 'lodash';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
-import { CanonicalTheme } from 'calypso/types';
+import { IAppState } from 'calypso/state/types';
 import 'calypso/state/themes/init';
 
 /**
@@ -35,15 +35,10 @@ export const knownConflictingThemes = new Set( [ 'bistro' ] );
  * the one with richest information. Checks WP.com (which has a long description
  * and multiple screenshots, and a preview URL) first, then WP.org (which has a
  * preview URL), then the given JP site.
- *
- * @param  {object}  state   Global state tree
- * @param  {number}  siteId  Jetpack Site ID to fall back to
- * @param  {string | null}  themeId Theme ID
- * @returns {?CanonicalTheme}         Theme object
  */
-export function getCanonicalTheme( state, siteId, themeId ) {
+export function getCanonicalTheme( state: IAppState, siteId: number, themeId: string | null ) {
 	let searchOrder = [ 'wpcom', 'wporg', siteId ];
-	if ( knownConflictingThemes.has( themeId ) ) {
+	if ( themeId && knownConflictingThemes.has( themeId ) ) {
 		searchOrder = [ siteId, 'wpcom', 'wporg' ];
 	}
 

--- a/client/state/themes/selectors/get-trending-themes.js
+++ b/client/state/themes/selectors/get-trending-themes.js
@@ -1,6 +1,7 @@
 import 'calypso/state/themes/init';
 import { arePremiumThemesEnabled } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { TrendingTheme } from 'calypso/types';
 
 const emptyList = [];
 
@@ -8,7 +9,7 @@ const emptyList = [];
  * Gets the list of trending themes.
  *
  * @param {object} state Global state tree
- * @returns {Array} the list of trending themes
+ * @returns {TrendingTheme[]} the list of trending themes
  */
 export function getTrendingThemes( state ) {
 	if ( ! state.themes.trendingThemes?.themes ) {

--- a/client/types.ts
+++ b/client/types.ts
@@ -22,34 +22,60 @@ export type PostType = 'page' | 'post' | string;
 export interface Theme {
 	author: string;
 	author_uri: string;
-	cost: ThemeCost;
 	date_launched: string;
 	date_updated: string;
 	demo_uri: string;
 	description: string;
-	descriptionLong: string;
-	download: string;
-	download_url: string;
 	id: string;
-	launch_date: string;
-	license: string;
-	license_uri: string;
 	name: string;
-	next: string;
-	popularity_rank: string;
-	preview_url: string;
+	price: {
+		value: number;
+		currency: string;
+		display: string;
+	};
+	rank_popularity: string;
+	rank_trending: string;
 	screenshot: string;
 	screenshots: string[];
 	stylesheet: string;
-	supportDocumentation: string;
-	tags: string[];
 	taxonomies?: {
 		theme_feature?: ThemeFeature[];
 	};
 	template: string;
 	theme_uri: string;
-	trending_rank: number;
 	version: string;
+}
+
+export interface CanonicalTheme extends Theme {
+	cost: ThemeCost;
+	descriptionLong: string;
+	download: string;
+	download_url: string;
+	launch_date: string;
+	license: string;
+	license_uri: string;
+	next: string;
+	popularity_rank: string;
+	preview_url: string;
+	supportDocumentation: string;
+	tags: string[];
+	trending_rank: number;
+}
+
+export interface TrendingTheme extends Theme {
+	date_launched: string;
+	date_updated: string;
+	demo_uri: string;
+	description: string;
+	id: string;
+	language: string;
+	price: {
+		value: number;
+		currency: string;
+		display: string;
+	};
+	rank_popularity: string;
+	rank_trending: string;
 }
 
 interface ThemeCost {
@@ -62,6 +88,10 @@ interface ThemeFeature {
 	name: string;
 	slug: string;
 	term_id: string;
+}
+
+export interface TrendingThemesFilter {
+	filter: string | undefined;
 }
 
 // Comment stuff

--- a/client/types.ts
+++ b/client/types.ts
@@ -39,7 +39,7 @@ export interface Theme {
 	screenshots: string[];
 	stylesheet: string;
 	taxonomies?: {
-		theme_feature?: ThemeFeature[];
+		theme_feature: ThemeFeature[];
 	};
 	template: string;
 	theme_uri: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Convert Trending Themes component jsx and related files to typescript

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open files in the editor and ensure no typescript errors are being thrown

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

https://github.com/Automattic/wp-calypso/issues/6053