### PR TITLE
phpMyAdmin hosting card: migrate data getter to direct wpcom.req.post

### DIFF
--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -14,6 +14,7 @@ import {
 	recordGoogleEvent,
 	bumpStat,
 } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import RestorePasswordDialog from './restore-db-password';
 
@@ -50,7 +51,7 @@ export default function PhpMyAdminCard( { disabled } ) {
 				window.open( `https://wordpress.com/pma-login?token=${ token }` );
 			}
 		} catch {
-			// ignore errors
+			dispatch( errorNotice( translate( 'Could not open phpMyAdmin. Please try again.' ) ) );
 		}
 		setLoading( false );
 	}


### PR DESCRIPTION
For an Atomic site, there is a `/hosting-config/:site` page available (accessible also from Settings > Hosting Configuration in sidebar) and it contains a card for opening phpMyAdmin:

<img width="574" alt="Screenshot 2022-02-03 at 10 28 35" src="https://user-images.githubusercontent.com/664258/152318367-ab369a48-5da6-4eb0-97cd-0ace3d7bd122.png">

How the "Open phpMyAdmin" button works is that it first issues a POST request to `public-api` to retrieve a token, and then opens a `wordpress.com/pma-login?token` URL in a new window.

It's the POST request this PR is migrating from a data getter to a simple `wpcom.req.post` request.

**How to test:**
Verify that the flow I describe above works for an Atomic site: clicking the button should retrieve a token and open a phpMyAdmin for the site in a new tab.