### PR TITLE
fix: keep locale in URL on pricing page

### DIFF
--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -19,9 +19,6 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 			);
 			return;
 		}
-
-		page.redirect( addQueryArgs( urlQueryArgs, `/pricing` ) );
-		return;
 	}
 
 	if ( context.pathname.endsWith( '/pricing' ) && urlQueryArgs.site ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR addresses issues with redirection on `/pricing` page with locale specified.
When entering `cloud.jetpack.com/:locale/pricing` we shouldn't be redirected to `cloud.jetpack.com/pricing`, but keep locale in URL.

#### Testing instructions
##### Scenario 1:
- Navigate to [Jetpack Cloud](https://calypso.live?image=registry.a8c.com/calypso/app:build-26609&env=jetpack) and change relative path to `/{locale}/pricing` (ex. `/fr/pricing`).
- Observe that you're not redirected.
- Refresh the page and observe that locale is still present in the URL and language displayed properly

##### Scenario 2 (a bit tricky):
- Pull the branch locally
- Run jetpack.cloud on https, command like: `PORT=443 PROTOCOL=https CALYPSO_ENV=jetpack-cloud-development yarn run start` (Note: you may need to generate an SSL certificate or typing `thisisunsafe` when redirected).
- In your hosts file make sure to map cloud.jetpack.com to local build: `127.0.0.1 cloud.jetpack.com`
- Navigate to localized URL like: fr.jetpack.com/pricing , you should be immediately redirected to `cloud.jetpack.com/fr/pricing`. Make sure that locale in the URL and the page is translated.
- Navigate to localized URL like: fr.jetpack.com. Hit the button 'Tarification' (Pricing). You should be forwarded to `cloud.jetpack.com/fr/pricing`. Make sure that locale in the URL and the page is translated.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead, attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to #
Tasks: 1164141197617539-as-1200430913114861/f 