### PR TITLE
`QueryConciergeAppointmentDetails`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-concierge-appointment-details/index.js
+++ b/client/components/data/query-concierge-appointment-details/index.js
@@ -1,19 +1,15 @@
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestConciergeAppointmentDetails } from 'calypso/state/concierge/actions';
 
-class QueryConciergeAppointmentDetails extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		const { appointmentId, scheduleId } = this.props;
-		this.props.requestConciergeAppointmentDetails( scheduleId, appointmentId );
-	}
+function QueryConciergeAppointmentDetails( { scheduleId, appointmentId } ) {
+	const dispatch = useDispatch();
 
-	render() {
-		return null;
-	}
+	useEffect( () => {
+		dispatch( requestConciergeAppointmentDetails( scheduleId, appointmentId ) );
+	}, [ dispatch, scheduleId, appointmentId ] );
+
+	return null;
 }
 
-export default connect( ( state ) => state, { requestConciergeAppointmentDetails } )(
-	QueryConciergeAppointmentDetails
-);
+export default QueryConciergeAppointmentDetails;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryConciergeAppointmentDetails`: refactor away from `UNSAFE_*`

#### Testing instructions

* Run `yarn run test-client concierge` and make sure tests pass
* Go to `me/quickstart/:site/book` and schedule an appointment
* After that the appointment should appear on the list at `me/quickstart/:site/book`
* Hit _Reschedule or cancel_
* On the following page, make sure you see a request to `/concierge/schedules/:scheduleId/appointments/:appointmentId/detail`
* Make sure to actually cancel the session after testing

Related to #58453 
