### PR TITLE
Woo Installer: Make back button work landing page agnostic

### DIFF
--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -46,8 +46,9 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 		} );
 
 		return page(
-			addQueryArgs( `/start/woocommerce-install/?siteSlug=${ wpcomDomain }`, {
+			addQueryArgs( '/start/woocommerce-install', {
 				back_to: `/woocommerce-installation/${ wpcomDomain }`,
+				siteSlug: wpcomDomain,
 			} )
 		);
 	}

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
 import page from 'page';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
@@ -44,7 +45,11 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 			feature: 'woop', // WooCommerce on Plans
 		} );
 
-		return page( `/start/woocommerce-install/?siteSlug=${ wpcomDomain }` );
+		return page(
+			addQueryArgs( `/start/woocommerce-install/?siteSlug=${ wpcomDomain }`, {
+				back_to: `/woocommerce-installation/${ wpcomDomain }`,
+			} )
+		);
 	}
 
 	function renderWarningNotice() {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -411,7 +411,7 @@ export function generateFlows( {
 			steps: [ 'store-address', 'business-info', 'confirm', 'transfer' ],
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',
-			providesDependenciesInQuery: [ 'siteSlug' ],
+			providesDependenciesInQuery: [ 'siteSlug', 'back_to' ],
 			lastModified: '2021-12-21',
 			disallowResume: false,
 		},

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -412,6 +412,7 @@ export function generateFlows( {
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',
 			providesDependenciesInQuery: [ 'siteSlug', 'back_to' ],
+			optionalDependenciesInQuery: [ 'back_to' ],
 			lastModified: '2021-12-21',
 			disallowResume: false,
 		},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -740,7 +740,7 @@ export function generateSteps( {
 		// Woocommerce Install steps.
 		'store-address': {
 			stepName: 'store-address',
-			dependencies: [ 'siteSlug' ],
+			dependencies: [ 'siteSlug', 'back_to' ],
 		},
 		'business-info': {
 			stepName: 'business-info',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -741,6 +741,7 @@ export function generateSteps( {
 		'store-address': {
 			stepName: 'store-address',
 			dependencies: [ 'siteSlug', 'back_to' ],
+			optionalDependencies: [ 'back_to' ],
 		},
 		'business-info': {
 			stepName: 'business-info',

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -10,6 +10,7 @@ import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
 import flows from 'calypso/signup/config/flows';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { updateDependencies } from 'calypso/state/signup/actions';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
@@ -290,6 +291,11 @@ export default {
 
 		// Update initialContext to help woocommerce-install support site switching.
 		if ( 'woocommerce-install' === flowName ) {
+			if ( context?.query?.back_to ) {
+				// forces back_to update
+				context.store.dispatch( updateDependencies( { back_to: context.query.back_to } ) );
+			}
+
 			initialContext = context;
 		}
 

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -1,3 +1,4 @@
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
@@ -154,7 +155,11 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 		} );
 		switch ( selectedOption ) {
 			case 'power':
-				page.redirect( `/start/woocommerce-install/?site=${ siteSlug }` );
+				page(
+					addQueryArgs( `/start/woocommerce-install/?site=${ siteSlug }`, {
+						back_to: `/start/setup-site/store-features?siteSlug=${ siteSlug }`,
+					} )
+				);
 				break;
 
 			case 'simple': {

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -156,8 +156,9 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 		switch ( selectedOption ) {
 			case 'power':
 				page(
-					addQueryArgs( `/start/woocommerce-install/?site=${ siteSlug }`, {
+					addQueryArgs( `/start/woocommerce-install`, {
 						back_to: `/start/setup-site/store-features?siteSlug=${ siteSlug }`,
+						siteSlug: siteSlug,
 					} )
 				);
 				break;

--- a/client/signup/steps/woocommerce-install/components/support-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/support-card/index.tsx
@@ -30,7 +30,7 @@ export default function SupportCard( { backUrl }: { backUrl?: string } ): ReactE
 				a: (
 					<SupportLinkStyle
 						href={ addQueryArgs( '/help/contact', {
-							redirect_to: backUrl || `${ window.location.pathname }?site=${ domain }`,
+							redirect_to: backUrl || `${ window.location.pathname }?siteSlug=${ domain }`,
 						} ) }
 					/>
 				),

--- a/client/signup/steps/woocommerce-install/index.tsx
+++ b/client/signup/steps/woocommerce-install/index.tsx
@@ -17,6 +17,7 @@ export interface WooCommerceInstallProps {
 	signupDependencies: {
 		siteSlug: string;
 		siteConfirmed?: number;
+		back_to?: string;
 	};
 }
 

--- a/client/signup/steps/woocommerce-install/index.tsx
+++ b/client/signup/steps/woocommerce-install/index.tsx
@@ -17,6 +17,23 @@ export interface WooCommerceInstallProps {
 	signupDependencies: {
 		siteSlug: string;
 		siteConfirmed?: number;
+	};
+}
+export interface WooCommerceStoreAddressProps {
+	siteId: number;
+	goToStep: GoToStep;
+	goToNextStep: GoToNextStep;
+	stepName: string;
+	stepSectionName: string;
+	isReskinned: boolean;
+	headerTitle: string;
+	headerDescription: string;
+	queryObject: {
+		site: string;
+	};
+	signupDependencies: {
+		site: string;
+		siteConfirmed?: number;
 		back_to?: string;
 	};
 }

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -56,6 +56,13 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	const { get, save, update } = useSiteSettings( siteId );
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 
+	// Get the correct URL for the back button.
+	const urlParams = new URLSearchParams( window.location.search );
+	const backPath = urlParams.get( 'back_to' ) ?? '';
+	const backUrl = backPath.match( /^\/(?!\/)/ )
+		? backPath
+		: `/woocommerce-installation/${ domain }`;
+
 	const { validate, clearError, getError, errors } = useAddressFormValidation( siteId );
 
 	// @todo: Add a general hook to get and update multi-option data like the profile.
@@ -207,7 +214,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 			flowName="woocommerce-install"
 			hideSkip={ true }
 			allowBackFirstStep={ true }
-			backUrl={ `/woocommerce-installation/${ domain }` }
+			backUrl={ backUrl }
 			headerText={ __( 'Add an address to accept payments' ) }
 			fallbackHeaderText={ __( 'Add an address to accept payments' ) }
 			subHeaderText={ __(

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -10,6 +10,7 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { fetchWooCommerceCountries } from 'calypso/state/countries/actions';
 import getCountries from 'calypso/state/selectors/get-countries';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ActionSection, StyledNextButton } from '..';
 import SupportCard from '../components/support-card';
@@ -56,7 +57,11 @@ export default function StepStoreAddress(
 
 	const { get, save, update } = useSiteSettings( siteId );
 
-	const backUrl = signupDependencies.back_to;
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const backPath = signupDependencies?.back_to;
+	// Check for a valid back path, otherwise go back to the WooCommerce install landing page.
+	const backUrl =
+		backPath && backPath.match( /^\/(?!\/)/ ) ? backPath : `/woocommerce-installation/${ domain }`;
 
 	const { validate, clearError, getError, errors } = useAddressFormValidation( siteId );
 

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -10,7 +10,6 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { fetchWooCommerceCountries } from 'calypso/state/countries/actions';
 import getCountries from 'calypso/state/selectors/get-countries';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ActionSection, StyledNextButton } from '..';
 import SupportCard from '../components/support-card';
@@ -24,7 +23,7 @@ import {
 	WOOCOMMERCE_ONBOARDING_PROFILE,
 	optionNameType,
 } from '../hooks/use-site-settings';
-import type { WooCommerceInstallProps } from '..';
+import type { WooCommerceStoreAddressProps } from '..';
 import './style.scss';
 
 const CityZipRow = styled.div`
@@ -37,7 +36,9 @@ const CityZipRow = styled.div`
 	justify-items: stretch;
 `;
 
-export default function StepStoreAddress( props: WooCommerceInstallProps ): ReactElement | null {
+export default function StepStoreAddress(
+	props: WooCommerceStoreAddressProps
+): ReactElement | null {
 	const { goToNextStep, isReskinned, signupDependencies } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
@@ -54,9 +55,8 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	} );
 
 	const { get, save, update } = useSiteSettings( siteId );
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 
-	const backUrl = signupDependencies.back_to ?? `/woocommerce-installation/${ domain }`;
+	const backUrl = signupDependencies.back_to;
 
 	const { validate, clearError, getError, errors } = useAddressFormValidation( siteId );
 

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -38,7 +38,7 @@ const CityZipRow = styled.div`
 `;
 
 export default function StepStoreAddress( props: WooCommerceInstallProps ): ReactElement | null {
-	const { goToNextStep, isReskinned } = props;
+	const { goToNextStep, isReskinned, signupDependencies } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
@@ -56,12 +56,7 @@ export default function StepStoreAddress( props: WooCommerceInstallProps ): Reac
 	const { get, save, update } = useSiteSettings( siteId );
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 
-	// Get the correct URL for the back button.
-	const urlParams = new URLSearchParams( window.location.search );
-	const backPath = urlParams.get( 'back_to' ) ?? '';
-	const backUrl = backPath.match( /^\/(?!\/)/ )
-		? backPath
-		: `/woocommerce-installation/${ domain }`;
+	const backUrl = signupDependencies.back_to ?? `/woocommerce-installation/${ domain }`;
 
 	const { validate, clearError, getError, errors } = useAddressFormValidation( siteId );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Store correct back URL in `back_to` query param

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On `woocommerce-installation/< site id >` click "Start a new store," then click back. Verify that you return to the same landing page.
* On `/start`, follow the signup wizard and choose "Sell" to enter the seller experience. On "Set up your store" choose "Upgrade," then click back. Verify that you return to the seller experience.
* On `/start`, follow the signup wizard and choose "Sell" to enter the seller experience. On "Set up your store" choose "Upgrade," then click fill the form and hit continue , then click back two times trying to get to the seller experience. Verify that you return to the seller experience.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60569
