### PR TITLE
State: Cleanup unused push notifications state

### DIFF
--- a/client/state/push-notifications/README.md
+++ b/client/state/push-notifications/README.md
@@ -27,7 +27,6 @@ function mapStateToProps( state ) {
 		getStatus: getStatus( state ),
 		isBlocked: isBlocked( state ),
 		isEnabled: isEnabled( state ),
-		isNoticeDismissed: isNoticeDismissed( state ),
 		// etc.
 	};
 }

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -17,7 +17,7 @@ import { settingsSchema, systemSchema } from './schema';
 const debug = debugFactory( 'calypso:push-notifications' );
 
 // If you change this, also change the corresponding test
-const UNPERSISTED_SYSTEM_NODES = [ 'apiReady', 'authorized', 'authorizationLoaded', 'blocked' ];
+const UNPERSISTED_SYSTEM_NODES = [ 'apiReady', 'blocked' ];
 
 const systemReducer = ( state = {}, action ) => {
 	switch ( action.type ) {
@@ -30,24 +30,18 @@ const systemReducer = ( state = {}, action ) => {
 
 		case PUSH_NOTIFICATIONS_AUTHORIZE: {
 			return Object.assign( {}, state, {
-				authorized: true,
-				authorizationLoaded: true,
 				blocked: false,
 			} );
 		}
 
 		case PUSH_NOTIFICATIONS_BLOCK: {
 			return Object.assign( {}, state, {
-				authorized: false,
-				authorizationLoaded: true,
 				blocked: true,
 			} );
 		}
 
 		case PUSH_NOTIFICATIONS_MUST_PROMPT: {
 			return Object.assign( {}, state, {
-				authorized: false,
-				authorizationLoaded: true,
 				blocked: false,
 			} );
 		}

--- a/client/state/push-notifications/schema.js
+++ b/client/state/push-notifications/schema.js
@@ -1,13 +1,10 @@
 const boolType = { type: 'boolean' };
 const stringType = { type: 'string' };
-const numberType = { type: 'number' };
 
 export const settingsSchema = {
 	type: 'object',
 	properties: {
 		enabled: boolType,
-		dismissedNotice: boolType,
-		dismissedNoticeAt: numberType,
 		showingUnblockInstructions: boolType,
 	},
 	additionalProperties: false,
@@ -17,8 +14,6 @@ export const systemSchema = {
 	type: 'object',
 	properties: {
 		apiReady: boolType,
-		authorized: boolType,
-		authorizationLoaded: boolType,
 		blocked: boolType,
 		wpcomSubscription: {
 			type: 'object',

--- a/client/state/push-notifications/selectors.js
+++ b/client/state/push-notifications/selectors.js
@@ -2,16 +2,12 @@ import 'calypso/state/push-notifications/init';
 
 // `getState().pushNotifications.system`
 export const isApiReady = ( state ) => !! state.pushNotifications.system.apiReady;
-export const isAuthorized = ( state ) => !! state.pushNotifications.system.authorized;
-export const isAuthorizationLoaded = ( state ) =>
-	!! state.pushNotifications.system.authorizationLoaded;
 export const isBlocked = ( state ) => !! state.pushNotifications.system.blocked;
 export const getSavedWPCOMSubscription = ( state ) =>
 	state.pushNotifications.system.wpcomSubscription;
 
 // `getState().pushNotifications.settings`
 export const isEnabled = ( state ) => !! state.pushNotifications.settings.enabled;
-export const isNoticeDismissed = ( state ) => !! state.pushNotifications.settings.dismissedNotice;
 export const isShowingUnblockInstructions = ( state ) =>
 	!! state.pushNotifications.settings.showingUnblockInstructions;
 

--- a/client/state/push-notifications/test/reducer.js
+++ b/client/state/push-notifications/test/reducer.js
@@ -28,8 +28,6 @@ describe( 'system reducer', () => {
 		const previousState = {
 			system: {
 				apiReady: true,
-				authorized: true,
-				authorizationLoaded: true,
 				blocked: false,
 				wpcomSubscription: wpcomSubscription,
 			},
@@ -55,8 +53,6 @@ describe( 'system reducer', () => {
 		const previousState = {
 			system: {
 				apiReady: true,
-				authorized: true,
-				authorizationLoaded: true,
 				blocked: false,
 				wpcomSubscription: wpcomSubscriptionId,
 			},
@@ -88,16 +84,12 @@ describe( 'settings reducer', () => {
 		const previousState = {
 			settings: {
 				enabled: false,
-				dismissedNotice: true,
-				dismissedNoticeAt: 1466067124796,
 			},
 		};
 		deepFreeze( previousState );
 		const newState = serialize( reducer, previousState ).root();
 
 		expect( newState.settings ).to.eql( {
-			dismissedNotice: true,
-			dismissedNoticeAt: 1466067124796,
 			enabled: false,
 		} );
 	} );
@@ -121,16 +113,12 @@ describe( 'settings reducer', () => {
 		const previousState = {
 			settings: {
 				enabled: false,
-				dismissedNotice: true,
-				dismissedNoticeAt: 1466067124796,
 			},
 		};
 		deepFreeze( previousState );
 		const newState = deserialize( reducer, previousState );
 
 		expect( newState.settings ).to.eql( {
-			dismissedNotice: true,
-			dismissedNoticeAt: 1466067124796,
 			enabled: false,
 		} );
 	} );

--- a/client/state/push-notifications/test/reducer.js
+++ b/client/state/push-notifications/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
@@ -21,7 +20,7 @@ describe( 'system reducer', () => {
 		deepFreeze( previousState );
 		const newState = serialize( reducer, previousState ).root();
 
-		expect( newState.system ).to.eql( { wpcomSubscription } );
+		expect( newState.system ).toStrictEqual( { wpcomSubscription } );
 	} );
 
 	test( 'should refuse to persist particular keys', () => {
@@ -35,7 +34,7 @@ describe( 'system reducer', () => {
 		deepFreeze( previousState );
 		const newState = serialize( reducer, previousState ).root();
 
-		expect( newState.system ).to.eql( { wpcomSubscription } );
+		expect( newState.system ).toStrictEqual( { wpcomSubscription } );
 	} );
 
 	test( 'should restore keys', () => {
@@ -43,7 +42,7 @@ describe( 'system reducer', () => {
 		deepFreeze( previousState );
 		const newState = deserialize( reducer, previousState );
 
-		expect( newState.system ).to.eql( {
+		expect( newState.system ).toStrictEqual( {
 			wpcomSubscription,
 		} );
 	} );
@@ -60,7 +59,7 @@ describe( 'system reducer', () => {
 		deepFreeze( previousState );
 		const newState = deserialize( reducer, previousState );
 
-		expect( newState.system ).to.eql( {
+		expect( newState.system ).toStrictEqual( {
 			wpcomSubscription: wpcomSubscriptionId,
 		} );
 	} );
@@ -75,7 +74,7 @@ describe( 'system reducer', () => {
 		};
 		const newState = reducer( {}, action );
 
-		expect( newState.system ).to.eql( { wpcomSubscription } );
+		expect( newState.system ).toStrictEqual( { wpcomSubscription } );
 	} );
 } );
 
@@ -89,7 +88,7 @@ describe( 'settings reducer', () => {
 		deepFreeze( previousState );
 		const newState = serialize( reducer, previousState ).root();
 
-		expect( newState.settings ).to.eql( {
+		expect( newState.settings ).toStrictEqual( {
 			enabled: false,
 		} );
 	} );
@@ -104,7 +103,7 @@ describe( 'settings reducer', () => {
 		deepFreeze( previousState );
 		const newState = serialize( reducer, previousState ).root();
 
-		expect( newState.settings ).to.eql( {
+		expect( newState.settings ).toStrictEqual( {
 			enabled: true,
 		} );
 	} );
@@ -118,7 +117,7 @@ describe( 'settings reducer', () => {
 		deepFreeze( previousState );
 		const newState = deserialize( reducer, previousState );
 
-		expect( newState.settings ).to.eql( {
+		expect( newState.settings ).toStrictEqual( {
 			enabled: false,
 		} );
 	} );
@@ -133,7 +132,7 @@ describe( 'settings reducer', () => {
 		deepFreeze( previousState );
 		const newState = deserialize( reducer, previousState );
 
-		expect( newState.settings ).to.eql( {
+		expect( newState.settings ).toStrictEqual( {
 			enabled: true,
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up some unused push notifications state pieces that are not in use since #11304 (over 4 years ago).

#### Testing instructions

Verify Calypso builds without errors, tests pass, and push notifications still work.