### PR TITLE
Fix reskinned domain search step layout

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -12,7 +12,7 @@
 		font-size: $font-body;
 
 		.is-white-signup & {
-			align-items: flex-start;
+			align-items: flex-end;
 		}
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -330,7 +330,7 @@ body.is-section-signup.is-white-signup {
 			font-weight: 500; /* stylelint-disable-line */
 		}
 
-		@include break-xlarge {
+		@include break-wide {
 			align-self: center;
 			margin-left: 12px;
 			margin-bottom: 0;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -225,7 +225,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 		flex-direction: column-reverse;
 		margin-bottom: initial;
 
-		@include break-xlarge {
+		@include break-wide {
 			flex-direction: row;
 		}
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -749,7 +749,8 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	}
 
 	.signup__step.is-domains,
-	.signup__step.is-emails {
+	.signup__step.is-emails,
+	.is-domain-only {
 		@include break-large {
 			margin: 0 0 0 20px;
 		}


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fix a couple of issue on Search domain step, reskinned version (white signup).

- Increase layout max-width from 1040px to 1280px fro domain-only flow
- Change price / sale price alignment to right

See pcYYhz-ye-p2#comment-522

![fix-layout](https://user-images.githubusercontent.com/2797601/152319291-92ad99e0-ce0d-4cff-9d2c-c30d77ad1ea8.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to `/start/domain` 
- Verify that issues mentioned above has been fixed