### PR TITLE
Partner portal: remove footer references

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -20,7 +20,6 @@ import {
 	valueToEnum,
 	ensurePartnerPortalReturnUrl,
 } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import JetpackComFooter from 'calypso/jetpack-cloud/sections/pricing/jpcom-footer';
 import { addQueryArgs } from 'calypso/lib/route';
 import {
 	getCurrentPartner,
@@ -33,21 +32,18 @@ import type PageJS from 'page';
 export function partnerContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
 	context.primary = <PartnerAccess />;
-	context.footer = <JetpackComFooter />;
 	next();
 }
 
 export function termsOfServiceContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
 	context.primary = <TermsOfServiceConsent />;
-	context.footer = <JetpackComFooter />;
 	next();
 }
 
 export function partnerKeyContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
 	context.primary = <SelectPartnerKey />;
-	context.footer = <JetpackComFooter />;
 	next();
 }
 
@@ -55,7 +51,6 @@ export function billingDashboardContext( context: PageJS.Context, next: () => vo
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = <BillingDashboard />;
-	context.footer = <JetpackComFooter />;
 	next();
 }
 
@@ -81,7 +76,6 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 			sortField={ sortField }
 		/>
 	);
-	context.footer = <JetpackComFooter />;
 	next();
 }
 
@@ -89,7 +83,6 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = <IssueLicense />;
-	context.footer = <JetpackComFooter />;
 	next();
 }
 
@@ -97,7 +90,6 @@ export function paymentMethodListContext( context: PageJS.Context, next: () => v
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = <PaymentMethodList />;
-	context.footer = <JetpackComFooter />;
 	next();
 }
 
@@ -105,14 +97,12 @@ export function paymentMethodAddContext( context: PageJS.Context, next: () => vo
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = <PaymentMethodAdd />;
-	context.footer = <JetpackComFooter />;
 	next();
 }
 
 export function landingPageContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
 	context.primary = <LandingPage />;
-	context.footer = <JetpackComFooter />;
 	next();
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

It seems that the Jetpack partner portal is not displaying any footer. This PR removes its references to the footer component, to reflect reality.

### Testing instructions

Confirm that the partner portal doesn't use any footer.