### PR TITLE
Remove "Menus" and "AMP" submenus

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -100,6 +100,10 @@ function load_core_fse() {
 	add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
 	add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
 	add_action( 'admin_menu', __NAMESPACE__ . '\hide_nav_menus_submenu' );
+
+	// Hides the AMP menu.
+	remove_action( 'admin_menu', 'amp_add_customizer_link' );
+
 	remove_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	remove_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
@@ -118,6 +122,10 @@ function unload_core_fse() {
 	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
 	remove_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
 	remove_action( 'admin_menu', __NAMESPACE__ . '\hide_nav_menus_submenu' );
+
+	// Shows the AMP menu.
+	add_action( 'admin_menu', 'amp_add_customizer_link' );
+
 	if ( defined( 'REST_API_REQUEST' ) && true === REST_API_REQUEST ) {
 		// Do not hook to init during the REST API requests, as it causes PHP warnings
 		// while loading the alloptions (unable to access wp_0_ prefixed tables).

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -99,6 +99,7 @@ function load_core_fse() {
 	add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
 	add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
 	add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
+	add_action( 'admin_menu', __NAMESPACE__ . '\hide_nav_menus_submenu' );
 	remove_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	remove_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
@@ -116,6 +117,7 @@ function unload_core_fse() {
 	remove_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
 	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
 	remove_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
+	remove_action( 'admin_menu', __NAMESPACE__ . '\hide_nav_menus_submenu' );
 	if ( defined( 'REST_API_REQUEST' ) && true === REST_API_REQUEST ) {
 		// Do not hook to init during the REST API requests, as it causes PHP warnings
 		// while loading the alloptions (unable to access wp_0_ prefixed tables).
@@ -358,6 +360,15 @@ function display_fse_section() {
  */
 function hide_core_site_editor() {
 	remove_submenu_page( 'themes.php', 'site-editor.php' );
+}
+
+/**
+ * Hide the (Nav) Menus submenu when site editing is enabled
+ *
+ * @return void
+ */
+function hide_nav_menus_submenu() {
+	remove_submenu_page( 'themes.php', 'nav-menus.php' );
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Remove AMP and Menus submenus
 
### Screenshots
#### Before
<img width="1281" alt="Screen Shot 2022-02-01 at 2 02 33 PM" src="https://user-images.githubusercontent.com/5414230/152353735-874ae3ef-0312-4300-8514-9ed3b0173f03.png">

#### After
<img width="1280" alt="Screen Shot 2022-02-03 at 5 38 16 AM" src="https://user-images.githubusercontent.com/5414230/152353631-5ebb244a-a6c3-415a-9e08-91f65ff30404.png">

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox an FSE enabled site and the public API
* Apply changes from this PR to your sandbox by running `install-plugin.sh editing-toolkit remove/menus-and-amp-submenus` in the sandbox
* Refresh the WordPress admin UI
* Verify that `Appearance > Menus` and `Appearance > AMP` submenus are gone (changes may need 5-10 seconds to take effect because of the slower performance on a sandboxed public API)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60339
