### PR TITLE
Add margin after my-sites' heading when there are no primary cards

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -98,6 +98,10 @@ body.is-section-home.theme-default.color-scheme {
 	
 }
 
+.customer-home__heading + .customer-home__layout {
+	margin-top: 24px;
+}
+
 .customer-home__layout {
 	@include grid-row( 4, 1 );
 	@include breakpoint-deprecated( '>1040px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, when there are no primary cards, the design on my-sites looks cramped (the heading and the content sections are too close without visual separator).

This PR adds some margin to indicate a visual separator between them.

#### Testing instructions

1. Open a site which has primary cards.
    - Verify that there are no visual changes.
       
       ![image](https://user-images.githubusercontent.com/1525580/151732219-8b467bd9-4677-4481-a721-af28635616c4.png)

2. Next, open a site which has no primary cards.
    - Verify that now there is a margin between site heading and the content.
        
       ![image](https://user-images.githubusercontent.com/1525580/151732450-72985a9a-afdc-4488-9b91-6df268709261.png)

Related to #54737
