### PR TITLE
Plugins Browser: Search plugins by developer

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -1,5 +1,9 @@
 import { useQuery, UseQueryResult, UseQueryOptions, QueryKey } from 'react-query';
-import { normalizePluginsList, normalizePluginData } from 'calypso/lib/plugins/utils';
+import {
+	extractSearchInformation,
+	normalizePluginsList,
+	normalizePluginData,
+} from 'calypso/lib/plugins/utils';
 import wpcom from 'calypso/lib/wp';
 
 type Type = 'all' | 'featured';
@@ -10,14 +14,17 @@ const pluginsApiNamespace = 'wpcom/v2';
 const getCacheKey = ( key: string ): QueryKey => [ 'wpcom-plugins', key ];
 
 const fetchWPCOMPlugins = ( type: Type, searchTerm?: string ) => {
+	const [ search, author ] = extractSearchInformation( searchTerm );
+
 	return wpcom.req.get(
 		{
 			path: plugisApiBase,
 			apiNamespace: pluginsApiNamespace,
 		},
 		{
-			q: searchTerm,
 			type: type,
+			...( search && { q: search } ),
+			...( author && { author } ),
 		}
 	);
 };

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -245,3 +245,21 @@ export function normalizePluginsList( pluginsList ) {
 export function filterNotices( logs, siteId, pluginId ) {
 	return filter( logs, filterNoticesBy.bind( this, siteId, pluginId ) );
 }
+
+/**
+ * Regex to extract the author from the search
+ */
+export const AUTHOR_PATTERN = /author:"(.*)"/;
+
+/**
+ * Extract author and search params from the plugin search query
+ *
+ * @param {string} searchTerm The full plugin search query
+ * @returns {Array<string|null>} The first item will be the search and the second will be the author if exists
+ */
+export function extractSearchInformation( searchTerm = '' ) {
+	const author = searchTerm.match( AUTHOR_PATTERN )?.[ 1 ] || null;
+	const search = searchTerm.replace( AUTHOR_PATTERN, '' );
+
+	return [ search, author ];
+}

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -249,7 +249,7 @@ export function filterNotices( logs, siteId, pluginId ) {
 /**
  * Regex to extract the author from the search
  */
-export const AUTHOR_PATTERN = /author:"(.*)"/;
+export const AUTHOR_PATTERN = /author:(?:\s)*"(.*)"/;
 
 /**
  * Extract author and search params from the plugin search query
@@ -259,7 +259,7 @@ export const AUTHOR_PATTERN = /author:"(.*)"/;
  */
 export function extractSearchInformation( searchTerm = '' ) {
 	const author = searchTerm.match( AUTHOR_PATTERN )?.[ 1 ] || null;
-	const search = searchTerm.replace( AUTHOR_PATTERN, '' );
+	const search = searchTerm.replace( AUTHOR_PATTERN, '' ).trim();
 
 	return [ search, author ];
 }

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -249,7 +249,7 @@ export function filterNotices( logs, siteId, pluginId ) {
 /**
  * Regex to extract the author from the search
  */
-export const AUTHOR_PATTERN = /author:(?:\s)*"(.*)"/;
+export const DEVELOPER_PATTERN = /developer:(?:\s)*"(.*)"/;
 
 /**
  * Extract author and search params from the plugin search query
@@ -258,8 +258,8 @@ export const AUTHOR_PATTERN = /author:(?:\s)*"(.*)"/;
  * @returns {Array<string|null>} The first item will be the search and the second will be the author if exists
  */
 export function extractSearchInformation( searchTerm = '' ) {
-	const author = searchTerm.match( AUTHOR_PATTERN )?.[ 1 ] || null;
-	const search = searchTerm.replace( AUTHOR_PATTERN, '' ).trim();
+	const author = searchTerm.match( DEVELOPER_PATTERN )?.[ 1 ] || null;
+	const search = searchTerm.replace( DEVELOPER_PATTERN, '' ).trim();
 
 	return [ search, author ];
 }

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -58,6 +58,7 @@ export function fetchPluginsList( options ) {
 	const pageSize = options.pageSize || DEFAULT_PAGE_SIZE;
 	const category = options.category || DEFAULT_CATEGORY;
 	const search = options.search;
+	const author = options.author;
 
 	const query = {
 		action: 'query_plugins',
@@ -72,6 +73,10 @@ export function fetchPluginsList( options ) {
 		query[ 'request[search]' ] = search;
 	} else {
 		query[ 'request[browse]' ] = category;
+	}
+
+	if ( author ) {
+		query[ 'request[author]' ] = author;
 	}
 
 	return getRequest( WPORG_PLUGINS_ENDPOINT, query );

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -71,12 +71,14 @@ export function fetchPluginsList( options ) {
 
 	if ( search ) {
 		query[ 'request[search]' ] = search;
-	} else {
-		query[ 'request[browse]' ] = category;
 	}
 
 	if ( author ) {
 		query[ 'request[author]' ] = author;
+	}
+
+	if ( ! search && ! author ) {
+		query[ 'request[browse]' ] = category;
 	}
 
 	return getRequest( WPORG_PLUGINS_ENDPOINT, query );

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -1,4 +1,8 @@
-import { normalizePluginData, normalizePluginsList } from 'calypso/lib/plugins/utils';
+import {
+	extractSearchInformation,
+	normalizePluginData,
+	normalizePluginsList,
+} from 'calypso/lib/plugins/utils';
 import wpcom from 'calypso/lib/wp';
 import {
 	fetchPluginInformation,
@@ -91,7 +95,7 @@ function receivePluginsList( category, page, searchTerm, data, error, pagination
 export function fetchPluginsList(
 	category,
 	page,
-	searchTerm,
+	searchTerm = '',
 	pageSize = PLUGINS_LIST_DEFAULT_SIZE
 ) {
 	return ( dispatch, getState ) => {
@@ -120,11 +124,14 @@ export function fetchPluginsList(
 			return;
 		}
 
+		const [ search, author ] = extractSearchInformation( searchTerm );
+
 		return fetchWporgPluginsList( {
 			pageSize,
 			page,
 			category,
-			search: searchTerm,
+			search,
+			author,
 			locale: getCurrentUserLocale( getState() ),
 		} )
 			.then( ( { info, plugins } ) => {


### PR DESCRIPTION
Using quotes to delimit long author names. Adds the author query parameter to the WPOrg request.

Depends on `D74695-code`

### Changes proposed in this Pull Request

* Get the author name from the search query
* Use the author name in the WPOrg plugin query
* Use the author name in the WPCom plugin query

### Testing instructions
0. Go to plugins page

**Search by author name**
1. Search by author using the template `author: "{author_name}"`. Eg: `author: "automattic"`
2. Check if the requests were created as follows:
  2.1 Check if the WPOrg request has the query parameter `request[author]=automattic`
  2.2 Check if the WPCOM request has the query parameter `author=automattic`

**Search by author name and general search**
1. Search by author using the template `developer: "{author_name}" {plugin_name}`. Eg: `developer: "automatic" woo`
2. Check if the requests were created as follows:
  2.1 Check if the WPOrg request has the query parameter `request[author]=automattic`
  2.2 Check if the WPCOM request has the query parameter `author=automattic`
  2.3 Check if the WPOrg request has the query parameter `request[search]=woo`
  2.4 Check if the WPCOM request has the query parameter `q=woo`

**General search**
1. Search the plugin. Eg: `woo`
2. Check if the requests were created as follows:
  2.1 Check if the WPOrg request has the query parameter `request[search]=woo`
  2.2 Check if the WPCOM request has the query parameter `q=woo`

### Demo
| Plugins Browser  | WPOrg request | WPCom request|
| ------------- | ------------- |----|
|<img width="1071" alt="Screen Shot 2022-02-18 at 12 56 32" src="https://user-images.githubusercontent.com/5039531/154716908-33c4c541-db44-44da-bc1b-3d2992d769bb.png">|<img width="191" alt="Screen Shot 2022-02-09 at 15 44 32" src="https://user-images.githubusercontent.com/5039531/153269475-fb3783d4-bd40-47ea-875e-cbf8595bc363.png">|<img width="185" alt="Screen Shot 2022-02-09 at 15 44 26" src="https://user-images.githubusercontent.com/5039531/153269721-a5c0c78d-2716-480e-8fd0-383280eea467.png">|





----

Related to #57749