### PR TITLE
Full Site Editing: don't hide the Customizer link

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -139,6 +139,15 @@ function load_helpers() {
 	if ( ! is_fse_theme() ) {
 		return;
 	}
+
+	// AMP registration on the default 10 priority is too early and confuses the current
+	// Gutenberg (v12.5.1 at this comment's writing) `gutenberg_remove_legacy_pages` function
+	// into mistaking it for the Customizer proper.
+	if ( function_exists( 'amp_add_customizer_link' ) ) {
+		remove_action( 'admin_menu', 'amp_add_customizer_link' );
+		add_action( 'admin_menu', 'amp_add_customizer_link', 11 );
+	}
+
 	if ( apply_filters( 'a8c_hide_core_fse_activation', false ) ) {
 		return;
 	}


### PR DESCRIPTION
AMP is interfering because of a Gutenberg bug in `gutenberg_remove_legacy_pages`

#### Changes proposed in this Pull Request

* Juggle AMP plugin menu page registration to prevent Gutenberg from mistaking it for the Customizer proper

What this fixes is a bug in `gutenberg_remove_legacy_pages` [here](https://github.com/WordPress/gutenberg/blob/a4ab23bfc20817092b05cf9d8d88134e8f9b47d8/lib/compat/wordpress-5.9/admin-menu.php#L24-L27) where any later-defined menu item containing `customize.php` will take over the `$customize_menu` variable to be [restored](https://github.com/WordPress/gutenberg/blob/a4ab23bfc20817092b05cf9d8d88134e8f9b47d8/lib/compat/wordpress-5.9/admin-menu.php#L44) if the site requires the Customizer. This becomes the AMP item, seeing as it uses the Customizer.

To fix this we're moving the AMP registration to happen on a later priority than `gutenberg_legacy_pages` so that it can't get confused. I'll also open an upstream patch on Gutenberg as any other plugin registering a Customizer-based menu item will also fall prey to this (the last item int he list will be kept, rather than the basic Customizer item)

#### Testing instructions
1. Apply this to your sandbox
2. Sandbox `public-api` if you, like me, sometimes mistakenly unsandbox it
3. In Calypso, an FSE-enabled site should still show the Customizer under Appearance (it won't prior to this patch)
4. In Calypso, a Classic site should still show the Customizer
