### PR TITLE
Signup: Correct page title grammar.

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -396,7 +396,7 @@ export function generateFlows( {
 			lastModified: '2021-10-14',
 			providesDependenciesInQuery: [ 'siteId', 'siteSlug' ],
 			optionalDependenciesInQuery: [ 'siteId' ],
-			pageTitle: translate( 'Setup your site' ),
+			pageTitle: translate( 'Set up your site' ),
 			enableBranchSteps: true,
 		},
 		{


### PR DESCRIPTION
Correct the page title grammar for the `setup-site` signup step, which appears in the browser tab.

**Testing Instructions**
* testing isn't necessary, just a double-check on the grammar. 