### PR TITLE
Use new final_discount property for displayed percentage

### DIFF
--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -65,7 +65,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 							{ translate(
 								'Get %(discount)d%% off your first year on all Jetpack products & plans.',
 								{
-									args: { discount: coupon.discount },
+									args: { discount: coupon.final_discount },
 								}
 							) }
 						</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the Holiday Sale Banner to use new `final_discount` field

#### Testing instructions

1. Sandbox `public-api.wordpress.com`
2. Follow testing instructions in D74110-code to create a test marketing coupon - use a discount of 20% to see a final total discount of 60% in the banner
3. Boot branch as Jetpack Cloud or use the live link and navigate to `/pricing`.
4. Verify that the top green banner uses the `final_discount` value of 60 - agreeing with the intro banner lower down in the image.
![Banner](https://user-images.githubusercontent.com/8742105/152307613-8ad49106-87f3-4d29-9526-df04b1cb391d.png)

Relates to this PR #60641