### PR TITLE
Playwright: wait until `networkidle` is fired when using navtabs within the MarketingPage.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -32,6 +32,7 @@ export class MarketingPage {
 	 */
 	async clickTab( name: string ): Promise< void > {
 		await clickNavTab( this.page, name );
+		await this.page.waitForLoadState( 'networkidle' );
 	}
 
 	/* SEO Preview Methods */

--- a/test/e2e/specs/specs-playwright/wp-marketing__seo.ts
+++ b/test/e2e/specs/specs-playwright/wp-marketing__seo.ts
@@ -3,13 +3,16 @@
  */
 
 import { DataHelper, SidebarComponent, MarketingPage, TestAccount } from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
 
-describe( DataHelper.createSuiteTitle( 'SEO Preview Page' ), function () {
-	let marketingPage;
-	let page;
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
+	let marketingPage: MarketingPage;
+	let page: Page;
 
 	beforeAll( async () => {
-		page = await global.browser.newPage();
+		page = await browser.newPage();
 
 		const testAccount = new TestAccount( 'eCommerceUser' );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/specs-playwright/wp-marketing__seo.ts
+++ b/test/e2e/specs/specs-playwright/wp-marketing__seo.ts
@@ -3,7 +3,7 @@
  */
 
 import { DataHelper, SidebarComponent, MarketingPage, TestAccount } from '@automattic/calypso-e2e';
-import { Page } from 'playwright';
+import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/59921 in an attempt to eliminate flakiness when interacting with the SEO preview button.

Key changes:
- wait until `networkidle` event is fired upon navigating using the `navtab`.
- minor changes to bring the SEO: Preview spec boilerplate in line with other suites.

#### Testing instructions

- [x] Ensure the following:
  - [x] SEO: Preview suite is run.
  - [x] SEO: Preview suites fires the `networkidle` event after clicking on the navtab.


Related to https://github.com/Automattic/wp-calypso/pull/59921, https://github.com/Automattic/wp-calypso/issues/59918
