### PR TITLE
Admin Menu: Remove amp submenu registration

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -124,7 +124,9 @@ function unload_core_fse() {
 	remove_action( 'admin_menu', __NAMESPACE__ . '\hide_nav_menus_submenu' );
 
 	// Shows the AMP menu.
-	add_action( 'admin_menu', 'amp_add_customizer_link', 11 );
+	if ( function_exists( 'amp_add_customizer_link' ) ) {
+		add_action( 'admin_menu', 'amp_add_customizer_link', 11 );
+	}
 
 	if ( defined( 'REST_API_REQUEST' ) && true === REST_API_REQUEST ) {
 		// Do not hook to init during the REST API requests, as it causes PHP warnings

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -150,14 +150,6 @@ function load_helpers() {
 		return;
 	}
 
-	// AMP registration on the default 10 priority is too early and confuses the current
-	// Gutenberg (v12.5.1 at this comment's writing) `gutenberg_remove_legacy_pages` function
-	// into mistaking it for the Customizer proper.
-	if ( function_exists( 'amp_add_customizer_link' ) ) {
-		remove_action( 'admin_menu', 'amp_add_customizer_link' );
-		add_action( 'admin_menu', 'amp_add_customizer_link', 11 );
-	}
-
 	if ( apply_filters( 'a8c_hide_core_fse_activation', false ) ) {
 		return;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -124,7 +124,7 @@ function unload_core_fse() {
 	remove_action( 'admin_menu', __NAMESPACE__ . '\hide_nav_menus_submenu' );
 
 	// Shows the AMP menu.
-	add_action( 'admin_menu', 'amp_add_customizer_link' );
+	add_action( 'admin_menu', 'amp_add_customizer_link', 11 );
 
 	if ( defined( 'REST_API_REQUEST' ) && true === REST_API_REQUEST ) {
 		// Do not hook to init during the REST API requests, as it causes PHP warnings


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Prevent AMP plugin submenu from being registered for full site editing enabled sites

### Screenshots
<img width="1280" alt="Screen Shot 2022-02-03 at 5 38 16 AM" src="https://user-images.githubusercontent.com/5414230/152353631-5ebb244a-a6c3-415a-9e08-91f65ff30404.png">

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox an FSE enabled site and the public API
* Apply changes from this PR to your sandbox by running install-plugin.sh editing-toolkit remove/amp-submenu-registration in the sandbox
* Refresh the WordPress admin UI
* Verify that the Appearance > AMP submenu are gone (changes may need 5-10 seconds to take effect because of the slower performance on a sandboxed public API)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/60692 and https://github.com/Automattic/wp-calypso/issues/60339
