### PR TITLE
Domains: Fix style of domain delete card button

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -20,7 +20,7 @@ const DomainDeleteInfoCard = ( {
 
 	if ( isLoadingPurchase || ! purchase || ! domain.currentUserIsOwner ) return null;
 
-	const removePurchaseClassName = 'is-compact button';
+	const removePurchaseClassName = 'domain-delete-info-card is-compact button';
 
 	const title =
 		domain.type === domainType.TRANSFER ? translate( 'Cancel transfer' ) : translate( 'Delete' );

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -57,7 +57,7 @@
 			margin-top: 0;
 
 			svg {
-				display: none;;
+				display: none;
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -52,5 +52,17 @@
 				}
 			}
 		}
+
+		.domain-delete-info-card {
+			display: flex;
+			flex-direction: row-reverse;
+			align-items: center;
+			margin-top: 0;
+
+			svg {
+				top: 3px;
+				right: 0;
+			}
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -54,14 +54,10 @@
 		}
 
 		.domain-delete-info-card {
-			display: flex;
-			flex-direction: row-reverse;
-			align-items: center;
 			margin-top: 0;
 
 			svg {
-				top: 3px;
-				right: 0;
+				display: none;;
 			}
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

#60311 updated the styling of the product cancelation buttons in the billing pages, but we also use that button in the domain delete card in the domain settings page. The update inadvertently made it look a little weird:

![Markup on 2022-02-04 at 15:56:45](https://user-images.githubusercontent.com/5324818/152592077-892b5c5a-3a2c-4680-8d22-2c36d9124cf3.png)

This PR updates the styling for that specific button so it looks like before without the trash icon:

![Markup on 2022-02-04 at 16:26:39](https://user-images.githubusercontent.com/5324818/152592409-0b0b0044-19c5-42df-9258-72e7b107b2e1.png)

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to the settings page of a domain you registered in WordPress.com
- Wait for the purchase infomration to load and ensure the "Delete" button appears correctly like in the screenshot above
