### PR TITLE
Fetch plugins from all sites 

### DIFF
--- a/client/components/data/query-jetpack-plugins/index.jsx
+++ b/client/components/data/query-jetpack-plugins/index.jsx
@@ -24,7 +24,7 @@ class QueryJetpackPlugins extends Component {
 		if ( isEqual( prevProps.siteIds, this.props.siteIds ) ) {
 			return;
 		}
-		this.refresh( prevProps.isRequestingForSites, prevProps.siteIds );
+		this.refresh( this.props.isRequestingForSites, this.props.prevProps.siteIds );
 	}
 
 	refresh( isRequesting, siteIds ) {

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -2,6 +2,7 @@ import { planHasFeature } from '@automattic/calypso-products';
 import i18n from 'i18n-calypso';
 import { get } from 'lodash';
 import { withoutHttp } from 'calypso/lib/url';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 
 export function userCan( capability, site ) {
 	return site && site.capabilities && site.capabilities[ capability ];
@@ -135,4 +136,22 @@ export function hasSiteFeature( site, feature ) {
 	if ( site && site.plan ) {
 		return planHasFeature( site.plan.product_slug, feature );
 	}
+}
+
+/**
+ * Compare two lists of sites and tell if they have the same ids
+ *
+ * @param {Array} siteListA
+ * @param {Array} siteListB
+ * @returns boolean
+ */
+export function compareSiteIds( siteListA, siteListB ) {
+	const siteIdsA = [ ...new Set( siteObjectsToSiteIds( siteListA ) ) ];
+	const siteIdsB = [ ...new Set( siteObjectsToSiteIds( siteListB ) ) ];
+
+	if ( siteIdsA.length !== siteIdsB.length ) {
+		return false;
+	}
+
+	return ! siteIdsA.some( ( id ) => siteIdsB.indexOf( id ) === -1 );
 }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
-import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
@@ -226,7 +225,6 @@ function PluginDetails( props ) {
 			<DocumentHead title={ getPageTitle() } />
 			<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
 			<SidebarNavigation />
-			<QueryJetpackPlugins siteIds={ siteIds } />
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QueryProductsList persist />
 			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fetch plugins information for all sites with plugins when there is no site selected
* Use the current props instead of the previous to retrieve plugin info

#### Testing instructions
**Browser Plugins**
* Go to `plugins` page, without a selected site
* Clear the indexed DB from your browser
* Reload the page and check if the `Installed on * sites`  is properly shown`

**Plugin Details without a site**
* Click on a plugin to go to the Plugin Details page
* Clear the indexed DB from your browser
* Reload the page and check if the `Installed on` area is properly shown

**Plugin Details with a selected site**
* Clear the indexed DB from your browser
* Reload the page and check if the `Installed on` area is properly shown

---


Related to #60704
