### PR TITLE
CI: Register `MarTech` as a subproject.

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -50,6 +50,7 @@ project {
 	subProject(_self.projects.WPComPlugins)
 	subProject(_self.projects.WPComTests)
 	subProject(_self.projects.WebApp)
+	subProject(_self.projects.MarTech)
 	buildType(BuildBaseImages)
 	buildType(CheckCodeStyle)
 	buildType(SmartBuildLauncher)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/60600, where the bulk of the MarTech project in TeamCity was added, but the project itself was not registered as a subproject to the overall configuration.

Key changes:
- register `MarTech` as a subproject.

#### Testing instructions

Not able to test TeamCity changes until it is merged.

Related to https://github.com/Automattic/wp-calypso/pull/60600.
