### PR TITLE
ToS acceptance screenshots: Split monolith file into smaller files.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-signup__screenshot.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__screenshot.ts
@@ -10,7 +10,6 @@ import {
 	PlansPage,
 	CartCheckoutPage,
 	SidebarComponent,
-	UserSignupPage,
 	BrowserManager,
 } from '@automattic/calypso-e2e';
 import archiver from 'archiver';
@@ -57,35 +56,6 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 			'ar',
 			'sv',
 		];
-
-		it( 'Screenshot white background signup page in desktop viewport, en and Mag-16 locales', async function () {
-			const userSignupPage = new UserSignupPage( page );
-			for ( const locale of [ ...magnificientNonEnLocales, 'en' ] ) {
-				await userSignupPage.visit( { path: locale } );
-				page.waitForSelector( selectors.isWhiteSignup );
-				await page.screenshot( {
-					path: `tos_white_signup_desktop_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 410, height: 820 } );
-				await page.screenshot( {
-					path: `tos_white_signup_mobile_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 1024, height: 1366 } );
-				await page.screenshot( {
-					path: `tos_white_signup_tablet_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 1280, height: 720 } );
-			}
-		} );
 
 		it( 'Screenshot blue background login page in desktop viewport, en and Mag-16 locales', async function () {
 			const loginPage = new LoginPage( page );

--- a/test/e2e/specs/specs-playwright/wp-tos-screenshots__checkout.ts
+++ b/test/e2e/specs/specs-playwright/wp-tos-screenshots__checkout.ts
@@ -18,11 +18,6 @@ import fetch from 'node-fetch';
 import { Page, Browser } from 'playwright';
 import type { LanguageSlug } from '@automattic/languages';
 
-const selectors = {
-	isWhiteLogin: '.is-section-login.is-white-login',
-	isBlueLogin: '.is-section-login:not( .is-white-login )',
-	isWhiteSignup: 'body.is-white-signup.is-section-signup',
-};
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), function () {
@@ -35,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		page = await browser.newPage();
 	} );
 
-	describe( 'ToS signup, login, and checkout', function () {
+	describe( 'ToS screenshots of WP.com checkout in desktop, tablet, and mobile viewports', function () {
 		jest.setTimeout( 1800000 );
 		let cartCheckoutPage: CartCheckoutPage;
 		const magnificientNonEnLocales = [
@@ -57,62 +52,9 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 			'sv',
 		];
 
-		it( 'Screenshot blue background login page in desktop viewport, en and Mag-16 locales', async function () {
+		it( 'Login to marTech user account', async function () {
 			const loginPage = new LoginPage( page );
-			for ( const locale of [ 'en', ...magnificientNonEnLocales ] ) {
-				await loginPage.visit( { path: locale } );
-				page.waitForSelector( selectors.isBlueLogin );
-				await page.screenshot( {
-					path: `tos_blue_login_desktop_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 410, height: 820 } );
-				await page.screenshot( {
-					path: `tos_blue_login_mobile_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 1024, height: 1366 } );
-				await page.screenshot( {
-					path: `tos_blue_login_tablet_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 1280, height: 720 } );
-			}
-		} );
-
-		it( 'Screenshot white background login page in desktop viewport, en and Mag-16 locales', async function () {
-			const loginPage = new LoginPage( page );
-			for ( const locale of [ 'en', ...magnificientNonEnLocales ] ) {
-				await loginPage.visit( { path: `new/${ locale }` } );
-				page.waitForSelector( selectors.isWhiteLogin );
-				await page.screenshot( {
-					path: `tos_white_login_desktop_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 410, height: 820 } );
-				await page.screenshot( {
-					path: `tos_white_login_mobile_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 1024, height: 1366 } );
-				await page.screenshot( {
-					path: `tos_white_login_tablet_${ locale }.png`,
-					fullPage: true,
-					type: 'jpeg',
-					quality: 20,
-				} );
-				page.setViewportSize( { width: 1280, height: 720 } );
-			}
+			await loginPage.visit( { path: 'new' } );
 			const credentials = DataHelper.getAccountCredential( 'martechTosUser' );
 			await loginPage.logInWithCredentials( ...credentials );
 		} );
@@ -125,6 +67,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 			await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'networkidle' } );
 			const changeUILanguageFlow = new ChangeUILanguageFlow( page );
 			await changeUILanguageFlow.changeUILanguage( 'en' as LanguageSlug );
+			await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'networkidle' } );
 		} );
 
 		it( 'Navigate to Upgrades > Plans', async function () {
@@ -154,7 +97,6 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 				page.setViewportSize( { width: 1280, height: 720 } );
 				await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'networkidle' } );
 				await changeUILanguageFlow.changeUILanguage( locale as LanguageSlug );
-				await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'networkidle' } );
 				await cartCheckoutPage.visit( blogName );
 				const paymentDetails = DataHelper.getTestPaymentDetails();
 				await cartCheckoutPage.enterBillingDetails( paymentDetails );
@@ -183,13 +125,13 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		} );
 
 		it( 'Zip screenshots and upload', async function () {
-			const zipFilename = 'tos-screenshots.zip';
+			const zipFilename = 'tos-screenshots-checkout.zip';
 			const archive = archiver( 'zip', {
 				zlib: { level: 9 }, // Sets the compression level.
 			} );
 			const output = fs.createWriteStream( zipFilename );
 			archive.pipe( output );
-			archive.glob( 'tos_*' );
+			archive.glob( 'tos_checkout_*' );
 			archive.finalize();
 
 			output.on( 'close', function () {

--- a/test/e2e/specs/specs-playwright/wp-tos-screenshots__login-blue.ts
+++ b/test/e2e/specs/specs-playwright/wp-tos-screenshots__login-blue.ts
@@ -2,13 +2,15 @@
  * @group legal
  */
 import fs from 'fs';
-import { DataHelper, UserSignupPage } from '@automattic/calypso-e2e';
+import { DataHelper, LoginPage } from '@automattic/calypso-e2e';
 import archiver from 'archiver';
 import FormData from 'form-data';
 import fetch from 'node-fetch';
 import { Page, Browser } from 'playwright';
 
-const selectors = { isWhiteSignup: 'body.is-white-signup.is-section-signup' };
+const selectors = {
+	isBlueLogin: '.is-section-login:not( .is-white-login )',
+};
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), function () {
@@ -18,7 +20,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		page = await browser.newPage();
 	} );
 
-	describe( 'ToS screenshots of WP.com signup in desktop, tablet, and mobile viewports', function () {
+	describe( 'ToS screenshots of WP.com blue login in desktop, tablet, and mobile viewports', function () {
 		jest.setTimeout( 1800000 );
 		const magnificientNonEnLocales = [
 			'pt-br',
@@ -39,28 +41,28 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 			'sv',
 		];
 
-		it( 'Screenshot white background signup page in en and Mag-16 locales', async function () {
-			const userSignupPage = new UserSignupPage( page );
-			for ( const locale of [ ...magnificientNonEnLocales, 'en' ] ) {
+		it( 'Screenshot blue background login page in en and Mag-16 locales', async function () {
+			const loginPage = new LoginPage( page );
+			for ( const locale of [ 'en', ...magnificientNonEnLocales ] ) {
 				page.setViewportSize( { width: 1280, height: 720 } );
-				await userSignupPage.visit( { path: locale } );
-				page.waitForSelector( selectors.isWhiteSignup );
+				await loginPage.visit( { path: locale } );
+				page.waitForSelector( selectors.isBlueLogin );
 				await page.screenshot( {
-					path: `tos_white_signup_desktop_${ locale }.png`,
+					path: `tos_blue_login_desktop_${ locale }.png`,
 					fullPage: true,
 					type: 'jpeg',
 					quality: 20,
 				} );
 				page.setViewportSize( { width: 410, height: 820 } );
 				await page.screenshot( {
-					path: `tos_white_signup_mobile_${ locale }.png`,
+					path: `tos_blue_login_mobile_${ locale }.png`,
 					fullPage: true,
 					type: 'jpeg',
 					quality: 20,
 				} );
 				page.setViewportSize( { width: 1024, height: 1366 } );
 				await page.screenshot( {
-					path: `tos_white_signup_tablet_${ locale }.png`,
+					path: `tos_blue_login_tablet_${ locale }.png`,
 					fullPage: true,
 					type: 'jpeg',
 					quality: 20,
@@ -69,13 +71,13 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		} );
 
 		it( 'Zip screenshots and upload', async function () {
-			const zipFilename = 'tos-screenshots-signup.zip';
+			const zipFilename = 'tos-screenshots-login-blue.zip';
 			const archive = archiver( 'zip', {
 				zlib: { level: 9 }, // Sets the compression level.
 			} );
 			const output = fs.createWriteStream( zipFilename );
 			archive.pipe( output );
-			archive.glob( 'tos_white_signup_*' );
+			archive.glob( 'tos_blue_login_*' );
 			archive.finalize();
 
 			output.on( 'close', function () {

--- a/test/e2e/specs/specs-playwright/wp-tos-screenshots__login-white.ts
+++ b/test/e2e/specs/specs-playwright/wp-tos-screenshots__login-white.ts
@@ -2,13 +2,15 @@
  * @group legal
  */
 import fs from 'fs';
-import { DataHelper, UserSignupPage } from '@automattic/calypso-e2e';
+import { DataHelper, LoginPage } from '@automattic/calypso-e2e';
 import archiver from 'archiver';
 import FormData from 'form-data';
 import fetch from 'node-fetch';
 import { Page, Browser } from 'playwright';
 
-const selectors = { isWhiteSignup: 'body.is-white-signup.is-section-signup' };
+const selectors = {
+	isWhiteLogin: '.is-section-login.is-white-login',
+};
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), function () {
@@ -18,7 +20,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		page = await browser.newPage();
 	} );
 
-	describe( 'ToS screenshots of WP.com signup in desktop, tablet, and mobile viewports', function () {
+	describe( 'ToS screenshots of WP.com white login in desktop, tablet, and mobile viewports', function () {
 		jest.setTimeout( 1800000 );
 		const magnificientNonEnLocales = [
 			'pt-br',
@@ -39,43 +41,45 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 			'sv',
 		];
 
-		it( 'Screenshot white background signup page in en and Mag-16 locales', async function () {
-			const userSignupPage = new UserSignupPage( page );
-			for ( const locale of [ ...magnificientNonEnLocales, 'en' ] ) {
+		it( 'Screenshot white background login page in en and Mag-16 locales', async function () {
+			const loginPage = new LoginPage( page );
+			for ( const locale of [ 'en', ...magnificientNonEnLocales ] ) {
 				page.setViewportSize( { width: 1280, height: 720 } );
-				await userSignupPage.visit( { path: locale } );
-				page.waitForSelector( selectors.isWhiteSignup );
+				await loginPage.visit( { path: `new/${ locale }` } );
+				page.waitForSelector( selectors.isWhiteLogin );
 				await page.screenshot( {
-					path: `tos_white_signup_desktop_${ locale }.png`,
+					path: `tos_white_login_desktop_${ locale }.png`,
 					fullPage: true,
 					type: 'jpeg',
 					quality: 20,
 				} );
 				page.setViewportSize( { width: 410, height: 820 } );
 				await page.screenshot( {
-					path: `tos_white_signup_mobile_${ locale }.png`,
+					path: `tos_white_login_mobile_${ locale }.png`,
 					fullPage: true,
 					type: 'jpeg',
 					quality: 20,
 				} );
 				page.setViewportSize( { width: 1024, height: 1366 } );
 				await page.screenshot( {
-					path: `tos_white_signup_tablet_${ locale }.png`,
+					path: `tos_white_login_tablet_${ locale }.png`,
 					fullPage: true,
 					type: 'jpeg',
 					quality: 20,
 				} );
 			}
+			const credentials = DataHelper.getAccountCredential( 'martechTosUser' );
+			await loginPage.logInWithCredentials( ...credentials );
 		} );
 
 		it( 'Zip screenshots and upload', async function () {
-			const zipFilename = 'tos-screenshots-signup.zip';
+			const zipFilename = 'tos-screenshots-login-white.zip';
 			const archive = archiver( 'zip', {
 				zlib: { level: 9 }, // Sets the compression level.
 			} );
 			const output = fs.createWriteStream( zipFilename );
 			archive.pipe( output );
-			archive.glob( 'tos_white_signup_*' );
+			archive.glob( 'tos_white_login_*' );
 			archive.finalize();
 
 			output.on( 'close', function () {

--- a/test/e2e/specs/specs-playwright/wp-tos-screenshots__signup.ts
+++ b/test/e2e/specs/specs-playwright/wp-tos-screenshots__signup.ts
@@ -1,0 +1,101 @@
+/**
+ * @group legal
+ */
+import fs from 'fs';
+import { DataHelper, UserSignupPage } from '@automattic/calypso-e2e';
+import archiver from 'archiver';
+import FormData from 'form-data';
+import fetch from 'node-fetch';
+import { Page, Browser } from 'playwright';
+
+const selectors = {
+	isWhiteLogin: '.is-section-login.is-white-login',
+	isBlueLogin: '.is-section-login:not( .is-white-login )',
+	isWhiteSignup: 'body.is-white-signup.is-section-signup',
+};
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), function () {
+	let page: Page;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+	} );
+
+	describe( 'ToS signup, login, and checkout', function () {
+		jest.setTimeout( 1800000 );
+		const magnificientNonEnLocales = [
+			'pt-br',
+			'fr',
+			'es',
+			'de',
+			'he',
+			'ja',
+			'it',
+			'nl',
+			'ru',
+			'tr',
+			'id',
+			'zh-cn',
+			'zh-tw',
+			'ko',
+			'ar',
+			'sv',
+		];
+
+		it( 'Screenshot white background signup page in desktop viewport, en and Mag-16 locales', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			for ( const locale of [ ...magnificientNonEnLocales, 'en' ] ) {
+				await userSignupPage.visit( { path: locale } );
+				page.waitForSelector( selectors.isWhiteSignup );
+				await page.screenshot( {
+					path: `tos_white_signup_desktop_${ locale }.png`,
+					fullPage: true,
+					type: 'jpeg',
+					quality: 20,
+				} );
+				page.setViewportSize( { width: 410, height: 820 } );
+				await page.screenshot( {
+					path: `tos_white_signup_mobile_${ locale }.png`,
+					fullPage: true,
+					type: 'jpeg',
+					quality: 20,
+				} );
+				page.setViewportSize( { width: 1024, height: 1366 } );
+				await page.screenshot( {
+					path: `tos_white_signup_tablet_${ locale }.png`,
+					fullPage: true,
+					type: 'jpeg',
+					quality: 20,
+				} );
+				page.setViewportSize( { width: 1280, height: 720 } );
+			}
+		} );
+
+		it( 'Zip screenshots and upload', async function () {
+			const zipFilename = 'tos-screenshots-signup.zip';
+			const archive = archiver( 'zip', {
+				zlib: { level: 9 }, // Sets the compression level.
+			} );
+			const output = fs.createWriteStream( zipFilename );
+			archive.pipe( output );
+			archive.glob( 'tos_white_signup_*' );
+			archive.finalize();
+
+			output.on( 'close', function () {
+				const form = new FormData();
+				const bearerToken = DataHelper.getTosUploadToken();
+				form.append( 'zip_file', fs.createReadStream( zipFilename ) );
+				fetch( 'https://public-api.wordpress.com/wpcom/v2/screenshots', {
+					method: 'POST',
+					body: form,
+					headers: {
+						Authorization: `Bearer ${ bearerToken }`,
+					},
+				} )
+					.then( ( response ) => response.json() )
+					.then( ( response ) => expect( response?.upload_status ).toStrictEqual( 'success' ) );
+			} );
+		} );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-tos-screenshots__signup.ts
+++ b/test/e2e/specs/specs-playwright/wp-tos-screenshots__signup.ts
@@ -8,11 +8,7 @@ import FormData from 'form-data';
 import fetch from 'node-fetch';
 import { Page, Browser } from 'playwright';
 
-const selectors = {
-	isWhiteLogin: '.is-section-login.is-white-login',
-	isBlueLogin: '.is-section-login:not( .is-white-login )',
-	isWhiteSignup: 'body.is-white-signup.is-section-signup',
-};
+const selectors = { isWhiteSignup: 'body.is-white-signup.is-section-signup' };
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), function () {
@@ -46,6 +42,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		it( 'Screenshot white background signup page in desktop viewport, en and Mag-16 locales', async function () {
 			const userSignupPage = new UserSignupPage( page );
 			for ( const locale of [ ...magnificientNonEnLocales, 'en' ] ) {
+				page.setViewportSize( { width: 1280, height: 720 } );
 				await userSignupPage.visit( { path: locale } );
 				page.waitForSelector( selectors.isWhiteSignup );
 				await page.screenshot( {
@@ -68,7 +65,6 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 					type: 'jpeg',
 					quality: 20,
 				} );
-				page.setViewportSize( { width: 1280, height: 720 } );
 			}
 		} );
 

--- a/test/e2e/specs/specs-playwright/wp-tos-screenshots__signup.ts
+++ b/test/e2e/specs/specs-playwright/wp-tos-screenshots__signup.ts
@@ -22,7 +22,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		page = await browser.newPage();
 	} );
 
-	describe( 'ToS signup, login, and checkout', function () {
+	describe( 'ToS screenshots of WP.com signup in desktop, tablet, and mobile', function () {
 		jest.setTimeout( 1800000 );
 		const magnificientNonEnLocales = [
 			'pt-br',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This spilts the screenshot feature into smaller files, one each for login, signup, and checkout pages. 
* With this PR, the screenshots will also be uploaded in smaller batches, with one zip file each for login, signup, and checkout.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as in https://github.com/Automattic/wp-calypso/pull/57741

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
