### PR TITLE
Update Payment Method to Methods

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/index.tsx
@@ -19,7 +19,7 @@ export default function AddStoredCreditCard(): ReactElement {
 	return (
 		<a
 			className="add-stored-credit-card"
-			href="/partner-portal/payment-method/add"
+			href="/partner-portal/payment-methods/add"
 			onClick={ navigateToCreateMethod }
 		>
 			<div className="add-stored-credit-card__content">

--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -55,7 +55,7 @@ export default function () {
 	// Manage payment methods.
 	if ( config.isEnabled( 'jetpack/partner-portal-payment' ) ) {
 		page(
-			`/partner-portal/payment-method`,
+			`/partner-portal/payment-methods`,
 			controller.requireAccessContext,
 			controller.requireTermsOfServiceConsentContext,
 			controller.requireSelectedPartnerKeyContext,
@@ -65,7 +65,7 @@ export default function () {
 		);
 
 		page(
-			`/partner-portal/payment-method/add`,
+			`/partner-portal/payment-methods/add`,
 			controller.requireAccessContext,
 			controller.requireTermsOfServiceConsentContext,
 			controller.requireSelectedPartnerKeyContext,

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -11,11 +11,11 @@ export default function PaymentMethodAdd(): ReactElement {
 
 	return (
 		<Main wideLayout className="payment-method-add">
-			<DocumentHead title={ translate( 'Payment Method' ) } />
+			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<SidebarNavigation />
 
 			<div className="payment-method-add__header">
-				<CardHeading size={ 36 }>{ translate( 'Payment Method' ) }</CardHeading>
+				<CardHeading size={ 36 }>{ translate( 'Payment Methods' ) }</CardHeading>
 			</div>
 
 			<Card className="payment-method-add__body">

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
@@ -19,11 +19,11 @@ export default function PaymentMethodList(): ReactElement {
 	return (
 		<Main wideLayout className="payment-method-list">
 			<QueryStoredCards />
-			<DocumentHead title={ translate( 'Payment Method' ) } />
+			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<SidebarNavigation />
 
 			<div className="payment-method-list__header">
-				<CardHeading size={ 36 }>{ translate( 'Payment Method' ) }</CardHeading>
+				<CardHeading size={ 36 }>{ translate( 'Payment Methods' ) }</CardHeading>
 			</div>
 
 			<div className="payment-method-list__body">

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -61,12 +61,12 @@ class PartnerPortalSidebar extends Component< Props > {
 						{ config.isEnabled( 'jetpack/partner-portal-payment' ) && (
 							<SidebarItem
 								customIcon={ <JetpackIcons icon="credit-card" /> }
-								label={ translate( 'Payment Method', {
+								label={ translate( 'Payment Methods', {
 									comment: 'Jeptack sidebar navigation item',
 								} ) }
-								link="/partner-portal/payment-method"
-								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Payment Method' ) }
-								selected={ itemLinkMatches( [ '/partner-portal/payment-method' ], path ) }
+								link="/partner-portal/payment-methods"
+								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Payment Methods' ) }
+								selected={ itemLinkMatches( [ '/partner-portal/payment-methods' ], path ) }
 							/>
 						) }
 					</SidebarMenu>


### PR DESCRIPTION
Updating the current "payment method" implementation to "payment methods" to match previous implementations

#### Changes proposed in this Pull Request

* Update the routing for the partner portal for payments from singular "payment method" to plural "payment methods" to be more consistent.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR
* Start both Calypso and Jetpack Cloud yarn start and yarn start-jetpack-cloud-p in order
* Go to http://jetpack.cloud.localhost:3001/partner-portal
* Ensure the side navigation reads "Payment Methods"
* Ensure that the main page also reads "Payment Methods"
* Verify that both routes for `payment-methods` and `payment-methods/add` are now plural.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

