### PR TITLE
Purchases: fix Paypal button background and adjust button width

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .payment-method-selector__terms {
 	color: var( --color-text-subtle );
 	margin: 5px 0 0;
@@ -39,9 +42,13 @@
 	}
 
 	.checkout-submit-button .checkout-button {
-		width: auto;
+		@include break-mobile {
+			width: auto;
+		}
 
-		background-color: var( --color-accent );
+		&:not( .is-status-paypal ) {
+			background-color: var( --color-accent );
+		}
 
 		&:focus {
 			outline: var( --color-primary-light ) solid 2px;


### PR DESCRIPTION
This fixes a visual regression that was introduced in #59324, where the Paypal button's background color is being set to the color scheme's accent color. I think this problem ultimately resides in the way we're styling buttons in the `@automattic/composite-checkout` package (which was built before Calypso's color schemes were released), but that's a much bigger change to make.

Fixes: #60635

**To test Calypso:**
- Purchase a plan with a credit card
- Visit `/me/purchases` and select the plan
- Click "change payment method"
- Verify that the submit button on this page looks correct (with the accent color)
- On a mobile device, verify that the submit button is full-width
- Click the Paypal radio button
- Verify that the submit button has the correct yellow background color
- On a mobile device, verify that the submit button is full-width

**To test Jetpack Cloud:**
- Purchase a Jetpack subscription with a credit card
- Click "Purchases" in the sidebar and select the subscriptions
- Click "change payment method"
- Verify that the submit button on this page looks correct (with the accent color)
- On a mobile device, verify that the submit button is full-width
- Click the Paypal radio button
- Verify that the submit button has the correct yellow background color
- On a mobile device, verify that the submit button is full-width