### PR TITLE
Remove usage of Calypso components and styles from dev helpers

### DIFF
--- a/client/lib/auth-helper/index.jsx
+++ b/client/lib/auth-helper/index.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import ReactDom from 'react-dom';
-import FormRadio from 'calypso/components/forms/form-radio';
 
 import './style.scss';
 
@@ -12,23 +11,33 @@ function AuthHelper() {
 		window.location.href = '?' + new URLSearchParams( { flags: value } ).toString();
 	}
 
-	/* eslint-disable jsx-a11y/label-has-associated-control */
 	return (
 		<>
 			<div>Auth: { isOAuth ? 'OAuth' : 'Cookies' }</div>
 			<div className="auth-helper__popover">
 				<label className="auth-helper__label">
-					<FormRadio name="auth" value="-oauth" defaultChecked={ ! isOAuth } onChange={ setAuth } />
+					<input
+						type="radio"
+						name="auth"
+						value="-oauth"
+						defaultChecked={ ! isOAuth }
+						onChange={ setAuth }
+					/>
 					Cookies
 				</label>
 				<label className="auth-helper__label">
-					<FormRadio name="auth" value="oauth" defaultChecked={ isOAuth } onChange={ setAuth } />
+					<input
+						type="radio"
+						name="auth"
+						value="oauth"
+						defaultChecked={ isOAuth }
+						onChange={ setAuth }
+					/>
 					OAuth
 				</label>
 			</div>
 		</>
 	);
-	/* eslint-enable jsx-a11y/label-has-associated-control */
 }
 
 export default ( element ) => ReactDom.render( <AuthHelper />, element );

--- a/client/lib/auth-helper/style.scss
+++ b/client/lib/auth-helper/style.scss
@@ -16,7 +16,9 @@
 	margin-bottom: 4px;
 	line-height: 16px;
 
-	.form-radio {
+	input[type='radio'] {
+		appearance: auto;
+		vertical-align: middle;
 		margin: 0 4px 0 0;
 	}
 }

--- a/client/lib/features-helper/feature-list.js
+++ b/client/lib/features-helper/feature-list.js
@@ -1,19 +1,17 @@
 import config from '@automattic/calypso-config';
-import { Card } from '@automattic/components';
-import { memo } from 'react';
 
 const headerClass = 'features-helper__feature-header';
 const itemClass = 'features-helper__feature-item';
 const enabledClass = 'features-helper__feature-item-enabled';
 const disabledClass = 'features-helper__feature-item-disabled';
 
-export const FeatureList = memo( () => {
+export default function FeatureList() {
 	const currentXLProjects = [];
 	const enabledFeatures = config.enabledFeatures();
 	return (
 		<>
 			<div>Features</div>
-			<Card className="features-helper__current-features">
+			<div className="features-helper__current-features">
 				<div className={ headerClass }>Current XL Projects</div>
 				{ currentXLProjects.map( ( flag ) => {
 					const isFlagEnabled = config.isEnabled( flag );
@@ -32,8 +30,7 @@ export const FeatureList = memo( () => {
 						{ flag }
 					</div>
 				) ) }
-			</Card>
+			</div>
 		</>
 	);
-} );
-export default FeatureList;
+}

--- a/client/lib/features-helper/style.scss
+++ b/client/lib/features-helper/style.scss
@@ -25,8 +25,11 @@
 	color: var( --studio-red-70 );
 }
 
-.environment.is-features:hover .features-helper__current-features.card {
+.environment.is-features:hover .features-helper__current-features {
 	display: block;
+	background: var( --color-surface );
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+	padding: 16px;
 	max-height: 80vh;
 	overflow-y: scroll;
 	position: absolute;

--- a/client/lib/preferences-helper/preference-list.js
+++ b/client/lib/preferences-helper/preference-list.js
@@ -1,47 +1,44 @@
-import { Card } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
 import Preference from './preference';
 
-class PreferenceList extends Component {
-	render() {
-		const { preferences, translate } = this.props;
-		return (
-			<div>
-				<QueryPreferences />
-				<a
-					href={ '/devdocs/client/state/preferences/README.md' }
-					title={ translate( 'Preferences' ) }
-				>
-					{ translate( 'Preferences' ) }
-				</a>
-				<Card className="preferences-helper__current-preferences">
-					{ ! isEmpty( preferences ) ? (
-						Object.keys( preferences ).map( ( preferenceName ) => (
-							<Preference
-								key={ preferenceName }
-								name={ preferenceName }
-								value={ preferences[ preferenceName ] }
-							/>
-						) )
-					) : (
-						<h5 className="preferences-helper__preference-header">
-							{ translate( 'No Preferences' ) }
-						</h5>
-					) }
-				</Card>
-			</div>
-		);
+function getPreferenceEntries( preferences ) {
+	if ( ! preferences ) {
+		return null;
 	}
+
+	const entries = Object.entries( preferences );
+	if ( entries.length === 0 ) {
+		return null;
+	}
+
+	return entries;
 }
 
-export default connect(
-	( state ) => ( {
-		preferences: getAllRemotePreferences( state ),
-	} ),
-	null
-)( localize( PreferenceList ) );
+export default function PreferenceList() {
+	const translate = useTranslate();
+	const preferences = useSelector( getAllRemotePreferences );
+	const preferenceEntries = useMemo( () => getPreferenceEntries( preferences ), [ preferences ] );
+	return (
+		<div>
+			<QueryPreferences />
+			<a href="/devdocs/client/state/preferences/README.md" title={ translate( 'Preferences' ) }>
+				{ translate( 'Preferences' ) }
+			</a>
+			<div className="preferences-helper__current-preferences">
+				{ preferenceEntries ? (
+					preferenceEntries.map( ( [ name, value ] ) => (
+						<Preference key={ name } name={ name } value={ value } />
+					) )
+				) : (
+					<h5 className="preferences-helper__preference-header">
+						{ translate( 'No Preferences' ) }
+					</h5>
+				) }
+			</div>
+		</div>
+	);
+}

--- a/client/lib/preferences-helper/style.scss
+++ b/client/lib/preferences-helper/style.scss
@@ -52,8 +52,11 @@
 	}
 }
 
-.environment.is-prefs:hover .preferences-helper__current-preferences.card {
+.environment.is-prefs:hover .preferences-helper__current-preferences {
 	display: block;
+	background: var( --color-surface );
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+	padding: 16px;
 	max-height: 80vh;
 	overflow-y: scroll;
 	position: absolute;


### PR DESCRIPTION
This fixes the reason why we had to revert #60551: the dev helper async chunks shipped the styles for `Card` (and `FormRadio`) components and changed the order in which they are applied.

This PR removes the usages of `Card` and `FormRadio` components from the dev helpers, making them into self-contained HTML with its own CSS styles. That removes any style interaction between the helpers and the main Calypso.

**How to test:**
Verify that the Preferences, Features and OAuth helpers still load correctly and look correctly.