### PR TITLE
Licensing Portal – Improve the credit cards grid to support small viewports

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/style.scss
@@ -1,6 +1,6 @@
 .payment-method-list__body {
 	display: grid;
-	grid-template-columns: repeat( 3, 1fr );
+	grid-template-columns: repeat( auto-fill, minmax( 300px, 1fr ) );
 	gap: 1rem;
 
 	& > * {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the grid support different column configurations so it gets displayed correctly under different viewport sizes.

Note: these changes don't include fetching the user's credit cards from our Jetpack Stripe account. Instead, credit cards are fetched from WPCOM's one. As a consequence, to test these changes, you will need to add some credit cards to your WP.com account in https://wordpress.com/me/purchases/payment-methods.

#### Testing instructions

* Download this PR.
* Start Calypso green with `yarn start-jetpack-cloud`.
* Go to http://jetpack.cloud.localhost:3000/partner-portal/payment-methods.
* Make sure all of your credit cards are listed.
* Play with different viewport sizes and make sure the grid looks well in each one of them.

#### Demo

https://user-images.githubusercontent.com/3418513/152556770-e86bba86-73fe-4643-a245-e26756a3a5fd.mp4

<img src="https://user-images.githubusercontent.com/3418513/152554988-9a953713-2d44-48f8-8896-0c63d2834d8e.png" width="300" />
<img src="https://user-images.githubusercontent.com/3418513/152555039-024d3ae5-bbd5-44d8-908c-6e99d38a16a9.png" width="700" />


Related to 1201734780767770-as-1201735230395238