### PR TITLE
Escape all parentheses in theme titles when rendering design picker

### DIFF
--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -166,10 +166,10 @@ describe( 'Design Picker design utils', () => {
 		// in a `background-url: url( ... )` CSS rule the parentheses will break it.
 		it( 'escapes parentheses within the site title', () => {
 			const mockDesign = availableDesignsConfig.featured[ 0 ];
-			mockDesign.title = 'Mock(Design)';
+			mockDesign.title = 'Mock(Design)(Title)';
 
 			expect( getDesignUrl( mockDesign, mockLocale ) ).toEqual(
-				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesign.stylesheet }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true&site_title=Mock%28Design%29`
+				`https://public-api.wordpress.com/rest/v1.1/template/demo/${ mockDesign.stylesheet }/${ mockDesign.template }?font_headings=${ mockDesign.fonts.headings }&font_base=${ mockDesign.fonts.base }&viewport_height=700&language=${ mockLocale }&use_screenshot_overrides=true&site_title=Mock%28Design%29%28Title%29`
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -34,7 +34,7 @@ export const getDesignUrl = (
 		// parentheses so we've got to do it ourselves.
 		url +=
 			'&site_title=' +
-			encodeURIComponent( design.title ).replace( '(', '%28' ).replace( ')', '%29' );
+			encodeURIComponent( design.title ).replace( /\(/g, '%28' ).replace( /\)/g, '%29' );
 	}
 
 	return url;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up to #60596 which fixed rendering of design picker by correctly escaping site titles in PTK URLs.

@tyxla pointed out (https://github.com/Automattic/wp-calypso/pull/60596#discussion_r794394125) that the fix would only escape the _first_ set of parentheses. It still worked fine for now because no theme title currently has multiple pairs of parentheses.

This diff tidies up the escaping so that it will work for the general case.

Today I learned there is a new `String.prototype.replaceAll()` method that will do a global replace. However, our project linter errors when I tried to use it. [It's available in all evergreen browsers](https://caniuse.com/?search=replaceAll) so _should_ be fine. But I guess it's possible that there are older android devices that might not support it. So I'll just trust the linter.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test at `/start/setup-site?siteSlug=<< site slug >>` where the test site is one that's enrolled in FSE (if you create a site using `calypso.localhost:3000` or using the `/new` flow then your site is guaranteed to be enrolled in FSE)
* Unit tests pass

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


