### PR TITLE
Update/onboarding importer improvements 5

### DIFF
--- a/client/signup/steps/import-from/blogger/index.tsx
+++ b/client/signup/steps/import-from/blogger/index.tsx
@@ -31,16 +31,18 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 	/**
 	 * Effects
 	 */
-	useEffect( runImport, [ job ] );
+	useEffect( handleJobStateTransition, [ job ] );
 
 	/**
 	 ↓ Methods
 	 */
-	function runImport() {
-		// If there is no existing import job, start a new
+	function handleJobStateTransition() {
+		// If there is no existing import job, create a new job
 		if ( job === undefined ) {
 			startImport( siteId, getImporterTypeForEngine( importer ) );
-		} else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
+		}
+		// If the job is in a ready state, start the import process
+		else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
 			importSite( prepareImportParams() );
 		}
 	}

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -31,18 +31,18 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 	/**
 	 * Effects
 	 */
-	useEffect( runImport, [ job ] );
+	useEffect( handleJobStateTransition, [ job ] );
 
 	/**
 	 ↓ Methods
 	 */
-	function runImport() {
-		// if ( ! run ) return;
-
-		// If there is no existing import job, start a new
+	function handleJobStateTransition() {
+		// If there is no existing import job, create a new job
 		if ( job === undefined ) {
 			startImport( siteId, getImporterTypeForEngine( importer ) );
-		} else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
+		}
+		// If the job is in a ready state, start the import process
+		else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
 			importSite( prepareImportParams() );
 		}
 	}

--- a/client/signup/steps/import-from/squarespace/index.tsx
+++ b/client/signup/steps/import-from/squarespace/index.tsx
@@ -31,16 +31,18 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 	/**
 	 * Effects
 	 */
-	useEffect( runImport, [ job ] );
+	useEffect( handleJobStateTransition, [ job ] );
 
 	/**
 	 ↓ Methods
 	 */
-	function runImport() {
-		// If there is no existing import job, start a new
+	function handleJobStateTransition() {
+		// If there is no existing import job, create a new job
 		if ( job === undefined ) {
 			startImport( siteId, getImporterTypeForEngine( importer ) );
-		} else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
+		}
+		// If the job is in a ready state, start the import process
+		else if ( job.importerState === appStates.READY_FOR_UPLOAD ) {
 			importSite( prepareImportParams() );
 		}
 	}

--- a/client/signup/steps/import-from/types.ts
+++ b/client/signup/steps/import-from/types.ts
@@ -7,6 +7,12 @@ export type QueryObject = {
 	to: string;
 };
 
+export interface ImportError {
+	error: boolean;
+	errorType: string;
+	errorMessage: string;
+}
+
 export interface ImportJob {
 	importerId: string;
 	importerState: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor: better naming for handling job transition as a side effect
* Improve the logic for showing error messages while Wix import is in progress. There was a case when the source site was unreachable (probably because of an API limit)

#### Testing instructions

* Go to `/start/importer/capture?siteSlug={SLUG}.wordpress.com`
* Enter a Wix website
* Run the import
* Check if it's finished and repeat the same steps from above (after a couple of times, there will be an error screen with info to try again soon)

Related to #57131, #60371
