### PR TITLE
Support adding a domain in the purchase flow

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -87,6 +87,7 @@ export function getAllowedPluginData( plugin ) {
 		'product_video',
 		'rating',
 		'ratings',
+		'requirements',
 		'sections',
 		'slug',
 		'support_URL',

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
@@ -1,5 +1,7 @@
-import { Button, Dialog } from '@automattic/components';
+import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PluginIcon from '../plugin-icon/plugin-icon';
 import './style.scss';
 
@@ -8,6 +10,7 @@ interface Props {
 	domains: Array< { isPrimary: boolean; isSubdomain: boolean } >;
 	closeDialog: () => void;
 	isDialogVisible: boolean;
+	onProceed: () => void;
 }
 
 export const PluginCustomDomainDialog = ( {
@@ -15,19 +18,38 @@ export const PluginCustomDomainDialog = ( {
 	domains,
 	closeDialog,
 	isDialogVisible,
+	onProceed,
 }: Props ): JSX.Element => {
 	const translate = useTranslate();
+	const selectedSiteUrl = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 
 	const hasNonPrimaryCustomDomain = domains.some(
 		( { isPrimary, isSubdomain } ) => ! isPrimary && ! isSubdomain
 	);
 
+	const buttons = [
+		{
+			action: 'learn-more',
+			label: translate( 'Learn more', { context: 'button label' } ),
+		},
+		{
+			action: 'manage-domains',
+			href: '/domains/manage/' + selectedSiteUrl,
+			label: translate( 'Manage domains', { context: 'button label' } ),
+		},
+		{
+			action: 'install-plugin',
+			label: translate( 'Install %(pluginName)s', {
+				args: { pluginName: plugin.name },
+				context: 'button label',
+			} ),
+			isPrimary: true,
+			onClick: onProceed,
+		},
+	];
+
 	return (
-		<Dialog
-			additionalClassNames={ 'plugin-custom-domain-dialog__modal' }
-			isVisible={ isDialogVisible }
-			onClose={ closeDialog }
-		>
+		<Dialog isVisible={ isDialogVisible } onClose={ closeDialog } buttons={ buttons }>
 			<div className="plugin-custom-domain-dialog__content">
 				<div className="plugin-custom-domain-dialog__icon">
 					<PluginIcon image={ plugin.icon } />
@@ -46,17 +68,6 @@ export const PluginCustomDomainDialog = ( {
 									args: { pluginName: plugin.name },
 								}
 						  ) }
-				</div>
-				<div className="plugin-custom-domain-dialog__buttons">
-					<Button>{ translate( 'Manage domains' ) }</Button>
-					<Button primary>
-						{ translate( 'Install %(pluginName)s', {
-							args: { pluginName: plugin.name },
-						} ) }
-					</Button>
-					<Button plain className="plugin-custom-domain-dialog__learn-more">
-						{ translate( 'or learn more' ) }
-					</Button>
 				</div>
 			</div>
 		</Dialog>

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
@@ -1,0 +1,50 @@
+import { Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import PluginIcon from '../plugin-icon/plugin-icon';
+
+interface Props {
+	plugin: { name: string; icon: string };
+	domains: Array< { isPrimary: boolean; isSubdomain: boolean } >;
+	closeDialog: () => void;
+	isDialogVisible: boolean;
+}
+
+export const PluginCustomDomainDialog = ( {
+	plugin,
+	domains,
+	closeDialog,
+	isDialogVisible,
+}: Props ): JSX.Element => {
+	const translate = useTranslate();
+
+	const hasNonPrimaryCustomDomain = domains.some(
+		( { isPrimary, isSubdomain } ) => ! isPrimary && ! isSubdomain
+	);
+
+	return (
+		<Dialog
+			additionalClassNames={ 'plugin-custom-domain-dialog__content' }
+			isVisible={ isDialogVisible }
+			onClose={ closeDialog }
+		>
+			<div>
+				<PluginIcon image={ plugin.icon } />
+				<p>
+					{ hasNonPrimaryCustomDomain
+						? translate(
+								'%(pluginName)s will help you optimize your site around your primary domain. We recommend setting your custom domain as your primary before installing.',
+								{
+									args: { pluginName: plugin.name },
+								}
+						  )
+						: translate(
+								'%(pluginName)s will help you optimize your site around your primary domain. We recommend adding a custom domain before installing.',
+								{
+									args: { pluginName: plugin.name },
+								}
+						  ) }
+				</p>
+			</div>
+		</Dialog>
+	);
+};

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
@@ -1,6 +1,7 @@
-import { Dialog } from '@automattic/components';
+import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PluginIcon from '../plugin-icon/plugin-icon';
+import './style.scss';
 
 interface Props {
 	plugin: { name: string; icon: string };
@@ -23,13 +24,15 @@ export const PluginCustomDomainDialog = ( {
 
 	return (
 		<Dialog
-			additionalClassNames={ 'plugin-custom-domain-dialog__content' }
+			additionalClassNames={ 'plugin-custom-domain-dialog__modal' }
 			isVisible={ isDialogVisible }
 			onClose={ closeDialog }
 		>
-			<div>
-				<PluginIcon image={ plugin.icon } />
-				<p>
+			<div className="plugin-custom-domain-dialog__content">
+				<div className="plugin-custom-domain-dialog__icon">
+					<PluginIcon image={ plugin.icon } />
+				</div>
+				<div className="plugin-custom-domain-dialog__description">
 					{ hasNonPrimaryCustomDomain
 						? translate(
 								'%(pluginName)s will help you optimize your site around your primary domain. We recommend setting your custom domain as your primary before installing.',
@@ -43,7 +46,18 @@ export const PluginCustomDomainDialog = ( {
 									args: { pluginName: plugin.name },
 								}
 						  ) }
-				</p>
+				</div>
+				<div className="plugin-custom-domain-dialog__buttons">
+					<Button>{ translate( 'Manage domains' ) }</Button>
+					<Button primary>
+						{ translate( 'Install %(pluginName)s', {
+							args: { pluginName: plugin.name },
+						} ) }
+					</Button>
+					<Button plain className="plugin-custom-domain-dialog__learn-more">
+						{ translate( 'or learn more' ) }
+					</Button>
+				</div>
 			</div>
 		</Dialog>
 	);

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
@@ -30,6 +30,7 @@ export const PluginCustomDomainDialog = ( {
 	const buttons = [
 		{
 			action: 'learn-more',
+			href: '/support/domains/#set-a-primary-address',
 			label: translate( 'Learn more' ),
 		},
 		{

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
@@ -30,18 +30,17 @@ export const PluginCustomDomainDialog = ( {
 	const buttons = [
 		{
 			action: 'learn-more',
-			label: translate( 'Learn more', { context: 'button label' } ),
+			label: translate( 'Learn more' ),
 		},
 		{
 			action: 'manage-domains',
 			href: '/domains/manage/' + selectedSiteUrl,
-			label: translate( 'Manage domains', { context: 'button label' } ),
+			label: translate( 'Manage domains' ),
 		},
 		{
 			action: 'install-plugin',
 			label: translate( 'Install %(pluginName)s', {
 				args: { pluginName: plugin.name },
-				context: 'button label',
 			} ),
 			isPrimary: true,
 			onClick: onProceed,

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
@@ -1,4 +1,5 @@
 import { Dialog } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -21,6 +22,8 @@ export const PluginCustomDomainDialog = ( {
 	onProceed,
 }: Props ): JSX.Element => {
 	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
+
 	const selectedSiteUrl = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 
 	const hasNonPrimaryCustomDomain = domains.some(
@@ -30,7 +33,7 @@ export const PluginCustomDomainDialog = ( {
 	const buttons = [
 		{
 			action: 'learn-more',
-			href: '/support/domains/#set-a-primary-address',
+			href: localizeUrl( 'https://wordpress.com/support/domains/#set-a-primary-address' ),
 			label: translate( 'Learn more' ),
 		},
 		{

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
@@ -1,0 +1,29 @@
+.plugin-custom-domain-dialog__modal {
+	box-shadow: 0 3px 8px rgba( 0, 0, 0, 0.12 ), 0 3px 1px rgba( 0, 0, 0, 0.04 );
+	border-radius: 4px;
+
+	.dialog__content {
+		padding: 48px;
+	}
+}
+
+.plugin-custom-domain-dialog__content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	row-gap: 32px;
+	max-width: 412px;
+	text-align: center;
+
+	.plugin-icon {
+		width: 72px;
+		height: 72px;
+	}
+}
+
+.plugin-custom-domain-dialog__learn-more {
+	text-decoration: underline;
+	font-weight: 500;
+	display: block;
+	margin: 16px auto 0;
+}

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
@@ -21,9 +21,19 @@
 	}
 }
 
-.plugin-custom-domain-dialog__learn-more {
-	text-decoration: underline;
-	font-weight: 500;
-	display: block;
-	margin: 16px auto 0;
+.plugin-custom-domain-dialog__buttons {
+	display: flex;
+	gap: 16px 8px;
+	flex-wrap: wrap;
+	justify-content: center;
+
+	button {
+		flex-grow: 1;
+		font-weight: 500;
+	}
+
+	.plugin-custom-domain-dialog__learn-more {
+		flex-basis: 100%;
+		text-decoration: underline;
+	}
 }

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
@@ -1,18 +1,8 @@
-.plugin-custom-domain-dialog__modal {
-	box-shadow: 0 3px 8px rgba( 0, 0, 0, 0.12 ), 0 3px 1px rgba( 0, 0, 0, 0.04 );
-	border-radius: 4px;
-
-	.dialog__content {
-		padding: 48px;
-	}
-}
-
 .plugin-custom-domain-dialog__content {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	row-gap: 32px;
-	max-width: 412px;
+	row-gap: 24px;
 	text-align: center;
 
 	.plugin-icon {
@@ -21,19 +11,12 @@
 	}
 }
 
-.plugin-custom-domain-dialog__buttons {
-	display: flex;
-	gap: 16px 8px;
-	flex-wrap: wrap;
-	justify-content: center;
+.plugin-custom-domain-dialog__description {
+	max-width: 412px;
+}
 
-	button {
-		flex-grow: 1;
-		font-weight: 500;
-	}
-
-	.plugin-custom-domain-dialog__learn-more {
-		flex-basis: 100%;
-		text-decoration: underline;
+.plugin-custom-domain-dialog__icon {
+	.plugin-icon {
+		margin: 0;
 	}
 }

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -226,7 +226,7 @@ const CTAButton = ( {
 	);
 
 	const pluginRequiresCustomPrimaryDomain =
-		( primaryDomain?.isWpcomDomain || primaryDomain?.isWpcomStagingDomain ) &&
+		( primaryDomain?.isWPCOMDomain || primaryDomain?.isWpcomStagingDomain ) &&
 		plugin?.requirements?.required_primary_domain;
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -226,7 +226,8 @@ const CTAButton = ( {
 	);
 
 	const pluginRequiresCustomPrimaryDomain =
-		primaryDomain?.isSubdomain && plugin?.requirements?.required_primary_domain;
+		( primaryDomain?.isWpcomDomain || primaryDomain?.isWpcomStagingDomain ) &&
+		plugin?.requirements?.required_primary_domain;
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 
 	const updatedKeepMeUpdatedPreference = useCallback(

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -224,6 +224,9 @@ const CTAButton = ( {
 	const primaryDomain = useSelector( ( state ) =>
 		getPrimaryDomainBySiteId( state, selectedSite?.ID )
 	);
+
+	const pluginRequiresCustomPrimaryDomain =
+		primaryDomain?.isSubdomain && plugin?.requirements?.required_primary_domain;
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 
 	const updatedKeepMeUpdatedPreference = useCallback(
@@ -241,11 +244,29 @@ const CTAButton = ( {
 
 	return (
 		<>
-			<PluginCustomDomainDialog isDialogVisible={ true } plugin={ plugin } domains={ domains } />
+			<PluginCustomDomainDialog
+				onProceed={ () => {
+					if ( hasEligibilityMessages ) {
+						return setShowEligibility( true );
+					}
+					onClickInstallPlugin( {
+						dispatch,
+						selectedSite,
+						plugin,
+						upgradeAndInstall: shouldUpgrade,
+						isMarketplaceProduct,
+						billingPeriod,
+					} );
+				} }
+				isDialogVisible={ showAddCustomDomain }
+				plugin={ plugin }
+				domains={ domains }
+				closeDialog={ () => setShowAddCustomDomain( false ) }
+			/>
 			<Dialog
 				additionalClassNames={ 'plugin-details-CTA__dialog-content' }
 				additionalOverlayClassNames={ 'plugin-details-CTA__modal-overlay' }
-				isVisible={ showEligibility || showAddCustomDomain }
+				isVisible={ showEligibility }
 				title={ translate( 'Eligibility' ) }
 				onClose={ () => setShowEligibility( false ) }
 			>
@@ -268,7 +289,7 @@ const CTAButton = ( {
 				className="plugin-details-CTA__install-button"
 				primary
 				onClick={ () => {
-					if ( primaryDomain?.isSubdomain ) {
+					if ( pluginRequiresCustomPrimaryDomain ) {
 						return setShowAddCustomDomain( true );
 					}
 					if ( hasEligibilityMessages ) {

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
@@ -19,7 +19,7 @@ const PluginIcon = ( { className, image, isPlaceholder } ) => {
 			{ isPlaceholder || ! image ? (
 				<Gridicon icon="plugins" />
 			) : (
-				<img className="plugin-icon__img" src={ image } />
+				<img className="plugin-icon__img" src={ image } alt="plugin-icon" />
 			) }
 		</div>
 	);
@@ -28,6 +28,7 @@ const PluginIcon = ( { className, image, isPlaceholder } ) => {
 PluginIcon.propTypes = {
 	image: PropTypes.string,
 	isPlaceholder: PropTypes.bool,
+	className: PropTypes.string,
 };
 
 export default PluginIcon;


### PR DESCRIPTION
#### Prerequisites

Before merging this PR:
- [X] We should decide where to route the `Learn more` link [related convo](https://github.com/Automattic/wp-calypso/issues/60444#issuecomment-1033944420)

#### Changes proposed in this Pull Request

* Adds a new dialog
* The dialog prompts the user to set their primary domain to a custom one if they have one or buy a custom domain
* The dialog is shown if the site's primary domain is a subdomain

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The slug of Yoast Premium currently differ in the Matkeplace and WPCom REST API responses, but there's already [a diff to resolve that](D74410-code). The testing steps below will work once the slugs are updated:

**Displaying the dialog if there's no custom domain**
* switch to a site that does not have a custom domain
* visit a plugin that requires a custom primary domain (eg. `/plugins/wordpress-seo-premium`)
* click on the install button
* verify that the dialog with this text is displayed:
  <img width="498" alt="image" src="https://user-images.githubusercontent.com/11555574/153243144-9d38a8f7-893b-4648-b0f0-b8f130c7aa01.png">

**Displaying the dialog for non-primary custom domain**
* switch to a site that has a custom domain
* set the primary domain to be **other than the custom domain**
* visit a plugin that requires a custom primary domain (eg. `/plugins/wordpress-seo-premium`)
* click on the install button
* verify that the dialog with this text is displayed:
  <img width="499" alt="image" src="https://user-images.githubusercontent.com/11555574/153433397-af7c5afa-e818-4a97-88fa-f31aba966395.png">

**Not displaying the dialog for custom primary domain**
* switch to a site that has a custom domain (or custom subdomain)
* visit a plugin that requires a custom primary domain (eg. `/plugins/wordpress-seo-premium`)
* click on the install button
* verify that the dialog is not displayed

**Adding a domain**
* click `Manage domains`
* add a domain to the cart
* navigate back to the plugin page
* click install and choose `Install Yoast Premium`
* verify that the cart contains both the domain and the plugin

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #60444