### PR TITLE
Use "Installed Plugins" instead of "Manage plugins" for consistency.

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -396,7 +396,7 @@ export class PluginsMain extends Component {
 		const navigationItems = [
 			{ label: this.props.translate( 'Plugins' ), href: `/plugins/${ selectedSiteSlug || '' }` },
 			{
-				label: this.props.translate( 'Manage' ),
+				label: this.props.translate( 'Installed Plugins' ),
 				href: `/plugins/manage/${ selectedSiteSlug || '' }`,
 			},
 		];

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -628,7 +628,7 @@ const ManageButton = ( { shouldShowManageButton, siteAdminUrl, siteSlug, jetpack
 
 	return (
 		<Button className="plugins-browser__button" href={ managePluginsDestination }>
-			<span className="plugins-browser__button-text">{ translate( 'Manage plugins' ) }</span>
+			<span className="plugins-browser__button-text">{ translate( 'Installed Plugins' ) }</span>
 		</Button>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Use "Installed Plugins" instead of "Manage plugins" for consistency.

#### Testing instructions
* Go to `plugins`, with an atomic site selected
* Check if there is a button with the text "Installed Plugins"
<img width="1061" alt="Screen Shot 2022-02-03 at 15 48 12" src="https://user-images.githubusercontent.com/5039531/152409683-a9d593c9-a668-4490-b7e5-3c7002557ba3.png">

* Switch to the `All my sites` option
* Click on the "Installed Plugins" button
* You should be redirected to a new screen
* Check if the breadcrumb says "Installed Plugins"
<img width="1058" alt="Screen Shot 2022-02-03 at 15 47 54" src="https://user-images.githubusercontent.com/5039531/152409643-541eea96-cd54-4670-afff-e7086b499a42.png">

---

Fixes #58294
