### PR TITLE
Adds App Download CTA AB Testing

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -71,11 +71,9 @@ export class AppBanner extends Component {
 		} else {
 			this.state = { isDraftPostModalShown: false };
 		}
-
-		this.loadExperiment();
 	}
 
-	loadExperiment() {
+	loadDismissTimesExperiment() {
 		// Set a default value just in case the assignment hasn't loaded yet
 		this.experimentIsControl = true;
 
@@ -160,6 +158,8 @@ export class AppBanner extends Component {
 		if ( ! this.props.shouldDisplayAppBanner || this.state.isDraftPostModalShown ) {
 			return null;
 		}
+
+		this.loadDismissTimesExperiment();
 
 		const { title, copy } = getAppBannerData( translate, currentSection );
 

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -78,8 +78,7 @@ export class AppBanner extends Component {
 		this.experimentIsControl = true;
 
 		loadExperimentAssignment( APP_BANNER_EXPERIMENT_NAME ).then( ( experimentObject ) => {
-			const variationName = experimentObject.variationName;
-			this.experimentIsControl = variationName == null;
+			this.experimentIsControl = ! experimentObject?.variationName;
 		} );
 	}
 

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -9,6 +9,11 @@ export const ALLOWED_SECTIONS = [ GUTENBERG, NOTES, READER, STATS ];
 export const ONE_WEEK_IN_MILLISECONDS = 604800000;
 export const ONE_MONTH_IN_MILLISECONDS = 2419200000; // 28 days
 
+// Experiment Configuration
+export const TWO_WEEKS_IN_MILLISECONDS = 1209600000;
+export const ONE_DAY_IN_MILLISECONDS = 86400000;
+export const APP_BANNER_EXPERIMENT_NAME = 'calypso_mobileweb_appbanner_frequency_20220128_v1';
+
 export function getAppBannerData( translate, sectionName ) {
 	switch ( sectionName ) {
 		case GUTENBERG:
@@ -55,10 +60,10 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 	return null;
 }
 
-function getDismissTimes() {
+function getDismissTimes( isControl ) {
 	const currentTime = Date.now();
-	const currentSection = ONE_MONTH_IN_MILLISECONDS;
-	const otherSections = ONE_WEEK_IN_MILLISECONDS;
+	const currentSection = isControl ? ONE_MONTH_IN_MILLISECONDS : TWO_WEEKS_IN_MILLISECONDS;
+	const otherSections = isControl ? ONE_WEEK_IN_MILLISECONDS : ONE_DAY_IN_MILLISECONDS;
 
 	return {
 		current: currentTime + currentSection,
@@ -66,8 +71,8 @@ function getDismissTimes() {
 	};
 }
 
-export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
-	const dismissTimes = getDismissTimes();
+export function getNewDismissTimes( dismissedSection, currentDismissTimes, isControl ) {
+	const dismissTimes = getDismissTimes( isControl );
 
 	return reduce(
 		ALLOWED_SECTIONS,

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -62,12 +62,12 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 
 function getDismissTimes( isControl ) {
 	const currentTime = Date.now();
-	const currentSection = isControl ? ONE_MONTH_IN_MILLISECONDS : TWO_WEEKS_IN_MILLISECONDS;
-	const otherSections = isControl ? ONE_WEEK_IN_MILLISECONDS : ONE_DAY_IN_MILLISECONDS;
+	const longerTime = isControl ? ONE_MONTH_IN_MILLISECONDS : TWO_WEEKS_IN_MILLISECONDS;
+	const shorterTime = isControl ? ONE_WEEK_IN_MILLISECONDS : ONE_DAY_IN_MILLISECONDS;
 
 	return {
-		current: currentTime + currentSection,
-		other: currentTime + otherSections,
+		longer_duration: currentTime + longerTime,
+		shorter_duration: currentTime + shorterTime,
 	};
 }
 
@@ -79,14 +79,14 @@ export function getNewDismissTimes( dismissedSection, currentDismissTimes, isCon
 		( result, section ) => {
 			if ( section === dismissedSection ) {
 				// Dismiss selected section for a longer period.
-				result[ section ] = dismissTimes.current;
+				result[ section ] = dismissTimes.longer_duration;
 			} else {
 				// Dismiss all other sections for a shorter period, but make sure that we preserve previous dismiss time
 				// if it was longer than that (e.g. if other section was also dismissed for a month).
 				result[ section ] =
-					get( currentDismissTimes, section, -Infinity ) > dismissTimes.other
+					get( currentDismissTimes, section, -Infinity ) > dismissTimes.shorter_duration
 						? get( currentDismissTimes, section )
-						: dismissTimes.other;
+						: dismissTimes.shorter_duration;
 			}
 
 			return result;

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -55,24 +55,33 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 	return null;
 }
 
-export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
+function getDismissTimes() {
 	const currentTime = Date.now();
-	const aWeekFromNow = currentTime + ONE_WEEK_IN_MILLISECONDS;
-	const aMonthFromNow = currentTime + ONE_MONTH_IN_MILLISECONDS;
+	const currentSection = ONE_MONTH_IN_MILLISECONDS;
+	const otherSections = ONE_WEEK_IN_MILLISECONDS;
+
+	return {
+		current: currentTime + currentSection,
+		other: currentTime + otherSections,
+	};
+}
+
+export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
+	const dismissTimes = getDismissTimes();
 
 	return reduce(
 		ALLOWED_SECTIONS,
 		( result, section ) => {
 			if ( section === dismissedSection ) {
-				// Dismiss selected section for a month.
-				result[ section ] = aMonthFromNow;
+				// Dismiss selected section for a longer period.
+				result[ section ] = dismissTimes.current;
 			} else {
-				// Dismiss all other sections for a week, but make sure that we preserve previous dismiss time
+				// Dismiss all other sections for a shorter period, but make sure that we preserve previous dismiss time
 				// if it was longer than that (e.g. if other section was also dismissed for a month).
 				result[ section ] =
-					get( currentDismissTimes, section, -Infinity ) > aWeekFromNow
+					get( currentDismissTimes, section, -Infinity ) > dismissTimes.other
 						? get( currentDismissTimes, section )
-						: aWeekFromNow;
+						: dismissTimes.other;
 			}
 
 			return result;

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -66,8 +66,8 @@ function getDismissTimes( isControl ) {
 	const shorterTime = isControl ? ONE_WEEK_IN_MILLISECONDS : ONE_DAY_IN_MILLISECONDS;
 
 	return {
-		longer_duration: currentTime + longerTime,
-		shorter_duration: currentTime + shorterTime,
+		longerDuration: currentTime + longerTime,
+		shorterDuration: currentTime + shorterTime,
 	};
 }
 
@@ -79,14 +79,14 @@ export function getNewDismissTimes( dismissedSection, currentDismissTimes, isCon
 		( result, section ) => {
 			if ( section === dismissedSection ) {
 				// Dismiss selected section for a longer period.
-				result[ section ] = dismissTimes.longer_duration;
+				result[ section ] = dismissTimes.longerDuration;
 			} else {
 				// Dismiss all other sections for a shorter period, but make sure that we preserve previous dismiss time
 				// if it was longer than that (e.g. if other section was also dismissed for a month).
 				result[ section ] =
-					get( currentDismissTimes, section, -Infinity ) > dismissTimes.shorter_duration
+					get( currentDismissTimes, section, -Infinity ) > dismissTimes.shorterDuration
 						? get( currentDismissTimes, section )
-						: dismissTimes.shorter_duration;
+						: dismissTimes.shorterDuration;
 			}
 
 			return result;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Relevant experiment post: pbxNRc-1l9-p2

This PR adds AB testing to the banner dismiss frequency to change the dismiss times from:
- Current section: 1 month
- Other sections: 1 week

to:

- Current section:  2 weeks
- Other sections 1 day

#### Testing instructions

1. Apply the PR
2. Enable "mobile" testing mode using dev tools in your browser of choice
3. Go to http://calypso.localhost:3000/read
4. Verify you see the 'Open In App' banner (see screenshots above)
5. If you do not, you can reset your preferences by entering Desktop mode in your browser, hovering the Dev button in the bottom right, then preferences, then tapping the X next to `appBannerDismissTimes`. Then reload the page
6. Tap the no thanks button
7. Enter Desktop mode and enter the dev preferences again, and look for: `appBannerDismissTimes`
8. Verify the section you were currently on's timestamp is set for 1 month from now
8.a Note: You can test this by pasting the timestamp into: https://www.unixtimestamp.com/
9. Verify the other sections are set for 1 week from now
10. Delete the preference
11. Open the file: `/client/blocks/app-banner/index.jsx`
12. Go to line: 81
13. Change: `const variationName = experimentObject.variationName;` to `const variationName = "hello"`;
14. Reload and tap the no thanks button
15. Enter the dev preferences again and look at the `appBannerDismissTimes`
16. Verify the current section's timestamp is set to 2 weeks from now
17. Verify the other sections are set for 1 day from now