### PR TITLE
Breadcrumbs: replace .at() function call with array length.

### DIFF
--- a/client/state/breadcrumb/reducer.js
+++ b/client/state/breadcrumb/reducer.js
@@ -14,7 +14,7 @@ export default ( state = [], action ) => {
 		case BREADCRUMB_APPEND_ITEM:
 			// Don't append if it is the same as the last item
 			// eslint-disable-next-line no-case-declarations
-			const currentLastItem = state.at( -1 ) || {};
+			const currentLastItem = state[ state.length - 1 ] || {};
 			if ( currentLastItem.label === action.item?.label ) {
 				return [ ...state ];
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`Array.prototype.at()` is not yet supported by Safari leading to Javascript parse errors
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at

* replace .at() function call with array length.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a plugin details page from Safari. Make sure breadcrumbs seems and works as expected

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #60735
