### PR TITLE
Fix `e.startsWith is not a function` error when loading plugin page

### DIFF
--- a/client/lib/plugins/test/utils.js
+++ b/client/lib/plugins/test/utils.js
@@ -182,4 +182,34 @@ describe( 'Plugins Utils', () => {
 			assert.deepEqual( log, [ logs[ 0 ] ] );
 		} );
 	} );
+
+	describe( 'isSamePluginIdSlug', () => {
+		test( 'should return false for ID and slug', () => {
+			assert.equal( PluginUtils.isSamePluginIdSlug( 1, 'slug' ), false );
+			assert.equal( PluginUtils.isSamePluginIdSlug( 'slug', 1 ), false );
+		} );
+
+		test( 'should return false for non-matching slugs', () => {
+			assert.equal( PluginUtils.isSamePluginIdSlug( 'slug1', 'slug2' ), false );
+			assert.equal( PluginUtils.isSamePluginIdSlug( 'slug2', 'slug1' ), false );
+		} );
+
+		test( 'should return false for non-matching ids', () => {
+			assert.equal( PluginUtils.isSamePluginIdSlug( 1, 2 ), false );
+			assert.equal( PluginUtils.isSamePluginIdSlug( 2, 1 ), false );
+		} );
+
+		test( 'should return true for number and string', () => {
+			assert.equal( PluginUtils.isSamePluginIdSlug( 1, '1' ), true );
+			assert.equal( PluginUtils.isSamePluginIdSlug( '1', 1 ), true );
+		} );
+
+		test( 'should return true for match before/after slash', () => {
+			assert.equal( PluginUtils.isSamePluginIdSlug( 'vendor/plugin', 'plugin' ), true );
+			assert.equal( PluginUtils.isSamePluginIdSlug( 'plugin', 'vendor/plugin' ), true );
+
+			assert.equal( PluginUtils.isSamePluginIdSlug( 'vendor/plugin', 'vendor' ), true );
+			assert.equal( PluginUtils.isSamePluginIdSlug( 'vendor', 'vendor/plugin' ), true );
+		} );
+	} );
 } );

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -30,12 +30,14 @@ function isSamePluginNotice( pluginId, log ) {
  * @returns {boolean} True if the plugin ID and slug match
  */
 export function isSamePluginIdSlug( idOrSlug, slugOrId ) {
+	const firstIdOrSlug = idOrSlug.toString();
+	const secondIdOrSlug = slugOrId.toString();
 	return (
-		idOrSlug === slugOrId ||
-		idOrSlug.startsWith( slugOrId + '/' ) ||
-		idOrSlug.endsWith( '/' + slugOrId ) ||
-		slugOrId.startsWith( idOrSlug + '/' ) ||
-		slugOrId.endsWith( '/' + idOrSlug )
+		firstIdOrSlug === secondIdOrSlug ||
+		firstIdOrSlug.startsWith( secondIdOrSlug + '/' ) ||
+		firstIdOrSlug.endsWith( '/' + secondIdOrSlug ) ||
+		secondIdOrSlug.startsWith( firstIdOrSlug + '/' ) ||
+		secondIdOrSlug.endsWith( '/' + firstIdOrSlug )
 	);
 }
 

--- a/packages/calypso-products/src/has-marketplace-product.ts
+++ b/packages/calypso-products/src/has-marketplace-product.ts
@@ -15,5 +15,5 @@ export const hasMarketplaceProduct = (
 	Object.entries( productsList ).some(
 		( [ subscriptionSlug, { product_type } ] ) =>
 			cleanSlug( productSlug ) === cleanSlug( subscriptionSlug ) &&
-			product_type.startsWith( 'marketplace' )
+			product_type?.startsWith( 'marketplace' )
 	);

--- a/packages/calypso-products/src/has-marketplace-product.ts
+++ b/packages/calypso-products/src/has-marketplace-product.ts
@@ -15,5 +15,7 @@ export const hasMarketplaceProduct = (
 	Object.entries( productsList ).some(
 		( [ subscriptionSlug, { product_type } ] ) =>
 			cleanSlug( productSlug ) === cleanSlug( subscriptionSlug ) &&
-			product_type?.startsWith( 'marketplace' )
+			// additional type check needed when called from JS context
+			typeof product_type === 'string' &&
+			product_type.startsWith( 'marketplace' )
 	);

--- a/packages/calypso-products/test/has-marketplace-product.js
+++ b/packages/calypso-products/test/has-marketplace-product.js
@@ -2,6 +2,8 @@ import { hasMarketplaceProduct } from '../src/has-marketplace-product';
 
 describe( 'hasMarketplaceProduct', () => {
 	const productsList = {
+		empty_product: {},
+		product_with_wrong_types: { product_type: 1, slug: 1 },
 		jetpack: { product_type: 'jetpack' },
 		woocommerce_bookings_monthly: { product_type: 'marketplace_plugin' },
 		woocommerce_bookings_yearly: { product_type: 'marketplace_plugin' },
@@ -12,8 +14,17 @@ describe( 'hasMarketplaceProduct', () => {
 		'woocommerce-test-plugin': { product_type: 'plugin' },
 		'woocommerce-test-plugin-advanced': { product_type: 'marketplace_plugin' },
 	};
+
 	test( "should return false when the product isn't in the products list", () => {
 		expect( hasMarketplaceProduct( productsList, 'yoast' ) ).toBe( false );
+	} );
+
+	test( 'should return false when the a product is empty', () => {
+		expect( hasMarketplaceProduct( productsList, 'empty_product' ) ).toBe( false );
+	} );
+
+	test( 'should return false when the a product has different types', () => {
+		expect( hasMarketplaceProduct( productsList, 'product_with_wrong_types' ) ).toBe( false );
 	} );
 
 	test( "should return false when the product isn't a marketplace product", () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* fix type error in `hasMarketplaceProduct` selector
* fix type error in `isSamePluginIdSlug` util
* add tests

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test  `hasMarketplaceProduct`:
- the updated unit tests should pass

To test  `isSamePluginIdSlug`:
- the updated unit tests should pass
- empty site data or open an incognito window
- visit the main page and log in
- visit `/plugins/woocommerce-shipment-tracking`
- verify that the page isn't blank and the below error isn't present:
  
![image](https://user-images.githubusercontent.com/11555574/152366310-8ec2a1d0-1592-4ce4-bd90-ff5d34df53cc.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #60760
