### PR TITLE
E2E: add test case to upload image using Calypso Media modal.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -1,5 +1,6 @@
 import { Page, ElementHandle, Frame } from 'playwright';
-import { MediaPage } from '..';
+import { ReactModalComponent } from '../components';
+import { MediaPage } from '../pages';
 
 type Sources = 'Media Library' | 'Google Photos' | 'Pexels';
 
@@ -82,12 +83,12 @@ export class ImageBlock {
 		const frame = ( await this.block.ownerFrame() ) as Frame;
 		const page = frame.page();
 
-		// The resulting React modal is essentially the MediaPage, just
-		// embedded within the modal, with additional buttons to
-		// confirm or cancel image insertion.
-		const mediaPage = new MediaPage( page );
-		await mediaPage.upload( path );
-		await mediaPage.clickModalButton( 'Confirm' );
+		// The resulting react modal embeds the MediaPage with additional
+		// buttons to confirm/cancel action.
+		const reactModalComponent = new ReactModalComponent( page, new MediaPage( page ) );
+		await reactModalComponent.pageObject.upload( path );
+		await reactModalComponent.clickButton( 'Insert' );
+
 		await this.waitUntilUploaded();
 		return await this.getImage();
 	}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -14,5 +14,6 @@ export * from './block-widget-editor-component';
 export * from './revisions-component';
 export * from './snackbar-notification-component';
 export * from './page-template-modal-component';
+export * from './react-modal-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/react-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/react-modal-component.ts
@@ -1,0 +1,34 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	actionButton: ( text: string ) => `button:has-text("${ text }")`,
+};
+
+/**
+ *
+ */
+export class ReactModalComponent< PageObject > {
+	private page: Page;
+	readonly pageObject: PageObject;
+
+	/**
+	 * Constructs an instance of this component.
+	 *
+	 * @param {Page} page The underlying page.
+	 * @param {any} pageObject Dependency injected page object.
+	 */
+	constructor( page: Page, pageObject: PageObject ) {
+		this.page = page;
+		this.pageObject = pageObject;
+	}
+
+	/**
+	 * Clicks on the button on the modal.
+	 *
+	 * @param {string} text Text to match on the button.
+	 */
+	async clickButton( text: string ): Promise< void > {
+		const locator = this.page.locator( selectors.actionButton( text ) );
+		await locator.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -287,7 +287,8 @@ export class GutenbergEditorPage {
 		// Confirm the block has been added to the editor body.
 		const elementHandle = await frame.waitForSelector( `${ blockEditorSelector }.is-selected` );
 
-		// Dismiss the block inserter if viewport is larger than mobile.
+		// Dismiss the block inserter if viewport is larger than mobile to ensure
+		// no interference from the block inserter in subsequent actions on the editor.
 		// In mobile, the block inserter will auto-close.
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await frame.click( selectors.blockInserterToggle );

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -29,6 +29,7 @@ const selectors = {
 	settingsToggle: '.edit-post-header__settings .interface-pinned-items button:first-child',
 	closeSettingsButton: 'button[aria-label="Close settings"]:visible',
 	saveDraftButton: '.editor-post-save-draft',
+	saveDraftDisabledButton: 'button.editor-post-saved-state.is-saved[aria-disabled="true"]',
 	previewButton: ':is(button:text("Preview"), a:text("Preview"))',
 	publishButton: ( parentSelector: string ) =>
 		`${ parentSelector } button:text("Publish")[aria-disabled=false]`,
@@ -284,7 +285,15 @@ export class GutenbergEditorPage {
 		await this.searchBlockInserter( blockName );
 		await frame.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );
 		// Confirm the block has been added to the editor body.
-		return await frame.waitForSelector( `${ blockEditorSelector }.is-selected` );
+		const elementHandle = await frame.waitForSelector( `${ blockEditorSelector }.is-selected` );
+
+		// Dismiss the block inserter if viewport is larger than mobile.
+		// In mobile, the block inserter will auto-close.
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			await frame.click( selectors.blockInserterToggle );
+		}
+
+		return elementHandle;
 	}
 
 	/**
@@ -471,10 +480,8 @@ export class GutenbergEditorPage {
 		const frame = await this.getEditorFrame();
 
 		await frame.click( selectors.saveDraftButton );
-		// Once the Save draft button is clicked, buttons on the post toolbar
-		// are disabled while the post is saved. Wait for the state of
-		// Publish button to return to 'enabled' before proceeding.
-		await frame.waitForSelector( selectors.publishButton( selectors.postToolbar ) );
+		// Wait for the Save Draft button to become disabled.
+		await frame.waitForSelector( selectors.saveDraftDisabledButton );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -1,6 +1,8 @@
 import { ElementHandle, Page } from 'playwright';
 import { waitForElementEnabled, clickNavTab } from '../../element-helper';
 
+type ModalAction = 'Confirm' | 'Cancel';
+
 const selectors = {
 	// Gallery view
 	gallery: '.media-library__content',
@@ -24,6 +26,10 @@ const selectors = {
 		`.image-editor__toolbar-button span:text("${ text }")`,
 	imageEditorResetButton: 'button[data-e2e-button="reset"]',
 	imageEditorCancelButton: 'button[data-e2e-button="cancel"]',
+
+	// When embedded in a modal
+	modalActionButton: ( action: ModalAction ) =>
+		`button[data-e2e-button="${ action.toLowerCase() }"]`,
 };
 
 /**
@@ -172,5 +178,16 @@ export class MediaPage {
 					.then( ( element ) => element.innerText() )
 			);
 		}
+	}
+
+	/* Modal mode */
+
+	/**
+	 *
+	 * @param action
+	 */
+	async clickModalButton( action: ModalAction ): Promise< void > {
+		const locator = this.page.locator( selectors.modalActionButton( action ) );
+		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -1,8 +1,6 @@
 import { ElementHandle, Page } from 'playwright';
 import { waitForElementEnabled, clickNavTab } from '../../element-helper';
 
-type ModalAction = 'Confirm' | 'Cancel';
-
 const selectors = {
 	// Gallery view
 	gallery: '.media-library__content',
@@ -26,10 +24,6 @@ const selectors = {
 		`.image-editor__toolbar-button span:text("${ text }")`,
 	imageEditorResetButton: 'button[data-e2e-button="reset"]',
 	imageEditorCancelButton: 'button[data-e2e-button="cancel"]',
-
-	// When embedded in a modal
-	modalActionButton: ( action: ModalAction ) =>
-		`button[data-e2e-button="${ action.toLowerCase() }"]`,
 };
 
 /**
@@ -178,17 +172,5 @@ export class MediaPage {
 					.then( ( element ) => element.innerText() )
 			);
 		}
-	}
-
-	/* Modal mode */
-
-	/**
-	 * Interacts with the react modal component that embeds MediaPage.
-	 *
-	 * @param {ModalAction} action Action to perform on the modal.
-	 */
-	async clickModalButton( action: ModalAction ): Promise< void > {
-		const locator = this.page.locator( selectors.modalActionButton( action ) );
-		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -183,8 +183,9 @@ export class MediaPage {
 	/* Modal mode */
 
 	/**
+	 * Interacts with the react modal component that embeds MediaPage.
 	 *
-	 * @param action
+	 * @param {ModalAction} action Action to perform on the modal.
 	 */
 	async clickModalButton( action: ModalAction ): Promise< void > {
 		const locator = this.page.locator( selectors.modalActionButton( action ) );

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -22,7 +22,6 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	let gutenbergEditorPage: GutenbergEditorPage;
 	let page: Page;
 	let testFiles: {
-		image: TestFile;
 		image_modal: TestFile;
 		image_reserved_name: TestFile;
 		audio: TestFile;
@@ -31,7 +30,6 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	beforeAll( async () => {
 		page = await browser.newPage();
 		testFiles = {
-			image: await MediaHelper.createTestFile( TEST_IMAGE_PATH ),
 			image_modal: await MediaHelper.createTestFile( TEST_IMAGE_PATH ),
 			image_reserved_name: await MediaHelper.createTestFile( TEST_IMAGE_PATH, {
 				postfix: 'filewith#?#?reservedurlchars',
@@ -53,73 +51,68 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		await gutenbergEditorPage.enterTitle( DataHelper.getRandomPhrase() );
 	} );
 
-	it( `${ ImageBlock.blockName } block: upload image file`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
-			ImageBlock.blockName,
-			ImageBlock.blockEditorSelector
-		);
-		const imageBlock = new ImageBlock( blockHandle );
-		await imageBlock.upload( testFiles.image.fullpath );
+	describe( 'Populate post with media blocks', function () {
+		it( `${ ImageBlock.blockName } block: upload image file with reserved URL characters`, async function () {
+			const blockHandle = await gutenbergEditorPage.addBlock(
+				ImageBlock.blockName,
+				ImageBlock.blockEditorSelector
+			);
+			const imageBlock = new ImageBlock( blockHandle );
+			await imageBlock.upload( testFiles.image_reserved_name.fullpath );
+		} );
+
+		it( `${ ImageBlock.blockName } block: upload image file using Calypso media modal `, async function () {
+			const blockHandle = await gutenbergEditorPage.addBlock(
+				ImageBlock.blockName,
+				ImageBlock.blockEditorSelector
+			);
+			const imageBlock = new ImageBlock( blockHandle );
+
+			await imageBlock.selectImageSource( 'Media Library' );
+			await imageBlock.uploadFromModal( testFiles.image_modal.fullpath );
+		} );
+
+		it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
+			const blockHandle = await gutenbergEditorPage.addBlock(
+				AudioBlock.blockName,
+				AudioBlock.blockEditorSelector
+			);
+			const audioBlock = new AudioBlock( blockHandle );
+			await audioBlock.upload( testFiles.audio.fullpath );
+		} );
+
+		it( `${ FileBlock.blockName } block: upload audio file`, async function () {
+			const blockHandle = await gutenbergEditorPage.addBlock(
+				FileBlock.blockName,
+				FileBlock.blockEditorSelector
+			);
+			const fileBlock = new FileBlock( blockHandle );
+			await fileBlock.upload( testFiles.audio.fullpath );
+		} );
+
+		it( 'Publish and visit post', async function () {
+			await gutenbergEditorPage.saveDraft();
+			await gutenbergEditorPage.publish( { visit: true } );
+		} );
 	} );
 
-	it( `${ ImageBlock.blockName } block: upload image file with reserved URL characters`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
-			ImageBlock.blockName,
-			ImageBlock.blockEditorSelector
-		);
-		const imageBlock = new ImageBlock( blockHandle );
-		await imageBlock.upload( testFiles.image_reserved_name.fullpath );
-	} );
+	describe( 'Validate published post', function () {
+		it( `Image with reserved characters in filename is visible`, async function () {
+			await ImageBlock.validatePublishedContent( page, [
+				testFiles.image_reserved_name.filename.replace( /[^a-zA-Z ]/g, '' ),
+			] );
+		} );
 
-	it( `${ ImageBlock.blockName } block: upload image file using Calypso media modal `, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
-			ImageBlock.blockName,
-			ImageBlock.blockEditorSelector
-		);
-		const imageBlock = new ImageBlock( blockHandle );
+		it( 'Image added via Calypso modal is visible', async function () {
+			await ImageBlock.validatePublishedContent( page, [ testFiles.image_modal.filename ] );
+		} );
 
-		await imageBlock.selectImageSource( 'Media Library' );
-		await imageBlock.uploadFromModal( testFiles.image_modal.fullpath );
-	} );
+		it( `Audio block is visible`, async function () {
+			await AudioBlock.validatePublishedContent( page );
+		} );
 
-	it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
-			AudioBlock.blockName,
-			AudioBlock.blockEditorSelector
-		);
-		const audioBlock = new AudioBlock( blockHandle );
-		await audioBlock.upload( testFiles.audio.fullpath );
-	} );
-
-	it( `${ FileBlock.blockName } block: upload audio file`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
-			FileBlock.blockName,
-			FileBlock.blockEditorSelector
-		);
-		const fileBlock = new FileBlock( blockHandle );
-		await fileBlock.upload( testFiles.audio.fullpath );
-	} );
-
-	it( 'Publish and visit post', async function () {
-		await gutenbergEditorPage.saveDraft();
-		await gutenbergEditorPage.publish( { visit: true } );
-	} );
-
-	it( `Confirm Image block is visible in published post`, async function () {
-		await ImageBlock.validatePublishedContent( page, [ testFiles.image.filename ] );
-	} );
-
-	it( `Confirm Image block is visible in published post (reserved name)`, async function () {
-		await ImageBlock.validatePublishedContent( page, [
-			testFiles.image_reserved_name.filename.replace( /[^a-zA-Z ]/g, '' ),
-		] );
-	} );
-
-	it( `Confirm Audio block is visible in published post`, async function () {
-		await AudioBlock.validatePublishedContent( page );
-	} );
-
-	it( `Confirm File block is visible in published post`, async function () {
-		await FileBlock.validatePublishedContent( page, [ testFiles.audio.filename ] );
+		it( `File block is visible`, async function () {
+			await FileBlock.validatePublishedContent( page, [ testFiles.audio.filename ] );
+		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -21,12 +21,18 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	let gutenbergEditorPage: GutenbergEditorPage;
 	let page: Page;
-	let testFiles: { image: TestFile; image_reserved_name: TestFile; audio: TestFile };
+	let testFiles: {
+		image: TestFile;
+		image_modal: TestFile;
+		image_reserved_name: TestFile;
+		audio: TestFile;
+	};
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		testFiles = {
 			image: await MediaHelper.createTestFile( TEST_IMAGE_PATH ),
+			image_modal: await MediaHelper.createTestFile( TEST_IMAGE_PATH ),
 			image_reserved_name: await MediaHelper.createTestFile( TEST_IMAGE_PATH, {
 				postfix: 'filewith#?#?reservedurlchars',
 			} ),
@@ -65,6 +71,17 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		await imageBlock.upload( testFiles.image_reserved_name.fullpath );
 	} );
 
+	it( `${ ImageBlock.blockName } block: upload image file using Calypso media modal `, async function () {
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			ImageBlock.blockName,
+			ImageBlock.blockEditorSelector
+		);
+		const imageBlock = new ImageBlock( blockHandle );
+
+		await imageBlock.selectImageSource( 'Media Library' );
+		await imageBlock.uploadFromModal( testFiles.image_modal.fullpath );
+	} );
+
 	it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
 		const blockHandle = await gutenbergEditorPage.addBlock(
 			AudioBlock.blockName,
@@ -84,6 +101,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	} );
 
 	it( 'Publish and visit post', async function () {
+		await gutenbergEditorPage.saveDraft();
 		await gutenbergEditorPage.publish( { visit: true } );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a test step in the `Blocks: Media (Upload)` spec to test functionality of the Calypso Media modal.

Context: pciE2j-sq-p2

Key changes:
- addition of methods and selectors in `ImageBlock` to support the use of calypso media modal screen.
- addition of method in `MediaPage` to handle scenario of the page being embedded in a modal.
- minor changes to supporting methods as required.

#### Testing instructions
 
- [x] Ensure for mobile and desktop:
  - [x] Blocks: Media (Upload) passes.
  - [x] New test step `upload image file using Calypso media modal` passes.


Related to #