### PR TITLE
Memoize ImportPreview component

### DIFF
--- a/client/signup/steps/import/ready/preview.tsx
+++ b/client/signup/steps/import/ready/preview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { MShotParams } from '../types';
 import useWindowDimensions from '../windowDimensions.effect';
@@ -85,4 +85,7 @@ const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
 	);
 };
 
-export default ImportPreview;
+export default memo(
+	ImportPreview,
+	( prevProps: Props, nextProps: Props ) => prevProps?.website === nextProps?.website
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Performance optimization: put `ImportPreview` under a [memo](https://reactjs.org/docs/react-api.html#reactmemo)

#### Testing instructions

1. Go to http://calypso.localhost:3000/start/importer/capture?siteSlug=SITE_SLUG
2. Insert an URL
3. On http://calypso.localhost:3000/start/importer/ready/preview?siteSlug=SITE_SLUG `ImportPreview` component must not download the image again when a repaint occurs. For example, when the user clicks "What can be imported?"

Related to #60802
