### PR TITLE
Update domain only flow: `loader` message

### DIFF
--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -20,6 +20,9 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 		case 'launch-site':
 			steps = [ { title: __( 'Your site will be live shortly.' ) } ]; // copy from 'packages/launch/src/focused-launch/success'
 			break;
+		case 'domain':
+			steps = [ { title: __( 'Preparing your domain' ) } ];
+			break;
 		default:
 			steps = [
 				! isDestinationSetupSiteFlow && { title: __( 'Building your site' ) },


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR updates the loader message (before the checkout) in domain-only flow.

It's part of the new domain-only flow (pcYYhz-ye-p2)

<img width="1442" alt="Loader" src="https://user-images.githubusercontent.com/2797601/151832271-827abfdd-fc9c-4f3e-9595-1f374c8414e6.png">

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to to `/start/domain/domain-only`
- Enter a domain name and select it, in order to move to the next step
- Select "Just buy a domain" option and verify that the loader is showed as in the screenshot above