### PR TITLE
Update/onboarding importer improvements 3

### DIFF
--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -51,7 +51,11 @@ interface Props {
 }
 const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const IMPORT_ROUTE = '/start/from/importing';
+	const dispatch = useDispatch();
 
+	/**
+	 ↓ Fields
+	 */
 	const {
 		urlData,
 		stepName,
@@ -65,17 +69,11 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 		fromSite,
 		path,
 	} = props;
-
-	/**
-	 ↓ Fields
-	 */
 	const engine: Importer = stepSectionName.toLowerCase() as Importer;
 	const [ runImportInitially, setRunImportInitially ] = useState( false );
 	const getImportJob = ( engine: Importer ): ImportJob | undefined => {
 		return siteImports.find( ( x ) => x.type === getImporterTypeForEngine( engine ) );
 	};
-
-	const dispatch = useDispatch();
 	const fromSiteData = useSelector( getUrlData );
 
 	/**
@@ -235,19 +233,10 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 						<div className="import-layout__center">
 							{ ( () => {
 								if ( isLoading() ) {
-									/**
-									 * Loading screen
-									 */
 									return <LoadingEllipsis />;
 								} else if ( ! siteSlug ) {
-									/**
-									 * Not found
-									 */
 									return <NotFound />;
 								} else if ( ! hasPermission() ) {
-									/**
-									 * Permission screen
-									 */
 									return <NotAuthorized siteSlug={ siteSlug } />;
 								} else if (
 									engine === 'blogger' &&

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -50,6 +50,8 @@ interface Props {
 	resetImport: ( siteId: number, importerId: string ) => void;
 }
 const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
+	const IMPORT_ROUTE = '/start/from/importing';
+
 	const {
 		urlData,
 		stepName,
@@ -95,7 +97,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function isLoading() {
-		return ! isImporterStatusHydrated;
+		return ! isImporterStatusHydrated || ! page.current.startsWith( IMPORT_ROUTE );
 	}
 
 	function hasPermission(): boolean {
@@ -232,16 +234,16 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 					>
 						<div className="import-layout__center">
 							{ ( () => {
-								if ( ! siteSlug ) {
-									/**
-									 * Not found
-									 */
-									return <NotFound />;
-								} else if ( isLoading() ) {
+								if ( isLoading() ) {
 									/**
 									 * Loading screen
 									 */
 									return <LoadingEllipsis />;
+								} else if ( ! siteSlug ) {
+									/**
+									 * Not found
+									 */
+									return <NotFound />;
 								} else if ( ! hasPermission() ) {
 									/**
 									 * Permission screen

--- a/client/signup/steps/import-from/wordpress/import-everything/index.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/index.tsx
@@ -18,6 +18,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { receiveSite, requestSite, updateSiteMigrationMeta } from 'calypso/state/sites/actions';
 import { getSite, getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import DoneButton from '../../components/done-button';
+import GettingStartedVideo from '../../components/getting-started-video';
 import NotAuthorized from '../../components/not-authorized';
 import { isTargetSitePlanCompatible } from '../../util';
 import { MigrationStatus, WPImportOption } from '../types';
@@ -132,25 +133,31 @@ export class ImportEverything extends SectionMigrate {
 		const { translate, sourceSite, targetSiteSlug } = this.props;
 
 		return (
-			<Progress>
-				<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
-				<Title>
-					{ ( MigrationStatus.BACKING_UP === this.state.migrationStatus ||
-						MigrationStatus.NEW === this.state.migrationStatus ) &&
-						sprintf( translate( 'Backing up %(website)s' ), { website: sourceSite.slug } ) + '...' }
-					{ MigrationStatus.RESTORING === this.state.migrationStatus &&
-						sprintf( translate( 'Restoring to %(website)s' ), { website: targetSiteSlug } ) +
-							'...' }
-				</Title>
-				<ProgressBar
-					color={ 'black' }
-					compact={ true }
-					value={ this.state.percent ? this.state.percent : 0 }
-				/>
-				<SubTitle>
-					{ translate( "This may take a few minutes. We'll notify you by email when it's done." ) }
-				</SubTitle>
-			</Progress>
+			<>
+				<Progress>
+					<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
+					<Title>
+						{ ( MigrationStatus.BACKING_UP === this.state.migrationStatus ||
+							MigrationStatus.NEW === this.state.migrationStatus ) &&
+							sprintf( translate( 'Backing up %(website)s' ), { website: sourceSite.slug } ) +
+								'...' }
+						{ MigrationStatus.RESTORING === this.state.migrationStatus &&
+							sprintf( translate( 'Restoring to %(website)s' ), { website: targetSiteSlug } ) +
+								'...' }
+					</Title>
+					<ProgressBar
+						color={ 'black' }
+						compact={ true }
+						value={ this.state.percent ? this.state.percent : 0 }
+					/>
+					<SubTitle>
+						{ translate(
+							"This may take a few minutes. We'll notify you by email when it's done."
+						) }
+					</SubTitle>
+				</Progress>
+				<GettingStartedVideo />
+			</>
 		);
 	}
 
@@ -158,13 +165,16 @@ export class ImportEverything extends SectionMigrate {
 		const { translate, targetSiteSlug } = this.props;
 
 		return (
-			<Hooray>
-				<Title>{ translate( 'Hooray!' ) }</Title>
-				<SubTitle>
-					{ translate( 'Congratulations. Your content was successfully imported.' ) }
-				</SubTitle>
-				<DoneButton siteSlug={ targetSiteSlug } />
-			</Hooray>
+			<>
+				<Hooray>
+					<Title>{ translate( 'Hooray!' ) }</Title>
+					<SubTitle>
+						{ translate( 'Congratulations. Your content was successfully imported.' ) }
+					</SubTitle>
+					<DoneButton siteSlug={ targetSiteSlug } />
+				</Hooray>
+				<GettingStartedVideo />
+			</>
 		);
 	}
 

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -1,6 +1,7 @@
 import page from 'page';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { addQueryArgs } from 'calypso/lib/route';
 import { convertToFriendlyWebsiteName } from 'calypso/signup/steps/import/util';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
@@ -62,7 +63,11 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	}
 
 	function checkImporterAvailability() {
-		! isSiteAtomic && isSiteJetpack && redirectToWpAdminImportPage();
+		isNotAtomicJetpack() && redirectToWpAdminImportPage();
+	}
+
+	function isNotAtomicJetpack() {
+		return ! isSiteAtomic && isSiteJetpack;
 	}
 
 	function checkOptionQueryParam() {
@@ -95,36 +100,42 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	 */
 	return (
 		<>
-			{ undefined === option && (
-				<ContentChooser
-					onJetpackSelection={ installJetpack }
-					onContentOnlySelection={ switchToContentUploadScreen }
-					onContentEverythingSelection={ switchToMigrationScreen }
-					{ ...props }
-				/>
-			) }
-
-			{ WPImportOption.EVERYTHING === option && (
-				<ImportEverything
-					url={ fromSite }
-					sourceSiteId={ fromSiteItem?.ID as number }
-					sourceUrlAnalyzedData={ fromSiteAnalyzedData }
-					targetSite={ siteItem as SitesItem }
-					targetSiteId={ siteItem?.ID as number }
-					targetSiteSlug={ siteSlug }
-				/>
-			) }
-
-			{ WPImportOption.CONTENT_ONLY === option && (
-				<ImportContentOnly
-					job={ job }
-					fromSite={ fromSite }
-					importer={ importer }
-					siteItem={ siteItem }
-					siteSlug={ siteSlug }
-					siteAnalyzedData={ fromSiteAnalyzedData }
-				/>
-			) }
+			{ ( () => {
+				if ( isNotAtomicJetpack() ) {
+					return <LoadingEllipsis />;
+				} else if ( undefined === option ) {
+					return (
+						<ContentChooser
+							onJetpackSelection={ installJetpack }
+							onContentOnlySelection={ switchToContentUploadScreen }
+							onContentEverythingSelection={ switchToMigrationScreen }
+							{ ...props }
+						/>
+					);
+				} else if ( WPImportOption.EVERYTHING === option ) {
+					return (
+						<ImportEverything
+							url={ fromSite }
+							sourceSiteId={ fromSiteItem?.ID as number }
+							sourceUrlAnalyzedData={ fromSiteAnalyzedData }
+							targetSite={ siteItem as SitesItem }
+							targetSiteId={ siteItem?.ID as number }
+							targetSiteSlug={ siteSlug }
+						/>
+					);
+				} else if ( WPImportOption.CONTENT_ONLY === option ) {
+					return (
+						<ImportContentOnly
+							job={ job }
+							fromSite={ fromSite }
+							importer={ importer }
+							siteItem={ siteItem }
+							siteSlug={ siteSlug }
+							siteAnalyzedData={ fromSiteAnalyzedData }
+						/>
+					);
+				}
+			} )() }
 		</>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* WordPress - Import everything flow: show GettingStartedVideo component under the Progress/Hooray screens
* Fix issue with a flickering NotFound screen while the page redirection is in progress

#### Testing instructions

* Go to `/start/from/importing/wordpress?from={SLUG}.wordpress.com&to={JETPACK_CONNECTED_SITE} (use: `jurassic.ninja`)
* Check how redirection works (NotFound component should not be visible for a moment)

#### Screenshots:
<table>
<tr>
<td>Before (there is a moment when you can see NotFound component)</td>
<td>After</td>
</tr>
<tr>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/151993434-e078e8a6-fc27-46ad-a48c-b951b93a3208.gif" />
</td>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/151993401-862856c1-73eb-4c76-ab7f-b43759c876a4.gif" />
</td>
</tr>
</table>
Related to #57131
