### PR TITLE
Reader: Remove `redux-bridge` usage from utils

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -33,6 +33,7 @@ import {
 import {
 	getStream,
 	getTransformedStreamItems,
+	getTransformedStreamItemsPosts,
 	shouldRequestRecs,
 } from 'calypso/state/reader/streams/selectors';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
@@ -385,6 +386,7 @@ class ReaderStream extends Component {
 			showSelectedPost( {
 				...args,
 				postKey: postKey.isCombination ? keyForPost( args ) : postKey,
+				postObject: this.props.postsItems[ index ],
 				streamKey,
 			} );
 
@@ -485,6 +487,11 @@ export default connect(
 				shouldCombine: shouldCombineCards,
 			} ),
 			notificationsOpen: isNotificationsOpen( state ),
+			postsItems: getTransformedStreamItemsPosts( state, {
+				streamKey,
+				recsStreamKey,
+				shouldCombine: shouldCombineCards,
+			} ),
 			stream,
 			recsStream: getStream( state, recsStreamKey ),
 			selectedPostKey: stream.selected,

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -8,11 +8,6 @@ import { showSelectedPost } from '../utils';
 jest.mock( 'page', () => ( {
 	show: jest.fn(),
 } ) );
-jest.mock( 'calypso/lib/redux-bridge', () => ( {
-	reduxGetState: function () {
-		return { reader: { posts: { items: {} } } };
-	},
-} ) );
 
 describe( 'reader utils', () => {
 	beforeEach( () => {

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,7 +1,5 @@
 import page from 'page';
-import { reduxGetState } from 'calypso/lib/redux-bridge';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
-import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 
 export function isSpecialClick( event ) {
 	return event.button > 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
@@ -15,7 +13,7 @@ export function isPostNotFound( post ) {
 	return post.statusCode === 404;
 }
 
-export function showSelectedPost( { replaceHistory, postKey, comments } ) {
+export function showSelectedPost( { replaceHistory, postKey, postObject, comments } ) {
 	if ( ! postKey ) {
 		return;
 	}
@@ -25,10 +23,8 @@ export function showSelectedPost( { replaceHistory, postKey, comments } ) {
 		return;
 	}
 
-	const post = getPostByKey( reduxGetState(), postKey );
-
-	if ( isXPost( post ) && ! replaceHistory ) {
-		return showFullXPost( XPostHelper.getXPostMetadata( post ) );
+	if ( isXPost( postObject ) && ! replaceHistory ) {
+		return showFullXPost( XPostHelper.getXPostMetadata( postObject ) );
 	}
 
 	// normal

--- a/client/state/reader/streams/selectors/get-reader-stream-transformed-items-posts.js
+++ b/client/state/reader/streams/selectors/get-reader-stream-transformed-items-posts.js
@@ -1,0 +1,27 @@
+import { createSelector } from '@automattic/state-utils';
+import { keyForPost } from 'calypso/reader/post-key';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import { getTransformedStreamItems } from 'calypso/state/reader/streams/selectors';
+
+import 'calypso/state/reader/init';
+
+const getTransformedStreamItemsPosts = createSelector(
+	( state, { streamKey, recsStreamKey, shouldCombine } ) =>
+		getTransformedStreamItems( state, {
+			streamKey,
+			recsStreamKey,
+			shouldCombine,
+		} ).map( ( postKey ) => {
+			const key = postKey.isCombination ? keyForPost( postKey ) : postKey;
+			return getPostByKey( state, key );
+		} ),
+	( state, { streamKey, recsStreamKey, shouldCombine } ) => [
+		getTransformedStreamItems( state, {
+			streamKey,
+			recsStreamKey,
+			shouldCombine,
+		} ),
+	]
+);
+
+export default getTransformedStreamItemsPosts;

--- a/client/state/reader/streams/selectors/index.js
+++ b/client/state/reader/streams/selectors/index.js
@@ -3,4 +3,5 @@ export { default as getOffsetItem } from './get-reader-stream-offset-item';
 export { default as getNextItem } from './get-reader-stream-next-item';
 export { default as getPreviousItem } from './get-reader-stream-prev-item';
 export { default as getTransformedStreamItems } from './get-reader-stream-transformed-items';
+export { default as getTransformedStreamItemsPosts } from './get-reader-stream-transformed-items-posts';
 export { default as shouldRequestRecs } from './get-reader-stream-should-request-recommendations';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes one of the last remaining instances of `redux-bridge` in the Reader. It was necessary to retrieve the post to show in `showSelectedPost()`, but now we'll retrieve it from Redux in the component and pass it to the function separately.

#### Testing instructions

* Smoke test Reader, particularly opening of various types of posts in all kinds of feeds you have.
* Go to `/read/a8c` and open a regular post, verify it opens correctly.
* Go to `/read/a8c` and open an x-post post, verify it opens correctly.
* Verify all tests pass.