### PR TITLE
Components: Refactor `WebPreview` away from `UNSAFE_` lifecycle methods

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -1,5 +1,4 @@
 import { RootChild } from '@automattic/components';
-import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -79,22 +78,12 @@ export class WebPreviewModal extends Component {
 	constructor( props ) {
 		super( props );
 
-		this._hasTouch = false;
-		this._isMobile = false;
-
 		this.state = {
 			device: props.defaultViewportDevice || 'computer',
 		};
 
 		this.keyDown = this.keyDown.bind( this );
 		this.setDeviceViewport = this.setDeviceViewport.bind( this );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		// Cache touch and mobile detection for the entire lifecycle of the component
-		this._hasTouch = hasTouch();
-		this._isMobile = isMobile();
 	}
 
 	componentDidMount() {
@@ -137,7 +126,7 @@ export class WebPreviewModal extends Component {
 
 	render() {
 		const className = classNames( this.props.className, 'web-preview', {
-			'is-touch': this._hasTouch,
+			'is-touch': hasTouch(),
 			'is-with-sidebar': this.props.hasSidebar,
 			'is-visible': this.props.showPreview,
 			'is-computer': this.state.device === 'computer',

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -23,7 +23,6 @@ const noop = () => {};
 
 export class WebPreviewContent extends Component {
 	previewId = uuid();
-	_hasTouch = false;
 
 	state = {
 		iframeUrl: null,
@@ -35,12 +34,6 @@ export class WebPreviewContent extends Component {
 	setIframeInstance = ( ref ) => {
 		this.iframe = ref;
 	};
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		// Cache touch and mobile detection for the entire lifecycle of the component
-		this._hasTouch = hasTouch();
-	}
 
 	componentDidMount() {
 		window.addEventListener( 'message', this.handleMessage );
@@ -270,7 +263,7 @@ export class WebPreviewContent extends Component {
 		const { translate, toolbarComponent: ToolbarComponent } = this.props;
 
 		const className = classNames( this.props.className, 'web-preview__inner', {
-			'is-touch': this._hasTouch,
+			'is-touch': hasTouch(),
 			'is-with-sidebar': this.props.hasSidebar,
 			'is-visible': this.props.showPreview,
 			'is-computer': this.state.device === 'computer',
@@ -375,7 +368,7 @@ WebPreviewContent.propTypes = {
 	// Called when the edit button is clicked
 	onEdit: PropTypes.func,
 	// Optional loading message to display during loading
-	loadingMessage: PropTypes.oneOfType( [ PropTypes.array, PropTypes.string ] ),
+	loadingMessage: PropTypes.node,
 	// The iframe's title element, used for accessibility purposes
 	iframeTitle: PropTypes.string,
 	// Makes room for a sidebar if desired


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `WebPreview` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

We also use the opportunity to fix a proptype error:

![](https://cldup.com/k3s31kbvj7.png)

#### Testing instructions
* Test the following on both mobile and desktop
* Go to `/view/:site`
* Verify it looks and works like it does in production.
* Verify the console error is also gone.