### PR TITLE
Domains: Fix hover style of disabled DNS records popover menu items

### DIFF
--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -192,7 +192,9 @@ body.dns__body-white {
 		}
 
 		&:disabled,
-		&:disabled:hover {
+		&:disabled:hover,
+		&.is-selected:disabled,
+		&:focus:disabled {
 			color: var( --studio-gray-20 );
 			svg {
 				fill: var( --color-neutral-20 );
@@ -202,10 +204,7 @@ body.dns__body-white {
 
 	.popover__menu-item.is-selected,
 	.popover__menu-item:hover,
-	.popover__menu-item:focus,
-	.popover__menu-item.is-selected:disabled,
-	.popover__menu-item:hover:disabled,
-	.popover__menu-item:focus:disabled {
+	.popover__menu-item:focus {
 		color: var( --studio-white );
 		background-color: var( --color-primary );
 		svg {

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -191,7 +191,9 @@ body.dns__body-white {
 			fill: var( --studio-gray-90 );
 		}
 
-		&:disabled, &:disabled:hover {
+		&:disabled,
+		&:disabled:hover {
+			color: var( --studio-gray-20 );
 			svg {
 				fill: var( --color-neutral-20 );
 			}
@@ -200,8 +202,12 @@ body.dns__body-white {
 
 	.popover__menu-item.is-selected,
 	.popover__menu-item:hover,
-	.popover__menu-item:focus {
+	.popover__menu-item:focus,
+	.popover__menu-item.is-selected:disabled,
+	.popover__menu-item:hover:disabled,
+	.popover__menu-item:focus:disabled {
 		color: var( --studio-white );
+		background-color: var( --color-primary );
 		svg {
 			fill: var( --studio-white );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the DNS records management page, one of the issues reported in #60680 is that the popover menu looked different between regular and "handled by WordPress.com" DNS records. For the latter, the menu item background didn't turn dark when hovered or selected, making the text unreadable:

![Markup on 2022-02-04 at 15:34:08](https://user-images.githubusercontent.com/5324818/152584060-3139edab-f003-4bb6-818a-241dd69447f5.png)

This PR fixes the CSS styling so now the disabled menu items' text is always readable, as the text and background colors won't change when the item's hovered:

<img width="1070" alt="Screen Shot 2022-02-04 at 19 14 26" src="https://user-images.githubusercontent.com/5324818/152610382-b841879d-5c3c-4740-847c-cef80f84038b.png">


### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to the DNS settings of a domain you registered with WordPress.com
- Click on the three dots menu of a protected ("handled by WordPress.com") DNS record and ensure the text is readable when hovered