### PR TITLE
Playwright: use correct environment variable for target viewport and fix failing tests.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -244,7 +244,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2E
 				checked = "true",
 				unchecked = "false"
 			)
-			param("env.TARGET_DEVICE", "$targetDevice")
+			param("env.VIEWPORT_NAME", "$targetDevice")
 		},
 		buildFeatures = {
 			notifications {
@@ -300,7 +300,7 @@ fun coblocksPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2EB
 				checked = "true",
 				unchecked = "false"
 			)
-			param("env.TARGET_DEVICE", "$targetDevice")
+			param("env.VIEWPORT_NAME", "$targetDevice")
 		},
 		buildFeatures = {
 			notifications {
@@ -541,7 +541,7 @@ private object I18NTests : E2EBuildType(
 			description = "Locales to use, separated by comma",
 			allowEmpty = false
 		)
-		param("env.TARGET_DEVICE", "desktop")
+		param("env.VIEWPORT_NAME", "desktop")
 	},
 	buildFeatures = {
 		notifications {
@@ -579,7 +579,7 @@ object P2E2ETests : E2EBuildType(
 	buildDescription = "Runs end-to-end tests against P2.",
 	testGroup = "p2",
 	buildParams = {
-		param("env.TARGET_DEVICE", "desktop")
+		param("env.VIEWPORT_NAME", "desktop")
 		param("env.URL", "https://wpcalypso.wordpress.com")
 	},
 	buildFeatures = {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -603,7 +603,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 		buildParams = {
 			param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,defaultUser,eCommerceUser")
 			param("env.LIVEBRANCHES", "true")
-			param("env.TARGET_DEVICE", "$targetDevice")
+			param("env.VIEWPORT_NAME", "$targetDevice")
 		},
 		buildFeatures = {
 			pullRequests {
@@ -641,7 +641,7 @@ object PreReleaseE2ETests : E2EBuildType(
 	concurrentBuilds = 1,
 	testGroup = "calypso-release",
 	buildParams = {
-		param("env.TARGET_DEVICE", "desktop")
+		param("env.VIEWPORT_NAME", "desktop")
 		param("env.URL", "https://wpcalypso.wordpress.com")
 	},
 	buildFeatures = {
@@ -667,7 +667,7 @@ object QuarantinedE2ETests: E2EBuildType(
 	concurrentBuilds = 1,
 	testGroup = "quarantined",
 	buildParams = {
-		param("env.TARGET_DEVICE", "desktop")
+		param("env.VIEWPORT_NAME", "desktop")
 		param("env.URL", "https://wpcalypso.wordpress.com")
 	},
 	buildFeatures = {

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
@@ -5,7 +5,9 @@ interface ConfigurationData {
 	buttonText?: string;
 }
 
-const blockParentSelector = 'div[aria-label="Block: WhatsApp Button"]';
+// The parent selector for the block changes between mobile and desktop viewport.
+const blockParentSelector =
+	'div[aria-label="Block: Send A Message"], div[aria-label="Block: WhatsApp Button"]';
 const selectors = {
 	// Editor
 	settings: 'button[aria-label="WhatsApp Button Settings"]',

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -88,7 +88,8 @@ export class EditorSettingsSidebarComponent {
 	 *
 	 * @param {PrivacyOptions} visibility Desired post visibility setting.
 	 * @param param1 Object parameter.
-	 * @param {string} param1.password Password for the post.
+	 * @param {string} param1.password Password for the post. Normally an optinal value, this
+	 * 	must be set if the `visibility` parameter is set to `Password`.
 	 */
 	async setVisibility(
 		visibility: PrivacyOptions,

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -87,8 +87,13 @@ export class EditorSettingsSidebarComponent {
 	 * Sets the post visibility to the provided visibility setting.
 	 *
 	 * @param {PrivacyOptions} visibility Desired post visibility setting.
+	 * @param param1 Object parameter.
+	 * @param {string} param1.password Password for the post.
 	 */
-	async setVisibility( visibility: PrivacyOptions ): Promise< void > {
+	async setVisibility(
+		visibility: PrivacyOptions,
+		{ password }: { password?: string } = {}
+	): Promise< void > {
 		await this.expandSection( 'Status & Visibility' );
 		await this.frame.click( selectors.visibilityToggle );
 		// Important to wait for the popover element to finish its animation, as the radio buttons
@@ -102,6 +107,17 @@ export class EditorSettingsSidebarComponent {
 			this.page.once( 'dialog', ( dialog ) => dialog.accept() ),
 			this.frame.click( selectors.visibilityOption( visibility ) ),
 		] );
+
+		// For Password-protected posts, the password field needs to be filled.
+		if ( visibility === 'Password' ) {
+			if ( ! password ) {
+				throw new Error( 'Post password is undefined.' );
+			}
+			await this.setPostPassword( password );
+		}
+
+		// Close the visibility sub-panel.
+		await this.frame.click( selectors.visibilityToggle );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -36,10 +36,7 @@ export class PublishedPostPage {
 	 */
 	async enterPostPassword( password: string ): Promise< void > {
 		await this.page.fill( selectors.postPasswordInput, password );
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.click( selectors.submitPasswordButton ),
-		] );
+		await Promise.all( [ this.page.waitForNavigation(), this.page.keyboard.press( 'Enter' ) ] );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/shared-specs/privacy-testing.ts
+++ b/test/e2e/specs/specs-playwright/shared-specs/privacy-testing.ts
@@ -68,9 +68,6 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 					password: pagePassword,
 				} );
 
-				// if ( visibility === 'Password' ) {
-				// 	await editorSettingsSidebarComponent.setPostPassword( pagePassword );
-				// }
 				await gutenbergEditorPage.closeSettings();
 			} );
 

--- a/test/e2e/specs/specs-playwright/shared-specs/privacy-testing.ts
+++ b/test/e2e/specs/specs-playwright/shared-specs/privacy-testing.ts
@@ -60,14 +60,18 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 
 			it( `Set page visibility to ${ visibility }`, async function () {
 				const frame = await gutenbergEditorPage.getEditorFrame();
+				await gutenbergEditorPage.openSettings();
+
 				editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
-
 				await editorSettingsSidebarComponent.clickTab( 'Page' );
-				await editorSettingsSidebarComponent.setVisibility( visibility as PrivacyOptions );
+				await editorSettingsSidebarComponent.setVisibility( visibility as PrivacyOptions, {
+					password: pagePassword,
+				} );
 
-				if ( visibility === 'Password' ) {
-					await editorSettingsSidebarComponent.setPostPassword( pagePassword );
-				}
+				// if ( visibility === 'Password' ) {
+				// 	await editorSettingsSidebarComponent.setPostPassword( pagePassword );
+				// }
+				await gutenbergEditorPage.closeSettings();
 			} );
 
 			it( 'Publish page', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the TeamCity configuration to use the correct environment variable to specify the target viewport.
Furthermore, this PR also fixes the resulting test failures arising from the change.

Key changes:
- use `VIEWPORT_NAME` instead of `TARGET_DEVICE` (which had been deprecated in https://github.com/Automattic/wp-calypso/pull/59811.
- use mobile/desktop compatible parent block selector for WhatsApp Button.
- close sub-panels and panels opened as part of the Post Privacy spec to accommodate limited screen real estate on mobile.


#### Testing instructions

- [x] WPCOM
  - [x] Post Privacy tests pass
  - [x] Jetpack Earn tests pass
- [x] Calypso
  - [x] PR tests pass.
  - [x] Pre-Release tests pass.


Related to https://github.com/Automattic/wp-calypso/pull/59811
