### PR TITLE
Reader: Cleanup unused lists state

### DIFF
--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -21,7 +21,7 @@ import {
 	READER_LIST_ITEM_ADD_FEED_RECEIVE,
 } from 'calypso/state/reader/action-types';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
-import { itemsSchema, subscriptionsSchema, errorsSchema } from './schema';
+import { itemsSchema, subscriptionsSchema } from './schema';
 
 /**
  * Tracks all known list objects, indexed by list ID.
@@ -204,22 +204,6 @@ export function isRequestingLists( state = false, action ) {
 	return state;
 }
 
-/**
- * Returns errors received when trying to update lists, keyed by list ID.
- *
- * @param  {object} state  Current state
- * @param  {object} action Action payload
- * @returns {object}        Updated state
- */
-export const errors = withSchemaValidation( errorsSchema, ( state = {}, action ) => {
-	switch ( action.type ) {
-		case READER_LIST_UPDATE_FAILURE:
-			return { ...state, [ action.list.ID ]: action.error.statusCode };
-	}
-
-	return state;
-} );
-
 export default combineReducers( {
 	items,
 	listItems,
@@ -228,5 +212,4 @@ export default combineReducers( {
 	isRequestingList,
 	isRequestingLists,
 	isUpdatingList,
-	errors,
 } );

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-case-declarations */
 
-import { filter, some, get, includes, keyBy, map, omit, reject } from 'lodash';
+import { filter, some, includes, keyBy, map, omit, reject } from 'lodash';
 import {
 	READER_LIST_CREATE,
 	READER_LIST_DELETE,
@@ -21,9 +21,7 @@ import {
 	READER_LIST_ITEM_ADD_FEED_RECEIVE,
 } from 'calypso/state/reader/action-types';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
-import { itemsSchema, subscriptionsSchema, updatedListsSchema, errorsSchema } from './schema';
-
-const union = ( ...arrays ) => [ ...new Set( [].concat( ...arrays ) ) ];
+import { itemsSchema, subscriptionsSchema, errorsSchema } from './schema';
 
 /**
  * Tracks all known list objects, indexed by list ID.
@@ -136,25 +134,6 @@ export const subscribedLists = withSchemaValidation(
 );
 
 /**
- * Tracks which list IDs have been updated recently. Used to show the correct success message.
- *
- * @param  {object} state  Current state
- * @param  {object} action Action payload
- * @returns {object}        Updated state
- */
-export const updatedLists = withSchemaValidation( updatedListsSchema, ( state = [], action ) => {
-	switch ( action.type ) {
-		case READER_LIST_UPDATE_SUCCESS:
-			const newListId = get( action, 'data.list.ID' );
-			if ( ! newListId ) {
-				return state;
-			}
-			return union( state, [ newListId ] );
-	}
-	return state;
-} );
-
-/**
  * Returns the updated requests state after an action has been dispatched.
  *
  * @param  {object} state  Current state
@@ -245,7 +224,6 @@ export default combineReducers( {
 	items,
 	listItems,
 	subscribedLists,
-	updatedLists,
 	isCreatingList,
 	isRequestingList,
 	isRequestingLists,

--- a/client/state/reader/lists/schema.js
+++ b/client/state/reader/lists/schema.js
@@ -23,10 +23,6 @@ export const subscriptionsSchema = {
 	type: 'array',
 };
 
-export const updatedListsSchema = {
-	type: 'array',
-};
-
 export const errorsSchema = {
 	type: 'object',
 };

--- a/client/state/reader/lists/schema.js
+++ b/client/state/reader/lists/schema.js
@@ -22,7 +22,3 @@ export const itemsSchema = {
 export const subscriptionsSchema = {
 	type: 'array',
 };
-
-export const errorsSchema = {
-	type: 'object',
-};

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -60,17 +60,6 @@ export const getSubscribedLists = createSelector(
 );
 
 /**
- * Returns true if the specified list has been marked as updated.
- *
- * @param  {object}  state  Global state tree
- * @param  {number}  listId  List ID
- * @returns {boolean}        Whether lists are being requested
- */
-export function isUpdatedList( state, listId ) {
-	return state.reader.lists.updatedLists.includes( listId );
-}
-
-/**
  * Returns true if the specified list has an error recorded.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -60,17 +60,6 @@ export const getSubscribedLists = createSelector(
 );
 
 /**
- * Returns true if the specified list has an error recorded.
- *
- * @param  {object}  state  Global state tree
- * @param  {number}  listId  List ID
- * @returns {boolean}        Whether list has an error
- */
-export function hasError( state, listId ) {
-	return state.reader.lists.errors.hasOwnProperty( listId );
-}
-
-/**
  * Returns information about a single Reader list.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -3,11 +3,10 @@ import {
 	READER_LIST_DELETE,
 	READER_LIST_FOLLOW_RECEIVE,
 	READER_LIST_UNFOLLOW_RECEIVE,
-	READER_LIST_UPDATE_SUCCESS,
 	READER_LIST_REQUEST_SUCCESS,
 	READER_LISTS_RECEIVE,
 } from 'calypso/state/reader/action-types';
-import { items, listItems, updatedLists, subscribedLists } from '../reducer';
+import { items, listItems, subscribedLists } from '../reducer';
 
 describe( 'reducer', () => {
 	describe( '#items()', () => {
@@ -86,27 +85,6 @@ describe( 'reducer', () => {
 					{ ID: 12346, feed_ID: 333 },
 				],
 			} );
-		} );
-	} );
-
-	describe( '#updatedLists()', () => {
-		test( 'should default to an empty array', () => {
-			const state = updatedLists( undefined, {} );
-			expect( state ).toEqual( [] );
-		} );
-
-		test( 'should add a list ID when a list is updated', () => {
-			const state = updatedLists( [], {
-				type: READER_LIST_UPDATE_SUCCESS,
-				data: {
-					list: {
-						ID: 841,
-						title: 'Hello World',
-					},
-				},
-			} );
-
-			expect( state ).toEqual( [ 841 ] );
 		} );
 	} );
 

--- a/client/state/reader/lists/test/selectors.js
+++ b/client/state/reader/lists/test/selectors.js
@@ -4,7 +4,6 @@ import {
 	getListByOwnerAndSlug,
 	getMatchingItem,
 	isSubscribedByOwnerAndSlug,
-	hasError,
 	isMissingByOwnerAndSlug,
 } from '../selectors';
 
@@ -234,38 +233,6 @@ describe( 'selectors', () => {
 			);
 
 			expect( isSubscribed ).toEqual( true );
-		} );
-	} );
-
-	describe( '#hasError()', () => {
-		test( 'should return false if there is no error for the list', () => {
-			const result = hasError(
-				{
-					reader: {
-						lists: {
-							errors: { 123: 400 },
-						},
-					},
-				},
-				456
-			);
-
-			expect( result ).toBeFalsy();
-		} );
-
-		test( 'should return true if the list has an error', () => {
-			const result = hasError(
-				{
-					reader: {
-						lists: {
-							errors: { 123: 400 },
-						},
-					},
-				},
-				123
-			);
-
-			expect( result ).toBeTruthy();
 		} );
 	} );
 

--- a/client/state/reader/lists/test/selectors.js
+++ b/client/state/reader/lists/test/selectors.js
@@ -1,7 +1,6 @@
 import {
 	isRequestingList,
 	getSubscribedLists,
-	isUpdatedList,
 	getListByOwnerAndSlug,
 	getMatchingItem,
 	isSubscribedByOwnerAndSlug,
@@ -80,38 +79,6 @@ describe( 'selectors', () => {
 				{ ID: 456, slug: 'ants', title: 'abc' },
 				{ ID: 123, slug: 'bananas', title: 'def' },
 			] );
-		} );
-	} );
-
-	describe( '#isUpdatedList()', () => {
-		test( 'should return false if list has not been updated', () => {
-			const isUpdated = isUpdatedList(
-				{
-					reader: {
-						lists: {
-							updatedLists: [],
-						},
-					},
-				},
-				123
-			);
-
-			expect( isUpdated ).toBeFalsy();
-		} );
-
-		test( 'should return true if the list has been updated', () => {
-			const isUpdated = isUpdatedList(
-				{
-					reader: {
-						lists: {
-							updatedLists: [ 123, 456 ],
-						},
-					},
-				},
-				123
-			);
-
-			expect( isUpdated ).toBeTruthy();
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes some reader state that has been unused since #10170. That includes the `isUpdatedList` and `hasError` selectors, as well as their related reducers, schema, and tests.

#### Testing instructions

Verify Calypso builds without errors, tests pass and Reader lists continue to work as they did before.