### PR TITLE
Max width on empty content component

### DIFF
--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -56,7 +56,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	}
 
 	return (
-		<div className="woop__landing-page">
+		<div className="woop__landing-page woocommerce_landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
 				<Button onClick={ onCTAClickHandler } primary disabled={ isTransferringBlocked }>
 					{ __( 'Start a new store' ) }
@@ -77,7 +77,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 				secondaryAction={ __( 'Learn more' ) }
 				secondaryActionURL="https://wordpress.com/support/introduction-to-woocommerce/"
 				secondaryActionTarget="_blank"
-				className="woop__landing-page-cta woocommerce_landing-page"
+				className="woop__landing-page-cta woocommerce_landing-page-empty-content"
 			/>
 			<WooCommerceColophon />
 		</div>

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -5,15 +5,18 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 }
 
 .woocommerce_landing-page {
-	padding-top: 3em;
+	.woocommerce_landing-page-empty-content {
+		padding-top: 3em;
+		max-width: 540px;
 
-	.empty-content__title {
-		@include onboarding-heading-text;
-		color: var( --studio-gray-90 );
-		padding: 1em 0 0.5em;
-	}
-	.empty-content__line {
-		@include onboarding-large-text;
-		margin-bottom: 1.5em;
+		.empty-content__title {
+			@include onboarding-heading-text;
+			color: var( --studio-gray-90 );
+			padding: 1em 0 0.5em;
+		}
+		.empty-content__line {
+			@include onboarding-large-text;
+			margin-bottom: 1.5em;
+		}
 	}
 }


### PR DESCRIPTION
Apply a max-width of 540px to the EmptyContent component

Before
![Screenshot 2022-02-02 at 17-15-14 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/152102461-6f4d253a-8b8e-4f37-849b-f89ea255a1ac.png)

After
![Screenshot 2022-02-02 at 17-16-30 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/152102590-0633934a-7776-46dc-8ea6-0084a696937a.png)

Related to #59190
