### PR TITLE
Playwright: update Gutenboarding flow to check for Site Editor issues.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/close-account-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/close-account-flow.ts
@@ -1,5 +1,4 @@
 import { Page } from 'playwright';
-import { NavbarComponent, MeSidebarComponent } from '../components';
 import { AccountSettingsPage, AccountClosedPage } from '../pages';
 
 /**
@@ -24,12 +23,8 @@ export class CloseAccountFlow {
 	 * then onto Account Settings.
 	 */
 	async closeAccount(): Promise< void > {
-		const navbarComponent = new NavbarComponent( this.page );
-		await navbarComponent.clickMe();
-		const meSidebarComponent = new MeSidebarComponent( this.page );
-		await meSidebarComponent.navigate( 'Account Settings' );
-
 		const accountSettingsPage = new AccountSettingsPage( this.page );
+		await accountSettingsPage.visit();
 		await accountSettingsPage.closeAccount();
 
 		const accountClosedPage = new AccountClosedPage( this.page );

--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { getCalypsoURL } from '../../../data-helper';
 import { reloadAndRetry } from '../../../element-helper';
 import type { LanguageSlug } from '@automattic/languages';
 
@@ -35,6 +36,13 @@ export class AccountSettingsPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+	}
+
+	/**
+	 * Visit the `/me/account` endpoint directly.
+	 */
+	async visit(): Promise< void > {
+		await this.page.goto( getCalypsoURL( 'me/account' ) );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the Gutenboarding flow to perform rudimentary checks of the Site Editor.

Context: p1643919837445449-slack-CBTN58FTJ

Key changes:
- wait until `/site-editor` loads after performing the signup in `Create account` step.
- ensure the site title is shown in the editor to check against WSOD.
- implement `visit` method for `AccountSettingsPage` for a more reliable `CloseAccountFlow`.

#### Testing instructions

- [x] Calypso
  - [x] Pre-Release tests pass
  - [x] Gutenboarding: Happy path spec passes.


Related to #60555, https://github.com/Automattic/wp-calypso/pull/60329