### PR TITLE
Seller Experience - Adding tracks event for store features step in onboarding

### DIFF
--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
 import paymentBlocksImage from 'calypso/assets/images/onboarding/payment-blocks.svg';
 import wooCommerceImage from 'calypso/assets/images/onboarding/woo-commerce.svg';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { localizeUrl } from 'calypso/lib/i18n-utils/utils';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
@@ -121,6 +122,9 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 	];
 
 	const onSelect = ( selectedOption: StoreFeatureSet ) => {
+		recordTracksEvent( 'calypso_signup_store_feature_select', {
+			store_feature: selectedOption,
+		} );
 		switch ( selectedOption ) {
 			case 'power':
 				page.redirect( `/start/woocommerce-install/?site=${ siteSlug }` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the "Store Features" step of the seller flow to include Tracks events for the "Simple" and "Power" buttons.
* This is the only change necessary to address https://github.com/Automattic/wp-calypso/issues/60558 - everything else we get for free from the existing infrastructure.
* I've also updated PCYsg-D4m-p2 to reflect events specific to the Sell flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this diff to your local Calypso
* Walk through the sell flow and select each of the buttons on the Store Features page (Simple and Power).
* Verify on Tracks that you can see the events described in PCYsg-D4m-p2, but most specifically that the `calypso_signup_store_feature_select` event gets properly recorded for both buttons.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #60558 