### PR TITLE
Fix back link on the support card for WooCommerce on plans installation flow

### DIFF
--- a/client/signup/steps/woocommerce-install/components/support-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/support-card/index.tsx
@@ -30,7 +30,7 @@ export default function SupportCard(): ReactElement {
 				a: (
 					<SupportLinkStyle
 						href={ addQueryArgs( '/help/contact', {
-							redirect_to: `/start/woocommerce-install/confirm?site=${ domain }`,
+							redirect_to: `${ window.location.pathname }?site=${ domain }`,
 						} ) }
 					/>
 				),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update back link on the support card to redirect back to the last-seen step of the "WooCommerce on plans" installation flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start with a WordPress.com site.
* Click on WooCommerce menu on the left.
* When prompted to setup store, click on it and follow on-screen instructions to configure each stage.
* At each stage, click on "Contact support" which takes you to a page with support form.
* Click on the "back" button on this form and make sure the page you are being redirected to is the one you came from.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Video of this fix:

https://user-images.githubusercontent.com/18581859/151856905-af773eae-6577-424c-b827-0bd4b552dd59.mov





Fixes https://github.com/Automattic/wp-calypso/issues/60678
