### PR TITLE
Reader: Refactor `FeaturedImage` away from `UNSAFE_` lifecycle methods

### DIFF
--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 const hideImageOnError = ( event ) => {
-	event.target.style.display = 'none';
+	event.target.parentNode.style.display = 'none';
 };
 
 export default function FeaturedImage( { src, alt } ) {

--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -1,33 +1,15 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 
-export default class FeaturedImage extends Component {
-	constructor( props ) {
-		super();
-		this.state = { src: props.src };
-		this.handleImageError = () => {
-			this.setState( { src: '' } );
-		};
-	}
+const hideImageOnError = ( event ) => {
+	event.target.style.display = 'none';
+};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.src !== this.props.src ) {
-			this.setState( { src: nextProps.src } );
-		}
-	}
-
-	render() {
-		if ( ! this.state.src ) {
-			return null;
-		}
-
-		return (
-			<div className="reader-full-post__featured-image">
-				<img src={ this.state.src } onError={ this.handleImageError } alt={ this.props.alt } />
-			</div>
-		);
-	}
+export default function FeaturedImage( { src, alt } ) {
+	return (
+		<div className="reader-full-post__featured-image">
+			<img src={ src } alt={ alt } onError={ hideImageOnError } />
+		</div>
+	);
 }
 
 FeaturedImage.propTypes = {

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -1,12 +1,17 @@
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { mount } from 'enzyme';
 import FeaturedImage from '../featured-image';
 
 describe( 'FeaturedImage', () => {
 	test( 'sets the source to an empty string if the image fails to load', () => {
 		const nonExistentImage = 'http://sketchy-feed.com/missing-image-2.jpg';
-		const wrapper = shallow( <FeaturedImage src={ nonExistentImage } /> );
-		wrapper.instance().handleImageError();
-		assert.equal( '', wrapper.state( 'src' ) );
+		const wrapper = mount( <FeaturedImage src={ nonExistentImage } /> );
+		const div = wrapper.find( '.reader-full-post__featured-image' ).at( 0 ).getDOMNode();
+
+		wrapper.find( 'img' ).simulate( 'error' );
+
+		expect( getComputedStyle( div ).getPropertyValue( 'display' ) ).toBe( 'none' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `FeaturedImage` component away from the `UNSAFE_` deprecated React component methods.

To get there, we refactor the component to a functional component and change the strategy for handling image load errors. Instead of relying on the component state, we just hide the image container if the image fails to load.

Part of #58453.

#### Testing instructions
* Go to `/read/feeds/124772731/posts/3817899116`
* Block the featured image request URL in your dev tools from loading.
* Refresh the page. 
* Verify the page looks good and the `reader-full-post__featured-image` element is hidden (has a `display: none` style applied).
* Unblock and verify that when the image loads, everything looks well.