### PR TITLE
Avoid posting PR comments for happychat and inline-help

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -20,6 +20,7 @@ open class WPComPluginBuild(
 	var releaseTag: String = "$pluginSlug-release-build",
 	var normalizeFiles: String = "",
 	var withSlackNotify: String = "false",
+	var withPRNotify: String = "true",
 	var buildEnv: String = "production",
 	var buildSteps: BuildSteps.() -> Unit = {},
 	var buildParams: ParametrizedWithType.() -> Unit = {},
@@ -34,6 +35,7 @@ open class WPComPluginBuild(
 		val pluginSlug = pluginSlug
 		val normalizeFiles = normalizeFiles
 		val withSlackNotify = withSlackNotify
+		val withPRNotify = withPRNotify
 		val buildSteps = buildSteps
 		val buildEnv = buildEnv
 		val params = params
@@ -170,7 +172,7 @@ open class WPComPluginBuild(
 						echo -e "Build tagging status: ${'$'}tag_response\n"
 
 						# On normal PRs, post a message about WordPress.com deployments.
-						if [[ "%teamcity.build.branch.is_default%" != "true" ]] ; then
+						if [[ "%teamcity.build.branch.is_default%" != "true" ]] && [ "$withPRNotify" == "true" ] ; then
 							%teamcity.build.checkoutDir%/bin/add-pr-comment.sh "%teamcity.build.branch%" "$pluginSlug" <<- EOF || true
 							**This PR modifies the release build for $pluginSlug**
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -168,6 +168,7 @@ private object Happychat : WPComPluginBuild(
 	pluginSlug = "happychat",
 	archiveDir = "./dist/",
 	docsLink = "TODO",
+	withPRNotify = "false",
 )
 
 private object InlineHelp : WPComPluginBuild(
@@ -176,4 +177,5 @@ private object InlineHelp : WPComPluginBuild(
 	pluginSlug = "inline-help",
 	archiveDir = "./dist/",
 	docsLink = "TODO",
+	withPRNotify = "false",
 )


### PR DESCRIPTION
### Changes proposed in this Pull Request
Turns off comments for happychat/inline-help. We need to implement idempotence for the builds, but until we do, we should turn the comments off. Hopefully we can turn comments back on quickly, but for now, it's just noise. (Comments should still work for the other calypso apps.)

### Testing instructions
TeamCity passes