### PR TITLE
Fix Site Editor tracking tests for Gv12.5

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -237,11 +237,6 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 	async changeGlobalStylesFontSize( value, blocksLevel ) {
 		if ( ! blocksLevel ) {
 			await this.clickGlobalStylesMenuItem( 'Aa\nText' );
-			// const locator = driverHelper.createTextLocator(
-			// 	By.css( '.edit-site-global-styles-sidebar button div' ),
-			// 	'Text'
-			// );
-			// await driverHelper.clickWhenClickable( this.driver, locator );
 		}
 		await driverHelper.clickIfPresent(
 			this.driver,

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -236,11 +236,17 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 
 	async changeGlobalStylesFontSize( value, blocksLevel ) {
 		if ( ! blocksLevel ) {
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( '.edit-site-global-styles-sidebar button[aria-label="Set custom size"]' )
-			);
+			await this.clickGlobalStylesMenuItem( 'Aa\nText' );
+			// const locator = driverHelper.createTextLocator(
+			// 	By.css( '.edit-site-global-styles-sidebar button div' ),
+			// 	'Text'
+			// );
+			// await driverHelper.clickWhenClickable( this.driver, locator );
 		}
+		await driverHelper.clickIfPresent(
+			this.driver,
+			By.css( '.edit-site-global-styles-sidebar button[aria-label="Set custom size"]' )
+		);
 		return await driverHelper.setWhenSettable(
 			this.driver,
 			By.css( '.edit-site-global-styles-sidebar .components-font-size-picker input' ),
@@ -305,7 +311,7 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		// If there were no Global Styles to save, close the panel.
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.entities-saved-states__panel button[aria-label="Close panel"]' )
+			driverHelper.createTextLocator( By.css( '.entities-saved-states__panel button' ), 'Cancel' )
 		);
 	}
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -1158,10 +1158,10 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				const blockToolbarOptionsLocator = By.css(
 					'[aria-label="Block tools"] [aria-label="Options"]'
 				);
-				const removeBlockOptionsItemLocator = driverHelper.createTextLocator(
-					By.css( '[aria-label="Options"] button' ),
-					'Remove Heading\n⌃⌥Z'
+				const removeBlockOptionsItemLocator = By.css(
+					'[aria-label="Options"] div.components-menu-group:last-of-type button:last-of-type'
 				);
+
 				await driverHelper.clickWhenClickable( this.driver, blockToolbarOptionsLocator );
 				await driverHelper.clickWhenClickable( this.driver, removeBlockOptionsItemLocator );
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -107,6 +107,9 @@ const testGlobalStylesColorAndTypography = async (
 	await editor.clickGlobalStylesMenuItem( 'Typography' );
 	await editor.changeGlobalStylesFontSize( '11', blocksLevel );
 	await editor.clickGlobalStylesBackButton();
+	if ( ! blocksLevel ) {
+		await editor.clickGlobalStylesBackButton();
+	}
 	// Update events are debounced to avoid event spam when items are updated using
 	// slider inputs. Therefore we must wait so this update event is not debounced.
 	await driver.sleep( 100 );
@@ -520,6 +523,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 				await editor.clickGlobalStylesMenuItem( 'Typography' );
 				await editor.changeGlobalStylesFontSize( '11' );
+				await editor.clickGlobalStylesBackButton();
 				await editor.clickGlobalStylesBackButton();
 				await editor.clickGlobalStylesMenuItem( 'Colors' );
 				await editor.changeGlobalStylesColor( 'Text', { valueIndex: 1 } );
@@ -1156,7 +1160,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				);
 				const removeBlockOptionsItemLocator = driverHelper.createTextLocator(
 					By.css( '[aria-label="Options"] button' ),
-					'Remove Heading'
+					'Remove Heading\n⌃⌥Z'
 				);
 				await driverHelper.clickWhenClickable( this.driver, blockToolbarOptionsLocator );
 				await driverHelper.clickWhenClickable( this.driver, removeBlockOptionsItemLocator );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates for various selector changes and menu nesting changes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the `wp-calypso-gutenberg-site-editor-tracking-spec.js` is now passing.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
