### PR TITLE
Emails: Fix display issues cropping up when stylesheets are loaded in a specific order

### DIFF
--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -162,17 +162,14 @@
 	}
 }
 
-.email-plan-header {
+.email-plan-header.card.is-compact {
 	align-items: center;
+	display: flex;
 	flex-wrap: wrap;
 
 	h2 {
 		font-size: $font-title-large;
 		word-break: break-all;
-	}
-
-	&.card {
-		display: flex;
 	}
 
 	&.success {
@@ -251,33 +248,29 @@
 	}
 }
 
-.email-plan-mailboxes-list__mailbox-list-item {
+.email-plan-mailboxes-list__mailbox-list-item.card.is-compact {
 	flex-direction: column;
+	display: flex;
 
-	&.card {
-		display: flex;
+	@include break-xlarge {
+		flex-direction: row;
 
-		&.is-compact {
-			@include break-xlarge {
-				flex-direction: row;
-				/* The padding jumps as we need the padding on this element instead
-				 * of mailbox-list-item-main when we shift to flex-direction: row
-				 */
-				padding-right: 72px;
-			}
+		/* The padding jumps as we need the padding on this element instead
+		 * of mailbox-list-item-main when we shift to flex-direction: row
+		 */
+		padding-right: 72px;
+	}
+
+	&.is-highlight {
+		padding-left: 13px;
+
+		@include break-mobile {
+			padding-left: 21px;
 		}
+	}
 
-		&.is-highlight {
-			padding-left: 13px;
-
-			@include break-mobile {
-				padding-left: 21px;
-			}
-		}
-
-		&.is-error {
-			border-left-color: var( --color-error-50 );
-		}
+	&.is-error {
+		border-left-color: var( --color-error-50 );
 	}
 
 	.email-plan-mailboxes-list__mailbox-list-item-main {
@@ -375,13 +368,10 @@
 	}
 }
 
-.email-plan-subscription__card {
+.email-plan-subscription__card.card.is-compact {
 	align-items: center;
+	display: flex;
 	flex-wrap: wrap;
-
-	&.card {
-		display: flex;
-	}
 
 	@include break-small {
 		flex-wrap: initial;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -120,12 +120,14 @@
 
 .email-list-inactive {
 	margin-top: 15px;
+
 	> .card {
 		align-items: center;
 		display: flex;
 		margin-bottom: 0;
 		padding-bottom: 20px;
 		padding-top: 20px;
+
 		> span {
 			flex: 1 1 auto;
 			line-height: 40px;
@@ -146,7 +148,7 @@
 }
 
 .email-plan__actions .vertical-nav-item.card,
-.email-plan-mailboxes-list__mailbox-list-item.card {
+.email-plan-mailboxes-list__mailbox-list-item.card.is-compact {
 	padding-bottom: 28px;
 	padding-top: 28px;
 }
@@ -161,13 +163,16 @@
 }
 
 .email-plan-header {
-	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
 
 	h2 {
 		font-size: $font-title-large;
 		word-break: break-all;
+	}
+
+	&.card {
+		display: flex;
 	}
 
 	&.success {
@@ -226,7 +231,8 @@
 	display: flex;
 	line-height: 24px;
 
-	> img, > svg {
+	> img,
+	> svg {
 		margin-right: 8px;
 	}
 
@@ -234,6 +240,7 @@
 		> img {
 			filter: grayscale( 100% ) brightness( 0.2 ) invert( 1 );
 		}
+
 		> svg {
 			fill: white;
 		}
@@ -245,10 +252,11 @@
 }
 
 .email-plan-mailboxes-list__mailbox-list-item {
-	display: flex;
 	flex-direction: column;
 
 	&.card {
+		display: flex;
+
 		&.is-compact {
 			@include break-xlarge {
 				flex-direction: row;
@@ -290,21 +298,25 @@
 			margin-top: 0.5em;
 		}
 	}
+
 	&.is-placeholder > span,
 	&.is-placeholder .email-plan-mailboxes-list__mailbox-list-item-main {
 		@include placeholder( --color-neutral-5 );
 		width: 50%;
 	}
+
 	&.no-emails > span {
 		color: var( --color-text-subtle );
 		font-style: italic;
 	}
+
 	> svg,
 	.email-plan-mailboxes-list__mailbox-list-item-main svg {
 		fill: var( --studio-gray-40 );
 		margin-right: 10px;
 		vertical-align: middle;
 	}
+
 	.email-plan-mailboxes-list__mailbox-list-item-main span {
 		vertical-align: middle;
 		word-break: break-all;
@@ -341,6 +353,7 @@
 			margin-right: 6px;
 			vertical-align: middle;
 		}
+
 		> span {
 			vertical-align: middle;
 		}
@@ -364,8 +377,11 @@
 
 .email-plan-subscription__card {
 	align-items: center;
-	display: flex;
 	flex-wrap: wrap;
+
+	&.card {
+		display: flex;
+	}
 
 	@include break-small {
 		flex-wrap: initial;
@@ -386,6 +402,7 @@
 		label {
 			font-size: $font-body;
 		}
+
 		/* vertically aligns the auto-renew toggle - not sure if there's a better way... */
 		> div > div {
 			margin-top: auto;


### PR DESCRIPTION
This pull request fixes some display issues that would appear when the stylesheets are loaded in a specific order (i.e. when the `.card` styles are loaded last):

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/151834633-dfc8d6d9-4163-409f-83e7-7849d32ace5b.png) | ![image](https://user-images.githubusercontent.com/594356/151834032-651cbb1a-0347-48eb-ac59-1eb603c19d42.png)


#### Testing instructions

While we can't control how stylesheets are loaded, we can at least making sure those changes don't break anything:

1. Run `git checkout fix/email-plan-display-issues` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/60673#issuecomment-1025942141)
2. Log into a WordPress. account that has an email account
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click that account to access the `Email Plan` page
5. Assert that the page looks fine