### PR TITLE
Add backUrl to SupportCard component

### DIFF
--- a/client/signup/steps/woocommerce-install/components/support-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/support-card/index.tsx
@@ -20,7 +20,7 @@ const SupportLinkStyle = styled.a`
 	font-weight: bold;
 `;
 
-export default function SupportCard(): ReactElement {
+export default function SupportCard( { backUrl }: { backUrl?: string } ): ReactElement {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 
@@ -30,7 +30,7 @@ export default function SupportCard(): ReactElement {
 				a: (
 					<SupportLinkStyle
 						href={ addQueryArgs( '/help/contact', {
-							redirect_to: `${ window.location.pathname }?site=${ domain }`,
+							redirect_to: backUrl || `${ window.location.pathname }?site=${ domain }`,
 						} ) }
 					/>
 				),

--- a/client/signup/steps/woocommerce-install/transfer/error.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/error.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SupportCard from '../components/support-card';
 import StepContent from './step-content';
 
@@ -10,7 +13,9 @@ const WarningsOrHoldsSection = styled.div`
 
 export default function Error(): ReactElement {
 	const { __ } = useI18n();
-	// todo: both messages sort of say the same thing, refer to figma and fix
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+
 	return (
 		<StepContent
 			title={ __( "We've hit a snag" ) }
@@ -19,7 +24,7 @@ export default function Error(): ReactElement {
 			) }
 		>
 			<WarningsOrHoldsSection>
-				<SupportCard />
+				<SupportCard backUrl={ `/woocommerce-installation/${ domain }` } />
 			</WarningsOrHoldsSection>
 		</StepContent>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a backUrl to override the default backUrl (current url). This is needed to avoid a transfer => error => contact support => back => new transfer error loop.

#### Testing instructions

* Generate a snag error (reducing the [install timeout](https://github.com/Automattic/wp-calypso/blob/5930fddf6751a4dc4ef96d6c15f00d6a0d0d9924/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx#L18) and commenting out the [status request](https://github.com/Automattic/wp-calypso/blob/5930fddf6751a4dc4ef96d6c15f00d6a0d0d9924/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx#L50) is one way to do this.
* Click contact support
* Click back
* [ ] Should end up back on the landing page instead of in the installer

Also:
* Test the fallback to the existing usage of current url for each other step in the flow per https://github.com/Automattic/wp-calypso/pull/60682
* [ ] Test address step
* [ ] Test business step
* [ ] Test confirm step

Related to https://github.com/Automattic/wp-calypso/issues/60797
