### PR TITLE
Reader: Include data layer for tag subscription

### DIFF
--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -29,6 +29,7 @@ import 'calypso/state/data-layer/wpcom/read/lists/items';
 import 'calypso/state/data-layer/wpcom/read/lists/feeds/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/sites/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/tags/delete';
+import 'calypso/state/data-layer/wpcom/read/lists/tags/new';
 import 'calypso/state/data-layer/wpcom/read/lists/feeds/new';
 import 'calypso/state/reader/init';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on #60918 I noticed that adding a tag (e.g. following a tag) doesn't actually add the tag, and if you refresh, the tag isn't in the list of followed tags.

To fix this, we only need to re-include the data layer, related to the tag addition.

#### Testing instructions

* Go to `/read`
* Scroll down the sidebar to reach the Tags section and expand it.
* Input a new tag in the "Add a tag" field and click "Add" to follow it.
* Verify that after refreshing the page, that followed tag is in the "Tags" list.