### PR TITLE
Fix calypso apps TeamCity build

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -12,7 +12,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 open class WPComPluginBuild(
-	var buildId: String,
+	var buildId: String = "",
 	var buildName: String,
 	var docsLink: String,
 	var archiveDir: String,

--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -164,7 +164,7 @@ open class WPComPluginBuild(
 
 					# 3. Check if the current build has changed, and if so, tag it for release.
 					# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-					if [ "%skip_release_diff%" = "true" ] || [ ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" --exclude="README.md" $archiveDir ./release-archive/ ] ; then
+					if [ "%skip_release_diff%" = "true" ] || ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" --exclude="README.md" $archiveDir ./release-archive/ ; then
 						echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 						tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
 						echo -e "Build tagging status: ${'$'}tag_response\n"

--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -12,7 +12,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 open class WPComPluginBuild(
-	var buildId: String = "",
+	var buildId: String,
 	var buildName: String,
 	var docsLink: String,
 	var archiveDir: String,

--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -145,21 +145,26 @@ open class WPComPluginBuild(
 					cd $workingDir
 					cp README.md $archiveDir
 
-					# 1. Download and unzip current release build.
-					mkdir ./release-archive
-					wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
-					unzip -q ./tmp-release-archive-download.zip -d ./release-archive
-					echo "Diffing against current trunk release build (`grep build_number ./release-archive/build_meta.txt | sed s/build_number=//`).";
+					# We can manually skip diff checking to account for the case
+					# that there is no existing release archive, in which case
+					# the next several lines would fail.
+					if [ "%skip_release_diff%" != "true" ] ; then
+						# 1. Download and unzip current release build.
+						mkdir ./release-archive
+						wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
+						unzip -q ./tmp-release-archive-download.zip -d ./release-archive
+						echo "Diffing against current trunk release build (`grep build_number ./release-archive/build_meta.txt | sed s/build_number=//`).";
 
-					# 2. Change anything from the release build which is "unstable", like the version number and build metadata.
-					# These operations restore idempotence between the two builds.
-					rm -f ./release-archive/build_meta.txt
+						# 2. Change anything from the release build which is "unstable", like the version number and build metadata.
+						# These operations restore idempotence between the two builds.
+						rm -f ./release-archive/build_meta.txt
 
-					$normalizeFiles
+						$normalizeFiles
+					fi
 
 					# 3. Check if the current build has changed, and if so, tag it for release.
 					# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-					if ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" --exclude="README.md" $archiveDir ./release-archive/ ; then
+					if [ "%skip_release_diff%" = "true" ] || [ ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" --exclude="README.md" $archiveDir ./release-archive/ ] ; then
 						echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 						tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
 						echo -e "Build tagging status: ${'$'}tag_response\n"

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -13,6 +13,14 @@ object WPComPlugins : Project({
 	params {
 		param("docker_image", "registry.a8c.com/calypso/ci-wpcom:latest")
 		param("build.prefix", "1")
+		checkbox(
+			name = "skip_release_diff",
+			value = "false",
+			label = "Skip release diff",
+			description = "Skips the diff against the previous successful build, uploading the artifact as the latest successful build.",
+			checked = "true",
+			unchecked = "false"
+		)
 	}
 
 	buildType(EditingToolkit)

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -155,6 +155,7 @@ private object O2Blocks : WPComPluginBuild(
 )
 
 private object Happychat : WPComPluginBuild(
+	buildId = "WPComPlugins_Happychat",
 	buildName = "Happychat",
 	pluginSlug = "happychat",
 	archiveDir = "./dist/",
@@ -162,6 +163,7 @@ private object Happychat : WPComPluginBuild(
 )
 
 private object InlineHelp : WPComPluginBuild(
+	buildId = "WPComPlugins_InlineHelp",
 	buildName = "Inline Help",
 	pluginSlug = "inline-help",
 	archiveDir = "./dist/",

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -155,7 +155,6 @@ private object O2Blocks : WPComPluginBuild(
 )
 
 private object Happychat : WPComPluginBuild(
-	buildId = "WPComPlugins_Happychat",
 	buildName = "Happychat",
 	pluginSlug = "happychat",
 	archiveDir = "./dist/",
@@ -163,7 +162,6 @@ private object Happychat : WPComPluginBuild(
 )
 
 private object InlineHelp : WPComPluginBuild(
-	buildId = "WPComPlugins_InlineHelp",
 	buildName = "Inline Help",
 	pluginSlug = "inline-help",
 	archiveDir = "./dist/",

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/class-full-site-editing.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/class-full-site-editing.php
@@ -246,9 +246,9 @@ class Full_Site_Editing {
 	/**
 	 * Returns the label for the Gutenberg close button.
 	 *
-	 * When we edit a Template from a Post/Page or a Template, we want to replace the close
-	 * icon with a "Back to" button, to clarify that it will take us back to the previous editing
-	 * view, and not the Template CPT list.
+	 * When we edit a Template from a Post/Page or a Template, we want to replace
+	 * the close icon with a "Back to" button, to clarify that it will take us
+	 * back to the previous editing view, and not the Template CPT list.
 	 *
 	 * @return null|string Override label string if it should be inserted, or null otherwise.
 	 */

--- a/apps/happychat/README.md
+++ b/apps/happychat/README.md
@@ -1,0 +1,3 @@
+# Happychat
+
+This package contains an extracted happychat widget which can be used in wp-admin or other contexts.

--- a/apps/inline-help/README.md
+++ b/apps/inline-help/README.md
@@ -1,0 +1,3 @@
+# Inline Help
+
+This package contains an extracted inline help widget which can be used in wp-admin or other contexts.

--- a/apps/inline-help/package.json
+++ b/apps/inline-help/package.json
@@ -46,6 +46,7 @@
 		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",
 		"jest": "^27.2.4",
+		"path-browserify": "^1.0.1",
 		"postcss": "^8.3.11",
 		"webpack": "^5.63.0",
 		"webpack-bundle-analyzer": "^4.5.0",

--- a/apps/inline-help/webpack.config.js
+++ b/apps/inline-help/webpack.config.js
@@ -90,6 +90,7 @@ module.exports = {
 		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),
 		new ExtensiveLodashReplacementPlugin(),
 		new InlineConstantExportsPlugin( /\/client\/state\/action-types.js$/ ),
+		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 		shouldEmitStats &&
 			new BundleAnalyzerPlugin( {
 				analyzerMode: 'server',

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,6 +647,7 @@ __metadata:
     enzyme: ^3.11.0
     html-webpack-plugin: ^5.0.0-beta.4
     jest: ^27.2.4
+    path-browserify: ^1.0.1
     postcss: ^8.3.11
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This resolves a few problems with the builds for the new calypso apps:

1. The inline-help app's webpack config didn't have a polyfill for `path`, which was used by a calypso client file that got imported. I copied the webpack plugin from the client config to solve that problem for now. This problem only showed up in the "yarn focused workspaces" mode.
2. Added a README for each of the apps. CI copies the readme so that it exists on WordPress.com. Right now, these are mostly blank.
3. Added a way to skip the diff against previous builds. Right now, there are no successful builds, so it doesn't have anything to compare against. We need a little shortcut when creating calypso apps, so I've added it. More info in my comment below.

#### Testing instructions
- TeamCity should pass.