### PR TITLE
Support Article: Add url query parameter to make the modal work as expected with back buttons

### DIFF
--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { withUrlSearchQueryState } from 'calypso/lib/url-search-query-state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
@@ -76,6 +77,7 @@ class InlineHelpRichResult extends Component {
 			// the user to the localized support blog, if one exists.
 			event.preventDefault();
 			this.props.openSupportArticleDialog( { postId, postUrl: link } );
+			this.props.updateUrlSearchQuery( postId );
 		}
 		// falls back on href
 	};
@@ -109,4 +111,7 @@ const mapDispatchToProps = {
 	openSupportArticleDialog,
 };
 
-export default connect( null, mapDispatchToProps )( localize( InlineHelpRichResult ) );
+export default connect(
+	null,
+	mapDispatchToProps
+)( localize( withUrlSearchQueryState( InlineHelpRichResult, 'support-article' ) ) );

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -49,22 +49,21 @@ export const SupportArticleDialog = ( {
 	const shouldQueryReaderPost = ! post && ! shouldRequestAlternates && ! isRequestingAlternates;
 
 	const [ supportArticleId, updateSupportArticle ] = useUrlSearchQueryState( 'support-article' );
-	if ( ! actionUrl ) {
-		actionUrl = 'https://support.wordpress.com?p=' + supportArticleId;
-	}
+
+	const articleUrl = actionUrl ? actionUrl : 'https://support.wordpress.com?p=' + supportArticleId;
 
 	useEffect( () => {
 		//If a url includes an anchor, let's scroll this into view!
-		if ( typeof window !== 'undefined' && actionUrl.indexOf( '#' ) !== -1 && post?.content ) {
+		if ( typeof window !== 'undefined' && articleUrl.indexOf( '#' ) !== -1 && post?.content ) {
 			setTimeout( () => {
-				const anchorId = actionUrl.split( '#' ).pop();
+				const anchorId = articleUrl.split( '#' ).pop();
 				const element = document.getElementById( anchorId );
 				if ( element ) {
 					element.scrollIntoView();
 				}
 			}, 0 );
 		}
-	}, [ actionUrl, post ] );
+	}, [ articleUrl, post ] );
 
 	const handleCloseDialog = () => {
 		closeSupportArticleDialog();
@@ -78,16 +77,14 @@ export const SupportArticleDialog = ( {
 			baseClassName="support-article-dialog__base dialog"
 			buttons={ [
 				<Button onClick={ handleCloseDialog }>{ translate( 'Close', { textOnly: true } ) }</Button>,
-				actionUrl && (
-					<Button
-						href={ actionUrl }
-						target={ actionIsExternal ? '_blank' : undefined }
-						primary
-						onClick={ actionIsExternal ? noop : handleCloseDialog }
-					>
-						{ actionLabel } { actionIsExternal && <Gridicon icon="external" size={ 12 } /> }
-					</Button>
-				),
+				<Button
+					href={ articleUrl }
+					target={ actionIsExternal ? '_blank' : undefined }
+					primary
+					onClick={ actionIsExternal ? noop : handleCloseDialog }
+				>
+					{ actionLabel } { actionIsExternal && <Gridicon icon="external" size={ 12 } /> }
+				</Button>,
 			].filter( Boolean ) }
 			onCancel={ handleCloseDialog }
 			onClose={ handleCloseDialog }
@@ -133,7 +130,7 @@ const getPostKey = memoize(
 const mapStateToProps = ( state ) => {
 	let postId = getInlineSupportArticlePostId( state );
 	if ( ! postId ) {
-		postId = parseInt( getUrlSearchQuery( 'support-article' ) );
+		postId = parseInt( getUrlSearchQuery( 'support-article' ), 10 );
 	}
 	const requestBlogId = getInlineSupportArticleBlogId( state );
 	const blogId = requestBlogId ?? SUPPORT_BLOG_ID;

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -83,7 +83,7 @@ export const SupportArticleDialog = ( {
 						href={ actionUrl }
 						target={ actionIsExternal ? '_blank' : undefined }
 						primary
-						onClick={ () => ( actionIsExternal ? noop() : handleCloseDialog() ) }
+						onClick={ actionIsExternal ? noop : handleCloseDialog }
 					>
 						{ actionLabel } { actionIsExternal && <Gridicon icon="external" size={ 12 } /> }
 					</Button>

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -67,8 +67,8 @@ export const SupportArticleDialog = ( {
 	}, [ actionUrl, post ] );
 
 	const handleCloseDialog = () => {
-		updateSupportArticle( null );
 		closeSupportArticleDialog();
+		updateSupportArticle( null );
 	};
 
 	return (

--- a/client/blocks/support-article-dialog/index.jsx
+++ b/client/blocks/support-article-dialog/index.jsx
@@ -1,20 +1,13 @@
-import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
-import { hasUrlSearchQuery } from 'calypso/lib/url-search-query-state';
-import isInlineSupportArticleVisible from 'calypso/state/selectors/is-inline-support-article-visible';
+import { useHasUrlSearchQuery } from 'calypso/lib/url-search-query-state';
 
-function SupportArticleDialogLoader( { isVisible } ) {
-	if ( isVisible === false ) {
-		isVisible = hasUrlSearchQuery( 'support-article' );
-	}
-
+function SupportArticleDialogLoader() {
+	const hasQueryInUrl = useHasUrlSearchQuery( 'support-article' );
 	return (
-		isVisible && (
+		hasQueryInUrl && (
 			<AsyncLoad require="calypso/blocks/support-article-dialog/dialog" placeholder={ null } />
 		)
 	);
 }
 
-export default connect( ( state ) => ( {
-	isVisible: isInlineSupportArticleVisible( state ),
-} ) )( SupportArticleDialogLoader );
+export default SupportArticleDialogLoader;

--- a/client/blocks/support-article-dialog/index.jsx
+++ b/client/blocks/support-article-dialog/index.jsx
@@ -1,8 +1,13 @@
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import { hasUrlSearchQuery } from 'calypso/lib/url-search-query-state';
 import isInlineSupportArticleVisible from 'calypso/state/selectors/is-inline-support-article-visible';
 
 function SupportArticleDialogLoader( { isVisible } ) {
+	if ( isVisible === false ) {
+		isVisible = hasUrlSearchQuery( 'support-article' );
+	}
+
 	return (
 		isVisible && (
 			<AsyncLoad require="calypso/blocks/support-article-dialog/dialog" placeholder={ null } />

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import QuerySupportArticleAlternates from 'calypso/components/data/query-support-article-alternates';
 import ExternalLink from 'calypso/components/external-link';
 import { isDefaultLocale, localizeUrl } from 'calypso/lib/i18n-utils';
+import { withUrlSearchQueryState } from 'calypso/lib/url-search-query-state';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -116,7 +117,10 @@ class InlineSupportLink extends Component {
 			<LinkComponent
 				className={ classnames( 'inline-support-link', className ) }
 				href={ url }
-				onClick={ ( event ) => openDialog( event, supportPostId, url ) }
+				onClick={ ( event ) => {
+					openDialog( event, supportPostId, url );
+					this.props.updateUrlSearchQuery( supportPostId );
+				} }
 				onMouseEnter={
 					! isDefaultLocale( localeSlug ) && ! shouldLazyLoadAlternates
 						? this.loadAlternates
@@ -173,4 +177,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 	};
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( InlineSupportLink ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( withUrlSearchQueryState( InlineSupportLink, 'support-article' ) ) );

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -118,8 +118,9 @@ class InlineSupportLink extends Component {
 				className={ classnames( 'inline-support-link', className ) }
 				href={ url }
 				onClick={ ( event ) => {
-					openDialog( event, supportPostId, url );
+					const openDialogReturn = openDialog( event, supportPostId, url );
 					this.props.updateUrlSearchQuery( supportPostId );
+					return openDialogReturn;
 				} }
 				onMouseEnter={
 					! isDefaultLocale( localeSlug ) && ! shouldLazyLoadAlternates

--- a/client/lib/url-search-query-state/index.js
+++ b/client/lib/url-search-query-state/index.js
@@ -6,7 +6,7 @@ function updateUrlSearchQuery( queryName, queryValue ) {
 		return;
 	}
 	const searchParams = new URLSearchParams( window.location.search );
-	// let historyObject = null;
+
 	let newQuery = '';
 	if ( queryValue ) {
 		searchParams.set( queryName, queryValue );

--- a/client/lib/url-search-query-state/index.js
+++ b/client/lib/url-search-query-state/index.js
@@ -58,8 +58,8 @@ export function useUrlSearchQueryState( queryName ) {
 }
 
 export const withUrlSearchQueryState = ( WrappedComponent, queryName ) => {
+	const updateUrlSearch = ( value ) => updateUrlSearchQuery( queryName, value );
 	return function WithSearchQueryState( props ) {
-		const updateUrlSearch = ( value ) => updateUrlSearchQuery( queryName, value );
 		return <WrappedComponent updateUrlSearchQuery={ updateUrlSearch } { ...props } />;
 	};
 };

--- a/client/lib/url-search-query-state/index.js
+++ b/client/lib/url-search-query-state/index.js
@@ -1,0 +1,43 @@
+import page from 'page';
+import { Component } from 'react';
+
+function updateUrlSearchQuery( queryName, queryValue ) {
+	const searchParams = new URLSearchParams( window.location.search );
+	// let historyObject = null;
+	let newQuery = '';
+	if ( queryValue ) {
+		searchParams.set( queryName, queryValue );
+	} else {
+		searchParams.delete( queryName );
+	}
+
+	if ( searchParams.toString() ) {
+		newQuery = '?' + decodeURIComponent( searchParams.toString() );
+	}
+
+	return page( window.location.pathname + newQuery );
+}
+
+export function hasUrlSearchQuery( queryName ) {
+	const searchParams = new URLSearchParams( window.location.search );
+	return searchParams.has( queryName );
+}
+
+export function getUrlSearchQuery( queryName ) {
+	const searchParams = new URLSearchParams( window.location.search );
+	return searchParams.get( queryName );
+}
+
+export function useUrlSearchQueryState( queryName ) {
+	const update = ( queryValue ) => updateUrlSearchQuery( queryName, queryValue );
+	return [ getUrlSearchQuery( queryName ), update ];
+}
+
+export const withUrlSearchQueryState = ( WrappedComponent, queryName ) => {
+	return class WithSearchQueryState extends Component {
+		render() {
+			const updateUrlSearch = ( value ) => updateUrlSearchQuery( queryName, value );
+			return <WrappedComponent updateUrlSearchQuery={ updateUrlSearch } { ...this.props } />;
+		}
+	};
+};

--- a/client/lib/url-search-query-state/index.js
+++ b/client/lib/url-search-query-state/index.js
@@ -1,5 +1,5 @@
 import page from 'page';
-import { Component, useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 function updateUrlSearchQuery( queryName, queryValue ) {
 	if ( typeof window === 'undefined' ) {
@@ -58,10 +58,8 @@ export function useUrlSearchQueryState( queryName ) {
 }
 
 export const withUrlSearchQueryState = ( WrappedComponent, queryName ) => {
-	return class WithSearchQueryState extends Component {
-		render() {
-			const updateUrlSearch = ( value ) => updateUrlSearchQuery( queryName, value );
-			return <WrappedComponent updateUrlSearchQuery={ updateUrlSearch } { ...this.props } />;
-		}
+	return function WithSearchQueryState( props ) {
+		const updateUrlSearch = ( value ) => updateUrlSearchQuery( queryName, value );
+		return <WrappedComponent updateUrlSearchQuery={ updateUrlSearch } { ...props } />;
 	};
 };

--- a/client/lib/url-search-query-state/index.js
+++ b/client/lib/url-search-query-state/index.js
@@ -19,7 +19,7 @@ function updateUrlSearchQuery( queryName, queryValue ) {
 	}
 	page( window.location.pathname + newQuery );
 	// Dispatch the custom event. So that we can listen for the event and update the state accordingly.
-	const event = new CustomEvent( 'changeUrlSearchQuery', { details: { queryName, queryValue } } );
+	const event = new CustomEvent( 'changeUrlSearchQuery' );
 	window.dispatchEvent( event );
 }
 

--- a/client/lib/url-search-query-state/index.js
+++ b/client/lib/url-search-query-state/index.js
@@ -2,7 +2,7 @@ import page from 'page';
 import { Component, useEffect, useState, useCallback } from 'react';
 
 function updateUrlSearchQuery( queryName, queryValue ) {
-	if ( ! window ) {
+	if ( typeof window === 'undefined' ) {
 		return;
 	}
 	const searchParams = new URLSearchParams( window.location.search );

--- a/client/lib/url-search-query-state/index.js
+++ b/client/lib/url-search-query-state/index.js
@@ -18,7 +18,7 @@ function updateUrlSearchQuery( queryName, queryValue ) {
 		newQuery = '?' + decodeURIComponent( searchParams.toString() );
 	}
 	page( window.location.pathname + newQuery );
-	// Dispatch the custom event.
+	// Dispatch the custom event. So that we can listen for the event and update the state accordingly.
 	const event = new CustomEvent( 'changeUrlSearchQuery', { details: { queryName, queryValue } } );
 	window.dispatchEvent( event );
 }

--- a/client/state/inline-support-article/actions.js
+++ b/client/state/inline-support-article/actions.js
@@ -4,34 +4,6 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/inline-support-article/init';
-/**
- * Update the url to contain 'support-article'
- *
- * @param {number} postId
- */
-function updateUrl( postId = null ) {
-	if ( ! window.history || ! URLSearchParams ) {
-		return;
-	}
-
-	const searchParams = new URLSearchParams( window.location.search );
-	let historyObject = null;
-	let newQuery = '';
-
-	if ( postId ) {
-		searchParams.set( 'support-article', postId );
-		historyObject = { postId };
-	} else {
-		searchParams.delete( 'support-article' );
-	}
-
-	if ( searchParams.toString() ) {
-		newQuery = '?' + decodeURIComponent( searchParams.toString() );
-	}
-
-	const newUrl = window.location.pathname + newQuery;
-	window.history.pushState( historyObject, '', newUrl );
-}
 
 /**
  * Shows the given support article (by postId) in a dialog.
@@ -51,7 +23,6 @@ export function openSupportArticleDialog( {
 	actionUrl = null,
 	blogId = null,
 } ) {
-	updateUrl( postId );
 	return {
 		type: SUPPORT_ARTICLE_DIALOG_OPEN,
 		postId,
@@ -68,6 +39,5 @@ export function openSupportArticleDialog( {
  * @returns {object}		Action
  */
 export function closeSupportArticleDialog() {
-	updateUrl();
 	return { type: SUPPORT_ARTICLE_DIALOG_CLOSE };
 }

--- a/client/state/inline-support-article/actions.js
+++ b/client/state/inline-support-article/actions.js
@@ -14,6 +14,7 @@ import 'calypso/state/inline-support-article/init';
  * @param {string} options.actionLabel Label of the action
  * @param {string} options.actionUrl   URL of the action
  * @param {number} options.blogId      The blog id of the support article
+ *
  * @returns {object}		Action
  */
 export function openSupportArticleDialog( {

--- a/client/state/inline-support-article/actions.js
+++ b/client/state/inline-support-article/actions.js
@@ -4,6 +4,34 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/inline-support-article/init';
+/**
+ * Update the url to contain 'support-article'
+ *
+ * @param {number} postId
+ */
+function updateUrl( postId = null ) {
+	if ( ! window.history || ! URLSearchParams ) {
+		return;
+	}
+
+	const searchParams = new URLSearchParams( window.location.search );
+	let historyObject = null;
+	let newQuery = '';
+
+	if ( postId ) {
+		searchParams.set( 'support-article', postId );
+		historyObject = { postId };
+	} else {
+		searchParams.delete( 'support-article' );
+	}
+
+	if ( searchParams.toString() ) {
+		newQuery = '?' + decodeURIComponent( searchParams.toString() );
+	}
+
+	const newUrl = window.location.pathname + newQuery;
+	window.history.pushState( historyObject, '', newUrl );
+}
 
 /**
  * Shows the given support article (by postId) in a dialog.
@@ -14,7 +42,6 @@ import 'calypso/state/inline-support-article/init';
  * @param {string} options.actionLabel Label of the action
  * @param {string} options.actionUrl   URL of the action
  * @param {number} options.blogId      The blog id of the support article
- *
  * @returns {object}		Action
  */
 export function openSupportArticleDialog( {
@@ -24,6 +51,7 @@ export function openSupportArticleDialog( {
 	actionUrl = null,
 	blogId = null,
 } ) {
+	updateUrl( postId );
 	return {
 		type: SUPPORT_ARTICLE_DIALOG_OPEN,
 		postId,
@@ -40,5 +68,6 @@ export function openSupportArticleDialog( {
  * @returns {object}		Action
  */
 export function closeSupportArticleDialog() {
+	updateUrl();
 	return { type: SUPPORT_ARTICLE_DIALOG_CLOSE };
 }

--- a/client/state/inline-support-article/reducer.js
+++ b/client/state/inline-support-article/reducer.js
@@ -5,7 +5,7 @@ import {
 } from 'calypso/state/action-types';
 
 function defaultPostId() {
-	if ( ! window || ! URLSearchParams ) {
+	if ( ! window && ! URLSearchParams ) {
 		return null;
 	}
 

--- a/client/state/inline-support-article/reducer.js
+++ b/client/state/inline-support-article/reducer.js
@@ -5,6 +5,10 @@ import {
 } from 'calypso/state/action-types';
 
 function defaultPostId() {
+	if ( ! window || ! URLSearchParams ) {
+		return null;
+	}
+
 	const searchParams = new URLSearchParams( window.location.search );
 	return searchParams.has( 'support-article' )
 		? parseInt( searchParams.get( 'support-article' ) )

--- a/client/state/inline-support-article/reducer.js
+++ b/client/state/inline-support-article/reducer.js
@@ -10,7 +10,6 @@ export default withStorageKey(
 		state = {
 			postId: null,
 			postUrl: null,
-			isVisible: false,
 			blogId: null,
 		},
 		action
@@ -28,7 +27,6 @@ export default withStorageKey(
 				return {
 					postUrl,
 					postId,
-					isVisible: true,
 					actionLabel,
 					actionUrl,
 					blogId,
@@ -37,7 +35,6 @@ export default withStorageKey(
 			case SUPPORT_ARTICLE_DIALOG_CLOSE:
 				return {
 					...state,
-					isVisible: false,
 				};
 		}
 

--- a/client/state/inline-support-article/reducer.js
+++ b/client/state/inline-support-article/reducer.js
@@ -4,13 +4,27 @@ import {
 	SUPPORT_ARTICLE_DIALOG_CLOSE,
 } from 'calypso/state/action-types';
 
+function defaultPostId() {
+	const searchParams = new URLSearchParams( window.location.search );
+	return searchParams.has( 'support-article' )
+		? parseInt( searchParams.get( 'support-article' ) )
+		: null;
+}
+
+function defaultPostUrl() {
+	const postId = defaultPostId();
+	if ( postId ) {
+		return 'https://support.wordpress.com?p=' + postId;
+	}
+	return null;
+}
+
 export default withStorageKey(
 	'inlineSupportArticle',
 	(
 		state = {
-			postId: null,
-			postUrl: null,
-			isVisible: false,
+			postId: defaultPostId(),
+			postUrl: defaultPostUrl(),
 			blogId: null,
 		},
 		action
@@ -28,7 +42,6 @@ export default withStorageKey(
 				return {
 					postUrl,
 					postId,
-					isVisible: true,
 					actionLabel,
 					actionUrl,
 					blogId,
@@ -37,7 +50,6 @@ export default withStorageKey(
 			case SUPPORT_ARTICLE_DIALOG_CLOSE:
 				return {
 					...state,
-					isVisible: false,
 				};
 		}
 

--- a/client/state/inline-support-article/reducer.js
+++ b/client/state/inline-support-article/reducer.js
@@ -4,31 +4,13 @@ import {
 	SUPPORT_ARTICLE_DIALOG_CLOSE,
 } from 'calypso/state/action-types';
 
-function defaultPostId() {
-	if ( ! window && ! URLSearchParams ) {
-		return null;
-	}
-
-	const searchParams = new URLSearchParams( window.location.search );
-	return searchParams.has( 'support-article' )
-		? parseInt( searchParams.get( 'support-article' ) )
-		: null;
-}
-
-function defaultPostUrl() {
-	const postId = defaultPostId();
-	if ( postId ) {
-		return 'https://support.wordpress.com?p=' + postId;
-	}
-	return null;
-}
-
 export default withStorageKey(
 	'inlineSupportArticle',
 	(
 		state = {
-			postId: defaultPostId(),
-			postUrl: defaultPostUrl(),
+			postId: null,
+			postUrl: null,
+			isVisible: false,
 			blogId: null,
 		},
 		action
@@ -46,6 +28,7 @@ export default withStorageKey(
 				return {
 					postUrl,
 					postId,
+					isVisible: true,
 					actionLabel,
 					actionUrl,
 					blogId,
@@ -54,6 +37,7 @@ export default withStorageKey(
 			case SUPPORT_ARTICLE_DIALOG_CLOSE:
 				return {
 					...state,
+					isVisible: false,
 				};
 		}
 

--- a/client/state/selectors/is-inline-support-article-visible.js
+++ b/client/state/selectors/is-inline-support-article-visible.js
@@ -1,9 +1,7 @@
-import { get } from 'lodash';
-
-import 'calypso/state/inline-support-article/init';
-
 /**
- * @param {object} state Global app state
  * @returns {object} ...
  */
-export default ( state ) => get( state, 'inlineSupportArticle.isVisible', false );
+export default () => {
+	const searchParams = new URLSearchParams( window.location.search );
+	return searchParams.has( 'support-article' );
+};

--- a/client/state/selectors/is-inline-support-article-visible.js
+++ b/client/state/selectors/is-inline-support-article-visible.js
@@ -1,9 +1,0 @@
-import { get } from 'lodash';
-
-import 'calypso/state/inline-support-article/init';
-
-/**
- * @param {object} state Global app state
- * @returns {object} ...
- */
-export default ( state ) => get( state, 'inlineSupportArticle.isVisible', false );

--- a/client/state/selectors/is-inline-support-article-visible.js
+++ b/client/state/selectors/is-inline-support-article-visible.js
@@ -1,7 +1,9 @@
+import { get } from 'lodash';
+
+import 'calypso/state/inline-support-article/init';
+
 /**
+ * @param {object} state Global app state
  * @returns {object} ...
  */
-export default () => {
-	const searchParams = new URLSearchParams( window.location.search );
-	return searchParams.has( 'support-article' );
-};
+export default ( state ) => get( state, 'inlineSupportArticle.isVisible', 'init' );

--- a/client/state/selectors/is-inline-support-article-visible.js
+++ b/client/state/selectors/is-inline-support-article-visible.js
@@ -6,4 +6,4 @@ import 'calypso/state/inline-support-article/init';
  * @param {object} state Global app state
  * @returns {object} ...
  */
-export default ( state ) => get( state, 'inlineSupportArticle.isVisible', 'init' );
+export default ( state ) => get( state, 'inlineSupportArticle.isVisible', false );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently when you open up a Suppor Article, the back button stops working as expected. 
This is more prominent on mobile where the modal takes up most of the screen. 
By adding a query parameter to the URL the back button works as expected again. 

It moves the SupportArticleDialog isVisibiliy to the URL. 
The new library found in client/lib/url-search-query-state/index.js registers listeners for when the URL changes for a particular query parameter and when the user navigates using the forward and backwards button. 

#### Testing instructions

1. Find a link that opens a support article. 
2. Notice that if you click the back button you end up on the page you expect. 
3. Open up the link again. 
4. Refresh the page. Notice that the modal opens/loads as expected on page load.
5. Close the support article and notice that the query parameter from the url is now gone. 

Related to
https://github.com/Automattic/wp-calypso/issues/58511 