### PR TITLE
Theme: Remove setNextLayoutFocus sidebar

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -3,7 +3,6 @@ import { Provider as ReduxProvider } from 'react-redux';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { requestTheme, setBackPath } from 'calypso/state/themes/actions';
 import { getTheme, getThemeRequestErrors } from 'calypso/state/themes/selectors';
-import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import ThemeSheetComponent from './main';
 import ThemeNotFoundError from './theme-not-found-error';
 
@@ -46,8 +45,6 @@ export function details( context, next ) {
 	if ( context.prevPath && context.prevPath.startsWith( '/themes' ) ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
 	}
-
-	context.store.dispatch( setNextLayoutFocus( 'sidebar' ) );
 
 	context.primary = (
 		<ThemeSheetComponent id={ slug } section={ section } pathName={ context.pathname } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Removes the sidebar focus on the next page when navigating around the theme details page. 

I think this focus was added but then was not removed later on. 

Before:

https://user-images.githubusercontent.com/115071/152885336-7f628726-5a8c-4abb-80bd-c5435e2b949e.mp4

After:

https://user-images.githubusercontent.com/115071/152885362-8573283f-4c0d-4996-b2dd-da8f675fc8e5.mp4


#### Testing instructions
On mobile and desktop
* Navigate to /themes/example.com
* Click on the single theme. (this should open the theme details pages) 
* Use the < back link notice that you don't have the "sidebar" focus when anymore.

Related to https://github.com/Automattic/wp-calypso/pull/60524#pullrequestreview-868460755

Also related https://github.com/Automattic/wp-calypso/pull/53988 
