### PR TITLE
Plans: fix translation text in popover

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -274,7 +274,7 @@ export const FEATURES_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'All paid WordPress.com plans purchased for an annual term include one year of free domain registration. ' +
-					'Domains registered through this promotion will renew at our {{a}}standard rate{{/a}}, plus applicable taxes, after the first year.{{br}}{{br}}' +
+					'Domains registered through this promotion will renew at our {{a}}standard rate{{/a}}, plus applicable taxes, after the first year.{{br /}}{{br /}}' +
 					'This offer is redeemable one time only, and does not apply to plan upgrades, renewals, or premium domains.',
 				{
 					components: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before:
<img width="345" alt="Screen Shot 2022-01-31 at 10 27 40 PM" src="https://user-images.githubusercontent.com/115071/151922340-e9900756-0ede-4cf2-9282-f3bf4e636302.png">


After:
<img width="376" alt="Screen Shot 2022-01-31 at 10 16 59 PM" src="https://user-images.githubusercontent.com/115071/151922281-d1e6da81-8944-4386-9553-f465e5eabb70.png">

This test should hopefully be already translated. 🤞 

#### Testing instructions

Visit /start/plans on mobile open the pop-up on the personal plan. 
Does it look as expected now? 
Do you see the translation in a different language? 
