### PR TITLE
Try/help happychat calypso app setup

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -19,6 +19,8 @@ object WPComPlugins : Project({
 	buildType(WpcomBlockEditor)
 	buildType(Notifications)
 	buildType(O2Blocks)
+	buildType(Happychat)
+	buildType(InlineHelp)
 
 	cleanup {
 		keepRule {
@@ -150,4 +152,20 @@ private object O2Blocks : WPComPluginBuild(
 			"""
 		}
 	}
+)
+
+private object Happychat : WPComPluginBuild(
+	buildId = "WPComPlugins_HappychatWidget",
+	buildName = "Happychat",
+	pluginSlug = "happychat",
+	archiveDir = "./dist/",
+	docsLink = "TODO",
+)
+
+private object InlineHelp : WPComPluginBuild(
+	buildId = "WPComPlugins_InlineHelpWidget",
+	buildName = "Inline Help",
+	pluginSlug = "inline-help",
+	archiveDir = "./dist/",
+	docsLink = "TODO",
 )

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -155,7 +155,7 @@ private object O2Blocks : WPComPluginBuild(
 )
 
 private object Happychat : WPComPluginBuild(
-	buildId = "WPComPlugins_HappychatWidget",
+	buildId = "WPComPlugins_Happychat",
 	buildName = "Happychat",
 	pluginSlug = "happychat",
 	archiveDir = "./dist/",
@@ -163,7 +163,7 @@ private object Happychat : WPComPluginBuild(
 )
 
 private object InlineHelp : WPComPluginBuild(
-	buildId = "WPComPlugins_InlineHelpWidget",
+	buildId = "WPComPlugins_InlineHelp",
 	buildName = "Inline Help",
 	pluginSlug = "inline-help",
 	archiveDir = "./dist/",

--- a/apps/happychat/package.json
+++ b/apps/happychat/package.json
@@ -17,12 +17,12 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
+		"build": "NODE_ENV=production yarn dev",
+		"build:happychat": "calypso-build",
 		"clean": "npx rimraf dist",
-		"build": "BROWSERSLIST_ENV=evergreen webpack --config='./webpack.config.js'",
-		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build",
+		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/calypso-happychat",
 		"dev-server": "webpack serve",
-		"start": "yarn dev-server",
-		"sync": "yarn clean && yarn build && sh ./bin/wpcom-watch-and-sync.sh"
+		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build"
 	},
 	"dependencies": {
 		"@automattic/calypso-polyfills": "workspace:^",
@@ -37,6 +37,7 @@
 		"wpcom-proxy-request": "workspace:^"
 	},
 	"devDependencies": {
+		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-babel-config": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",

--- a/apps/inline-help/package.json
+++ b/apps/inline-help/package.json
@@ -18,11 +18,11 @@
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
 		"clean": "npx rimraf dist",
-		"build": "BROWSERSLIST_ENV=evergreen webpack --config='./webpack.config.js'",
-		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build",
+		"build": "NODE_ENV=production yarn dev",
+		"build:inline-help": "calypso-build",
+		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/inline-help",
 		"dev-server": "webpack serve",
-		"start": "yarn dev-server",
-		"sync": "yarn clean && yarn build && sh ./bin/wpcom-watch-and-sync.sh"
+		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build"
 	},
 	"dependencies": {
 		"@automattic/calypso-polyfills": "workspace:^",
@@ -37,6 +37,7 @@
 		"wpcom-proxy-request": "workspace:^"
 	},
 	"devDependencies": {
+		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-babel-config": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",

--- a/packages/calypso-apps-builder/index.js
+++ b/packages/calypso-apps-builder/index.js
@@ -124,7 +124,7 @@ function setupRemoteSync( localPath, remotePath, shouldWatch = false ) {
 		} );
 
 		if ( shouldWatch ) {
-			chokidar.watch( localPath ).on( 'change', debouncedSync );
+			chokidar.watch( localPath ).on( 'all', debouncedSync );
 		} else {
 			debouncedSync();
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -587,6 +587,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/happychat-app@workspace:apps/happychat"
   dependencies:
+    "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-babel-config": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-polyfills": "workspace:^"
@@ -635,6 +636,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/inline-help@workspace:apps/inline-help"
   dependencies:
+    "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-babel-config": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-polyfills": "workspace:^"


### PR DESCRIPTION
### Changes proposed in this Pull Request

(Follow-up from #60546)

I've updated the new calypso apps to use `calypso-apps-builder`. This way, all of the sandbox sync logic can be shared among all calypso apps. I also wonder if we can simplify the webpack config now that we use `calypso-build` here.

I also added basic CI for the two apps. I'm not sure if we'll need to make additional changes to support these projects.

I've also started the changes to `install-plugin.sh`. We can start testing that after this gets merged (since the TeamCity stuff won't load until we merge.)

### Testing instructions
for each of the new calypso apps (inline-help and happychat), do the following:
1. `cd` into `apps/$app`
2. Run `yarn build`. Verify that production files were output to the `./dist` directory.
3. Run `yarn dev --sync`. Verify that dev files have been copied to your sandbox into a new directory. (Note that these files have not been loaded on WordPress.com yet, so you're just testing that the sync itself works.)
4. Run `yarn dev-server` and then visit `calypso.localhost:3000`. Verify that the individual apps load there.