### PR TITLE
Bugfix: Retrieve installed plugins information when not available in cache

### DIFF
--- a/client/components/data/query-jetpack-plugins/index.jsx
+++ b/client/components/data/query-jetpack-plugins/index.jsx
@@ -24,7 +24,7 @@ class QueryJetpackPlugins extends Component {
 		if ( isEqual( prevProps.siteIds, this.props.siteIds ) ) {
 			return;
 		}
-		this.refresh( prevProps.isRequestingForSites, prevProps.siteIds );
+		this.refresh( this.props.isRequestingForSites, this.props.siteIds );
 	}
 
 	refresh( isRequesting, siteIds ) {

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -2,7 +2,6 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
-import { fetchPlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -26,11 +25,8 @@ const useSiteMenuItems = () => {
 	useEffect( () => {
 		if ( selectedSiteId && siteDomain ) {
 			dispatch( requestAdminMenu( selectedSiteId ) );
-			if ( isJetpack ) {
-				dispatch( fetchPlugins( [ selectedSiteId ] ) );
-			}
 		}
-	}, [ dispatch, isJetpack, selectedSiteId, siteDomain, locale ] );
+	}, [ dispatch, selectedSiteId, siteDomain, locale ] );
 
 	/**
 	 * As a general rule we allow fallback data to remain as static as possible.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add plugin query to Plugin Details page for direct accesses
* Use the current sites instead of the previous to retrieve plugin info

### Testing instructions
**Browser Plugins**
* Go to `plugins` page, without a selected site
* Clear the indexed DB from your browser
* Reload the page and check if the `Installed on * sites`  is properly shown`

**Plugin Details**
* Click on a plugin to go to the Plugin Details page
* Clear the indexed DB from your browser
* Reload the page and check if the `Installed on` area is properly shown
---

Fixes #60704
