### PR TITLE
Refresh sidebar to update plan name in `clearPurchases()` and `removePurchase()`

### DIFF
--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -104,7 +104,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 	removePurchase = async () => {
 		const { domain, productName, purchase, translate, userId } = this.props;
 
-		await this.props.removePurchase( purchase.id, userId );
+		await this.props.removePurchase( purchase.id, userId, purchase.siteId );
 
 		const { purchasesError } = this.props;
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -199,8 +199,9 @@ class CancelPurchaseButton extends Component {
 					return;
 				}
 
-				this.props.refreshSitePlans( purchase.siteId );
-				this.props.clearPurchases( purchase.siteId );
+				const siteId = purchase.siteId;
+				this.props.refreshSitePlans( siteId );
+				this.props.clearPurchases( siteId );
 				this.props.successNotice( response.message, { displayOnNextPage: true } );
 				page.redirect( this.props.purchaseListUrl );
 			}

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -85,10 +85,11 @@ class CancelPurchaseButton extends Component {
 		cancelPurchase( purchase.id, ( success ) => {
 			const purchaseName = getName( purchase );
 			const subscriptionEndDate = getSubscriptionEndDate( purchase );
+			const siteId = purchase.siteId;
 
-			this.props.refreshSitePlans( purchase.siteId );
+			this.props.refreshSitePlans( siteId );
 
-			this.props.clearPurchases();
+			this.props.clearPurchases( siteId );
 
 			if ( success ) {
 				this.props.successNotice(
@@ -141,9 +142,11 @@ class CancelPurchaseButton extends Component {
 
 		this.props.successNotice( response.message, { displayOnNextPage: true } );
 
-		this.props.refreshSitePlans( this.props.purchase.siteId );
+		const siteId = this.props.purchase.siteId;
 
-		this.props.clearPurchases();
+		this.props.refreshSitePlans( siteId );
+
+		this.props.clearPurchases( siteId );
 
 		page.redirect( this.props.purchaseListUrl );
 	};
@@ -165,8 +168,9 @@ class CancelPurchaseButton extends Component {
 					return;
 				}
 
-				this.props.refreshSitePlans( purchase.siteId );
-				this.props.clearPurchases();
+				const siteId = purchase.siteId;
+				this.props.refreshSitePlans( siteId );
+				this.props.clearPurchases( siteId );
 				this.props.successNotice( response.message, { displayOnNextPage: true } );
 				page.redirect( this.props.purchaseListUrl );
 			}
@@ -196,7 +200,7 @@ class CancelPurchaseButton extends Component {
 				}
 
 				this.props.refreshSitePlans( purchase.siteId );
-				this.props.clearPurchases();
+				this.props.clearPurchases( purchase.siteId );
 				this.props.successNotice( response.message, { displayOnNextPage: true } );
 				page.redirect( this.props.purchaseListUrl );
 			}

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -135,7 +135,7 @@ class ConfirmCancelDomain extends Component {
 			}
 
 			this.props.refreshSitePlans( purchase.siteId );
-			this.props.clearPurchases();
+			this.props.clearPurchases( purchase.siteId );
 
 			recordTracksEvent( 'calypso_domain_cancel_form_submit', {
 				product_slug: purchase.productSlug,

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -134,8 +134,9 @@ class ConfirmCancelDomain extends Component {
 				return;
 			}
 
-			this.props.refreshSitePlans( purchase.siteId );
-			this.props.clearPurchases( purchase.siteId );
+			const siteId = purchase.siteId;
+			this.props.refreshSitePlans( siteId );
+			this.props.clearPurchases( siteId );
 
 			recordTracksEvent( 'calypso_domain_cancel_form_submit', {
 				product_slug: purchase.productSlug,

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -147,7 +147,7 @@ class RemovePurchase extends Component {
 	handlePurchaseRemoval = async ( purchase ) => {
 		const { userId, isDomainOnlySite, translate, purchasesError } = this.props;
 
-		await this.props.removePurchase( purchase.id, userId );
+		await this.props.removePurchase( purchase.id, userId, purchase.siteId );
 
 		const productName = getName( purchase );
 		let successMessage;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -160,7 +160,7 @@ export default function useCreatePaymentCompleteCallback( {
 			const receiptId = transactionResult?.receipt_id;
 			debug( 'transactionResult was', transactionResult );
 
-			reduxDispatch( clearPurchases() );
+			reduxDispatch( clearPurchases( siteId ) );
 
 			// Removes the destination cookie only if redirecting to the signup destination.
 			// (e.g. if the destination is an upsell nudge, it does not remove the cookie).

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -160,7 +160,7 @@ export default function useCreatePaymentCompleteCallback( {
 			const receiptId = transactionResult?.receipt_id;
 			debug( 'transactionResult was', transactionResult );
 
-			reduxDispatch( clearPurchases( siteId ) );
+			reduxDispatch( clearPurchases() );
 
 			// Removes the destination cookie only if redirecting to the signup destination.
 			// (e.g. if the destination is an upsell nudge, it does not remove the cookie).

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -90,6 +90,7 @@ export const removePurchase = ( purchaseId, userId, siteId ) => ( dispatch ) => 
 
 				dispatch( requestHappychatEligibility() );
 
+				// Refresh the sidebar to update the site Plan.
 				if ( siteId !== undefined ) {
 					dispatch( requestAdminMenu( siteId ) );
 				}

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -13,15 +13,20 @@ import {
 	PURCHASE_REMOVE_FAILED,
 } from 'calypso/state/action-types';
 import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
-
+import { requestAdminMenu } from '../admin-menu/actions';
 import 'calypso/state/purchases/init';
 
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' );
 const PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase.' );
 
-export const clearPurchases = () => ( dispatch ) => {
+export const clearPurchases = ( siteId ) => ( dispatch ) => {
 	dispatch( { type: PURCHASES_REMOVE } );
 	dispatch( requestHappychatEligibility() );
+
+	// Refresh the sidebar to update the site Plan.
+	if ( siteId !== undefined ) {
+		dispatch( requestAdminMenu( siteId ) );
+	}
 };
 
 export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
@@ -69,7 +74,7 @@ export const fetchUserPurchases = ( userId ) => ( dispatch ) => {
 		} );
 };
 
-export const removePurchase = ( purchaseId, userId ) => ( dispatch ) => {
+export const removePurchase = ( purchaseId, userId, siteId ) => ( dispatch ) => {
 	return new Promise( ( resolve ) =>
 		wpcom.req
 			.post( {
@@ -84,6 +89,10 @@ export const removePurchase = ( purchaseId, userId ) => ( dispatch ) => {
 				} );
 
 				dispatch( requestHappychatEligibility() );
+
+				if ( siteId !== undefined ) {
+					dispatch( requestAdminMenu( siteId ) );
+				}
 
 				resolve( data );
 			} )

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -98,7 +98,8 @@ describe( 'actions', () => {
 		test( 'should dispatch fetch/complete actions', () => {
 			return removePurchase(
 				purchaseId,
-				userId
+				userId,
+				siteId
 			)( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PURCHASE_REMOVE_COMPLETED,
@@ -123,7 +124,8 @@ describe( 'actions', () => {
 		test( 'should dispatch fetch/remove actions', () => {
 			return removePurchase(
 				purchaseId,
-				userId
+				userId,
+				siteId
 			)( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PURCHASE_REMOVE_FAILED,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the sidebar menu in `clearPurchases()` and `removePurchase()`. This is done to update the Plan description when the user downgrades or cancels a plan.

To accomplish this the `siteId` must be passed to `clearPurchases()` and `removePurchase()` so we can refresh the sidebar using `dispatch( requestAdminMenu( siteId ) )`.

![plan-sidebar](https://user-images.githubusercontent.com/140841/152597563-6a82a73e-e0d8-4e73-a126-1737e7f8f3ce.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #