### PR TITLE
VideoPress: Add support for retrieving "Original" video url for newly transcoded videos

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -174,6 +174,21 @@ class EditorMediaModalDetailFields extends Component {
 		);
 	};
 
+	renderOriginalVideoUrl = () => {
+		const videopressGuid = this.getItemValue( 'videopress_guid' );
+
+		// only render this field if its for a videopress video, and if the provided URL doesn't match the original_url
+		if ( ! videopressGuid || this.getItemValue( 'URL' ) === this.getItemValue( 'original_url' ) ) {
+			return;
+		}
+
+		return (
+			<EditorMediaModalFieldset legend={ this.props.translate( 'Original URL' ) }>
+				<ClipboardButtonInput value={ this.getItemValue( 'original_url' ) } />
+			</EditorMediaModalFieldset>
+		);
+	};
+
 	renderRating = () => {
 		const items = [
 			{
@@ -317,6 +332,7 @@ class EditorMediaModalDetailFields extends Component {
 				{ this.renderAllowDownloadOption() }
 				{ this.renderRating() }
 				{ this.renderVideoPressShortcode() }
+				{ this.renderOriginalVideoUrl() }
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -177,7 +177,7 @@ class EditorMediaModalDetailFields extends Component {
 	renderOriginalVideoUrl = () => {
 		const videopressGuid = this.getItemValue( 'videopress_guid' );
 
-		// only render this field if its for a videopress video, and if the provided URL doesn't match the original_url (or it is blank)
+		// only render this field if its for a videopress video, and if the provided URL doesn't match the original_url (or it is not blank)
 		if (
 			! videopressGuid ||
 			this.getItemValue( 'URL' ) === this.getItemValue( 'original_url' ) ||

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { debounce } from 'lodash';
+import { debounce, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReactDom from 'react-dom';
@@ -177,8 +177,12 @@ class EditorMediaModalDetailFields extends Component {
 	renderOriginalVideoUrl = () => {
 		const videopressGuid = this.getItemValue( 'videopress_guid' );
 
-		// only render this field if its for a videopress video, and if the provided URL doesn't match the original_url
-		if ( ! videopressGuid || this.getItemValue( 'URL' ) === this.getItemValue( 'original_url' ) ) {
+		// only render this field if its for a videopress video, and if the provided URL doesn't match the original_url (or it is blank)
+		if (
+			! videopressGuid ||
+			this.getItemValue( 'URL' ) === this.getItemValue( 'original_url' ) ||
+			isEmpty( this.getItemValue( 'original_url' ) )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
This PR adds a new field to VideoPress Media Library entries to give the user access to their originally uploaded source video, now that we will be returning a "Compatibility" video format in the "URL" field to ensure videos uploaded to VideoPress can be shared and used anywhere on their site and be compatible with the most web browsers.

See pxWta-1bH-p2

#### Changes proposed in this Pull Request

* Add a new `Original URL` field to the detail modal for VideoPress videos where the "URL" field now returns the "Compat" video format (for easy sharing everywhere).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D74381-code to your wpcom sandbox (if it hasn't already been deployed, ensure entire stack is either deployed or on your sandbox)
* upload a video to a site with VideoPress support 
* Open the video in the Media Library in Calypso
* The video should have an "Original URL" field (with a `yoursite.files.wordpress.com` host), and the "URL" field should have a `*_1080p_compat.mp4` file extension (with a `videos.files.wordpress.com` host)
* Open an older video from your media library, the "Original URL" field should not be present and the "Original URL" field should have the source video in it (with a `yoursite.files.wordpress.com` host)
* Do the same test with a Jetpack site, however in all cases the host should always be `videos.files.wordpress.com`