### PR TITLE
Show "Footer credit" setting on Atomic sites.

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -607,6 +607,7 @@ export class SiteSettingsFormGeneral extends Component {
 			isSavingSettings,
 			site,
 			siteIsJetpack,
+			siteIsAtomic,
 			siteIsVip,
 			siteSlug,
 			translate,
@@ -641,7 +642,7 @@ export class SiteSettingsFormGeneral extends Component {
 
 				{ this.props.isUnlaunchedSite ? this.renderLaunchSite() : this.privacySettings() }
 
-				{ ! isWPForTeamsSite && ! siteIsJetpack && (
+				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<div className="site-settings__footer-credit-container">
 						<SettingsSectionHeader
 							title={ translate( 'Footer credit' ) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -33,7 +33,12 @@ import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { launchSite } from 'calypso/state/sites/launch/actions';
-import { getSiteOption, isJetpackSite, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
+import {
+	getSiteOption,
+	isJetpackSite,
+	isCurrentPlanPaid,
+	getCustomizerUrl,
+} from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -602,16 +607,16 @@ export class SiteSettingsFormGeneral extends Component {
 
 	render() {
 		const {
+			customizerUrl,
 			handleSubmitForm,
 			isRequestingSettings,
 			isSavingSettings,
+			isWPForTeamsSite,
 			site,
 			siteIsJetpack,
 			siteIsAtomic,
 			siteIsVip,
-			siteSlug,
 			translate,
-			isWPForTeamsSite,
 		} = this.props;
 
 		const classes = classNames( 'site-settings__general-settings', {
@@ -658,10 +663,7 @@ export class SiteSettingsFormGeneral extends Component {
 								) }
 							</p>
 							<div>
-								<Button
-									className="site-settings__footer-credit-change"
-									href={ '/customize/identity/' + siteSlug }
-								>
+								<Button className="site-settings__footer-credit-change" href={ customizerUrl }>
 									{ translate( 'Change footer credit' ) }
 								</Button>
 							</div>
@@ -708,6 +710,7 @@ const connectComponent = connect( ( state ) => {
 		siteDomains: getDomainsBySiteId( state, siteId ),
 		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 		isP2HubSite: isSiteP2Hub( state, siteId ),
+		customizerUrl: getCustomizerUrl( state, siteId ),
 		isAtomicAndEditingToolkitDeactivated:
 			isAtomicSite( state, siteId ) &&
 			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -710,7 +710,7 @@ const connectComponent = connect( ( state ) => {
 		siteDomains: getDomainsBySiteId( state, siteId ),
 		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 		isP2HubSite: isSiteP2Hub( state, siteId ),
-		customizerUrl: getCustomizerUrl( state, siteId ),
+		customizerUrl: getCustomizerUrl( state, siteId, 'identity' ),
 		isAtomicAndEditingToolkitDeactivated:
 			isAtomicSite( state, siteId ) &&
 			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Show the "Footer credit" panel in Settings on Atomic sites for all plans.

![atomic-free-footer-setting](https://user-images.githubusercontent.com/140841/152054902-33802b14-848f-482c-b154-c217d1451111.png)


### Testing instructions

How to create an Atomic site on any plan: pb5gDS-1mr-p2

#### Expected Behavior

* The "Footer credit" Settings panel should be visible on all Simple sites and Atomic sites.
* The "Footer credit" Settings panel should NOT be visible on Non-Atomic Jetpack sites or P2 sites.
* If the plan is lower than Business, the "Footer credit" panel should include an "upgrade nudge."<br /><br /><img src="https://user-images.githubusercontent.com/140841/152055082-80cb85fb-84ce-4407-8af7-b234dcf1e25f.png" width="400" alt="Upgrade Nudge" />
* The "Change footer credit" link should link to the Calypso Customizer for Simple sites, and to the wp-admin Customizer for Atomic sites.<br /><br /><img src="https://user-images.githubusercontent.com/140841/152064643-a8b20f57-6693-4024-8383-68bfe48f92c5.png" width="300" alt="Simple Site" /> <img src="https://user-images.githubusercontent.com/140841/152064640-3897dad3-15fe-481e-ace6-be99cffa5a68.png" width="300" alt="Atomic Site" />

Related to #51587