### PR TITLE
Domains: Add link to domain connection setup in domain notice

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -193,12 +193,18 @@ export function resolveDomainStatus(
 				}
 			}
 
-			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom ) {
+			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom && siteSlug ) {
 				const status = translate(
-					'{{strong}}Verifying connection:{{/strong}} You can continue to work on your site, but you domain won’t be reachable just yet.',
+					'{{strong}}Verifying connection:{{/strong}} You can continue to work on your site, but you domain won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
 					{
 						components: {
 							strong: <strong />,
+							a: (
+								<a
+									href={ domainMappingSetup( siteSlug as string, domain.domain, setupStep ) }
+									onClick={ ( e ) => e.stopPropagation() }
+								/>
+							),
 						},
 					}
 				);
@@ -209,10 +215,16 @@ export function resolveDomainStatus(
 					icon: 'verifying',
 					listStatusText: status,
 					noticeText: translate(
-						'It can take between a few minutes to 72 hours to verify the connection. You can continue to work on your site, but {{strong}}%(domainName)s{{/strong}} won’t be reachable just yet.',
+						'It can take between a few minutes to 72 hours to verify the connection. You can continue to work on your site, but {{strong}}%(domainName)s{{/strong}} won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
 						{
 							components: {
 								strong: <strong />,
+								a: (
+									<a
+										href={ domainMappingSetup( siteSlug as string, domain.domain, setupStep ) }
+										onClick={ ( e ) => e.stopPropagation() }
+									/>
+								),
 							},
 							args: {
 								domainName: domain.name,

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -75,6 +75,18 @@ export function resolveDomainStatus(
 		},
 	};
 
+	const mappingSetupStep =
+		domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update';
+	const mappingSetupComponents = {
+		strong: <strong />,
+		a: (
+			<a
+				href={ domainMappingSetup( siteSlug as string, domain.domain, mappingSetupStep ) }
+				onClick={ ( e ) => e.stopPropagation() }
+			/>
+		),
+	};
+
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
 			if ( isExpiringSoon( domain, 30 ) ) {
@@ -95,25 +107,9 @@ export function resolveDomainStatus(
 				let noticeText = null;
 
 				if ( ! domain.pointsToWpcom ) {
-					const options = {
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainMappingSetup(
-										siteSlug as string,
-										domain.domain,
-										domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update'
-									) }
-									onClick={ ( e ) => e.stopPropagation() }
-								/>
-							),
-						},
-					};
-
 					noticeText = translate(
 						"We noticed that something wasn't updated correctly. Please try {{a}}this setup{{/a}} again.",
-						options
+						{ components: mappingSetupComponents }
 					);
 				}
 
@@ -151,30 +147,16 @@ export function resolveDomainStatus(
 					moment.utc().isAfter( registrationDatePlus3Days );
 
 				if ( hasMappingError ) {
-					const setupStep =
-						domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update';
-					const options = {
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainMappingSetup( siteSlug, domain.domain, setupStep ) }
-									onClick={ ( e ) => e.stopPropagation() }
-								/>
-							),
-						},
-					};
-
 					let status;
 					if ( domain?.connectionMode === 'advanced' ) {
 						status = translate(
 							'{{strong}}Connection error:{{/strong}} The A records are incorrect. Please {{a}}try this step{{/a}} again.',
-							options
+							{ components: mappingSetupComponents }
 						);
 					} else {
 						status = translate(
 							'{{strong}}Connection error:{{/strong}} The name servers are incorrect. Please {{a}}try this step{{/a}} again.',
-							options
+							{ components: mappingSetupComponents }
 						);
 					}
 					return {
@@ -185,7 +167,7 @@ export function resolveDomainStatus(
 						listStatusText: status,
 						noticeText: translate(
 							"We noticed that something wasn't updated correctly. Please try {{a}}this setup{{/a}} again.",
-							options
+							{ components: mappingSetupComponents }
 						),
 						listStatusClass: 'alert',
 						listStatusWeight: 1000,
@@ -196,17 +178,7 @@ export function resolveDomainStatus(
 			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom && siteSlug ) {
 				const status = translate(
 					'{{strong}}Verifying connection:{{/strong}} You can continue to work on your site, but you domain won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
-					{
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainMappingSetup( siteSlug as string, domain.domain, setupStep ) }
-									onClick={ ( e ) => e.stopPropagation() }
-								/>
-							),
-						},
-					}
+					{ components: mappingSetupComponents }
 				);
 				return {
 					statusText: translate( 'Verifying' ),
@@ -217,15 +189,7 @@ export function resolveDomainStatus(
 					noticeText: translate(
 						'It can take between a few minutes to 72 hours to verify the connection. You can continue to work on your site, but {{strong}}%(domainName)s{{/strong}} won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
 						{
-							components: {
-								strong: <strong />,
-								a: (
-									<a
-										href={ domainMappingSetup( siteSlug as string, domain.domain, setupStep ) }
-										onClick={ ( e ) => e.stopPropagation() }
-									/>
-								),
-							},
+							components: mappingSetupComponents,
 							args: {
 								domainName: domain.name,
 							},

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -175,7 +175,7 @@ export function resolveDomainStatus(
 				}
 			}
 
-			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom && siteSlug ) {
+			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom ) {
 				const status = translate(
 					'{{strong}}Verifying connection:{{/strong}} You can continue to work on your site, but you domain won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
 					{ components: mappingSetupComponents }


### PR DESCRIPTION
### Changes proposed in this Pull Request

After a user connects a domain to a site and before it is resolves to WPCOM, we show a "We're verifying your connection" notice for that domain, like this:

<img width="1069" alt="Screen Shot 2022-02-02 at 16 53 26" src="https://user-images.githubusercontent.com/5324818/152227011-515a13ee-7aee-4964-9299-822c1550d97c.png">

That notice is shown for up to 72 hours after the domain connection is created. If the domain still isn't resolving to WPCOM after that, we show a notice asking the user to try the setup again:

<img width="1065" alt="Screen Shot 2022-02-02 at 16 55 07" src="https://user-images.githubusercontent.com/5324818/152228360-eb85ad19-19e6-4a4d-aff0-4ce210f00035.png">

However, notice that in the first notice we don't provide a way for the user to review their DNS configuration before the 72 hours limit - they might want to double check their configurations before that as they might have gotten something wrong.  This PR adds a link to the domain connection setup to that notice:

![Markup on 2022-02-02 at 15:47:06](https://user-images.githubusercontent.com/5324818/152228085-c898fc31-c1e3-4c54-a5ff-6c75b30cb39c.png)

See p7DVsv-dyZ-p2#comment-39306 for more context.

### Testing instructions

- Build this branch locally or open the live Calypso link
- Select a site where you have a recently (less than 3 days) connected domain that's not resolving (pointing to WPCOM) yet
  - If you don't have any domain in that state, apply D74311-code to your sandbox and it'll add a mocked domain like that
- Go to Upgrades > Domains
- In the site domains page, ensure the "Verifying connection" notice contains a link to the connection setup
- Click on the connection setup link and ensure it takes you to the correct setup step (the one with our name servers or the one with A and CNAME records, depending on if you chose the default or advanced connection setups)