### PR TITLE
Woo Installer: Changes site dependency for siteSlug

### DIFF
--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -44,7 +44,7 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 			feature: 'woop', // WooCommerce on Plans
 		} );
 
-		return page( `/start/woocommerce-install/?site=${ wpcomDomain }` );
+		return page( `/start/woocommerce-install/?siteSlug=${ wpcomDomain }` );
 	}
 
 	function renderWarningNotice() {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -420,7 +420,7 @@ export function generateFlows( {
 			steps: [ 'store-address', 'business-info', 'confirm', 'transfer' ],
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',
-			providesDependenciesInQuery: [ 'site' ],
+			providesDependenciesInQuery: [ 'siteSlug' ],
 			lastModified: '2021-12-21',
 			disallowResume: false,
 		},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -735,20 +735,20 @@ export function generateSteps( {
 		// Woocommerce Install steps.
 		'store-address': {
 			stepName: 'store-address',
-			dependencies: [ 'site' ],
+			dependencies: [ 'siteSlug' ],
 		},
 		'business-info': {
 			stepName: 'business-info',
-			dependencies: [ 'site' ],
+			dependencies: [ 'siteSlug' ],
 		},
 		confirm: {
 			stepName: 'confirm',
-			dependencies: [ 'site' ],
+			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'siteConfirmed' ],
 		},
 		transfer: {
 			stepName: 'transfer',
-			dependencies: [ 'site', 'siteConfirmed' ],
+			dependencies: [ 'siteSlug', 'siteConfirmed' ],
 		},
 	};
 }

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -290,6 +290,19 @@ export default {
 
 		// Update initialContext to help woocommerce-install support site switching.
 		if ( 'woocommerce-install' === flowName ) {
+			const currentSiteId = getSiteId( context.store.getState(), context.query.siteSlug );
+			const previousSiteId = getSiteId(
+				initialContext.store.getState(),
+				initialContext.query.siteSlug
+			);
+
+			if ( currentSiteId !== previousSiteId ) {
+				// when changing sites setSelectedSiteForSignup uses the queryDependencies stored
+				// in the redux store this causes that when a site slug changes the first step doesn't
+				// catch the siteId change, this forces that change.
+				context.store.dispatch( setSelectedSiteId( currentSiteId ) );
+			}
+
 			initialContext = context;
 		}
 
@@ -387,6 +400,7 @@ export default {
 			next();
 			return;
 		}
+
 		const siteId = getSiteId( getState(), siteIdOrSlug );
 		if ( siteId ) {
 			dispatch( setSelectedSiteId( siteId ) );

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -326,7 +326,6 @@ export default {
 		if (
 			! providesDependenciesInQuery?.includes( 'siteId' ) &&
 			! providesDependenciesInQuery?.includes( 'siteSlug' ) &&
-			! providesDependenciesInQuery?.includes( 'site' ) &&
 			! isManageSiteFlow
 		) {
 			context.store.dispatch( setSelectedSiteId( null ) );
@@ -380,8 +379,6 @@ export default {
 		const signupDependencies = getSignupDependencyStore( getState() );
 
 		const siteIdOrSlug =
-			query?.site ||
-			signupDependencies?.site ||
 			signupDependencies?.siteSlug ||
 			query?.siteSlug ||
 			signupDependencies?.siteId ||

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -188,8 +188,11 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 		required: requiresUpgrade,
 		checkoutUrl: addQueryArgs(
 			{
-				redirect_to: addQueryArgs( { site: wpcomDomain }, '/start/woocommerce-install/transfer' ),
-				cancel_to: addQueryArgs( { site: wpcomDomain }, '/start/woocommerce-install/confirm' ),
+				redirect_to: addQueryArgs(
+					{ siteSlug: wpcomDomain },
+					'/start/woocommerce-install/transfer'
+				),
+				cancel_to: addQueryArgs( { siteSlug: wpcomDomain }, '/start/woocommerce-install/confirm' ),
 			},
 			`/checkout/${ wpcomDomain }/${ upgradingPlan?.product_slug ?? '' }`
 		),

--- a/client/signup/steps/woocommerce-install/index.tsx
+++ b/client/signup/steps/woocommerce-install/index.tsx
@@ -12,10 +12,10 @@ export interface WooCommerceInstallProps {
 	headerTitle: string;
 	headerDescription: string;
 	queryObject: {
-		site: string;
+		siteSlug: string;
 	};
 	signupDependencies: {
-		site: string;
+		siteSlug: string;
 		siteConfirmed?: number;
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the dependency name on the `woocommerce-install` flow from `site` to `siteSlug`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the `woocommerce-install` flow with a non-atomic account.
* Test the `woocommerce-install` flow with an atomic account.
* Test the `woocommerce-install` flow with an account with a plan below business.
* Test that #60892 changes are still working

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60568, https://github.com/Automattic/wp-calypso/issues/60907
