### PR TITLE
`QueryReaderFeed`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -164,7 +164,7 @@ class ReaderCombinedCardComponent extends Component {
 						posts={ posts }
 					/>
 				</div>
-				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
+				{ feedId && <QueryReaderFeed feedId={ +feedId } /> }
 				{ siteId && <QueryReaderSite siteId={ +siteId } /> }
 			</Card>
 		);

--- a/client/components/data/query-reader-feed/index.jsx
+++ b/client/components/data/query-reader-feed/index.jsx
@@ -1,49 +1,24 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { requestFeed } from 'calypso/state/reader/feeds/actions';
 import { shouldFeedBeFetched } from 'calypso/state/reader/feeds/selectors';
 
-class QueryReaderFeed extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		if ( this.props.shouldFeedBeFetched ) {
-			this.props.requestFeed( this.props.feedId );
+function QueryReaderFeed( { feedId } ) {
+	const dispatch = useDispatch();
+	const shouldFetch = useSelector( ( state ) => shouldFeedBeFetched( state, feedId ) );
+
+	useEffect( () => {
+		if ( feedId && shouldFetch ) {
+			dispatch( requestFeed( feedId ) );
 		}
-	}
+	}, [ dispatch, feedId, shouldFetch ] );
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.shouldFeedBeFetched || this.props.feedId === nextProps.feedId ) {
-			return;
-		}
-
-		nextProps.requestFeed( nextProps.feedId );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QueryReaderFeed.propTypes = {
 	feedId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
-	shouldFeedBeFetched: PropTypes.bool,
-	requestFeed: PropTypes.func,
 };
 
-QueryReaderFeed.defaultProps = {
-	requestFeed: () => {},
-};
-
-export default connect(
-	( state, ownProps ) => {
-		const { feedId } = ownProps;
-		return {
-			shouldFeedBeFetched: shouldFeedBeFetched( state, feedId ),
-		};
-	},
-	{
-		requestFeed,
-	}
-)( QueryReaderFeed );
+export default QueryReaderFeed;

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -79,7 +79,7 @@ class ReaderPostCardAdapter extends Component {
 				postKey={ this.props.postKey }
 				compact={ this.props.compact }
 			>
-				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
+				{ feedId && <QueryReaderFeed feedId={ feedId } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } /> }
 				{ isDiscover && <QueryReaderSite siteId={ discoverPostKey.blogId } /> }
 				{ hasDiscoverSourcePost && <QueryReaderPost postKey={ discoverPostKey } /> }

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -209,7 +209,7 @@ class CrossPost extends PureComponent {
 					) }
 					{ post.author && this.getDescription( post.author.first_name ) }
 				</div>
-				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
+				{ feedId && <QueryReaderFeed feedId={ +feedId } /> }
 				{ siteId && <QueryReaderSite siteId={ +siteId } /> }
 			</Card>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryReaderFeed`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/read`
* Depending on your feed should see a bunch of requests to `/read/feed/:feedId` (the ones without any query params)
* Open a single post from that list, there shouldn't be another request to the corresponding reader feed
* Hit reload and verify now you see that request

Related to #58453 
