### PR TITLE
Themes: Convert themes helpers to typescript

### DIFF
--- a/client/my-sites/themes/helpers.ts
+++ b/client/my-sites/themes/helpers.ts
@@ -16,7 +16,16 @@ interface ThemeOption {
 }
 
 interface ThemeOptions {
-	[ key: string ]: ThemeOption;
+	activate: ThemeOption;
+	customize: ThemeOption;
+	deleteTheme: ThemeOption;
+	help: ThemeOption;
+	preview: ThemeOption;
+	purchase: ThemeOption;
+	separator: ThemeOption;
+	signup: ThemeOption;
+	tryandcustomize: ThemeOption;
+	upgradePlan: ThemeOption;
 }
 
 export function trackClick( componentName: string, eventName: BaseSyntheticEvent, verb = 'click' ) {
@@ -25,6 +34,7 @@ export function trackClick( componentName: string, eventName: BaseSyntheticEvent
 }
 
 export function addTracking( options: ThemeOptions ): ThemeOptions {
+	console.log( { options } );
 	return mapValues( options, appendActionTracking );
 }
 

--- a/client/my-sites/themes/helpers.ts
+++ b/client/my-sites/themes/helpers.ts
@@ -47,10 +47,10 @@ export function getAnalyticsData(
 		tier,
 		site_id,
 	}: {
-		filter: string | undefined;
-		vertical: string | undefined;
-		tier: string | undefined;
-		site_id: string | undefined;
+		filter?: string;
+		vertical?: string;
+		tier?: string;
+		site_id?: string;
 	}
 ) {
 	let analyticsPath = '/themes';

--- a/client/my-sites/themes/helpers.ts
+++ b/client/my-sites/themes/helpers.ts
@@ -1,5 +1,4 @@
 import { mapValues } from 'lodash';
-import { BaseSyntheticEvent } from 'react';
 import titlecase from 'to-title-case';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { isMagnificentLocale } from 'calypso/lib/i18n-utils';
@@ -28,7 +27,7 @@ interface ThemeOptions {
 	upgradePlan: ThemeOption;
 }
 
-export function trackClick( componentName: string, eventName: BaseSyntheticEvent, verb = 'click' ) {
+export function trackClick( componentName: string, eventName: string, verb = 'click' ) {
 	const stat = `${ componentName } ${ eventName } ${ verb }`;
 	gaRecordEvent( 'Themes', titlecase( stat ) );
 }

--- a/client/my-sites/themes/helpers.ts
+++ b/client/my-sites/themes/helpers.ts
@@ -1,10 +1,11 @@
+import { Action } from '@wordpress/data';
 import { mapValues } from 'lodash';
 import titlecase from 'to-title-case';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { isMagnificentLocale } from 'calypso/lib/i18n-utils';
 
 interface ThemeOption {
-	action?(): void;
+	action?: ( action: Action ) => void;
 	extendedLabel?: string;
 	getUrl?(): string;
 	header?: string;
@@ -40,7 +41,7 @@ function appendActionTracking( option: ThemeOption, name: string ): ThemeOption 
 	const { action } = option;
 
 	return Object.assign( {}, option, {
-		action: ( t ) => {
+		action: ( t: Action ) => {
 			action && action( t );
 			trackClick( 'more button', name );
 		},

--- a/client/my-sites/themes/helpers.ts
+++ b/client/my-sites/themes/helpers.ts
@@ -34,7 +34,6 @@ export function trackClick( componentName: string, eventName: BaseSyntheticEvent
 }
 
 export function addTracking( options: ThemeOptions ): ThemeOptions {
-	console.log( { options } );
 	return mapValues( options, appendActionTracking );
 }
 

--- a/client/my-sites/themes/helpers.ts
+++ b/client/my-sites/themes/helpers.ts
@@ -6,9 +6,9 @@ import { isMagnificentLocale } from 'calypso/lib/i18n-utils';
 interface ThemeOption {
 	action?(): void;
 	extendedLabel?: string;
-	getUrl?: () => string;
+	getUrl?(): string;
 	header?: string;
-	hideForTheme?: () => void;
+	hideForTheme?(): void;
 	icon?: string;
 	label?: string;
 	separator?: boolean;

--- a/client/my-sites/themes/helpers.ts
+++ b/client/my-sites/themes/helpers.ts
@@ -5,7 +5,7 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { isMagnificentLocale } from 'calypso/lib/i18n-utils';
 
 interface ThemeOption {
-	action?: () => void;
+	action?(): void;
 	extendedLabel?: string;
 	getUrl?: () => string;
 	header?: string;

--- a/client/my-sites/themes/helpers.ts
+++ b/client/my-sites/themes/helpers.ts
@@ -1,18 +1,34 @@
 import { mapValues } from 'lodash';
+import { BaseSyntheticEvent } from 'react';
 import titlecase from 'to-title-case';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { isMagnificentLocale } from 'calypso/lib/i18n-utils';
 
-export function trackClick( componentName, eventName, verb = 'click' ) {
+interface ThemeOption {
+	action?: () => void;
+	extendedLabel?: string;
+	getUrl?: () => string;
+	header?: string;
+	hideForTheme?: () => void;
+	icon?: string;
+	label?: string;
+	separator?: boolean;
+}
+
+interface ThemeOptions {
+	[ key: string ]: ThemeOption;
+}
+
+export function trackClick( componentName: string, eventName: BaseSyntheticEvent, verb = 'click' ) {
 	const stat = `${ componentName } ${ eventName } ${ verb }`;
 	gaRecordEvent( 'Themes', titlecase( stat ) );
 }
 
-export function addTracking( options ) {
+export function addTracking( options: ThemeOptions ): ThemeOptions {
 	return mapValues( options, appendActionTracking );
 }
 
-function appendActionTracking( option, name ) {
+function appendActionTracking( option: ThemeOption, name: string ): ThemeOption {
 	const { action } = option;
 
 	return Object.assign( {}, option, {
@@ -23,7 +39,20 @@ function appendActionTracking( option, name ) {
 	} );
 }
 
-export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
+export function getAnalyticsData(
+	path: string,
+	{
+		filter,
+		vertical,
+		tier,
+		site_id,
+	}: {
+		filter: string | undefined;
+		vertical: string | undefined;
+		tier: string | undefined;
+		site_id: string | undefined;
+	}
+) {
 	let analyticsPath = '/themes';
 	let analyticsPageTitle = 'Themes';
 
@@ -51,7 +80,7 @@ export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
 	return { analyticsPath, analyticsPageTitle };
 }
 
-export function localizeThemesPath( path, locale, isLoggedOut = true ) {
+export function localizeThemesPath( path: string, locale: string, isLoggedOut = true ): string {
 	const shouldPrefix = isLoggedOut && isMagnificentLocale( locale ) && path.startsWith( '/theme' );
 
 	return shouldPrefix ? `/${ locale }${ path }` : path;

--- a/client/my-sites/themes/package-lock.json
+++ b/client/my-sites/themes/package-lock.json
@@ -1,0 +1,26 @@
+{
+	"name": "themes",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"devDependencies": {
+				"@types/to-title-case": "^1.0.0"
+			}
+		},
+		"node_modules/@types/to-title-case": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/to-title-case/-/to-title-case-1.0.0.tgz",
+			"integrity": "sha512-064+ER3yeChxTQwM0LTRTlG7GK6/HXM9ekX1y/KqJi0pvBBIrvUnYWZ2JQGivCAuw29CuLq0b6zUPL9FY/JMnQ==",
+			"dev": true
+		}
+	},
+	"dependencies": {
+		"@types/to-title-case": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/to-title-case/-/to-title-case-1.0.0.tgz",
+			"integrity": "sha512-064+ER3yeChxTQwM0LTRTlG7GK6/HXM9ekX1y/KqJi0pvBBIrvUnYWZ2JQGivCAuw29CuLq0b6zUPL9FY/JMnQ==",
+			"dev": true
+		}
+	}
+}

--- a/client/my-sites/themes/package.json
+++ b/client/my-sites/themes/package.json
@@ -1,4 +1,7 @@
 {
 	"main": "index.node.js",
-	"browser": "index.web.js"
+	"browser": "index.web.js",
+	"devDependencies": {
+		"@types/to-title-case": "^1.0.0"
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Convert Themes Helpers from js to typescript

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open files in the editor and ensure no typescript errors are being thrown

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

https://github.com/Automattic/wp-calypso/issues/60530
