### PR TITLE
Mini-cart: improve CSS styles

### DIFF
--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -9,7 +9,7 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 
 const MiniCartWrapper = styled.div`
 	box-sizing: border-box;
-	padding: 32px 24px;
+	padding: 16px;
 	max-width: 480px;
 	text-align: left;
 	font-size: 1rem;
@@ -22,18 +22,25 @@ const MiniCartHeader = styled.div`
 `;
 
 const MiniCartTitle = styled.h2`
-	font-size: 2rem;
+	font-size: 1.5rem;
 	line-height: 1em;
 	font-family: 'Recoleta';
+	margin-bottom: 5px;
 	grid-column: 1/2;
 	grid-row: 1;
 `;
 
 const MiniCartCloseButton = styled.button`
+	color: var( --color-text-subtle );
+	cursor: pointer;
 	grid-column: 2/3;
 	grid-row: 1;
 	justify-self: end;
 	font-size: 1.4em;
+	&:hover,
+	&:focus {
+		color: var( --color-neutral-70 );
+	}
 `;
 
 const MiniCartSiteTitle = styled.span`


### PR DESCRIPTION
When I open the min-cart popup inside Calypso UI, it's visually unpleasant. The "Cart" label is by far the biggest thing on the screen, but is it really the most important thing?

<img width="904" alt="Screenshot 2022-02-08 at 10 00 12" src="https://user-images.githubusercontent.com/664258/152969002-0ef15878-f911-40f6-a07d-e3bc23550e0d.png">

This PR makes a few style changes:
- make the "Cart" font size smaller, the same as other Calypso header
- add a little margin below the "Cart" header
- make the popover padding smaller (16px), like other Calypso popovers do
- change the close button color from black to gray+darker-on-hover, like other Calypso close buttons
- add a `cursor: pointer` style to the close button so that it feels active on mouse hover

The result looks like:
<img width="905" alt="Screenshot 2022-02-08 at 11 14 44" src="https://user-images.githubusercontent.com/664258/152970523-dc69bc93-a099-4749-87d3-7666dd557d61.png">

Another thing that would be nice to change is the font size of the cart content text and the CTA button. Calypso uses 14px font size as a baseline, Gutenberg uses 13px, but the Cart UI uses 16px. It doesn't really fit into any of our common design styles. But that would change not only the mini-cart package, but the entire checkout UI, so I didn't change anything in this area.

Let me know what you think. Is there agreement that the changes are for the better?
