### PR TITLE
FSE: roll out to 100% of new sites

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -43,7 +43,7 @@ import { getSiteId } from 'calypso/state/sites/selectors';
 const Visibility = Site.Visibility;
 const debug = debugFactory( 'calypso:signup:step-actions' );
 
-const FSE_BETA_ROLLOUT_PERCENTAGE_START_FLOW = 50;
+const FSE_BETA_ROLLOUT_PERCENTAGE_START_FLOW = 100;
 
 const isUserAssignedFSEBeta = ( userId ) => {
 	if ( ! userId ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the /start rollout percentage to 100%

#### Testing instructions

See https://github.com/Automattic/wp-calypso/pull/60330 and https://github.com/Automattic/wp-calypso/pull/60620


