### PR TITLE
Shopping Cart: Remove unused properties of RequestCart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -18,7 +18,7 @@ import {
 	domainProduct,
 	planWithoutDomain,
 	fetchStripeConfiguration,
-	mockSetCartEndpoint,
+	mockSetCartEndpointWith,
 	mockGetCartEndpointWith,
 	getActivePersonalPlanDataForType,
 	getPersonalPlanForInterval,
@@ -78,6 +78,11 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			sub_total_display: 'R$156',
 			coupon_discounts_integer: [],
 		};
+
+		const mockSetCartEndpoint = mockSetCartEndpointWith( {
+			currency: initialCart.currency,
+			locale: initialCart.locale,
+		} );
 
 		const store = createTestReduxStore();
 		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -30,7 +30,7 @@ import {
 	planWithBundledDomain,
 	planWithoutDomain,
 	fetchStripeConfiguration,
-	mockSetCartEndpoint,
+	mockSetCartEndpointWith,
 	mockGetCartEndpointWith,
 	getActivePersonalPlanDataForType,
 	createTestReduxStore,
@@ -92,6 +92,11 @@ describe( 'CompositeCheckout', () => {
 			sub_total_display: 'R$156',
 			coupon_discounts_integer: [],
 		};
+
+		const mockSetCartEndpoint = mockSetCartEndpointWith( {
+			currency: initialCart.currency,
+			locale: initialCart.locale,
+		} );
 
 		const store = createTestReduxStore();
 

--- a/client/my-sites/checkout/composite-checkout/test/util/index.js
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.js
@@ -258,55 +258,52 @@ export const fetchStripeConfiguration = async () => {
 	};
 };
 
-export async function mockSetCartEndpoint( _, requestCart ) {
-	const {
-		products: requestProducts,
-		currency: requestCurrency,
-		coupon: requestCoupon,
-		locale: requestLocale,
-	} = requestCart;
-	const products = requestProducts.map( convertRequestProductToResponseProduct( requestCurrency ) );
+export async function mockSetCartEndpointWith( { currency, locale } ) {
+	return async ( _, requestCart ) => {
+		const { products: requestProducts, coupon: requestCoupon } = requestCart;
+		const products = requestProducts.map( convertRequestProductToResponseProduct( currency ) );
 
-	const taxInteger = products.reduce( ( accum, current ) => {
-		return accum + current.item_tax;
-	}, 0 );
+		const taxInteger = products.reduce( ( accum, current ) => {
+			return accum + current.item_tax;
+		}, 0 );
 
-	const totalInteger = products.reduce( ( accum, current ) => {
-		return accum + current.item_subtotal_integer;
-	}, taxInteger );
+		const totalInteger = products.reduce( ( accum, current ) => {
+			return accum + current.item_subtotal_integer;
+		}, taxInteger );
 
-	return {
-		allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
-		blog_id: '1234',
-		cart_generated_at_timestamp: 12345,
-		cart_key: '1234',
-		coupon: requestCoupon,
-		coupon_discounts_integer: [],
-		coupon_savings_total_display: requestCoupon ? 'R$10' : 'R$0',
-		coupon_savings_total_integer: requestCoupon ? 1000 : 0,
-		create_new_blog: false,
-		credits_display: '0',
-		credits_integer: 0,
-		currency: requestCurrency,
-		is_coupon_applied: true,
-		is_signup: false,
-		locale: requestLocale,
-		next_domain_is_free: false,
-		products,
-		savings_total_display: requestCoupon ? 'R$10' : 'R$0',
-		savings_total_integer: requestCoupon ? 1000 : 0,
-		sub_total_display: 'R$149',
-		sub_total_integer: totalInteger - taxInteger,
-		sub_total_with_taxes_display: 'R$156',
-		sub_total_with_taxes_integer: totalInteger,
-		tax: { location: {}, display_taxes: true },
-		total_cost: 0,
-		total_cost_display: 'R$156',
-		total_cost_integer: totalInteger,
-		total_tax: '',
-		total_tax_breakdown: [],
-		total_tax_display: 'R$7',
-		total_tax_integer: taxInteger,
+		return {
+			allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
+			blog_id: '1234',
+			cart_generated_at_timestamp: 12345,
+			cart_key: '1234',
+			coupon: requestCoupon,
+			coupon_discounts_integer: [],
+			coupon_savings_total_display: requestCoupon ? 'R$10' : 'R$0',
+			coupon_savings_total_integer: requestCoupon ? 1000 : 0,
+			create_new_blog: false,
+			credits_display: '0',
+			credits_integer: 0,
+			currency,
+			is_coupon_applied: true,
+			is_signup: false,
+			locale,
+			next_domain_is_free: false,
+			products,
+			savings_total_display: requestCoupon ? 'R$10' : 'R$0',
+			savings_total_integer: requestCoupon ? 1000 : 0,
+			sub_total_display: 'R$149',
+			sub_total_integer: totalInteger - taxInteger,
+			sub_total_with_taxes_display: 'R$156',
+			sub_total_with_taxes_integer: totalInteger,
+			tax: { location: {}, display_taxes: true },
+			total_cost: 0,
+			total_cost_display: 'R$156',
+			total_cost_integer: totalInteger,
+			total_tax: '',
+			total_tax_breakdown: [],
+			total_tax_display: 'R$7',
+			total_tax_integer: taxInteger,
+		};
 	};
 }
 

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -31,10 +31,7 @@ function convertResponseCartProductToRequestCartProduct(
 
 export function convertResponseCartToRequestCart( {
 	products,
-	currency,
-	locale,
 	coupon,
-	is_coupon_applied,
 	tax,
 }: TempResponseCart ): RequestCart {
 	let requestCartTax = null;
@@ -49,13 +46,9 @@ export function convertResponseCartToRequestCart( {
 	}
 	return {
 		products: products.map( convertResponseCartProductToRequestCartProduct ),
-		currency,
-		locale,
 		coupon,
-		is_coupon_applied,
 		temporary: false,
 		tax: requestCartTax,
-		extra: '', // This property doesn't appear to be used for anything
 	};
 }
 

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -69,6 +69,7 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		uuid: 'product001',
 		cost: 0,
 		price: 0,
+		item_tax: 0,
 		product_type: 'test',
 		included_domain_purchase_amount: 0,
 	};

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -193,11 +193,7 @@ export interface RequestCart {
 	products: RequestCartProduct[];
 	tax: RequestCartTaxData;
 	coupon: string;
-	currency: string;
-	locale: string;
-	is_coupon_applied: boolean;
 	temporary: false;
-	extra: string;
 }
 
 export type RequestCartTaxData = null | {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -328,6 +328,7 @@ export interface ResponseCartProduct {
 	coupon_savings_display?: string;
 	coupon_savings_integer?: number;
 	price: number;
+	item_tax: number;
 	product_type: string;
 	included_domain_purchase_amount: number;
 	is_renewal?: boolean;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before we had a separation of types between the `RequestCart` (the data sent to the shopping-cart endpoint) and the `ResponseCart` (the data received from the shopping-cart endpoint), a very large amount of data was being prepared and sent to the endpoint superstitiously. After some recent work on the shopping-cart endpoint, I've determined that there are several more properties being sent to the shopping-cart endpoint as part of the request that are not used. This PR removes them.

Specifically:

- `currency` (this is returned in the response but sending a value has no effect as it is based on the first product's currency).
- `locale` (this one I'm not as certain of; it's listed clearly in the definition documentation for the endpoint but nowhere I can find in the actual code).
- `is_coupon_applied` (this is derived from the `coupon` property and cannot be changed by the client).
- `extra` (I think this was just a typo at some point when folks confused the cart with the cart products, which do have an `extra` property).

You can verify that these properties were never actually set by the client; they are retrieved from the shopping-cart endpoint when the cart is initialized, then they are sent back to the server for subsequent requests without modification.

#### Testing instructions

Verify that the above properties are never modified by anything in the `@automattic/shopping-cart` package.