### PR TITLE
Woo landing page: Add footer section

### DIFF
--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -1,11 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import FormattedHeader from 'calypso/components/formatted-header';
+import PromoCard from 'calypso/components/promo-section/promo-card';
 import WarningCard from 'calypso/components/warning-card';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
 import WooCommerceColophon from '../woocommerce-colophon';
@@ -80,6 +82,34 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 				className="woop__landing-page-cta woocommerce_landing-page-empty-content"
 			/>
 			<WooCommerceColophon wpcomDomain={ wpcomDomain || '' } />
+			<div className="woop__landing-page-features-section">
+				<FormattedHeader headerText={ __( 'Everything you need to create a successful store' ) } />
+				<div className="woop__landing-page-features">
+					<PromoCard
+						title={ __( 'Run Your Store From Anywhere' ) }
+						image={ <Gridicon icon="globe" /> }
+					>
+						<p>
+							{ __(
+								'Manage your business on the go with the WooCommerce Mobile App. Create products, process orders, and keep an eye on key stats in real-time.'
+							) }
+						</p>
+					</PromoCard>
+					<PromoCard
+						title={ __( 'Learn With a Global Community' ) }
+						image={ <Gridicon icon="user-circle" /> }
+					>
+						<p>{ __( 'WooCommerce is one of the fastest-growing eCommerce communities.' ) }</p>
+					</PromoCard>
+					<PromoCard title={ __( 'Customize and Extend' ) } image={ <Gridicon icon="story" /> }>
+						<p>
+							{ __(
+								'From subscriptions to gym classes to luxury cars, WooCommerce is fully customizable.'
+							) }
+						</p>
+					</PromoCard>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -7,7 +7,7 @@ import page from 'page';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
-import PromoCard from 'calypso/components/promo-section/promo-card';
+import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import WarningCard from 'calypso/components/warning-card';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
 import WooCommerceColophon from '../woocommerce-colophon';
@@ -57,6 +57,30 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 		);
 	}
 
+	const promos: PromoSectionProps = {
+		promos: [
+			{
+				title: __( 'Run Your Store From Anywhere' ),
+				body: __(
+					'Manage your business on the go with the WooCommerce Mobile App. Create products, process orders, and keep an eye on key stats in real-time.'
+				),
+				image: <Gridicon icon="globe" />,
+			},
+			{
+				title: __( 'Learn With a Global Community' ),
+				body: __( 'WooCommerce is one of the fastest-growing eCommerce communities.' ),
+				image: <Gridicon icon="user-circle" />,
+			},
+			{
+				title: __( 'Customize and Extend' ),
+				body: __(
+					'From subscriptions to gym classes to luxury cars, WooCommerce is fully customizable.'
+				),
+				image: <Gridicon icon="story" />,
+			},
+		],
+	};
+
 	return (
 		<div className="woop__landing-page woocommerce_landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
@@ -85,29 +109,7 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 			<div className="woop__landing-page-features-section">
 				<FormattedHeader headerText={ __( 'Everything you need to create a successful store' ) } />
 				<div className="woop__landing-page-features">
-					<PromoCard
-						title={ __( 'Run Your Store From Anywhere' ) }
-						image={ <Gridicon icon="globe" /> }
-					>
-						<p>
-							{ __(
-								'Manage your business on the go with the WooCommerce Mobile App. Create products, process orders, and keep an eye on key stats in real-time.'
-							) }
-						</p>
-					</PromoCard>
-					<PromoCard
-						title={ __( 'Learn With a Global Community' ) }
-						image={ <Gridicon icon="user-circle" /> }
-					>
-						<p>{ __( 'WooCommerce is one of the fastest-growing eCommerce communities.' ) }</p>
-					</PromoCard>
-					<PromoCard title={ __( 'Customize and Extend' ) } image={ <Gridicon icon="story" /> }>
-						<p>
-							{ __(
-								'From subscriptions to gym classes to luxury cars, WooCommerce is fully customizable.'
-							) }
-						</p>
-					</PromoCard>
+					<PromoSection { ...promos } />
 				</div>
 			</div>
 		</div>

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -51,6 +51,15 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 
 	background-color: var( --color-woocommerce-onboarding-background );
 	.formatted-header .formatted-header__title {
+
+		@media ( max-width: 480px ) {
+			margin-left: 0;
+			margin-right: 0;
+			width: 100%;
+			max-width: fit-content;
+			text-align: center;
+		}
+
 		text-align: left;
 		margin-left: 32px;
 		font-size: 2rem;
@@ -60,14 +69,27 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 	}
 
 	.promo-section__promos .promo-card {
-		/* Todo: add media queries */
-		width: calc( 33% - 1em );
+		// 3 column layout
+		@media ( min-width: 1281px ) {
+			width: calc( 33% - 1em );
+		}
 		box-shadow: none;
 		background-color: var( --color-woocommerce-onboarding-background );
 
 		.action-panel__title {
+			@media ( max-width: 480px ) {
+				display: block;
+				width: 100%;
+				text-align: center;
+			}
 			font-weight: 500;
 			font-size: 1.25rem;
+		}
+
+		.action-panel__body {
+			@media ( max-width: 480px ) {
+				text-align: center;
+			}
 		}
 
 		.gridicon {

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -52,7 +52,7 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 	background-color: var( --color-woocommerce-onboarding-background );
 	.formatted-header .formatted-header__title {
 
-		@media ( max-width: 480px ) {
+		@media ( max-width: $break-mobile ) {
 			margin-left: 0;
 			margin-right: 0;
 			width: 100%;
@@ -70,14 +70,14 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 
 	.promo-section__promos .promo-card {
 		// 3 column layout
-		@media ( min-width: 1281px ) {
+		@media ( min-width: $break-wide ) {
 			width: calc( 33% - 1em );
 		}
 		box-shadow: none;
 		background-color: var( --color-woocommerce-onboarding-background );
 
 		.action-panel__title {
-			@media ( max-width: 480px ) {
+			@media ( max-width: $break-mobile ) {
 				display: block;
 				width: 100%;
 				text-align: center;
@@ -87,7 +87,7 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 		}
 
 		.action-panel__body {
-			@media ( max-width: 480px ) {
+			@media ( max-width: $break-mobile ) {
 				text-align: center;
 			}
 		}

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -1,7 +1,17 @@
 @import '@automattic/onboarding/styles/mixins';
+@import 'jetpack-connect/colors.scss';
 
 body.is-section-woocommerce-installation.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
+}
+
+.woocommerce {
+	.main.is-wide-layout {
+		width: 100%;
+		padding-bottom: 0;
+		max-width: 100%;
+		margin: 0;
+	}
 }
 
 .woocommerce_landing-page {
@@ -22,9 +32,20 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 }
 
 .woop__landing-page-features-section {
+	@include woocommerce-colors();
+
+	// on desktop make the section full width so it takes the whole space
+	@media ( min-width: 660px ) {
+		margin-left: -30px;
+		width: calc( 100% + 60px );
+	}
+
+	background-color: var( --color-woocommerce-onboarding-background );
+
 	.promo-section__promos .promo-card {
 		/* Todo: add media queries */
 		width: calc( 33% - 1em );
 		box-shadow: none;
+		background-color: var( --color-woocommerce-onboarding-background );
 	}
 }

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -1,6 +1,10 @@
 @import '@automattic/onboarding/styles/mixins';
 @import 'jetpack-connect/colors.scss';
 
+.is-group-woocommerce-installation.is-section-woocommerce-installation .layout__content {
+	padding-bottom: 0; //removes whitespace in the end
+}
+
 body.is-section-woocommerce-installation.theme-default.color-scheme {
 	--color-surface-backdrop: var( --studio-white );
 }
@@ -33,14 +37,27 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 
 .woop__landing-page-features-section {
 	@include woocommerce-colors();
+	margin-top: 100px;
+	padding-top: 60px;
+	padding-bottom: 40px;
+	padding-left: 20px;
+    padding-right: 20px;
 
 	// on desktop make the section full width so it takes the whole space
 	@media ( min-width: 660px ) {
 		margin-left: -30px;
-		width: calc( 100% + 60px );
+		width: calc( 100% + 20px );
 	}
 
 	background-color: var( --color-woocommerce-onboarding-background );
+	.formatted-header .formatted-header__title {
+		text-align: left;
+		margin-left: 32px;
+		font-size: 2rem;
+		max-width: 377px;
+		line-height: 40px;
+		font-family: 'Recoleta';
+	}
 
 	.promo-section__promos .promo-card {
 		/* Todo: add media queries */

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -20,3 +20,11 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 		}
 	}
 }
+
+.woop__landing-page-features-section {
+	.promo-section__promos .promo-card {
+		/* Todo: add media queries */
+		width: calc( 33% - 1em );
+		box-shadow: none;
+	}
+}

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -65,7 +65,7 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 		font-size: 2rem;
 		max-width: 377px;
 		line-height: 40px;
-		font-family: 'Recoleta';
+		@include onboarding-font-recoleta;
 	}
 
 	.promo-section__promos .promo-card {

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -47,5 +47,14 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 		width: calc( 33% - 1em );
 		box-shadow: none;
 		background-color: var( --color-woocommerce-onboarding-background );
+
+		.action-panel__title {
+			font-weight: 500;
+			font-size: 1.25rem;
+		}
+
+		.gridicon {
+			fill: #0675c4; // TODO: maybe we need to define this color as a variable somewhere?
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sets up the footer section, I'm using `PromoCard`'s ([link](https://wpcalypso.wordpress.com/devdocs/design/promo-card)) for this as they seem to fit. Not sure how I feel about these, they sort of work to align the gridicons / text but not perfectly and we'll need to fix a fair bit of the css. Maybe we're better off creating our own for this?

Before
![Screenshot 2022-02-02 at 18-02-29 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/152108776-525751cc-65f5-4c08-9aec-23634069dff6.png)

After
![Screenshot 2022-02-03 at 10-28-17 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/152255000-90e29f10-58e1-441c-8039-ec6ce09362ea.png)


#### Testing instructions

http://calypso.localhost:3000/woocommerce-installation/


Related to https://github.com/Automattic/wp-calypso/issues/59190