### PR TITLE
Validate if a domain is mapped before rendering the mapping setup flow

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -2,7 +2,6 @@ import { Gridicon } from '@automattic/components';
 import { BackButton } from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { get } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { useState, useEffect, useRef, useCallback } from 'react';
@@ -56,7 +55,9 @@ function ConnectDomainStep( {
 	}, [ initialStep, setPageSlug ] );
 
 	useEffect( () => {
-		if ( isDomainConnected ) page( domainUseMyDomain( selectedSite.slug ) );
+		if ( isDomainConnected ) {
+			page( domainUseMyDomain( selectedSite.slug ) );
+		}
 	}, [ isDomainConnected, selectedSite.slug ] );
 
 	const verifyConnection = useCallback(
@@ -202,7 +203,7 @@ ConnectDomainStep.propTypes = {
 
 export default connect( ( state ) => {
 	const selectedSite = getSelectedSite( state );
-	const siteId = get( selectedSite, 'ID', null );
+	const siteId = selectedSite?.ID;
 
 	return {
 		domains: getDomainsBySiteId( state, siteId ),


### PR DESCRIPTION
## Changes proposed in this Pull Request

We are rendering the domain mapping page even though the domain isn't mapped for that site. This PR fixes this issue: if a domain it's not valid, then user is redirect to "Use a domain I own" page.

## Testing instructions

- Build this branch locally or open the live Calypso link
- Open this url `/domains/mapping/{:VALID-SITE}/setup/{:INVALID-DOMAIN}` where `VALID-SITE` is one of your site and `INVALID-DOMAIN` it's a domain not mapped to your site
- Verify that the browser redirect to "Use a domain I own" page
