### PR TITLE
Turn on the onboarding WordPress flow for wpcalypso env

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -46,7 +46,7 @@
 		"onboarding/import-from-medium": true,
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
-		"onboarding/import-from-wordpress": false,
+		"onboarding/import-from-wordpress": true,
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,

--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -2,7 +2,7 @@
  * @group calypso-pr
  */
 
-import { DataHelper, skipDescribeIf, StartImportFlow, TestAccount } from '@automattic/calypso-e2e';
+import { DataHelper, StartImportFlow, TestAccount } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
@@ -10,12 +10,6 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	let page: Page;
 	let startImportFlow: StartImportFlow;
-
-	// Check if we are running on wpcalypso or production.
-	// Remove when 'onboarding/import-from-wordpress' will be enabled on wpcalypso.
-	const isLocal = DataHelper.getCalypsoURL()
-		.toLowerCase()
-		.includes( 'http://calypso.localhost:3000' );
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -37,11 +31,8 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		} );
 	};
 
-	/**
-	 * Remove the skip-if conditional when 'onboarding/import-from-wordpress' is enabled on wpcalypso.
-	 * Substitute it with 'describe'.
-	 */
-	skipDescribeIf( ! isLocal )( 'Follow the WordPress import flow', () => {
+	// WordPress content-only flow
+	describe( 'Follow the WordPress import flow', () => {
 		navigateToSetup();
 
 		it( 'Start a WordPress import', async () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turn on the onboarding WordPress flow for `wpcalypso` env

#### Testing instructions

1. Ensure that the environment variable `NODE_CONFIG_ENV` is set. Otherwise: `export NODE_CONFIG_ENV='decrypted'`
2. Ensure that in the `test/e2e/config/local-decrypted.json` blob there's a `"calypsoBaseURL": "http://calypso.localhost:3000"`.
3. From `test/e2e` run `yarn install`
4. First console tab run: `yarn && yarn start`
5. Second console tab run: `yarn workspace @automattic/calypso-e2e build --watch`
6. Third tab, from `test/e2e` run: `yarn jest specs/specs-playwright/wp-start__importer.ts`
