### PR TITLE
Correctly format currency in new domain-only search

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -40,6 +40,7 @@ class DomainRegistrationSuggestion extends Component {
 			product_slug: PropTypes.string,
 			cost: PropTypes.string,
 			match_reasons: PropTypes.arrayOf( PropTypes.oneOf( VALID_MATCH_REASONS ) ),
+			currency_code: PropTypes.string,
 		} ).isRequired,
 		onButtonClick: PropTypes.func.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
@@ -394,7 +395,8 @@ class DomainRegistrationSuggestion extends Component {
 const mapStateToProps = ( state, props ) => {
 	const productSlug = get( props, 'suggestion.product_slug' );
 	const productsList = getProductsList( state );
-	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
+	const currentUserCurrencyCode =
+		props.suggestion.currency_code || getCurrentUserCurrencyCode( state );
 	const stripZeros = props.showStrikedOutPrice ? true : false;
 	const isPremium = props.premiumDomain?.is_premium || props.suggestion?.is_premium;
 	const flowName = getCurrentFlowName( state );


### PR DESCRIPTION
## Changes proposed in this Pull Request

The reskinned version of Search a Domain step always shows US Dollar as currency even is the price is calculated on a different currency (_see screenshot below_). This happen because `currencyCode` in Redux Store is not loaded (and return US Dollar as default)

<img width="1685" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/2797601/151823333-f33fcbe4-8fcf-4d9b-96e8-3a58edfc2273.png">

This PR fixes this issue.

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to "/start/domain"
- Enter a domain and verify that prices are showed using your currency (you can use SA to temporary change your currency)
