### PR TITLE
Credit cards: Set cardholderName error when field is empty during validation

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -103,7 +103,7 @@ function ButtonContents( { formStatus, total, activeButtonText = undefined } ) {
 }
 
 function isCreditCardFormValid( store, paymentPartner, __ ) {
-	debug( 'validating credit card fields' );
+	debug( 'validating credit card fields for partner', paymentPartner );
 
 	switch ( paymentPartner ) {
 		case 'stripe': {
@@ -112,6 +112,9 @@ function isCreditCardFormValid( store, paymentPartner, __ ) {
 			if ( ! cardholderName?.value.length ) {
 				// Touch the field so it displays a validation error
 				store.dispatch( store.actions.setFieldValue( 'cardholderName', '' ) );
+				store.dispatch(
+					store.actions.setFieldError( 'cardholderName', __( 'This field is required' ) )
+				);
 			}
 			const errors = store.selectors.getCardDataErrors( store.getState() );
 			const incompleteFieldKeys = store.selectors.getIncompleteFieldKeys( store.getState() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This displays an error message when the cardholder name field of the credit card form (in checkout, the add payment method, and update payment method forms) is empty on submission.

<img width="626" alt="Screen Shot 2022-02-04 at 11 56 01 AM" src="https://user-images.githubusercontent.com/2036909/152575298-16eaa4a2-5df0-4d69-9fdc-7e9cebbbdff3.png">

Fixes https://github.com/Automattic/wp-calypso/issues/60628

#### Testing instructions

- Add a product to your cart and visit checkout.
- Select "Credit and debit card" as the payment method.
- Leave the cardholder name field blank and press the submit button.
- Verify that you see an error message about the field being required.

- Visit the add card form at `/me/purchases/add-payment-method`.
- Leave the cardholder name field blank and press the submit button.
- Verify that you see an error message about the field being required.