### PR TITLE
Prevent scrolling on preview page in start flow

### DIFF
--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -68,8 +68,6 @@
 }
 
 .design-picker__preview {
-	padding-bottom: 30px;
-
 	.step-wrapper__content {
 		height: calc( 100vh - 245px );
 
@@ -78,7 +76,11 @@
 		}
 
 		@include break-small {
-			height: calc( 100vh - 128px );
+			height: calc( 100vh - 132px );
+		}
+
+		@include break-medium {
+			height: calc( 100vh - 148px );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove padding and change height so that scrolling is impossible on the preview page.

#### Testing instructions

go to `/start/setup-site/design-setup-site?siteSlug=$yourSite.wordpress.com`
Scroll down the page, and select a theme to preview.
Verify that you cannot scroll on the preview page and that it is otherwise rendering as expected.
Test on mobile

Fixes #60380
