### PR TITLE
Uploading plugins fails on Atomic Sites

### DIFF
--- a/packages/calypso-products/src/has-marketplace-product.ts
+++ b/packages/calypso-products/src/has-marketplace-product.ts
@@ -1,5 +1,5 @@
 const cleanSlug = ( slug: string ) =>
-	slug.replace( /_/g, '-' ).split( /-(monthly|yearly|2y)/ )[ 0 ];
+	slug && slug.replace( /_/g, '-' ).split( /-(monthly|yearly|2y)/ )[ 0 ];
 
 /**
  * Returns true if a list of products contains a marketplace product with the specified product slug.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixed issue with plugin upload. There was a problem with the slug comparison. The slug is only cleaned if it's not empty.

#### Testing instructions

- Go to 'Plugins' on an Atomic Site and click 'Upload'
- upload a file
- Verify the installation goes as normal and doesn’t show any errors
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60748 
