### PR TITLE
Fix broken domain mapping flow

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -35,9 +35,6 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 	const mode = connectADomainStepsDefinition[ pageSlug ].mode;
 	const step = connectADomainStepsDefinition[ pageSlug ].step;
 
-	// const isDomainConnected =
-	// 	hasSiteDomainsLoaded && domains.some( ( _domain ) => _domain.domain === domain );
-
 	const statusRef = useRef( {} );
 
 	useEffect( () => {
@@ -45,12 +42,6 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 			setPageSlug( initialStep );
 		}
 	}, [ initialStep, setPageSlug ] );
-
-	// useEffect( () => {
-	// 	if ( ! isDomainConnected ) {
-	// 		page( domainUseMyDomain( selectedSite.slug ) );
-	// 	}
-	// }, [ isDomainConnected, selectedSite.slug ] );
 
 	const verifyConnection = useCallback(
 		( setStepAfterVerify = true ) => {

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -10,7 +10,7 @@ import ConnectDomainStepSupportInfoLink from 'calypso/components/domains/connect
 import DomainTransferRecommendation from 'calypso/components/domains/domain-transfer-recommendation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import wpcom from 'calypso/lib/wp';
-import { domainManagementList, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepSwitchSetupInfoLink from './connect-domain-step-switch-setup-info-link';
@@ -21,15 +21,7 @@ import { connectADomainStepsDefinition } from './page-definitions.js';
 
 import './style.scss';
 
-function ConnectDomainStep( {
-	domain,
-	selectedSite,
-	initialSetupInfo,
-	initialStep,
-	showErrors,
-	domains,
-	hasSiteDomainsLoaded,
-} ) {
+function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialStep, showErrors } ) {
 	const { __ } = useI18n();
 	const [ pageSlug, setPageSlug ] = useState( stepSlug.SUGGESTED_START );
 	const [ verificationStatus, setVerificationStatus ] = useState( {} );
@@ -43,8 +35,8 @@ function ConnectDomainStep( {
 	const mode = connectADomainStepsDefinition[ pageSlug ].mode;
 	const step = connectADomainStepsDefinition[ pageSlug ].step;
 
-	const isDomainConnected =
-		hasSiteDomainsLoaded && ! domains.some( ( _domain ) => _domain.domain === domain );
+	// const isDomainConnected =
+	// 	hasSiteDomainsLoaded && domains.some( ( _domain ) => _domain.domain === domain );
 
 	const statusRef = useRef( {} );
 
@@ -54,11 +46,11 @@ function ConnectDomainStep( {
 		}
 	}, [ initialStep, setPageSlug ] );
 
-	useEffect( () => {
-		if ( isDomainConnected ) {
-			page( domainUseMyDomain( selectedSite.slug ) );
-		}
-	}, [ isDomainConnected, selectedSite.slug ] );
+	// useEffect( () => {
+	// 	if ( ! isDomainConnected ) {
+	// 		page( domainUseMyDomain( selectedSite.slug ) );
+	// 	}
+	// }, [ isDomainConnected, selectedSite.slug ] );
 
 	const verifyConnection = useCallback(
 		( setStepAfterVerify = true ) => {
@@ -95,11 +87,7 @@ function ConnectDomainStep( {
 	);
 
 	useEffect( () => {
-		if (
-			statusRef.current?.hasLoadedStatusInfo?.[ domain ] ||
-			loadingDomainSetupInfo ||
-			! isDomainConnected
-		) {
+		if ( statusRef.current?.hasLoadedStatusInfo?.[ domain ] || loadingDomainSetupInfo ) {
 			return;
 		}
 
@@ -116,28 +104,16 @@ function ConnectDomainStep( {
 				.catch( ( error ) => setDomainSetupInfoError( { error } ) )
 				.finally( () => setLoadingDomainSetupInfo( false ) );
 		} )();
-
-		return () => {
-			setDomainSetupInfo( {} );
-			setLoadingDomainSetupInfo( false );
-		};
-	}, [
-		domain,
-		domainSetupInfo,
-		initialSetupInfo,
-		loadingDomainSetupInfo,
-		selectedSite.ID,
-		isDomainConnected,
-	] );
+	}, [ domain, domainSetupInfo, initialSetupInfo, loadingDomainSetupInfo, selectedSite.ID ] );
 
 	useEffect( () => {
-		if ( ! showErrors || statusRef.current?.hasFetchedVerificationStatus || ! isDomainConnected ) {
+		if ( ! showErrors || statusRef.current?.hasFetchedVerificationStatus ) {
 			return;
 		}
 
 		statusRef.current.hasFetchedVerificationStatus = true;
 		verifyConnection( false );
-	}, [ showErrors, verifyConnection, isDomainConnected ] );
+	}, [ showErrors, verifyConnection ] );
 
 	const goBack = () => {
 		const prevPageSlug = connectADomainStepsDefinition[ pageSlug ]?.prev;


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes an issue introduced with https://github.com/Automattic/wp-calypso/pull/60658, where after selecting the "Connect a domain" option the user is redirected back to "Use I domain I own"  (see video below).

https://d.pr/v/qKxqJE

## Testing instructions
- Build this branch locally or open the live Calypso link
- Select a site, then click "Add a domain -> Use a domain I own"
- Insert a valid domain name, then select "Connect a domain"
- Verify that you are redirect to the "Connection Setup" page


