### PR TITLE
Site editor: only use wp-admin if not Gutenframe eligible

### DIFF
--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -1,4 +1,4 @@
-import { shouldLoadGutenframe } from 'calypso/state/selectors/should-load-gutenframe';
+import isEligibleForGutenframe from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
 import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
 
 /**
@@ -11,7 +11,7 @@ import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
 export const getSiteEditorUrl = ( state, siteId ) => {
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 
-	if ( ! shouldLoadGutenframe( state, siteId ) ) {
+	if ( ! isEligibleForGutenframe( state, siteId ) ) {
 		return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prevents using the Site editor in wp-admin (rather than the Calypso iframe) because you've previously visited the post lists in wp-admin.

`getPreferredEditorView` (https://github.com/Automattic/wp-calypso/blob/ed605c861a0363155c28d4738a6333e720401ba2/client/state/selectors/get-preferred-editor-view.js) will return `classic` if you've last visited the posts list in wp-admin (a.k.a the "Classic view").

<img width="913" alt="image" src="https://user-images.githubusercontent.com/1699996/151639886-10839393-f334-4b93-bb0e-ce0a922625ef.png">

Then the `shouldLoadGutenframe` check will fail (https://github.com/Automattic/wp-calypso/blob/ed605c861a0363155c28d4738a6333e720401ba2/client/state/selectors/should-load-gutenframe.js), and cause the `getSiteEditorUrl` selector to return the wp-admin version (https://github.com/Automattic/wp-calypso/blob/ed605c861a0363155c28d4738a6333e720401ba2/client/state/selectors/get-site-editor-url.js).

Using the posts list in wp-admin doesn't seem like a good indicator for loading the Site editor in wp-admin vs Calypso, so this change updates the check for strictly Gutenberg eligibility (which checks things like if plugins installed on Atomic/Jetpack sites known to be incompatible with the block editor).

#### Testing instructions

* On an FSE eligible site with a block theme activated, visit the classic view of the posts lists (see the Screen options at the top of the Posts list page)
* Then go to Appearance > Themes
* The Edit link at the top should go to `/site-editor/{site}`

<img width="612" alt="image" src="https://user-images.githubusercontent.com/1699996/151640576-4abebd26-5068-41ad-bcca-a527712f251a.png">

Related to #60591
