### PR TITLE
Update sidebar Plan name when user cancels or downgrades their plan.

### DIFF
--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -13,8 +13,8 @@ import {
 	PURCHASE_REMOVE_FAILED,
 } from 'calypso/state/action-types';
 import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
-import { requestAdminMenu } from '../admin-menu/actions';
-import { getSelectedSiteId } from '../ui/selectors';
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import 'calypso/state/purchases/init';
 
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' );

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -13,15 +13,19 @@ import {
 	PURCHASE_REMOVE_FAILED,
 } from 'calypso/state/action-types';
 import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
-
+import { requestAdminMenu } from '../admin-menu/actions';
+import { getSelectedSiteId } from '../ui/selectors';
 import 'calypso/state/purchases/init';
 
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' );
 const PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase.' );
 
-export const clearPurchases = () => ( dispatch ) => {
+export const clearPurchases = () => ( dispatch, getState ) => {
+	const siteId = getSelectedSiteId( getState() );
+
 	dispatch( { type: PURCHASES_REMOVE } );
 	dispatch( requestHappychatEligibility() );
+	dispatch( requestAdminMenu( siteId ) );
 };
 
 export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
@@ -69,7 +73,9 @@ export const fetchUserPurchases = ( userId ) => ( dispatch ) => {
 		} );
 };
 
-export const removePurchase = ( purchaseId, userId ) => ( dispatch ) => {
+export const removePurchase = ( purchaseId, userId ) => ( dispatch, getState ) => {
+	const siteId = getSelectedSiteId( getState() );
+
 	return new Promise( ( resolve ) =>
 		wpcom.req
 			.post( {
@@ -84,6 +90,7 @@ export const removePurchase = ( purchaseId, userId ) => ( dispatch ) => {
 				} );
 
 				dispatch( requestHappychatEligibility() );
+				dispatch( requestAdminMenu( siteId ) );
 
 				resolve( data );
 			} )

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -25,7 +25,9 @@ export const clearPurchases = () => ( dispatch, getState ) => {
 
 	dispatch( { type: PURCHASES_REMOVE } );
 	dispatch( requestHappychatEligibility() );
-	dispatch( requestAdminMenu( siteId ) );
+	if ( siteId ) {
+		dispatch( requestAdminMenu( siteId ) );
+	}
 };
 
 export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
@@ -90,7 +92,9 @@ export const removePurchase = ( purchaseId, userId ) => ( dispatch, getState ) =
 				} );
 
 				dispatch( requestHappychatEligibility() );
-				dispatch( requestAdminMenu( siteId ) );
+				if ( siteId ) {
+					dispatch( requestAdminMenu( siteId ) );
+				}
 
 				resolve( data );
 			} )

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -12,8 +12,8 @@ import {
 	PURCHASE_REMOVE_COMPLETED,
 	PURCHASE_REMOVE_FAILED,
 } from 'calypso/state/action-types';
-import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
+import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import 'calypso/state/purchases/init';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a call to `requestAdminMenu()` in `clearPurchases()` and `removePurchase()` to refresh the sidebar so the Plan name is updated after a user cancels or downgrades their Plan.

![plan-sidebar](https://user-images.githubusercontent.com/140841/152597563-6a82a73e-e0d8-4e73-a126-1737e7f8f3ce.png)

#### Testing instructions

* Checkout this PR
* Using a test account try purchasing a plan and then canceling your plan.
* The Plan name in the sidebar (see image above) should always be correct and up-to-date.

Related to #59834