### PR TITLE
App Banner: Use the current route to display open up the iOS Gutenberg editor correctly

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -212,12 +212,16 @@ export function getiOSDeepLink( currentRoute, currentSection ) {
 
 	return fragment.length > 0 ? `${ baseURI }#${ fragment }` : baseURI;
 }
-
+/**
+ * Returns the universal link that then gets used to send the user to the correct editor.
+ * If the app is installed otherwise they will end up on the new site creaton flow after creating an account.
+ *
+ * @param {string} currentRoute
+ * @returns string
+ */
 function getEditorPath( currentRoute ) {
-	const paths = currentRoute.split( '/' );
-	// if ( paths[ 0 ] && paths[ 1 ] && paths[ 2 ] ) {
-	// 	return '/' + paths[ 0 ] + '/' + paths[ 1 ] + '/' + paths[ 2 ];
-	// }
+	const paths = currentRoute.split( '/' ).filter( ( path ) => path );
+
 	if ( paths[ 0 ] && paths[ 1 ] ) {
 		return '/' + paths[ 0 ] + '/' + paths[ 1 ];
 	}

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -219,7 +219,7 @@ export function buildDeepLinkFragment( currentRoute, currentSection ) {
 	const getFragment = () => {
 		switch ( currentSection ) {
 			case GUTENBERG:
-				return '/post';
+				return currentRoute;
 			case NOTES:
 				return '/notifications';
 			case READER:

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -213,13 +213,27 @@ export function getiOSDeepLink( currentRoute, currentSection ) {
 	return fragment.length > 0 ? `${ baseURI }#${ fragment }` : baseURI;
 }
 
+function getEditorPath( currentRoute ) {
+	const paths = currentRoute.split( '/' );
+	// if ( paths[ 0 ] && paths[ 1 ] && paths[ 2 ] ) {
+	// 	return '/' + paths[ 0 ] + '/' + paths[ 1 ] + '/' + paths[ 2 ];
+	// }
+	if ( paths[ 0 ] && paths[ 1 ] ) {
+		return '/' + paths[ 0 ] + '/' + paths[ 1 ];
+	}
+	if ( paths[ 0 ] ) {
+		return '/' + paths[ 0 ];
+	}
+	return '/post';
+}
+
 export function buildDeepLinkFragment( currentRoute, currentSection ) {
 	const hasRoute = currentRoute !== null && currentRoute !== '/';
 
 	const getFragment = () => {
 		switch ( currentSection ) {
 			case GUTENBERG:
-				return currentRoute;
+				return getEditorPath( currentRoute );
 			case NOTES:
 				return '/notifications';
 			case READER:

--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -4,7 +4,7 @@ import { includes } from 'lodash';
 import {
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
 	ALLOWED_SECTIONS,
-	isDismissed,
+	// isDismissed,
 	getCurrentSection,
 } from 'calypso/blocks/app-banner/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
@@ -50,8 +50,8 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 		return false;
 	}
 
-	const dismissedUntil = getPreference( state, APP_BANNER_DISMISS_TIMES_PREFERENCE );
-	const dismissed = isDismissed( dismissedUntil, currentSection );
+	// const dismissedUntil = getPreference( state, APP_BANNER_DISMISS_TIMES_PREFERENCE );
+	const dismissed = false; // isDismissed( dismissedUntil, currentSection );
 
 	return isMobile() && ! isWpMobileApp() && ! dismissed;
 };

--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -4,7 +4,7 @@ import { includes } from 'lodash';
 import {
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
 	ALLOWED_SECTIONS,
-	// isDismissed,
+	isDismissed,
 	getCurrentSection,
 } from 'calypso/blocks/app-banner/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
@@ -50,8 +50,8 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 		return false;
 	}
 
-	// const dismissedUntil = getPreference( state, APP_BANNER_DISMISS_TIMES_PREFERENCE );
-	const dismissed = false; // isDismissed( dismissedUntil, currentSection );
+	const dismissedUntil = getPreference( state, APP_BANNER_DISMISS_TIMES_PREFERENCE );
+	const dismissed = isDismissed( dismissedUntil, currentSection );
 
 	return isMobile() && ! isWpMobileApp() && ! dismissed;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR intends to fix the App banner that appears in the Gutenberg editor. 
Hopefully this will fix 
1. The link in the banner should open up the correct for the correct post type: page or post
2. The link in the banner should open up for the correct site

#### Testing instructions

Use the QR code provided. 
Does clicking the banner open the page in the mobile app as expected. 

Currently opening the correct post/page is not supported on the mobile side :( yet. 

Related https://github.com/wordpress-mobile/WordPress-iOS/pull/13707
Makes me think that this should work for pages. 


