### PR TITLE
Use the discount calculation method from /plans to /start/plans

### DIFF
--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -368,16 +368,20 @@ export default connect(
 				}
 
 				const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
-				let discountPrice = getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
+				const discountPrice = getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
 
 				let annualPricePerMonth = discountPrice || rawPrice;
 				if ( isMonthlyPlan ) {
 					// Get annual price per month for comparison
 					const yearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( plan ) );
 					if ( yearlyPlan ) {
-						discountPrice = getDiscountedRawPrice( state, yearlyPlan.product_id, showMonthlyPrice );
+						const yearlyPlanDiscount = getDiscountedRawPrice(
+							state,
+							yearlyPlan.product_id,
+							showMonthlyPrice
+						);
 						annualPricePerMonth =
-							discountPrice || getPlanRawPrice( state, yearlyPlan.product_id, true );
+							yearlyPlanDiscount || getPlanRawPrice( state, yearlyPlan.product_id, true );
 					}
 				}
 

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -381,7 +381,8 @@ export default connect(
 							showMonthlyPrice
 						);
 						annualPricePerMonth =
-							yearlyPlanDiscount || getPlanRawPrice( state, yearlyPlan.product_id, true );
+							yearlyPlanDiscount ||
+							getPlanRawPrice( state, yearlyPlan.product_id, showMonthlyPrice );
 					}
 				}
 

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -368,14 +368,16 @@ export default connect(
 				}
 
 				const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
-				const discountPrice = getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
+				let discountPrice = getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
 
-				let annualPricePerMonth = rawPrice;
+				let annualPricePerMonth = discountPrice || rawPrice;
 				if ( isMonthlyPlan ) {
 					// Get annual price per month for comparison
 					const yearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( plan ) );
 					if ( yearlyPlan ) {
-						annualPricePerMonth = getPlanRawPrice( state, yearlyPlan.product_id, true );
+						discountPrice = getDiscountedRawPrice( state, yearlyPlan.product_id, showMonthlyPrice );
+						annualPricePerMonth =
+							discountPrice || getPlanRawPrice( state, yearlyPlan.product_id, true );
 					}
 				}
 

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -18,7 +18,11 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import { Primitive } from 'utility-types';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/url';
-import { getPlanBySlug, getPlanRawPrice } from 'calypso/state/plans/selectors';
+import {
+	getPlanBySlug,
+	getPlanRawPrice,
+	getDiscountedRawPrice,
+} from 'calypso/state/plans/selectors';
 
 type Props = {
 	kind: 'interval' | 'customer';
@@ -209,7 +213,9 @@ function useMaxDiscount( plans: string[] ): number {
 			}
 
 			const monthlyPlanAnnualCost = getPlanRawPrice( state, monthlyPlan.product_id ) * 12;
-			const yearlyPlanCost = getPlanRawPrice( state, yearlyPlan.product_id );
+			const rawPrice = getPlanRawPrice( state, yearlyPlan.product_id );
+			const discountPrice = getDiscountedRawPrice( state, yearlyPlan.product_id );
+			const yearlyPlanCost = discountPrice || rawPrice;
 
 			return Math.round(
 				( ( monthlyPlanAnnualCost - yearlyPlanCost ) / ( monthlyPlanAnnualCost || 1 ) ) * 100


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More context: pdgrnI-he-p2
This matches the annual plan savings % figure from the signup flow plans step with the ones from the /plans page.


#### Testing instructions

* Create or Log in to an account that benefits from 1st-year promotional pricing (more info p7DVsv-9lB-p2)
* Go to the /start/plans page (click on the `View plans` link, on the right, if you're redirected to /start/domains)
* Make sure the Annual discount figures match the ones from the /plans page.:

<img width="480" alt="Screenshot on 2022-02-04 at 14-45-20" src="https://user-images.githubusercontent.com/2749938/152532848-b28b63b3-4083-4198-b559-cf66ccc9365a.png">
<img width="480" alt="Screenshot on 2022-02-04 at 14-45-11" src="https://user-images.githubusercontent.com/2749938/152532845-c8e7f600-f4a5-4cd4-97e9-f66cd545c541.png">

* Select the Monthly tab and make sure the proposed discount figures match the ones from the Annual plans

<img width="480" alt="Screenshot on 2022-02-14 at 11-38-27" src="https://user-images.githubusercontent.com/2749938/153846530-a9d46278-3fe2-4e5f-951b-159ac20d7819.png">

* Also try with an account that doesn't benefit from the 1st-year promotional pricing.

* Make sure there're no related JS errors in the console.

