### PR TITLE
Update Happiness Bug Report template with matrix.

### DIFF
--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -121,7 +121,18 @@ body:
         ---
 
         <br>
-  - type: dropdown
+  - type: markdown
+    attributes:
+      value: |
+        | A | All users | Most users (>%50) | Some users (<50%) | One user |
+        | Platform unusable | [Pri] BLOCKER | [Pri] BLOCKER | [Pri] BLOCKER | [Pri] High |
+        | Hard blocking, no workaround | [Pri] High | [Pri] High | [Pri] High | [Pri] High |
+        | Difficult workaround | [Pri] High | [Pri] Normal | [Pri] Normal | [Pri] Normal |
+        | Easy workaround | [Pri] Normal | [Pri] Normal | [Pri] Low | [Pri] Low |
+        | No user impact | [Pri] Normal | [Pri] Normal | [Pri] Low | [Pri] Low |
+
+        For the source, please refer to pciE2j-oG-p2.
+    - type: dropdown
     id: reproducibility
     attributes:
       label: Reproducibility

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -121,6 +121,7 @@ body:
         ---
 
         | ↓ Blocking Level/Visibility →| All users | Most users (>%50) | Some users (<50%) | One user |
+        | --- | --- | --- | --- | --- |
         | Platform unusable | [Pri] BLOCKER | [Pri] BLOCKER | [Pri] BLOCKER | [Pri] High |
         | Hard blocking, no workaround | [Pri] High | [Pri] High | [Pri] High | [Pri] High |
         | Difficult workaround | [Pri] High | [Pri] Normal | [Pri] Normal | [Pri] Normal |

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -120,11 +120,7 @@ body:
 
         ---
 
-        <br>
-  - type: markdown
-    attributes:
-      value: |
-        | A | All users | Most users (>%50) | Some users (<50%) | One user |
+        | ↓ Blocking Level/Visibility →| All users | Most users (>%50) | Some users (<50%) | One user |
         | Platform unusable | [Pri] BLOCKER | [Pri] BLOCKER | [Pri] BLOCKER | [Pri] High |
         | Hard blocking, no workaround | [Pri] High | [Pri] High | [Pri] High | [Pri] High |
         | Difficult workaround | [Pri] High | [Pri] Normal | [Pri] Normal | [Pri] Normal |
@@ -132,7 +128,9 @@ body:
         | No user impact | [Pri] Normal | [Pri] Normal | [Pri] Low | [Pri] Low |
 
         For the source, please refer to pciE2j-oG-p2.
-    - type: dropdown
+
+        <br>
+  - type: dropdown
     id: reproducibility
     attributes:
       label: Reproducibility


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a markdown version of the bug matrix, documented at pciE2j-oG-p2 into the Happiness Bug Report template.

#### Testing instructions

Ensure the [template](https://github.com/Automattic/wp-calypso/blob/update/happiness-bug-report-matrix/.github/ISSUE_TEMPLATE/happiness-bug-report.yml) renders.

