### PR TITLE
P2: update endpoint for settings validation

### DIFF
--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -129,7 +129,7 @@ const P2PreapprovedDomainsForm = ( {
 		try {
 			const { success, errors } = await wpcom.req.get(
 				{
-					path: `/p2/hub-settings/domains/validate`,
+					path: `/p2/preapproved-joining/settings/validate`,
 					apiNamespace: 'wpcom/v2',
 				},
 				{ domains: tokens }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In this PR, we update the endpoint for validating pre-approved email domains for P2 workspaces.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the calypso.live link and navigate to the settings page of a P2 workspace hub, i.e. `/settings/general/<site-slug>` 
* Enter "gmail.com" in the domains field. You should get an error popup, saying it's too generic. This means validation is working again.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
