### PR TITLE
Update domain only thank you page

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -81,7 +81,7 @@ const ThankYouNotice = ( props: ThankYouNoticeProps ) => {
 			{ noticeIcon && (
 				<Gridicon icon={ noticeIcon } className="thank-you__notice-icon" size={ 24 } />
 			) }
-			{ noticeIconCustom && noticeIconCustom }
+			{ noticeIconCustom }
 			{ noticeTitle }
 		</ThankYouNoticeContainer>
 	);

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -74,13 +74,14 @@ const ThankYouNoticeContainer = styled.div`
 `;
 
 const ThankYouNotice = ( props: ThankYouNoticeProps ) => {
-	const { noticeTitle, noticeIcon } = props;
+	const { noticeTitle, noticeIcon, noticeIconCustom } = props;
 
 	return (
 		<ThankYouNoticeContainer className="thank-you__notice">
 			{ noticeIcon && (
 				<Gridicon icon={ noticeIcon } className="thank-you__notice-icon" size={ 24 } />
 			) }
+			{ noticeIconCustom && noticeIconCustom }
 			{ noticeTitle }
 		</ThankYouNoticeContainer>
 	);

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -11,6 +11,7 @@ export type ThankYouNextStepProps = {
 export type ThankYouNoticeProps = {
 	noticeTitle: React.ReactNode | React.ReactFragment;
 	noticeIcon?: string;
+	noticeIconCustom?: React.ReactNode | React.ReactFragment;
 };
 
 export type ThankYouSectionProps = {

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -39,6 +39,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 
 	return (
 		<ThankYou
+			headerBackgroundColor="var( --studio-white )"
 			containerClassName="checkout-thank-you__domains"
 			sections={ thankYouProps.sections }
 			showSupportSection={ true }

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Button, Gridicon } from '@automattic/components';
-import { useMemo } from 'react';
+import { translate } from 'i18n-calypso';
+import { useMemo, useEffect } from 'react';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { ThankYou } from 'calypso/components/thank-you';
@@ -44,7 +45,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	}, [ type, domain, selectedSiteSlug, email, hasProfessionalEmail, hideProfessionalEmailStep ] );
 	const dispatch = useDispatch();
 
-	React.useEffect( () => {
+	useEffect( () => {
 		dispatch( hideMasterbar() );
 		return () => {
 			dispatch( showMasterbar() );
@@ -57,7 +58,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 				<WordPressLogo className="checkout-thank-you__domains-header-logo" size={ 24 } />
 				<Button borderless={ true } href={ domainManagementRoot() }>
 					<Gridicon icon={ 'chevron-left' } size={ 18 } />
-					<span>All Domains</span>
+					<span>{ translate( 'All domains' ) }</span>
 				</Button>
 			</div>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
 import { ThankYou } from 'calypso/components/thank-you';
 import domainThankYouContent from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content';
 import {
 	DomainThankYouProps,
 	DomainThankYouType,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
+import { hideMasterbar, showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 
 import './style.scss';
 
@@ -36,6 +38,14 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 			hideProfessionalEmailStep,
 		} );
 	}, [ type, domain, selectedSiteSlug, email, hasProfessionalEmail, hideProfessionalEmailStep ] );
+	const dispatch = useDispatch();
+
+	React.useEffect( () => {
+		dispatch( hideMasterbar() );
+		return () => {
+			dispatch( showMasterbar() );
+		};
+	}, [ dispatch ] );
 
 	return (
 		<ThankYou

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -1,12 +1,16 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Button, Gridicon } from '@automattic/components';
 import { useMemo } from 'react';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { ThankYou } from 'calypso/components/thank-you';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import domainThankYouContent from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content';
 import {
 	DomainThankYouProps,
 	DomainThankYouType,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
+import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 
 import './style.scss';
@@ -47,17 +51,32 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		};
 	}, [ dispatch ] );
 
+	const renderHeader = () => {
+		return (
+			<div className="checkout-thank-you__domains-header">
+				<WordPressLogo className="checkout-thank-you__domains-header-logo" size={ 24 } />
+				<Button borderless={ true } href={ domainManagementRoot() }>
+					<Gridicon icon={ 'chevron-left' } size={ 18 } />
+					<span>All Domains</span>
+				</Button>
+			</div>
+		);
+	};
+
 	return (
-		<ThankYou
-			headerBackgroundColor="var( --studio-white )"
-			containerClassName="checkout-thank-you__domains"
-			sections={ thankYouProps.sections }
-			showSupportSection={ true }
-			thankYouImage={ thankYouProps.thankYouImage }
-			thankYouTitle={ thankYouProps.thankYouTitle }
-			thankYouSubtitle={ thankYouProps.thankYouSubtitle }
-			thankYouNotice={ thankYouProps.thankYouNotice }
-		/>
+		<>
+			{ renderHeader() }
+			<ThankYou
+				headerBackgroundColor="var( --studio-white )"
+				containerClassName="checkout-thank-you__domains"
+				sections={ thankYouProps.sections }
+				showSupportSection={ true }
+				thankYouImage={ thankYouProps.thankYouImage }
+				thankYouTitle={ thankYouProps.thankYouTitle }
+				thankYouSubtitle={ thankYouProps.thankYouSubtitle }
+				thankYouNotice={ thankYouProps.thankYouNotice }
+			/>
+		</>
 	);
 };
 

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -56,8 +56,8 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		return (
 			<div className="checkout-thank-you__domains-header">
 				<WordPressLogo className="checkout-thank-you__domains-header-logo" size={ 24 } />
-				<Button borderless={ true } href={ domainManagementRoot() }>
-					<Gridicon icon={ 'chevron-left' } size={ 18 } />
+				<Button borderless href={ domainManagementRoot() }>
+					<Gridicon icon="chevron-left" size={ 18 } />
 					<span>{ translate( 'All domains' ) }</span>
 				</Button>
 			</div>

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -11,3 +11,34 @@
 		padding-left: 0;
 	}
 }
+
+.checkout-thank-you__domains {
+	.thank-you__container-header {
+		min-height: auto;
+		margin-top: 80px;
+		padding-bottom: 0;
+	}
+	.thank-you__header-title {
+		color: var( --studio-gray-100 );
+		@include break-small {
+			font-size: $font-headline-medium;
+		}
+	}
+	.thank-you__header-subtitle {
+		color: var( --studio-gray-100 );
+	}
+	.thank-you__body {
+		margin-top: 72px;
+	}
+	.thank-you__notice {
+		background-color: var( --studio-gray-0 );
+		color: var( --studio-gray-50 );
+		max-width: 600px;
+		height: auto;
+		margin: auto;
+		svg {
+			fill: var( --studio-gray-50 );
+			margin-right: 3px;
+		}
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -18,18 +18,22 @@
 		margin-top: 80px;
 		padding-bottom: 0;
 	}
+
 	.thank-you__header-title {
 		color: var( --studio-gray-100 );
 		@include break-small {
 			font-size: $font-headline-medium;
 		}
 	}
+
 	.thank-you__header-subtitle {
 		color: var( --studio-gray-100 );
 	}
+
 	.thank-you__body {
 		margin-top: 72px;
 	}
+
 	.thank-you__notice {
 		background-color: var( --studio-gray-0 );
 		color: var( --studio-gray-50 );
@@ -41,9 +45,11 @@
 			margin-right: 3px;
 		}
 	}
+
 	.thank-you__step-cta .button {
 		padding: 8px 10px;
 	}
+
 	.thank-you__step {
 		align-items: center;
 	}
@@ -57,6 +63,7 @@
 	display: flex;
 	align-items: center;
 	padding: 16px 24px;
+
 	.button.is-borderless {
 		svg.gridicon {
 			height: 16px;
@@ -67,6 +74,7 @@
 		align-items: flex-start;
 		font-weight: 500;
 	}
+
 	.checkout-thank-you__domains-header-logo {
 		fill: var( --studio-gray-60 );
 		margin-right: 28px;

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -41,6 +41,12 @@
 			margin-right: 3px;
 		}
 	}
+	.thank-you__step-cta .button {
+		padding: 8px 10px;
+	}
+	.thank-you__step {
+		align-items: center;
+	}
 }
 
 .checkout-thank-you__domains-header {

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -42,3 +42,27 @@
 		}
 	}
 }
+
+.checkout-thank-you__domains-header {
+	position: absolute;
+	top: 0;
+	left: 0;
+	color: var( --studio-gray-60 );
+	display: flex;
+	align-items: center;
+	padding: 16px 24px;
+	.button.is-borderless {
+		svg.gridicon {
+			height: 16px;
+			width: 16px;
+			margin-right: 12px;
+		}
+		display: flex;
+		align-items: flex-start;
+		font-weight: 500;
+	}
+	.checkout-thank-you__domains-header-logo {
+		fill: var( --studio-gray-60 );
+		margin-right: 28px;
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -28,6 +28,40 @@ const DomainRegistrationThankYouProps = ( {
 		true
 	);
 
+	const createSiteStep = {
+		stepKey: 'domain_registration_whats_next_create-site',
+		stepTitle: translate( 'Add a site' ),
+		stepDescription: translate( 'Choose a theme, customize and launch your site.' ),
+		stepCta: (
+			<FullWidthButton
+				href={ createSiteFromDomainOnly( domain, null ) }
+				busy={ false }
+				disabled={ false }
+			>
+				{ translate( 'Create a site' ) }
+			</FullWidthButton>
+		),
+	};
+
+	const viewDomainsStep = {
+		stepKey: 'domain_registration_whats_next_view_domains',
+		stepTitle: selectedSiteSlug
+			? translate( 'Organize your domains' )
+			: translate( 'Manage your domains' ),
+		stepDescription: selectedSiteSlug
+			? translate(
+					'Set up a primary domain, connect other domains and make sure people can find your site.'
+			  )
+			: translate(
+					'View domain settings, manage every aspect of your domain and add additional domains.'
+			  ),
+		stepCta: (
+			<FullWidthButton href={ domainManagementList( '' ) } busy={ false } disabled={ false }>
+				{ selectedSiteSlug ? translate( 'Manage domains' ) : translate( 'View your domains' ) }
+			</FullWidthButton>
+		),
+	};
+
 	const returnProps: DomainThankYouProps = {
 		thankYouNotice: {
 			noticeTitle: translate(
@@ -41,48 +75,8 @@ const DomainRegistrationThankYouProps = ( {
 				sectionTitle: translate( 'What’s next?' ),
 				nextSteps: [
 					...( professionalEmail ? [ professionalEmail ] : [] ),
-					...( ! selectedSiteSlug
-						? [
-								{
-									stepKey: 'domain_registration_whats_next_create-site',
-									stepTitle: translate( 'Add a site' ),
-									stepDescription: translate( 'Choose a theme, customize and launch your site.' ),
-									stepCta: (
-										<FullWidthButton
-											href={ createSiteFromDomainOnly( domain, null ) }
-											busy={ false }
-											disabled={ false }
-										>
-											{ translate( 'Create a site' ) }
-										</FullWidthButton>
-									),
-								},
-						  ]
-						: [] ),
-					{
-						stepKey: 'domain_registration_whats_next_view_domains',
-						stepTitle: selectedSiteSlug
-							? translate( 'Organize your domains' )
-							: translate( 'Manage your domains' ),
-						stepDescription: selectedSiteSlug
-							? translate(
-									'Set up a primary domain, connect other domains and make sure people can find your site.'
-							  )
-							: translate(
-									'View domain settings, manage every aspect of your domain and add additional domains.'
-							  ),
-						stepCta: (
-							<FullWidthButton
-								href={ domainManagementList( '' ) }
-								busy={ false }
-								disabled={ false }
-							>
-								{ selectedSiteSlug
-									? translate( 'Manage domains' )
-									: translate( 'View your domains' ) }
-							</FullWidthButton>
-						),
-					},
+					...( ! selectedSiteSlug ? [ createSiteStep ] : [] ),
+					viewDomainsStep,
 				],
 			},
 		],

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -1,3 +1,4 @@
+import { Icon, info } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import domainRegisteredSuccess from 'calypso/assets/images/domains/domain.svg';
 import { buildDomainStepForProfessionalEmail } from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
@@ -24,15 +25,22 @@ const DomainRegistrationThankYouProps = ( {
 			selectedSiteSlug,
 		},
 		'REGISTRATION',
-		false
+		true
 	);
 
 	const returnProps: DomainThankYouProps = {
+		thankYouNotice: {
+			noticeTitle: translate(
+				'During setup your domain may be unreliable during the first 30 minutes.'
+			),
+			noticeIconCustom: <Icon icon={ info } size={ 24 } />,
+		},
 		sections: [
 			{
 				sectionKey: 'domain_registration_whats_next',
 				sectionTitle: translate( 'What’s next?' ),
 				nextSteps: [
+					...( professionalEmail ? [ professionalEmail ] : [] ),
 					{
 						stepKey: 'domain_registration_whats_next_plugin_setup',
 						stepTitle: translate( 'Organize your domains' ),
@@ -42,7 +50,6 @@ const DomainRegistrationThankYouProps = ( {
 						stepCta: (
 							<FullWidthButton
 								href={ domainManagementList( selectedSiteSlug ?? domain, null ) }
-								primary
 								busy={ false }
 								disabled={ false }
 							>
@@ -50,7 +57,6 @@ const DomainRegistrationThankYouProps = ( {
 							</FullWidthButton>
 						),
 					},
-					...( professionalEmail ? [ professionalEmail ] : [] ),
 				],
 			},
 		],
@@ -60,7 +66,7 @@ const DomainRegistrationThankYouProps = ( {
 			width: '150px',
 			height: 'auto',
 		},
-		thankYouTitle: translate( 'Congratulations on your purchase!' ),
+		thankYouTitle: translate( 'All ready to go!' ),
 		thankYouSubtitle: translate(
 			'Your new domain {{strong}}%(domain)s{{/strong}} is being set up.',
 			{

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -31,7 +31,7 @@ const DomainRegistrationThankYouProps = ( {
 	const returnProps: DomainThankYouProps = {
 		thankYouNotice: {
 			noticeTitle: translate(
-				'During setup your domain may be unreliable during the first 30 minutes.'
+				'It may take up to 30 minutes for your domain to start working properly.'
 			),
 			noticeIconCustom: <Icon icon={ info } size={ 24 } />,
 		},

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -2,7 +2,7 @@ import { Icon, info } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import domainRegisteredSuccess from 'calypso/assets/images/domains/domain.svg';
 import { buildDomainStepForProfessionalEmail } from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
-import { domainManagementList } from 'calypso/my-sites/domains/paths';
+import { domainManagementList, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import type {
 	DomainThankYouParams,
@@ -42,6 +42,20 @@ const DomainRegistrationThankYouProps = ( {
 				nextSteps: [
 					...( professionalEmail ? [ professionalEmail ] : [] ),
 					{
+						stepKey: 'domain_registration_whats_next_create-site',
+						stepTitle: translate( 'Add a site' ),
+						stepDescription: translate( 'Choose a theme, customize and launch your site.' ),
+						stepCta: (
+							<FullWidthButton
+								href={ createSiteFromDomainOnly( selectedSiteSlug ?? domain, null ) }
+								busy={ false }
+								disabled={ false }
+							>
+								{ translate( 'Create a site' ) }
+							</FullWidthButton>
+						),
+					},
+					{
 						stepKey: 'domain_registration_whats_next_plugin_setup',
 						stepTitle: translate( 'Manage your domains' ),
 						stepDescription: translate(
@@ -49,7 +63,7 @@ const DomainRegistrationThankYouProps = ( {
 						),
 						stepCta: (
 							<FullWidthButton
-								href={ domainManagementList( selectedSiteSlug ?? domain, null ) }
+								href={ domainManagementList( '' ) }
 								busy={ false }
 								disabled={ false }
 							>

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -43,9 +43,9 @@ const DomainRegistrationThankYouProps = ( {
 					...( professionalEmail ? [ professionalEmail ] : [] ),
 					{
 						stepKey: 'domain_registration_whats_next_plugin_setup',
-						stepTitle: translate( 'Organize your domains' ),
+						stepTitle: translate( 'Manage your domains' ),
 						stepDescription: translate(
-							'Set up a primary domain, connect other domains and make sure people can find your site'
+							'View domain settings, manage every aspect of your domain and add additional domains.'
 						),
 						stepCta: (
 							<FullWidthButton
@@ -53,7 +53,7 @@ const DomainRegistrationThankYouProps = ( {
 								busy={ false }
 								disabled={ false }
 							>
-								{ translate( 'Manage domains' ) }
+								{ translate( 'View your domains' ) }
 							</FullWidthButton>
 						),
 					},

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -41,33 +41,45 @@ const DomainRegistrationThankYouProps = ( {
 				sectionTitle: translate( 'What’s next?' ),
 				nextSteps: [
 					...( professionalEmail ? [ professionalEmail ] : [] ),
-					{
-						stepKey: 'domain_registration_whats_next_create-site',
-						stepTitle: translate( 'Add a site' ),
-						stepDescription: translate( 'Choose a theme, customize and launch your site.' ),
-						stepCta: (
-							<FullWidthButton
-								href={ createSiteFromDomainOnly( selectedSiteSlug ?? domain, null ) }
-								busy={ false }
-								disabled={ false }
-							>
-								{ translate( 'Create a site' ) }
-							</FullWidthButton>
-						),
-					},
+					...( ! selectedSiteSlug
+						? [
+								{
+									stepKey: 'domain_registration_whats_next_create-site',
+									stepTitle: translate( 'Add a site' ),
+									stepDescription: translate( 'Choose a theme, customize and launch your site.' ),
+									stepCta: (
+										<FullWidthButton
+											href={ createSiteFromDomainOnly( domain, null ) }
+											busy={ false }
+											disabled={ false }
+										>
+											{ translate( 'Create a site' ) }
+										</FullWidthButton>
+									),
+								},
+						  ]
+						: [] ),
 					{
 						stepKey: 'domain_registration_whats_next_view_domains',
-						stepTitle: translate( 'Manage your domains' ),
-						stepDescription: translate(
-							'View domain settings, manage every aspect of your domain and add additional domains.'
-						),
+						stepTitle: selectedSiteSlug
+							? translate( 'Organize your domains' )
+							: translate( 'Manage your domains' ),
+						stepDescription: selectedSiteSlug
+							? translate(
+									'Set up a primary domain, connect other domains and make sure people can find your site.'
+							  )
+							: translate(
+									'View domain settings, manage every aspect of your domain and add additional domains.'
+							  ),
 						stepCta: (
 							<FullWidthButton
 								href={ domainManagementList( '' ) }
 								busy={ false }
 								disabled={ false }
 							>
-								{ translate( 'View your domains' ) }
+								{ selectedSiteSlug
+									? translate( 'Manage domains' )
+									: translate( 'View your domains' ) }
 							</FullWidthButton>
 						),
 					},

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -56,7 +56,7 @@ const DomainRegistrationThankYouProps = ( {
 						),
 					},
 					{
-						stepKey: 'domain_registration_whats_next_plugin_setup',
+						stepKey: 'domain_registration_whats_next_view_domains',
 						stepTitle: translate( 'Manage your domains' ),
 						stepDescription: translate(
 							'View domain settings, manage every aspect of your domain and add additional domains.'

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer.tsx
@@ -1,3 +1,4 @@
+import { Icon, info } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import domainTransferredSuccess from 'calypso/assets/images/domains/transfer.svg';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
@@ -15,7 +16,7 @@ const domainTransferThankYouProps = ( {
 }: DomainThankYouParams ): DomainThankYouProps => ( {
 	thankYouNotice: {
 		noticeTitle: translate( 'The transfer process can take up to 5 days to complete' ),
-		noticeIcon: 'info',
+		noticeIconCustom: <Icon icon={ info } size={ 24 } />,
 	},
 	sections: [
 		{


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR updates the thank you page in the domain-only flow. It's part of the new domain-only flow (pcYYhz-ye-p2)

Initially this page page will be used for all 3 sub-flow ("_just buy a domain_", "_add a new site_", "_add an existing site_"). Then we will create different variations in subsequents PRs.

Please note that this PR also: 
- updates the style of all domains purchase thank you page (registration/mapping and transfer).
- fixes 665-gh-Automattic/payments-shilling (it completely removes the masterbar)

![thankyou-before](https://user-images.githubusercontent.com/2797601/152844840-75ecabc6-0aad-428b-b23a-b1da01e16cb1.png)

![thankyou-after](https://user-images.githubusercontent.com/2797601/152947890-b15e5b18-c944-4d04-ac92-4ff35ddb0763.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to to `/start/domain/domain-only`
- Enter a domain name and select it, in order to move to the next step
- Select "_Just buy a domain_" and complete the checkout (if you have a valid receipt for a domain only purchase you can directly visit the thank you page navigating this url `/checkout/thank-you/no-site/[:receipt-id]`)
- Verify that the layout is updated according the screenshot above