### PR TITLE
Gutenboarding: add Livro theme to design picker

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -912,6 +912,16 @@
 			"is_premium": false,
 			"is_fse": true,
 			"features": []
+		},
+		{
+			"title": "Livro",
+			"slug": "livro",
+			"template": "livro",
+			"theme": "livro",
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
+			"is_premium": false,
+			"is_fse": true,
+			"features": []
 		}
 	]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the recently launched Livro theme to the /new (FSE) design choices

#### Testing instructions

* Create a new site from /new and choose Livro as the design
* Ensure the site looks as expected

Note that this theme doesn't currently have starter content, see recent internal discussion about that: pNEWy-eFy-p2