### PR TITLE
`QueryReaderTagImages`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-reader-tag-images/index.jsx
+++ b/client/components/data/query-reader-tag-images/index.jsx
@@ -1,49 +1,19 @@
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { requestTagImages } from 'calypso/state/reader/tags/images/actions';
 import { shouldRequestTagImages } from 'calypso/state/reader/tags/images/selectors';
 
-class QueryReaderTagImages extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.shouldRequestTagImages || ! this.props.tag ) {
-			return;
+function QueryReaderTagImages( { tag } ) {
+	const dispatch = useDispatch();
+	const shouldFetch = useSelector( ( state ) => shouldRequestTagImages( state, tag ) );
+
+	useEffect( () => {
+		if ( tag && shouldFetch ) {
+			dispatch( requestTagImages( tag ) );
 		}
+	}, [ dispatch, tag, shouldFetch ] );
 
-		this.props.requestTagImages( this.props.tag );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.shouldRequestTagImages ) {
-			return;
-		}
-
-		this.props.requestTagImages( nextProps.tag );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-QueryReaderTagImages.propTypes = {
-	shouldRequestTagImages: PropTypes.bool,
-	requestTagImages: PropTypes.func,
-};
-
-QueryReaderTagImages.defaultProps = {
-	requestTagImages: () => {},
-};
-
-export default connect(
-	( state, ownProps ) => {
-		return {
-			shouldRequestTagImages: shouldRequestTagImages( state, ownProps.tag ),
-		};
-	},
-	{
-		requestTagImages,
-	}
-)( QueryReaderTagImages );
+export default QueryReaderTagImages;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryReaderTagImages`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/read` and open the list of tags in the sidebar
* Click on one of the tags, make sure you see a request to `/read/tags/:tag/images`
* Click on another tag, see another request
* Go back to the previous tag, you shouldn't see another request

Related to #58453 
