### PR TITLE
Onboarding importers: show error screen if a job is failed

### DIFF
--- a/client/signup/steps/import-from/blogger/index.tsx
+++ b/client/signup/steps/import-from/blogger/index.tsx
@@ -8,6 +8,7 @@ import { resetImport, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import CompleteScreen from '../components/complete-screen';
+import ErrorMessage from '../components/error-message';
 import GettingStartedVideo from '../components/getting-started-video';
 import ImporterDrag from '../components/importer-drag';
 import ProgressScreen from '../components/progress-screen';
@@ -96,6 +97,10 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 		return job?.importerState === appStates.IMPORT_SUCCESS;
 	}
 
+	function checkIsFailed() {
+		return job && job.importerState === appStates.IMPORT_FAILURE;
+	}
+
 	function showVideoComponent() {
 		return checkProgress() || checkIsSuccess();
 	}
@@ -107,9 +112,6 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 					if ( ! job ) {
 						return;
 					} else if ( checkIsSuccess() ) {
-						/**
-						 * Complete screen
-						 */
 						return (
 							<CompleteScreen
 								siteId={ siteId }
@@ -118,10 +120,9 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 								resetImport={ resetImport }
 							/>
 						);
+					} else if ( checkIsFailed() ) {
+						return <ErrorMessage siteSlug={ siteSlug } />;
 					} else if ( checkProgress() ) {
-						/**
-						 * Progress screen
-						 */
 						return <ProgressScreen job={ job } />;
 					}
 

--- a/client/signup/steps/import-from/blogger/index.tsx
+++ b/client/signup/steps/import-from/blogger/index.tsx
@@ -98,7 +98,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 	}
 
 	function checkIsFailed() {
-		return job && job.importerState === appStates.IMPORT_FAILURE;
+		return job?.importerState === appStates.IMPORT_FAILURE;
 	}
 
 	function showVideoComponent() {

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -8,6 +8,7 @@ import { resetImport, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import CompleteScreen from '../components/complete-screen';
+import ErrorMessage from '../components/error-message';
 import GettingStartedVideo from '../components/getting-started-video';
 import ImporterDrag from '../components/importer-drag';
 import ProgressScreen from '../components/progress-screen';
@@ -104,6 +105,10 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 		return job?.importerState === appStates.IMPORT_SUCCESS;
 	}
 
+	function checkIsFailed() {
+		return job?.importerState === appStates.IMPORT_FAILURE;
+	}
+
 	function showVideoComponent() {
 		return checkProgress() || checkIsSuccess();
 	}
@@ -115,9 +120,6 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 					if ( ! job ) {
 						return;
 					} else if ( checkIsSuccess() ) {
-						/**
-						 * Complete screen
-						 */
 						return (
 							<CompleteScreen
 								siteId={ siteId }
@@ -126,10 +128,9 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 								resetImport={ resetImport }
 							/>
 						);
+					} else if ( checkIsFailed() ) {
+						return <ErrorMessage siteSlug={ siteSlug } />;
 					} else if ( checkProgress() ) {
-						/**
-						 * Progress screen
-						 */
 						return <ProgressScreen job={ job } />;
 					}
 

--- a/client/signup/steps/import-from/squarespace/index.tsx
+++ b/client/signup/steps/import-from/squarespace/index.tsx
@@ -8,6 +8,7 @@ import { resetImport, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import CompleteScreen from '../components/complete-screen';
+import ErrorMessage from '../components/error-message';
 import GettingStartedVideo from '../components/getting-started-video';
 import ImporterDrag from '../components/importer-drag';
 import ProgressScreen from '../components/progress-screen';
@@ -96,6 +97,10 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 		return job?.importerState === appStates.IMPORT_SUCCESS;
 	}
 
+	function checkIsFailed() {
+		return job?.importerState === appStates.IMPORT_FAILURE;
+	}
+
 	function showVideoComponent() {
 		return checkProgress() || checkIsSuccess();
 	}
@@ -107,9 +112,6 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 					if ( ! job ) {
 						return;
 					} else if ( checkIsSuccess() ) {
-						/**
-						 * Complete screen
-						 */
 						return (
 							<CompleteScreen
 								siteId={ siteId }
@@ -118,10 +120,9 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 								resetImport={ resetImport }
 							/>
 						);
+					} else if ( checkIsFailed() ) {
+						return <ErrorMessage siteSlug={ siteSlug } />;
 					} else if ( checkProgress() ) {
-						/**
-						 * Progress screen
-						 */
 						return <ProgressScreen job={ job } />;
 					}
 

--- a/client/signup/steps/import-from/wordpress/import-content-only/index.tsx
+++ b/client/signup/steps/import-from/wordpress/import-content-only/index.tsx
@@ -11,6 +11,7 @@ import { startImport, resetImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import CompleteScreen from '../../components/complete-screen';
+import ErrorMessage from '../../components/error-message';
 import GettingStartedVideo from '../../components/getting-started-video';
 import ImporterDrag from '../../components/importer-drag';
 import ProgressScreen from '../../components/progress-screen';
@@ -105,6 +106,10 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 		return job?.importerState === appStates.IMPORT_SUCCESS;
 	}
 
+	function checkIsFailed() {
+		return job?.importerState === appStates.IMPORT_FAILURE;
+	}
+
 	function showVideoComponent() {
 		return checkProgress() || checkIsSuccess();
 	}
@@ -148,6 +153,8 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 				{ ( () => {
 					if ( checkIsSuccess() ) {
 						return renderHooray();
+					} else if ( checkIsFailed() ) {
+						return <ErrorMessage siteSlug={ siteSlug } />;
 					} else if ( checkProgress() ) {
 						return renderProgress();
 					}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Cover import job failed case and show error message screen

#### Screenshot
<img width="797" alt="Screenshot 2022-02-04 at 16 22 23" src="https://user-images.githubusercontent.com/1241413/152555035-a7611fbd-ff98-4920-8b49-2964d271c66d.png">

Related to #60374
