### PR TITLE
Themes Showcase: Allow block-templates filter search term

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -21,8 +21,6 @@ import {
 	isThemeActive,
 	isInstallingTheme,
 	prependThemeFilterKeys,
-	getActiveTheme,
-	getCanonicalTheme,
 } from 'calypso/state/themes/selectors';
 import { trackClick } from './helpers';
 import './themes-selection.scss';
@@ -194,13 +192,9 @@ function bindGetPremiumThemePrice( state, siteId ) {
 	return ( themeId ) => getPremiumThemePrice( state, themeId, siteId );
 }
 
-function isThemeUniversal( theme ) {
-	return theme?.template !== 'blockbase' && theme?.id !== 'blockbase';
-}
-
 function filterOutUniversalThemes( themes = [] ) {
 	return themes.filter( ( theme ) => {
-		return isThemeUniversal( theme );
+		return theme?.template !== 'blockbase' && theme?.id !== 'blockbase';
 	} );
 }
 
@@ -249,15 +243,11 @@ export const ConnectedThemesSelection = withBlockEditorSettings(
 			let themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
 
 			// The block templates filter is used to search for full site editing (FSE) themes, which includes both
-			// universal and block themes. If, however, a user is already on a universal theme without FSE enabled
-			// (universal classic), selecting another universal theme will not enable the full site editor. Because
-			// of this, we filter out universal themes from the block-templates filter search results for universal
-			// classic sites. This logic will be removed when FSE is enabled for all sites with universal themes.
-			const currentTheme = getCanonicalTheme( state, siteId, getActiveTheme( state, siteId ) );
-			const isUniversalClassicSite =
-				! blockEditorSettings?.is_fse_active && isThemeUniversal( currentTheme );
-
-			if ( filter === 'block-templates' && isUniversalClassicSite ) {
+			// universal and block themes. If, however, a user is in the classic experience without FSE enabled,
+			// selecting another universal theme will not enable the full site editor. Because of this, we filter out
+			// universal themes from the block-templates filter search results for classic sites. This logic will be
+			// removed when FSE is enabled for all sites with universal themes.
+			if ( filter === 'block-templates' && ! blockEditorSettings?.is_fse_eligible ) {
 				themes = filterOutUniversalThemes( themes );
 			}
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -194,9 +194,13 @@ function bindGetPremiumThemePrice( state, siteId ) {
 	return ( themeId ) => getPremiumThemePrice( state, themeId, siteId );
 }
 
+function isThemeUniversal( theme ) {
+	return theme?.template !== 'blockbase' && theme?.id !== 'blockbase';
+}
+
 function filterOutUniversalThemes( themes = [] ) {
 	return themes.filter( ( theme ) => {
-		return theme?.template !== 'blockbase';
+		return isThemeUniversal( theme );
 	} );
 }
 
@@ -249,10 +253,9 @@ export const ConnectedThemesSelection = withBlockEditorSettings(
 			// (universal classic), selecting another universal theme will not enable the full site editor. Because
 			// of this, we filter out universal themes from the block-templates filter search results for universal
 			// classic sites. This logic will be removed when FSE is enabled for all sites with universal themes.
-			const currentThemeId = getActiveTheme( state, siteId );
-			const currentTheme = getCanonicalTheme( state, siteId, currentThemeId );
+			const currentTheme = getCanonicalTheme( state, siteId, getActiveTheme( state, siteId ) );
 			const isUniversalClassicSite =
-				! blockEditorSettings?.is_fse_active && currentTheme?.template === 'blockbase';
+				! blockEditorSettings?.is_fse_active && isThemeUniversal( currentTheme );
 
 			if ( filter === 'block-templates' && isUniversalClassicSite ) {
 				themes = filterOutUniversalThemes( themes );

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import QueryThemes from 'calypso/components/data/query-themes';
 import ThemesList from 'calypso/components/themes-list';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer.js';
@@ -20,6 +21,8 @@ import {
 	isThemeActive,
 	isInstallingTheme,
 	prependThemeFilterKeys,
+	getActiveTheme,
+	getCanonicalTheme,
 } from 'calypso/state/themes/selectors';
 import { trackClick } from './helpers';
 import './themes-selection.scss';
@@ -191,69 +194,95 @@ function bindGetPremiumThemePrice( state, siteId ) {
 	return ( themeId ) => getPremiumThemePrice( state, themeId, siteId );
 }
 
+function filterOutUniversalThemes( themes = [] ) {
+	return themes.filter( ( theme ) => {
+		return theme?.template !== 'blockbase';
+	} );
+}
+
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
 // We do not want pagination triggered in that use of the component.
-export const ConnectedThemesSelection = connect(
-	(
-		state,
-		{
-			filter,
-			page,
-			search,
-			tier,
-			vertical,
-			siteId,
-			source,
-			isLoading: isCustomizedThemeListLoading,
-		}
-	) => {
-		const isJetpack = isJetpackSite( state, siteId );
-		const isAtomic = isSiteAutomatedTransfer( state, siteId );
-		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
+export const ConnectedThemesSelection = withBlockEditorSettings(
+	connect(
+		(
+			state,
+			{
+				filter,
+				page,
+				search,
+				tier,
+				vertical,
+				siteId,
+				source,
+				isLoading: isCustomizedThemeListLoading,
+				blockEditorSettings,
+			}
+		) => {
+			const isJetpack = isJetpackSite( state, siteId );
+			const isAtomic = isSiteAutomatedTransfer( state, siteId );
+			const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
 
-		let sourceSiteId;
-		if ( source === 'wpcom' || source === 'wporg' ) {
-			sourceSiteId = source;
-		} else {
-			sourceSiteId = siteId && isJetpack && ! isAtomic ? siteId : 'wpcom';
-		}
+			let sourceSiteId;
+			if ( source === 'wpcom' || source === 'wporg' ) {
+				sourceSiteId = source;
+			} else {
+				sourceSiteId = siteId && isJetpack && ! isAtomic ? siteId : 'wpcom';
+			}
 
-		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
-		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
-		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
-		// Jetpack themes endpoint.
-		const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
-		const query = {
-			search,
-			page,
-			tier: premiumThemesEnabled ? tier : 'free',
-			filter: compact( [ filter, vertical ] ).join( ',' ),
-			number,
-		};
-		return {
-			query,
-			source: sourceSiteId,
-			siteId: siteId,
-			siteSlug: getSiteSlug( state, siteId ),
-			themes: getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [],
-			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
-			isRequesting:
-				isCustomizedThemeListLoading || isRequestingThemesForQuery( state, sourceSiteId, query ),
-			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
-			isLoggedIn: isUserLoggedIn( state ),
-			isThemeActive: bindIsThemeActive( state, siteId ),
-			isInstallingTheme: bindIsInstallingTheme( state, siteId ),
-			// Note: This component assumes that purchase and plans data is already present in the state tree
-			// (used by the `isPremiumThemeAvailable` selector). That data is provided by the `<QuerySitePurchases />`
-			// and `<QuerySitePlans />` components, respectively. At the time of implementation, neither of them
-			// provides caching, and both are already being rendered by a parent component. So to avoid
-			// redundant AJAX requests, we're not rendering these query components locally.
-			getPremiumThemePrice: bindGetPremiumThemePrice( state, siteId ),
-			filterString: prependThemeFilterKeys( state, query.filter ),
-		};
-	},
-	{ setThemePreviewOptions, recordGoogleEvent, recordTracksEvent }
-)( ThemesSelection );
+			// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
+			// results and sends all of the themes at once. QueryManager is not expecting such behaviour
+			// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
+			// Jetpack themes endpoint.
+			const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
+			const query = {
+				search,
+				page,
+				tier: premiumThemesEnabled ? tier : 'free',
+				filter: compact( [ filter, vertical ] ).join( ',' ),
+				number,
+			};
+
+			let themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
+
+			// The block templates filter is used to search for full site editing (FSE) themes, which includes both
+			// universal and block themes. If, however, a user is already on a universal theme without FSE enabled
+			// (universal classic), selecting another universal theme will not enable the full site editor. Because
+			// of this, we filter out universal themes from the block-templates filter search results for universal
+			// classic sites. This logic will be removed when FSE is enabled for all sites with universal themes.
+			const currentThemeId = getActiveTheme( state, siteId );
+			const currentTheme = getCanonicalTheme( state, siteId, currentThemeId );
+			const isUniversalClassicSite =
+				! blockEditorSettings?.is_fse_active && currentTheme?.template === 'blockbase';
+
+			if ( filter === 'block-templates' && isUniversalClassicSite ) {
+				themes = filterOutUniversalThemes( themes );
+			}
+
+			return {
+				query,
+				source: sourceSiteId,
+				siteId: siteId,
+				siteSlug: getSiteSlug( state, siteId ),
+				themes,
+				themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
+				isRequesting:
+					isCustomizedThemeListLoading || isRequestingThemesForQuery( state, sourceSiteId, query ),
+				isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
+				isLoggedIn: isUserLoggedIn( state ),
+				isThemeActive: bindIsThemeActive( state, siteId ),
+				isInstallingTheme: bindIsInstallingTheme( state, siteId ),
+				// Note: This component assumes that purchase and plans data is already present in the state tree
+				// (used by the `isPremiumThemeAvailable` selector). That data is provided by the `<QuerySitePurchases />`
+				// and `<QuerySitePlans />` components, respectively. At the time of implementation, neither of them
+				// provides caching, and both are already being rendered by a parent component. So to avoid
+				// redundant AJAX requests, we're not rendering these query components locally.
+				getPremiumThemePrice: bindGetPremiumThemePrice( state, siteId ),
+				filterString: prependThemeFilterKeys( state, query.filter ),
+			};
+		},
+		{ setThemePreviewOptions, recordGoogleEvent, recordTracksEvent }
+	)( ThemesSelection )
+);
 
 /**
  * Provide page state management needed for `ThemesSelection`. We cannot store the

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -21,8 +21,7 @@ const fetchFilters = ( action ) =>
 	);
 
 const storeFilters = ( action, data ) => {
-	let filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
-	filters = action.isCoreFse ? filters : omit( filters, 'feature.block-templates' );
+	const filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
 	return { type: THEME_FILTERS_ADD, filters };
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* The block templates filter doesn't work as expected for non `fse-eligible` stickered sites
* Props to @Addison-Stavlo for spotting the issue

**Note:**
We should consider how this will affect the Universal theme classic experience. Should universal classic users be able to search for `block-templates` right now?

### Screenshots
#### Before
![2022-02-07 10 57 57](https://user-images.githubusercontent.com/5414230/152853637-13f8d2d7-12ca-43b2-a5bc-8bba55e59bf6.gif)

#### After
![2022-02-07 10 53 56](https://user-images.githubusercontent.com/5414230/152853351-2260e8ee-6cf5-484a-9748-d75ad76310c6.gif)

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to the local dev environment
* `yarn start`
* Visit the themes showcase for a site in `calypso.localhost:3000`
* Verify that searching for the `block-templates` filter returns the correct themes

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60750
