### PR TITLE
Design Picker: Tidy up unit test warnings

### DIFF
--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -44,6 +44,7 @@ describe( '<DesignPicker /> integration', () => {
 		const firstDesignButton = screen.getAllByRole( 'button' )[ 0 ];
 		expect( firstDesignButton ).toHaveTextContent( /blank\scanvas/i );
 	} );
+
 	( [ 'light', 'dark' ] as DesignPickerProps[ 'theme' ][] ).forEach( ( theme ) =>
 		it( `Should have design-picker--theme-${ theme } class when theme prop is set to ${ theme }`, () => {
 			const mockedOnSelectCallback = jest.fn();

--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -27,7 +27,13 @@ describe( '<DesignPicker /> integration', () => {
 	it( 'should select a design', async () => {
 		const mockedOnSelectCallback = jest.fn();
 
-		render( <DesignPicker locale={ MOCK_LOCALE } onSelect={ mockedOnSelectCallback } /> );
+		render(
+			<DesignPicker
+				locale={ MOCK_LOCALE }
+				onSelect={ mockedOnSelectCallback }
+				recommendedCategorySlug={ null }
+			/>
+		);
 
 		fireEvent.click( screen.getByLabelText( new RegExp( MOCK_DESIGN_TITLE, 'i' ) ) );
 
@@ -39,7 +45,13 @@ describe( '<DesignPicker /> integration', () => {
 	} );
 
 	it( 'should show Blank Canvas designs as the first design', async () => {
-		render( <DesignPicker locale={ MOCK_LOCALE } onSelect={ jest.fn() } /> );
+		render(
+			<DesignPicker
+				locale={ MOCK_LOCALE }
+				onSelect={ jest.fn() }
+				recommendedCategorySlug={ null }
+			/>
+		);
 
 		const firstDesignButton = screen.getAllByRole( 'button' )[ 0 ];
 		expect( firstDesignButton ).toHaveTextContent( /blank\scanvas/i );
@@ -50,7 +62,12 @@ describe( '<DesignPicker /> integration', () => {
 			const mockedOnSelectCallback = jest.fn();
 
 			const renderedContainer = render(
-				<DesignPicker locale={ MOCK_LOCALE } theme={ theme } onSelect={ mockedOnSelectCallback } />
+				<DesignPicker
+					locale={ MOCK_LOCALE }
+					theme={ theme }
+					onSelect={ mockedOnSelectCallback }
+					recommendedCategorySlug={ null }
+				/>
 			);
 
 			expect( renderedContainer.container.firstChild ).toHaveClass(

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -14,6 +14,7 @@ import {
 	isBlankCanvasDesign,
 	filterDesignsByCategory,
 	sortDesigns,
+	excludeFseDesigns,
 } from '../utils';
 import { DesignPickerCategoryFilter } from './design-picker-category-filter';
 import type { Categorization } from '../hooks/use-categorization';
@@ -234,7 +235,8 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	onPreview,
 	onUpgrade,
 	designs = getAvailableDesigns( {
-		featuredDesignsFilter: ( design ) => ! design.features.includes( 'anchorfm' ),
+		featuredDesignsFilter: ( design ) =>
+			! design.features.includes( 'anchorfm' ) && excludeFseDesigns( design ),
 	} ).featured,
 	premiumBadge,
 	isGridMinimal,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A new required `recommendedCategorySlug` prop was added in #60415. It feels like the prop could be optional, but this fixes the TypeScript error in `integration.test.tsx` because of the missing prop.

Multiple "duplicate key" warnings were introduced to the tests when duplicate theme slugs started to be added to `available-designs-config.json` (e.g. #59361). This is because Gutenboarding wants to have FSE and non-FSE versions of each theme. I could have fixed this by appending the `is_fse` value to the `key` prop, but in the real world, all uses of the `<DesignPicker>` are filtering the themes so that no duplicate themes are displayed. I figured it was better to just do the same filtering of the theme list used by the tests.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `integration.test.tsx` in your editor and see there's no TS errors
* `yarn test-packages ./packages/design-picker/src/__tests__/integration.test.tsx` was displaying React warnings about duplicate keys, but it no longer does.

Before:
<img width="1019" alt="Screenshot 2022-01-31 at 11 32 57 AM" src="https://user-images.githubusercontent.com/1500769/151721820-23bfcea1-2196-423d-9bfe-1c87cf094fa8.png">

After:
<img width="1019" alt="Screenshot 2022-01-31 at 11 33 49 AM" src="https://user-images.githubusercontent.com/1500769/151721832-836fdcaf-bf91-41b4-92bb-05c1d19da4c9.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


