### PR TITLE
Stop showing the untested version message when the site is not jetpack (simple site users).

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -90,12 +90,12 @@ const PluginsBrowserListElement = ( props ) => {
 		const wpVersion = selectedSite?.options?.software_version;
 		const pluginTestedVersion = plugin?.tested;
 
-		if ( ! wpVersion || ! pluginTestedVersion ) {
+		if ( ! selectedSite?.jetpack || ! wpVersion || ! pluginTestedVersion ) {
 			return false;
 		}
 
 		return version_compare( wpVersion, pluginTestedVersion, '>' );
-	} );
+	}, [ selectedSite, plugin ] );
 
 	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Stop showing the untested version message when the site is not jetpack (simple site users).

### Testing instructions

* Go to the `plugins` page

**Simple Sites**
* Select a non-atomic site (a site that never had a plugin installed)
* You shouldn't see the untested version message on any plugin

**Atomic Sites**

* Select an atomic site (a site that  has a plugin installed)
* You should see the untested version message when it applies. Currently, it is showing on the Woocomerce plugin.

**Self-hosted jetpack sites**
* Select  a self-hosted jetpack site
* You should see the untested version message when it applies. 
---

Fixes #60323