### PR TITLE
Filterbar: Increase specificity

### DIFF
--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -8,7 +8,7 @@
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
-.filterbar__wrap.filterbar__wrap {
+.filterbar__wrap.card {
 	position: relative;
 	display: flex;
 	flex: 1 1 auto;

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -8,7 +8,7 @@
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
-.filterbar__wrap.card {
+.filterbar__wrap.filterbar__wrap {
 	position: relative;
 	display: flex;
 	flex: 1 1 auto;
@@ -192,15 +192,15 @@
 	.DayPicker-Day.DayPicker-Day--start {
 		background-color: var( --color-primary-light );
 		border-radius: 0;
-		border-top-left-radius: 50%;
-		border-bottom-left-radius: 50%;
+		border-top-left-radius: 50%; /* stylelint-disable-line */
+		border-bottom-left-radius: 50%; /* stylelint-disable-line */
 	}
 
 	.DayPicker-Day.DayPicker-Day--end {
 		background-color: var( --color-primary-light );
 		border-radius: 0;
-		border-top-right-radius: 50%;
-		border-bottom-right-radius: 50%;
+		border-top-right-radius: 50%; /* stylelint-disable-line */
+		border-bottom-right-radius: 50%; /* stylelint-disable-line */
 	}
 
 	.DayPicker-Day.DayPicker-Day--today .date-picker__day {
@@ -220,7 +220,7 @@
 		position: absolute;
 		display: block;
 		background-color: var( --color-neutral-70 );
-		border-radius: 50%;
+		border-radius: 50%; /* stylelint-disable-line */
 		width: 26px;
 		height: 26px;
 		left: 6px;
@@ -240,7 +240,7 @@
 
 	.DayPicker-Day.DayPicker-Day--start .date-picker__day,
 	.DayPicker-Day.DayPicker-Day--end .date-picker__day {
-		border-radius: 50%;
+		border-radius: 50%; /* stylelint-disable-line */
 		color: var( --color-text-inverted );
 		padding: 0;
 		position: relative;
@@ -279,7 +279,7 @@
 		right: auto;
 		z-index: -1;
 		background-color: var( --color-primary );
-		border-radius: 50%;
+		border-radius: 50%; /* stylelint-disable-line */
 	}
 
 	.DayPicker-Day--start:hover .date-picker__day::after,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixed the Filterbar on the activity log by increasing the specificity of the component.

Before:
<img width="1117" alt="Screen Shot 2022-01-31 at 11 34 59 AM" src="https://user-images.githubusercontent.com/115071/151860589-7fce8171-3d4d-49be-8b99-1051eacf920c.png">


After:
<img width="1092" alt="Screen Shot 2022-01-31 at 11 35 08 AM" src="https://user-images.githubusercontent.com/115071/151860564-ff3dab1c-29d6-405a-8b78-c9a008567cd9.png">


#### Testing instructions
Visit /activity-log/example.com where the site needs to have a business plan. 
Notice that the activity log filterbar now shows up as expected.
