### PR TITLE
Themes: Fix overlap in on the theme page.

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -78,7 +78,6 @@ $theme-info-height: 54px;
 	font-family: inherit;
 	overflow: hidden;
 	white-space: nowrap;
-	top: -1px;
 
 	&::before {
 		@include long-content-fade();


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes an overlap in the theme name. 

Before:
<img width="249" alt="Screen Shot 2022-02-04 at 1 34 21 PM" src="https://user-images.githubusercontent.com/115071/152838384-318ebce6-b6bc-4858-9616-6c8150546bdb.png">


After:
<img width="252" alt="Screen Shot 2022-02-04 at 1 34 33 PM" src="https://user-images.githubusercontent.com/115071/152606687-f963c0db-9d81-4a47-ade1-e6d0fa2a9ec9.png">



#### Testing instructions
Visit /themes/example.com and /themes in incognito and notice that the theme card looks as expected. 



Related to #
https://github.com/Automattic/wp-calypso/pull/60524#pullrequestreview-868460755 
