### PR TITLE
CI: upgrade to Playwright 1.18

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "1.16",
+		"playwright": "^1.18",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "^1.18",
+		"playwright": "1.16",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -37,7 +37,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"copy-webpack-plugin": "^10.1.0",
-		"electron": "12.1.0",
+		"electron": "^17.0.0",
 		"electron-builder": "^22.11.7",
 		"electron-notarize": "^0.1.1",
 		"electron-rebuild": "^2.3.5",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -37,7 +37,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"copy-webpack-plugin": "^10.1.0",
-		"electron": "^17.0.0",
+		"electron": "17.0.0",
 		"electron-builder": "^22.11.7",
 		"electron-notarize": "^0.1.1",
 		"electron-rebuild": "^2.3.5",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -37,7 +37,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"copy-webpack-plugin": "^10.1.0",
-		"electron": "17.0.0",
+		"electron": "12.1.0",
 		"electron-builder": "^22.11.7",
 		"electron-notarize": "^0.1.1",
 		"electron-rebuild": "^2.3.5",

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -13,7 +13,7 @@ switch ( process.platform ) {
 	case 'darwin':
 		APP_PATH = path.join(
 			__dirname,
-			'../../../release/mac-arm64/WordPress.com.app/Contents/MacOS/WordPress.com'
+			'../../../release/mac/WordPress.com.app/Contents/MacOS/WordPress.com'
 		);
 		break;
 	default:

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -13,7 +13,7 @@ switch ( process.platform ) {
 	case 'darwin':
 		APP_PATH = path.join(
 			__dirname,
-			'../../../release/mac/WordPress.com.app/Contents/MacOS/WordPress.com'
+			'../../../release/mac-arm64/WordPress.com.app/Contents/MacOS/WordPress.com'
 		);
 		break;
 	default:
@@ -119,7 +119,6 @@ describe( 'User Can log in', () => {
 
 		if ( electronApp ) {
 			try {
-				await electronApp.context().close();
 				await electronApp.close();
 			} catch {}
 		}

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -21,7 +21,7 @@
 		"@types/totp-generator": "^0.0.3",
 		"config": "^3.3.6",
 		"mailosaur": "^7.3.1",
-		"playwright": "1.16",
+		"playwright": "^1.18",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -62,7 +62,7 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"mocha-teamcity-reporter": "^3.0.0",
 		"node-fetch": "^2.6.1",
-		"playwright": "1.16",
+		"playwright": "^1.18",
 		"png-itxt": "^1.3.0",
 		"push-receiver": "^2.0.0",
 		"react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9884,7 +9884,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: ^1.18
+    playwright: 1.16
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -28534,6 +28534,32 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:=1.16.3":
+  version: 1.16.3
+  resolution: "playwright-core@npm:1.16.3"
+  dependencies:
+    commander: ^8.2.0
+    debug: ^4.1.1
+    extract-zip: ^2.0.1
+    https-proxy-agent: ^5.0.0
+    jpeg-js: ^0.4.2
+    mime: ^2.4.6
+    pngjs: ^5.0.0
+    progress: ^2.0.3
+    proper-lockfile: ^4.1.1
+    proxy-from-env: ^1.1.0
+    rimraf: ^3.0.2
+    socks-proxy-agent: ^6.1.0
+    stack-utils: ^2.0.3
+    ws: ^7.4.6
+    yauzl: ^2.10.0
+    yazl: ^2.5.1
+  bin:
+    playwright: cli.js
+  checksum: 9ae0cc2714d24fc464ab29cd9c9f4ed2b6d6cf0d88ed1034d40763501f4a9c5094bdff2008c1eb23123671eb61590b0c71af1971714d3b0b7541e42d3ba0d519
+  languageName: node
+  linkType: hard
+
 "playwright-core@npm:=1.18.1":
   version: 1.18.1
   resolution: "playwright-core@npm:1.18.1"
@@ -28557,6 +28583,17 @@ fsevents@~2.1.2:
   bin:
     playwright: cli.js
   checksum: e64581928d9a42dce66f623b3af8ff8774ab2b09518756eb72449b3c5988cbe7336e898926b0bf3a56c8f317e4419f7aaa2ca3d826e9b705e8912738ffb3d9c0
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.16":
+  version: 1.16.3
+  resolution: "playwright@npm:1.16.3"
+  dependencies:
+    playwright-core: =1.16.3
+  bin:
+    playwright: cli.js
+  checksum: dff5dd835a6d0a61d15b03dd2626971274c839babbc6533c6d0716129ec470fc3b95f3996d4e6f4a794c55e3380c20c97049a13d4fe8b06cc6a32fa418e4c0e2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,7 +3290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/get@npm:^1.13.0":
+"@electron/get@npm:^1.0.1":
   version: 1.13.1
   resolution: "@electron/get@npm:1.13.1"
   dependencies:
@@ -9872,7 +9872,7 @@ __metadata:
     archiver: ^3.1.1
     copy-webpack-plugin: ^10.1.0
     cross-env: ^7.0.3
-    electron: 17.0.0
+    electron: 12.1.0
     electron-builder: ^22.11.7
     electron-fetch: ^1.7.4
     electron-notarize: ^0.1.1
@@ -16238,16 +16238,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:17.0.0":
-  version: 17.0.0
-  resolution: "electron@npm:17.0.0"
+"electron@npm:12.1.0":
+  version: 12.1.0
+  resolution: "electron@npm:12.1.0"
   dependencies:
-    "@electron/get": ^1.13.0
+    "@electron/get": ^1.0.1
     "@types/node": ^14.6.2
     extract-zip: ^1.0.3
   bin:
     electron: cli.js
-  checksum: de761a77581469d3f36ab717fda9674105291351adfb5b3e5ea93bafc545958fc25d39f3a72b2898c4d3bcc06cf9cc7157edb7365a8cf3696007ffca0f0ee4a6
+  checksum: d33b4603d7f9cdfa9755dc9b14d41a00f5775eda8e0d4b2e3d0530180f808d96a7225383ba5c96a8a6de6647908a169599e4ab6b2cd577fd97640a8a1a8b41eb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9872,7 +9872,7 @@ __metadata:
     archiver: ^3.1.1
     copy-webpack-plugin: ^10.1.0
     cross-env: ^7.0.3
-    electron: ^17.0.0
+    electron: 17.0.0
     electron-builder: ^22.11.7
     electron-fetch: ^1.7.4
     electron-notarize: ^0.1.1
@@ -16238,7 +16238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^17.0.0":
+"electron@npm:17.0.0":
   version: 17.0.0
   resolution: "electron@npm:17.0.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,7 +237,7 @@ __metadata:
     config: ^3.3.6
     mailosaur: ^7.3.1
     node-fetch: ^2.6.6
-    playwright: 1.16
+    playwright: ^1.18
     totp-generator: ^0.0.12
     typescript: ^4.5.5
   languageName: unknown
@@ -9884,7 +9884,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: 1.16
+    playwright: ^1.18
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -28534,9 +28534,9 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:=1.16.3":
-  version: 1.16.3
-  resolution: "playwright-core@npm:1.16.3"
+"playwright-core@npm:=1.18.1":
+  version: 1.18.1
+  resolution: "playwright-core@npm:1.18.1"
   dependencies:
     commander: ^8.2.0
     debug: ^4.1.1
@@ -28556,18 +28556,18 @@ fsevents@~2.1.2:
     yazl: ^2.5.1
   bin:
     playwright: cli.js
-  checksum: 9ae0cc2714d24fc464ab29cd9c9f4ed2b6d6cf0d88ed1034d40763501f4a9c5094bdff2008c1eb23123671eb61590b0c71af1971714d3b0b7541e42d3ba0d519
+  checksum: e64581928d9a42dce66f623b3af8ff8774ab2b09518756eb72449b3c5988cbe7336e898926b0bf3a56c8f317e4419f7aaa2ca3d826e9b705e8912738ffb3d9c0
   languageName: node
   linkType: hard
 
-"playwright@npm:1.16":
-  version: 1.16.3
-  resolution: "playwright@npm:1.16.3"
+"playwright@npm:^1.18":
+  version: 1.18.1
+  resolution: "playwright@npm:1.18.1"
   dependencies:
-    playwright-core: =1.16.3
+    playwright-core: =1.18.1
   bin:
     playwright: cli.js
-  checksum: dff5dd835a6d0a61d15b03dd2626971274c839babbc6533c6d0716129ec470fc3b95f3996d4e6f4a794c55e3380c20c97049a13d4fe8b06cc6a32fa418e4c0e2
+  checksum: 5a24f4b10abe6f1f1262d6e5fa269cc18a8254e192787995b9d6ea8e19e8d92c9d5cdea92839022fcf2c41c5727f89a88ea84c168a9fea8ef074e2d14e18e1d5
   languageName: node
   linkType: hard
 
@@ -38343,7 +38343,7 @@ testarmada-magellan@11.0.10:
     mocha-multi-reporters: ^1.5.1
     mocha-teamcity-reporter: ^3.0.0
     node-fetch: ^2.6.1
-    playwright: 1.16
+    playwright: ^1.18
     png-itxt: ^1.3.0
     postcss: ^8.3.11
     push-receiver: ^2.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,7 +3290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/get@npm:^1.0.1":
+"@electron/get@npm:^1.13.0":
   version: 1.13.1
   resolution: "@electron/get@npm:1.13.1"
   dependencies:
@@ -9872,7 +9872,7 @@ __metadata:
     archiver: ^3.1.1
     copy-webpack-plugin: ^10.1.0
     cross-env: ^7.0.3
-    electron: 12.1.0
+    electron: ^17.0.0
     electron-builder: ^22.11.7
     electron-fetch: ^1.7.4
     electron-notarize: ^0.1.1
@@ -16238,16 +16238,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:12.1.0":
-  version: 12.1.0
-  resolution: "electron@npm:12.1.0"
+"electron@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "electron@npm:17.0.0"
   dependencies:
-    "@electron/get": ^1.0.1
+    "@electron/get": ^1.13.0
     "@types/node": ^14.6.2
     extract-zip: ^1.0.3
   bin:
     electron: cli.js
-  checksum: d33b4603d7f9cdfa9755dc9b14d41a00f5775eda8e0d4b2e3d0530180f808d96a7225383ba5c96a8a6de6647908a169599e4ab6b2cd577fd97640a8a1a8b41eb
+  checksum: de761a77581469d3f36ab717fda9674105291351adfb5b3e5ea93bafc545958fc25d39f3a72b2898c4d3bcc06cf9cc7157edb7365a8cf3696007ffca0f0ee4a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Playwright 1.18 and 1.17 brings forth multiple improvements for our framework:
- (1.18) better TypeScript support to import ESM modules without compilation.
- (1.18) updated browser versions - Chrome 99
- (1.17) frame locators - ability to select elements within an iframe without having to first extract the iframe.

This PR updates the version of Playwright used for everything **except** for the desktop tests to Playwright 1.18.

#### Testing instructions

- [ ] Ensure that:
  - [ ] all existing build configurations that pass, should continue to pass.
  - [x] i18n and Quarantined E2E should execute, but failure is expected.


Related to #
