### PR TITLE
Add user time since registration to Fiverr logo make link

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -189,9 +189,7 @@ export const QuickLinks = ( {
 						gridicon="plugins"
 					/>
 					<ActionBox
-						href={
-							'https://wp.me/logo-maker/?utm_campaign=my_home&utm_term=' + daysSinceSignup + 'd'
-						}
+						href={ 'https://wp.me/logo-maker/?utm_campaign=my_home_' + daysSinceSignup + 'd' }
 						onClick={ trackDesignLogoAction }
 						target="_blank"
 						label={

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -12,6 +12,7 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/ana
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getCurrentUserTimeSinceSignup from 'calypso/state/selectors/get-current-user-time-since-signup';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import isSiteUsingLegacyFSE from 'calypso/state/selectors/is-site-using-legacy-fse';
@@ -62,6 +63,7 @@ export const QuickLinks = ( {
 	siteSlug,
 	blockEditorSettings,
 	areBlockEditorSettingsLoading,
+	daysSinceSignup,
 } ) => {
 	const isFSEActive = blockEditorSettings?.is_fse_active ?? false;
 
@@ -187,7 +189,9 @@ export const QuickLinks = ( {
 						gridicon="plugins"
 					/>
 					<ActionBox
-						href="https://wp.me/logo-maker/?utm_campaign=my_home"
+						href={
+							'https://wp.me/logo-maker/?utm_campaign=my_home&utm_term=' + daysSinceSignup + 'd'
+						}
 						onClick={ trackDesignLogoAction }
 						target="_blank"
 						label={
@@ -406,6 +410,7 @@ const mapStateToProps = ( state ) => {
 		isExpanded: getPreference( state, 'homeQuickLinksToggleStatus' ) !== 'collapsed',
 		isUnifiedNavEnabled: isNavUnificationEnabled,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
+		daysSinceSignup: getCurrentUserTimeSinceSignup( state ),
 	};
 };
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -23,6 +23,7 @@ import {
 import { hasTrafficGuidePurchase } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import getCurrentUserTimeSinceSignup from 'calypso/state/selectors/get-current-user-time-since-signup';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import * as T from 'calypso/types';
@@ -43,6 +44,7 @@ export const MarketingTools: FunctionComponent = () => {
 	const showFacebookUpsell = [ 'value_bundle', 'personal-bundle', 'free_plan' ].includes(
 		sitePlan
 	);
+	const daysSinceSignup = useSelector( getCurrentUserTimeSinceSignup );
 
 	const handleBusinessToolsClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_business_tools_button_click' );
@@ -112,7 +114,7 @@ export const MarketingTools: FunctionComponent = () => {
 				>
 					<Button
 						onClick={ handleCreateALogoClick }
-						href="https://wp.me/logo-maker/?utm_campaign=marketing_tab"
+						href={ 'https://wp.me/logo-maker/?utm_campaign=marketing_tab_' + daysSinceSignup + 'd' }
 						target="_blank"
 					>
 						{ translate( 'Create a logo' ) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -25,6 +25,7 @@ import guessTimezone from 'calypso/lib/i18n-utils/guess-timezone';
 import scrollTo from 'calypso/lib/scroll-to';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import getCurrentUserTimeSinceSignup from 'calypso/state/selectors/get-current-user-time-since-signup';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -93,6 +94,7 @@ export class SiteSettingsFormGeneral extends Component {
 			eventTracker,
 			onChangeField,
 			uniqueEventTracker,
+			daysSinceSignup,
 		} = this.props;
 
 		return (
@@ -150,7 +152,9 @@ export class SiteSettingsFormGeneral extends Component {
 					<div className="site-settings__fiver-cta-button">
 						<Button
 							target="_blank"
-							href={ 'https://wp.me/logo-maker/?utm_campaign=general_settings' }
+							href={
+								'https://wp.me/logo-maker/?utm_campaign=general_settings_' + daysSinceSignup + 'd'
+							}
 							onClick={ this.trackFiverrLogoMakerClick }
 						>
 							<Gridicon icon="external" />
@@ -714,6 +718,7 @@ const connectComponent = connect( ( state ) => {
 		isAtomicAndEditingToolkitDeactivated:
 			isAtomicSite( state, siteId ) &&
 			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
+		daysSinceSignup: getCurrentUserTimeSinceSignup( state ),
 	};
 }, mapDispatchToProps );
 

--- a/client/state/selectors/get-current-user-time-since-signup.js
+++ b/client/state/selectors/get-current-user-time-since-signup.js
@@ -1,7 +1,5 @@
 import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
 
-const DAY_IN_MS = 1000 * 60 * 60 * 24;
-
 /**
  * Returns the number of days since the user signed up.
  *
@@ -9,6 +7,7 @@ const DAY_IN_MS = 1000 * 60 * 60 * 24;
  * @returns {number} Days since user registration (rounded to nearest day).
  */
 export default function getCurrentUserTimeSinceSignup( state ) {
+	const DAY_IN_MS = 86400000;
 	const signupDate = new Date( getCurrentUserDate( state ) );
 
 	if ( ! signupDate ) {

--- a/client/state/selectors/get-current-user-time-since-signup.js
+++ b/client/state/selectors/get-current-user-time-since-signup.js
@@ -6,10 +6,10 @@ const DAY_IN_MS = 1000 * 60 * 60 * 24;
  * Returns the number of days since the user signed up.
  *
  * @param {object} state Global state tree.
- * @returns {number} Days since user registration.
+ * @returns {number} Days since user registration (rounded to nearest day).
  */
 export default function getCurrentUserTimeSinceSignup( state ) {
-	const signupDate = getCurrentUserDate( state );
+	const signupDate = new Date( getCurrentUserDate( state ) );
 
 	if ( ! signupDate ) {
 		return null;
@@ -17,5 +17,5 @@ export default function getCurrentUserTimeSinceSignup( state ) {
 
 	const todayDate = Date.now();
 
-	return todayDate - Date( signupDate ) / DAY_IN_MS;
+	return Math.round( ( todayDate - signupDate ) / DAY_IN_MS );
 }

--- a/client/state/selectors/get-current-user-time-since-signup.js
+++ b/client/state/selectors/get-current-user-time-since-signup.js
@@ -1,0 +1,21 @@
+import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
+
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
+
+/**
+ * Returns the number of days since the user signed up.
+ *
+ * @param {object} state Global state tree.
+ * @returns {number} Days since user registration.
+ */
+export default function getCurrentUserTimeSinceSignup( state ) {
+	const signupDate = getCurrentUserDate( state );
+
+	if ( ! signupDate ) {
+		return null;
+	}
+
+	const todayDate = Date.now();
+
+	return todayDate - Date( signupDate ) / DAY_IN_MS;
+}

--- a/client/state/selectors/test/get-current-user-time-since-signup.js
+++ b/client/state/selectors/test/get-current-user-time-since-signup.js
@@ -1,0 +1,64 @@
+import getCurrentUserTimeSinceSignup from '../get-current-user-time-since-signup';
+
+describe( 'getCurrentUserTimeSinceSignup()', () => {
+	beforeAll( () => {
+		// Time travel.
+		jest
+			.useFakeTimers()
+			// Mock date => 2022-01-01T05:04:12+00:00.
+			.setSystemTime( new Date( 1641013452000 ) );
+	} );
+
+	afterAll( () => {
+		// Back to present.
+		jest.useRealTimers();
+	} );
+
+	test( 'It should return the correct amount of days from the user signup date', () => {
+		// Fake global state.
+		const prevState = {
+			currentUser: {
+				user: {
+					date: '2013-02-12T23:34:51+00:00',
+				},
+			},
+		};
+
+		const howManyDays = getCurrentUserTimeSinceSignup( prevState );
+
+		// It should be 3244 days
+		expect( howManyDays ).toEqual( 3244 );
+	} );
+
+	test( 'It should round down the date difference to nearest day', () => {
+		// Fake global state.
+		const prevState = {
+			currentUser: {
+				user: {
+					date: '2022-01-01T03:04:12+00:00',
+				},
+			},
+		};
+
+		const howManyDays = getCurrentUserTimeSinceSignup( prevState );
+
+		// It should be 0 (2 hours)
+		expect( howManyDays ).toEqual( 0 );
+	} );
+
+	test( 'It should round up the date difference to nearest day', () => {
+		// Fake global state.
+		const prevState = {
+			currentUser: {
+				user: {
+					date: '2021-12-31T10:04:12+00:00',
+				},
+			},
+		};
+
+		const howManyDays = getCurrentUserTimeSinceSignup( prevState );
+
+		// It should be 1 (19 hours)
+		expect( howManyDays ).toEqual( 1 );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR will add the days since user registration to the Fiverr logo maker links. This is done to better understand at which part of the user journey users interact with the logo maker. For more context see: pau2Xa-3XU-p2

#### Testing instructions
* Unit tests pass.
* Check on "My Home" and verify that the Fiverr logo maker link href contains a `utm_campaign` key, with a value containing `source_accountage+d`. i.e.  `?utm_campaign=my_home_3288d`
* Check the logo maker CTA in tools>marketing (should be similar to above)
* Check the logo maker CTA under settings>general (should be similar to above)
* You can grab you signup date by running `state.currentUser.user.date` from the console in your browser, and you'll get something like this back: `'2013-02-01T21:10:44+00:00'`