### PR TITLE
Themes Showcase: Fix current theme track click event names

### DIFF
--- a/client/my-sites/themes/current-theme/index.tsx
+++ b/client/my-sites/themes/current-theme/index.tsx
@@ -2,7 +2,7 @@ import { Card, Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, TranslateResult } from 'i18n-calypso';
 import { map, pickBy } from 'lodash';
-import { Component, MouseEvent } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
@@ -38,9 +38,9 @@ interface CurrentThemeProps {
  * related actions.
  */
 class CurrentTheme extends Component< CurrentThemeProps > {
-	trackClick = ( event: MouseEvent< HTMLButtonElement > ) => trackClick( 'current theme', event );
-	trackLinkClick = ( event: MouseEvent< HTMLAnchorElement > ) =>
-		trackClick( 'current theme', event );
+	trackClick = ( eventName: string ) => () => {
+		trackClick( 'current theme', eventName );
+	};
 
 	render() {
 		const { currentTheme, currentThemeId, siteId, translate } = this.props;
@@ -104,7 +104,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 													href={
 														currentThemeId && option.getUrl ? option.getUrl( currentThemeId ) : ''
 													}
-													onClick={ this.trackClick }
+													onClick={ this.trackClick( name ) }
 												>
 													{ option.icon && <Gridicon icon={ option.icon } size={ 18 } /> }
 													{ option.label }
@@ -123,7 +123,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 								<a
 									className="current-theme__theme-description-link"
 									href={ options.info.getUrl( currentThemeId ) }
-									onClick={ this.trackLinkClick }
+									onClick={ this.trackClick( 'read more link' ) }
 								>
 									{ translate( 'Read more' ) }
 								</a>
@@ -133,7 +133,7 @@ class CurrentTheme extends Component< CurrentThemeProps > {
 								<a
 									className="current-theme__theme-customize"
 									href={ options.customize.getUrl( currentThemeId ) }
-									onClick={ this.trackLinkClick }
+									onClick={ this.trackClick( 'customize theme link' ) }
 								>
 									{ options?.customize?.icon && (
 										<Gridicon icon={ options.customize.icon } size={ 24 } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`trackClick` expects an `eventName` of type `string`.

https://github.com/Automattic/wp-calypso/blob/d1c30ef963b6825854f91fd99ea51901dc4a07fe/client/my-sites/themes/helpers.js#L6-L9

Instead, we mistakenly pass in the event object. This PR updates event names for current theme links and buttons to strings.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Add console logs to the [trackClick helper](https://github.com/Automattic/wp-calypso/blob/d1c30ef963b6825854f91fd99ea51901dc4a07fe/client/my-sites/themes/helpers.js#L6-L9) for `eventName`
* Navigate to Appearance > Themes
* Click on any of the buttons in the Current Theme Card
* Shrink the width of the browser viewport until the "Read more" and "Customize theme" links appear
* Click on either of the links and ensure the correct event names are logged 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Discovered while working on this PR https://github.com/Automattic/wp-calypso/pull/60657