### PR TITLE
Add `domain-only` filter to All domains list

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -48,7 +48,7 @@ import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import BulkEditContactInfo from './bulk-edit-contact-info';
 import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
-import { filterDomainsByOwner, filterDomainsDomainOnly } from './helpers';
+import { filterDomainsByOwner, filterDomainOnlyDomains } from './helpers';
 import ListItemPlaceholder from './item-placeholder';
 import {
 	countDomainsInOrangeStatus,
@@ -272,7 +272,7 @@ class AllDomains extends Component {
 
 		const domains =
 			selectedFilter === 'domain-only'
-				? filterDomainsDomainOnly( this.mergeFilteredDomainsWithDomainsDetails(), sites )
+				? filterDomainOnlyDomains( this.mergeFilteredDomainsWithDomainsDetails(), sites )
 				: filterDomainsByOwner( this.mergeFilteredDomainsWithDomainsDetails(), selectedFilter );
 
 		const domainsTableColumns = [
@@ -574,10 +574,10 @@ class AllDomains extends Component {
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-others' )?.length,
 			},
 			{
-				label: translate( 'Domain only' ),
+				label: translate( 'Parked domains' ),
 				value: 'domain-only',
 				path: domainManagementRoot() + '?' + stringify( { filter: 'domain-only' } ),
-				count: filterDomainsDomainOnly( nonWpcomDomains, sites )?.length,
+				count: filterDomainOnlyDomains( nonWpcomDomains, sites )?.length,
 			},
 		];
 

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -48,7 +48,7 @@ import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import BulkEditContactInfo from './bulk-edit-contact-info';
 import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
-import { filterDomainsByOwner } from './helpers';
+import { filterDomainsByOwner, filterDomainsDomainOnly } from './helpers';
 import ListItemPlaceholder from './item-placeholder';
 import {
 	countDomainsInOrangeStatus,
@@ -270,6 +270,11 @@ class AllDomains extends Component {
 
 		const selectedFilter = context?.query?.filter;
 
+		const domains =
+			selectedFilter === 'domain-only'
+				? filterDomainsDomainOnly( this.mergeFilteredDomainsWithDomainsDetails(), sites )
+				: filterDomainsByOwner( this.mergeFilteredDomainsWithDomainsDetails(), selectedFilter );
+
 		const domainsTableColumns = [
 			{
 				name: 'domain',
@@ -335,11 +340,10 @@ class AllDomains extends Component {
 					getReverseSimpleSortFunctionBy( 'domain' ),
 				],
 				bubble: countDomainsInOrangeStatus(
-					filterDomainsByOwner( this.mergeFilteredDomainsWithDomainsDetails(), selectedFilter ).map(
-						( domain ) =>
-							resolveDomainStatus( domain, null, {
-								getMappingErrors: true,
-							} )
+					domains.map( ( domain ) =>
+						resolveDomainStatus( domain, null, {
+							getMappingErrors: true,
+						} )
 					)
 				),
 			},
@@ -376,10 +380,7 @@ class AllDomains extends Component {
 				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
 				<DomainsTable
 					currentRoute={ currentRoute }
-					domains={ filterDomainsByOwner(
-						this.mergeFilteredDomainsWithDomainsDetails(),
-						selectedFilter
-					) }
+					domains={ domains }
 					handleDomainItemToggle={ this.handleDomainItemToggle }
 					domainsTableColumns={ domainsTableColumns }
 					isManagingAllSites={ true }
@@ -548,7 +549,7 @@ class AllDomains extends Component {
 	}
 
 	renderDomainTableFilterButton() {
-		const { context, translate } = this.props;
+		const { context, translate, sites } = this.props;
 
 		const selectedFilter = context?.query?.filter;
 		const nonWpcomDomains = this.mergeFilteredDomainsWithDomainsDetails();
@@ -571,6 +572,12 @@ class AllDomains extends Component {
 				value: 'owned-by-others',
 				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-others' } ),
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-others' )?.length,
+			},
+			{
+				label: translate( 'Domain only' ),
+				value: 'domain-only',
+				path: domainManagementRoot() + '?' + stringify( { filter: 'domain-only' } ),
+				count: filterDomainsDomainOnly( nonWpcomDomains, sites )?.length,
 			},
 		];
 

--- a/client/my-sites/domains/domain-management/list/helpers.ts
+++ b/client/my-sites/domains/domain-management/list/helpers.ts
@@ -1,29 +1,14 @@
 import { ResponseDomain } from 'calypso/lib/domains/types';
+import { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 type FilterDomainsByOwnerType = (
 	domains: Array< ResponseDomain >,
 	filter: 'owned-by-me' | 'owned-by-others' | undefined
 ) => Array< ResponseDomain >;
 
-type JSONValue =
-	| string
-	| number
-	| boolean
-	| null
-	| { [ x: string ]: JSONValue }
-	| Array< JSONValue >;
-
-type Site = {
-	[ key: string ]: JSONValue;
-	options: {
-		[ key: string ]: JSONValue;
-		is_domain_only: boolean;
-	};
-};
-
 type FilterDomainsDomainOnlyType = (
 	domains: Array< ResponseDomain >,
-	sites: Array< Site >
+	sites: Array< SiteData >
 ) => Array< ResponseDomain >;
 
 export const filterDomainsByOwner: FilterDomainsByOwnerType = ( domains, filter ) => {
@@ -37,8 +22,8 @@ export const filterDomainsByOwner: FilterDomainsByOwnerType = ( domains, filter 
 	} );
 };
 
-export const filterDomainsDomainOnly: FilterDomainsDomainOnlyType = ( domains, sites ) => {
+export const filterDomainOnlyDomains: FilterDomainsDomainOnlyType = ( domains, sites ) => {
 	return domains.filter( ( domain: ResponseDomain ) => {
-		return sites[ domain.blogId ].options.is_domain_only;
+		return sites[ domain.blogId ].options?.is_domain_only;
 	} );
 };

--- a/client/my-sites/domains/domain-management/list/helpers.ts
+++ b/client/my-sites/domains/domain-management/list/helpers.ts
@@ -5,6 +5,27 @@ type FilterDomainsByOwnerType = (
 	filter: 'owned-by-me' | 'owned-by-others' | undefined
 ) => Array< ResponseDomain >;
 
+type JSONValue =
+	| string
+	| number
+	| boolean
+	| null
+	| { [ x: string ]: JSONValue }
+	| Array< JSONValue >;
+
+type Site = {
+	[ key: string ]: JSONValue;
+	options: {
+		[ key: string ]: JSONValue;
+		is_domain_only: boolean;
+	};
+};
+
+type FilterDomainsDomainOnlyType = (
+	domains: Array< ResponseDomain >,
+	sites: Array< Site >
+) => Array< ResponseDomain >;
+
 export const filterDomainsByOwner: FilterDomainsByOwnerType = ( domains, filter ) => {
 	return domains.filter( ( domain: ResponseDomain ) => {
 		if ( 'owned-by-me' === filter ) {
@@ -13,5 +34,11 @@ export const filterDomainsByOwner: FilterDomainsByOwnerType = ( domains, filter 
 			return ! domain.currentUserIsOwner;
 		}
 		return true;
+	} );
+};
+
+export const filterDomainsDomainOnly: FilterDomainsDomainOnlyType = ( domains, sites ) => {
+	return domains.filter( ( domain: ResponseDomain ) => {
+		return sites[ domain.blogId ].options.is_domain_only;
 	} );
 };

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -35,5 +35,6 @@ export interface SiteDataOptions {
 	is_automated_transfer: boolean;
 	is_wpforteams_site: boolean;
 	is_difm_lite_in_progress: boolean;
+	is_domain_only: boolean;
 	// TODO: fill out the rest of this
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR add a new filter (domain-only) in All domains management page.

It's part of the new domain-only flow (pcYYhz-ye-p2)

![filter-1](https://user-images.githubusercontent.com/2797601/152330364-0367e06b-8f32-4fd8-aed7-562bfa1f8708.png)

![filter-2](https://user-images.githubusercontent.com/2797601/152330371-0badeaff-89f8-4e96-9f79-03104950be47.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to to `/domains/manage`
- Select "Domain only" filter and verify that works correctly.