### PR TITLE
Query product list even when a jetpack self hosted site is selected.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -222,7 +222,7 @@ const PluginsBrowser = ( {
 					<QueryWporgPlugins category="featured" />
 				</>
 			) }
-			{ ! jetpackNonAtomic && <QueryProductsList persist /> }
+			<QueryProductsList persist />
 			<QueryJetpackPlugins siteIds={ siteIds } />
 			<PageViewTrackerWrapper
 				category={ category }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Remove the jetpack self-hosted check for querying product list.

### Testing instructions
* Go to `plugins` page with a selected self hosted jetpack site
* Delete the browser indexed DB to clear the cach
* Search for a term which has paid plugins. Ex: woo
* The plugins should appear with the correct price

### Demo

|  Before | After|
| ------------- | ------------- |
| <img width="1218" alt="Screen Shot 2022-02-01 at 14 10 57" src="https://user-images.githubusercontent.com/5039531/152020082-58ab530f-958c-42fd-b930-b3d5b26bb973.png">|<img width="1218" alt="Screen Shot 2022-02-01 at 14 28 02" src="https://user-images.githubusercontent.com/5039531/152019974-92a34fa3-e225-4805-93db-29ccedcd5909.png">|




---
 Fixes #60552