### PR TITLE
Hide "Add existing site" option in `site-or-domain` step, if the user doesn't have any site

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -5,10 +5,11 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import HeaderImage from 'calypso/assets/images/domains/domain.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import { getUserSiteCountForPlatform } from 'calypso/components/site-selector/utils';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug } from 'calypso/lib/domains';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SelectItems from '../../select-items';
@@ -35,7 +36,7 @@ class SiteOrDomain extends Component {
 	}
 
 	getChoices() {
-		const { translate, isReskinned, isLoggedIn } = this.props;
+		const { translate, isReskinned, isLoggedIn, siteCount } = this.props;
 
 		const choices = [];
 
@@ -64,7 +65,7 @@ class SiteOrDomain extends Component {
 				value: 'page',
 				actionText: translate( 'Start site' ),
 			} );
-			if ( isLoggedIn ) {
+			if ( isLoggedIn && siteCount > 0 ) {
 				choices.push( {
 					key: 'existing-site',
 					title: translate( 'Existing WordPress.com site' ),
@@ -91,7 +92,7 @@ class SiteOrDomain extends Component {
 					'Choose a theme, customize, and launch your site. A free domain for one year is included with all annual plans.'
 				),
 			} );
-			if ( this.props.isLoggedIn ) {
+			if ( isLoggedIn && siteCount > 0 ) {
 				choices.push( {
 					type: 'existing-site',
 					label: translate( 'Existing WordPress.com site' ),
@@ -257,11 +258,13 @@ export default connect(
 	( state ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
+		const user = getCurrentUser( state );
 
 		return {
 			isLoggedIn: isUserLoggedIn( state ),
 			productsList,
 			productsLoaded,
+			siteCount: getUserSiteCountForPlatform( user ),
 		};
 	},
 	{ submitSignupStep }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR prevent the "Add existing site" option to be displayed, in domain only flow second step, if the user is logged in but doesn't have any site.

<img width="1619" alt="Schermata 2022-02-02 alle 12 30 48" src="https://user-images.githubusercontent.com/2797601/152159182-32a9e56c-bcb7-41e2-a645-6fc16b77fd9b.png">

## Testing instructions

- Build this branch locally or open the live Calypso link
- Login with an account that doesn't have any site associate
- Navigate to `start/domain` and select a domain
- Verify that the subsequent step has only two option: "Just buy a domain" and "New site"