### PR TITLE
Update the grid columns from 12 to 3 at Plugin Details page. 

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -119,24 +119,22 @@ body.is-section-plugins:not( .is-nav-unification ) {
 }
 
 .plugin-details__layout {
-	@include grid-row( 4, 1 );
 	@include breakpoint-deprecated( '>1040px' ) {
 		@include display-grid;
-		@include grid-template-columns( 12, 24px, 1fr );
-		grid-gap: 80px;
+		@include grid-template-columns( 3, 80px, 1fr );
 	}
 
 	.plugin-details__layout-col-left {
 		position: relative;
 		@include breakpoint-deprecated( '>1040px' ) {
-			@include grid-column( 1, 8 );
+			@include grid-column( 1, 2 );
 		}
 	}
 
 	.plugin-details__layout-col-right {
 		position: relative;
 		@include breakpoint-deprecated( '>1040px' ) {
-			@include grid-column( 9, 4 );
+			@include grid-column( 3, 1 );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Update the grid columns from 12 to 3 on the Plugin Details page. 
The grid only needs 3 columns as one section will take 66% of the space and the other one will take the rest 33%.

As the `grid-gap` is added after every column, it was being over-added because of the unnecessary columns, making the min-width of the grid to be the **number of gaps** (11) X **size of gaps (40px)** which is not responsive enough.

Using only 3 columns, only two gaps will exist(making the min-width 80px), which is not a problem as we have a breakpoint at `1040px`.

#### Testing instructions
* Go to `plugins`
* Click on a plugin to go to the Plugin Details page
* Open the browser developer tools and enable the responsive mode
* Check the page with different widths and see if anything is out of the place
* Check especially for the width `~ 1100px` that was causing the bug mentioned at #60618

#### Demo

| Before  | After |
| ------------- | ------------- |
|<img width="1106" alt="Screen Shot 2022-01-31 at 19 05 14" src="https://user-images.githubusercontent.com/5039531/151881888-fd663e1d-84c4-4303-a9e1-58d05a536725.png">|<img width="1106" alt="Screen Shot 2022-01-31 at 19 05 32" src="https://user-images.githubusercontent.com/5039531/151881918-45347ff9-0488-4e5c-b60c-7a23221285f5.png">|


---

Fixes #60618