### PR TITLE
Resize the colophon

### DIFF
--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -1,3 +1,5 @@
+@import '@automattic/onboarding/styles/mixins';
+
 .woocommerce {
 	@import 'dashboard/setup/style';
 
@@ -10,6 +12,8 @@
 	}
 
 	.woocommerce-colophon {
+		@include onboarding-small-text;
+
 		margin-top: 1em;
 		text-align: center;
 		color: var( --color-text-subtle );

--- a/client/my-sites/woocommerce/woocommerce-colophon.js
+++ b/client/my-sites/woocommerce/woocommerce-colophon.js
@@ -15,7 +15,7 @@ function WooCommerceColophon() {
 			<ExternalLink icon={ false } onClick={ onClick } href="https://woocommerce.com">
 				{ translate( 'Powered by {{WooCommerceLogo /}}', {
 					components: {
-						WooCommerceLogo: <WooCommerceLogo height={ 32 } width={ 120 } />,
+						WooCommerceLogo: <WooCommerceLogo />,
 					},
 				} ) }
 			</ExternalLink>

--- a/client/my-sites/woocommerce/woocommerce-logo.js
+++ b/client/my-sites/woocommerce/woocommerce-logo.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-const WooCommerceLogo = ( { height = 32, width = 120 } ) => {
+const WooCommerceLogo = ( { height = 24, width = 90 } ) => {
 	return (
 		<svg
 			className="woocommerce-logo"


### PR DESCRIPTION
Resize the colophon to be inline with the figma

Before
![Screenshot 2022-02-02 at 17-26-18 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/152104789-109fb0c6-3da7-4ad9-9cbc-34aacbfc8a1e.png)

After
![Screenshot 2022-02-02 at 17-26-26 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/152104803-3d2abe5e-d72a-4327-8991-defb97412453.png)


Related to https://github.com/Automattic/wp-calypso/issues/59190
