### PR TITLE
Site Keyrings: remove Lodash from selectors, rewrite query comp to functional

### DIFF
--- a/client/components/data/query-site-keyrings/index.js
+++ b/client/components/data/query-site-keyrings/index.js
@@ -1,55 +1,25 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestSiteKeyrings } from 'calypso/state/site-keyrings/actions';
 import { isRequestingSiteKeyrings } from 'calypso/state/site-keyrings/selectors';
 
-class QuerySiteKeyrings extends Component {
-	static propTypes = {
-		siteId: PropTypes.number,
-		requestingSiteKeyrings: PropTypes.bool.isRequired,
-		requestSiteKeyrings: PropTypes.func.isRequired,
-	};
-
-	state = {
-		siteId: null,
-	};
-
-	static getDerivedStateFromProps( nextProps, prevState ) {
-		if ( ! nextProps.siteId || prevState.siteId === nextProps.siteId ) {
-			return null;
-		}
-
-		return { siteId: nextProps.siteId };
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( siteId && ! isRequestingSiteKeyrings( getState(), siteId ) ) {
+		dispatch( requestSiteKeyrings( siteId ) );
 	}
+};
 
-	shouldComponentUpdate( nextProps ) {
-		return this.state.siteId !== nextProps.siteId;
-	}
-
-	componentDidMount() {
-		this.requestKeyrings();
-	}
-
-	componentDidUpdate() {
-		this.requestKeyrings();
-	}
-
-	requestKeyrings() {
-		const { siteId } = this.state;
-		if ( ! this.props.requestingSiteKeyrings && siteId ) {
-			this.props.requestSiteKeyrings( siteId );
-		}
-	}
-
-	render() {
-		return null;
-	}
+function QuerySiteKeyrings( { siteId } ) {
+	const dispatch = useDispatch();
+	useEffect( () => {
+		dispatch( request( siteId ) );
+	}, [ siteId ] );
+	return null;
 }
 
-export default connect(
-	( state, { siteId } ) => ( {
-		requestingSiteKeyrings: isRequestingSiteKeyrings( state, siteId ),
-	} ),
-	{ requestSiteKeyrings }
-)( QuerySiteKeyrings );
+QuerySiteKeyrings.propTypes = {
+	siteId: PropTypes.number,
+};
+
+export default QuerySiteKeyrings;

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -206,7 +206,7 @@ class GoogleMyBusinessStats extends Component {
 
 				<StatsNavigation selectedItem={ 'googleMyBusiness' } siteId={ siteId } slug={ siteSlug } />
 
-				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
+				<QuerySiteKeyrings siteId={ siteId } />
 				<QueryKeyringConnections forceRefresh />
 				<QueryKeyringServices />
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -353,7 +353,7 @@ class StatsSite extends Component {
 			<Main wideLayout>
 				<QueryKeyringConnections />
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
-				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
+				<QuerySiteKeyrings siteId={ siteId } />
 				<DocumentHead title={ translate( 'Stats and Insights' ) } />
 				<PageViewTracker
 					path={ `/stats/${ period }/:site` }

--- a/client/state/site-keyrings/selectors.js
+++ b/client/state/site-keyrings/selectors.js
@@ -1,6 +1,6 @@
-import { get, filter, find } from 'lodash';
-
 import 'calypso/state/site-keyrings/init';
+
+const EMPTY_ARRAY = [];
 
 /**
  * Returns true if we are requesting keyrings for the specified site ID, false otherwise.
@@ -10,7 +10,7 @@ import 'calypso/state/site-keyrings/init';
  * @returns {boolean}        Whether site keyrings is being requested
  */
 export function isRequestingSiteKeyrings( state, siteId ) {
-	return get( state.siteKeyrings.requesting, [ siteId ], false );
+	return state.siteKeyrings.requesting[ siteId ] ?? false;
 }
 
 /**
@@ -21,7 +21,7 @@ export function isRequestingSiteKeyrings( state, siteId ) {
  * @returns {object}  Site keyrings indexed by keyring ids
  */
 export function getSiteKeyrings( state, siteId ) {
-	return get( state.siteKeyrings.items, [ siteId ], [] );
+	return state.siteKeyrings.items[ siteId ] ?? EMPTY_ARRAY;
 }
 
 /**
@@ -33,7 +33,9 @@ export function getSiteKeyrings( state, siteId ) {
  * @returns {Array}   Site keyrings list
  */
 export function getSiteKeyringsForService( state, siteId, service ) {
-	return filter( getSiteKeyrings( state, siteId ), { service } );
+	return getSiteKeyrings( state, siteId ).filter(
+		( siteKeyring ) => siteKeyring.service === service
+	);
 }
 
 /**
@@ -47,9 +49,10 @@ export function getSiteKeyringsForService( state, siteId, service ) {
  * @returns {?object}                Site Keyring connection
  */
 export function getSiteKeyringConnection( state, siteId, keyringId, externalUserId = null ) {
-	return find( getSiteKeyrings( state, siteId ), ( siteKeyring ) => {
-		return externalUserId === null
-			? siteKeyring.keyring_id === keyringId
-			: siteKeyring.keyring_id === keyringId && siteKeyring.external_user_id === externalUserId;
+	return getSiteKeyrings( state, siteId ).find( ( siteKeyring ) => {
+		return (
+			siteKeyring.keyring_id === keyringId &&
+			( externalUserId === null || siteKeyring.external_user_id === externalUserId )
+		);
 	} );
 }


### PR DESCRIPTION
Inspired by @tyxla's keyrings state cleanup in #60764, here are a few more changes:
- remove Lodash from site keyrings selectors
- rewrite `QuerySiteKeyrings` to functional with hooks
- remove redundant `{ siteId && <Query siteId> }` guards around the query component
