### PR TITLE
Log snag errors to logstash

### DIFF
--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -1,5 +1,7 @@
+import config from '@automattic/calypso-config';
 import { ReactElement, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { logToLogstash } from 'calypso/lib/logstash';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -39,6 +41,20 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 				error: failureInfo.error,
 			} )
 		);
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: failureInfo.error,
+			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+			blog_id: siteId,
+			extra: {
+				env: config( 'env_id' ),
+				type: 'calypso_woocommerce_dashboard_snag_error',
+				action: failureInfo.type,
+				site: domain,
+				code: failureInfo.code,
+				message: failureInfo.error,
+			},
+		} );
 		setHasFailed( true );
 	};
 

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -41,6 +41,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 				error: failureInfo.error,
 			} )
 		);
+
 		logToLogstash( {
 			feature: 'calypso_client',
 			message: failureInfo.error,
@@ -53,6 +54,9 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 				site: domain,
 				code: failureInfo.code,
 				message: failureInfo.error,
+			},
+			properties: {
+				type: 'calypso_woocommerce_dashboard_snag_error', // everything added here is queryable
 			},
 		} );
 		setHasFailed( true );

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -57,6 +57,7 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			},
 			properties: {
 				type: 'calypso_woocommerce_dashboard_snag_error', // everything added here is queryable
+				action: failureInfo.type,
 			},
 		} );
 		setHasFailed( true );

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -56,8 +56,11 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 				message: failureInfo.error,
 			},
 			properties: {
-				type: 'calypso_woocommerce_dashboard_snag_error', // everything added here is queryable
+				env: config( 'env_id' ),
+				type: 'calypso_woocommerce_dashboard_snag_error',
 				action: failureInfo.type,
+				site: domain,
+				code: failureInfo.code,
 			},
 		} );
 		setHasFailed( true );

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -47,14 +47,6 @@ export default function Transfer( props: WooCommerceInstallProps ): ReactElement
 			message: failureInfo.error,
 			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 			blog_id: siteId,
-			extra: {
-				env: config( 'env_id' ),
-				type: 'calypso_woocommerce_dashboard_snag_error',
-				action: failureInfo.type,
-				site: domain,
-				code: failureInfo.code,
-				message: failureInfo.error,
-			},
 			properties: {
 				env: config( 'env_id' ),
 				type: 'calypso_woocommerce_dashboard_snag_error',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds snag errors to calypso logs

#### Testing instructions

* Generate a snag error (reducing the [install timeout](https://github.com/Automattic/wp-calypso/blob/5930fddf6751a4dc4ef96d6c15f00d6a0d0d9924/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx#L18) and commenting out the [status request](https://github.com/Automattic/wp-calypso/blob/5930fddf6751a4dc4ef96d6c15f00d6a0d0d9924/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx#L50) is one way to do this.
* Watch kibana for the error to be logged.

![Screenshot 2022-02-03 at 16-01-54 Discover - Elastic](https://user-images.githubusercontent.com/811776/152284470-912d239f-fd68-47a3-a9d7-18ee5cabdc5a.png)


Related to #60318
