### PR TITLE
Reader: Refactor `QueryReaderThumbnails` away from `UNSAFE_` methods

### DIFF
--- a/client/components/data/query-reader-thumbnails/index.jsx
+++ b/client/components/data/query-reader-thumbnails/index.jsx
@@ -1,41 +1,23 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestThumbnail } from 'calypso/state/reader/thumbnails/actions';
 import { getThumbnailForIframe } from 'calypso/state/reader/thumbnails/selectors';
 
-class QueryReaderThumbnails extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
+const request = ( embedUrl ) => ( dispatch, getState ) => {
+	if ( embedUrl && ! getThumbnailForIframe( getState(), embedUrl ) ) {
+		dispatch( requestThumbnail( embedUrl ) );
 	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.embedUrl !== this.props.embedUrl ) {
-			this.request( nextProps );
-		}
-	}
-
-	request( props ) {
-		if ( ! props.shouldRequestThumbnail || ! props.embedUrl ) {
-			return;
-		}
-		props.requestThumbnail( props.embedUrl );
-	}
-
-	render() {
-		return null;
-	}
-}
-
-QueryReaderThumbnails.propTypes = {
-	shouldRequestThumbnail: PropTypes.bool,
-	requestThumbnail: PropTypes.func,
 };
 
-const mapStateToProps = ( state, ownProps ) => ( {
-	shouldRequestThumbnail: ! getThumbnailForIframe( state, ownProps.embedUrl ),
-} );
+export default function QueryReaderThumbnails( { embedUrl } ) {
+	const dispatch = useDispatch();
 
-export default connect( mapStateToProps, { requestThumbnail } )( QueryReaderThumbnails );
+	useEffect( () => {
+		dispatch( request( embedUrl ) );
+	}, [ dispatch, embedUrl ] );
+
+	return null;
+}
+
+QueryReaderThumbnails.propTypes = { embedUrl: PropTypes.string.isRequired };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `QueryReaderThumbnails` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/read`
* Search for `youtube`
* Scroll down a few pages.
* Verify you see requests to `*/mqdefault.jpg` for every thumbnail of a post with a video.
* Verify the thumbnails still appear properly for each post.