### PR TITLE
Use correct self-closing component interpolation syntax for br in FEATURE_FREE_DOMAIN

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -274,7 +274,7 @@ export const FEATURES_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'All paid WordPress.com plans purchased for an annual term include one year of free domain registration. ' +
-					'Domains registered through this promotion will renew at our {{a}}standard rate{{/a}}, plus applicable taxes, after the first year.{{br}}{{br}}' +
+					'Domains registered through this promotion will renew at our {{a}}standard rate{{/a}}, plus applicable taxes, after the first year.{{br /}}{{br /}}' +
 					'This offer is redeemable one time only, and does not apply to plan upgrades, renewals, or premium domains.',
 				{
 					components: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently it is using unclosed `{{br}}` syntax, which caused the whole string to appear as-is without interpolation. This PR fixes the syntax.

#### Testing instructions

1. In the browser dev tools, set device to be mobile.
1. Go to `/start`.
1. You will be redirected to `/start/domains`.
1. Pick a domain.
1. You will be redirected to `/start/plans`.
1. Make sure you are seeing a vertically stacked list of plans.
1. Scroll down to the Personal plan.
1. Click the "Show features" chevron icon (`v`) to expand it.
1. Click the `(i)` icon button next to the "Free domain for one year" feature.
1. You will see a tooltip containing the description of the feature.
    * Before this PR:
    
       
       <img width="357" alt="Screen Shot 2022-02-03 at 09 03 38" src="https://user-images.githubusercontent.com/1525580/152269563-685657dd-0777-410c-9767-8e60c96cbb86.png">


    * After this PR:
      
       <img width="357" alt="Screen Shot 2022-02-03 at 09 03 38" src="https://user-images.githubusercontent.com/1525580/152269431-31a636ad-e5c2-4d94-b016-106ea5fa8d60.png">

#### Note

As noted in the linked issue, the plan grid on `/plans/<slug>` page (not signup page) somehow already has the correct interpolation. This is because it is using a different feature variable (`FEATURE_CUSTOM_DOMAIN`), which already has the correct syntax:

https://github.com/Automattic/wp-calypso/blob/400f843f903a94f75579262cb18eefd020a309b4/client/lib/plans/features-list.js#L440-L463


Related to #56866
