### PR TITLE
WooCommerce Install Landing Page - Changing Colophon Link

### DIFF
--- a/client/my-sites/woocommerce/woocommerce-colophon.tsx
+++ b/client/my-sites/woocommerce/woocommerce-colophon.tsx
@@ -9,7 +9,7 @@ export interface WooCommerceColophonProps {
 function WooCommerceColophon( props: WooCommerceColophonProps ) {
 	const translate = useTranslate();
 	const { wpcomDomain } = props;
-	const woocommercePluginURL = `http://calypso.localhost:3000/plugins/woocommerce/${ wpcomDomain }`;
+	const woocommercePluginURL = `/plugins/woocommerce/${ wpcomDomain }`;
 
 	const onClick = () => {
 		recordTracksEvent( 'calypso_woocommerce_woocommercecolophon_click' );

--- a/client/my-sites/woocommerce/woocommerce-colophon.tsx
+++ b/client/my-sites/woocommerce/woocommerce-colophon.tsx
@@ -1,10 +1,15 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
-import ExternalLink from 'calypso/components/external-link';
 import WooCommerceLogo from './woocommerce-logo';
 
-function WooCommerceColophon() {
+export interface WooCommerceColophonProps {
+	wpcomDomain: string;
+}
+
+function WooCommerceColophon( props: WooCommerceColophonProps ) {
 	const translate = useTranslate();
+	const { wpcomDomain } = props;
+	const woocommercePluginURL = `http://calypso.localhost:3000/plugins/woocommerce/${ wpcomDomain }`;
 
 	const onClick = () => {
 		recordTracksEvent( 'calypso_woocommerce_woocommercecolophon_click' );
@@ -12,13 +17,13 @@ function WooCommerceColophon() {
 
 	return (
 		<div className="woocommerce-colophon">
-			<ExternalLink icon={ false } onClick={ onClick } href="https://woocommerce.com">
+			<a onClick={ onClick } href={ woocommercePluginURL }>
 				{ translate( 'Powered by {{WooCommerceLogo /}}', {
 					components: {
 						WooCommerceLogo: <WooCommerceLogo />,
 					},
 				} ) }
-			</ExternalLink>
+			</a>
 		</div>
 	);
 }

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -79,7 +79,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 				secondaryActionTarget="_blank"
 				className="woop__landing-page-cta woocommerce_landing-page-empty-content"
 			/>
-			<WooCommerceColophon />
+			<WooCommerceColophon wpcomDomain={ wpcomDomain || '' } />
 		</div>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the colophon url to point to the sites WooCommerce plugin page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://calypso.localhost:3000/woocommerce-installation/<site-id>`
* Click on the powered by woo link
* It should navigate to `http://calypso.localhost:3000/plugins/woocommerce/<site-id>`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59190
