### PR TITLE
CI: Fail type check on new TS errors

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -334,16 +334,7 @@ object RunAllUnitTests : BuildType({
 				# These are not expected to fail
 				yarn tsc --build packages/*/tsconfig.json
 				yarn tsc --build apps/editing-toolkit/tsconfig.json
-
-				# These have known errors, so we report them as checkstyle
-				(
-					# Enable pipe errors in this subshell. After all, we know these will fail.
-					set +e
-					yarn tsc --build client 2>&1 | tee tsc_out
-					mkdir -p checkstyle_results
-					yarn run typescript-checkstyle < tsc_out | sed -e "s#${'$'}PWD#~#g" > ./checkstyle_results/tsc.xml
-					cat ./checkstyle_results/tsc.xml
-				)
+				yarn tsc --build client/tsconfig.json
 			"""
 		}
 		bashNodeScript {

--- a/client/state/notices/actions.ts
+++ b/client/state/notices/actions.ts
@@ -8,9 +8,9 @@ import type {
 
 import 'calypso/state/notices/init';
 
-export const removeNotice: NoticeRemovalActionCreator = () => {
+export const removeNotice: NoticeRemovalActionCreator = ( noticeId ) => {
 	return {
-		noticeId: 123,
+		noticeId,
 		type: NOTICE_REMOVE,
 	};
 };

--- a/client/state/notices/actions.ts
+++ b/client/state/notices/actions.ts
@@ -8,9 +8,9 @@ import type {
 
 import 'calypso/state/notices/init';
 
-export const removeNotice: NoticeRemovalActionCreator = ( noticeId ) => {
+export const removeNotice: NoticeRemovalActionCreator = () => {
 	return {
-		noticeId,
+		noticeId: 123,
 		type: NOTICE_REMOVE,
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, since #58276, we convert `tsc`'s output to `checkstyle` and use that to fail the build if the number of errors increases. This was useful when we were working on reducing the TS errors in the codebase, but is no longer necessary.

Following the great recent work by @sirbrillig and others, we no longer have TypeScript errors in Calypso's `client` package. 🎉   

This means we can now just typecheck the `client` package using `tsc`, just like we do for the rest of the `packages` inside Calypso's monorepo.

This PR removes the `tsc` to `checkstyle` conversion in favor of a simple `tsc` command. That way we'll be able to see the concrete TS errors in the build - if any were introduced. For example, see [this build](https://teamcity.a8c.com/buildConfiguration/calypso_RunAllUnitTests/7368989?showRootCauses=true&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true&showLog=7368989_516_404) that was generated for the [dummy commit](https://github.com/Automattic/wp-calypso/pull/60925/commits/f0f828d7f0c6632486b61cb14e6263a8a28564d1) I added (and later [reverted](https://github.com/Automattic/wp-calypso/pull/60925/commits/bed71f2302f4a10fe28c2965fee7330a5e772ce0)) to test what happens when we introduce a new TS error.

#### Testing instructions

* Verify the "Unit Tests" build is green.
* Take a look at the build of the second commit and verify it displays the TS error that was introduced.