### PR TITLE
Fix issue with showing WordPress importer when it comes from the list page

### DIFF
--- a/client/signup/steps/import-from/components/importing-pane/importing-pane.tsx
+++ b/client/signup/steps/import-from/components/importing-pane/importing-pane.tsx
@@ -30,8 +30,10 @@ class ImportingPane extends ImportingPaneBase {
 		} );
 
 		// Add the site favicon as author's icon
-		for ( const author of importerStatus.customData.sourceAuthors ) {
-			author.icon = ( urlData as UrlData )?.meta?.favicon;
+		if ( importerStatus?.customData?.sourceAuthors ) {
+			for ( const author of importerStatus.customData.sourceAuthors ) {
+				author.icon = ( urlData as UrlData )?.meta?.favicon;
+			}
 		}
 
 		let { percentComplete, statusMessage } = this.props.importerStatus;

--- a/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
+++ b/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
@@ -34,6 +34,7 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	/**
 	 ↓ Fields
 	 */
+	const showJetpackConnectionBlock = !! fromSite;
 	const [ hasOriginSiteJetpackConnected, setHasOriginSiteJetpackConnected ] = useState( false );
 	const [ isFetchingSite, setIsFetchingSite ] = useState( false );
 
@@ -46,6 +47,8 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	 ↓ Methods
 	 */
 	function checkOriginSiteJetpackConnection() {
+		if ( ! fromSite ) return;
+
 		setIsFetchingSite( true );
 
 		wpcom
@@ -86,7 +89,7 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 							{ __( 'Continue' ) }
 						</NextButton>
 					</ActionCard>
-					{ ! hasOriginSiteJetpackConnected && ! isFetchingSite && (
+					{ showJetpackConnectionBlock && ! hasOriginSiteJetpackConnected && ! isFetchingSite && (
 						<SelectItems
 							onSelect={ onJetpackSelection }
 							items={ [

--- a/client/signup/steps/import-from/wordpress/import-content-only/index.tsx
+++ b/client/signup/steps/import-from/wordpress/import-content-only/index.tsx
@@ -24,7 +24,6 @@ interface Props {
 	siteItem: SitesItem | null;
 	siteSlug: string;
 	siteAnalyzedData: UrlData;
-	fromSite: string;
 }
 
 const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
@@ -33,7 +32,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	/**
 	 ↓ Fields
 	 */
-	const { job, importer, siteItem, siteSlug, siteAnalyzedData, fromSite } = props;
+	const { job, importer, siteItem, siteSlug, siteAnalyzedData } = props;
 
 	/**
 	 ↓ Effects
@@ -55,7 +54,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function prepareImportParams(): ImportJobParams {
-		const targetSiteUrl = fromSite.startsWith( 'http' ) ? fromSite : 'https://' + fromSite;
+		const targetSiteUrl = siteSlug.startsWith( 'http' ) ? siteSlug : 'https://' + siteSlug;
 
 		return {
 			engine: importer,

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -35,7 +35,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	const { job, fromSite, siteSlug, siteId } = props;
 	const siteItem = useSelector( ( state ) => getSiteBySlug( state, siteSlug ) );
 	const fromSiteItem = useSelector( ( state ) =>
-		getSiteBySlug( state, convertToFriendlyWebsiteName( fromSite ) )
+		getSiteBySlug( state, fromSite ? convertToFriendlyWebsiteName( fromSite ) : '' )
 	);
 	const isSiteAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
@@ -127,7 +127,6 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 					return (
 						<ImportContentOnly
 							job={ job }
-							fromSite={ fromSite }
 							importer={ importer }
 							siteItem={ siteItem }
 							siteSlug={ siteSlug }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixed issue with showing WordPress importer when it comes from the list page.
* Added a minor safety check for accessing the undefined value.

#### Testing instructions
- Go to `start/importer/capture?siteSlug={SLUG}.wordpress.com`
- Click on the "I don't have a site address" in the top right corner
- Select the WordPress importer
- Click on the "Import your content"
- Check if the page is rendered and the available option is "Content only" import type (before this change, it was a blank page with errors in the console)

Related to #57131
