### PR TITLE
Domains: Fix typo in connected domain notice

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -177,7 +177,7 @@ export function resolveDomainStatus(
 
 			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom ) {
 				const status = translate(
-					'{{strong}}Verifying connection:{{/strong}} You can continue to work on your site, but you domain won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
+					'{{strong}}Verifying connection:{{/strong}} You can continue to work on your site, but your domain won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
 					{ components: mappingSetupComponents }
 				);
 				return {


### PR DESCRIPTION
### Changes proposed in this Pull Request

There was a typo in one of the connected domain notices: It read `You can continue to work on your site, but *you* domain won’t be reachable just yet`. This PR fixes the `you` to `your`.

### Testing instructions

Code inspection