### PR TITLE
Refresh sidebar to update plan name in `fetchSitePurchases()`

### DIFF
--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -13,7 +13,7 @@ import {
 	PURCHASE_REMOVE_FAILED,
 } from 'calypso/state/action-types';
 import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
-
+import { requestAdminMenu } from '../admin-menu/actions';
 import 'calypso/state/purchases/init';
 
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' );
@@ -29,6 +29,9 @@ export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
 		type: PURCHASES_SITE_FETCH,
 		siteId,
 	} );
+
+	// Refresh sidebar menu to ensure Plan description is updated.
+	dispatch( requestAdminMenu( siteId ) );
 
 	return wpcom.req
 		.get( `/sites/${ siteId }/purchases` )


### PR DESCRIPTION
This PR updates the sidebar when `fetchSitePurchases( siteId )` is called. This happens when the user visits the "Purchases" or "Plans" pages. Since the user is sent to the "Purchases" page if they cancel their plan, this will update the plan description in the sidebar.

![plan-sidebar](https://user-images.githubusercontent.com/140841/152596535-dc467594-2893-40bf-a436-73ecfd7e9382.png)

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
