### PR TITLE
Woo landing page design iterations

### DIFF
--- a/client/components/cta-section/index.tsx
+++ b/client/components/cta-section/index.tsx
@@ -3,16 +3,7 @@ import { TranslateResult } from 'i18n-calypso';
 import { ReactElement } from 'react';
 
 const Container = styled.div`
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	align-items: center;
 	min-height: 500px;
-	column-gap: 2em;
-	row-gap: 2em;
-
-	@media ( max-width: 660px ) {
-		grid-template-columns: 1fr;
-	}
 `;
 
 const CtaContainer = styled.div`

--- a/client/components/cta-section/index.tsx
+++ b/client/components/cta-section/index.tsx
@@ -24,9 +24,9 @@ const CtaContainer = styled.div`
 	}
 `;
 
-// const ContentContainer = styled.div`
-// 	justify-self: end;
-// `;
+const ContentContainer = styled.div`
+	justify-self: end;
+`;
 
 const Headline = styled.h3`
 	font-size: 16px;
@@ -44,23 +44,31 @@ const Title = styled.h4`
 interface Props {
 	title?: TranslateResult;
 	headline?: TranslateResult;
-	notice: ReactElement | null;
-	ctaRef?: React.RefObject< HTMLButtonElement >;
+	notice?: ReactElement | null;
+	cta?: ReactElement | null;
+	byline?: ReactElement | null;
+	children?: ReactElement | null;
 }
 
-const CtaSection: React.FunctionComponent< Props > = ( props ) => {
-	const { children, title, headline, notice = null } = props;
+const CtaSection: React.FunctionComponent< Props > = ( {
+	title = '',
+	headline = '',
+	notice = null,
+	cta = null,
+	children = null,
+	byline = null,
+} ) => {
 	return (
 		<Container>
 			<CtaContainer>
 				<Title>{ title }</Title>
 				<Headline>{ headline }</Headline>
 				{ notice }
-				{ children }
+				{ cta }
+				{ byline }
 			</CtaContainer>
-			{ /* <ContentContainer>{ children }</ContentContainer> */ }
+			<ContentContainer>{ children }</ContentContainer>
 		</Container>
 	);
 };
-
 export default CtaSection;

--- a/client/components/cta-section/index.tsx
+++ b/client/components/cta-section/index.tsx
@@ -53,8 +53,8 @@ const CtaSection: React.FunctionComponent< Props > = ( props ) => {
 	return (
 		<Container>
 			<CtaContainer>
-				<Headline>{ title }</Headline>
-				<Title>{ headline }</Title>
+				<Title>{ title }</Title>
+				<Headline>{ headline }</Headline>
 				{ notice }
 				{ children }
 			</CtaContainer>

--- a/client/components/cta-section/index.tsx
+++ b/client/components/cta-section/index.tsx
@@ -1,9 +1,19 @@
+import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
 import { ReactElement } from 'react';
 
 const Container = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	align-items: center;
 	min-height: 500px;
+	column-gap: 2em;
+	row-gap: 2em;
+
+	@media ( max-width: 660px ) {
+		grid-template-columns: 1fr;
+	}
 `;
 
 const CtaContainer = styled.div`
@@ -35,31 +45,37 @@ const Title = styled.h4`
 interface Props {
 	title?: TranslateResult;
 	headline?: TranslateResult;
-	notice?: ReactElement | null;
-	cta?: ReactElement | null;
-	byline?: ReactElement | null;
-	children?: ReactElement | null;
+	buttonText: TranslateResult;
+	buttonDisabled: boolean;
+	buttonAction: () => void;
+	notice: ReactElement | null;
+	ctaRef?: React.RefObject< HTMLButtonElement >;
 }
 
-const CtaSection: React.FunctionComponent< Props > = ( {
-	title = '',
-	headline = '',
-	notice = null,
-	cta = null,
-	children = null,
-	byline = null,
-} ) => {
+const CtaSection: React.FunctionComponent< Props > = ( props ) => {
+	const {
+		children,
+		title,
+		headline,
+		buttonText,
+		buttonDisabled = false,
+		buttonAction,
+		notice = null,
+		ctaRef,
+	} = props;
 	return (
 		<Container>
 			<CtaContainer>
-				<Title>{ title }</Title>
-				<Headline>{ headline }</Headline>
+				<Headline>{ title }</Headline>
+				<Title>{ headline }</Title>
 				{ notice }
-				{ cta }
-				{ byline }
+				<Button primary onClick={ buttonAction } ref={ ctaRef } disabled={ buttonDisabled }>
+					{ buttonText }
+				</Button>
 			</CtaContainer>
 			<ContentContainer>{ children }</ContentContainer>
 		</Container>
 	);
 };
+
 export default CtaSection;

--- a/client/components/cta-section/index.tsx
+++ b/client/components/cta-section/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
 import { ReactElement } from 'react';
@@ -25,9 +24,9 @@ const CtaContainer = styled.div`
 	}
 `;
 
-const ContentContainer = styled.div`
-	justify-self: end;
-`;
+// const ContentContainer = styled.div`
+// 	justify-self: end;
+// `;
 
 const Headline = styled.h3`
 	font-size: 16px;
@@ -45,35 +44,21 @@ const Title = styled.h4`
 interface Props {
 	title?: TranslateResult;
 	headline?: TranslateResult;
-	buttonText: TranslateResult;
-	buttonDisabled: boolean;
-	buttonAction: () => void;
 	notice: ReactElement | null;
 	ctaRef?: React.RefObject< HTMLButtonElement >;
 }
 
 const CtaSection: React.FunctionComponent< Props > = ( props ) => {
-	const {
-		children,
-		title,
-		headline,
-		buttonText,
-		buttonDisabled = false,
-		buttonAction,
-		notice = null,
-		ctaRef,
-	} = props;
+	const { children, title, headline, notice = null } = props;
 	return (
 		<Container>
 			<CtaContainer>
 				<Headline>{ title }</Headline>
 				<Title>{ headline }</Title>
 				{ notice }
-				<Button primary onClick={ buttonAction } ref={ ctaRef } disabled={ buttonDisabled }>
-					{ buttonText }
-				</Button>
+				{ children }
 			</CtaContainer>
-			<ContentContainer>{ children }</ContentContainer>
+			{ /* <ContentContainer>{ children }</ContentContainer> */ }
 		</Container>
 	);
 };

--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -44,9 +44,9 @@ function render() {
 | `actionURL`             | `string`        | `null`                                   | `href` value for the primary action button.                                                                                                   |
 | `actionCallback`        | `function`      | `null`                                   | `onClick` value for the primary action button.                                                                                                |
 | `actionTarget`          | `string`        | `null`                                   | If omitted, no target attribute is specified.                                                                                                 |
-| `actionHoverCallback`\* | `bool`          | `0`                                      | Indicates activity while a background action is being performed.                                                                             |
-| `actionDisabled`        | `bool`          | `null`                                   | Disables the button.                                                                                                     |
-| `actionRef`             | `function`      | `null`                                   | Adds a ref to the button.                 |
+| `actionHoverCallback`\* | `bool`          | `0`                                      | Indicates activity while a background action is being performed.                                                                              |
+| `actionDisabled`        | `bool`          | `null`                                   | Disables the button.                                                                                                                          |
+| `actionRef`             | `function`      | `null`                                   | Adds a ref to the button.                                                                                                                     |
 | `isCompact`             | `bool`          | `false`                                  | Shows a smaller version of the component.                                                                                                     |
 
 ### Additional props

--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -44,7 +44,9 @@ function render() {
 | `actionURL`             | `string`        | `null`                                   | `href` value for the primary action button.                                                                                                   |
 | `actionCallback`        | `function`      | `null`                                   | `onClick` value for the primary action button.                                                                                                |
 | `actionTarget`          | `string`        | `null`                                   | If omitted, no target attribute is specified.                                                                                                 |
-| `actionHoverCallback`\* | `bool`          | `0`                                      | Indicates activity while a background action is being performed.                                                                              |
+| `actionHoverCallback`\* | `bool`          | `0`                                      | Indicates activity while a background action is being performed.                                                                             |
+| `actionDisabled`        | `bool`          | `null`                                   | Disables the button.                                                                                                     |
+| `actionRef`             | `function`      | `null`                                   | Adds a ref to the button.                 |
 | `isCompact`             | `bool`          | `false`                                  | Shows a smaller version of the component.                                                                                                     |
 
 ### Additional props

--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -17,6 +17,8 @@ class EmptyContent extends Component {
 		actionCallback: PropTypes.func,
 		actionTarget: PropTypes.string,
 		actionHoverCallback: PropTypes.func,
+		actionDisabled: PropTypes.bool,
+		actionRef: PropTypes.func,
 		secondaryAction: PropTypes.node,
 		secondaryActionURL: PropTypes.string,
 		secondaryActionCallback: PropTypes.func,
@@ -44,6 +46,8 @@ class EmptyContent extends Component {
 					onClick={ this.props.actionCallback }
 					href={ localizeUrl( this.props.actionURL ) }
 					target={ this.props.actionTarget }
+					disabled={ this.props.actionDisabled }
+					ref={ this.props.actionRef }
 					onMouseEnter={ this.props.actionHoverCallback }
 					onTouchStart={ this.props.actionHoverCallback }
 				>

--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -18,7 +18,10 @@ class EmptyContent extends Component {
 		actionTarget: PropTypes.string,
 		actionHoverCallback: PropTypes.func,
 		actionDisabled: PropTypes.bool,
-		actionRef: PropTypes.func,
+		actionRef: PropTypes.oneOfType( [
+			PropTypes.func,
+			PropTypes.shape( { current: PropTypes.instanceOf( Element ) } ),
+		] ),
 		secondaryAction: PropTypes.node,
 		secondaryActionURL: PropTypes.string,
 		secondaryActionCallback: PropTypes.func,

--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -20,7 +20,7 @@ class EmptyContent extends Component {
 		actionDisabled: PropTypes.bool,
 		actionRef: PropTypes.oneOfType( [
 			PropTypes.func,
-			PropTypes.shape( { current: PropTypes.instanceOf( Element ) } ),
+			PropTypes.shape( { current: PropTypes.any } ),
 		] ),
 		secondaryAction: PropTypes.node,
 		secondaryActionURL: PropTypes.string,

--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	.woocommerce-colophon {
-		margin-top: 40px;
+		margin-top: 1em;
 		text-align: center;
 		color: var( --color-text-subtle );
 

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -4,15 +4,11 @@ import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
-import Image01 from 'calypso/assets/images/woocommerce/woop-cta-image01.jpeg';
-import Image02 from 'calypso/assets/images/woocommerce/woop-cta-image02.jpeg';
-import Image03 from 'calypso/assets/images/woocommerce/woop-cta-image03.jpeg';
-import Image04 from 'calypso/assets/images/woocommerce/woop-cta-image04.jpeg';
 import CtaSection from 'calypso/components/cta-section';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
-import MasonryWave from 'calypso/components/masonry-wave';
 import WarningCard from 'calypso/components/warning-card';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
+import WooCommerceColophon from '../woocommerce-colophon';
 
 import './style.scss';
 
@@ -24,8 +20,6 @@ interface Props {
 	startSetup: () => void;
 	siteId: number;
 }
-
-const images = [ { src: Image01 }, { src: Image02 }, { src: Image03 }, { src: Image04 } ];
 
 const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	const { __ } = useI18n();
@@ -76,9 +70,8 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 				buttonDisabled={ isTransferringBlocked }
 				ctaRef={ ctaRef }
 				notice={ renderWarningNotice() }
-			>
-				<MasonryWave images={ images } />
-			</CtaSection>
+			></CtaSection>
+			<WooCommerceColophon />
 		</div>
 	);
 };

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -64,7 +64,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 			</FixedNavigationHeader>
 			{ renderWarningNotice() }
 			<EmptyContent
-				title={ __( 'Setup a store and start selling online' ) }
+				title={ __( 'Set up a store and start selling online' ) }
 				illustration="/calypso/images/illustrations/illustration-shopping-bags.svg"
 				illustrationWidth="150"
 				line={ __(

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -59,13 +59,15 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 		<div className="woop__landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
 				<Button onClick={ onCTAClickHandler } primary disabled={ isTransferringBlocked }>
-					{ __( 'Set up my store!' ) }
+					{ __( 'Start a new store' ) }
 				</Button>
 			</FixedNavigationHeader>
 			<CtaSection
-				title={ __( 'Have something to sell?' ) }
-				headline={ __( 'Build exactly the eCommerce website you want.' ) }
-				buttonText={ __( 'Set up my store!' ) }
+				title={ __(
+					'Set up a new store in minutes. Get secure payments, configurable shipping options, and more, out of the box.'
+				) }
+				headline={ __( 'Setup a store and start selling online' ) }
+				buttonText={ __( 'Start a new store' ) }
 				buttonAction={ onCTAClickHandler }
 				buttonDisabled={ isTransferringBlocked }
 				ctaRef={ ctaRef }

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -66,7 +66,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 			<EmptyContent
 				title={ __( 'Set up a store and start selling online' ) }
 				illustration="/calypso/images/illustrations/illustration-shopping-bags.svg"
-				illustrationWidth="150"
+				illustrationWidth={ 150 }
 				line={ __(
 					'Set up a new store in minutes. Get secure payments, configurable shipping options, and more, out of the box.'
 				) }

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -67,12 +67,21 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 					'Set up a new store in minutes. Get secure payments, configurable shipping options, and more, out of the box.'
 				) }
 				headline={ __( 'Setup a store and start selling online' ) }
-				buttonText={ __( 'Start a new store' ) }
-				buttonAction={ onCTAClickHandler }
-				buttonDisabled={ isTransferringBlocked }
-				ctaRef={ ctaRef }
 				notice={ renderWarningNotice() }
-			></CtaSection>
+			>
+				<Button href="https://wordpress.com/support/introduction-to-woocommerce/" ref={ ctaRef }>
+					{ __( 'Learn more' ) }
+				</Button>
+				<Button
+					primary
+					onClick={ onCTAClickHandler }
+					ref={ ctaRef }
+					disabled={ isTransferringBlocked }
+				>
+					{ __( 'Start a new store' ) }
+				</Button>
+			</CtaSection>
+
 			<WooCommerceColophon />
 		</div>
 	);

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -68,21 +68,26 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 					'Set up a new store in minutes. Get secure payments, configurable shipping options, and more, out of the box.'
 				) }
 				notice={ renderWarningNotice() }
-			>
-				<Button href="https://wordpress.com/support/introduction-to-woocommerce/" ref={ ctaRef }>
-					{ __( 'Learn more' ) }
-				</Button>
-				<Button
-					primary
-					onClick={ onCTAClickHandler }
-					ref={ ctaRef }
-					disabled={ isTransferringBlocked }
-				>
-					{ __( 'Start a new store' ) }
-				</Button>
-			</CtaSection>
-
-			<WooCommerceColophon />
+				cta={
+					<>
+						<Button
+							href="https://wordpress.com/support/introduction-to-woocommerce/"
+							ref={ ctaRef }
+						>
+							{ __( 'Learn more' ) }
+						</Button>
+						<Button
+							primary
+							onClick={ onCTAClickHandler }
+							ref={ ctaRef }
+							disabled={ isTransferringBlocked }
+						>
+							{ __( 'Start a new store' ) }
+						</Button>
+					</>
+				}
+				byline={ <WooCommerceColophon /> }
+			/>
 		</div>
 	);
 };

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -63,10 +63,10 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 				</Button>
 			</FixedNavigationHeader>
 			<CtaSection
-				title={ __(
+				title={ __( 'Setup a store and start selling online' ) }
+				headline={ __(
 					'Set up a new store in minutes. Get secure payments, configurable shipping options, and more, out of the box.'
 				) }
-				headline={ __( 'Setup a store and start selling online' ) }
 				notice={ renderWarningNotice() }
 			>
 				<Button href="https://wordpress.com/support/introduction-to-woocommerce/" ref={ ctaRef }>

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
-import StoreIllustration from 'calypso/assets/images/domains/free-domain.svg';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import WarningCard from 'calypso/components/warning-card';
@@ -63,6 +62,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 					{ __( 'Start a new store' ) }
 				</Button>
 			</FixedNavigationHeader>
+			{ renderWarningNotice() }
 			<EmptyContent
 				title={ __( 'Setup a store and start selling online' ) }
 				illustration="/calypso/images/illustrations/illustration-shopping-bags.svg"

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -72,6 +72,8 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 				) }
 				action={ __( 'Start a new store' ) }
 				actionCallback={ onCTAClickHandler }
+				actionDisabled={ isTransferringBlocked }
+				actionRef={ ctaRef }
 				secondaryAction={ __( 'Learn more' ) }
 				secondaryActionURL="https://wordpress.com/support/introduction-to-woocommerce/"
 				secondaryActionTarget="_blank"

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -4,7 +4,8 @@ import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
-import CtaSection from 'calypso/components/cta-section';
+import StoreIllustration from 'calypso/assets/images/domains/free-domain.svg';
+import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import WarningCard from 'calypso/components/warning-card';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
@@ -62,32 +63,21 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 					{ __( 'Start a new store' ) }
 				</Button>
 			</FixedNavigationHeader>
-			<CtaSection
+			<EmptyContent
 				title={ __( 'Setup a store and start selling online' ) }
-				headline={ __(
+				illustration="/calypso/images/illustrations/illustration-shopping-bags.svg"
+				illustrationWidth="150"
+				line={ __(
 					'Set up a new store in minutes. Get secure payments, configurable shipping options, and more, out of the box.'
 				) }
-				notice={ renderWarningNotice() }
-				cta={
-					<>
-						<Button
-							href="https://wordpress.com/support/introduction-to-woocommerce/"
-							ref={ ctaRef }
-						>
-							{ __( 'Learn more' ) }
-						</Button>
-						<Button
-							primary
-							onClick={ onCTAClickHandler }
-							ref={ ctaRef }
-							disabled={ isTransferringBlocked }
-						>
-							{ __( 'Start a new store' ) }
-						</Button>
-					</>
-				}
-				byline={ <WooCommerceColophon /> }
+				action={ __( 'Start a new store' ) }
+				actionCallback={ onCTAClickHandler }
+				secondaryAction={ __( 'Learn more' ) }
+				secondaryActionURL="https://wordpress.com/support/introduction-to-woocommerce/"
+				secondaryActionTarget="_blank"
+				className="woop__landing-page-cta woocommerce_landing-page"
 			/>
+			<WooCommerceColophon />
 		</div>
 	);
 };

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -1,3 +1,17 @@
 body.is-section-woocommerce-installation.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
 }
+
+.woocommerce_landing-page {
+	.empty-content__title {
+		font-family: Recoleta;
+		color: var( --studio-gray-90 );
+		font-size: 2.81rem;
+		line-height: 1.19;
+		padding-bottom: 1em;
+	}
+	.empty-content__line {
+		font-size: 16px;
+		padding-bottom: 10px;
+	}
+}

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -1,17 +1,19 @@
+@import '@automattic/onboarding/styles/mixins';
+
 body.is-section-woocommerce-installation.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
 }
 
 .woocommerce_landing-page {
+	padding-top: 3em;
+
 	.empty-content__title {
-		font-family: Recoleta;
+		@include onboarding-heading-text;
 		color: var( --studio-gray-90 );
-		font-size: 2.81rem;
-		line-height: 1.19;
-		padding-bottom: 1em;
+		padding: 1em 0 0.5em;
 	}
 	.empty-content__line {
-		font-size: 16px;
-		padding-bottom: 10px;
+		@include onboarding-large-text;
+		margin-bottom: 1.5em;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Misc changes to move towards design specified in #59190 / r6eTqDpL2GGk96hcPLhsBb-fi-877%3A2069
* There was a few divergences from the figma (discussed wtih @SaxonF)
  * Using `EmptyComponent` button ordering. Fix in EmptyComponent if we want this changed or do via css for woop only.
  * Opted for no play icon in the secondary cta for now.
  * Using https://wordpress.com/support/introduction-to-woocommerce/ as secondary cta link
  * Used existing `WooCommerceColophon` couldn't find any logo badge like seen in figma.

#### Testing instructions

- Visit http://calypso.localhost:3000/woocommerce-installation/site-id

Before

![Screenshot 2022-02-01 at 17-42-41 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/151923710-60965595-a1b2-40bd-af52-5ccc0b3ff618.png)

After
![Screenshot 2022-02-01 at 17-41-21 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/151923677-20eb0ff6-88be-4632-86a2-a7502b22e0d5.png)


Related to #59190