### PR TITLE
Themes: rename Recommended tab for FSE sites

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -13,6 +13,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import SubMasterbarNav from 'calypso/components/sub-masterbar-nav';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
@@ -66,7 +67,9 @@ class ThemeShowcase extends Component {
 		this.tabFilters = {
 			RECOMMENDED: {
 				key: 'recommended',
-				text: props.translate( 'Recommended' ),
+				text: this.props.blockEditorSettings?.is_fse_eligible
+					? props.translate( 'Full Site Editing (Recommended)' )
+					: props.translate( 'Recommended' ),
 				order: 1,
 			},
 			TRENDING: { key: 'trending', text: props.translate( 'Trending' ), order: 2 },
@@ -101,6 +104,9 @@ class ThemeShowcase extends Component {
 		trackMoreThemesClick: PropTypes.func,
 		loggedOutComponent: PropTypes.bool,
 		isJetpackSite: PropTypes.bool,
+		blockEditorSettings: PropTypes.shape( {
+			is_fse_eligible: PropTypes.bool,
+		} ),
 	};
 
 	static defaultProps = {
@@ -434,4 +440,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 	};
 };
 
-export default connect( mapStateToProps, null )( localize( ThemeShowcase ) );
+export default connect(
+	mapStateToProps,
+	null
+)( withBlockEditorSettings( localize( ThemeShowcase ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Users have been looking for FSE themes by name. We're already using the Recommended tab to display FSE compatible themes, but it's not obvious that's the case.

This change simple renames the Recommended tab to "Full Site Editing (Recommended)" for FSE sites.

#### Testing instructions

* Visit /themes/{site} for an FSE site and see the renamed tab
* Do the same for a classic site and see that the tab is not any different

| **Before** | **After** |
| - | - |
| <img width="600" alt="image" src="https://user-images.githubusercontent.com/1699996/152443541-de31ef40-a3e7-4deb-ad13-4bd21afe43f6.png"> | <img width="600" alt="image" src="https://user-images.githubusercontent.com/1699996/152443578-baea6d45-0619-4483-9bfe-68690f693690.png"> |


Related to https://github.com/Automattic/wp-calypso/issues/60750
