### PR TITLE
Update design picker config so that only Blank Canvas would have the is_featured_picks property

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -39,7 +39,6 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_featured_picks": true,
 			"features": []
 		},
 		{
@@ -50,7 +49,6 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_featured_picks": true,
 			"features": []
 		},
 		{
@@ -61,7 +59,6 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_featured_picks": true,
 			"features": []
 		},
 		{
@@ -72,7 +69,6 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_featured_picks": true,
 			"features": []
 		},
 		{
@@ -83,7 +79,6 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_featured_picks": true,
 			"features": []
 		},
 		{
@@ -94,7 +89,6 @@
 			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_featured_picks": true,
 			"features": []
 		},
 		{


### PR DESCRIPTION
This change ensures that when randomizing the designs, only Blank Canvas is at the top while the rest are randomized. The reason the property `is_featured_picks` affects randomization is because after shuffling the designs, the shuffled list is then sorted by putting designs with the property `is_featured_picks` at the start of the list.

The list would be structured as follows: 
```
[...(shuffled designs with `is_featured_picks`), ...(shuffled designs without `is_featured_picks`)]
```

#### Changes proposed in this Pull Request

* Remove the `is_featured_picks` property from all designs except Blank Canvas. Previously, the Twenty Twenty designs also had this property.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/new/design`.
* Blank Canvas should always be first of the list.
* The rest of the list should be ordered randomly.

Before:
![Screen Shot 2022-02-08 at 11 37 43 AM](https://user-images.githubusercontent.com/797888/152913528-60f09167-35f6-4a28-bcef-977001765d15.png)



After:
![Screen Shot 2022-02-08 at 11 30 31 AM](https://user-images.githubusercontent.com/797888/152913316-620d10b5-de58-4deb-97cf-e79baad48a77.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60840
