### PR TITLE
Replace link button with InlineSupportLink

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -177,6 +177,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/webmaster-tools/',
 		post_id: 5022,
 	},
+	'introduction-to-woocommerce': {
+		link: 'https://wordpress.com/support/introduction-to-woocommerce/',
+		post_id: 176336,
+	},
 };
 
 export default contextLinks;

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -102,7 +102,11 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 				actionDisabled={ isTransferringBlocked }
 				actionRef={ ctaRef }
 				secondaryAction={
-					<InlineSupportLink supportContext="introduction-to-woocommerce" showIcon={ false }>
+					<InlineSupportLink
+						className="landing-page__learnmore empty-content__action button"
+						supportContext="introduction-to-woocommerce"
+						showIcon={ false }
+					>
 						{ __( 'Learn more' ) }
 					</InlineSupportLink>
 				}

--- a/client/my-sites/woocommerce/woop/landing-page.tsx
+++ b/client/my-sites/woocommerce/woop/landing-page.tsx
@@ -7,6 +7,7 @@ import page from 'page';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import WarningCard from 'calypso/components/warning-card';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
@@ -100,9 +101,11 @@ const WoopLandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 				actionCallback={ onCTAClickHandler }
 				actionDisabled={ isTransferringBlocked }
 				actionRef={ ctaRef }
-				secondaryAction={ __( 'Learn more' ) }
-				secondaryActionURL="https://wordpress.com/support/introduction-to-woocommerce/"
-				secondaryActionTarget="_blank"
+				secondaryAction={
+					<InlineSupportLink supportContext="introduction-to-woocommerce" showIcon={ false }>
+						{ __( 'Learn more' ) }
+					</InlineSupportLink>
+				}
 				className="woop__landing-page-cta woocommerce_landing-page-empty-content"
 			/>
 			<WooCommerceColophon wpcomDomain={ wpcomDomain || '' } />

--- a/client/my-sites/woocommerce/woop/style.scss
+++ b/client/my-sites/woocommerce/woop/style.scss
@@ -41,7 +41,7 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 	padding-top: 60px;
 	padding-bottom: 40px;
 	padding-left: 20px;
-    padding-right: 20px;
+	padding-right: 20px;
 
 	// on desktop make the section full width so it takes the whole space
 	@media ( min-width: 660px ) {
@@ -51,7 +51,6 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 
 	background-color: var( --color-woocommerce-onboarding-background );
 	.formatted-header .formatted-header__title {
-
 		@media ( max-width: $break-mobile ) {
 			margin-left: 0;
 			margin-right: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace learn more button with inline help component

#### Testing instructions

- http://calypso.localhost:3000/woocommerce-installation/test803879000.wordpress.com
- Click learn more


https://user-images.githubusercontent.com/811776/152471694-01d13469-19bc-4ce7-b8aa-a800d7cc8f43.mp4


https://user-images.githubusercontent.com/811776/152471698-c9965e51-93d5-4667-bb0c-a30334b8d72a.mp4


Related to https://github.com/Automattic/wp-calypso/issues/60792
