### PR TITLE
Signup: Anchor.fm users take a different path after signup

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -85,8 +85,12 @@ export default function useOnSiteCreation(): void {
 			setSelectedSite( newSite.blogid );
 
 			let destination;
+
 			if ( design?.is_fse ) {
 				destination = `/site-editor/${ newSite.site_slug }/`;
+			} else if ( design?.features?.includes( 'anchorfm' ) ) {
+				//Anchor.fm users should land in the page editor
+				destination = `/page/${ newSite.site_slug }/home/`;
 			} else {
 				destination = `/home/${ newSite.site_slug }/`;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As part of our agreement with Anchor, we need to send Anchor.fm users to the editor rather than My Home after signup. This was changed for all users in #58976 to accommodate FSE, but the current Anchor themes are not FSE-compatible, so they need their own flow.

**Before**

Screen after finishing signup through the Anchor flow:

<img width="1895" alt="Screen Shot 2022-02-01 at 3 33 46 PM" src="https://user-images.githubusercontent.com/2124984/152046900-11c4035d-9343-46ef-b891-a12e72b6e009.png">


**After**

Screen after finishing signup through the Anchor flow:

<img width="1908" alt="Screen Shot 2022-02-01 at 3 32 00 PM" src="https://user-images.githubusercontent.com/2124984/152046952-05a51719-f566-4477-b470-18ba09370695.png">


#### Testing instructions

* Switch to this PR, navigate to signup with the `anchor_podcast` param and your podcast ID: `/new?anchor_podcast=81118bf0`
* Go through the signup flow
* Land in the editor with the home page ready to edit!

Fixes #60316
