### PR TITLE
Set scrollTop to 0 when going from design picker to preview

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -102,6 +102,10 @@ export default function DesignPickerStep( props ) {
 		let timeoutID;
 		if ( props.stepSectionName ) {
 			scrollTop.current = document.scrollingElement.scrollTop;
+			// Defer reset scroll position to ensure DesignPreview (WebPreview) is rendered
+			timeoutID = window.setTimeout( () => {
+				document.scrollingElement.scrollTop = 0;
+			} );
 		} else {
 			// Defer restore scroll position to ensure DesignPicker is rendered
 			timeoutID = window.setTimeout( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change sets the vertical scrolling back to zero when going from the design picker step to the design preview step. Doing so prevents user scrolling in the design picker carrying over to the preview step, which can sometimes cause the top nav area to be cut-off/hidden in the viewport. 

![Screen Shot 2022-02-08 at 2 26 50 PM](https://user-images.githubusercontent.com/797888/152931329-882cb2c3-b077-4a61-a9af-bc46e176703e.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Head to `/start` and follow steps until reaching the design picker.
2. Scroll down to select to preview design that is not on the top of the page.
3. Click the "Preview {design-name}" button.
4. Once in the design preview step, see that the page scroll is reset to the top and the top nav bar is fully visible.
5. (Optional) Click the back button in the top nav bar to return to the design picker.
6. (Optional) Repeat steps 2-4.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60380
