### PR TITLE
TC: Migrate translate script from CircleCI job to TeamCity

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -582,6 +582,7 @@ object Translate : BuildType({
 				# Install modules
 				${_self.yarn_install_cmd}
 			"""
+			dockerImage = "%docker_image_e2e%"
 		}
 		bashNodeScript {
 			name = "Extract strings"
@@ -592,6 +593,7 @@ object Translate : BuildType({
 				# Move `calypso-strings.pot` to artifacts directory
 				mv public/calypso-strings.pot "./translate"
 			"""
+			dockerImage = "%docker_image_e2e%"
 		}
 		bashNodeScript {
 			name = "Build New Strings .pot"
@@ -605,6 +607,7 @@ object Translate : BuildType({
 				# Remove GP LocalCI Client
 				rm -rf gp-localci-client
 			"""
+			dockerImage = "%docker_image_e2e%"
 		}
 	}
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -591,7 +591,8 @@ object Translate : BuildType({
 				yarn run translate
 
 				# Move `calypso-strings.pot` to artifacts directory
-				mv public/calypso-strings.pot "./translate"
+				mkdir -p ./translate
+				mv public/calypso-strings.pot ./translate/
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -599,6 +599,10 @@ object Translate : BuildType({
 		bashNodeScript {
 			name = "Build New Strings .pot"
 			scriptContent = """
+				# Export LocalCI Client Authentication Variables
+				export LOCALCI_APP_SECRET="%TRANSLATE_GH_APP_SECRET%"
+				export LOCALCI_APP_ID="%TRANSLATE_GH_APP_ID%"
+
 				# Clone GP LocalCI Client
 				git clone --single-branch --depth=1 https://github.com/Automattic/gp-localci-client.git
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the scripts for building `calypso-strings.pot` and `localci-new-strings.pot` file to TeamCity Translate build configuration.
* Pinging translate.wordpress.com will be implemented at later point when the required changes on the other end get deployed.

#### Testing instructions

* Review build configuration changes.
* Run Custom TeamCity build for this branch (or recent builds for this branch) and confirm `calypso-strings.pot` is being built and stored as an artifact.
* Note that `localci-new-strings.pot` will only be build if there are new strings added to the PR. Please refer to Translate build `#69` for a build that has `localci-new-strings.pot` artifact.

Related to 378-gh-Automattic/i18n-issues
