### PR TITLE
Add Jetpack Sale Coupons to Variant Selectors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -18,6 +18,7 @@ import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useEffect, useState, useMemo, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { getJetpackCouponDiscountMap } from 'calypso/state/marketing/selectors';
 import { requestPlans } from 'calypso/state/plans/actions';
 import { requestProductsList } from 'calypso/state/products-list/actions';
 import { computeProductsWithPrices } from 'calypso/state/products-list/selectors';
@@ -86,6 +87,8 @@ export function useGetProductVariants(
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
+	const jetpackCouponDiscountMap = useSelector( getJetpackCouponDiscountMap );
+
 	const sitePlans: SitesPlansResult | null = useSelector( ( state ) =>
 		siteId ? getPlansBySiteId( state, siteId ) : null
 	);
@@ -98,7 +101,13 @@ export function useGetProductVariants(
 	debug( 'variantProductSlugs', variantProductSlugs );
 
 	const variantsWithPrices: AvailableProductVariant[] = useSelector( ( state ) => {
-		return computeProductsWithPrices( state, siteId, variantProductSlugs, 0, {} );
+		return computeProductsWithPrices(
+			state,
+			siteId,
+			variantProductSlugs,
+			0,
+			jetpackCouponDiscountMap
+		);
 	} );
 
 	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -49,14 +49,15 @@ export function getJetpackCouponDiscountMap( state: AppState ): DiscountMap {
 	const discount = ( 100 - ( getJetpackSaleCoupon( state )?.discount || 0 ) ) / 100;
 	const discountMap: DiscountMap = {};
 
-	[ JETPACK_RESET_PLANS_BY_TERM, JETPACK_PRODUCTS_BY_TERM ].forEach( ( productSlugMap ) =>
-		productSlugMap.forEach( ( { yearly } ) => {
-			// search requires special discount support since
+	//  outside of sales ( where the discount is 100% or full price ) there is no need to build this object
+	if ( discount < 1 ) {
+		[ ...JETPACK_RESET_PLANS_BY_TERM, ...JETPACK_PRODUCTS_BY_TERM ].forEach( ( { yearly } ) => {
+			// search requires special discount support since it does not have an introductory offer
 			if ( yearly !== PRODUCT_JETPACK_SEARCH ) {
 				discountMap[ yearly ] = discount;
 			}
-		} )
-	);
+		} );
+	}
 
 	return discountMap;
 }

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -46,15 +46,17 @@ interface DiscountMap {
 }
 
 export function getJetpackCouponDiscountMap( state: AppState ): DiscountMap {
-	const discount = ( 100 - ( getJetpackSaleCoupon( state )?.discount || 0 ) ) / 100;
+	// discountedPricePercentage is 1 - discountPercentage.
+	const discountedPricePercentage =
+		( 100 - ( getJetpackSaleCoupon( state )?.discount || 0 ) ) / 100;
 	const discountMap: DiscountMap = {};
 
-	//  outside of sales ( where the discount is 100% or full price ) there is no need to build this object
-	if ( discount < 1 ) {
+	//  outside of sales ( when the discountedPricePercentage is 100% or full price ) there is no need to build this object
+	if ( discountedPricePercentage < 1 ) {
 		[ ...JETPACK_RESET_PLANS_BY_TERM, ...JETPACK_PRODUCTS_BY_TERM ].forEach( ( { yearly } ) => {
 			// search requires special discount support since it does not have an introductory offer
 			if ( yearly !== PRODUCT_JETPACK_SEARCH ) {
-				discountMap[ yearly ] = discount;
+				discountMap[ yearly ] = discountedPricePercentage;
 			}
 		} );
 	}

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -1,3 +1,8 @@
+import {
+	JETPACK_PRODUCTS_BY_TERM,
+	JETPACK_RESET_PLANS_BY_TERM,
+	PRODUCT_JETPACK_SEARCH,
+} from '@automattic/calypso-products';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import type { AppState } from 'calypso/types';
 import 'calypso/state/marketing/init';
@@ -34,4 +39,24 @@ export function getJetpackSaleCouponDiscountRatio( state: AppState ): number {
 export function getFullJetpackSaleCouponDiscountRatio( state: AppState ): number {
 	const discount = getJetpackSaleCoupon( state )?.final_discount || 0;
 	return discount / 100;
+}
+
+interface DiscountMap {
+	[ productSlug: string ]: number;
+}
+
+export function getJetpackCouponDiscountMap( state: AppState ): DiscountMap {
+	const discount = ( 100 - ( getJetpackSaleCoupon( state )?.discount || 0 ) ) / 100;
+	const discountMap: DiscountMap = {};
+
+	[ JETPACK_RESET_PLANS_BY_TERM, JETPACK_PRODUCTS_BY_TERM ].forEach( ( productSlugMap ) =>
+		productSlugMap.forEach( ( { yearly } ) => {
+			// search requires special discount support since
+			if ( yearly !== PRODUCT_JETPACK_SEARCH ) {
+				discountMap[ yearly ] = discount;
+			}
+		} )
+	);
+
+	return discountMap;
 }

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -21,7 +21,7 @@ export const computeFullAndMonthlyPricesForPlan = (
 	credits,
 	couponDiscounts
 ) => {
-	const couponDiscount = couponDiscounts[ planObject.getProductId() ] || 0;
+	const couponDiscount = couponDiscounts[ planObject.getStoreSlug() ] || 1;
 
 	if ( planObject.group === GROUP_WPCOM ) {
 		return computePricesForWpComPlan( state, siteId, planObject );
@@ -35,8 +35,11 @@ export const computeFullAndMonthlyPricesForPlan = (
 
 	return {
 		priceFull: planOrProductPrice,
-		priceFinal: Math.max( planOrProductPrice - credits - couponDiscount, 0 ),
-		introductoryOfferPrice,
+		priceFinal: Math.max( planOrProductPrice * couponDiscount - credits, 0 ),
+		introductoryOfferPrice:
+			introductoryOfferPrice !== null
+				? Math.max( introductoryOfferPrice * couponDiscount - credits, 0 )
+				: introductoryOfferPrice,
 	};
 };
 

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -142,7 +142,7 @@ describe( 'selectors', () => {
 
 		test( 'Should return proper priceFinal if couponDiscounts are provided', () => {
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, { def: 60 } ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, { abc: 0.5 } ) ).toEqual( {
 				introductoryOfferPrice: null,
 				priceFull: 120,
 				priceFinal: 60,
@@ -234,7 +234,7 @@ describe( 'selectors', () => {
 			};
 
 			expect(
-				computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, { def: 60, mno: 120 } )
+				computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, { abc: 0.5, jkl: 0.8 } )
 			).toEqual( [
 				{
 					planSlug: 'plan1',
@@ -249,7 +249,7 @@ describe( 'selectors', () => {
 					plan: testPlans.plan2,
 					product: state.productsList.items.plan2,
 					priceFull: 240,
-					priceFinal: 120,
+					priceFinal: 192,
 					introductoryOfferPrice: null,
 				},
 			] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `computeFullAndMonthlyPricesForPlan` to use a map of discount percentages instead of absolute discounts
* Create new `getJetpackCouponDiscountMap` selector to provide a map of discounts for `computeFullAndMonthlyPricesForPlan`
* Update relevant tests to handle discount percentages.

#### Testing instructions

1. Verify `yarn test-client client/state/products-list/test/selectors.js` tests pass.
2. Follow instructions in D74110-code to setup a test coupon and return in via the coupon API.
   - I have a test coupon, `calebtest`, in the store sandbox that should work for testing purposes.
3. Sandbox `public-api.wordpress.com`, boot branch as Calypso Blue or use Calypso Live link, and navigate to `/plans/:siteSlug` for a test jetpack site.
4. Verify that your test coupon is working by observing that the "Get X% off your first year.*" is greater than 50%.
   - It should be X% greater. For example, a 20% sale should be 50 x 1.2 = 60% off.
5. Add a Jetpack plan or Product to the cart.
6. In the cart verify:
   1. That the annual variant selector is for the full amount of the discount
   2. The monthly variant has not changed
   3. The total amount for the product has decreased as well
   -  **Note:** you may need to manually add the coupon at this point 
<img width="568" alt="Screen Shot 2022-02-07 at 12 27 49" src="https://user-images.githubusercontent.com/2810519/152868042-2b952f3b-9ba0-4b6a-ab9b-f46a7ee4c5cc.png">

  
