### PR TITLE
Add new importer migration tests

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -9,11 +9,10 @@ const selectors = {
 
 	// Inputs
 	urlInput: 'input.capture__input',
-	migrationInput: ( value: string ) =>
-		`input#sites-block__faux-site-selector-url-input[value="${ value }"]`,
+
+	// The "content only" "continue" button of '/start/from/importing/wordpress'
 	wordPress: ( text: string ) =>
-		'.content-chooser .import-layout__column:nth-child(2) .list__importer-option:nth-child(2)' +
-		` .action-card__button-container button:text("${ text }")`,
+		`.content-chooser .import-layout__column:nth-child(2) > div > div:last-child button:text("${ text }")`,
 
 	// Errors
 	analyzeError: ( text: string ) => `div.capture__input-error-msg:text("${ text }")`,
@@ -44,7 +43,7 @@ export class StartImportFlow {
 	constructor( private page: Page ) {}
 
 	/**
-	 * Given text, clicks on the first instance of the button with the text.
+	 * Given text, click on the button's first instance with the text.
 	 *
 	 * @param {string} text User-visible text on the button.
 	 */
@@ -99,13 +98,6 @@ export class StartImportFlow {
 	 */
 	async validateDesignPage(): Promise< void > {
 		await this.page.waitForSelector( selectors.setupHeader );
-	}
-
-	/**
-	 * Validates that we've landed on the migration page.
-	 */
-	async validateMigrationPage( siteSlug: string ): Promise< void > {
-		await this.page.waitForSelector( selectors.migrationInput( siteSlug ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -11,6 +11,9 @@ const selectors = {
 	urlInput: 'input.capture__input',
 	migrationInput: ( value: string ) =>
 		`input#sites-block__faux-site-selector-url-input[value="${ value }"]`,
+	wordPress: ( text: string ) =>
+		'.content-chooser .import-layout__column:nth-child(2) .list__importer-option:nth-child(2)' +
+		` .action-card__button-container button:text("${ text }")`,
 
 	// Errors
 	analyzeError: ( text: string ) => `div.capture__input-error-msg:text("${ text }")`,
@@ -103,6 +106,13 @@ export class StartImportFlow {
 	 */
 	async validateMigrationPage( siteSlug: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.migrationInput( siteSlug ) );
+	}
+
+	/**
+	 * Validates that we've landed on the WordPress migration page.
+	 */
+	async validateWordPressPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.wordPress( 'Continue' ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -11,8 +11,11 @@ const selectors = {
 	urlInput: 'input.capture__input',
 
 	// The "content only" "continue" button of '/start/from/importing/wordpress'
-	wordPress: ( text: string ) =>
-		`.content-chooser .import-layout__column:nth-child(2) > div > div:last-child button:text("${ text }")`,
+	wpContentOnlyContinueButton:
+		'.content-chooser .import-layout__column:nth-child(2) > div > div:last-child button:text("Continue")',
+
+	// ImporterDrag page
+	importerDrag: ( text: string ) => `div.importer-wrapper__${ text }`,
 
 	// Errors
 	analyzeError: ( text: string ) => `div.capture__input-error-msg:text("${ text }")`,
@@ -104,7 +107,21 @@ export class StartImportFlow {
 	 * Validates that we've landed on the WordPress migration page.
 	 */
 	async validateWordPressPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.wordPress( 'Continue' ) );
+		await this.page.waitForSelector( selectors.wpContentOnlyContinueButton );
+	}
+
+	/**
+	 * Validates that we've landed on the importer drag page.
+	 */
+	async validateImporterDragPage( importer: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.importerDrag( importer ) );
+	}
+
+	/**
+	 * Continue 'content only' WordPress migration.
+	 */
+	async contentOnlyWordPressPage(): Promise< void > {
+		await this.page.click( selectors.wpContentOnlyContinueButton );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -2,14 +2,20 @@
  * @group calypso-pr
  */
 
-import { DataHelper, TestAccount, StartImportFlow } from '@automattic/calypso-e2e';
-import { Page, Browser } from 'playwright';
+import { DataHelper, skipDescribeIf, StartImportFlow, TestAccount } from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	let page: Page;
 	let startImportFlow: StartImportFlow;
+
+	// Check if we are running on wpcalypso or production.
+	// Remove when 'onboarding/import-from-wordpress' will be enabled on wpcalypso.
+	const isStagingOrProd = DataHelper.getCalypsoURL()
+		.toLowerCase()
+		.includes( 'https://wordpress.com' );
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -20,7 +26,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	} );
 
 	/**
-	 * Navigate to initial setup page
+	 * Navigate to initial setup page.
 	 *
 	 * @param siteSlug The site slug URL.
 	 */
@@ -31,20 +37,18 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		} );
 	};
 
-	// A normal and valid import flow.
-	describe( 'Follow the import flow', () => {
+	/**
+	 * Remove the skip-if conditional when 'onboarding/import-from-wordpress' is enabled on wpcalypso.
+	 * Substitute it with 'describe'.
+	 */
+	skipDescribeIf( isStagingOrProd )( 'Follow the WordPress import flow', () => {
 		navigateToSetup();
 
 		it( 'Start a WordPress import', async () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
-
-			// Remove when onboarding/import-from-wordpress will be enabled on wpcalypso
-			await startImportFlow.validateMigrationPage( 'https://make.wordpress.org/' );
-
-			// Add when onboarding/import-from-wordpress will be enabled on wpcalypso
-			// await startImportFlow.validateWordPressPage();
+			await startImportFlow.validateWordPressPage();
 		} );
 	} );
 
@@ -91,7 +95,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		} );
 	} );
 
-	// Go back through pages
+	// Go back through pages.
 	describe( 'Go back to first page', () => {
 		navigateToSetup();
 
@@ -113,7 +117,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		} );
 	} );
 
-	// Go back from a importer error page
+	// Go back from a importer error page.
 	describe( 'Go back from error', () => {
 		navigateToSetup();
 

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -86,6 +86,18 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		} );
 	} );
 
+	// Blogger, Medium, Squarespace
+	describe( 'Follow the import file flow', () => {
+		navigateToSetup();
+
+		it( 'Start an valid import file', async () => {
+			await startImportFlow.enterURL( 'https://squarespace.com' );
+			await startImportFlow.validateImportPage();
+			await startImportFlow.clickButton( 'Import your content' );
+			await startImportFlow.validateImporterDragPage( 'squarespace' );
+		} );
+	} );
+
 	// The "I don't have a site address" flow.
 	describe( "I don't have a site flow", () => {
 		navigateToSetup();

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -13,9 +13,9 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 	// Check if we are running on wpcalypso or production.
 	// Remove when 'onboarding/import-from-wordpress' will be enabled on wpcalypso.
-	const isStagingOrProd = DataHelper.getCalypsoURL()
+	const isLocal = DataHelper.getCalypsoURL()
 		.toLowerCase()
-		.includes( 'https://wordpress.com' );
+		.includes( 'http://calypso.localhost:3000' );
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -41,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	 * Remove the skip-if conditional when 'onboarding/import-from-wordpress' is enabled on wpcalypso.
 	 * Substitute it with 'describe'.
 	 */
-	skipDescribeIf( isStagingOrProd )( 'Follow the WordPress import flow', () => {
+	skipDescribeIf( ! isLocal )( 'Follow the WordPress import flow', () => {
 		navigateToSetup();
 
 		it( 'Start a WordPress import', async () => {

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -40,8 +40,11 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
 
-			// When the new flows will be created this check will need to be replaced
+			// Remove when onboarding/import-from-wordpress will be enabled on wpcalypso
 			await startImportFlow.validateMigrationPage( 'https://make.wordpress.org/' );
+
+			// Add when onboarding/import-from-wordpress will be enabled on wpcalypso
+			// await startImportFlow.validateWordPressPage();
 		} );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -49,6 +49,8 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
 			await startImportFlow.validateWordPressPage();
+			await startImportFlow.contentOnlyWordPressPage();
+			await startImportFlow.validateImporterDragPage( 'wordpress' );
 		} );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -90,7 +90,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	describe( 'Follow the import file flow', () => {
 		navigateToSetup();
 
-		it( 'Start an valid import file', async () => {
+		it( 'Start a valid import file', async () => {
 			await startImportFlow.enterURL( 'https://squarespace.com' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add new importer tests

#### Testing instructions

1. Ensure that the environment variable `NODE_CONFIG_ENV` is set. Otherwise: `export NODE_CONFIG_ENV='decrypted'`
2. Ensure that in the `test/e2e/config/local-decrypted.json` blob there's a `"calypsoBaseURL": "http://calypso.localhost:3000"`.
3. From `test/e2e` run `yarn install`
4. First console tab run: `yarn && yarn start`
5. Second console tab run: `yarn workspace @a8cuser/calypso-e2e build --watch`
6. Third tab, from `test/e2e` run: `yarn jest specs/specs-playwright/wp-start__importer.ts`

Detailed instructions here: **pcmemI-h6-p2**. Jest will open a Chromium window and all the tests will be run there.

#### Troubleshooting
If Playwright has a problem authenticating the user (it blocks on `/start/setup-site/intent` page) delete the temporary cookies that you find on `test/e2e/cookies/*` and run the test again.

Related to #59518
