### PR TITLE
Restore the use of monthlyItemCost as the default crossed out price value on Jetpack pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -129,6 +129,7 @@ const useItemPrice = (
 		? sitePrices.isFetching
 		: listPrices.isFetching || introductoryOfferPrices.isFetching;
 	const itemCost = siteId ? sitePrices.itemCost : listPrices.itemCost;
+	const monthlyItemCost = siteId ? sitePrices.monthlyItemCost : listPrices.monthlyItemCost;
 
 	const priceTierList = useMemo(
 		() => ( siteId ? sitePrices.priceTierList : listPrices.priceTierList ),
@@ -149,7 +150,7 @@ const useItemPrice = (
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
 		if ( item.term !== TERM_MONTHLY ) {
-			originalPrice = getMonthlyPrice( itemCost );
+			originalPrice = monthlyItemCost ?? getMonthlyPrice( itemCost );
 			discountedPrice = introductoryOfferPrices.introOfferCost
 				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
 				: undefined;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts a change made in https://github.com/Automattic/wp-calypso/pull/60212, that removed the use of item's explicitly set monthly cost as the strikethrough price.

Based on this discussion from last month: p1639142664050800-slack-CQXNTE9K9

#### Testing instructions

* Check out this PR and open http://jetpack.cloud.localhost:3000/pricing
* Note the values of the crossed out prices
* Check out c08735d229a042dc9e4e4831256d831069f21340 (the commit prior to the removal of `monthlyItemCost`
* Validate the crossed out prices match this PR
* Run tests