### PR TITLE
Jetpack server credentials: migrate provider guess to React Query

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
@@ -409,6 +409,10 @@ export const otherHosts: Host[] = [
 		id: 'wpengine',
 		name: 'WPEngine',
 	},
+	{
+		id: 'jurassic_ninja',
+		name: 'Jurassic Ninja',
+	},
 ];
 
 export const getProviderNameFromId = ( searchId?: string ): string | null => {

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-selection/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-selection/index.tsx
@@ -1,34 +1,34 @@
 import { Gridicon } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useEffect, useMemo } from 'react';
+import { FunctionComponent, useMemo } from 'react';
+import { useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
+import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getHttpData, requestHttpData, DataState } from 'calypso/state/data-layer/http-data';
-import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getProviderNameFromId, topHosts, otherHosts } from '../host-info';
 import type { SiteId } from 'calypso/types';
-import type { AnyAction } from 'redux';
 import './style.scss';
 
-function getRequestHostingProviderGuessId( siteId: SiteId ) {
-	return `site-hosting-provider-guess-${ siteId }`;
+interface Guess {
+	guess: string;
 }
 
-function requestHostingProviderGuess( siteId: SiteId ) {
-	const requestId = getRequestHostingProviderGuessId( siteId );
-	return requestHttpData(
-		requestId,
-		http( {
-			method: 'GET',
-			path: `/sites/${ siteId }/hosting-provider`,
-			apiNamespace: 'wpcom/v2',
-		} ) as AnyAction,
+function useHostingProviderGuessQuery( siteId: SiteId ) {
+	return useQuery(
+		[ 'site-hosting-provider-guess', siteId ],
+		(): Promise< Guess > =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/hosting-provider`,
+				apiNamespace: 'wpcom/v2',
+			} ),
 		{
-			fromApi: () => ( { guess } ) => [ [ requestId, guess ] ],
+			enabled: !! siteId,
+			meta: { persist: false },
+			select: ( data ) => data.guess,
 		}
 	);
 }
@@ -40,16 +40,7 @@ const HostSelection: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const {
-		state: providerGuessState,
-		data: guess = null,
-		// error: providerGuessError,
-	} = useSelector( () => getHttpData( getRequestHostingProviderGuessId( siteId ) ) );
-
-	const loadingProviderGuess = ! [ DataState.Success, DataState.Failure ].includes(
-		providerGuessState
-	);
-
+	const { isLoading, data: guess } = useHostingProviderGuessQuery( siteId );
 	const providerGuessName = getProviderNameFromId( guess );
 
 	const hostsToShow = useMemo( () => {
@@ -68,10 +59,6 @@ const HostSelection: FunctionComponent = () => {
 			} )
 		);
 	};
-
-	useEffect( () => {
-		requestHostingProviderGuess( siteId as SiteId );
-	}, [ siteId ] );
 
 	return (
 		<div className="host-selection">
@@ -103,9 +90,7 @@ const HostSelection: FunctionComponent = () => {
 				{ hostsToShow.map( ( { id, name } ) => (
 					<a
 						className={
-							loadingProviderGuess
-								? 'host-selection__list-item-placeholder'
-								: 'host-selection__list-item'
+							isLoading ? 'host-selection__list-item-placeholder' : 'host-selection__list-item'
 						}
 						key={ id }
 						href={ `${ settingsPath( siteSlug ?? undefined ) }?host=${ id }` }
@@ -126,11 +111,8 @@ const HostSelection: FunctionComponent = () => {
 				) ) }
 				<a
 					className={
-						loadingProviderGuess
-							? 'host-selection__list-item-placeholder'
-							: 'host-selection__list-item'
+						isLoading ? 'host-selection__list-item-placeholder' : 'host-selection__list-item'
 					}
-					key={ 'generic' }
 					href={ `${ settingsPath( siteSlug ?? undefined ) }?host=generic` }
 					onClick={ () => recordHostSelectionEvent( 'generic' ) }
 				>


### PR DESCRIPTION
In Jetpack Cloud, go to a `/settings/:site` page and it will show setup screen for remote server credentials:
<img width="738" alt="Screenshot 2022-02-02 at 16 41 47" src="https://user-images.githubusercontent.com/664258/152188052-2d100bcf-89e2-4f1d-a853-f395ba6e6e0b.png">

Part of the UI is trying to guess the hosting provider of your Jetpack site by calling a REST endpoint that tries to do that on the server, and then highlight the guess in the UI.

It's this hosting provider guess REST request that this PR migrates to React Query.

To make testing easier, I added Jurassic Ninja to the list of known hosting providers. The server endpoint knows it under the `jurassic_ninja` key, so now the Calypso UI knows it too. The item was added to the `otherHosts` list which is never displayed in full in the list (unlike `topHosts`) so the change shouldn't be observable by anyone who doesn't outright use Jurassic Ninja.

**How to test:**
Connect a Jurassic Ninja site (or any other Jetpack site) and verify that the guess is retrieved and displayed correctly in the UI described above.
