### PR TITLE
Checkout: show the plan upsell even for PWPO users

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -21,8 +21,6 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
-import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { isRequestingPlans } from 'calypso/state/plans/selectors';
 import { getPlanPrice } from 'calypso/state/products-list/selectors';
 import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
@@ -173,9 +171,7 @@ const mapStateToProps = ( state, { cart, addItemToCart } ) => {
 			selectedSiteId &&
 			getPlanPrice( state, selectedSiteId, personalPlan, false ),
 		selectedSite: selectedSite,
-		showPlanUpsell: getCurrentUser( state )
-			? selectedSiteId && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
-			: false,
+		showPlanUpsell: selectedSiteId ?? false,
 		addItemToCart,
 	};
 };

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -162,16 +162,16 @@ const mapStateToProps = ( state, { cart, addItemToCart } ) => {
 	return {
 		hasPaidPlan: siteHasPaidPlan( selectedSite ),
 		hasPlanInCart: hasPlan( cart ),
-		isPlansListFetching: isPlansListFetching,
+		isPlansListFetching,
 		isRegisteringOrTransferringDomain: hasDomainRegistration( cart ) || hasTransferProduct( cart ),
 		isSitePlansListFetching: isRequestingSitePlans( state ),
-		personalPlan: personalPlan,
+		personalPlan,
 		planPrice:
 			! isPlansListFetching &&
 			selectedSiteId &&
 			getPlanPrice( state, selectedSiteId, personalPlan, false ),
-		selectedSite: selectedSite,
-		showPlanUpsell: selectedSiteId ?? false,
+		selectedSite,
+		showPlanUpsell: !! selectedSiteId,
 		addItemToCart,
 	};
 };

--- a/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
@@ -45,21 +45,23 @@ const UpsellWrapper = styled.div< DivProps >`
 			border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 			margin-left: 0;
 			margin-right: 0;
-			padding-left: 20px;
-			padding-right: 20px;
+			padding-left: 24px;
+			padding-right: 24px;
 		}
 
 		.section-header__label {
 			color: ${ ( props ) => props.theme.colors.textColor };
-			font-size: 16px;
+			font-size: 14px;
+			font-weight: 600;
 		}
 	}
 
 	.cart__upsell-body {
 		padding: 0 20px 20px;
+		font-size: 14px;
 
 		@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-			padding: 20px;
+			padding: 16px 24px 24px;
 		}
 
 		p {


### PR DESCRIPTION
I don't know if there's a reason we should be hiding the plan upsell for PWPO users, since we'd still like them to purchase a plan if they want to. This shows the upsell for PWPO users in Checkout also.

/cc @Automattic/nomado in case there are different flows that need to be tested, or a specific reason not to show the nudge.

Fixes: #56242

![Screen Shot 2022-01-31 at 3 41 40 PM](https://user-images.githubusercontent.com/942359/151869922-deba8b2d-cdef-4fa4-8327-27b7a5584486.png)

**To test:**
- On a free site, visit /domains, add a domain to your cart, and visit Checkout
- Verify that the Personal plan upsell is shown below the total in the sidebar
- Click the "Add to cart" button on the upsell
- Verify that an annual Personal plan is added to the cart and the domain is now free