### PR TITLE
Reader: Refactor `ReaderFeaturedVideo` away from `UNSAFE_` lifecycle methods

### DIFF
--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -82,8 +82,7 @@ class ReaderFeaturedVideo extends Component {
 		}
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps() {
+	componentDidUpdate() {
 		this.throttledUpdateVideoSize();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ReaderFeaturedVideo` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/read/feeds/8956683`
* Scroll down a bit until you find a post with a featured video.
* Resize your window and verify that the video continues to resize properly.